### PR TITLE
feat(ci): Add logs for devservices after setup

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -125,4 +125,6 @@ runs:
         # have tests listen on the docker gateway ip so loopback can occur
         echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"
 
+        devservices logs
+
         docker ps -a


### PR DESCRIPTION
There are rare instances where devservices setup takes >5 min. This adds logs for devservices after setup to help investigate

Example: https://github.com/getsentry/sentry/actions/runs/13773710313/job/38518081771