### PR TITLE
fix(source-maps-nuxt-js): Add .vue to the list VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -57,6 +57,7 @@ const VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS = [
   '.bundle', // React Native Android file ending
   '.hbc', // Hermes Bytecode (from Expo updates) file ending
   '.js.gz', // file ending idiomatic for Ember.js
+  '.vue', // Nuxt.js file ending
 ];
 
 export interface DeprecatedLineProps {


### PR DESCRIPTION
**Problem**

In a new nuxt.js project, after instrumenting Sentry and testing everything in a test environment, I see the [issue](https://sentry-pri-nuxt.sentry.io/issues/32395492/events/8dfaac86dd084cc19ec6cea251cf4958/) in Sentry with a bad stack trace - which is expected since source maps were not sent - however, the "Unminify Code" button should be displayed by the UI, and this does not happen.

![Screenshot 2025-03-10 at 07 07 03](https://github.com/user-attachments/assets/7b73c881-77af-4bdd-8399-e75ffa45f846)


**Solution**
It seems that the extension `.vue` was missing in the VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS list.

![image](https://github.com/user-attachments/assets/089df321-5a38-4312-94cd-8b35476f7a4c)

- Contibutes to https://github.com/getsentry/sentry/issues/79408
