### PR TITLE
feat(shared-views): Use position from starred table in GET views endpoint 

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -1,7 +1,8 @@
 from typing import TypedDict
 
-from sentry.api.serializers import Serializer, register
+from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SORT_LITERALS
 
 
@@ -51,4 +52,27 @@ class GroupSearchViewSerializer(Serializer):
             "timeFilters": obj.time_filters,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
+        }
+
+
+@register(GroupSearchViewStarred)
+class GroupSearchViewStarredSerializer(Serializer):
+    def __init__(self, *args, **kwargs):
+        self.has_global_views = kwargs.pop("has_global_views", None)
+        self.default_project = kwargs.pop("default_project", None)
+        super().__init__(*args, **kwargs)
+
+    def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
+        serialized_view: GroupSearchViewSerializerResponse = serialize(
+            obj.group_search_view,
+            user,
+            serializer=GroupSearchViewSerializer(
+                has_global_views=self.has_global_views,
+                default_project=self.default_project,
+            ),
+        )
+
+        return {
+            **serialized_view,
+            "position": obj.position,
         }

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -13,7 +13,10 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
+from sentry.api.serializers.models.groupsearchview import (
+    GroupSearchViewSerializer,
+    GroupSearchViewStarredSerializer,
+)
 from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidator,
     GroupSearchViewValidatorResponse,
@@ -106,6 +109,25 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"detail": "You do not have access to any projects."},
                 )
