### PR TITLE
chore(sentry apps): Add slos for metric alert webhooks

### DIFF
--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -49,7 +49,7 @@ from sentry.sentry_apps.metrics import (
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import json, metrics
+from sentry.utils import json
 from sentry.utils.sentry_apps import send_and_save_webhook_request
 
 if TYPE_CHECKING:
@@ -389,8 +389,6 @@ class DatabaseBackedIntegrationService(IntegrationService):
                 sentry_sdk.capture_exception(e)
                 lifecycle.record_failure(e)
                 return False
-
-            metrics.incr("notifications.sent", instance=sentry_app.slug, skip_internal=False)
 
             try:
                 install = SentryAppInstallation.objects.get(

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -373,9 +373,8 @@ class DatabaseBackedIntegrationService(IntegrationService):
         notification_uuid: str | None = None,
     ) -> bool:
         try:
-            event = SentryAppEventType(
-                f"metric_alert.{INCIDENT_STATUS[IncidentStatus(new_status)].lower()}"
-            )
+            new_status_str = INCIDENT_STATUS[IncidentStatus(new_status)].lower()
+            event = SentryAppEventType(f"metric_alert.{new_status_str}")
         except ValueError as e:
             sentry_sdk.capture_exception(e)
             return False
@@ -406,7 +405,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
 
             app_platform_event = AppPlatformEvent(
                 resource="metric_alert",
-                action=INCIDENT_STATUS[IncidentStatus(new_status)].lower(),
+                action=new_status_str,
                 install=install,
                 data=json.loads(incident_attachment_json),
             )

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -372,7 +372,6 @@ class DatabaseBackedIntegrationService(IntegrationService):
         metric_value: float,
         notification_uuid: str | None = None,
     ) -> bool:
-
         try:
             event = SentryAppEventType(
                 f"metric_alert.{INCIDENT_STATUS[IncidentStatus(new_status)].lower()}"

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -96,7 +96,6 @@ def send_incident_alert_notification(
         incident_attachment_json=json.dumps(incident_attachment),
         metric_value=metric_value,
     )
-
     return success
 
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Generator, Sequence
 from typing import Any
 
+import sentry_sdk
 from django import forms
 
 from sentry.api.serializers import serialize
@@ -87,15 +88,20 @@ def send_incident_alert_notification(
         incident, new_status, metric_value, notification_uuid
     )
 
-    success = integration_service.send_incident_alert_notification(
-        sentry_app_id=action.sentry_app_id,
-        action_id=action.id,
-        incident_id=incident.id,
-        organization_id=organization.id,
-        new_status=new_status.value,
-        incident_attachment_json=json.dumps(incident_attachment),
-        metric_value=metric_value,
-    )
+    try:
+        success = integration_service.send_incident_alert_notification(
+            sentry_app_id=action.sentry_app_id,
+            action_id=action.id,
+            incident_id=incident.id,
+            organization_id=organization.id,
+            new_status=new_status.value,
+            incident_attachment_json=json.dumps(incident_attachment),
+            metric_value=metric_value,
+        )
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        success = False
+
     return success
 
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Generator, Sequence
 from typing import Any
 
-import sentry_sdk
 from django import forms
 
 from sentry.api.serializers import serialize
@@ -88,19 +87,15 @@ def send_incident_alert_notification(
         incident, new_status, metric_value, notification_uuid
     )
 
-    try:
-        success = integration_service.send_incident_alert_notification(
-            sentry_app_id=action.sentry_app_id,
-            action_id=action.id,
-            incident_id=incident.id,
-            organization_id=organization.id,
-            new_status=new_status.value,
-            incident_attachment_json=json.dumps(incident_attachment),
-            metric_value=metric_value,
-        )
-    except Exception as e:
-        sentry_sdk.capture_exception(e)
-        success = False
+    success = integration_service.send_incident_alert_notification(
+        sentry_app_id=action.sentry_app_id,
+        action_id=action.id,
+        incident_id=incident.id,
+        organization_id=organization.id,
+        new_status=new_status.value,
+        incident_attachment_json=json.dumps(incident_attachment),
+        metric_value=metric_value,
+    )
 
     return success
 

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -5,6 +5,13 @@ import responses
 from sentry.incidents.action_handlers import SentryAppActionHandler
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import IncidentStatus
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.sentry_apps.metrics import SentryAppWebhookHaltReason
+from sentry.testutils.asserts import (
+    assert_count_of_metric,
+    assert_halt_metric,
+    assert_success_metric,
+)
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
 
@@ -59,7 +66,8 @@ class SentryAppActionHandlerTest(FireTest):
         )
 
     @responses.activate
