### PR TITLE
fix(projects): Fix styling for project card header

### DIFF
--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -439,7 +439,6 @@ const StyledIdBadge = styled(IdBadge)`
 const SummaryLinks = styled('div')`
   display: flex;
   position: relative;
-  top: -${space(2)};
   align-items: center;
   font-weight: ${p => p.theme.fontWeightNormal};
 
@@ -447,7 +446,7 @@ const SummaryLinks = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
 
   /* Need to offset for the project icon and margin */
-  margin-left: 40px;
+  margin-left: 24px;
 
   a {
     color: ${p => p.theme.subText};


### PR DESCRIPTION
No idea what changed, but this fixes it

Before:

![CleanShot 2025-03-10 at 14 43 55](https://github.com/user-attachments/assets/f21f8585-208a-44b6-8eb6-d7143b63dc97)

After:

![CleanShot 2025-03-10 at 14 43 47](https://github.com/user-attachments/assets/9b16ec58-1a39-4edc-be78-b2928a27a7bd)
