### PR TITLE
fix(widget-builder): Stop scrolling when widget builder is open

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -1,6 +1,6 @@
 import {type CSSProperties, Fragment, useCallback, useEffect, useState} from 'react';
 import {closestCorners, DndContext, useDraggable, useDroppable} from '@dnd-kit/core';
-import {css, useTheme} from '@emotion/react';
+import {css, Global, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 import cloneDeep from 'lodash/cloneDeep';
@@ -148,6 +148,13 @@ function WidgetBuilderV2({
     <Fragment>
       {isOpen && (
         <Fragment>
+          <Global
+            styles={css`
+              body {
+                overflow: hidden;
+              }
+            `}
+          />
           <Backdrop style={{opacity: 0.5, pointerEvents: 'auto'}} />
           <AnimatePresence>
             {isOpen && (


### PR DESCRIPTION
Applies global styling to the `body` object to prevent scrolling when the widget builder is open. Will be helpful for when we update the cut-off dropdowns to use portals so they overflow properly