### PR TITLE
fix(dashboards): Ignore release health widget limit

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -87,7 +87,7 @@ export function WidgetCardDataLoader({
         organization={organization}
         widget={widget}
         selection={selection}
-        limit={widget.limit ?? tableItemLimit}
+        limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
       >


### PR DESCRIPTION
Take 2 of https://github.com/getsentry/sentry/pull/86117

I removed this by accident when fixing a merge conflict.