### PR TITLE
feat(autofix): Add code highlighting and other ui polish

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -427,7 +427,7 @@ export function AutofixChanges({
   previousInsightCount,
   agentCommentThread,
 }: AutofixChangesProps) {
-  const data = useAutofixData({groupId});
+  const {data} = useAutofixData({groupId});
   const [isBusy, setIsBusy] = useState(false);
   const iconCodeRef = useRef<HTMLDivElement>(null);
 
@@ -475,9 +475,9 @@ export function AutofixChanges({
           <ClippedBox clipHeight={408}>
             <HeaderWrapper>
               <HeaderText>
-                <div ref={iconCodeRef}>
-                  <IconCode size="sm" />
-                </div>
+                <HeaderIconWrapper ref={iconCodeRef}>
+                  <IconCode size="sm" color="blue400" />
+                </HeaderIconWrapper>
                 {t('Code Changes')}
               </HeaderText>
               {!prsMade && (
@@ -648,6 +648,12 @@ const HeaderWrapper = styled('div')`
   padding-left: ${space(0.5)};
   padding-bottom: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const HeaderIconWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 const ProcessingStatusIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -91,9 +91,10 @@ describe('AutofixDiff', function () {
 
     await userEvent.click(screen.getByRole('button', {name: 'Edit changes'}));
 
+    expect(screen.getByText('Editing')).toBeInTheDocument();
     expect(
-      screen.getByText('Editing src/sentry/processing/backpressure/memory.py')
-    ).toBeInTheDocument();
+      screen.getAllByText('src/sentry/processing/backpressure/memory.py')
+    ).toHaveLength(2); // one in the header of the diff and one in the popup
 
     const textarea = screen.getByRole('textbox');
     await userEvent.clear(textarea);
@@ -107,10 +108,11 @@ describe('AutofixDiff', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Save'}));
 
     await waitFor(() => {
-      expect(
-        screen.queryByText('Editing src/sentry/processing/backpressure/memory.py')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Editing')).not.toBeInTheDocument();
     });
+    expect(
+      screen.getAllByText('src/sentry/processing/backpressure/memory.py')
+    ).toHaveLength(1); // one in the header of the diff and none in the popup
   });
 
   it('can reject changes', async function () {

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -18,8 +18,10 @@ import {DIFF_COLORS} from 'sentry/components/splitDiff';
 import {IconChevron, IconClose, IconDelete, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {singleLineRenderer} from 'sentry/utils/marked';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 type AutofixDiffProps = {
   diff: FilePatch[];
@@ -73,19 +75,103 @@ function addChangesToDiffLines(lines: DiffLineWithChanges[]): DiffLineWithChange
   return lines;
 }
 
-function DiffLineCode({line}: {line: DiffLineWithChanges}) {
-  if (!line.changes) {
-    return <Fragment>{line.value}</Fragment>;
+function detectLanguageFromPath(filePath: string): string {
+  if (!filePath) {
+    return 'plaintext';
   }
 
+  // Extract the file extension
+  const extension = filePath.split('.').pop()?.toLowerCase();
+
+  if (!extension) {
+    return 'plaintext';
+  }
+
+  // Map common file extensions to Prism language identifiers
+  const extensionMap: Record<string, string> = {
+    js: 'javascript',
+    jsx: 'jsx',
+    ts: 'typescript',
+    tsx: 'tsx',
+    py: 'python',
+    rb: 'ruby',
+    go: 'go',
+    java: 'java',
+    php: 'php',
+    c: 'c',
+    cpp: 'cpp',
+    cs: 'csharp',
+    html: 'html',
+    css: 'css',
+    scss: 'scss',
+    json: 'json',
+    md: 'markdown',
+    yaml: 'yaml',
+    yml: 'yaml',
+    sh: 'bash',
+    bash: 'bash',
+    rs: 'rust',
+    swift: 'swift',
+    kt: 'kotlin',
+    sql: 'sql',
+    xml: 'xml',
+  };
+
+  return extensionMap[extension] || 'plaintext';
+}
+
+const SyntaxHighlightedCode = styled('div')<{language: string}>`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.codeFontSize};
+  white-space: pre;
+
+  pre,
+  code {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+  }
+`;
+
+function DiffLineCode({line, fileName}: {line: DiffLineWithChanges; fileName?: string}) {
+  const language = useMemo(
+    () => (fileName ? detectLanguageFromPath(fileName) : 'plaintext'),
+    [fileName]
+  );
+
+  // Always call hooks at the top level, before any conditional logic
+  const tokens = usePrismTokens({code: line.value, language});
+
+  // If we have changes (diff), use the CodeDiff component
+  if (line.changes) {
+    return (
+      <Fragment>
+        {line.changes.map((change, i) => (
+          <CodeDiff key={i} added={change.added} removed={change.removed}>
+            {change.value}
+          </CodeDiff>
+        ))}
+      </Fragment>
+    );
+  }
+
+  // For non-changed lines, apply syntax highlighting
   return (
-    <Fragment>
-      {line.changes.map((change, i) => (
-        <CodeDiff key={i} added={change.added} removed={change.removed}>
-          {change.value}
-        </CodeDiff>
-      ))}
-    </Fragment>
+    <SyntaxHighlightedCode language={language}>
+      <pre className={`language-${language}`}>
+        <code>
+          {tokens.map((lineTokens, i) => (
+            <Fragment key={i}>
+              {lineTokens.map((token, j) => (
+                <span key={j} className={token.className}>
+                  {token.children}
+                </span>
+              ))}
+            </Fragment>
+          ))}
+        </code>
+      </pre>
+    </SyntaxHighlightedCode>
   );
 }
 
@@ -406,7 +492,7 @@ function DiffHunkContent({
             }}
             onMouseLeave={() => setHoveredGroup(null)}
           >
-            <DiffLineCode line={line} />
+            <DiffLineCode line={line} fileName={fileName} />
             {editable && lineGroups.some(group => index === group.start) && (
               <ButtonGroup>
                 <ActionButton
@@ -430,7 +516,11 @@ function DiffHunkContent({
             {editingGroup === index && (
               <EditOverlay ref={overlayRef}>
                 <OverlayHeader>
-                  <OverlayTitle>{t('Editing %s', fileName)}</OverlayTitle>
+                  <OverlayTitle
+                    dangerouslySetInnerHTML={{
+                      __html: singleLineRenderer(t('Editing `%s`', fileName)),
+                    }}
+                  />
                 </OverlayHeader>
                 <OverlayContent>
                   <SectionTitle>{getDeletedLineTitle(index)}</SectionTitle>
@@ -797,6 +887,7 @@ const StyledTextArea = styled(TextArea)`
   background-color: ${DIFF_COLORS.addedRow};
   border-color: ${p => p.theme.border};
   position: relative;
+  min-height: 250px;
 
   &:focus {
     border-color: ${p => p.theme.focusBorder};

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -79,10 +79,7 @@ function detectLanguageFromPath(filePath: string): string {
   if (!filePath) {
     return 'plaintext';
   }
-
-  // Extract the file extension
   const extension = filePath.split('.').pop()?.toLowerCase();
-
   if (!extension) {
     return 'plaintext';
   }
@@ -120,7 +117,7 @@ function detectLanguageFromPath(filePath: string): string {
   return extensionMap[extension] || 'plaintext';
 }
 
-const SyntaxHighlightedCode = styled('div')<{language: string}>`
+const SyntaxHighlightedCode = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.codeFontSize};
   white-space: pre;
@@ -139,7 +136,6 @@ function DiffLineCode({line, fileName}: {line: DiffLineWithChanges; fileName?: s
     [fileName]
   );
 
-  // Always call hooks at the top level, before any conditional logic
   const tokens = usePrismTokens({code: line.value, language});
 
   // If we have changes (diff), use the CodeDiff component
@@ -157,7 +153,7 @@ function DiffLineCode({line, fileName}: {line: DiffLineWithChanges; fileName?: s
 
   // For non-changed lines, apply syntax highlighting
   return (
-    <SyntaxHighlightedCode language={language}>
+    <SyntaxHighlightedCode>
       <pre className={`language-${language}`}>
         <code>
           {tokens.map((lineTokens, i) => (

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -138,7 +138,7 @@ function AutofixHighlightPopupContent({
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Fetch current autofix data to get comment thread
-  const autofixData = useAutofixData({groupId});
+  const {data: autofixData} = useAutofixData({groupId});
   const currentStep = !isAgentComment
     ? autofixData?.steps?.[stepIndex]
     : autofixData?.steps?.[stepIndex + 1];

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -158,7 +158,7 @@ describe('AutofixInsightCards', () => {
     await userEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(addSuccessMessage).toHaveBeenCalledWith('Thanks, rethinking this...');
+      expect(addSuccessMessage).toHaveBeenCalledWith('Rethinking this...');
     });
   });
 

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -447,7 +447,7 @@ export function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: 
     },
     onSuccess: _ => {
       queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
-      addSuccessMessage(t('Thanks, rethinking this...'));
+      addSuccessMessage(t('Rethinking this...'));
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when sending Autofix your message.'));

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -189,7 +189,9 @@ function RootCauseDescription({
       </AnimatePresence>
       <div ref={containerRef}>
         {cause.description && (
-          <p dangerouslySetInnerHTML={{__html: singleLineRenderer(cause.description)}} />
+          <Description
+            dangerouslySetInnerHTML={{__html: singleLineRenderer(cause.description)}}
+          />
         )}
         {cause.root_cause_reproduction && (
           <AutofixTimeline events={cause.root_cause_reproduction} />
@@ -289,9 +291,9 @@ function AutofixRootCauseDisplay({
         <CustomRootCausePadding>
           <HeaderWrapper>
             <HeaderText>
-              <div ref={iconFocusRef}>
-                <IconFocus size="sm" />
-              </div>
+              <IconWrapper ref={iconFocusRef}>
+                <IconFocus size="sm" color="pink400" />
+              </IconWrapper>
               {t('Custom Root Cause')}
             </HeaderText>
             <CopyRootCauseButton
@@ -310,9 +312,9 @@ function AutofixRootCauseDisplay({
       <ClippedBox clipHeight={408}>
         <HeaderWrapper>
           <HeaderText>
-            <div ref={iconFocusRef}>
-              <IconFocus size="sm" />
-            </div>
+            <IconWrapper ref={iconFocusRef}>
+              <IconFocus size="sm" color="pink400" />
+            </IconWrapper>
             {t('Root Cause')}
           </HeaderText>
           <ButtonBar>
@@ -424,6 +426,12 @@ export function AutofixRootCause(props: AutofixRootCauseProps) {
   );
 }
 
+const Description = styled('div')`
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+  padding-bottom: ${space(2)};
+  margin-bottom: ${space(2)};
+`;
+
 const NoCausesPadding = styled('div')`
   padding: 0 ${space(2)};
 `;
@@ -449,6 +457,12 @@ const HeaderWrapper = styled('div')`
   padding-bottom: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   gap: ${space(1)};
+`;
+
+const IconWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 const HeaderText = styled('div')`

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -355,9 +355,7 @@ describe('AutofixSolution', () => {
     );
 
     // Find and fill the input
-    const input = screen.getByPlaceholderText(
-      'Add additional instructions for Autofix...'
-    );
+    const input = screen.getByPlaceholderText('Add more instructions...');
     await userEvent.type(input, 'This is a custom instruction');
 
     // Enable the Add button by typing non-empty text
@@ -422,9 +420,7 @@ describe('AutofixSolution', () => {
     );
 
     // Find and fill the input, then press Enter
-    const input = screen.getByPlaceholderText(
-      'Add additional instructions for Autofix...'
-    );
+    const input = screen.getByPlaceholderText('Add more instructions...');
     await userEvent.type(input, 'Enter key instruction{Enter}');
 
     // Verify the custom instruction was added

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -10,6 +10,7 @@ import {Chevron} from 'sentry/components/chevron';
 import ClippedBox from 'sentry/components/clippedBox';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
+import {Input} from 'sentry/components/core/input';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
   type AutofixRepository,
@@ -183,7 +184,9 @@ function SolutionDescription({
       </AnimatePresence>
       <div ref={containerRef}>
         {description && (
-          <p dangerouslySetInnerHTML={{__html: singleLineRenderer(description)}} />
+          <Description
+            dangerouslySetInnerHTML={{__html: singleLineRenderer(description)}}
+          />
         )}
         <SolutionEventList
           events={solution}
@@ -194,6 +197,12 @@ function SolutionDescription({
     </SolutionDescriptionWrapper>
   );
 }
+
+const Description = styled('div')`
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+  padding-bottom: ${space(2)};
+  margin-bottom: ${space(2)};
+`;
 
 type SolutionEventListProps = {
   events: AutofixSolutionTimelineEvent[];
@@ -272,11 +281,11 @@ function SolutionEventList({
                       aria-label={isSelected ? t('Deselect item') : t('Select item')}
                     >
                       {isHumanAction ? (
-                        <IconDelete size="xs" />
+                        <IconDelete size="xs" color="red400" />
                       ) : isSelected ? (
-                        <IconClose size="xs" />
+                        <IconClose size="xs" color="red400" />
                       ) : (
-                        <IconAdd size="xs" />
+                        <IconAdd size="xs" color="green400" />
                       )}
                     </SelectionButton>
                   </SelectionButtonWrapper>
@@ -476,9 +485,9 @@ function AutofixSolutionDisplay({
         <CustomSolutionPadding>
           <HeaderWrapper>
             <HeaderText>
-              <div ref={iconFixRef}>
-                <IconFix size="sm" />
-              </div>
+              <HeaderIconWrapper ref={iconFixRef}>
+                <IconFix size="sm" color="green400" />
+              </HeaderIconWrapper>
               {t('Custom Solution')}
             </HeaderText>
             <CopySolutionButton solution={solution} customSolution={customSolution} />
@@ -496,9 +505,9 @@ function AutofixSolutionDisplay({
       <ClippedBox clipHeight={408}>
         <HeaderWrapper>
           <HeaderText>
-            <div ref={iconFixRef}>
-              <IconFix size="sm" />
-            </div>
+            <HeaderIconWrapper ref={iconFixRef}>
+              <IconFix size="sm" color="green400" />
+            </HeaderIconWrapper>
             {t('Solution')}
           </HeaderText>
           <ButtonBar gap={1}>
@@ -619,27 +628,26 @@ function AutofixSolutionDisplay({
             onToggleActive={handleToggleActive}
           />
           <AddInstructionWrapper>
-            <InstructionsInputWrapper>
-              <form onSubmit={handleFormSubmit} style={{display: 'flex', width: '100%'}}>
-                <InstructionsInput
-                  type="text"
-                  name="additional-instructions"
-                  placeholder={t('Add additional instructions for Autofix...')}
-                  value={instructions}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setInstructions(e.target.value)
-                  }
-                />
-                <AddStepButton
-                  type="submit"
-                  size="xs"
-                  disabled={!instructions.trim()}
-                  aria-label={t('Add to solution')}
-                  icon={<IconAdd size="xs" />}
-                >
-                  <span>{t('Add')}</span>
-                </AddStepButton>
-              </form>
+            <InstructionsInputWrapper onSubmit={handleFormSubmit}>
+              <InstructionsInput
+                type="text"
+                name="additional-instructions"
+                placeholder={t('Add more instructions...')}
+                value={instructions}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setInstructions(e.target.value)
+                }
+                size="sm"
+              />
+              <SubmitButton
+                size="zero"
+                type="submit"
+                borderless
+                disabled={!instructions.trim()}
+                aria-label={t('Add to solution')}
+              >
+                <IconAdd size="xs" />
+              </SubmitButton>
             </InstructionsInputWrapper>
           </AddInstructionWrapper>
         </Content>
@@ -686,7 +694,7 @@ const SolutionContainer = styled('div')`
 `;
 
 const Content = styled('div')`
-  padding: ${space(1)} 0;
+  padding: ${space(1)} 0 0;
 `;
 
 const HeaderWrapper = styled('div')`
@@ -753,6 +761,12 @@ const StyledSpan = styled('span')`
   }
 `;
 
+const HeaderIconWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const StyledTimelineHeader = styled('div')<{isSelected: boolean; isActive?: boolean}>`
   display: flex;
   align-items: center;
@@ -764,6 +778,7 @@ const StyledTimelineHeader = styled('div')<{isSelected: boolean; isActive?: bool
   font-weight: ${p => (p.isActive ? p.theme.fontWeightBold : p.theme.fontWeightNormal)};
   gap: ${space(1)};
   opacity: ${p => (p.isSelected ? 1 : 0.6)};
+  text-decoration: ${p => (p.isSelected ? 'none' : 'line-through')};
   transition: opacity 0.2s ease;
 
   & > div:first-of-type {
@@ -834,38 +849,30 @@ const StyledIconChevron = styled(IconChevron)`
   }
 `;
 
-const InstructionsInputWrapper = styled('div')`
+const InstructionsInputWrapper = styled('form')`
   display: flex;
+  position: relative;
   border-radius: ${p => p.theme.borderRadius};
-  background-color: ${p => p.theme.backgroundSecondary};
   margin-top: ${space(0.5)};
+  margin-right: ${space(0.25)};
+  align-items: center;
+  gap: ${space(1)};
 `;
 
-const InstructionsInput = styled('input')`
+const InstructionsInput = styled(Input)`
   flex-grow: 1;
   border: none;
-  outline: none;
-  padding: ${space(1)};
-  line-height: 1.4;
-  color: ${p => p.theme.gray500};
-  background-color: transparent;
+  box-shadow: none;
 
   &::placeholder {
     color: ${p => p.theme.gray300};
   }
-
-  &:focus {
-    outline: none;
-    color: ${p => p.theme.textColor};
-  }
 `;
 
-const AddStepButton = styled(Button)`
-  margin: ${space(0.5)};
-  min-width: 60px;
-  border-radius: 5px;
+const SubmitButton = styled(Button)`
+  flex-shrink: 0;
 `;
 
 const AddInstructionWrapper = styled('div')`
-  padding: ${space(1)} ${space(1)} ${space(1)} ${space(4)};
+  padding: ${space(1)} ${space(1)} 0 ${space(3)};
 `;

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -861,8 +861,6 @@ const InstructionsInputWrapper = styled('form')`
 
 const InstructionsInput = styled(Input)`
   flex-grow: 1;
-  border: none;
-  box-shadow: none;
 
   &::placeholder {
     color: ${p => p.theme.gray300};

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -855,8 +855,6 @@ const InstructionsInputWrapper = styled('form')`
   border-radius: ${p => p.theme.borderRadius};
   margin-top: ${space(0.5)};
   margin-right: ${space(0.25)};
-  align-items: center;
-  gap: ${space(1)};
 `;
 
 const InstructionsInput = styled(Input)`
@@ -868,7 +866,11 @@ const InstructionsInput = styled(Input)`
 `;
 
 const SubmitButton = styled(Button)`
-  flex-shrink: 0;
+  position: absolute;
+  right: ${space(1)};
+  top: 50%;
+  transform: translateY(-50%);
+  height: 24px;
 `;
 
 const AddInstructionWrapper = styled('div')`

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -122,13 +122,13 @@ const isPolling = (autofixData: AutofixData | null, runStarted: boolean) => {
 };
 
 export const useAutofixData = ({groupId}: {groupId: string}) => {
-  const {data} = useApiQuery<AutofixResponse>(makeAutofixQueryKey(groupId), {
+  const {data, isPending} = useApiQuery<AutofixResponse>(makeAutofixQueryKey(groupId), {
     staleTime: Infinity,
     enabled: false,
     notifyOnChangeProps: ['data'],
   });
 
-  return data?.autofix ?? null;
+  return {data: data?.autofix ?? null, isPending};
 };
 
 export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -78,12 +78,12 @@ describe('GroupSummary', function () {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+      expect(screen.getByText("What's Wrong")).toBeInTheDocument();
     });
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
-    expect(screen.getByText('In the trace')).toBeInTheDocument();
+    expect(screen.getByText('In the Trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
-    expect(screen.getByText('Possible cause')).toBeInTheDocument();
+    expect(screen.getByText('Possible Cause')).toBeInTheDocument();
     expect(screen.getByText('Test possible cause')).toBeInTheDocument();
   });
 
@@ -99,12 +99,12 @@ describe('GroupSummary', function () {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+      expect(screen.getByText("What's Wrong")).toBeInTheDocument();
     });
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
-    expect(screen.getByText('In the trace')).toBeInTheDocument();
+    expect(screen.getByText('In the Trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
-    expect(screen.getByText('Possible cause')).toBeInTheDocument();
+    expect(screen.getByText('Possible Cause')).toBeInTheDocument();
     expect(screen.getByText('Test possible cause')).toBeInTheDocument();
   });
 
@@ -120,12 +120,12 @@ describe('GroupSummary', function () {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+      expect(screen.getByText("What's Wrong")).toBeInTheDocument();
     });
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
-    expect(screen.getByText('In the trace')).toBeInTheDocument();
+    expect(screen.getByText('In the Trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
-    expect(screen.queryByText('Possible cause')).not.toBeInTheDocument();
+    expect(screen.queryByText('Possible Cause')).not.toBeInTheDocument();
     expect(screen.queryByText('Test possible cause')).not.toBeInTheDocument();
   });
 
@@ -176,11 +176,11 @@ describe('GroupSummary', function () {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+      expect(screen.getByText("What's Wrong")).toBeInTheDocument();
     });
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
-    expect(screen.queryByText('In the trace')).not.toBeInTheDocument();
-    expect(screen.getByText('Possible cause')).toBeInTheDocument();
+    expect(screen.queryByText('In the Trace')).not.toBeInTheDocument();
+    expect(screen.getByText('Possible Cause')).toBeInTheDocument();
     expect(screen.getByText('Test possible cause')).toBeInTheDocument();
   });
 
@@ -197,7 +197,7 @@ describe('GroupSummary', function () {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+      expect(screen.getByText("What's Wrong")).toBeInTheDocument();
     });
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
   });

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -332,7 +332,7 @@ const CardLineDecorationWrapper = styled('div')`
 `;
 
 const CardLineDecoration = styled('div')`
-  width: 2px;
+  width: 1px;
   align-self: stretch;
   background-color: ${p => p.theme.border};
 `;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -171,14 +171,14 @@ export function GroupSummary({
   const insightCards = [
     {
       id: 'whats_wrong',
-      title: t("What's wrong"),
+      title: t("What's Wrong"),
       insight: data?.whatsWrong,
       icon: <IconFatal size="sm" />,
       showWhenLoading: true,
     },
     {
       id: 'trace',
-      title: t('In the trace'),
+      title: t('In the Trace'),
       insight: data?.trace,
       icon: <IconSpan size="sm" />,
       showWhenLoading: false,
@@ -187,7 +187,7 @@ export function GroupSummary({
       ? [
           {
             id: 'possible_cause',
-            title: t('Possible cause'),
+            title: t('Possible Cause'),
             insight: data?.possibleCause,
             icon: <IconFocus size="sm" />,
             showWhenLoading: true,

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -398,7 +398,8 @@ const StyledCard = styled('div')`
   overflow: hidden;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(2)};
+  padding: ${space(2)} ${space(3)};
+  box-shadow: ${p => p.theme.dropShadowMedium};
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -9,6 +9,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {EntryType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 import * as RegionUtils from 'sentry/utils/regions';
 import SolutionsSection from 'sentry/views/issueDetails/streamline/sidebar/solutionsSection';
 import {Tab} from 'sentry/views/issueDetails/types';
@@ -33,6 +34,66 @@ describe('SolutionsSection', () => {
     features: ['gen-ai-features'],
   });
 
+  const mockIssueTypeConfig: IssueTypeConfig = {
+    issueSummary: {
+      enabled: true,
+    },
+    resources: {
+      description: 'Test Resource',
+      links: [{link: 'https://example.com', text: 'Test Link'}],
+      linksByPlatform: {},
+    },
+    actions: {
+      archiveUntilOccurrence: {enabled: false},
+      delete: {enabled: false},
+      deleteAndDiscard: {enabled: false},
+      ignore: {enabled: false},
+      merge: {enabled: false},
+      resolve: {enabled: true},
+      resolveInRelease: {enabled: false},
+      share: {enabled: false},
+    },
+    customCopy: {
+      resolution: 'Resolved',
+      eventUnits: 'Events',
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: false},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: false},
+      tagsTab: {enabled: false},
+    },
+    detector: {enabled: false},
+    autofix: true,
+    discover: {enabled: false},
+    eventAndUserCounts: {enabled: true},
+    evidence: null,
+    header: {
+      filterBar: {enabled: true, fixedEnvironment: false},
+      graph: {enabled: true, type: 'discover-events'},
+      tagDistribution: {enabled: false},
+      occurrenceSummary: {enabled: false},
+    },
+    logLevel: {enabled: true},
+    mergedIssues: {enabled: false},
+    performanceDurationRegression: {enabled: false},
+    profilingDurationRegression: {enabled: false},
+    regression: {enabled: false},
+    showFeedbackWidget: false,
+    similarIssues: {enabled: false},
+    spanEvidence: {enabled: false},
+    stacktrace: {enabled: false},
+    stats: {enabled: false},
+    tags: {enabled: false},
+    useOpenPeriodChecks: false,
+    usesIssuePlatform: false,
+  };
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
@@ -52,65 +113,7 @@ describe('SolutionsSection', () => {
       },
     });
 
-    jest.mocked(getConfigForIssueType).mockReturnValue({
-      issueSummary: {
-        enabled: true,
-      },
-      resources: {
-        description: 'Test Resource',
-        links: [{link: 'https://example.com', text: 'Test Link'}],
-        linksByPlatform: {},
-      },
-      actions: {
-        archiveUntilOccurrence: {enabled: false},
-        delete: {enabled: false},
-        deleteAndDiscard: {enabled: false},
-        ignore: {enabled: false},
-        merge: {enabled: false},
-        resolve: {enabled: true},
-        resolveInRelease: {enabled: false},
-        share: {enabled: false},
-      },
-      customCopy: {
-        resolution: 'Resolved',
-        eventUnits: 'Events',
-      },
-      pages: {
-        landingPage: Tab.DETAILS,
-        events: {enabled: false},
-        openPeriods: {enabled: false},
-        checkIns: {enabled: false},
-        uptimeChecks: {enabled: false},
-        attachments: {enabled: false},
-        userFeedback: {enabled: false},
-        replays: {enabled: false},
-        tagsTab: {enabled: false},
-      },
-      detector: {enabled: false},
-      autofix: true,
-      discover: {enabled: false},
-      eventAndUserCounts: {enabled: true},
-      evidence: null,
-      header: {
-        filterBar: {enabled: true, fixedEnvironment: false},
-        graph: {enabled: true, type: 'discover-events'},
-        tagDistribution: {enabled: false},
-        occurrenceSummary: {enabled: false},
-      },
-      logLevel: {enabled: true},
-      mergedIssues: {enabled: false},
-      performanceDurationRegression: {enabled: false},
-      profilingDurationRegression: {enabled: false},
-      regression: {enabled: false},
-      showFeedbackWidget: false,
-      similarIssues: {enabled: false},
-      spanEvidence: {enabled: false},
-      stacktrace: {enabled: false},
-      stats: {enabled: false},
-      tags: {enabled: false},
-      useOpenPeriodChecks: false,
-      usesIssuePlatform: false,
-    });
+    jest.mocked(getConfigForIssueType).mockReturnValue(mockIssueTypeConfig);
   });
 
   it('renders loading state when summary is pending', () => {
@@ -122,6 +125,11 @@ describe('SolutionsSection', () => {
       body: new Promise(() => {}), // Never resolves, keeping the loading state
     });
 
+    jest.mocked(getConfigForIssueType).mockReturnValue({
+      ...mockIssueTypeConfig,
+      autofix: false,
+    });
+
     render(
       <SolutionsSection event={mockEvent} group={mockGroup} project={mockProject} />,
       {
@@ -130,7 +138,7 @@ describe('SolutionsSection', () => {
     );
 
     expect(screen.getByText('Solutions Hub')).toBeInTheDocument();
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3); // whatsWrong, possibleCause, and Open Autofix
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3); // what's wrong, possible cause, and CTA button
   });
 
   it('renders summary when AI features are enabled and data is available', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/button';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import {GroupSummaryWithAutofix} from 'sentry/components/group/groupSummaryWithAutofix';
+import Placeholder from 'sentry/components/placeholder';
 import {IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -55,6 +56,10 @@ function SolutionsSectionContent({
 }) {
   const aiConfig = useAiConfig(group, event, project);
 
+  if (!event) {
+    return <Placeholder height="160px" />;
+  }
+
   if (aiConfig.hasSummary) {
     if (aiConfig.hasAutofix) {
       return (
@@ -103,7 +108,7 @@ export default function SolutionsSection({
     <HeaderContainer>
       {t('Solutions Hub')}
       {aiConfig.hasSummary && (
-        <FeatureBadge
+        <StyledFeatureBadge
           type="beta"
           tooltipProps={{
             title: tct(
@@ -215,4 +220,8 @@ const HeaderContainer = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.25)};
+`;
+
+const StyledFeatureBadge = styled(FeatureBadge)`
+  margin-bottom: 3px;
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
@@ -1,10 +1,15 @@
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {Chevron} from 'sentry/components/chevron';
-import {AutofixStatus, AutofixStepType} from 'sentry/components/events/autofix/types';
-import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
+import {
+  AutofixStatus,
+  type AutofixStep,
+  AutofixStepType,
+} from 'sentry/components/events/autofix/types';
+import {useAiAutofix, useAutofixData} from 'sentry/components/events/autofix/useAutofix';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -37,6 +42,7 @@ export function SolutionsSectionCtaButton({
 }: Props) {
   const openButtonRef = useRef<HTMLButtonElement>(null);
 
+  const {isPending: isAutofixPending} = useAutofixData({groupId: group.id});
   const {autofixData} = useAiAutofix(group, event);
 
   const openSolutionsDrawer = useOpenSolutionsDrawer(
@@ -45,12 +51,73 @@ export function SolutionsSectionCtaButton({
     event,
     openButtonRef
   );
+  const isDrawerOpenRef = useRef(false);
+
+  // Keep track of previous steps to detect state transitions and notify the user
+  const prevStepsRef = useRef<AutofixStep[]>();
+  useEffect(() => {
+    if (isDrawerOpenRef.current) {
+      return;
+    }
+
+    if (!autofixData?.steps || !prevStepsRef.current) {
+      prevStepsRef.current = autofixData?.steps;
+      return;
+    }
+
+    const prevSteps = prevStepsRef.current;
+    const currentSteps = autofixData.steps;
+
+    // Find the most recent step
+    const processingStep = currentSteps.findLast(
+      step => step.type === AutofixStepType.DEFAULT
+    );
+
+    if (processingStep && processingStep.status === AutofixStatus.COMPLETED) {
+      // Check if this is a new completion (wasn't completed in previous state)
+      const prevProcessingStep = prevSteps.findLast(
+        step => step.type === AutofixStepType.DEFAULT
+      );
+      if (prevProcessingStep && prevProcessingStep.status !== AutofixStatus.COMPLETED) {
+        if (currentSteps.find(step => step.type === AutofixStepType.CHANGES)) {
+          addSuccessMessage(t('Autofix has finished coding.'));
+        } else if (currentSteps.find(step => step.type === AutofixStepType.SOLUTION)) {
+          addSuccessMessage(t('Autofix has found a solution.'));
+        } else if (
+          currentSteps.find(step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS)
+        ) {
+          addSuccessMessage(t('Autofix has found the root cause.'));
+        }
+      }
+    }
+
+    prevStepsRef.current = autofixData?.steps;
+  }, [autofixData?.steps]);
+
+  // Update drawer state when opening
+  const handleOpenDrawer = () => {
+    isDrawerOpenRef.current = true;
+    openSolutionsDrawer();
+  };
+
+  // Listen for drawer close events
+  useEffect(() => {
+    const handleClickOutside = () => {
+      isDrawerOpenRef.current = false;
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
 
   const showCtaButton =
     aiConfig.needsGenAIConsent ||
     aiConfig.hasAutofix ||
     (aiConfig.hasSummary && aiConfig.hasResources);
-  const isButtonLoading = aiConfig.isAutofixSetupLoading;
+  const isButtonLoading = aiConfig.isAutofixSetupLoading || isAutofixPending;
 
   const lastStep = autofixData?.steps?.[autofixData.steps.length - 1];
   const isAutofixInProgress = lastStep?.status === AutofixStatus.PROCESSING;
@@ -116,7 +183,7 @@ export function SolutionsSectionCtaButton({
   return (
     <StyledButton
       ref={openButtonRef}
-      onClick={() => openSolutionsDrawer()}
+      onClick={handleOpenDrawer}
       analyticsEventKey="issue_details.solutions_hub_opened"
       analyticsEventName="Issue Details: Solutions Hub Opened"
       analyticsParams={{


### PR DESCRIPTION
- Add code highlighting to diff view
- Add toast notifications when the drawer is closed and Autofix completes a step
- Add code changes card in sidebar
- Fix loading state for sidebar when there's autofix content
- Minor styling and padding fixes

<img width="397" alt="Screenshot 2025-03-07 at 8 37 28 AM" src="https://github.com/user-attachments/assets/04cd8d82-c15d-4181-80c1-e07406b31789" />
<img width="337" alt="Screenshot 2025-03-07 at 8 40 25 AM" src="https://github.com/user-attachments/assets/54a7a2a3-8830-4e81-a250-0ebe30df5b9b" />
<img width="655" alt="Screenshot 2025-03-06 at 2 43 03 PM" src="https://github.com/user-attachments/assets/ed3b3fa2-7b8d-4c39-bfe4-141d538593d1" />
<img width="365" alt="Screenshot 2025-03-06 at 4 02 31 PM" src="https://github.com/user-attachments/assets/13351480-b4c5-4bc7-a72a-a4f43935963e" />

<img width="609" alt="Screenshot 2025-03-07 at 10 57 55 AM" src="https://github.com/user-attachments/assets/e709c08c-62ae-485a-bc0c-cf194827b31e" />


