### PR TITLE
feat(issue-stream): Use container queries for determining which columns to hide

### DIFF
--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -15,7 +15,7 @@ const IssueStreamHeaderLabel = styled('div')<{breakpoint?: string}>`
   ${p =>
     p.breakpoint &&
     css`
-      @media (max-width: ${p.breakpoint}) {
+      @container (width < ${p.breakpoint}) {
         display: none;
       }
     `}

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -305,7 +305,7 @@ class GroupList extends Component<Props, State> {
 
     return (
       <Fragment>
-        <Panel>
+        <PanelContainer>
           <GroupListHeader
             withChart={!!withChart}
             narrowGroups={narrowGroups}
@@ -347,7 +347,7 @@ class GroupList extends Component<Props, State> {
                   );
                 })}
           </PanelBody>
-        </Panel>
+        </PanelContainer>
         {withPagination && (
           <Pagination pageLinks={pageLinks} onCursor={this.handleCursorChange} />
         )}
@@ -366,4 +366,8 @@ const GroupPlaceholder = styled('div')`
   &:not(:last-child) {
     border-bottom: solid 1px ${p => p.theme.innerBorder};
   }
+`;
+
+const PanelContainer = styled(Panel)`
+  container-type: inline-size;
 `;

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -6,6 +6,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
+import {COLUMN_BREAKPOINTS} from 'sentry/views/issueList/actions/utils';
 
 import type {GroupListColumn} from './groupList';
 
@@ -30,23 +31,39 @@ function GroupListHeader({
       {hasNewLayout ? (
         <Fragment>
           {withColumns.includes('firstSeen') && (
-            <FirstSeenWrapper>{t('First Seen')}</FirstSeenWrapper>
+            <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN}>
+              {t('First Seen')}
+            </FirstSeenWrapper>
           )}
           {withColumns.includes('lastSeen') && (
-            <LastSeenWrapper>{t('Age')}</LastSeenWrapper>
+            <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN}>
+              {t('Age')}
+            </LastSeenWrapper>
           )}
-          {withChart && <NarrowGraphLabel>{t('Graph')}</NarrowGraphLabel>}
+          {withChart && (
+            <NarrowGraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
+              {t('Graph')}
+            </NarrowGraphLabel>
+          )}
           {withColumns.includes('event') && (
-            <NarrowEventsOrUsersLabel>{t('events')}</NarrowEventsOrUsersLabel>
+            <NarrowEventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
+              {t('events')}
+            </NarrowEventsOrUsersLabel>
           )}
           {withColumns.includes('users') && (
-            <NarrowEventsOrUsersLabel>{t('users')}</NarrowEventsOrUsersLabel>
+            <NarrowEventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.USERS}>
+              {t('users')}
+            </NarrowEventsOrUsersLabel>
           )}
           {withColumns.includes('priority') && (
-            <NarrowPriorityLabel>{t('Priority')}</NarrowPriorityLabel>
+            <NarrowPriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>
+              {t('Priority')}
+            </NarrowPriorityLabel>
           )}
           {withColumns.includes('assignee') && (
-            <NarrowAssigneeLabel>{t('Assignee')}</NarrowAssigneeLabel>
+            <NarrowAssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
+              {t('Assignee')}
+            </NarrowAssigneeLabel>
           )}
           {withColumns.includes('lastTriggered') && (
             <NarrowLastTriggeredLabel>{t('Last Triggered')}</NarrowLastTriggeredLabel>
@@ -163,20 +180,12 @@ const NarrowEventsOrUsersLabel = styled(GroupListHeaderLabel)`
   display: flex;
   justify-content: space-between;
   width: 60px;
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    display: none;
-  }
 `;
 
 const NarrowPriorityLabel = styled(GroupListHeaderLabel)`
   display: flex;
   justify-content: space-between;
   width: 70px;
-
-  @media (max-width: ${p => p.theme.breakpoints.large}) {
-    display: none;
-  }
 `;
 
 const NarrowAssigneeLabel = styled(GroupListHeaderLabel)`

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -962,7 +962,7 @@ const NarrowChartWrapper = styled('div')<{breakpoint: string}>`
   align-self: center;
   margin-right: ${space(2)};
 
-  @media (max-width: ${p => p.breakpoint}) {
+  @container (width < ${p => p.breakpoint}) {
     display: none;
   }
 `;
@@ -975,7 +975,7 @@ const LastSeenWrapper = styled('div')<{breakpoint: string}>`
   padding-right: ${space(2)};
   margin-right: ${space(2)};
 
-  @media (max-width: ${p => p.breakpoint}) {
+  @container (width < ${p => p.breakpoint}) {
     display: none;
   }
 `;
@@ -988,7 +988,7 @@ const FirstSeenWrapper = styled('div')<{breakpoint: string}>`
   padding-right: ${space(2)};
   margin-right: ${space(2)};
 
-  @media (max-width: ${p => p.breakpoint}) {
+  @container (width < ${p => p.breakpoint}) {
     display: none;
   }
 `;
