### PR TITLE
ref(eap): swap `ResolvedColumn` and `ResolvedAttribute`

### DIFF
--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -1,19 +1,19 @@
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ResolvedColumn
+from sentry.search.eap.columns import ResolvedAttribute
 
 COMMON_COLUMNS = [
-    ResolvedColumn(
+    ResolvedAttribute(
         public_alias="organization.id",
         internal_name="sentry.organization_id",
         search_type="string",
     ),
-    ResolvedColumn(
+    ResolvedAttribute(
         public_alias="project.id",
         internal_name="sentry.project_id",
         internal_type=constants.INT,
         search_type="string",
     ),
-    ResolvedColumn(
+    ResolvedAttribute(
         public_alias="project_id",
         internal_name="sentry.project_id",
         internal_type=constants.INT,

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -1,6 +1,6 @@
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
-    ResolvedColumn,
+    ResolvedAttribute,
     VirtualColumnDefinition,
     datetime_processor,
     project_context_constructor,
@@ -14,41 +14,41 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
     for column in COMMON_COLUMNS
     + [
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span_id",
             internal_name="sentry.span_id",
             search_type="string",
             validator=is_span_id,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="log.body",
             internal_name="sentry.body",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="log.severity_number",
             internal_name="sentry.severity_number",
             search_type="integer",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="log.severity_text",
             internal_name="sentry.severity_text",
             search_type="string",
         ),
         # Message maps to body, this is to allow wildcard searching
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="message",
             internal_name="sentry.body",
             search_type="string",
             secondary_alias=True,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="trace",
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             search_type="string",

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -40,7 +40,7 @@ from sentry.search.eap.columns import (
     ColumnDefinitions,
     FormulaDefinition,
     ResolvedAggregate,
-    ResolvedColumn,
+    ResolvedAttribute,
     ResolvedFormula,
     VirtualColumnDefinition,
 )
@@ -61,9 +61,9 @@ class SearchResolver:
     params: SnubaParams
     config: SearchResolverConfig
     definitions: ColumnDefinitions
-    _resolved_attribute_cache: dict[str, tuple[ResolvedColumn, VirtualColumnDefinition | None]] = (
-        field(default_factory=dict)
-    )
+    _resolved_attribute_cache: dict[
+        str, tuple[ResolvedAttribute, VirtualColumnDefinition | None]
+    ] = field(default_factory=dict)
     _resolved_function_cache: dict[
         str, tuple[ResolvedFormula | ResolvedAggregate, VirtualColumnDefinition | None]
     ] = field(default_factory=dict)
@@ -329,7 +329,7 @@ class SearchResolver:
         self,
         term: str,
         raw_value: str | list[str],
-        resolved_column: ResolvedColumn,
+        resolved_column: ResolvedAttribute,
         context: VirtualColumnDefinition,
     ) -> list[str] | str:
         # Convert the term to the expected values
@@ -473,7 +473,7 @@ class SearchResolver:
 
     def _resolve_search_value(
         self,
-        column: ResolvedColumn,
+        column: ResolvedAttribute,
         operator: str,
         value: str | float | datetime | Sequence[float] | Sequence[str],
     ) -> AttributeValue:
@@ -553,7 +553,7 @@ class SearchResolver:
 
     @sentry_sdk.trace
     def resolve_columns(self, selected_columns: list[str]) -> tuple[
-        list[ResolvedColumn | ResolvedAggregate | ResolvedFormula],
+        list[ResolvedAttribute | ResolvedAggregate | ResolvedFormula],
         list[VirtualColumnDefinition | None],
     ]:
         """Given a list of columns resolve them and get their context if applicable
@@ -591,7 +591,7 @@ class SearchResolver:
     def resolve_column(
         self, column: str, match: Match | None = None
     ) -> tuple[
-        ResolvedColumn | ResolvedAggregate | ResolvedFormula, VirtualColumnDefinition | None
+        ResolvedAttribute | ResolvedAggregate | ResolvedFormula, VirtualColumnDefinition | None
     ]:
         """Column is either an attribute or an aggregate, this function will determine which it is and call the relevant
         resolve function"""
@@ -608,7 +608,7 @@ class SearchResolver:
     @sentry_sdk.trace
     def resolve_attributes(
         self, columns: list[str]
-    ) -> tuple[list[ResolvedColumn], list[VirtualColumnDefinition | None]]:
+    ) -> tuple[list[ResolvedAttribute], list[VirtualColumnDefinition | None]]:
         """Helper function to resolve a list of attributes instead of 1 attribute at a time"""
         resolved_columns = []
         resolved_contexts = []
@@ -620,7 +620,7 @@ class SearchResolver:
 
     def resolve_attribute(
         self, column: str
-    ) -> tuple[ResolvedColumn, VirtualColumnDefinition | None]:
+    ) -> tuple[ResolvedAttribute, VirtualColumnDefinition | None]:
         """Attributes are columns that aren't 'functions' or 'aggregates', usually this means string or numeric
         attributes (aka. tags), but can also refer to fields like span.description"""
         # If a virtual context is defined the column definition is always the same
@@ -628,7 +628,7 @@ class SearchResolver:
             return self._resolved_attribute_cache[column]
         if column in self.definitions.contexts:
             column_context = self.definitions.contexts[column]
-            column_definition = ResolvedColumn(
+            column_definition = ResolvedAttribute(
                 public_alias=column, internal_name=column, search_type="string"
             )
         elif column in self.definitions.columns:
@@ -660,7 +660,7 @@ class SearchResolver:
                 field = f"sentry.{field}"
 
             search_type = cast(constants.SearchType, field_type)
-            column_definition = ResolvedColumn(
+            column_definition = ResolvedAttribute(
                 public_alias=column, internal_name=field, search_type=search_type
             )
             column_context = None
@@ -708,7 +708,7 @@ class SearchResolver:
         else:
             raise InvalidSearchQuery(f"Unknown function {function}")
 
-        parsed_args: list[ResolvedColumn | Any] = []
+        parsed_args: list[ResolvedAttribute | Any] = []
 
         # Parse the arguments
         arguments = fields.parse_arguments(function, columns)
@@ -762,7 +762,7 @@ class SearchResolver:
             raise InvalidSearchQuery("Cannot use more than one argument")
         elif len(parsed_args) == 1:
             parsed_arg = parsed_args[0]
-            if not isinstance(parsed_arg, ResolvedColumn):
+            if not isinstance(parsed_arg, ResolvedAttribute):
                 resolved_argument = parsed_arg
                 search_type = function_definition.default_search_type
             elif isinstance(parsed_arg.proto_definition, AttributeKey):

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -2,7 +2,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import VirtualColumnContext
 
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
-    ResolvedColumn,
+    ResolvedAttribute,
     VirtualColumnDefinition,
     datetime_processor,
     project_context_constructor,
@@ -32,204 +32,204 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
     for column in COMMON_COLUMNS
     + [
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="id",
             internal_name="sentry.span_id",
             search_type="string",
             validator=is_span_id,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="parent_span",
             internal_name="sentry.parent_span_id",
             search_type="string",
             validator=is_span_id,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.action",
             internal_name="sentry.action",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.description",
             internal_name="sentry.name",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="description",
             internal_name="sentry.name",
             search_type="string",
             secondary_alias=True,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="sentry.normalized_description",
             internal_name="sentry.description",
             search_type="string",
         ),
         # Message maps to description, this is to allow wildcard searching
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="message",
             internal_name="sentry.name",
             search_type="string",
             secondary_alias=True,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.domain",
             internal_name="sentry.domain",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.group",
             internal_name="sentry.group",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.op",
             internal_name="sentry.op",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.category",
             internal_name="sentry.category",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.self_time",
             internal_name="sentry.exclusive_time_ms",
             search_type="millisecond",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.duration",
             internal_name="sentry.duration_ms",
             search_type="millisecond",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.status",
             internal_name="sentry.status",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.status_code",
             internal_name="sentry.status_code",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="trace",
             internal_name="sentry.trace_id",
             search_type="string",
             validator=validate_event_id,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="transaction",
             internal_name="sentry.segment_name",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="is_transaction",
             internal_name="sentry.is_segment",
             search_type="boolean",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="transaction.span_id",
             internal_name="sentry.segment_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="profile.id",
             internal_name="sentry.profile_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="profiler.id",
             internal_name="profiler_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="thread.id",
             internal_name="thread.id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="thread.name",
             internal_name="thread.name",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="replay.id",
             internal_name="sentry.replay_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="span.ai.pipeline.group",
             internal_name="sentry.ai_pipeline_group",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="ai.total_tokens.used",
             internal_name="ai_total_tokens_used",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="ai.total_cost",
             internal_name="ai.total_cost",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="http.decoded_response_content_length",
             internal_name="http.decoded_response_content_length",
             search_type="byte",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="http.response_content_length",
             internal_name="http.response_content_length",
             search_type="byte",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="http.response_transfer_size",
             internal_name="http.response_transfer_size",
             search_type="byte",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="sampling_rate",
             internal_name="sentry.sampling_factor",
             search_type="percentage",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             search_type="string",
             processor=datetime_processor,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="cache.hit",
             internal_name="cache.hit",
             search_type="boolean",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias=PRECISE_START_TS,
             internal_name="sentry.start_timestamp",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias=PRECISE_FINISH_TS,
             internal_name="sentry.end_timestamp",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="mobile.frames_delay",
             internal_name="frames.delay",
             search_type="second",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="mobile.frames_slow",
             internal_name="frames.slow",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="mobile.frames_frozen",
             internal_name="frames.frozen",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="mobile.frames_total",
             internal_name="frames.total",
             search_type="number",
@@ -237,7 +237,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         # These fields are extracted from span measurements but were accessed
         # 2 ways, with + without the measurements. prefix. So expose both for compatibility.
         simple_measurements_field("cache.item_size", search_type="byte", secondary_alias=True),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="cache.item_size",
             internal_name="cache.item_size",
             search_type="byte",
@@ -245,7 +245,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         simple_measurements_field(
             "messaging.message.body.size", search_type="byte", secondary_alias=True
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="messaging.message.body.size",
             internal_name="messaging.message.body.size",
             search_type="byte",
@@ -253,13 +253,13 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         simple_measurements_field(
             "messaging.message.receive.latency", search_type="millisecond", secondary_alias=True
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="messaging.message.receive.latency",
             internal_name="messaging.message.receive.latency",
             search_type="millisecond",
         ),
         simple_measurements_field("messaging.message.retry.count", secondary_alias=True),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="messaging.message.retry.count",
             internal_name="messaging.message.retry.count",
             search_type="number",

--- a/src/sentry/search/eap/uptime_checks/attributes.py
+++ b/src/sentry/search/eap/uptime_checks/attributes.py
@@ -1,6 +1,6 @@
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
-    ResolvedColumn,
+    ResolvedAttribute,
     VirtualColumnDefinition,
     datetime_processor,
     project_context_constructor,
@@ -12,59 +12,59 @@ UPTIME_CHECK_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
     for column in COMMON_COLUMNS
     + [
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="environment",
             internal_name="environment",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="uptime_subscription_id",
             internal_name="uptime_subscription_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="uptime_check_id",
             internal_name="uptime_check_id",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="scheduled_check_time",
             internal_name="scheduled_check_time",
             search_type="string",
             processor=datetime_processor,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="timestamp",
             search_type="string",
             processor=datetime_processor,
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="duration_ms",
             internal_name="duration_ms",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="region",
             internal_name="region",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="check_status",
             internal_name="check_status",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="check_status_reason",
             internal_name="check_status_reason",
             search_type="string",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="http_status_code",
             internal_name="http_status_code",
             search_type="number",
         ),
-        ResolvedColumn(
+        ResolvedAttribute(
             public_alias="trace_id",
             internal_name="trace_id",
             search_type="string",

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -5,7 +5,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceIt
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeAggregation, AttributeKey
 
-from sentry.search.eap.columns import ResolvedAggregate, ResolvedColumn, ResolvedFormula
+from sentry.search.eap.columns import ResolvedAggregate, ResolvedAttribute, ResolvedFormula
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
 from sentry.search.events.fields import get_function_alias
@@ -16,7 +16,7 @@ from sentry.utils.snuba import process_value
 logger = logging.getLogger("sentry.snuba.spans_rpc")
 
 
-def categorize_column(column: ResolvedColumn | ResolvedAggregate | ResolvedFormula) -> Column:
+def categorize_column(column: ResolvedAttribute | ResolvedAggregate | ResolvedFormula) -> Column:
     if isinstance(column, ResolvedFormula):
         return Column(formula=column.proto_definition, label=column.public_alias)
     if isinstance(column, ResolvedAggregate):

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,7 +13,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, OrFilter, Tr
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.columns import ResolvedAggregate, ResolvedColumn, ResolvedFormula
+from sentry.search.eap.columns import ResolvedAggregate, ResolvedAttribute, ResolvedFormula
 from sentry.search.eap.constants import DOUBLE, INT, MAX_ROLLUP_POINTS, STRING, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
@@ -76,7 +76,7 @@ def get_timeseries_query(
     config: SearchResolverConfig,
     granularity_secs: int,
     extra_conditions: TraceItemFilter | None = None,
-) -> tuple[TimeSeriesRequest, list[ResolvedFormula | ResolvedAggregate], list[ResolvedColumn]]:
+) -> tuple[TimeSeriesRequest, list[ResolvedFormula | ResolvedAggregate], list[ResolvedAttribute]]:
     resolver = get_resolver(params=params, config=config)
     meta = resolver.resolve_meta(referrer=referrer)
     query, _, query_contexts = resolver.resolve_query(query_string)


### PR DESCRIPTION
Forgot to refactor this in my previous cleanups. A `Column` is either a `Attribute`, `Aggregate` or `Formula`. In the code this was defined backwards, so I changed `ResolvedColumn` to be called `ResolvedAttribute`, and `ResolvedAttribute` to be called `ResolvedColumn`