### PR TITLE
ref(flags): always double quote in searchbar to escape special chars

### DIFF
--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -189,8 +189,8 @@ export const useFetchIssueTags = ({
     });
 
     featureFlagTags.forEach(tag => {
-      // Wrap with flags[] and if necessary, quote to escape ':', which is used by our search syntax.
-      const key = tag.key.includes(':') ? `flags["${tag.key}"]` : `flags[${tag.key}]`;
+      // Wrap with flags[""]. flags[] is required for the search endpoint and "" is used to escape special characters.
+      const key = `flags["${tag.key}"]`;
       if (allTagsCollection[key]) {
         allTagsCollection[key]!.totalValues =
           (allTagsCollection[key]!.totalValues ?? 0) + (tag.totalValues ?? 0);


### PR DESCRIPTION
@malwilley pointed out that aside from `:`, there can be other special chars we need to escape. So it's proactive and simpler to always double quote here.