### PR TITLE
ref(quick-start): Replace 'record' with 'create_or_update' in 'record_new_project'

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -98,14 +98,17 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
         ),
     )
 
-    success = OrganizationOnboardingTask.objects.record(
+    _, created = OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,
         task=OnboardingTask.FIRST_PROJECT,
-        user_id=user_id,
-        status=OnboardingTaskStatus.COMPLETE,
-        project_id=project.id,
+        values={
+            "user_id": user_id,
+            "status": OnboardingTaskStatus.COMPLETE,
+            "project_id": project.id,
+        },
     )
-    if not success:
+    # if we updated the task "first project", it means that it already exists and now we want to create the task "second platform"
+    if not created:
         # Check if the "first project" task already exists and log an error if needed
         first_project_task_exists = OrganizationOnboardingTask.objects.filter(
             organization_id=project.organization_id, task=OnboardingTask.FIRST_PROJECT
@@ -117,12 +120,14 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
                 level="warning",
             )
 
-        OrganizationOnboardingTask.objects.record(
+        OrganizationOnboardingTask.objects.create_or_update(
             organization_id=project.organization_id,
             task=OnboardingTask.SECOND_PLATFORM,
-            user_id=user_id,
-            status=OnboardingTaskStatus.COMPLETE,
-            project_id=project.id,
+            values={
+                "user_id": user_id,
+                "status": OnboardingTaskStatus.COMPLETE,
+                "project_id": project.id,
+            },
         )
         analytics.record(
             "second_platform.added",


### PR DESCRIPTION
**Problem**
Users occasionally experience an issue where the onboarding task for the "first project" is not recorded, even if one or more projects have been created. Our hypothesis is that a rollback is triggered during the process, and due to the 1-hour cache, the onboarding task isn't recorded when users attempt to create a project again. You can read more [here](https://github.com/getsentry/projects/issues/720#issuecomment-2705919512).


**Solution**
We plan to spend some time refactoring the onboarding receivers to fix this properly as the issue maybe be happening for other receivers too. But for now, this PR updates the `record_new_project` function to use `create_or_update` instead of `record`. This removes the need for a cache when handling the "first project" and "second platform" onboarding tasks. Since this function doesn't run often - unlike `record_release_received`, which uses the `event_process` signal - it's fine to skip the cache here


- Contributes to https://github.com/getsentry/projects/issues/720