### PR TITLE
feat(workflow_engine): Only execute enabled Detectors

### DIFF
--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -21,7 +21,9 @@ def process_data_sources(
     # Fetch all data sources and associated detectors for the given data packets
     with sentry_sdk.start_span(op="workflow_engine.process_data_sources.fetch_data_sources"):
         data_sources = DataSource.objects.filter(
-            source_id__in=data_packet_ids, type=query_type
+            source_id__in=data_packet_ids,
+            type=query_type,
+            detectors__enabled=True,
         ).prefetch_related(Prefetch("detectors"))
 
     # Build a lookup dict for source_id to detectors

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -52,6 +52,14 @@ class TestProcessDataSources(BaseWorkflowTest):
             (self.packet_two, [self.detector_two]),
         ]
 
+    def test_disabled_detector(self):
+        self.detector_one.enabled = False
+        self.detector_one.save()
+
+        assert process_data_sources(self.data_packets, "test") == [
+            (self.packet_two, [self.detector_two])
+        ]
+
     def test_multiple_detectors(self):
         self.detector_three = self.create_detector(name="test_detector3")
         self.detector_four = self.create_detector(name="test_detector4")


### PR DESCRIPTION
## Description
This will update the `process_data_sources` method to only select enabled detectors.