### PR TITLE
feat(billing): Change CTA for sponsored plans

### DIFF
--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -73,8 +73,8 @@ class OnDemandBudgets extends Component<Props> {
         }
       >
         <div>
-          <Button to={`/settings/${organization.slug}/support/`}>
-            {t('Contact Support')}
+          <Button to={`/settings/${organization.slug}/billing/checkout/`}>
+            {t('Subscribe To A Paid Plan')}
           </Button>
         </div>
       </FieldGroup>

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -73,8 +73,11 @@ class OnDemandBudgets extends Component<Props> {
         }
       >
         <div>
-          <Button to={`/settings/${organization.slug}/billing/checkout/`}>
-            {t('Subscribe To A Paid Plan')}
+          <Button
+            priority="primary"
+            to={`/settings/${organization.slug}/billing/checkout/`}
+          >
+            {t('Upgrade Plan')}
           </Button>
         </div>
       </FieldGroup>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -69,7 +69,7 @@ describe('OnDemandBudgets', () => {
     expect(
       screen.getByText('On-Demand is not supported for your account.')
     ).toBeInTheDocument();
-    expect(screen.getByText('Subscribe To A Paid Plan')).toBeInTheDocument();
+    expect(screen.getByText('Upgrade Plan')).toBeInTheDocument();
   });
 
   it('renders credit card modal on the on-demand setting for account without a credit card', async function () {

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -69,7 +69,7 @@ describe('OnDemandBudgets', () => {
     expect(
       screen.getByText('On-Demand is not supported for your account.')
     ).toBeInTheDocument();
-    expect(screen.getByText('Contact Support')).toBeInTheDocument();
+    expect(screen.getByText('Subscribe To A Paid Plan')).toBeInTheDocument();
   });
 
   it('renders credit card modal on the on-demand setting for account without a credit card', async function () {


### PR DESCRIPTION
Closes: https://github.com/getsentry/sentry/issues/86244

Changes this button to a "Upgrade Plan" CTA instead of "Contact Support".

<img width="769" alt="Screenshot 2025-03-10 at 11 21 19 AM" src="https://github.com/user-attachments/assets/33900fc2-4886-4f0f-9ca0-b287cc55e13f" />

