### PR TITLE
ref(assemble): Remove old `find_missing_chunks` method

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -478,7 +478,7 @@ def batch_assemble(project, files):
     checksums_to_check -= checksums_without_chunks
 
     # 4. Find missing chunks and group them per checksum.
-    all_missing_chunks = find_missing_chunks(project.organization.id, list(chunks_to_check.keys()))
+    all_missing_chunks = find_missing_chunks(project.organization.id, set(chunks_to_check.keys()))
 
     missing_chunks_per_checksum: dict[str, set[str]] = {}
     for chunk in all_missing_chunks:

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -478,7 +478,7 @@ def batch_assemble(project, files):
     checksums_to_check -= checksums_without_chunks
 
     # 4. Find missing chunks and group them per checksum.
-    all_missing_chunks = find_missing_chunks(project.organization, list(chunks_to_check.keys()))
+    all_missing_chunks = find_missing_chunks(project.organization.id, list(chunks_to_check.keys()))
 
     missing_chunks_per_checksum: dict[str, set[str]] = {}
     for chunk in all_missing_chunks:

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -92,7 +92,7 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             chunks = data.get("chunks", [])
 
             # We check if all requested chunks have been uploaded.
-            missing_chunks = find_missing_chunks(organization.id, chunks)
+            missing_chunks = find_missing_chunks(organization.id, set(chunks))
 
             # In case there are some missing chunks, we will tell the client which chunks we require.
             if missing_chunks:

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -92,8 +92,8 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             chunks = data.get("chunks", [])
 
             # We check if all requested chunks have been uploaded.
