### PR TITLE
♻️ ref(metric alerts): Consolidate Metric Alert Model Coupling to 1 Place

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -59,8 +59,8 @@ class ActionHandler(metaclass=abc.ABCMeta):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         pass
@@ -71,8 +71,8 @@ class ActionHandler(metaclass=abc.ABCMeta):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         pass
@@ -103,8 +103,8 @@ class DefaultActionHandler(ActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         if not RuleSnooze.objects.is_snoozed_for_all(alert_rule=incident.alert_rule):
@@ -122,8 +122,8 @@ class DefaultActionHandler(ActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         if not RuleSnooze.objects.is_snoozed_for_all(alert_rule=incident.alert_rule):
@@ -142,8 +142,8 @@ class DefaultActionHandler(ActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         pass
@@ -213,8 +213,8 @@ class EmailActionHandler(ActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         self.email_users(
@@ -231,8 +231,8 @@ class EmailActionHandler(ActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         self.email_users(
@@ -304,8 +304,8 @@ class PagerDutyActionHandler(DefaultActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ):
         from sentry.integrations.pagerduty.utils import send_incident_alert_notification
@@ -348,8 +348,8 @@ class OpsgenieActionHandler(DefaultActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ):
         from sentry.integrations.opsgenie.utils import send_incident_alert_notification
@@ -382,8 +382,8 @@ class SentryAppActionHandler(DefaultActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ):
         from sentry.rules.actions.notify_event_service import send_incident_alert_notification

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -499,14 +499,19 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
-        metric_value: int | float,
         new_status: IncidentStatus,
+        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         handler = AlertRuleTriggerAction.build_handler(AlertRuleTriggerAction.Type(self.type))
         if handler:
             return handler.fire(
-                action, incident, project, metric_value, new_status, notification_uuid
+                action=action,
+                incident=incident,
+                project=project,
+                new_status=new_status,
+                metric_value=metric_value,
+                notification_uuid=notification_uuid,
             )
 
     def resolve(
@@ -514,14 +519,19 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
-        metric_value: int | float,
         new_status: IncidentStatus,
+        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         handler = AlertRuleTriggerAction.build_handler(AlertRuleTriggerAction.Type(self.type))
         if handler:
             return handler.resolve(
-                action, incident, project, metric_value, new_status, notification_uuid
+                action=action,
+                incident=incident,
+                project=project,
+                metric_value=metric_value,
+                new_status=new_status,
+                notification_uuid=notification_uuid,
             )
 
     def get_single_sentry_app_config(self) -> dict[str, Any] | None:

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -499,8 +499,8 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         handler = AlertRuleTriggerAction.build_handler(AlertRuleTriggerAction.Type(self.type))
@@ -519,8 +519,8 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         handler = AlertRuleTriggerAction.build_handler(AlertRuleTriggerAction.Type(self.type))

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -26,7 +26,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -25,8 +25,8 @@ from ..utils import logger
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
+    metric_value: int | float | None,
     new_status: IncidentStatus,
-    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -6,6 +6,7 @@ from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
+from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -39,6 +40,7 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
+        project: Project,
         new_status: IncidentStatus,
         metric_value: float | int | None = None,
         notification_uuid: str | None = None,

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -39,8 +39,8 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
-        metric_value: float,
         new_status: IncidentStatus,
+        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.discord.actions.metric_alert import (

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -41,8 +41,8 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.discord.actions.metric_alert import (

--- a/src/sentry/integrations/messaging/spec.py
+++ b/src/sentry/integrations/messaging/spec.py
@@ -133,8 +133,9 @@ class MessagingIntegrationSpec(ABC):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
-        metric_value: float,
+        project: Project,
         new_status: IncidentStatus,
+        metric_value: float | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         raise NotImplementedError
@@ -174,12 +175,17 @@ class MessagingActionHandler(DefaultActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
-        metric_value: int | float,
         new_status: IncidentStatus,
+        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         success = self._spec.send_incident_alert_notification(
-            action, incident, metric_value, new_status, notification_uuid
+            action=action,
+            incident=incident,
+            project=project,
+            metric_value=metric_value,
+            new_status=new_status,
+            notification_uuid=notification_uuid,
         )
         if success:
             self.record_alert_sent_analytics(

--- a/src/sentry/integrations/messaging/spec.py
+++ b/src/sentry/integrations/messaging/spec.py
@@ -134,8 +134,8 @@ class MessagingIntegrationSpec(ABC):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: float | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         raise NotImplementedError
@@ -175,8 +175,8 @@ class MessagingActionHandler(DefaultActionHandler):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: int | float | None = None,
         notification_uuid: str | None = None,
     ) -> None:
         success = self._spec.send_incident_alert_notification(

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -6,6 +6,7 @@ from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
+from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -41,6 +42,7 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
+        project: Project,
         new_status: IncidentStatus,
         metric_value: float | int | None = None,
         notification_uuid: str | None = None,

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -41,8 +41,8 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
-        metric_value: float,
         new_status: IncidentStatus,
+        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.msteams.utils import send_incident_alert_notification

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -43,8 +43,8 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.msteams.utils import send_incident_alert_notification

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -103,7 +103,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     from .card_builder.incident_attachment import build_incident_attachment

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -102,8 +102,8 @@ def get_channel_id(organization: Organization, integration_id: int, name: str) -
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
+    metric_value: float | int | None,
     new_status: IncidentStatus,
-    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     from .card_builder.incident_attachment import build_incident_attachment

--- a/src/sentry/integrations/slack/spec.py
+++ b/src/sentry/integrations/slack/spec.py
@@ -43,8 +43,8 @@ class SlackMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
-        metric_value: float,
         new_status: IncidentStatus,
+        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
 

--- a/src/sentry/integrations/slack/spec.py
+++ b/src/sentry/integrations/slack/spec.py
@@ -6,6 +6,7 @@ from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
+from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -43,6 +44,7 @@ class SlackMessagingSpec(MessagingIntegrationSpec):
         self,
         action: AlertRuleTriggerAction,
         incident: Incident,
+        project: Project,
         new_status: IncidentStatus,
         metric_value: float | int | None = None,
         notification_uuid: str | None = None,

--- a/src/sentry/integrations/slack/spec.py
+++ b/src/sentry/integrations/slack/spec.py
@@ -45,8 +45,8 @@ class SlackMessagingSpec(MessagingIntegrationSpec):
         action: AlertRuleTriggerAction,
         incident: Incident,
         project: Project,
+        metric_value: int | float | None,
         new_status: IncidentStatus,
-        metric_value: float | int | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
 

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -44,7 +44,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     # Make sure organization integration is still active:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -43,8 +43,8 @@ _logger = logging.getLogger(__name__)
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
+    metric_value: float | int | None,
     new_status: IncidentStatus,
-    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     # Make sure organization integration is still active:

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -71,7 +71,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float,
+    metric_value: float | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     """

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -71,7 +71,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     """

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -70,8 +70,8 @@ def build_incident_attachment(
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
+    metric_value: float | int | None,
     new_status: IncidentStatus,
-    metric_value: float | int | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     """

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -735,7 +735,7 @@ class NotificationContext:
     def from_action_model(cls, action: Action) -> NotificationContext:
         return cls(
             integration_id=action.integration_id,
-            target_identifier=action.target_identifier,
-            target_display=action.target_display,
+            target_identifier=action.config.get("target_identifier"),
+            target_display=action.config.get("target_display"),
             sentry_app_config=action.data,
         )

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict
 
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
@@ -708,3 +709,33 @@ class EmailDataBlob(DataBlob):
     """
 
     fallthroughType: str = ""
+
+
+@dataclass
+class NotificationContext:
+    """
+    NotificationContext is a dataclass that represents the context required send a notification.
+    """
+
+    integration_id: int | None = None
+    target_identifier: str | None = None
+    target_display: str | None = None
+    sentry_app_config: list[dict[str, Any]] | dict[str, Any] | None = None
+
+    @classmethod
+    def from_alert_rule_trigger_action(cls, action: AlertRuleTriggerAction) -> NotificationContext:
+        return cls(
+            integration_id=action.integration_id,
+            target_identifier=action.target_identifier,
+            target_display=action.target_display,
+            sentry_app_config=action.sentry_app_config,
+        )
+
+    @classmethod
+    def from_action_model(cls, action: Action) -> NotificationContext:
+        return cls(
+            integration_id=action.integration_id,
+            target_identifier=action.target_identifier,
+            target_display=action.target_display,
+            sentry_app_config=action.data,
+        )

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -62,7 +62,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                IncidentStatus(incident.status),
+                metric_value=metric_value,
             )
 
         data = orjson.loads(responses.calls[0].request.body)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -90,7 +90,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0
@@ -104,7 +108,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus.WARNING,
             )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
@@ -120,7 +128,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus.WARNING,
             )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
@@ -139,7 +151,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus.WARNING,
             )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
@@ -155,7 +171,11 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus.WARNING,
             )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -62,10 +62,10 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action,
-                incident,
-                self.project,
-                IncidentStatus(incident.status),
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                new_status=IncidentStatus(incident.status),
                 metric_value=metric_value,
             )
 
@@ -94,9 +94,9 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -112,9 +112,9 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus.WARNING,
             )
@@ -132,9 +132,9 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus.WARNING,
             )
@@ -175,9 +175,9 @@ class DiscordActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus.WARNING,
             )

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -53,9 +53,9 @@ class EmailActionHandlerTest(FireTest):
         handler = EmailActionHandler()
         with self.tasks():
             handler.fire(
-                action,
-                incident,
-                self.project,
+                action=action,
+                incident=incident,
+                project=self.project,
                 metric_value=1000,
                 new_status=IncidentStatus(incident.status),
             )

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -52,7 +52,13 @@ class EmailActionHandlerTest(FireTest):
         )
         handler = EmailActionHandler()
         with self.tasks():
-            handler.fire(action, incident, self.project, 1000, IncidentStatus(incident.status))
+            handler.fire(
+                action,
+                incident,
+                self.project,
+                metric_value=1000,
+                new_status=IncidentStatus(incident.status),
+            )
         out = mail.outbox[0]
         assert out.to == [self.user.email]
         assert out.subject == "[{}] {} - {}".format(

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -90,7 +90,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
         data = json.loads(responses.calls[0].request.body)
 
@@ -236,7 +240,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0
@@ -259,7 +267,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
@@ -287,7 +299,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -90,9 +90,9 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -240,9 +240,9 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -267,9 +267,9 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -299,9 +299,9 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -214,10 +214,10 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action,
-                incident,
-                self.project,
-                IncidentStatus(incident.status),
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                new_status=IncidentStatus(incident.status),
                 metric_value=metric_value,
             )
         data = responses.calls[0].request.body
@@ -256,9 +256,9 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -277,9 +277,9 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -303,9 +303,9 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -252,7 +252,11 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0
@@ -269,7 +273,11 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0
@@ -291,7 +299,11 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -214,7 +214,11 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                IncidentStatus(incident.status),
+                metric_value=metric_value,
             )
         data = responses.calls[0].request.body
 

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -182,7 +182,11 @@ class PagerDutyActionHandlerTest(FireTest):
         new_status = IncidentStatus(incident.status)
         with self.tasks():
             getattr(self.handler, method)(
-                self.action, incident, self.project, metric_value, new_status
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                metric_value=metric_value,
+                new_status=new_status,
             )
         data = responses.calls[0].request.body
 
@@ -195,7 +199,9 @@ class PagerDutyActionHandlerTest(FireTest):
             new_status=new_status,
             metric_value=metric_value,
         )
-        expected_payload = attach_custom_severity(expected_payload, self.action, new_status)
+        expected_payload = attach_custom_severity(
+            expected_payload, self.action.sentry_app_config, new_status
+        )
 
         assert json.loads(data) == expected_payload
 
@@ -248,9 +254,9 @@ class PagerDutyActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -248,7 +248,11 @@ class PagerDutyActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -145,7 +145,11 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                IncidentStatus(incident.status),
+                metric_value,
             )
         data = responses.calls[0].request.body
         assert (

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -48,7 +48,11 @@ class SentryAppActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
         data = responses.calls[0].request.body
         assert (
@@ -75,7 +79,11 @@ class SentryAppActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert len(responses.calls) == 0

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -48,9 +48,9 @@ class SentryAppActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -79,9 +79,9 @@ class SentryAppActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -145,11 +145,11 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             getattr(self.handler, method)(
-                self.action,
-                incident,
-                self.project,
-                IncidentStatus(incident.status),
-                metric_value,
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                new_status=IncidentStatus(incident.status),
+                metric_value=metric_value,
             )
         data = responses.calls[0].request.body
         assert (

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -254,7 +254,11 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
@@ -266,7 +270,11 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         assert not mock_post.called
@@ -283,7 +291,11 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+                self.action,
+                incident,
+                self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus(incident.status),
             )
 
         mock_post.assert_called

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -85,7 +85,13 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         status = IncidentStatus(incident.status)
         with self.tasks():
-            getattr(self.handler, method)(self.action, incident, self.project, status, metric_value)
+            getattr(self.handler, method)(
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                new_status=status,
+                metric_value=metric_value,
+            )
 
         return incident, chart_url
 
@@ -254,9 +260,9 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                action,
-                incident,
-                self.project,
+                action=action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -270,9 +276,9 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )
@@ -291,9 +297,9 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         with self.tasks():
             self.handler.fire(
-                self.action,
-                incident,
-                self.project,
+                action=self.action,
+                incident=incident,
+                project=self.project,
                 metric_value=metric_value,
                 new_status=IncidentStatus(incident.status),
             )

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -85,7 +85,7 @@ class SlackActionHandlerTest(FireTest):
         metric_value = 1000
         status = IncidentStatus(incident.status)
         with self.tasks():
-            getattr(self.handler, method)(self.action, incident, self.project, metric_value, status)
+            getattr(self.handler, method)(self.action, incident, self.project, status, metric_value)
 
         return incident, chart_url
 

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -241,7 +241,9 @@ class AlertRuleTriggerActionActivateBaseTest:
 
     def test_no_handler(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
-        result = trigger.fire(Mock(), Mock(), Mock(), 123, IncidentStatus.CRITICAL)  # type: ignore[func-returns-value]
+        result = trigger.fire(
+            Mock(), Mock(), Mock(), metric_value=123, new_status=IncidentStatus.CRITICAL
+        )  # type: ignore[func-returns-value]
 
         # TODO(RyanSkonnord): Remove assertion (see test_handler)
         assert result is None
@@ -253,7 +255,9 @@ class AlertRuleTriggerActionActivateBaseTest:
         type = AlertRuleTriggerAction.Type.EMAIL
         AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
         trigger = AlertRuleTriggerAction(type=type.value)
-        result = getattr(trigger, self.method)(Mock(), Mock(), Mock(), 123, IncidentStatus.CRITICAL)
+        result = getattr(trigger, self.method)(
+            Mock(), Mock(), Mock(), metric_value=123, new_status=IncidentStatus.CRITICAL
+        )
 
         # TODO(RyanSkonnord): Don't assert on return value.
         # All concrete ActionHandlers return None from their fire and resolve

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -986,8 +986,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     self.action,
                     incident,
                     self.project,
-                    trigger.alert_threshold + 1,
                     IncidentStatus.CRITICAL,
+                    trigger.alert_threshold + 1,
                     uuid,
                 )
             ],
