### PR TITLE
fix(sentry app alerts): revert typing for sentry app incident alert RPC method

### DIFF
--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -364,7 +364,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         new_status: int,
         incident_attachment_json: str,
         organization_id: int,
-        metric_value: float,
+        metric_value: float | str | None,
         notification_uuid: str | None = None,
     ) -> bool:
         try:

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -228,7 +228,7 @@ class IntegrationService(RpcService):
         new_status: int,
         incident_attachment_json: str,
         organization_id: int,
-        metric_value: float,
+        metric_value: float | str | None,
         notification_uuid: str | None = None,
     ) -> bool:
         pass


### PR DESCRIPTION
`metric_value` can be None , idk what other types it can be though 🤷 