### PR TITLE
ref(product-selection): Update code to not strip url

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -345,13 +345,16 @@ export function ProductSelection({
     return selectedDefaults.filter(product => !(product in disabledProducts));
   }, [products, platform, disabledProducts]);
 
+  const safeDependencies = useRef({onLoad, urlProducts});
+
   useEffect(() => {
-    onLoad?.(defaultProducts);
-    setParams({
-      product: defaultProducts,
-    });
-    // Adding defaultProducts to the dependency array causes an max-depth error
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    safeDependencies.current = {onLoad, urlProducts};
+  });
+
+  useEffect(() => {
+    safeDependencies.current.onLoad?.(
+      safeDependencies.current.urlProducts as ProductSolution[]
+    );
   }, []);
 
   const handleClickProduct = useCallback(


### PR DESCRIPTION
**Before**

(for context): Previously, the `onLoad` function updated the URL with the default selected products, which changed after the [PR](https://github.com/getsentry/sentry/pull/86395) was merged. 

Currently, the products in the URL are always stripped and replaced with the new default (an empty array - products are no longer selected by default).

**After**

This PR updates the logic to prevent stripping the product parameter from the URL, even if it contains invalid values. This ensures that, even on page refresh, the same parameters are preserved in the URL.

Additionally, the tests have been updated to reflect this change.


closes https://github.com/getsentry/projects/issues/787