-    def test_rule_snoozed(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_rule_snoozed(self, mock_record):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
         self.snooze_rule(alert_rule=alert_rule)
@@ -80,11 +88,82 @@ class SentryAppActionHandlerTest(FireTest):
 
         assert len(responses.calls) == 0
 
-    def test_fire_metric_alert(self):
+        # SLO asserts
+        # PREPARE_WEBHOOK (never got to this point)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=0
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=0
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_rule_bad_response(self, mock_record):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/webhook",
+            status=400,
+            content_type="application/json",
+            body=json.dumps({"ok": "true"}),
+        )
+
+        metric_value = 1000
+        with self.tasks():
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
+
+        assert len(responses.calls) == 1
+
+        # SLO asserts
+        assert_halt_metric(
+            mock_record=mock_record,
+            error_msg=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.GOT_CLIENT_ERROR}_{400}",
+        )
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (halt)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=1
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
+        )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_fire_metric_alert(self, mock_record):
         self.run_fire_test()
 
-    def test_resolve_metric_alert(self):
+        # SLO asserts
+        assert_success_metric(mock_record)
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+        )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_resolve_metric_alert(self, mock_record):
         self.run_fire_test("resolve")
+        # SLO asserts
+        assert_success_metric(mock_record)
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+        )
 
 
 @freeze_time()
@@ -157,14 +236,39 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
             {"name": "teamId", "value": 1},
         ]
 
-    def test_fire_metric_alert(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_fire_metric_alert(self, mock_record):
         self.run_fire_test()
 
-    def test_resolve_metric_alert(self):
+        # SLO asserts
+        assert_success_metric(mock_record)
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+        )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_resolve_metric_alert(self, mock_record):
         self.run_fire_test("resolve")
 
+        # SLO asserts
+        assert_success_metric(mock_record)
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+        )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.analytics.record")
-    def test_alert_sent_recorded(self, mock_record):
+    def test_alert_sent_recorded(self, mock_record, mock_record_event):
         self.run_fire_test()
         mock_record.assert_called_with(
             "alert.sent",
@@ -175,4 +279,15 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
             alert_type="metric_alert",
             external_id=str(self.action.sentry_app_id),
             notification_uuid="",
+        )
+
+        # SLO asserts
+        assert_success_metric(mock_record_event)
+
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record_event, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record_event, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
         )

--- a/tests/sentry/integrations/services/test_integration.py
+++ b/tests/sentry/integrations/services/test_integration.py
@@ -18,8 +18,9 @@ from sentry.integrations.services.integration.serial import (
     serialize_organization_integration,
 )
 from sentry.integrations.types import EventLifecycleOutcome, ExternalProviders
+from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.silo.base import SiloMode
-from sentry.testutils.asserts import assert_count_of_metric, assert_success_metric
+from sentry.testutils.asserts import assert_count_of_metric, assert_failure_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
@@ -334,7 +335,7 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
             sentry_app_id=9876,  # does not exist
             action_id=1,
             incident_id=1,
-            new_status=0,
+            new_status=10,
             metric_value=100,
             organization_id=self.organization.id,
             incident_attachment_json="{}",
@@ -342,12 +343,14 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         assert not result
 
         # SLO asserts
-        assert_success_metric(mock_record)
+        assert_failure_metric(
+            mock_record, SentryApp.DoesNotExist("SentryApp matching query does not exist.")
+        )
 
-        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        # PREPARE_WEBHOOK (failure)
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=1
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+            mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
         )


### PR DESCRIPTION
Metric alerts for sentry apps are not a task but they are triggered by an action handler. 
Flow is

[SentryAppActionHandler](https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/action_handlers.py#L350) -> [send_incident_alert_notification](https://github.com/getsentry/sentry/blob/master/src/sentry/rules/actions/notify_event_service.py#L70) -> [integration_service.send_incident_alert_notification](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/services/integration/impl.py#L358)

We're declaring the `PREPARE_WEBHOOK` context manager in the RPC method (i`ntegration_service.send_incident_alert_notification`) as that's where all the prep happens. However we will capture the exception in the caller (`send_incident_alert_notification`). 