@@ -1030,8 +1030,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     w_action,
                     incident,
                     self.project,
-                    c_trigger.alert_threshold + 1,
                     IncidentStatus.CRITICAL,
+                    c_trigger.alert_threshold + 1,
                     mock.ANY,
                 )
             ],
@@ -1070,8 +1070,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     self.action,
                     incident,
                     self.project,
-                    trigger.alert_threshold + 1,
                     IncidentStatus.CRITICAL,
+                    trigger.alert_threshold + 1,
                     mock.ANY,
                 )
             ],

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -4267,7 +4267,16 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_actions_fired_for_incident(
             incident,
             [action_warning],
-            [(action_warning, incident, self.project, IncidentStatus.CRITICAL, 75.0, mock.ANY)],
+            [
+                {
+                    "action": action_warning,
+                    "incident": incident,
+                    "project": self.project,
+                    "new_status": IncidentStatus.CRITICAL,
+                    "metric_value": 75.0,
+                    "notification_uuid": mock.ANY,
+                }
+            ],
         )
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
@@ -4284,7 +4293,16 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_actions_resolved_for_incident(
             incident,
             [action_warning],
-            [(action_warning, incident, self.project, IncidentStatus.WARNING, 85.0, mock.ANY)],
+            [
+                {
+                    "action": action_warning,
+                    "incident": incident,
+                    "project": self.project,
+                    "new_status": IncidentStatus.WARNING,
+                    "metric_value": 85.0,
+                    "notification_uuid": mock.ANY,
+                }
+            ],
         )
         self.assert_trigger_exists_with_status(incident, trigger_warning, TriggerStatus.ACTIVE)
 

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -98,12 +98,12 @@ class HandleTriggerActionTest(TestCase):
                 )
             mock_handler.assert_called_once_with()
             mock_handler.return_value.fire.assert_called_once_with(
-                self.action,
-                incident,
-                self.project,
-                metric_value,
-                IncidentStatus.CRITICAL,
-                str(activity.notification_uuid),
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                new_status=IncidentStatus.CRITICAL,
+                metric_value=metric_value,
+                notification_uuid=str(activity.notification_uuid),
             )
 
 


### PR DESCRIPTION
this consolidates all the model coupling for metric alerts logic from models to a single place! so far i just did pagerduty to validate the idea.

essentially we abstract actions + alert rule trigger actions via a dataclass (something we can reuse later as well). we build these data classes from models, then pass them down the notification building logic. 😎 \


also i had to update the typing since it was fundamentally incorrect (metric_value can also be None is some scenarios)

i have a commit locally to fix tests but the diff will be massive so waiting for a cursory review