### PR TITLE
chore(aci): shadow rollout metrics

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -470,6 +470,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable issue alert metrics for shadow rollout (see: alerts create issues)
+    manager.add("organizations:workflow-engine-issue-alert-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -471,7 +471,6 @@ def fire_rules(
             if features.has(
                 "organizations:workflow-engine-issue-alert-metrics",
                 project.organization,
-                actor=None,
             ):
                 metrics.incr(
                     "post_process.delayed_processing.triggered_actions",

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -990,7 +990,6 @@ def process_rules(job: PostProcessJob) -> None:
         if features.has(
             "organizations:workflow-engine-issue-alert-metrics",
             group_event.project.organization,
-            actor=None,
         ):
             metrics.incr(
                 "post_process.process_rules.triggered_actions",

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -987,11 +987,16 @@ def process_rules(job: PostProcessJob) -> None:
             has_alert = True
             safe_execute(callback, group_event, futures)
 
-        metrics.incr(
-            "post_process.process_rules.triggered_actions",
-            amount=len(callback_and_futures),
-            tags={"event_type": group_event.group.type},
-        )
+        if features.has(
+            "organizations:workflow-engine-issue-alert-metrics",
+            group_event.project.organization,
+            actor=None,
+        ):
+            metrics.incr(
+                "post_process.process_rules.triggered_actions",
+                amount=len(callback_and_futures),
+                tags={"event_type": group_event.group.type},
+            )
 
     job["has_alert"] = has_alert
     return

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -413,7 +413,6 @@ def fire_actions_for_groups(
         if features.has(
             "organizations:workflow-engine-issue-alert-metrics",
             group.project.organization,
-            actor=None,
         ):
             metrics.incr(
                 "workflow_engine.delayed_workflow.triggered_actions",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -156,7 +156,6 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
         if features.has(
             "organizations:workflow-engine-issue-alert-metrics",
             detector.project.organization,
-            actor=None,
         ):
             metrics.incr(
                 "workflow_engine.process_workflows.triggered_actions",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -155,7 +155,7 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
 
         metrics.incr(
             "workflow_engine.process_workflows.triggered_actions",
-            len(actions),
+            amount=len(actions),
             tags={"detector_type": detector.type},
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -7,6 +7,7 @@ from sentry import buffer
 from sentry.eventstream.base import GroupState
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -108,60 +109,61 @@ class TestProcessWorkflows(BaseWorkflowTest):
         triggered_workflows = process_workflows(self.job)
         assert triggered_workflows == {self.error_workflow, workflow}
 
-    def test_no_detector(self):
+    @patch("sentry.workflow_engine.processors.workflow.metrics")
+    @patch("sentry.workflow_engine.processors.workflow.logger")
+    def test_no_detector(self, mock_logger, mock_metrics):
         self.group_event.occurrence = self.build_occurrence(evidence_data={})
 
-        with mock.patch("sentry.workflow_engine.processors.workflow.logger") as mock_logger:
-            with mock.patch("sentry.workflow_engine.processors.workflow.metrics") as mock_metrics:
-                triggered_workflows = process_workflows(self.job)
+        triggered_workflows = process_workflows(self.job)
 
-                assert not triggered_workflows
+        assert not triggered_workflows
 
-                mock_metrics.incr.assert_called_once_with("workflow_engine.process_workflows.error")
-                mock_logger.exception.assert_called_once_with(
-                    "Detector not found for event",
-                    extra={"event_id": self.event.event_id},
-                )
+        mock_metrics.incr.assert_called_once_with("workflow_engine.process_workflows.error")
+        mock_logger.exception.assert_called_once_with(
+            "Detector not found for event",
+            extra={"event_id": self.event.event_id},
+        )
 
-    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
-    def test_no_metrics_triggered(self, mock_logger):
+    @patch("sentry.utils.metrics.incr")
+    @patch("sentry.workflow_engine.processors.workflow.logger")
+    def test_no_metrics_triggered(self, mock_logger, mock_incr):
         self.job["event"].project_id = 0
 
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_workflows(self.job)
-            mock_incr.assert_called_once_with("workflow_engine.process_workflows.error")
-            mock_logger.exception.assert_called_once()
+        process_workflows(self.job)
+        mock_incr.assert_called_once_with("workflow_engine.process_workflows.error")
+        mock_logger.exception.assert_called_once()
 
-    def test_metrics_with_workflows(self):
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_workflows(self.job)
+    @patch("sentry.utils.metrics.incr")
+    def test_metrics_with_workflows(self, mock_incr):
+        process_workflows(self.job)
 
-            mock_incr.assert_any_call(
-                "workflow_engine.process_workflows",
-                1,
-                tags={"detector_type": self.error_detector.type},
-            )
+        mock_incr.assert_any_call(
+            "workflow_engine.process_workflows",
+            1,
+            tags={"detector_type": self.error_detector.type},
+        )
 
-    def test_metrics_triggered_workflows(self):
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_workflows(self.job)
+    @patch("sentry.utils.metrics.incr")
+    def test_metrics_triggered_workflows(self, mock_incr):
+        process_workflows(self.job)
 
-            mock_incr.assert_any_call(
-                "workflow_engine.process_workflows.triggered_workflows",
-                1,
-                tags={"detector_type": self.error_detector.type},
-            )
+        mock_incr.assert_any_call(
+            "workflow_engine.process_workflows.triggered_workflows",
+            1,
+            tags={"detector_type": self.error_detector.type},
+        )
 
-    def test_metrics_triggered_actions(self):
+    @with_feature("organizations:workflow-engine-issue-alert-metrics")
+    @patch("sentry.utils.metrics.incr")
+    def test_metrics_triggered_actions(self, mock_incr):
         # add actions to the workflow
 
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_workflows(self.job)
-            mock_incr.assert_any_call(
-                "workflow_engine.process_workflows.triggered_actions",
-                amount=0,
-                tags={"detector_type": self.error_detector.type},
-            )
+        process_workflows(self.job)
+        mock_incr.assert_any_call(
+            "workflow_engine.process_workflows.triggered_actions",
+            amount=0,
+            tags={"detector_type": self.error_detector.type},
+        )
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
@@ -392,8 +394,8 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
         self.condition = self.create_data_condition(condition_group=self.data_condition_group)
         _, self.event, self.group_event = self.create_group_event()
 
-    @mock.patch("sentry.buffer.backend.push_to_hash")
-    @mock.patch("sentry.buffer.backend.push_to_sorted_set")
+    @patch("sentry.buffer.backend.push_to_hash")
+    @patch("sentry.buffer.backend.push_to_sorted_set")
     def test_enqueue_workflow__adds_to_workflow_engine_buffer(
         self, mock_push_to_hash, mock_push_to_sorted_set
     ):
@@ -409,8 +411,8 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
             value=self.group_event.project_id,
         )
 
-    @mock.patch("sentry.buffer.backend.push_to_hash")
-    @mock.patch("sentry.buffer.backend.push_to_sorted_set")
+    @patch("sentry.buffer.backend.push_to_hash")
+    @patch("sentry.buffer.backend.push_to_sorted_set")
     def test_enqueue_workflow__adds_to_workflow_engine_set(
         self, mock_push_to_hash, mock_push_to_sorted_set
     ):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -159,7 +159,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             process_workflows(self.job)
             mock_incr.assert_any_call(
                 "workflow_engine.process_workflows.triggered_actions",
-                0,
+                amount=0,
                 tags={"detector_type": self.error_detector.type},
             )
 


### PR DESCRIPTION
Emit metrics when actions are fired in the existing system and in equivalent places in workflow engine. Feature flag this so we're not overwhelmed with comparing a ton of organizations' rules/workflows firing.