### PR TITLE
feat(ourlogs): Add multi-term highlighting

### DIFF
--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -7,13 +7,13 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import LogsTextMultiHighlight from 'sentry/views/explore/logs/logsTextMultiHighlight';
 import {
   CenteredRow,
   ColoredLogCircle,
   ColoredLogText,
   type getLogColors,
   LogDate,
-  LogsHighlight,
   WrappingText,
 } from 'sentry/views/explore/logs/styles';
 import {
@@ -105,11 +105,11 @@ export function TraceIDRenderer(props: LogFieldRendererProps) {
 
 export function LogBodyRenderer(props: LogFieldRendererProps) {
   const attribute_value = props.item.value as string;
-  const highlightTerm = props.extra?.highlightTerms[0] ?? '';
-  // TODO: Allow more than one highlight term to be highlighted at once.
   return (
     <WrappingText wrap={props.extra.wrapBody}>
-      <LogsHighlight text={highlightTerm}>{attribute_value}</LogsHighlight>
+      <LogsTextMultiHighlight terms={props.extra.highlightTerms}>
+        {attribute_value}
+      </LogsTextMultiHighlight>
     </WrappingText>
   );
 }

--- a/static/app/views/explore/logs/logsTextMultiHighlight.spec.tsx
+++ b/static/app/views/explore/logs/logsTextMultiHighlight.spec.tsx
@@ -1,0 +1,58 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import LogsTextMultiHighlight from 'sentry/views/explore/logs/logsTextMultiHighlight';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {getLogBodySearchTerms} from 'sentry/views/explore/logs/utils';
+
+describe('LogsTextMultiHighlight', function () {
+  it('properly escapes regex special characters in search terms', function () {
+    const text =
+      'This is a (text) with [regex] special characters like .* and +? and {curly} braces';
+    const terms = ['(text)', '[regex]', '.*', '+?', '{curly}'];
+
+    render(<LogsTextMultiHighlight terms={terms}>{text}</LogsTextMultiHighlight>);
+
+    terms.forEach(term => {
+      const highlightedElements = screen.getAllByText(term);
+      expect(highlightedElements.length).toBeGreaterThan(0);
+
+      const hasHighlightedSpan = highlightedElements.some(
+        el => el.tagName.toLowerCase() === 'span'
+      );
+      expect(hasHighlightedSpan).toBe(true);
+    });
+  });
+
+  it('handles regex special characters within search terms', function () {
+    const text = 'The error code was [ERR-123+456]';
+    const terms = ['[ERR-123+456]'];
+
+    render(<LogsTextMultiHighlight terms={terms}>{text}</LogsTextMultiHighlight>);
+
+    const highlightedElement = screen.getByText('[ERR-123+456]');
+    expect(highlightedElement.tagName.toLowerCase()).toBe('span');
+  });
+
+  it('highlights terms parsed from complex query with getLogBodySearchTerms', function () {
+    const query = `bareterm ${OurLogKnownFieldKey.BODY}:logbodyterm !bareterm2`;
+    const search = new MutableSearch(query);
+    const terms = getLogBodySearchTerms(search);
+
+    const text = 'This contains bareterm and logbodyterm and !bareterm2';
+
+    render(<LogsTextMultiHighlight terms={terms}>{text}</LogsTextMultiHighlight>);
+
+    expect(terms).toContain('bareterm');
+    expect(terms).toContain('logbodyterm');
+    expect(terms).toContain('!bareterm2');
+
+    terms.forEach(term => {
+      const highlightedElements = screen.getAllByText(term);
+      const hasHighlightedSpan = highlightedElements.some(
+        el => el.tagName.toLowerCase() === 'span'
+      );
+      expect(hasHighlightedSpan).toBe(true);
+    });
+  });
+});

--- a/static/app/views/explore/logs/logsTextMultiHighlight.tsx
+++ b/static/app/views/explore/logs/logsTextMultiHighlight.tsx
@@ -1,0 +1,76 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+type HighlightProps = {
+  /**
+   * The original text
+   */
+  children: string;
+  /**
+   * The terms to highlight
+   */
+  terms: string[];
+  /**
+   * Should highlighting be disabled?
+   */
+  disabled?: boolean;
+};
+
+type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof HighlightProps> &
+  HighlightProps;
+
+function _LogsTextMultiHighlight({className, children, disabled, terms}: Props) {
+  // There are instances when children is not string in breadcrumbs but not caught by TS
+  if (!terms?.length || disabled || typeof children !== 'string') {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  const validTerms = terms.filter(Boolean);
+  if (validTerms.length === 0) {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  // TODO: Replace with 'RegExp.escape' when it's available.
+  const escapedTerms = validTerms.map(term =>
+    term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  );
+
+  const pattern = new RegExp(`(${escapedTerms.join('|')})`, 'gi');
+
+  // Split the text by the pattern
+  const parts = children.split(pattern);
+
+  if (parts.length === 1) {
+    // No matches found
+    return <Fragment>{children}</Fragment>;
+  }
+
+  // Build the result with highlighted sections
+  const result = parts.map((part, index) => {
+    // Check if this part matches any of the terms (case-insensitive)
+    const isMatch = validTerms.some(term => part.toLowerCase() === term.toLowerCase());
+
+    if (isMatch) {
+      return (
+        <span key={index} className={className}>
+          {part}
+        </span>
+      );
+    }
+
+    return part;
+  });
+
+  return <Fragment>{result}</Fragment>;
+}
+
+const LogsTextMultiHighlight = styled(_LogsTextMultiHighlight)`
+  font-weight: ${p => p.theme.fontWeightBold};
+  background-color: ${p => p.theme.gray200};
+  margin-right: 1px;
+  margin-left: 1px;
+  padding-right: 1px;
+  padding-left: 1px;
+`;
+
+export default LogsTextMultiHighlight;

--- a/static/app/views/explore/logs/utils.spec.tsx
+++ b/static/app/views/explore/logs/utils.spec.tsx
@@ -1,0 +1,59 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {getLogBodySearchTerms} from 'sentry/views/explore/logs/utils';
+
+describe('explore/logs/utils', function () {
+  describe('getLogBodySearchTerms', function () {
+    it('splits terms correctly', function () {
+      [
+        {
+          query: 'freetext',
+          expected: ['freetext'],
+        },
+        {
+          query: '*freetext_wrapped_wildcards*',
+          expected: ['freetext_wrapped_wildcards'],
+        },
+        {
+          query: 'foo*bar*baz',
+          expected: ['foo', 'bar', 'baz'],
+        },
+        {
+          query: '*foo*bar*baz*',
+          expected: ['foo', 'bar', 'baz'],
+        },
+        {
+          query: 'double**wildcard',
+          expected: ['double', 'wildcard'],
+        },
+        {
+          query: `freetext ${OurLogKnownFieldKey.BODY}:logbodyterm`,
+          expected: ['freetext', 'logbodyterm'],
+        },
+        {
+          query: `freetext ${OurLogKnownFieldKey.BODY}:*wildbodyterm*`,
+          expected: ['freetext', 'wildbodyterm'],
+        },
+        {
+          query: `freetext ${OurLogKnownFieldKey.BODY}:[logbodyterm,logbodyterm2]`,
+          expected: ['freetext', 'logbodyterm', 'logbodyterm2'],
+        },
+        {
+          query: `freetext ${OurLogKnownFieldKey.BODY}:[logbodyterm,logbodyterm2] !freetext2`,
+          expected: ['freetext', '!freetext2', 'logbodyterm', 'logbodyterm2'],
+        },
+        {
+          query: '*',
+          expected: [],
+        },
+        {
+          query: '',
+          expected: [],
+        },
+      ].forEach(({query, expected}) => {
+        const search = new MutableSearch(query);
+        expect(getLogBodySearchTerms(search)).toEqual(expected);
+      });
+    });
+  });
+});

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -113,11 +113,18 @@ export function severityLevelToText(level: SeverityLevel) {
 }
 
 export function getLogBodySearchTerms(search: MutableSearch): string[] {
-  const searchTerms: string[] = search.freeText.map(text => text.replaceAll('*', ''));
-  const bodyFilters = search.getFilterValues('log.body');
-  for (const filter of bodyFilters) {
-    if (!filter.startsWith('!') && !filter.startsWith('[')) {
-      searchTerms.push(filter);
+  const searchTerms: string[] = search.freeText.flatMap(text =>
+    text.split('*').filter(term => term.length > 0)
+  );
+  const filterTerms: string[] = [];
+  filterTerms.push(...search.getFilterValues(OurLogKnownFieldKey.BODY));
+
+  for (const filter of filterTerms) {
+    if (!filter.startsWith('[')) {
+      searchTerms.push(filter.replaceAll('*', ''));
+    }
+    if (filter.startsWith('[') && filter.endsWith(']')) {
+      searchTerms.push(...filter.slice(1, -1).split(','));
     }
   }
   return searchTerms;


### PR DESCRIPTION
### Summary
This switches to using a log-text specific component for multi term highlighting, with some added tests for premutations of ways of mixing freetext with filter values.



#### Screenshot
![Screenshot 2025-03-10 at 3 03 37 PM](https://github.com/user-attachments/assets/d00b7267-34b0-4bfa-8e49-00ded025fc21)