-            with sentry_sdk.start_span(op="artifact_bundle.assemble.find_missing_chunks"):
-                missing_chunks = find_missing_chunks(organization, chunks)
+            missing_chunks = find_missing_chunks(organization.id, chunks)
+
             # In case there are some missing chunks, we will tell the client which chunks we require.
             if missing_chunks:
                 return Response(

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -4,28 +4,19 @@ from datetime import timedelta
 import sentry_sdk
 from django.utils import timezone
 
-from sentry import features
-from sentry.models.files import FileBlob, FileBlobOwner
-from sentry.models.organization import Organization
+from sentry.models.files import FileBlob
 
 
-def find_missing_chunks(organization: Organization, chunks: Sequence[str]):
+def find_missing_chunks(organization_id: int, chunks: Sequence[str]):
     """Returns a list of chunks which are missing for an org."""
-    if features.has("organizations:find-missing-chunks-new", organization):
-        return _find_missing_chunks_new(organization.id, set(chunks))
-
-    return _find_missing_chunks_old(organization.id, set(chunks))
-
-
-def _find_missing_chunks_new(organization_id: int, chunks: set[str]):
-    with sentry_sdk.start_span(op="find_missing_chunks_new") as span:
+    with sentry_sdk.start_span(op="find_missing_chunks") as span:
         span.set_tag("organization_id", organization_id)
         span.set_data("chunks_size", len(chunks))
 
         if not chunks:
             return []
 
-        with sentry_sdk.start_span(op="find_missing_chunks_new.fetch_owned_file_blobs"):
+        with sentry_sdk.start_span(op="find_missing_chunks.fetch_owned_file_blobs"):
             owned_file_blobs = FileBlob.objects.filter(
                 checksum__in=chunks, fileblobowner__organization_id=organization_id
             ).values_list(
@@ -39,7 +30,7 @@ def _find_missing_chunks_new(organization_id: int, chunks: set[str]):
         owned_file_chunks = {checksum for _, checksum, _ in owned_file_blobs}
         unowned_file_chunks = chunks - owned_file_chunks
 
-        with sentry_sdk.start_span(op="find_missing_chunks_new.fetch_unowned_file_blobs"):
+        with sentry_sdk.start_span(op="find_missing_chunks.fetch_unowned_file_blobs"):
             unowned_file_blobs = FileBlob.objects.filter(
                 checksum__in=unowned_file_chunks,
             ).values_list(
@@ -65,27 +56,3 @@ def _find_missing_chunks_new(organization_id: int, chunks: set[str]):
 
         # We return all the file chunks that are not bound to the supply organization.
         return list(unowned_file_chunks)
-
-
-def _find_missing_chunks_old(organization_id: int, chunks: set[str]):
-    with sentry_sdk.start_span(op="find_missing_chunks_old") as span:
-        span.set_tag("organization_id", organization_id)
-        span.set_data("chunks_size", len(chunks))
-
-        now = timezone.now()
-        threshold = now - timedelta(hours=12)
-
-        with sentry_sdk.start_span(op="find_missing_chunks_old.update_timestamp"):
-            FileBlob.objects.filter(checksum__in=chunks, timestamp__lte=threshold).update(
-                timestamp=now
-            )
-
-        # Compute the set of all existing chunks.
-        with sentry_sdk.start_span(op="find_missing_chunks_old.get_owned_chunks"):
-            owned = set(
-                FileBlobOwner.objects.filter(
-                    blob__checksum__in=chunks, organization_id=organization_id
-                ).values_list("blob__checksum", flat=True)
-            )
-
-        return list(chunks - owned)

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from datetime import timedelta
 
 import sentry_sdk
@@ -7,7 +6,7 @@ from django.utils import timezone
 from sentry.models.files import FileBlob
 
 
-def find_missing_chunks(organization_id: int, chunks: Sequence[str]):
+def find_missing_chunks(organization_id: int, chunks: set[str]):
     """Returns a list of chunks which are missing for an org."""
     with sentry_sdk.start_span(op="find_missing_chunks") as span:
         span.set_tag("organization_id", organization_id)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -488,13 +488,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable updated form for 3p publishing flow
     manager.add("organizations:streamlined-publishing-flow", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new find missing chunks algorithm
-    manager.add(
-        "organizations:find-missing-chunks-new",
-        OrganizationFeature,
-        FeatureHandlerStrategy.FLAGPOLE,
-        api_expose=False
-    )
     # Enable per-project selection for Jira integration
     manager.add("organizations:jira-per-project-statuses", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Relay extracting logs from breadcrumbs for a project.

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -12,7 +12,6 @@ from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
@@ -29,7 +28,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
             args=[self.organization.slug],
         )
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_json_schema(self):
         response = self.client.post(
             self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
@@ -118,7 +116,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.NOT_FOUND
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_with_invalid_projects(self):
         bundle_file = self.create_artifact_bundle_zip(
             org=self.organization.slug, release=self.release.version
@@ -144,7 +141,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 400, response.content
         assert response.data["error"] == "One or more projects are invalid"
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_with_valid_project_slugs(self):
         # Test with all valid project slugs
         valid_project = self.create_project()
@@ -170,7 +166,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_with_valid_project_ids(self):
         # Test with all valid project IDs
         valid_project = self.create_project()
@@ -196,7 +191,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_with_mix_of_slugs_and_ids(self):
         # Test with a mix of valid project slugs and IDs
         valid_project = self.create_project()
@@ -227,7 +221,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    @with_feature("organizations:find-missing-chunks-new")
     @patch("sentry.tasks.assemble.assemble_artifacts")
     def test_assemble_without_version_and_dist(self, mock_assemble_artifacts):
         bundle_file = self.create_artifact_bundle_zip(
@@ -264,7 +257,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
             }
         )
 
-    @with_feature("organizations:find-missing-chunks-new")
     @patch("sentry.tasks.assemble.assemble_artifacts")
     def test_assemble_with_version_and_no_dist(self, mock_assemble_artifacts):
         bundle_file = self.create_artifact_bundle_zip(
@@ -302,7 +294,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
             }
         )
 
-    @with_feature("organizations:find-missing-chunks-new")
     @patch("sentry.tasks.assemble.assemble_artifacts")
     def test_assemble_with_version_and_dist(self, mock_assemble_artifacts):
         dist = "android"
@@ -342,7 +333,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
             }
         )
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_with_missing_chunks(self):
         dist = "android"
         bundle_file = self.create_artifact_bundle_zip(
@@ -387,7 +377,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_response(self):
         bundle_file = self.create_artifact_bundle_zip(
             org=self.organization.slug, release=self.release.version
@@ -417,7 +406,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
 
-    @with_feature("organizations:find-missing-chunks-new")
     def test_assemble_org_auth_token(self):
         org2 = self.create_organization(owner=self.user)
 


### PR DESCRIPTION
This PR removes the old `find_missing_chunks` method in favor of the new one.