### PR TITLE
ref(tsc): Remove `DeprecatedAsyncView` from `<ReleasesDetail>`

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -129,7 +129,7 @@ function ReleasesDetail({children, releaseMeta}: Props) {
   }, [releaseQuery, deploysQuery, sessionsQuery]);
 
   const isLoading =
-    releaseQuery.isPending || deploysQuery.isLoading || sessionsQuery.isPending;
+    releaseQuery.isPending || deploysQuery.isPending || sessionsQuery.isPending;
 
   const isError =
     releaseQuery.isError ||

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -188,16 +188,16 @@ function ReleasesDetail({children, releaseMeta}: Props) {
           organization={organization}
           release={releaseQuery.data}
           project={project}
-          refetchData={refetchData}
           releaseMeta={releaseMeta}
+          refetchData={refetchData}
         />
-        <ReleaseContext.Provider
+        <ReleaseContext
           value={{
-            refetchData,
             release: releaseQuery.data,
             project,
             deploys: deploysQuery.data || [],
             releaseMeta,
+            refetchData,
             hasHealthData:
               getCount(sessionsQuery.data?.groups, SessionFieldWithOperation.SESSIONS) >
               0,
@@ -205,7 +205,7 @@ function ReleasesDetail({children, releaseMeta}: Props) {
           }}
         >
           {children}
-        </ReleaseContext.Provider>
+        </ReleaseContext>
       </NoProjectMessage>
     </Layout.Page>
   );


### PR DESCRIPTION
This removes `DeprecatedAsyncView` from `<ReleasesDetail>`, follow-up to  https://github.com/getsentry/sentry/pull/86646

Depends on https://github.com/getsentry/sentry/pull/87421
