### PR TITLE
feat(issue-stream): Add prefetching of issue group when hovered

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -1,6 +1,7 @@
-import {Fragment} from 'react';
+import {Fragment, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useHover} from '@react-aria/interactions';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
@@ -12,9 +13,14 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, GroupTombstoneHelper} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {getLocation, getMessage, isTombstone} from 'sentry/utils/events';
+import {getLocation, getMessage, isGroup, isTombstone} from 'sentry/utils/events';
+import {fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import withOrganization from 'sentry/utils/withOrganization';
+import {makeFetchGroupQueryKey} from 'sentry/views/issueDetails/useGroup';
 import {createIssueLink} from 'sentry/views/issueList/utils';
 
 import EventTitleError from './eventTitleError';
@@ -30,6 +36,45 @@ interface EventOrGroupHeaderProps {
   onClick?: () => void;
   query?: string;
   source?: string;
+}
+
+function usePreloadGroupOnHover({
+  groupId,
+  disabled,
+}: {
+  disabled: boolean;
+  groupId: string;
+}) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const {selection} = usePageFilters();
+  const api = useApi({persistInFlight: true});
+  const queryFn = fetchDataQuery(api);
+
+  const {hoverProps} = useHover({
+    onHoverStart: () => {
+      timeoutRef.current = setTimeout(() => {
+        queryClient.prefetchQuery({
+          queryKey: makeFetchGroupQueryKey({
+            groupId,
+            organizationSlug: organization.slug,
+            environments: selection.environments,
+          }),
+          queryFn,
+          staleTime: 30_000,
+        });
+      }, 300);
+    },
+    onHoverEnd: () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    },
+    isDisabled: disabled,
+  });
+
+  return hoverProps;
 }
 
 /**
@@ -48,6 +93,10 @@ function EventOrGroupHeader({
   const location = useLocation();
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+  const preloadHoverProps = usePreloadGroupOnHover({
+    groupId: data.id,
+    disabled: !hasNewLayout || isTombstone(data) || !isGroup(data),
+  });
 
   function getTitleChildren() {
     const {isBookmarked, hasSeen} = data as Group;
@@ -99,6 +148,7 @@ function EventOrGroupHeader({
       return (
         <NewTitleWithLink
           {...commonEleProps}
+          {...preloadHoverProps}
           to={to}
           onClick={onClick}
           data-issue-title-link

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -17,7 +17,6 @@ import {getLocation, getMessage, isGroup, isTombstone} from 'sentry/utils/events
 import {fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withOrganization from 'sentry/utils/withOrganization';
 import {makeFetchGroupQueryKey} from 'sentry/views/issueDetails/useGroup';
@@ -41,11 +40,12 @@ interface EventOrGroupHeaderProps {
 function usePreloadGroupOnHover({
   groupId,
   disabled,
+  organization,
 }: {
   disabled: boolean;
   groupId: string;
+  organization: Organization;
 }) {
-  const organization = useOrganization();
   const queryClient = useQueryClient();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const {selection} = usePageFilters();
@@ -96,6 +96,7 @@ function EventOrGroupHeader({
   const preloadHoverProps = usePreloadGroupOnHover({
     groupId: data.id,
     disabled: !hasNewLayout || isTombstone(data) || !isGroup(data),
+    organization,
   });
 
   function getTitleChildren() {

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -512,6 +512,6 @@ export function eventIsProfilingIssue(event: BaseGroup | Event | GroupTombstoneH
   return evidenceData.templateName === 'profile';
 }
 
-function isGroup(event: BaseGroup | Event): event is BaseGroup {
+export function isGroup(event: BaseGroup | Event): event is BaseGroup {
   return (event as BaseGroup).status !== undefined;
 }


### PR DESCRIPTION
Previously, we were prefetching when hovering over the issue title to speed up the subsequent issue details page load (this is done in the GroupPreviewHovercard component). With the new layout you can click anywhere to go to the issue, so this PR adds the prefetch on the link element which spans the full row.

For now I am only preloading the group and not the event. The streamlined UI uses more complex logic for determining the query key which breaks the current event preloading anyway.