### PR TITLE
fix(ts): Ignore lint errors for CSS container queries

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -112,7 +112,13 @@
     "plugins": [
       // The styled plugin provides language server autocompletion for styled
       // component template strings
-      { "name": "@styled/typescript-styled-plugin" }
+      {
+        "name": "@styled/typescript-styled-plugin",
+        "lint": {
+          "validProperties": ["container-type"],
+          "unknownAtRules": "ignore"
+        }
+      }
     ]
   },
   "include": ["../static/app", "../static/gsApp", "../tests/js"],


### PR DESCRIPTION
Fixes this issue:

![CleanShot 2025-03-10 at 15 38 31](https://github.com/user-attachments/assets/b5143f91-afa8-4084-886e-63d34eefaf0c)

This library is no longer maintained, so we have to configure this manually. See https://github.com/orgs/styled-components/discussions/4160