+
+        if features.has("organizations:issue-view-sharing", organization):
+            starred_views = GroupSearchViewStarred.objects.filter(
+                organization=organization, user_id=request.user.id
+            )
+
+            return self.paginate(
+                request=request,
+                queryset=starred_views,
+                order_by="position",
+                on_results=lambda x: serialize(
+                    x,
+                    request.user,
+                    serializer=GroupSearchViewStarredSerializer(
+                        has_global_views=has_global_views,
+                        default_project=default_project,
+                    ),
+                ),
+            )
 
         return self.paginate(
             request=request,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -66,19 +66,16 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_first_starred_view_decrements_succeeding_positions(self) -> None:
-        for idx, view in enumerate(self.base_data["user_one_views"]):
-            GroupSearchViewStarred.objects.create(
-                group_search_view=view,
-                user_id=self.user.id,
-                organization_id=self.organization.id,
-                position=idx,
-            )
-
         # Delete the first view
         response = self.client.delete(self.url)
         assert response.status_code == 204
 
-        assert GroupSearchViewStarred.objects.count() == 2
+        assert (
+            GroupSearchViewStarred.objects.filter(
+                organization_id=self.organization.id, user_id=self.user.id
+            ).count()
+            == 2
+        )
 
         # All succeeeding views should have their position decremented
         for idx, gsv in enumerate(
@@ -91,14 +88,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_last_starred_view_does_not_decrement_positions(self) -> None:
-        for idx, view in enumerate(self.base_data["user_one_views"]):
-            GroupSearchViewStarred.objects.create(
-                group_search_view=view,
-                user_id=self.user.id,
-                organization_id=self.organization.id,
-                position=idx,
-            )
-
         # Delete the last view
         response = self.client.delete(
             reverse(
@@ -111,7 +100,12 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         )
         assert response.status_code == 204
 
-        assert GroupSearchViewStarred.objects.count() == 2
+        assert (
+            GroupSearchViewStarred.objects.filter(
+                organization_id=self.organization.id, user_id=self.user.id
+            ).count()
+            == 2
+        )
 
         for idx, gsv in enumerate(
             GroupSearchViewStarred.objects.filter(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -43,6 +43,12 @@ class BaseGSVTestCase(APITestCase):
             query_sort="date",
             position=0,
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=first_custom_view_user_one,
+            position=0,
+        )
 
         # This is out of order to test that the endpoint returns the views in the correct order
         third_custom_view_user_one = GroupSearchView.objects.create(
@@ -51,6 +57,12 @@ class BaseGSVTestCase(APITestCase):
             user_id=user_1.id,
             query="is:ignored",
             query_sort="freq",
+            position=2,
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=third_custom_view_user_one,
             position=2,
         )
 
@@ -62,6 +74,12 @@ class BaseGSVTestCase(APITestCase):
             query_sort="new",
             position=1,
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=second_custom_view_user_one,
+            position=1,
+        )
 
         first_custom_view_user_two = GroupSearchView.objects.create(
             name="Custom View One",
@@ -71,6 +89,12 @@ class BaseGSVTestCase(APITestCase):
             query_sort="date",
             position=0,
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=first_custom_view_user_two,
+            position=0,
+        )
 
         second_custom_view_user_two = GroupSearchView.objects.create(
             name="Custom View Two",
@@ -78,6 +102,12 @@ class BaseGSVTestCase(APITestCase):
             user_id=self.user_2.id,
             query="is:resolved",
             query_sort="new",
+            position=1,
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=second_custom_view_user_two,
             position=1,
         )
 
@@ -97,6 +127,7 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_get_user_one_custom_views(self) -> None:
         objs = self.create_base_data()
 
@@ -107,6 +138,7 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_get_user_two_custom_views(self) -> None:
         objs = self.create_base_data()
 
@@ -117,6 +149,7 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_get_default_views(self) -> None:
         self.create_base_data()
 
@@ -133,6 +166,7 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_get_views_has_correct_default_page_filters(self) -> None:
         self.create_base_data()
 
@@ -159,14 +193,8 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_deletes_missing_views(self) -> None:
-        starred_views = GroupSearchViewStarred.objects.filter(
-            organization=self.organization, user_id=self.user.id
-        )
-
-        # Verify that no starred views exist initially
-        assert len(starred_views) == 0
-
         views = self.client.get(self.url).data
 
         update_custom_view_three = views[2]
@@ -203,6 +231,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_adds_view_with_no_id(self) -> None:
         views = self.client.get(self.url).data
         views.append(
@@ -231,6 +260,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_reorder_views(self) -> None:
         views = self.client.get(self.url).data
         view_one = views[0]
@@ -260,6 +290,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_rename_views(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -272,6 +303,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_change_query(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -284,6 +316,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_change_sort(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -296,6 +329,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_change_everything(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -319,6 +353,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_invalid_no_views(self) -> None:
         response = self.get_error_response(self.organization.slug, views=[])
 
@@ -330,6 +365,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_invalid_sort(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -348,6 +384,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_invalid_over_max_views(self) -> None:
         from sentry.api.serializers.rest_framework.groupsearchview import MAX_VIEWS
 
@@ -366,6 +403,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_updated_deleted_view(self) -> None:
         views = self.client.get(self.url).data
 
@@ -431,6 +469,12 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             time_filters={"period": "14d"},
             environments=[],
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=first_custom_view_user_one,
+            position=0,
+        )
         first_custom_view_user_one.projects.set([self.project1])
 
         second_custom_view_user_one = GroupSearchView.objects.create(
@@ -443,6 +487,12 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             time_filters={"period": "7d"},
             environments=["staging", "production"],
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=second_custom_view_user_one,
+            position=1,
+        )
         second_custom_view_user_one.projects.set([self.project1, self.project2, self.project3])
 
         third_custom_view_user_one = GroupSearchView.objects.create(
@@ -454,6 +504,12 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             position=2,
             time_filters={"period": "30d"},
             environments=["development"],
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=third_custom_view_user_one,
+            position=2,
         )
         third_custom_view_user_one.projects.set([])
 
@@ -470,6 +526,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_not_including_page_filters_does_not_reset_them_for_existing_views(self) -> None:
         views = self.client.get(self.url).data
 
@@ -495,6 +552,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_default_page_filters_with_global_views(self) -> None:
         views = self.client.get(self.url).data
         views.append(
@@ -513,6 +571,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_one_project_to_zero_projects(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -524,6 +583,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_to_all_projects(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -535,6 +595,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_one_environment_to_zero_environments(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -545,6 +606,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_update_time_filters(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -555,6 +617,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_empty_time_filters_resets_to_default(self) -> None:
         views = self.client.get(self.url).data
         views[0]["timeFilters"] = {}
@@ -603,6 +666,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
     # the test has finished. This causes the endpoint to unexpectedly succeed when it should fail.
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_invalid_project_ids(self) -> None:
         url = reverse(
             "sentry-api-0-organization-group-search-views",
@@ -691,6 +755,12 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             time_filters={"period": "14d"},
             environments=[],
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=first_issue_view_user_one,
+            position=0,
+        )
         first_issue_view_user_one.projects.set([self.project3])
 
         second_issue_view_user_one = GroupSearchView.objects.create(
@@ -703,6 +773,12 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             is_all_projects=False,
             time_filters={"period": "7d"},
             environments=["staging", "production"],
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=second_issue_view_user_one,
+            position=1,
         )
         second_issue_view_user_one.projects.set([])
 
@@ -717,6 +793,12 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             time_filters={"period": "30d"},
             environments=["development"],
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=user_1.id,
+            group_search_view=third_issue_view_user_one,
+            position=2,
+        )
         third_issue_view_user_one.projects.set([])
 
         first_issue_view_user_two = GroupSearchView.objects.create(
@@ -729,6 +811,12 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             is_all_projects=False,
             time_filters={"period": "14d"},
             environments=[],
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=first_issue_view_user_two,
+            position=0,
         )
         first_issue_view_user_two.projects.set([])
 
@@ -743,6 +831,12 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             time_filters={"period": "14d"},
             environments=[],
         )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_4.id,
+            group_search_view=first_issue_view_user_four,
+            position=0,
+        )
         first_issue_view_user_four.projects.set([])
 
     def setUp(self) -> None:
@@ -754,6 +848,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_basic_get_page_filters_with_global_filters(self) -> None:
         self.login_as(user=self.user)
         response = self.client.get(self.url)
@@ -807,6 +902,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_default_page_filters_with_global_views(self) -> None:
         self.login_as(user=self.user_3)
         response = self.client.get(self.url)
@@ -865,6 +961,7 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
+    @with_feature({"organizations:issue-view-sharing": True})
     def test_cannot_rename_other_users_views(self) -> None:
         self.login_as(user=self.user)
         views = self.client.get(self.url).data


### PR DESCRIPTION
This PR adds a path in the GET /group-search-views/ endpoint that uses the position column from the GroupSearchViewStarred table, rather than the position from the GroupSearchView table. 

This is a somewhat risky change, so it is  gated by the `issue-view-sharing` feature flag, which is only enabled for me right now. I want do some end to end testing myself before removing this check and dropping the position column from the GroupSearchView table. 