### PR TITLE
ref(getting-started): Change code to always update loader script when products changes

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.spec.tsx
@@ -29,6 +29,11 @@ function renderMockRequests({
   });
 
   MockApiClient.addMockResponse({
+    url: `/projects/${orgSlug}/${project.slug}/keys/${PROJECT_KEY?.id}/`,
+    method: 'PUT',
+  });
+
+  MockApiClient.addMockResponse({
     url: `/organizations/${orgSlug}/sdks/`,
   });
 }

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -480,6 +480,28 @@ const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
       });
     };
   },
+  onProductSelectionChange: params => {
+    return products => {
+      updateDynamicSdkLoaderOptions({
+        orgSlug: params.organization.slug,
+        projectSlug: params.projectSlug,
+        products,
+        projectKey: params.projectKeyId,
+        api: params.api,
+      });
+    };
+  },
+  onProductSelectionLoad: params => {
+    return products => {
+      updateDynamicSdkLoaderOptions({
+        orgSlug: params.organization.slug,
+        projectSlug: params.projectSlug,
+        products,
+        projectKey: params.projectKeyId,
+        api: params.api,
+      });
+    };
+  },
   onPlatformOptionsChange: params => {
     return () => {
       trackAnalytics('onboarding.setup_loader_docs_rendered', {


### PR DESCRIPTION
I noticed that the dynamicSdkLoader options are not updated when users switch to the package manager option in the JavaScript platform within the Getting Started Docs. We should ensure that the loader is always kept up to date, as users may switch back to the Loader Script or go to settings to instrument their SDK after completing the onboarding. 

