### PR TITLE
test(issues): Remove issue config from solutions test

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -234,11 +234,6 @@ describe('SolutionsSection', () => {
         },
       });
 
-      // jest.mocked(getConfigForIssueType).mockReturnValue({
-      //   ...jest.mocked(getConfigForIssueType)(mockGroup, mockGroup.project),
-      //   resources: null,
-      // });
-
       render(
         <SolutionsSection event={mockEvent} group={mockGroup} project={mockProject} />,
         {


### PR DESCRIPTION
It's annoying to modify this test every time we add something to the issue type config. Removes a loading test and uses more real data to trigger test cases.