### PR TITLE
feat(trace-eap-waterfall): Supporting search on eap spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -384,6 +384,7 @@ describe('TraceSearchEvaluator', () => {
     });
   });
 
+  // TODO Abdullah Khan: Add eap span tests for self_time/exclusive_time
   describe('eap span', () => {
     it('text filter', async () => {
       const tree = makeTree([makeEAPSpan({op: 'db'}), makeEAPSpan({op: 'http'})]);

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -36,6 +36,24 @@ function makeSpan(overrides: Partial<RawSpanType> = {}): TraceTree.Span {
   };
 }
 
+function makeEAPSpan(overrides: Partial<TraceTree.EAPSpan> = {}): TraceTree.EAPSpan {
+  return {
+    event_id: '',
+    op: '',
+    description: '',
+    start_timestamp: 0,
+    end_timestamp: 10,
+    is_transaction: false,
+    project_id: 1,
+    project_slug: 'project_slug',
+    transaction: '',
+    parent_span_id: null,
+    children: [],
+    duration: 10,
+    ...overrides,
+  } as TraceTree.EAPSpan;
+}
+
 function makeError(overrides: Partial<TraceTree.TraceError> = {}): TraceTree.TraceError {
   return {
     issue_id: 1,
@@ -359,6 +377,72 @@ describe('TraceSearchEvaluator', () => {
 
       const cb = jest.fn();
       search('exclusive_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+  });
+
+  describe('eap span', () => {
+    it('text filter', async () => {
+      const tree = makeTree([makeEAPSpan({op: 'db'}), makeEAPSpan({op: 'http'})]);
+
+      const cb = jest.fn();
+      search('op:db', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('text filter with prefix', async () => {
+      const tree = makeTree([makeEAPSpan({op: 'db'}), makeEAPSpan({op: 'http'})]);
+
+      const cb = jest.fn();
+      search('span.op:db', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('span.duration (milliseconds)', async () => {
+      const tree = makeTree([
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 1}),
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.duration:>500ms', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('span.duration (seconds)', async () => {
+      const tree = makeTree([
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 1}),
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.duration:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('span.total_time', async () => {
+      const tree = makeTree([
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 1}),
+        makeEAPSpan({start_timestamp: 0, end_timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.total_time:>0.5s', tree, cb);
       await waitFor(() => expect(cb).toHaveBeenCalled());
       expect(cb.mock.calls[0][0][1].size).toBe(1);
       expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -13,6 +13,7 @@ import {
 
 import {
   isAutogroupedNode,
+  isEAPSpanNode,
   isSpanNode,
   isTraceErrorNode,
   isTransactionNode,
@@ -471,12 +472,13 @@ function resolveValueFromKey(
 
         if (
           SPAN_DURATION_ALIASES.has(token.key.value) &&
-          isSpanNode(node) &&
+          (isSpanNode(node) || isEAPSpanNode(node)) &&
           node.space
         ) {
           return node.space[1];
         }
 
+        // TODO Abdullah Khan: Add EAPSpanNode support for exclusive_time
         if (
           SPAN_SELF_TIME_ALIASES.has(token.key.value) &&
           isSpanNode(node) &&
@@ -543,7 +545,7 @@ function resolveValueFromKey(
       const [maybeEntity, ...rest] = key.split('.');
       switch (maybeEntity) {
         case 'span':
-          if (isSpanNode(node)) {
+          if (isSpanNode(node) || isEAPSpanNode(node)) {
             // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             return value[rest.join('.')];
           }
@@ -574,14 +576,16 @@ function evaluateNodeFreeText(
   query: string,
   node: TraceTreeNode<TraceTree.NodeValue>
 ): boolean {
-  if (isSpanNode(node)) {
+  if (isSpanNode(node) || isEAPSpanNode(node)) {
     if (node.value.op?.includes(query)) {
       return true;
     }
     if (node.value.description?.includes(query)) {
       return true;
     }
-    if (node.value.span_id && node.value.span_id === query) {
+
+    const spanId = 'span_id' in node.value ? node.value.span_id : node.value.event_id;
+    if (spanId && spanId === query) {
       return true;
     }
   }


### PR DESCRIPTION
<img width="985" alt="Screenshot 2025-03-10 at 4 49 23 PM" src="https://github.com/user-attachments/assets/31ae84c8-ad03-4947-b58b-5789be0f3970" />
