### PR TITLE
fix(dashboards): Append widget on duplicate

### DIFF
--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -344,19 +344,19 @@ describe('Dashboards > Dashboard', () => {
     await userEvent.click(await screen.findByLabelText('Widget actions'));
     await userEvent.click(await screen.findByText('Duplicate Widget'));
 
-    // The new widget is inserted before the duplicated widget
+    // The new widget is inserted after the duplicated widget
     const expectedWidgets = [
-      // New Widget
-      expect.objectContaining(
-        WidgetFixture({
-          id: undefined,
-          layout: expect.objectContaining({h: 1, w: 1, x: 0, y: 0, minH: 1}),
-        })
-      ),
       // Duplicated Widget
       expect.objectContaining(
         WidgetFixture({
           id: '1',
+          layout: expect.objectContaining({h: 1, w: 1, x: 0, y: 0, minH: 1}),
+        })
+      ),
+      // New Widget is appended at the end
+      expect.objectContaining(
+        WidgetFixture({
+          id: undefined,
           layout: expect.objectContaining({h: 1, w: 1, x: 0, y: 1, minH: 1}),
         })
       ),

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -324,7 +324,7 @@ class Dashboard extends Component<Props, State> {
     }
   };
 
-  handleDuplicateWidget = (widget: Widget, index: number) => () => {
+  handleDuplicateWidget = (widget: Widget) => () => {
     const {
       organization,
       dashboard,
@@ -342,8 +342,7 @@ class Dashboard extends Component<Props, State> {
       assignTempId({...widget, id: undefined, tempId: undefined})
     );
 
-    let nextList = [...dashboard.widgets];
-    nextList.splice(index, 0, widgetCopy);
+    let nextList = [...dashboard.widgets, widgetCopy];
     nextList = generateWidgetsAfterCompaction(nextList);
 
     onUpdate(nextList);
@@ -440,7 +439,7 @@ class Dashboard extends Component<Props, State> {
       widgetLimitReached,
       onDelete: this.handleDeleteWidget(widget),
       onEdit: this.handleEditWidget(index),
-      onDuplicate: this.handleDuplicateWidget(widget, index),
+      onDuplicate: this.handleDuplicateWidget(widget),
       onSetTransactionsDataset: () => this.handleChangeSplitDataset(widget, index),
 
       isPreview,


### PR DESCRIPTION
Similar to #86594, we shouldn't displace other widgets when a widget is duplicated but rather add the new widget to the end. This means that deletions will break links that people save to widgets.

This problem also affects deletions which we can't really handle well with indices at the moment because of edit mode. @nikkikapadia suggested we move to using widget ID's in the URL, we should look at doing that long-term but for now we'll make these experiences easier. Long term we can try something with `tempId`s in the URL if a widget is added in edit mode.