### PR TITLE
fix(widget-builder): New widgets should not shift old widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -65,7 +65,7 @@ type WidgetBuilderV2Props = {
   dashboardFilters: DashboardFilters;
   isOpen: boolean;
   onClose: () => void;
-  onSave: ({index, widget}: {index: number; widget: Widget}) => void;
+  onSave: ({index, widget}: {index: number | undefined; widget: Widget}) => void;
   openWidgetTemplates: boolean;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;
 };

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -4,6 +4,7 @@ import {validateWidget} from 'sentry/actionCreators/dashboards';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import useApi from 'sentry/utils/useApi';
@@ -15,7 +16,7 @@ import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder
 
 interface SaveButtonProps {
   isEditing: boolean;
-  onSave: ({index, widget}: {index: number; widget: Widget}) => void;
+  onSave: ({index, widget}: {index: number | undefined; widget: Widget}) => void;
   setError: (error: Record<string, any>) => void;
 }
 
@@ -37,7 +38,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
     setIsSaving(true);
     try {
       await validateWidget(api, organization.slug, widget);
-      onSave({index: Number(widgetIndex), widget});
+      onSave({index: defined(widgetIndex) ? Number(widgetIndex) : undefined, widget});
     } catch (error) {
       setIsSaving(false);
       const errorDetails = error.responseJSON || error;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -14,6 +14,7 @@ import {
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import ModalStore from 'sentry/stores/modalStore';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
+import {useParams} from 'sentry/utils/useParams';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
@@ -22,6 +23,7 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
 jest.mock('sentry/actionCreators/indicator');
+jest.mock('sentry/utils/useParams');
 
 describe('WidgetBuilderSlideout', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;
@@ -34,6 +36,8 @@ describe('WidgetBuilderSlideout', () => {
 
     jest.mocked(useSpanTags).mockReturnValue({});
 
+    jest.mocked(useParams).mockReturnValue({widgetIndex: undefined});
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
     });
@@ -41,15 +45,13 @@ describe('WidgetBuilderSlideout', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/widgets/',
       method: 'POST',
-      body: {
-        title: 'Title is required during creation',
-      },
-      statusCode: 400,
+      statusCode: 200,
     });
   });
 
   afterEach(() => {
     ModalStore.reset();
+    jest.clearAllMocks();
   });
 
   it('should show the sort by step if the widget is a chart and there are fields selected', async () => {
@@ -225,6 +227,15 @@ describe('WidgetBuilderSlideout', () => {
   });
 
   it('should not save and close the widget builder if the widget is invalid', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/widgets/',
+      method: 'POST',
+      body: {
+        title: 'Title is required during creation',
+      },
+      statusCode: 400,
+    });
+
     render(
       <WidgetBuilderProvider>
         <WidgetBuilderSlideout
@@ -376,5 +387,65 @@ describe('WidgetBuilderSlideout', () => {
     );
 
     expect(await screen.findByText('Thresholds')).toBeInTheDocument();
+  });
+
+  it('calls the save method with the index if it is defined', async () => {
+    jest.mocked(useParams).mockReturnValue({widgetIndex: '1'});
+
+    const onSave = jest.fn();
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={onSave}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Update Widget'));
+
+    expect(onSave).toHaveBeenCalledWith({index: 1, widget: expect.any(Object)});
+  });
+
+  it('passes undefined as the index for onSave if the index is not defined', async () => {
+    jest.mocked(useParams).mockReturnValue({widgetIndex: undefined});
+
+    const onSave = jest.fn();
+
+    // This is the case where we're adding a new widget
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={onSave}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Add Widget'));
+
+    expect(onSave).toHaveBeenCalledWith({index: undefined, widget: expect.any(Object)});
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -49,7 +49,7 @@ type WidgetBuilderSlideoutProps = {
   isWidgetInvalid: boolean;
   onClose: () => void;
   onQueryConditionChange: (valid: boolean) => void;
-  onSave: ({index, widget}: {index: number; widget: Widget}) => void;
+  onSave: ({index, widget}: {index: number | undefined; widget: Widget}) => void;
   openWidgetTemplates: boolean;
   setIsPreviewDraggable: (draggable: boolean) => void;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;


### PR DESCRIPTION
We were casting the widget index with Number without checking whether it was undefined or not before (because creating a widget means there is no index). The code path this resulted in for the save handler caused the widget to be inserted at the front of the list and since we rely on index to show links such as widget builder, it was shifting those links over by 1.

Check for undefined before converting the route parameter into a Number.

Fixes #86591