### PR TITLE
fix(builder): Changes to dataset trigger metrics compatibility check

### DIFF
--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -5,6 +5,7 @@ import type {Location} from 'history';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {MetricsCompatibilityData} from 'sentry/utils/performance/metricsEnhanced/metricsCompatibilityQuery';
@@ -70,6 +71,7 @@ export function MetricsCardinalityProvider(props: {
   };
   const eventView = EventView.fromLocation(props.location);
   eventView.fields = [{field: 'tpm()'}];
+  eventView.dataset = DiscoverDatasets.TRANSACTIONS;
   const _eventView = adjustEventViewTime(eventView);
 
   if (


### PR DESCRIPTION
Because the widget builder uses the `dataset` query param, `EventView.fromLocation()` was picking it up and changing the query param which triggered all of the metrics compatibility checks.

This caused any changes to the widget builder dataset to reload the whole dashboard. We weren't seeing this on `sentry` or other internal orgs because they get some `performance-remove-metrics-compatibility-fallback` flag that bypasses the compatibility checks

I figured that we should pin the dataset to `transactions` because we don't want to run compatibility checks on other datasets like errors. `EventView.fromLocation()` seems like it was just there to pull in time ranges or projects.