### PR TITLE
fix(tests): Fix flaky symbolicator tests

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -79,7 +79,8 @@ class Fixtures:
                 is_sentry_app=False,
             )
         except IntegrityError:
-            return User.objects.get(email="admin@localhost")
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                return User.objects.get(email="admin@localhost")
 
     @cached_property
     def organization(self):


### PR DESCRIPTION
The previous fix added here (https://github.com/getsentry/sentry/pull/85584, https://github.com/getsentry/sentry/pull/86162) does sadly not quite work as it runs into: 
```
sentry.silo.base.SiloLimit.AvailabilityError: Called User.get_queryset on server in REGION mode. User is available only in: MONOLITH, CONTROL
``` 
This PR should mitigate this and thus fix the falkey tests for good.

Fixes: https://github.com/getsentry/sentry/issues/86601
