### PR TITLE
fix: Add file path filters to Electron symbol source

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2850,7 +2850,20 @@ SENTRY_BUILTIN_SOURCES = {
         "name": "Electron",
         "layout": {"type": "native"},
         "url": "https://symbols.electronjs.org/",
-        "filters": {"filetypes": ["pdb", "breakpad", "sourcebundle"]},
+        "filters": {
+            "filetypes": ["pdb", "breakpad", "sourcebundle"],
+            # These file paths were empirically determined by examining
+            # logs of successful downloads from the Electron symbol server.
+            "file_paths": [
+                "*electron*",
+                "*ffmpeg*",
+                "*libEGL*",
+                "*libGLESv2*",
+                "*node*",
+                "*slack*",
+                "*vk_swiftshader*",
+            ],
+        },
         "is_public": True,
     },
     # === Various Linux distributions ===


### PR DESCRIPTION
This gates downloads from the public Electron symbol source behind a file path filter. This means that only downloads for modules with a debug file or code file matching one of these globs will even be attempted.

This is to reduce the number of requests we make to the Electron symbol source that definitely will not succeed. The list of glob patterns we allow has been determined by examining Symbolicator log entries for successful downloads from the source. As such, it is always possible that there is a file on the source which is not covered by any of these patterns and which we just haven't seen in all the logs we examined.