### PR TITLE
feat(auditlog): custom message for ORG_ADD auditlog entries when channel is passed

### DIFF
--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -101,6 +101,16 @@ class MemberPendingAuditLogEvent(AuditLogEvent):
         return f"required member {user_display_name} to setup 2FA"
 
 
+class OrgAddAuditLogEvent(AuditLogEvent):
+    def __init__(self):
+        super().__init__(event_id=10, name="ORG_ADD", api_name="org.create")
+
+    def render(self, audit_log_entry: AuditLogEntry):
+        if channel := audit_log_entry.data.get("channel"):
+            return f"created the organization with {channel} integration"
+        return "created the organization"
+
+
 class OrgEditAuditLogEvent(AuditLogEvent):
     def __init__(self):
         super().__init__(event_id=11, name="ORG_EDIT", api_name="org.edit")

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -26,14 +26,7 @@ default_manager.add(events.MemberRemoveAuditLogEvent())
 default_manager.add(events.MemberJoinTeamAuditLogEvent())
 default_manager.add(events.MemberLeaveTeamAuditLogEvent())
 default_manager.add(events.MemberPendingAuditLogEvent())
-default_manager.add(
-    AuditLogEvent(
-        event_id=10,
-        name="ORG_ADD",
-        api_name="org.create",
-        template="created the organization",
-    )
-)
+default_manager.add(events.OrgAddAuditLogEvent())
 default_manager.add(events.OrgEditAuditLogEvent())
 default_manager.add(
     AuditLogEvent(

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -109,9 +109,7 @@ class CreateAuditEntryTest(TestCase):
         assert entry.event == audit_log.get_event_id("ORG_ADD")
 
         audit_log_event = audit_log.get(entry.event)
-        note = audit_log_event.render(entry)
-        assert note.startswith("created the organization")
-        assert "vercel" in note
+        assert audit_log_event.render(entry) == "created the organization with vercel integration"
 
     def test_audit_entry_org_delete_log(self):
         if SiloMode.get_current_mode() == SiloMode.CONTROL:

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -68,6 +68,51 @@ class CreateAuditEntryTest(TestCase):
 
         self.assert_no_delete_log_created()
 
+    def test_audit_entry_org_add_log(self):
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            return
+
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.org.id,
+            event=audit_log.get_event_id("ORG_ADD"),
+            data=self.org.get_audit_log_data(),
+        )
+
+        assert entry.actor == self.user
+        assert entry.actor_label is None
+        assert entry.target_object == self.org.id
+        assert entry.event == audit_log.get_event_id("ORG_ADD")
+
+        audit_log_event = audit_log.get(entry.event)
+        assert audit_log_event.render(entry) == "created the organization"
+
+    def test_audit_entry_org_add_log_with_channel(self):
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            return
+
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.org.id,
+            event=audit_log.get_event_id("ORG_ADD"),
+            data={
+                "channel": "vercel",
+                **self.org.get_audit_log_data(),
+            },
+        )
+
+        assert entry.actor == self.user
+        assert entry.actor_label is None
+        assert entry.target_object == self.org.id
+        assert entry.event == audit_log.get_event_id("ORG_ADD")
+
+        audit_log_event = audit_log.get(entry.event)
+        note = audit_log_event.render(entry)
+        assert note.startswith("created the organization")
+        assert "vercel" in note
+
     def test_audit_entry_org_delete_log(self):
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             return


### PR DESCRIPTION
Closes https://github.com/getsentry/projects/issues/779

Custom auditlog event message when an org is created via a partner provisioning.