### PR TITLE
ref(fe): Convert `<DocIntegrationDetailsView />` to FC

### DIFF
--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import startCase from 'lodash/startCase';
 
@@ -84,19 +84,21 @@ function Tabs({
   getTabDisplay,
 }: {
   activeTab: Tab;
-  getTabDisplay: (tab: Tab) => string;
-  onTabChange: (tab: Tab) => void;
   tabs: Tab[];
+  getTabDisplay?: (tab: Tab) => string;
+  onTabChange?: (tab: Tab) => void;
 }) {
+  // If getTabDisplay is not provided, use the tab as the display text
+  const renderTab = useMemo(() => getTabDisplay ?? ((tab: Tab) => tab), [getTabDisplay]);
   return (
     <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
       {tabs.map(tab => (
         <li
           key={tab}
           className={activeTab === tab ? 'active' : ''}
-          onClick={() => onTabChange(tab)}
+          onClick={() => onTabChange?.(tab)}
         >
-          <CapitalizedLink>{getTabDisplay(tab)}</CapitalizedLink>
+          <CapitalizedLink>{renderTab(tab)}</CapitalizedLink>
         </li>
       ))}
     </ul>
@@ -210,10 +212,10 @@ function InformationCard({
   alerts = [],
   resourceLinks = [],
 }: {
-  alerts: AlertType[];
   description: string;
   featureData: IntegrationFeature[];
   integrationSlug: string;
+  alerts?: AlertType[];
   author?: string;
   permissions?: React.ReactNode;
   resourceLinks?: Array<{title: string; url: string}>;

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
@@ -1,33 +1,38 @@
 import {DocIntegrationFixture} from 'sentry-fixture/docIntegration';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import DocIntegrationDetailedView from 'sentry/views/settings/organizationIntegrations/docIntegrationDetailedView';
 
 describe('DocIntegrationDetailedView', function () {
-  const {routerProps, organization} = initializeOrg();
+  const organization = OrganizationFixture();
   const doc = DocIntegrationFixture();
+  const router = RouterFixture({
+    params: {orgId: organization.slug, integrationSlug: doc.slug},
+  });
 
-  beforeEach(function () {});
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+  });
 
   it('renders', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: `/doc-integrations/${doc.slug}/`,
       body: doc,
     });
-    render(
-      <DocIntegrationDetailedView
-        {...routerProps}
-        organization={organization}
-        params={{integrationSlug: doc.slug}}
-      />
-    );
-    await tick();
+    render(<DocIntegrationDetailedView />, {
+      organization,
+      router,
+    });
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(await screen.findByText(doc.name)).toBeInTheDocument();
 
     expect(getMock).toHaveBeenCalledTimes(1);
 
-    const docLink = screen.getByTestId('learn-more');
+    const docLink = screen.getByRole('link', {name: 'Learn More'});
     expect(docLink).toBeInTheDocument();
     expect(docLink).toHaveAttribute('href', doc.url);
 

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -1,88 +1,67 @@
+import {useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {DocIntegrationAvatar} from 'sentry/components/core/avatar/docIntegrationAvatar';
-import type DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DocIntegration} from 'sentry/types/integrations';
-import withOrganization from 'sentry/utils/withOrganization';
+import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import type {Tab} from 'sentry/views/settings/organizationIntegrations/abstractIntegrationDetailedView';
+import IntegrationLayout from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
-import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+export default function DocIntegrationDetailsView() {
+  const tabs: Tab[] = ['overview'];
+  const organization = useOrganization();
+  const {integrationSlug} = useParams<{integrationSlug: string}>();
 
-type Tab = AbstractIntegrationDetailedView['state']['tab'];
+  const {data: doc, isPending} = useApiQuery<DocIntegration>(
+    [`/doc-integrations/${integrationSlug}/`],
+    {staleTime: Infinity, retry: false}
+  );
 
-type State = {
-  doc: DocIntegration;
-};
+  const integrationType = 'document';
+  const description = useMemo(() => doc?.description ?? '', [doc]);
+  const author = useMemo(() => doc?.author ?? '', [doc]);
+  const resourceLinks = useMemo(() => doc?.resources ?? [], [doc]);
+  const installationStatus = null;
+  const integrationName = useMemo(() => doc?.name ?? '', [doc]);
+  const featureData = useMemo(() => doc?.features ?? [], [doc]);
 
-class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
-  AbstractIntegrationDetailedView['props'],
-  State & AbstractIntegrationDetailedView['state']
-> {
-  tabs: Tab[] = ['overview'];
-
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {
-      params: {integrationSlug},
-    } = this.props;
-    return [['doc', `/doc-integrations/${integrationSlug}/`]];
-  }
-
-  get integrationType() {
-    return 'document' as const;
-  }
-
-  get integration(): DocIntegration {
-    return this.state.doc;
-  }
-
-  get description() {
-    return this.integration.description;
-  }
-
-  get author() {
-    return this.integration.author;
-  }
-
-  get resourceLinks() {
-    return this.integration.resources ?? [];
-  }
-
-  get installationStatus() {
-    return null;
-  }
-
-  get integrationName() {
-    return this.integration.name;
-  }
-
-  get featureData() {
-    return this.integration.features ?? [];
-  }
-
-  get requiresAccess() {
-    return false;
-  }
-
-  componentDidMount() {
-    super.componentDidMount();
-    this.trackIntegrationAnalytics('integrations.integration_viewed', {
+  useEffect(() => {
+    trackIntegrationAnalytics('integrations.integration_viewed', {
+      view: 'integrations_directory_integration_detail',
+      integration: integrationSlug,
+      integration_type: integrationType,
+      already_installed: installationStatus !== 'Not Installed',
+      organization,
       integration_tab: 'overview',
     });
-  }
+  }, [integrationSlug, integrationType, installationStatus, organization]);
 
-  trackClick = () => {
-    this.trackIntegrationAnalytics('integrations.installation_start');
-  };
-
-  renderTopButton() {
+  const renderTopButton = useCallback(() => {
+    if (!doc) {
+      return null;
+    }
     return (
       <ExternalLink
-        href={this.integration.url}
-        onClick={this.trackClick}
+        href={doc.url}
+        onClick={() => {
+          trackIntegrationAnalytics('integrations.installation_start', {
+            view: 'integrations_directory_integration_detail',
+            integration: integrationSlug,
+            integration_type: integrationType,
+            already_installed: installationStatus !== 'Not Installed',
+            organization,
+          });
+        }}
         data-test-id="learn-more"
       >
         <LearnMoreButton
@@ -95,16 +74,58 @@ class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
         </LearnMoreButton>
       </ExternalLink>
     );
+  }, [doc, integrationSlug, integrationType, installationStatus, organization]);
+
+  if (isPending) {
+    return <LoadingIndicator />;
   }
 
-  renderIntegrationIcon() {
-    return <DocIntegrationAvatar docIntegration={this.integration} size={50} />;
+  if (!doc) {
+    return <LoadingError message={t('There was an error loading this integration.')} />;
   }
 
-  // No configurations.
-  renderConfigurations() {
-    return null;
-  }
+  return (
+    <IntegrationLayout.Body
+      integrationName={integrationName}
+      alert={null}
+      topSection={
+        <IntegrationLayout.TopSection
+          featureData={featureData}
+          integrationName={integrationName}
+          installationStatus={installationStatus}
+          integrationIcon={<DocIntegrationAvatar docIntegration={doc} size={50} />}
+          addInstallButton={
+            <IntegrationLayout.AddInstallButton
+              featureData={featureData}
+              hideButtonIfDisabled={false}
+              requiresAccess={false}
+              renderTopButton={renderTopButton}
+            />
+          }
+          additionalCTA={null}
+        />
+      }
+      tabs={
+        <IntegrationLayout.Tabs
+          tabs={tabs}
+          activeTab={'overview'}
+          onTabChange={() => {}}
+          getTabDisplay={(tab: Tab) => tab}
+        />
+      }
+      content={
+        <IntegrationLayout.InformationCard
+          integrationSlug={integrationSlug}
+          description={description}
+          alerts={[]}
+          featureData={featureData}
+          author={author}
+          resourceLinks={resourceLinks}
+          permissions={null}
+        />
+      }
+    />
+  );
 }
 
 const LearnMoreButton = styled(Button)`
@@ -117,5 +138,3 @@ const StyledIconOpen = styled(IconOpen)`
   position: relative;
   top: 1px;
 `;
-
-export default withOrganization(DocIntegrationDetailedView);

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -28,11 +28,11 @@ export default function DocIntegrationDetailsView() {
   );
 
   const integrationType = 'document';
-  const description = useMemo(() => doc?.description ?? '', [doc]);
-  const author = useMemo(() => doc?.author ?? '', [doc]);
-  const resourceLinks = useMemo(() => doc?.resources ?? [], [doc]);
+  const description = doc?.description ?? '';
+  const author = doc?.author ?? '';
   const installationStatus = null;
-  const integrationName = useMemo(() => doc?.name ?? '', [doc]);
+  const resourceLinks = useMemo(() => doc?.resources ?? [], [doc]);
+  const integrationName = doc?.name ?? '';
   const featureData = useMemo(() => doc?.features ?? [], [doc]);
 
   useEffect(() => {
@@ -105,19 +105,11 @@ export default function DocIntegrationDetailsView() {
           additionalCTA={null}
         />
       }
-      tabs={
-        <IntegrationLayout.Tabs
-          tabs={tabs}
-          activeTab={'overview'}
-          onTabChange={() => {}}
-          getTabDisplay={(tab: Tab) => tab}
-        />
-      }
+      tabs={<IntegrationLayout.Tabs tabs={tabs} activeTab={'overview'} />}
       content={
         <IntegrationLayout.InformationCard
           integrationSlug={integrationSlug}
           description={description}
-          alerts={[]}
           featureData={featureData}
           author={author}
           resourceLinks={resourceLinks}


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/86656

Not making any visual changes even though they would probably be welcome. For example, we still render tabs even though docs integrations only have one, so it's not really necessary.