### PR TITLE
chore(hybridcloud) Remove relocation outbox handlers

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -17,7 +17,7 @@ _used_categories: set[OutboxCategory] = set()
 
 class OutboxCategory(IntEnum):
     USER_UPDATE = 0
-    WEBHOOK_PROXY = 1
+    WEBHOOK_PROXY = 1  # no longer in use
     ORGANIZATION_UPDATE = 2
     ORGANIZATION_MEMBER_UPDATE = 3
     UNUSED_TWO = 4
@@ -36,8 +36,7 @@ class OutboxCategory(IntEnum):
     PROVISION_ORGANIZATION = 17
     POST_ORGANIZATION_PROVISION = 18
     UNUSED_ONE = 19
-    # No longer in use.
-    DISABLE_AUTH_PROVIDER = 20
+    DISABLE_AUTH_PROVIDER = 20  # no longer in use
     RESET_IDP_FLAGS = 21
     MARK_INVALID_SSO = 22
     SUBSCRIPTION_UPDATE = 23
@@ -55,8 +54,8 @@ class OutboxCategory(IntEnum):
     ISSUE_COMMENT_UPDATE = 34
     EXTERNAL_ACTOR_UPDATE = 35
 
-    RELOCATION_EXPORT_REQUEST = 36
-    RELOCATION_EXPORT_REPLY = 37
+    RELOCATION_EXPORT_REQUEST = 36  # no longer in use
+    RELOCATION_EXPORT_REPLY = 37  # no longer in use
 
     SEND_VERCEL_INVOICE = 38
 
@@ -279,6 +278,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.AUTH_IDENTITY_UPDATE,
         },
     )
+    # Webhook scope is no longer in use
     WEBHOOK_SCOPE = scope_categories(2, {OutboxCategory.WEBHOOK_PROXY})
     AUDIT_LOG_SCOPE = scope_categories(3, {OutboxCategory.AUDIT_LOG_EVENT})
     USER_IP_SCOPE = scope_categories(
@@ -299,11 +299,8 @@ class OutboxScope(IntEnum):
             OutboxCategory.SENTRY_APP_UPDATE,
         },
     )
-    # Deprecate?
-    TEAM_SCOPE = scope_categories(
-        7,
-        set(),
-    )
+    # No longer in use
+    TEAM_SCOPE = scope_categories(7, set())
     PROVISION_SCOPE = scope_categories(
         8,
         {
@@ -311,6 +308,7 @@ class OutboxScope(IntEnum):
         },
     )
     SUBSCRIPTION_SCOPE = scope_categories(9, {OutboxCategory.SUBSCRIPTION_UPDATE})
+    # relocation scope is no longer in use.
     RELOCATION_SCOPE = scope_categories(
         10, {OutboxCategory.RELOCATION_EXPORT_REQUEST, OutboxCategory.RELOCATION_EXPORT_REPLY}
     )

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -14,16 +14,13 @@ from typing import Any
 
 from django.dispatch import receiver
 
-from sentry import options
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.outbox.signals import process_control_outbox
 from sentry.integrations.models.integration import Integration
 from sentry.issues.services.issue import issue_service
 from sentry.models.apiapplication import ApiApplication
-from sentry.models.files.utils import get_relocation_storage
 from sentry.organizations.services.organization import RpcOrganizationSignal, organization_service
 from sentry.receivers.outbox import maybe_process_tombstone
-from sentry.relocation.services.relocation_export.service import region_relocation_export_service
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.tasks.sentry_apps import clear_region_cache
 
@@ -105,61 +102,3 @@ def process_issue_email_reply(shard_identifier: int, payload: Any, **kwds):
         from_email=payload["from_email"],
         text=payload["text"],
     )
