### PR TITLE
feat(uptime): Add checker to detect broken auto detected monitors and disable them

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1210,6 +1210,11 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute="*/10"),
         "options": {"expires": 10 * 60},
     },
+    "uptime-broken-monitor-checker": {
+        "task": "sentry.uptime.tasks.broken_monitor_checker",
+        "schedule": crontab(minute="0", hour="*/1"),
+        "options": {"expires": 10 * 60},
+    },
     "poll_tempest": {
         "task": "sentry.tempest.tasks.poll_tempest",
         # Run every minute

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1996,6 +1996,7 @@ class Factories:
         name: str | None,
         owner: Actor | None,
         uptime_status: UptimeStatus,
+        uptime_status_update_date: datetime,
     ):
         if name is None:
             name = petname.generate().title()
@@ -2017,6 +2018,7 @@ class Factories:
             owner_team_id=owner_team_id,
             owner_user_id=owner_user_id,
             uptime_status=uptime_status,
+            uptime_status_update_date=uptime_status_update_date,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -739,11 +739,14 @@ class Fixtures:
         name: str | None = None,
         owner: User | Team | None = None,
         uptime_status=UptimeStatus.OK,
+        uptime_status_update_date: datetime | None = None,
     ) -> ProjectUptimeSubscription:
         if project is None:
             project = self.project
         if env is None:
             env = self.environment
+        if uptime_status_update_date is None:
+            uptime_status_update_date = timezone.now()
 
         if uptime_subscription is None:
             uptime_subscription = self.create_uptime_subscription()
@@ -756,6 +759,7 @@ class Fixtures:
             name,
             Actor.from_object(owner) if owner else None,
             uptime_status,
+            uptime_status_update_date,
         )
 
     @pytest.fixture(autouse=True)

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import uuid
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -14,15 +15,22 @@ from redis import StrictRedis
 from rediscluster import RedisCluster
 
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.constants import ObjectStatus
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_kafka
 from sentry.uptime.config_producer import get_partition_keys
-from sentry.uptime.models import UptimeSubscription, UptimeSubscriptionRegion
+from sentry.uptime.models import (
+    ProjectUptimeSubscriptionMode,
+    UptimeStatus,
+    UptimeSubscription,
+    UptimeSubscriptionRegion,
+)
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.uptime.subscriptions.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
+    broken_monitor_checker,
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
     send_uptime_config_deletion,
@@ -477,3 +485,61 @@ class UpdateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         self.assert_redis_config(
             "default", sub, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
         )
+
+
+class BrokenMonitorCheckerTest(UptimeTestCase):
+    def test(self):
+        self.run_test(
+            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeStatus.FAILED,
+            timezone.now() - timedelta(days=8),
+            ObjectStatus.DISABLED,
+            UptimeStatus.OK,
+        )
+
+    def test_manual(self):
+        self.run_test(
+            ProjectUptimeSubscriptionMode.MANUAL,
+            UptimeStatus.FAILED,
+            timezone.now() - timedelta(days=8),
+            ObjectStatus.ACTIVE,
+            UptimeStatus.FAILED,
+        )
+
+    def test_auto_young(self):
+        self.run_test(
+            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeStatus.FAILED,
+            timezone.now() - timedelta(days=4),
+            ObjectStatus.ACTIVE,
+            UptimeStatus.FAILED,
+        )
+
+    def test_auto_not_failed(self):
+        self.run_test(
+            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeStatus.OK,
+            timezone.now() - timedelta(days=8),
+            ObjectStatus.ACTIVE,
+            UptimeStatus.OK,
+        )
+
+    def run_test(
+        self,
+        mode: ProjectUptimeSubscriptionMode,
+        uptime_status: UptimeStatus,
+        update_date: datetime,
+        expected_status: int,
+        expected_uptime_status: UptimeStatus,
+    ):
+        proj_sub = self.create_project_uptime_subscription(
+            mode=mode,
+            uptime_status=uptime_status,
+            uptime_status_update_date=update_date,
+        )
+        with self.tasks():
+            broken_monitor_checker()
+
+        proj_sub.refresh_from_db()
+        assert proj_sub.status == expected_status
+        assert proj_sub.uptime_status == expected_uptime_status


### PR DESCRIPTION
When an autodetected monitor has been broken for longer than a week we just want to disable it, since it's not providing much value and makes it harder to understand our system.

<!-- Describe your PR here. -->