### PR TITLE
feat(github-enterprise): Stacktrace linking for GitHub Enterprise

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -15,7 +15,6 @@ from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
-    IntegrationFeatureNotImplementedError,
     IntegrationFeatures,
     IntegrationMetadata,
 )
@@ -212,7 +211,7 @@ class GitHubEnterpriseIntegration(
         ]
 
     def source_url_matches(self, url: str) -> bool:
-        raise IntegrationFeatureNotImplementedError
+        return url.startswith(f"https://{self.model.metadata["domain_name"]}")
 
     def format_source_url(self, repo: Repository, filepath: str, branch: str | None) -> str:
         # Must format the url ourselves since `check_file` is a head request
@@ -220,10 +219,14 @@ class GitHubEnterpriseIntegration(
         return f"{repo.url}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
-        raise IntegrationFeatureNotImplementedError
+        url = url.replace(f"{repo.url}/blob/", "")
+        branch, _, _ = url.partition("/")
+        return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
-        raise IntegrationFeatureNotImplementedError
+        url = url.replace(f"{repo.url}/blob/", "")
+        _, _, source_path = url.partition("/")
+        return source_path
 
     def search_issues(self, query: str | None, **kwargs):
         return self.get_client().search_issues(query)

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -445,3 +445,68 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
                 ),
             )
         ]
+
+    @responses.activate
+    def test_source_url_matches(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = get_installation_of_type(
+            GitHubEnterpriseIntegration, integration, self.organization.id
+        )
+
+        test_cases = [
+            ("https://github.example.org/Test-Organization/foo", True),
+            ("https://github.example.org/Test-Organization/bar", True),
+            ("https://github.example.org/Other-Organization/bar", False),
+            ("https://github.com/Test-Organization/foo", False),
+        ]
+
+        for url, expected in test_cases:
+            assert installation.source_url_matches(url) == expected
+
+    @responses.activate
+    def test_extract_branch_from_source_url(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.example.org/Test-Organization/foo",
+                provider="integrations:github_enterprise",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
+        installation = get_installation_of_type(
+            GitHubEnterpriseIntegration, integration, self.organization.id
+        )
+
+        source_url = "https://github.example.org/Test-Organization/foo/blob/master/src/sentry/integrations/github/integration.py"
+
+        assert installation.extract_branch_from_source_url(repo, source_url) == "master"
+
+    @responses.activate
+    def test_extract_source_path_from_source_url(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.example.org/Test-Organization/foo",
+                provider="integrations:github_enterprise",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
+        installation = get_installation_of_type(
+            GitHubEnterpriseIntegration, integration, self.organization.id
+        )
+
+        source_url = "https://github.example.org/Test-Organization/foo/blob/master/src/sentry/integrations/github/integration.py"
+
+        assert (
+            installation.extract_source_path_from_source_url(repo, source_url)
+            == "src/sentry/integrations/github/integration.py"
+        )


### PR DESCRIPTION
Stacktrace linking support for GitHub Enterprise.

The feature has already been included in the list of features:
https://github.com/getsentry/sentry/blob/e1b27a332bbf6b0f0962b8fed99fec10d68d990d/src/sentry/integrations/github_enterprise/integration.py#L354-L361