### PR TITLE
fix(sourcemaps): handle azure devops repositories having spaces in them

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Mapping, MutableMapping, Sequence
 from time import time
 from typing import Any
-from urllib.parse import parse_qs, quote, urlencode, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlencode, urlparse
 
 from django import forms
 from django.http.request import HttpRequest
@@ -337,8 +337,12 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 
     def format_source_url(self, repo: Repository, filepath: str, branch: str | None) -> str:
         filepath = filepath.lstrip("/")
-        project = quote(repo.config["project"])
-        repo_id = quote(repo.config["name"])
+        # First unquote to ensure we're starting with unencoded strings
+        # This prevents double-encoding if the strings are already encoded,
+        # as azure devops projects/repos can have spaces in them
+        project = quote(unquote(repo.config["project"]))
+        repo_id = quote(unquote(repo.config["name"]))
+
         query_string = urlencode(
             {
                 "path": f"/{filepath}",


### PR DESCRIPTION
Azure Devops code repositories can have spaces in their project / repo names. this was causing issues in stacktrace linking, as we'd double encode the `%` character and create an incorrect link. This PR resolves this issue by always unquoting the string before quoting.

confirmed the test fails without the corresponding change in `integration.py`. 

Fixes https://github.com/getsentry/sentry/issues/86486