### PR TITLE
ref(email): "Set Up Tracing", not Performance

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -314,7 +314,7 @@
           {% url 'sentry-organization-performance' organization.slug as performance_landing %}
           {% querystring referrer="weekly_report_upsell" notification_uuid=notification_uuid as query %}
           <a href="{% org_url organization performance_landing query=query %}"
-             class="btn" style="margin-top: 8px;">Set Up Performance</a>
+             class="btn" style="margin-top: 8px;">Set Up Tracing</a>
         </div>
       </td>
     {% endif %}


### PR DESCRIPTION
"Set Up Tracing" is the [consistent call to action we now use across Sentry](https://github.com/search?q=repo%3Agetsentry%2Fsentry%20%22Set%20Up%20Tracing%22&type=code), rather than "Set Up Performance". This fixes the last place we were using the old verbiage.