### PR TITLE
feat(autofix): Get state checks repo access every minute

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -85,13 +85,14 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
 
 def get_autofix_state(
-    *, group_id: int | None = None, run_id: int | None = None
+    *, group_id: int | None = None, run_id: int | None = None, check_repo_access: bool = False
 ) -> AutofixState | None:
     path = "/v1/automation/autofix/state"
     body = orjson.dumps(
         {
             "group_id": group_id,
             "run_id": run_id,
+            "check_repo_access": check_repo_access,
         }
     )
 

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -123,7 +123,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":123,"run_id":null}',
+            data=b'{"group_id":123,"run_id":null,"check_repo_access":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -154,7 +154,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":null,"run_id":456}',
+            data=b'{"group_id":null,"run_id":456,"check_repo_access":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 


### PR DESCRIPTION
Utilizing memcache, we run the repo access check at most every minute, this way when users come back from setting up/fixing their GitHub integration the warning will be updated.

Tested locally between sentry and seer