### PR TITLE
fix(autofix): Github links, remove seer branding, and UI cleanup

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -871,6 +871,8 @@ const SubmitButton = styled(Button)`
   top: 50%;
   transform: translateY(-50%);
   height: 24px;
+  width: 24px;
+  border-radius: 5px;
 `;
 
 const AddInstructionWrapper = styled('div')`

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
@@ -133,8 +133,7 @@ describe('SolutionsHubDrawer', () => {
 
     expect(screen.getByText(mockEvent.id)).toBeInTheDocument();
 
-    // The heading is "Sentry AI" with a beta badge next to it
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Autofix')).toBeInTheDocument();
 
     expect(screen.getByTestId('ai-setup-data-consent')).toBeInTheDocument();
   });
@@ -156,7 +155,7 @@ describe('SolutionsHubDrawer', () => {
       screen.queryByTestId('ai-setup-loading-indicator')
     );
 
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Autofix')).toBeInTheDocument();
 
     // Verify the Start Autofix button is available
     const startButton = screen.getByRole('button', {name: 'Start Autofix'});
@@ -435,7 +434,7 @@ describe('SolutionsHubDrawer', () => {
       screen.queryByTestId('ai-setup-loading-indicator')
     );
 
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Autofix')).toBeInTheDocument();
 
     // Since "Install the GitHub Integration" text isn't found, let's check for
     // the "Set Up the GitHub Integration" text which is what the component is actually showing

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -188,7 +188,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
       <SolutionsDrawerNavigator>
         <Header>
           <SeerIcon size="lg" />
-          {t('Seer')}
+          {t('Autofix')}
           <StyledFeatureBadge
             type="beta"
             tooltipProps={{

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.spec.tsx
@@ -37,6 +37,21 @@ describe('SolutionsHubNotices', function () {
     );
 
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
+
+    // Test for text fragments with formatting
+    expect(screen.getByText(/Autofix is/, {exact: false})).toBeInTheDocument();
+    expect(screen.getByText('a lot better')).toBeInTheDocument();
+    expect(
+      screen.getByText(/when it has your codebase as context/, {exact: false})
+    ).toBeInTheDocument();
+
+    // Test for text with links
+    expect(screen.getByText(/Set up the/, {exact: false})).toBeInTheDocument();
+    expect(screen.getByText('GitHub Integration', {selector: 'a'})).toBeInTheDocument();
+    expect(
+      screen.getByText(/to allow Autofix to go deeper/, {exact: false})
+    ).toBeInTheDocument();
+
     expect(screen.getByText('Set Up Now')).toBeInTheDocument();
     expect(screen.getByRole('img', {name: 'Install'})).toBeInTheDocument();
   });
@@ -180,12 +195,15 @@ describe('SolutionsHubNotices', function () {
     );
 
     const integrationLink = screen.getByText('GitHub integration');
-    expect(integrationLink).toHaveAttribute('href', '/settings/integrations/github/456');
+    expect(integrationLink).toHaveAttribute(
+      'href',
+      '/settings/org-slug/integrations/github/456'
+    );
 
     const codeMappingsLink = screen.getByText('code mappings');
     expect(codeMappingsLink).toHaveAttribute(
       'href',
-      '/settings/integrations/github/456/?tab=codeMappings'
+      '/settings/org-slug/integrations/github/456/?tab=codeMappings'
     );
   });
 
@@ -205,7 +223,7 @@ describe('SolutionsHubNotices', function () {
     // Should have both the GitHub setup card and the unreadable repos warning
     const setupCard = screen.getByText('Set Up the GitHub Integration').closest('div');
     const warningAlert = screen
-      .getByText(/Autofix can't access these repositories/)
+      .getByText(/Autofix can't access these repositories:/)
       .closest('div');
 
     expect(setupCard).toBeInTheDocument();

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.tsx
@@ -9,6 +9,7 @@ import type {AutofixRepository} from 'sentry/components/events/autofix/types';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface SolutionsHubNoticesProps {
   autofixRepositories: AutofixRepository[];
@@ -16,6 +17,8 @@ interface SolutionsHubNoticesProps {
 }
 
 function GithubIntegrationSetupCard() {
+  const organization = useOrganization();
+
   return (
     <IntegrationCard key="no-readable-repos">
       <CardContent>
@@ -30,12 +33,20 @@ function GithubIntegrationSetupCard() {
             {tct(
               'Set up the [integrationLink:GitHub Integration] to allow Autofix to go deeper when troubleshooting and fixing your issues–including writing the code and opening PRs.',
               {
-                integrationLink: <ExternalLink href="/settings/integrations/github/" />,
+                integrationLink: (
+                  <ExternalLink
+                    href={`/settings/${organization.slug}/integrations/github/`}
+                  />
+                ),
               }
             )}
           </span>
         </CardDescription>
-        <LinkButton href="/settings/integrations/github/" size="sm" priority="primary">
+        <LinkButton
+          href={`/settings/${organization.slug}/integrations/github/`}
+          size="sm"
+          priority="primary"
+        >
           {t('Set Up Now')}
         </LinkButton>
       </CardContent>
@@ -48,6 +59,7 @@ export function SolutionsHubNotices({
   autofixRepositories,
   hasGithubIntegration,
 }: SolutionsHubNoticesProps) {
+  const organization = useOrganization();
   const unreadableRepos = autofixRepositories.filter(repo => repo.is_readable === false);
   const notices: JSX.Element[] = [];
 
@@ -80,14 +92,14 @@ export function SolutionsHubNotices({
                   <ExternalLink
                     href={
                       integrationId
-                        ? `/settings/integrations/github/${integrationId}/`
-                        : '/settings/integrations/github/'
+                        ? `/settings/${organization.slug}/integrations/github/${integrationId}/`
+                        : `/settings/${organization.slug}/integrations/github/`
                     }
                   />
                 ),
                 codeMappingsLink: integrationId ? (
                   <ExternalLink
-                    href={`/settings/integrations/github/${integrationId}/?tab=codeMappings`}
+                    href={`/settings/${organization.slug}/integrations/github/${integrationId}/?tab=codeMappings`}
                   />
                 ) : null,
               }
@@ -113,12 +125,12 @@ export function SolutionsHubNotices({
                 repo: <b>{unreadableRepo.name}</b>,
                 integrationLink: (
                   <ExternalLink
-                    href={`/settings/integrations/github/${unreadableRepo.integration_id}`}
+                    href={`/settings/${organization.slug}/integrations/github/${unreadableRepo.integration_id}`}
                   />
                 ),
                 codeMappingsLink: (
                   <ExternalLink
-                    href={`/settings/integrations/github/${unreadableRepo.integration_id}/?tab=codeMappings`}
+                    href={`/settings/${organization.slug}/integrations/github/${unreadableRepo.integration_id}/?tab=codeMappings`}
                   />
                 ),
               }

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -207,7 +207,7 @@ describe('SolutionsSection', () => {
   });
 
   describe('Solutions Hub button text', () => {
-    it('shows "Set Up Seer" when AI needs setup', async () => {
+    it('shows "Set Up Autofix" when AI needs setup', async () => {
       const customOrganization = OrganizationFixture({
         genAIConsent: false,
         hideAiFeatures: false,
@@ -235,10 +235,10 @@ describe('SolutionsSection', () => {
       });
 
       expect(
-        screen.getByText('Explore potential root causes and solutions with Seer.')
+        screen.getByText('Explore potential root causes and solutions with Autofix.')
       ).toBeInTheDocument();
 
-      expect(screen.getByRole('button', {name: 'Set Up Seer'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Set Up Autofix'})).toBeInTheDocument();
     });
 
     it('shows "Find Root Cause" even when autofix needs setup', async () => {
@@ -384,7 +384,6 @@ describe('SolutionsSection', () => {
       );
 
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', {name: 'Set Up Seer'})).not.toBeInTheDocument();
       expect(
         screen.queryByRole('button', {name: 'Set Up Autofix'})
       ).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
@@ -132,7 +132,9 @@ export default function SolutionsSection({
     >
       <SolutionsSectionContainer>
         {aiConfig.needsGenAIConsent ? (
-          <Summary>{t('Explore potential root causes and solutions with Seer.')}</Summary>
+          <Summary>
+            {t('Explore potential root causes and solutions with Autofix.')}
+          </Summary>
         ) : aiConfig.hasAutofix || aiConfig.hasSummary ? (
           <SolutionsSectionContent group={group} project={project} event={event} />
         ) : issueTypeConfig.resources ? (

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
@@ -130,7 +130,7 @@ export function SolutionsSectionCtaButton({
 
   const getButtonText = () => {
     if (aiConfig.needsGenAIConsent) {
-      return t('Set Up Seer');
+      return t('Set Up Autofix');
     }
 
     if (!aiConfig.hasAutofix) {


### PR DESCRIPTION
- Updates GitHub Integration links to contain the org slug
- Removes "Seer" branding for "Autofix" for now.
![CleanShot 2025-03-07 at 15 18 00@2x](https://github.com/user-attachments/assets/c624d3a6-27e1-4d9b-8420-1667b21f6702)

- Minor UI cleanup, make button square:

![CleanShot 2025-03-07 at 13 44 04@2x](https://github.com/user-attachments/assets/bccdff55-f418-4204-9e6a-95cd9aef7876)
