### PR TITLE
fix(issue-views): Remove prioritized from defaults. Save default_view to starred

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -8,6 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 
@@ -55,7 +56,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
         )
 
         # This entire endpoint will be removed once custom views are GA'd
-        GroupSearchView.objects.create_or_update(
+        default_view, created = GroupSearchView.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,
             position=0,
@@ -65,18 +66,12 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
                 "query_sort": result["sort"],
             },
         )
-        # These groupsearchview entries are temporarily here to ensure that pinned searches
-        # are being dynamically upgraded to custom views until custom views are GA'd, at which
-        # point saved searches will be removed entirely, along with this endpoint.
-        GroupSearchView.objects.create_or_update(
+        default_view_id = default_view.id if created else default_view
+        GroupSearchViewStarred.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,
-            position=1,
-            values={
-                "name": "Prioritized",
-                "query": "is:unresolved issue.priority:[high, medium]",
-                "query_sort": SortOptions.DATE,
-            },
+            group_search_view_id=default_view_id,
+            values={"position": 0},
         )
 
         pinned_search = SavedSearch.objects.get(

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -2,6 +2,7 @@ from functools import cached_property
 
 from sentry.api.endpoints.organization_pinned_searches import PINNED_SEARCH_NAME
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 from sentry.testutils.cases import APITestCase
@@ -36,22 +37,20 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             visibility=Visibility.OWNER_PINNED,
         ).exists()
 
-        assert GroupSearchView.objects.filter(
+        # Errors out if no default view is found, inherently verifying existence.
+        default_view = GroupSearchView.objects.get(
             organization=self.organization,
             name="Default Search",
             user_id=self.member.id,
             query=query,
             query_sort=sort,
             position=0,
-        ).exists()
-
-        assert GroupSearchView.objects.filter(
+        )
+        assert GroupSearchViewStarred.objects.filter(
             organization=self.organization,
             user_id=self.member.id,
-            position=1,
-            name="Prioritized",
-            query="is:unresolved issue.priority:[high, medium]",
-            query_sort="date",
+            group_search_view=default_view,
+            position=0,
         ).exists()
 
         query = "test_2"


### PR DESCRIPTION
This PR combines two changes that are somewhat related: 

1. Removes the "Prioritized" view from the list of views persisted when a default search is added. 
2. Writes positions of the newly created groupsearchview to the groupsearchviewstarred table. These tables have gotten out of sync because this endpoint was leaking groupsearchviews without saving them in groupsearchview starred. 

I will need to create another backfill migration to re-sync the two tables after this. 