### PR TITLE
ref(ui): Move injected `router` into `<PickProjectToContinue>`

### DIFF
--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
-import type {LocationDescriptor, LocationDescriptorObject} from 'history';
+import type {LocationDescriptor} from 'history';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import ContextPickerModal from 'sentry/components/contextPickerModal';
@@ -15,9 +15,7 @@ type Props = {
   /**
    * Path used on the redirect router if the user did select a project
    */
-  nextPath: Pick<LocationDescriptorObject, 'query'> & {
-    pathname: NonNullable<LocationDescriptorObject['pathname']>;
-  };
+  nextPath: LocationDescriptor;
   /**
    * Path used on the redirect router if the user did not select a project
    */
@@ -34,8 +32,8 @@ function PickProjectToContinue({
 }: Props) {
   const navigating = useRef(false);
   const navigate = useNavigate();
-  const nextPathQuery = nextPath.query;
-  let path = `${nextPath.pathname}?project=`;
+  const nextPathQuery = typeof nextPath === 'string' ? {} : nextPath.query;
+  let path = `${typeof nextPath === 'string' ? nextPath : nextPath.pathname}?project=`;
 
   if (nextPathQuery) {
     const filteredQuery = Object.entries(nextPathQuery)
@@ -44,7 +42,7 @@ function PickProjectToContinue({
 
     const newPathQuery = [...filteredQuery, 'project='].join('&');
 
-    path = `${nextPath.pathname}?${newPathQuery}`;
+    path = `${typeof nextPath === 'string' ? nextPath : nextPath.pathname}?${newPathQuery}`;
   }
 
   useEffect(() => {

--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -37,6 +37,16 @@ function PickProjectToContinue({
   const nextPathQuery = nextPath.query;
   let path = `${nextPath.pathname}?project=`;
 
+  if (nextPathQuery) {
+    const filteredQuery = Object.entries(nextPathQuery)
+      .filter(([key, _value]) => key !== 'project')
+      .map(([key, value]) => `${key}=${value}`);
+
+    const newPathQuery = [...filteredQuery, 'project='].join('&');
+
+    path = `${nextPath.pathname}?${newPathQuery}`;
+  }
+
   useEffect(() => {
     if (projects.length === 1) {
       return;
@@ -77,16 +87,6 @@ function PickProjectToContinue({
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  if (nextPathQuery) {
-    const filteredQuery = Object.entries(nextPathQuery)
-      .filter(([key, _value]) => key !== 'project')
-      .map(([key, value]) => `${key}=${value}`);
-
-    const newPathQuery = [...filteredQuery, 'project='].join('&');
-
-    path = `${nextPath.pathname}?${newPathQuery}`;
-  }
 
   // if the project in URL is missing, but this release belongs to only one project, redirect there
   if (projects.length === 1) {

--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -1,9 +1,10 @@
+import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor, LocationDescriptorObject} from 'history';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import ContextPickerModal from 'sentry/components/contextPickerModal';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type Project = {
   id: string;
@@ -22,20 +23,60 @@ type Props = {
    */
   noProjectRedirectPath: LocationDescriptor;
   projects: Project[];
-  router: InjectedRouter;
   allowAllProjectsSelection?: boolean;
 };
 
 function PickProjectToContinue({
   noProjectRedirectPath,
   nextPath,
-  router,
   projects,
   allowAllProjectsSelection = false,
 }: Props) {
+  const navigating = useRef(false);
+  const navigate = useNavigate();
   const nextPathQuery = nextPath.query;
-  let navigating = false;
   let path = `${nextPath.pathname}?project=`;
+
+  useEffect(() => {
+    if (projects.length === 1) {
+      return;
+    }
+
+    openModal(
+      modalProps => (
+        <ContextPickerModal
+          {...modalProps}
+          needOrg={false}
+          needProject
+          nextPath={`${path}:project`}
+          onFinish={to => {
+            navigating.current = true;
+            navigate(to, {replace: true});
+            modalProps.closeModal();
+          }}
+          projectSlugs={projects.map(p => p.slug)}
+          allowAllProjectsSelection={allowAllProjectsSelection}
+        />
+      ),
+      {
+        onClose() {
+          // this callback is fired when the user selects a project, or not. we
+          // want this to be executed only if the user didn't select any
+          // project (closed modal either via button, Esc, clicking outside,
+          // ...)
+          if (!navigating.current) {
+            navigate(noProjectRedirectPath);
+            navigating.current = false;
+          }
+        },
+      }
+    );
+    // We only ever want to call `openModal` once. As long as `projects.length`
+    // is > 1, we should open the modal. We rely on the user selecting a project
+    // and `<GlobalModal>` will close the modal when `location.pathname` changes.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (nextPathQuery) {
     const filteredQuery = Object.entries(nextPathQuery)
@@ -49,37 +90,14 @@ function PickProjectToContinue({
 
   // if the project in URL is missing, but this release belongs to only one project, redirect there
   if (projects.length === 1) {
-    router.replace(path + projects[0]!.id);
+    navigate(path + projects[0]!.id, {replace: true});
     return null;
   }
 
-  openModal(
-    modalProps => (
-      <ContextPickerModal
-        {...modalProps}
-        needOrg={false}
-        needProject
-        nextPath={`${path}:project`}
-        onFinish={to => {
-          navigating = true;
-          router.replace(to);
-          modalProps.closeModal();
-        }}
-        projectSlugs={projects.map(p => p.slug)}
-        allowAllProjectsSelection={allowAllProjectsSelection}
-      />
-    ),
-    {
-      onClose() {
-        // we want this to be executed only if the user didn't select any project
-        // (closed modal either via button, Esc, clicking outside, ...)
-        if (!navigating) {
-          router.push(noProjectRedirectPath);
-        }
-      },
-    }
-  );
+<<<<<<< HEAD
 
+=======
+>>>>>>> a0495df3ad1 (ref(ui): Remove `router` prop from `<PickProjectToContinue>`)
   return <ContextPickerBackground />;
 }
 

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -29,7 +29,6 @@ import {
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import {decodeScalar} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import useRouter from 'sentry/utils/useRouter';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
 import {
@@ -110,7 +109,6 @@ function PageLayout(props: Props) {
     projectId = filterProjects;
   }
 
-  const router = useRouter();
   const transactionName = getTransactionName(location);
   const [error, setError] = useState<string | undefined>();
   const metricsCardinality = useMetricsCardinalityContext();
@@ -232,7 +230,6 @@ function PageLayout(props: Props) {
               <PickProjectToContinue
                 data-test-id="transaction-sumamry-project-picker-modal"
                 projects={selectableProjects}
-                router={router}
                 nextPath={{
                   pathname: generateTransactionSummaryRoute({organization}),
                   query: {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -732,11 +732,9 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByText('My Projects')).toBeInTheDocument();
 
       await userEvent.click(firstProjectOption);
-      expect(spy).toHaveBeenCalledWith({
-        pathname:
-          '/organizations/org-slug/performance/summary/?transaction=/performance&statsPeriod=14d&referrer=performance-transaction-summary&transactionCursor=1:0:0&project=1',
-        state: undefined,
-      });
+      expect(spy).toHaveBeenCalledWith(
+        '/organizations/org-slug/insights/summary/?transaction=/performance&statsPeriod=14d&referrer=performance-transaction-summary&transactionCursor=1:0:0&project=1'
+      );
     });
 
     it('fetches transaction threshold', function () {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -732,9 +732,11 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByText('My Projects')).toBeInTheDocument();
 
       await userEvent.click(firstProjectOption);
-      expect(spy).toHaveBeenCalledWith(
-        '/organizations/org-slug/insights/summary/?transaction=/performance&statsPeriod=14d&referrer=performance-transaction-summary&transactionCursor=1:0:0&project=1'
-      );
+      expect(spy).toHaveBeenCalledWith({
+        pathname:
+          '/organizations/org-slug/performance/summary/?transaction=/performance&statsPeriod=14d&referrer=performance-transaction-summary&transactionCursor=1:0:0&project=1',
+        state: undefined,
+      });
     });
 
     it('fetches transaction threshold', function () {

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -33,7 +33,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
@@ -257,7 +256,6 @@ function ReleasesDetailContainer(props: ReleasesDetailContainerProps) {
   const params = useParams<{release: string}>();
   const location = useLocation();
   const navigate = useNavigate();
-  const router = useRouter();
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const {release} = params;
@@ -317,7 +315,6 @@ function ReleasesDetailContainer(props: ReleasesDetailContainerProps) {
           id: String(id),
           slug,
         }))}
-        router={router}
         nextPath={{
           pathname: makeReleasesPathname({
             path: `/${encodeURIComponent(release)}/`,

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -28,7 +28,6 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import type {WithRouteAnalyticsProps} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import {getCount} from 'sentry/utils/sessions';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -28,6 +28,7 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import type {WithRouteAnalyticsProps} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import {getCount} from 'sentry/utils/sessions';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';


### PR DESCRIPTION
Remove injected router and instead call `useRouter` inside of `<PickProjectToContinue>`. I tried using `useNavigate`, but a bunch of tests failed.