### PR TITLE
feat(ui): Add a use* hook for features

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -21,7 +21,12 @@ export interface OrganizationSummary {
   avatar: Avatar;
   codecovAccess: boolean;
   dateCreated: string;
-  features: string[];
+  features: Omit<string[], 'includes'> & {
+    /**
+     * @deprecated use useHasFeatures hook instead, or the Feature acl component.
+     */
+    includes: (searchElement: string, fromIndex?: number) => boolean;
+  };
   githubNudgeInvite: boolean;
   githubOpenPRBot: boolean;
   githubPRBot: boolean;

--- a/static/app/utils/useHasFeatures.spec.tsx
+++ b/static/app/utils/useHasFeatures.spec.tsx
@@ -1,0 +1,27 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useHasFeatures} from 'sentry/utils/useHasFeatures';
+import useOrganization from 'sentry/utils/useOrganization';
+
+jest.mock('sentry/utils/useOrganization');
+
+const mockUseOrganization = jest.mocked(useOrganization);
+
+describe('useHasFeatures', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockUseOrganization.mockReturnValue(
+      OrganizationFixture({features: ['feature1', 'feature2']})
+    );
+  });
+  it('returns true if all features are enabled', () => {
+    const {result} = renderHook(() => useHasFeatures(['feature1', 'feature2']));
+    expect(result.current).toBe(true);
+  });
+  it('returns false if any feature is disabled', () => {
+    const {result} = renderHook(() => useHasFeatures(['feature1', 'feature3']));
+    expect(result.current).toBe(false);
+  });
+});

--- a/static/app/utils/useHasFeatures.tsx
+++ b/static/app/utils/useHasFeatures.tsx
@@ -1,0 +1,16 @@
+import {useMemo} from 'react';
+
+import useOrganization from 'sentry/utils/useOrganization';
+
+/**
+ * This accepts a list of feature flags which all must exist for the function to return true.
+ */
+export function useHasFeatures(features: string[]): boolean {
+  const organization = useOrganization();
+  const featureSet = useMemo(
+    () => new Set(organization.features),
+    [organization.features]
+  );
+  const hasAllFeatures = features.every(feature => featureSet.has(feature));
+  return hasAllFeatures;
+}


### PR DESCRIPTION
### Summary
We have hundreds of `useOrganization` hooks just to call features, with which we do `includes` for single features, or might have to do `every` etc. for multiple. It'd be nice QoL to have a standard feature use hook, with which things like our [featureflags util](https://github.com/getsentry/sentry/blob/d9f3eb1874398c66e843a08f18865846b02666ce/static/app/utils/featureFlags.ts) could hook into without having to proxy.


