### PR TITLE
fix(inc-1071): Route stale messages to correct topic

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2961,6 +2961,7 @@ KAFKA_TOPIC_OVERRIDES: Mapping[str, str] = {}
 KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "events": "default",
     "ingest-events-dlq": "default",
+    "ingest-events-backlog": "default",
     "snuba-commit-log": "default",
     "transactions": "default",
     "snuba-transactions-commit-log": "default",

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -30,6 +30,7 @@ class Topic(Enum):
     EAP_SPANS_SUBSCRIPTIONS_RESULTS = "eap-spans-subscription-results"
     INGEST_EVENTS = "ingest-events"
     INGEST_EVENTS_DLQ = "ingest-events-dlq"
+    INGEST_EVENTS_BACKLOG = "ingest-events-backlog"
     INGEST_FEEDBACK_EVENTS = "ingest-feedback-events"
     INGEST_FEEDBACK_EVENTS_DLQ = "ingest-feedback-events-dlq"
     INGEST_ATTACHMENTS = "ingest-attachments"

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -323,7 +323,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
             "consumer_type": ConsumerType.Events,
         },
         "dlq_topic": Topic.INGEST_EVENTS_DLQ,
-        "stale_topic": Topic.INGEST_EVENTS_DLQ,
+        "stale_topic": Topic.INGEST_EVENTS_BACKLOG,
     },
     "ingest-feedback-events": {
         "topic": Topic.INGEST_FEEDBACK_EVENTS,


### PR DESCRIPTION
should be `ingest-events-backlog` not `ingest-events-dlq`