-
-
-# See the comment on /src/sentry/relocation/tasks/process.py::uploading_start for a detailed description of
-# how this outbox drain handler fits into the entire SAAS->SAAS relocation workflow.
-@receiver(process_control_outbox, sender=OutboxCategory.RELOCATION_EXPORT_REQUEST)
-def process_relocation_request_new_export(payload: Mapping[str, Any], **kwds):
-    encrypt_with_public_key = (
-        payload["encrypt_with_public_key"].encode("utf-8")
-        if isinstance(payload["encrypt_with_public_key"], str)
-        else payload["encrypt_with_public_key"]
-    )
-    region_relocation_export_service.request_new_export(
-        relocation_uuid=payload["relocation_uuid"],
-        requesting_region_name=payload["requesting_region_name"],
-        replying_region_name=payload["replying_region_name"],
-        org_slug=payload["org_slug"],
-        encrypt_with_public_key=encrypt_with_public_key,
-    )
-
-
-# See the comment on /src/sentry/relocation/tasks/process.py::uploading_start for a detailed description of
-# how this outbox drain handler fits into the entire SAAS->SAAS relocation workflow.
-@receiver(process_control_outbox, sender=OutboxCategory.RELOCATION_EXPORT_REPLY)
-def process_relocation_reply_with_export(payload: Mapping[str, Any], **kwds):
-    # We expect the `ProxyRelocationExportService::reply_with_export` implementation to have written
-    # the export data to the control silo's local relocation-specific GCS bucket. Here, we just read
-    # it into memory and attempt the RPC call back to the requesting region.
-    uuid = payload["relocation_uuid"]
-    slug = payload["org_slug"]
-
-    killswitch_orgs = options.get("relocation.outbox-orgslug.killswitch")
-    if slug in killswitch_orgs:
-        logger.info(
-            "relocation.killswitch.org",
-            extra={
-                "org_slug": slug,
-                "relocation_uuid": uuid,
-            },
-        )
-        return
-
-    relocation_storage = get_relocation_storage()
-    path = f"runs/{uuid}/saas_to_saas_export/{slug}.tar"
-    try:
-        encrypted_bytes = relocation_storage.open(path)
-    except Exception:
-        raise FileNotFoundError("Could not open SaaS -> SaaS export in proxy relocation bucket.")
-
-    with encrypted_bytes:
-        region_relocation_export_service.reply_with_export(
-            relocation_uuid=payload["relocation_uuid"],
-            requesting_region_name=payload["requesting_region_name"],
-            replying_region_name=payload["replying_region_name"],
-            org_slug=payload["org_slug"],
-            # TODO(azaslavsky): finish transfer from `encrypted_contents` -> `encrypted_bytes`.
-            encrypted_contents=None,
-            encrypted_bytes=[int(byte) for byte in encrypted_bytes.read()],
-        )

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 from django.db import connections
-from django.test import RequestFactory
 from pytest import raises
 
 from sentry.hybridcloud.models.outbox import (
@@ -52,12 +51,6 @@ def setup_clear_fixture_outbox_messages() -> None:
 
 @control_silo_test
 class ControlOutboxTest(TestCase):
-    webhook_request = RequestFactory().post(
-        "/extensions/github/webhook/?query=test",
-        data={"installation": {"id": "github:1"}},
-        content_type="application/json",
-        HTTP_X_GITHUB_EMOTICON=">:^]",
-    )
     region = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENANT)
     region_config = (region,)
 
@@ -593,9 +586,9 @@ class OutboxAggregationTest(TestCase):
             for i in range(shard_count):
                 ControlOutbox(
                     region_name=region_name,
-                    shard_scope=OutboxScope.WEBHOOK_SCOPE,
+                    shard_scope=OutboxScope.AUDIT_LOG_SCOPE,
                     shard_identifier=shard_id,
-                    category=OutboxCategory.WEBHOOK_PROXY,
+                    category=OutboxCategory.AUDIT_LOG_EVENT,
                     object_identifier=shard_id * 10000 + i,
                     payload={"foo": "bar"},
                 ).save()
@@ -607,19 +600,19 @@ class OutboxAggregationTest(TestCase):
             dict(
                 shard_identifier=2,
                 region_name="us",
-                shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
+                shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
                 depth=7,
             ),
             dict(
                 shard_identifier=1,
                 region_name="eu",
-                shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
+                shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
                 depth=4,
             ),
             dict(
                 shard_identifier=3,
                 region_name="us",
-                shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
+                shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
                 depth=1,
             ),
         ]
@@ -630,7 +623,7 @@ class OutboxAggregationTest(TestCase):
             dict(
                 shard_identifier=2,
                 region_name="us",
-                shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
+                shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
                 depth=7,
             )
         ]

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -4,8 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
-from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
-from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
@@ -123,7 +122,6 @@ class GithubRequestParserTest(TestCase):
         request = self.factory.post(
             self.path, data={"installation": {"id": "github:1"}}, content_type="application/json"
         )
-        assert ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).count() == 0
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
         response = parser.get_response()

--- a/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
@@ -4,8 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
-from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
-from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.middleware.integrations.parsers.github_enterprise import GithubEnterpriseRequestParser
@@ -145,8 +144,6 @@ class GithubEnterpriseRequestParserTest(TestCase):
             content_type="application/json",
             HTTP_X_GITHUB_ENTERPRISE_HOST=self.external_host,
         )
-
-        assert ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).count() == 0
 
         parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -7,8 +7,7 @@ from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
 from fixtures.gitlab import EXTERNAL_ID, PUSH_EVENT, WEBHOOK_SECRET, WEBHOOK_TOKEN
-from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
-from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.middleware.integrations.classifications import IntegrationClassification
@@ -244,7 +243,6 @@ class GitlabRequestParserTest(TestCase):
         integration = self.get_integration()
         parser = GitlabRequestParser(request=request, response_handler=self.get_response)
 
-        assert ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).count() == 0
         response = parser.get_response()
 
         assert isinstance(response, HttpResponse)


### PR DESCRIPTION
relocations has been moved to relocation transfers instead of outboxes, and has been working well in production for a few relocations.