### PR TITLE
ref(fe): Convert `<PluginDetailedView />` to FC

### DIFF
--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -80,6 +80,27 @@ function PluginDetailedView() {
     [plugin]
   );
   const featureData = useMemo(() => plugin?.featureDescriptions ?? [], [plugin]);
+
+  useEffect(() => {
+    if (!isPending && plugin) {
+      trackIntegrationAnalytics('integrations.integration_viewed', {
+        view: 'integrations_directory_integration_detail',
+        integration: integrationSlug,
+        integration_type: integrationType,
+        already_installed: installationStatus !== 'Not Installed', // pending counts as installed here
+        organization,
+        integration_tab: activeTab,
+      });
+    }
+  }, [
+    isPending,
+    integrationSlug,
+    plugin,
+    activeTab,
+    installationStatus,
+    organization,
+    integrationType,
+  ]);
 
   const getTabDisplay = useCallback((tab: Tab) => {
     if (tab === 'configurations') {

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import ContextPickerModal from 'sentry/components/contextPickerModal';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
@@ -57,7 +59,7 @@ function PluginDetailedView() {
   const navigate = useNavigate();
   const {integrationSlug} = useParams<{integrationSlug: string}>();
 
-  const {data: plugins} = useApiQuery<PluginWithProjectList[]>(
+  const {data: plugins, isPending} = useApiQuery<PluginWithProjectList[]>(
     makePluginQueryKey({orgSlug: organization.slug, pluginSlug: integrationSlug}),
     {staleTime: Infinity, retry: false}
   );
@@ -270,6 +272,14 @@ function PluginDetailedView() {
     plugin,
     renderTopButton,
   ]);
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (!plugin) {
+    return <LoadingError message={t('There was an error loading this integration.')} />;
+  }
 
   return (
     <IntegrationLayout.Body

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -64,21 +64,18 @@ function PluginDetailedView() {
     {staleTime: Infinity, retry: false}
   );
 
-  // XXX: For the FC conversion, these all need to be memoized to prevent render callbacks being
-  // computed on every render.
   const integrationType = 'plugin';
   const plugin = useMemo(() => plugins?.[0], [plugins]);
-  const description = useMemo(() => plugin?.description || '', [plugin]);
-  const author = useMemo(() => plugin?.author?.name, [plugin]);
-  const resourceLinks = useMemo(() => plugin?.resourceLinks || [], [plugin]);
-  const installationStatus: IntegrationInstallationStatus = useMemo(
-    () => (plugin?.projectList?.length ? INSTALLED : NOT_INSTALLED),
-    [plugin]
-  );
+  const description = plugin?.description || '';
+  const author = plugin?.author?.name ?? '';
+  const installationStatus: IntegrationInstallationStatus = plugin?.projectList?.length
+    ? INSTALLED
+    : NOT_INSTALLED;
   const integrationName = useMemo(
     () => `${plugin?.name}${plugin?.isHidden ? t(' (Legacy)') : ''}`,
     [plugin]
   );
+  const resourceLinks = useMemo(() => plugin?.resourceLinks || [], [plugin]);
   const featureData = useMemo(() => plugin?.featureDescriptions ?? [], [plugin]);
 
   useEffect(() => {
@@ -336,7 +333,6 @@ function PluginDetailedView() {
           <IntegrationLayout.InformationCard
             integrationSlug={integrationSlug}
             description={description}
-            alerts={[]}
             featureData={featureData}
             author={author}
             resourceLinks={resourceLinks}


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/86656

Tests are passing and an inspection of the page doesn't seem to have any issues. Requires that other PR because I pulled out a lot of the components that the abstract class renders to make conversions a bit easier, and to ensure the children still all render the same components (but without inheritance).