@@ -1001,7 +1001,7 @@ const NarrowEventsOrUsersCountsWrapper = styled('div')<{breakpoint: string}>`
   margin-right: ${space(2)};
   width: 60px;
 
-  @media (max-width: ${p => p.breakpoint}) {
+  @container (width < ${p => p.breakpoint}) {
     display: none;
   }
 `;
@@ -1046,7 +1046,7 @@ const NarrowPriorityWrapper = styled('div')<{breakpoint: string}>`
   display: flex;
   justify-content: flex-start;
 
-  @media (max-width: ${p => p.theme.breakpoints.large}) {
+  @container (width < ${p => p.breakpoint}) {
     display: none;
   }
 `;

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -101,13 +101,13 @@ function PreviewTable({
 
   return (
     <Fragment>
-      <Panel>
+      <PanelContainer>
         <GroupListHeader
           withChart={false}
           withColumns={['assignee', 'event', 'lastTriggered', 'users']}
         />
         <PanelBody>{renderBody()}</PanelBody>
-      </Panel>
+      </PanelContainer>
       {renderPagination()}
     </Fragment>
   );
@@ -115,6 +115,10 @@ function PreviewTable({
 
 const StyledPagination = styled(Pagination)`
   margin-top: 0;
+`;
+
+const PanelContainer = styled(Panel)`
+  container-type: inline-size;
 `;
 
 export default PreviewTable;

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -232,10 +232,6 @@ const NarrowPriorityLabel = styled(IssueStreamHeaderLabel)`
   display: flex;
   justify-content: space-between;
   width: 70px;
-
-  @media (max-width: ${p => p.theme.breakpoints.large}) {
-    display: none;
-  }
 `;
 
 const AssigneeLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -4,7 +4,6 @@ import {Alert} from 'sentry/components/core/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct, tn} from 'sentry/locale';
 import {capitalize} from 'sentry/utils/string/capitalize';
-import commonTheme from 'sentry/utils/theme';
 
 import ExtraDescription from './extraDescription';
 
@@ -158,16 +157,15 @@ export function getLabel(numIssues: number, allInQuerySelected: boolean) {
   };
 }
 
-// A mapping of which screen sizes will trigger the column to disappear
+// A mapping of which container sizes will trigger the column to disappear
 // e.g. 'Trend': screen.small => 'Trend' column will disappear on screen.small widths
 export const COLUMN_BREAKPOINTS = {
   ISSUE: undefined, // Issue column is always visible
-  TREND: commonTheme.breakpoints.small,
-  LAST_SEEN: commonTheme.breakpoints.medium,
-  FIRST_SEEN: commonTheme.breakpoints.medium,
-  SEEN: commonTheme.breakpoints.xlarge,
-  EVENTS: commonTheme.breakpoints.medium,
-  USERS: commonTheme.breakpoints.medium,
-  PRIORITY: commonTheme.breakpoints.large,
-  ASSIGNEE: commonTheme.breakpoints.xsmall,
+  TREND: '800px',
+  LAST_SEEN: '500px',
+  FIRST_SEEN: '900px',
+  EVENTS: '700px',
+  USERS: '900px',
+  PRIORITY: '1100px',
+  ASSIGNEE: '500px',
 };

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -74,7 +74,7 @@ function IssueListTable({
     />
   ) : (
     <Fragment>
-      <Panel>
+      <ContainerPanel>
         {groupIds.length !== 0 && (
           <IssueListActions
             selection={selection}
@@ -111,7 +111,7 @@ function IssueListTable({
             />
           </VisuallyCompleteWithData>
         </PanelBody>
-      </Panel>
+      </ContainerPanel>
       <StyledPagination
         caption={paginationCaption}
         pageLinks={pageLinks}
@@ -124,6 +124,10 @@ function IssueListTable({
 
 const StyledPagination = styled(Pagination)`
   margin-top: 0;
+`;
+
+const ContainerPanel = styled(Panel)`
+  container-type: inline-size;
 `;
 
 export default IssueListTable;


### PR DESCRIPTION
This is much more flexible than the current method which uses media breakpoints. Note that this is only applied when the new issues stream layout is enabled.

![CleanShot 2025-03-10 at 15 57 49](https://github.com/user-attachments/assets/afa46a83-f528-457b-9a59-6477948fd734)
![CleanShot 2025-03-10 at 15 57 42](https://github.com/user-attachments/assets/a2c3a3ca-d05f-4ef2-9e49-e1efadcbb190)
![CleanShot 2025-03-10 at 15 57 32](https://github.com/user-attachments/assets/64aab7c7-620b-42ab-b17e-614e82fdf704)
![CleanShot 2025-03-10 at 15 57 22](https://github.com/user-attachments/assets/2f46980b-c0dc-4f04-affe-f4cafb115cee)
