### PR TITLE
fix(issues): Prevent debug meta error when missing images

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -17,7 +17,7 @@ import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
 import type {Image, ImageWithCombinedStatus} from 'sentry/types/debugImage';
 import {ImageStatus} from 'sentry/types/debugImage';
-import type {Event} from 'sentry/types/event';
+import type {EntryDebugMeta, Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -37,13 +37,31 @@ import {
   getFileName,
   IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT,
   normalizeId,
-  shouldSkipSection,
 } from './utils';
 
+function shouldSkipSection(
+  filteredImages: Image[],
+  images: EntryDebugMeta['data']['images']
+) {
+  if (filteredImages.length) {
+    return false;
+  }
+
+  const definedImages = images?.filter(image => defined(image));
+
+  if (!definedImages?.length) {
+    return true;
+  }
+
+  if (definedImages.every(image => image.type === 'proguard')) {
+    return true;
+  }
+
+  return false;
+}
+
 interface DebugMetaProps {
-  data: {
-    images: Array<Image | null>;
-  };
+  data: EntryDebugMeta['data'];
   event: Event;
   projectSlug: Project['slug'];
   groupId?: Group['id'];
@@ -120,13 +138,11 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   const getRelevantImages = useCallback(() => {
-    const {images} = data;
-
     // There are a bunch of images in debug_meta that are not relevant to this
     // component. Filter those out to reduce the noise. Most importantly, this
     // includes proguard images, which are rendered separately.
 
-    const relevantImages = images.filter((image): image is Image => {
+    const relevantImages = data.images?.filter((image): image is Image => {
       // in particular proguard images do not have a code file, skip them
       if (image === null || image.code_file === null || image.type === 'proguard') {
         return false;
@@ -140,7 +156,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       return true;
     });
 
-    if (!relevantImages.length) {
+    if (!relevantImages?.length) {
       return;
     }
 
@@ -351,9 +367,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
 
   const filteredImages = applyImageFilters(allImages, filterSelections, searchTerm);
 
-  const {images} = data;
-
-  if (shouldSkipSection(filteredImages, images)) {
+  if (shouldSkipSection(filteredImages, data.images)) {
     return null;
   }
 

--- a/static/app/components/events/interfaces/debugMeta/utils.tsx
+++ b/static/app/components/events/interfaces/debugMeta/utils.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import {formatAddress, getImageRange} from 'sentry/components/events/interfaces/utils';
 import type {Image} from 'sentry/types/debugImage';
 import {ImageStatus} from 'sentry/types/debugImage';
-import {defined} from 'sentry/utils';
 
 const IMAGE_ADDR_LEN = 12;
 export const IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT = 400;
@@ -42,24 +41,6 @@ export function getFileName(path?: string | null) {
 
 export function normalizeId(id?: string) {
   return id?.trim().toLowerCase().replace(/[- ]/g, '') ?? '';
-}
-
-export function shouldSkipSection(filteredImages: Image[], images: Array<Image | null>) {
-  if (filteredImages.length) {
-    return false;
-  }
-
-  const definedImages = images.filter(image => defined(image));
-
-  if (!definedImages.length) {
-    return true;
-  }
-
-  if (definedImages.every(image => image.type === 'proguard')) {
-    return true;
-  }
-
-  return false;
 }
 
 export function getImageAddress(image: Image) {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -284,7 +284,13 @@ export enum EntryType {
 
 export type EntryDebugMeta = {
   data: {
-    images: Array<Image | null>;
+    images?: Array<Image | null>;
+    sdk_info?: {
+      sdk_name: string;
+      version_major: number;
+      version_minor: number;
+      version_patchlevel: number;
+    };
   };
   type: EntryType.DEBUGMETA;
 };

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -33,7 +33,10 @@ export function displayReprocessEventAction(event: Event | null): boolean {
   }
 
   const hasDebugImages = (event?.entries ?? []).some(
-    entry => entry.type === EntryType.DEBUGMETA && entry.data.images.length > 0
+    entry =>
+      entry.type === EntryType.DEBUGMETA &&
+      Array.isArray(entry.data?.images) &&
+      entry.data.images.length > 0
   );
 
   // Otherwise, check alternative platforms if they actually have Debug Files


### PR DESCRIPTION
fixes JAVASCRIPT-2YD3

i guess debug meta can contain other properties

moves a utility function to the only area it is used.
