### PR TITLE
fix(views):Exclude newly added views from last visited update as well

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -44,6 +44,7 @@ export function IssueViewTab({
     if (
       initialTabKey !== TEMPORARY_TAB_KEY &&
       !initialTabKey.startsWith('default') &&
+      !initialTabKey.startsWith('_') &&
       view.id === initialTabKey
     ) {
       updateViewLastVisited({viewId: view.id});


### PR DESCRIPTION
Fixes SENTRY-3PNK 

(again) 

I forgot to include views that start with _ in the excluded views. Those also do not exist in the db 