### PR TITLE
feat(issue-stream): Pull out last seen and age into columns

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -119,7 +119,7 @@ function EventOrGroupHeader({
 
   return (
     <div data-test-id="event-issue-header">
-      <Title extraMargin={hasNewLayout}>{getTitle()}</Title>
+      <Title>{getTitle()}</Title>
       {eventLocation && !hasNewLayout ? <Location>{eventLocation}</Location> : null}
       <StyledEventMessage
         data={data}
@@ -139,8 +139,8 @@ const truncateStyles = css`
   white-space: nowrap;
 `;
 
-const Title = styled('div')<{extraMargin: boolean}>`
-  margin-bottom: ${p => (p.extraMargin ? space(0.5) : space(0.25))};
+const Title = styled('div')`
+  margin-bottom: ${space(0.25)};
   font-size: ${p => p.theme.fontSizeLarge};
   & em {
     font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -47,7 +47,8 @@ export type GroupListColumn =
   | 'priority'
   | 'assignee'
   | 'lastTriggered'
-  | 'firstLastSeen';
+  | 'firstSeen'
+  | 'lastSeen';
 
 type Props = WithRouterProps & {
   api: Client;

--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -31,7 +31,7 @@ export function SavedSearchModalContent({organization}: SavedSearchModalContentP
 
   const selectFieldSortOptions = sortOptions.map(sortOption => ({
     value: sortOption,
-    label: getSortLabel(sortOption),
+    label: getSortLabel(sortOption, organization),
   }));
 
   return (

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -184,7 +184,7 @@ describe('StreamGroup', function () {
       <StreamGroup
         id="1337"
         query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
-        withColumns={['firstLastSeen']}
+        withColumns={['firstSeen', 'lastSeen']}
       />,
       {
         organization: OrganizationFixture({

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -116,7 +116,7 @@ function GroupCheckbox({
 
   return (
     <GroupCheckBoxWrapper hasNewLayout={hasNewLayout}>
-      <CheckboxLabel>
+      <CheckboxLabel hasNewLayout={hasNewLayout}>
         <CheckboxWithBackground
           id={group.id}
           aria-label={t('Select Issue')}
@@ -763,7 +763,7 @@ const Wrapper = styled(PanelItem)<{
     p.hasNewLayout &&
     css`
       padding: ${space(1)} 0;
-      min-height: 78px;
+      min-height: 82px;
 
       &:not(:has(:hover)):not(:focus-within):not(:has(input:checked)) {
         ${CheckboxLabel} {
@@ -862,7 +862,7 @@ const GroupCheckBoxWrapper = styled('div')<{hasNewLayout: boolean}>`
   z-index: 1;
 `;
 
-const CheckboxLabel = styled('label')`
+const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`
   position: absolute;
   top: 0;
   left: 0;
@@ -872,6 +872,12 @@ const CheckboxLabel = styled('label')`
   padding-left: ${space(2)};
   padding-top: ${space(1.5)};
   margin: 0;
+
+  ${p =>
+    p.hasNewLayout &&
+    css`
+      padding-top: 14px;
+    `}
 `;
 
 const CheckboxWithBackground = styled(Checkbox)`
@@ -1109,5 +1115,5 @@ const UnreadIndicator = styled('div')`
   background-color: ${p => p.theme.purple400};
   border-radius: 50%;
   margin-left: ${space(3)};
-  margin-top: ${space(1)};
+  margin-top: 10px;
 `;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -116,7 +116,7 @@ function GroupCheckbox({
 
   return (
     <GroupCheckBoxWrapper hasNewLayout={hasNewLayout}>
-      <CheckboxLabel hasNewLayout={hasNewLayout}>
+      <CheckboxLabel>
         <CheckboxWithBackground
           id={group.id}
           aria-label={t('Select Issue')}
@@ -134,33 +134,43 @@ function GroupCheckbox({
   );
 }
 
-function GroupFirstLastSeen({group}: {group: Group}) {
+function GroupLastSeen({group}: {group: Group}) {
   if (!group.lifetime) {
     return <Placeholder height="18px" width="60px" />;
   }
 
-  if (!group.lifetime.firstSeen || !group.lifetime.lastSeen) {
+  if (!group.lifetime.lastSeen) {
     return null;
   }
 
   return (
-    <Fragment>
-      <PositionedTimeSince
-        date={group.lifetime.firstSeen}
-        unitStyle="short"
-        suffix=""
-        aria-label={t('First Seen')}
-        tooltipPrefix={t('First Seen')}
-      />
-      <SeenSeparator>/</SeenSeparator>
-      <PositionedTimeSince
-        date={group.lifetime.lastSeen}
-        suffix="ago"
-        unitStyle="short"
-        aria-label={t('Last Seen')}
-        tooltipPrefix={t('Last Seen')}
-      />
-    </Fragment>
+    <PositionedTimeSince
+      date={group.lifetime.lastSeen}
+      suffix="ago"
+      unitStyle="short"
+      aria-label={t('Last Seen')}
+      tooltipPrefix={t('Last Seen')}
+    />
+  );
+}
+
+function GroupFirstSeen({group}: {group: Group}) {
+  if (!group.lifetime) {
+    return <Placeholder height="18px" width="30px" />;
+  }
+
+  if (!group.lifetime.firstSeen) {
+    return null;
+  }
+
+  return (
+    <PositionedTimeSince
+      date={group.lifetime.firstSeen}
+      unitStyle="short"
+      suffix=""
+      aria-label={t('First Seen')}
+      tooltipPrefix={t('First Seen')}
+    />
   );
 }
 
@@ -622,10 +632,16 @@ function StreamGroup({
       </GroupSummary>
       {hasGuideAnchor && issueStreamAnchor}
 
-      {withColumns.includes('firstLastSeen') && (
-        <FirstLastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_LAST_SEEN}>
-          <GroupFirstLastSeen group={group} />
-        </FirstLastSeenWrapper>
+      {withColumns.includes('lastSeen') && (
+        <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN}>
+          <GroupLastSeen group={group} />
+        </LastSeenWrapper>
+      )}
+
+      {withColumns.includes('firstSeen') && (
+        <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN}>
+          <GroupFirstSeen group={group} />
+        </FirstSeenWrapper>
       )}
 
       {withChart && !displayReprocessingLayout ? (
@@ -644,10 +660,7 @@ function StreamGroup({
             ) : null}
           </NarrowChartWrapper>
         ) : (
-          <ChartWrapper
-            narrowGroups={narrowGroups}
-            margin={withColumns.includes('firstLastSeen')}
-          >
+          <ChartWrapper narrowGroups={narrowGroups}>
             {issueTypeConfig.stats.enabled ? (
               <GroupStatusChart
                 hideZeros
@@ -674,9 +687,7 @@ function StreamGroup({
                 ) : null}
               </NarrowEventsOrUsersCountsWrapper>
             ) : (
-              <EventCountsWrapper
-                leftMargin={withColumns.includes('firstLastSeen') ? undefined : '0px'}
-              >
+              <EventCountsWrapper>
                 {issueTypeConfig.stats.enabled ? groupCount : null}
               </EventCountsWrapper>
             )
@@ -752,7 +763,7 @@ const Wrapper = styled(PanelItem)<{
     p.hasNewLayout &&
     css`
       padding: ${space(1)} 0;
-      min-height: 86px;
+      min-height: 78px;
 
       &:not(:has(:hover)):not(:focus-within):not(:has(input:checked)) {
         ${CheckboxLabel} {
@@ -851,7 +862,7 @@ const GroupCheckBoxWrapper = styled('div')<{hasNewLayout: boolean}>`
   z-index: 1;
 `;
 
-const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`
+const CheckboxLabel = styled('label')`
   position: absolute;
   top: 0;
   left: 0;
@@ -861,12 +872,6 @@ const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`
   padding-left: ${space(2)};
   padding-top: ${space(1.5)};
   margin: 0;
-
-  ${p =>
-    p.hasNewLayout &&
-    css`
-      padding-top: ${space(2)};
-    `}
 `;
 
 const CheckboxWithBackground = styled(Checkbox)`
@@ -930,10 +935,10 @@ const CountTooltipContent = styled('div')`
   }
 `;
 
-const ChartWrapper = styled('div')<{margin: boolean; narrowGroups: boolean}>`
+const ChartWrapper = styled('div')<{narrowGroups: boolean}>`
   width: 200px;
   align-self: center;
-  margin-right: ${p => (p.margin ? space(2) : 0)};
+  margin-right: ${space(2)};
 
   @media (max-width: ${p =>
       p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
@@ -951,12 +956,25 @@ const NarrowChartWrapper = styled('div')<{breakpoint: string}>`
   }
 `;
 
-const FirstLastSeenWrapper = styled('div')<{breakpoint: string}>`
+const LastSeenWrapper = styled('div')<{breakpoint: string}>`
   display: flex;
-  gap: ${space(0.25)};
-  align-self: center;
-  width: 130px;
-  padding-right: ${space(1)};
+  align-items: center;
+  justify-content: flex-end;
+  width: 86px;
+  padding-right: ${space(2)};
+  margin-right: ${space(2)};
+
+  @media (max-width: ${p => p.breakpoint}) {
+    display: none;
+  }
+`;
+
+const FirstSeenWrapper = styled('div')<{breakpoint: string}>`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 50px;
+  padding-right: ${space(2)};
   margin-right: ${space(2)};
 
   @media (max-width: ${p => p.breakpoint}) {
@@ -967,6 +985,7 @@ const FirstLastSeenWrapper = styled('div')<{breakpoint: string}>`
 const NarrowEventsOrUsersCountsWrapper = styled('div')<{breakpoint: string}>`
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   align-self: center;
   margin-right: ${space(2)};
   width: 60px;
@@ -1084,15 +1103,11 @@ const PositionedTimeSince = styled(TimeSince)`
   position: relative;
 `;
 
-const SeenSeparator = styled('span')`
-  color: ${p => p.theme.subText};
-`;
-
 const UnreadIndicator = styled('div')`
   width: 8px;
   height: 8px;
   background-color: ${p => p.theme.purple400};
   border-radius: 50%;
   margin-left: ${space(3)};
-  margin-top: ${space(1.5)};
+  margin-top: ${space(1)};
 `;

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -81,7 +81,7 @@ function disableSortOptions(_widgetQuery: WidgetQuery) {
   };
 }
 
-function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQuery) {
+function getTableSortOptions(organization: Organization, _widgetQuery: WidgetQuery) {
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
@@ -90,7 +90,7 @@ function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQu
     IssueSortOptions.USER,
   ];
   return sortOptions.map(sortOption => ({
-    label: getSortLabel(sortOption),
+    label: getSortLabel(sortOption, organization),
     value: sortOption,
   }));
 }

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -1,7 +1,6 @@
 import type {SelectValue} from 'sentry/types/core';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
-import {getSortLabel, IssueSortOptions} from 'sentry/views/issueList/utils';
 
 import type {ColumnType} from './fields';
 import {ISSUE_FIELDS} from './fields';
@@ -26,20 +25,4 @@ export function generateIssueWidgetFieldOptions(
   });
 
   return fieldOptions;
-}
-
-export const ISSUE_WIDGET_SORT_OPTIONS = [
-  IssueSortOptions.DATE,
-  IssueSortOptions.NEW,
-  IssueSortOptions.FREQ,
-  IssueSortOptions.TRENDS,
-  IssueSortOptions.USER,
-];
-
-export function generateIssueWidgetOrderOptions(): Array<SelectValue<string>> {
-  const sortOptions = [...ISSUE_WIDGET_SORT_OPTIONS];
-  return sortOptions.map(sortOption => ({
-    label: getSortLabel(sortOption),
-    value: sortOption,
-  }));
 }

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -39,10 +39,14 @@ function Headers({
         <Fragment>
           {organization.features.includes('issue-stream-table-layout') ? (
             <Fragment>
-              <FirstLastSeenLabel breakpoint={COLUMN_BREAKPOINTS.FIRST_LAST_SEEN}>
-                {t('First / Last Seen')}
+              <LastSeenLabel breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN}>
+                {t('Last Seen')}
                 <HeaderDivider />
-              </FirstLastSeenLabel>
+              </LastSeenLabel>
+              <FirstSeenLabel breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN}>
+                {t('Age')}
+                <HeaderDivider />
+              </FirstSeenLabel>
             </Fragment>
           ) : null}
           {organization.features.includes('issue-stream-table-layout') ? (
@@ -175,12 +179,18 @@ const GraphToggle = styled('a')<{active: boolean}>`
   }
 `;
 
-const FirstLastSeenLabel = styled(IssueStreamHeaderLabel)`
-  width: 130px;
+const LastSeenLabel = styled(IssueStreamHeaderLabel)`
+  width: 86px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  text-align: left;
+`;
+
+const FirstSeenLabel = styled(IssueStreamHeaderLabel)`
+  width: 50px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 `;
 
 const EventsOrUsersLabel = styled(ToolbarHeader)`

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -2,6 +2,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
@@ -43,6 +44,7 @@ function IssueListSortOptions({
   triggerSize = 'xs',
   showIcon = true,
 }: Props) {
+  const organization = useOrganization();
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
@@ -60,7 +62,7 @@ function IssueListSortOptions({
       onChange={opt => onSelect(opt.value)}
       options={sortKeys.map(key => ({
         value: key,
-        label: getSortLabel(key),
+        label: getSortLabel(key, organization),
         details: getSortTooltip(key),
       }))}
       menuWidth={240}

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -163,7 +163,8 @@ export function getLabel(numIssues: number, allInQuerySelected: boolean) {
 export const COLUMN_BREAKPOINTS = {
   ISSUE: undefined, // Issue column is always visible
   TREND: commonTheme.breakpoints.small,
-  FIRST_LAST_SEEN: commonTheme.breakpoints.medium,
+  LAST_SEEN: commonTheme.breakpoints.medium,
+  FIRST_SEEN: commonTheme.breakpoints.medium,
   SEEN: commonTheme.breakpoints.xlarge,
   EVENTS: commonTheme.breakpoints.medium,
   USERS: commonTheme.breakpoints.medium,

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -110,7 +110,7 @@ function GroupList({
   const columns: GroupListColumn[] = [
     'graph',
     ...(organization.features.includes('issue-stream-table-layout')
-      ? ['firstLastSeen' as const]
+      ? ['firstSeen' as const, 'lastSeen' as const]
       : []),
     'event',
     'users',

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -185,10 +185,12 @@ export function isDefaultIssueStreamSearch({query, sort}: {query: string; sort: 
   return query === DEFAULT_QUERY && sort === DEFAULT_ISSUE_STREAM_SORT;
 }
 
-export function getSortLabel(key: string) {
+export function getSortLabel(key: string, organization: Organization) {
   switch (key) {
     case IssueSortOptions.NEW:
-      return t('First Seen');
+      return organization.features.includes('issue-stream-table-layout')
+        ? t('Age')
+        : t('First Seen');
     case IssueSortOptions.TRENDS:
       return t('Trends');
     case IssueSortOptions.FREQ:


### PR DESCRIPTION
Splits out the combined column back into two columns. Now called "last seen" and "age".

![CleanShot 2025-03-07 at 09 14 54](https://github.com/user-attachments/assets/3d0e744f-555f-41a6-90f6-8453cae6d9c8)
