### PR TITLE
ref(eap): fix cache.hit tests to match actual span data

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2712,14 +2712,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
                 self.create_span(
                     {
                         "description": "get cache 1",
-                        "measurements": {"cache.hit": {"value": 0}},
+                        "data": {"cache.hit": False},
                     },
                     start_ts=self.ten_mins_ago,
                 ),
                 self.create_span(
                     {
                         "description": "get cache 2",
-                        "measurements": {"cache.hit": {"value": 1}},
+                        "data": {"cache.hit": True},
                     },
                     start_ts=self.ten_mins_ago,
                 ),


### PR DESCRIPTION
Although the old test case worked, it is more accurate to place "cache.hit" into the "data" section of the span. This matches what SDKs send us, and it allows us to more nicely define cache.hit