### PR TITLE
chore(react19): Swap JSX global for React.JSX

### DIFF
--- a/static/app/components/collapsePanel.tsx
+++ b/static/app/components/collapsePanel.tsx
@@ -14,7 +14,7 @@ type ChildRenderProps = {
 };
 
 type Props = {
-  children: (props: ChildRenderProps) => JSX.Element;
+  children: (props: ChildRenderProps) => React.JSX.Element;
   items: number;
   buttonTitle?: string;
   collapseCount?: number;

--- a/static/app/components/comboBox/comboBox.stories.tsx
+++ b/static/app/components/comboBox/comboBox.stories.tsx
@@ -26,7 +26,7 @@ const options: Array<ComboBoxOptionOrSection<string>> = [
       <Fragment>
         <strong>{'Option Three (deprecated)'}</strong>
         <Divider />
-        This is a description using JSX.
+        This is a description using React.JSX.
         <Divider />
         <KeyValueTable>
           <KeyValueTableRow keyName="Coffee" value="Black hot drink" />

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -148,7 +148,9 @@ export interface ControlProps
   /**
    * Optional content to display below the menu's header and above the options.
    */
-  menuBody?: React.ReactNode | ((actions: {closeOverlay: () => void}) => JSX.Element);
+  menuBody?:
+    | React.ReactNode
+    | ((actions: {closeOverlay: () => void}) => React.JSX.Element);
   /**
    * Footer to be rendered at the bottom of the menu.
    */

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -44,9 +44,15 @@ export type SelectProps<Value extends SelectKey> =
 
 // A series of TS function overloads to properly parse prop types across 2 dimensions:
 // option value types (number vs string), and selection mode (singular vs multiple)
-function CompactSelect<Value extends number>(props: SelectProps<Value>): JSX.Element;
-function CompactSelect<Value extends string>(props: SelectProps<Value>): JSX.Element;
-function CompactSelect<Value extends SelectKey>(props: SelectProps<Value>): JSX.Element;
+function CompactSelect<Value extends number>(
+  props: SelectProps<Value>
+): React.JSX.Element;
+function CompactSelect<Value extends string>(
+  props: SelectProps<Value>
+): React.JSX.Element;
+function CompactSelect<Value extends SelectKey>(
+  props: SelectProps<Value>
+): React.JSX.Element;
 
 /**
  * Flexible select component with a customizable trigger button

--- a/static/app/components/draggableTabs/item.tsx
+++ b/static/app/components/draggableTabs/item.tsx
@@ -9,4 +9,4 @@ export interface DraggableTabListItemProps extends ItemProps<any> {
   to?: LocationDescriptor;
 }
 
-export const Item = _Item as (props: DraggableTabListItemProps) => JSX.Element;
+export const Item = _Item as (props: DraggableTabListItemProps) => React.JSX.Element;

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -105,7 +105,7 @@ function KeyValueList({
   );
 }
 
-function MultiValueContainer({values}: {values: string[]}): JSX.Element {
+function MultiValueContainer({values}: {values: string[]}): React.JSX.Element {
   return (
     <Fragment>
       {values.map((val, idx) => (

--- a/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
@@ -108,10 +108,10 @@ export function Row({
   extra = null,
 }: {
   children: React.ReactNode;
-  title: JSX.Element | string | null;
+  title: React.JSX.Element | string | null;
   extra?: React.ReactNode;
   keep?: boolean;
-  prefix?: JSX.Element;
+  prefix?: React.JSX.Element;
 }) {
   if (!keep && !children) {
     return null;

--- a/static/app/components/events/interfaces/spans/dragManager.tsx
+++ b/static/app/components/events/interfaces/spans/dragManager.tsx
@@ -47,7 +47,7 @@ export type DragManagerChildrenProps = {
 };
 
 type DragManagerProps = {
-  children: (props: DragManagerChildrenProps) => JSX.Element;
+  children: (props: DragManagerChildrenProps) => React.JSX.Element;
 
   // this is the DOM element where the drag events occur. it's also the reference point
   // for calculating the relative mouse x coordinate.

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -696,10 +696,10 @@ export function Row({
   toolTipText,
 }: {
   children: React.ReactNode;
-  title: JSX.Element | string | null;
+  title: React.JSX.Element | string | null;
   extra?: React.ReactNode;
   keep?: boolean;
-  prefix?: JSX.Element;
+  prefix?: React.JSX.Element;
   toolTipText?: string;
 }) {
   if (!keep && !children) {

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
@@ -292,7 +292,7 @@ class NewTraceDetailsSpanTree extends Component<PropType> {
     isCurrentSpanFilteredOut: boolean;
     isCurrentSpanHidden: boolean;
     outOfViewSpansAbove: EnhancedProcessedSpanType[];
-  }): JSX.Element | null {
+  }): React.JSX.Element | null {
     const {
       isCurrentSpanHidden,
       outOfViewSpansAbove,

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -679,10 +679,10 @@ export function Row({
   extra = null,
 }: {
   children: React.ReactNode;
-  title: JSX.Element | string | null;
+  title: React.JSX.Element | string | null;
   extra?: React.ReactNode;
   keep?: boolean;
-  prefix?: JSX.Element;
+  prefix?: React.JSX.Element;
 }) {
   if (!keep && !children) {
     return null;

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -288,7 +288,7 @@ class SpanTree extends Component<PropType> {
     isCurrentSpanFilteredOut: boolean;
     isCurrentSpanHidden: boolean;
     outOfViewSpansAbove: EnhancedProcessedSpanType[];
-  }): JSX.Element | null {
+  }): React.JSX.Element | null {
     const {
       isCurrentSpanHidden,
       outOfViewSpansAbove,

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -304,7 +304,7 @@ type SpanDescendantNode = {
 };
 
 type SpanMessageNode = {
-  element: JSX.Element;
+  element: React.JSX.Element;
   type: SpanTreeNodeType.MESSAGE;
 };
 

--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -109,7 +109,7 @@ export function SegmentedControl<Value extends string>({
 
 SegmentedControl.Item = Item as <Value extends string>(
   props: SegmentedControlItemProps<Value>
-) => JSX.Element;
+) => React.JSX.Element;
 
 interface SegmentProps<Value extends string>
   extends SegmentedControlItemProps<Value>,

--- a/static/app/components/tabs/item.tsx
+++ b/static/app/components/tabs/item.tsx
@@ -9,4 +9,4 @@ export interface TabListItemProps extends ItemProps<any> {
   to?: LocationDescriptor;
 }
 
-export const Item = _Item as (props: TabListItemProps) => JSX.Element;
+export const Item = _Item as (props: TabListItemProps) => React.JSX.Element;

--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -415,4 +415,4 @@ export {TeamSelector};
 // TODO(davidenwang): this is broken due to incorrect types on react-select
 export default withOrganization(TeamSelector) as unknown as (
   p: Omit<Props, 'organization'>
-) => JSX.Element;
+) => React.JSX.Element;

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -404,9 +404,9 @@ export function ngettext(singular: string, plural: string, ...args: FormatArg[])
 export function gettextComponentTemplate(
   template: string,
   components: ComponentMap
-): JSX.Element {
+): React.JSX.Element {
   const parsedTemplate = parseComponentTemplate(getClient().gettext(template));
-  return mark(renderTemplate(parsedTemplate, components) as JSX.Element);
+  return mark(renderTemplate(parsedTemplate, components) as React.JSX.Element);
 }
 
 /**

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2563,6 +2563,6 @@ export const routes = memoize(buildRoutes);
 // Exported for use in tests.
 export {buildRoutes};
 
-function NoOp({children}: {children: JSX.Element}) {
+function NoOp({children}: {children: React.JSX.Element}) {
   return children;
 }

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -146,7 +146,7 @@ export type IssueTypeConfig = {
    * about the given issue type
    */
   resources: {
-    description: string | JSX.Element;
+    description: string | React.JSX.Element;
     /**
      * Resources to be shown for all platforms
      */

--- a/static/app/utils/oxfordizeArray.tsx
+++ b/static/app/utils/oxfordizeArray.tsx
@@ -27,7 +27,7 @@ export function Oxfordize({children}: Props) {
     );
   }
 
-  const joinedElements: JSX.Element[] = [];
+  const joinedElements: React.JSX.Element[] = [];
   for (const [i, element] of elements.slice(0, -1).entries()) {
     joinedElements.push(<Fragment key={i}>{element}, </Fragment>);
   }

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -18,7 +18,7 @@ import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 
 function isValidComponent(
-  element: JSX.Element
+  element: React.JSX.Element
 ): element is React.ReactElement<any, React.NamedExoticComponent<any>> {
   return typeof element.type !== 'string';
 }
@@ -60,7 +60,7 @@ function withReactRouter3Props(Component: React.ComponentType<any>) {
   return WithReactRouter3Props;
 }
 
-function NoOp({children}: {children: JSX.Element}) {
+function NoOp({children}: {children: React.JSX.Element}) {
   return children;
 }
 
@@ -110,7 +110,7 @@ function getElement(Component: React.ComponentType<any> | undefined) {
  * Transforms a react-router 3 style route tree into a valid react-router 6
  * router tree.
  */
-export function buildReactRouter6Routes(tree: JSX.Element) {
+export function buildReactRouter6Routes(tree: React.JSX.Element) {
   const routes: RouteObject[] = [];
 
   Children.forEach(tree, routeNode => {

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -43,7 +43,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
    * Dataset specific search bar for the 'Filter' step in the
    * widget builder.
    */
-  SearchBar: (props: WidgetBuilderSearchBarProps) => JSX.Element;
+  SearchBar: (props: WidgetBuilderSearchBarProps) => React.JSX.Element;
   /**
    * Default field to add to the widget query when adding a new field.
    */

--- a/static/app/views/dashboards/discoverSplitAlert.tsx
+++ b/static/app/views/dashboards/discoverSplitAlert.tsx
@@ -12,7 +12,7 @@ interface DiscoverSplitAlertProps {
 export function useDiscoverSplitAlert({
   widget,
   onSetTransactionsDataset,
-}: DiscoverSplitAlertProps): JSX.Element | null {
+}: DiscoverSplitAlertProps): React.JSX.Element | null {
   if (
     widget?.datasetSource !== DatasetSource.FORCED ||
     widget?.widgetType !== WidgetType.ERRORS

--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -19,7 +19,7 @@ import WidgetLine from './chartPreviews/line';
 import WidgetBigNumber from './chartPreviews/number';
 import WidgetTable from './chartPreviews/table';
 
-function miniWidget(displayType: DisplayType): () => JSX.Element {
+function miniWidget(displayType: DisplayType): () => React.JSX.Element {
   switch (displayType) {
     case DisplayType.BAR:
       return WidgetBar;

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -18,7 +18,7 @@ import GenericWidgetQueries from './genericWidgetQueries';
 
 type Props = {
   api: Client;
-  children: (props: GenericWidgetQueriesChildrenProps) => JSX.Element;
+  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
   organization: Organization;
   selection: PageFilters;
   widget: Widget;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -37,7 +37,7 @@ import GenericWidgetQueries from './genericWidgetQueries';
 
 type Props = {
   api: Client;
-  children: (props: GenericWidgetQueriesChildrenProps) => JSX.Element;
+  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
   organization: Organization;
   selection: PageFilters;
   widget: Widget;

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -36,7 +36,7 @@ type TableResult = TableData | EventsTableData;
 
 type Props = {
   api: Client;
-  children: (props: GenericWidgetQueriesChildrenProps) => JSX.Element;
+  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
   organization: Organization;
   selection: PageFilters;
   widget: Widget;

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -39,7 +39,7 @@ export function getIsMetricsDataFromSeriesResponse(
 
 type Props = {
   api: Client;
-  children: (props: GenericWidgetQueriesChildrenProps) => JSX.Element;
+  children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
   organization: Organization;
   selection: PageFilters;
   widget: Widget;

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -10,7 +10,7 @@ import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleF
 
 type Props = {
   children: React.ReactNode;
-  button?: JSX.Element;
+  button?: React.JSX.Element;
   className?: string;
   subtitle?: React.ReactNode;
   title?: React.ReactNode;

--- a/static/app/views/insights/common/components/miniChartPanel.tsx
+++ b/static/app/views/insights/common/components/miniChartPanel.tsx
@@ -6,7 +6,7 @@ import textStyles from 'sentry/styles/text';
 
 type Props = {
   children: React.ReactNode;
-  button?: JSX.Element;
+  button?: React.JSX.Element;
   subtitle?: string;
   title?: string;
 };

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
@@ -25,7 +25,7 @@ function getActionLabelAndTextValue({
 }: {
   action: ExternalIssueAction;
   integrationDisplayName: string;
-}): {label: string | JSX.Element; textValue: string} {
+}): {label: string | React.JSX.Element; textValue: string} {
   // If there's no subtext or subtext matches name, just show name
   if (!action.nameSubText || action.nameSubText === action.name) {
     return {

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -34,8 +34,8 @@ export default function getGroupActivityItem(
   const issuesLink = `/organizations/${organization.slug}/issues/`;
 
   function getIgnoredMessage(data: GroupActivitySetIgnored['data']): {
-    message: JSX.Element | string | null;
-    title: JSX.Element | string;
+    message: React.JSX.Element | string | null;
+    title: React.JSX.Element | string;
   } {
     if (data.ignoreDuration) {
       return {
@@ -168,8 +168,8 @@ export default function getGroupActivityItem(
   }
 
   function getEscalatingMessage(data: GroupActivitySetEscalating['data']): {
-    message: JSX.Element | string | null;
-    title: JSX.Element | string;
+    message: React.JSX.Element | string | null;
+    title: React.JSX.Element | string;
   } {
     if (data.forecast) {
       return {
@@ -247,8 +247,8 @@ export default function getGroupActivityItem(
   }
 
   function renderContent(): {
-    message: JSX.Element | string | null;
-    title: JSX.Element | string;
+    message: React.JSX.Element | string | null;
+    title: React.JSX.Element | string;
   } {
     switch (activity.type) {
       case GroupActivityType.NOTE:
@@ -257,7 +257,7 @@ export default function getGroupActivityItem(
           message: activity.data.text,
         };
       case GroupActivityType.SET_RESOLVED: {
-        let resolvedMessage: JSX.Element;
+        let resolvedMessage: React.JSX.Element;
         if ('integration_id' in activity.data && activity.data.integration_id) {
           resolvedMessage = tct('by [author] via [integration]', {
             integration: (

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubNotices.tsx
@@ -61,7 +61,7 @@ export function SolutionsHubNotices({
 }: SolutionsHubNoticesProps) {
   const organization = useOrganization();
   const unreadableRepos = autofixRepositories.filter(repo => repo.is_readable === false);
-  const notices: JSX.Element[] = [];
+  const notices: React.JSX.Element[] = [];
 
   const integrationId = autofixRepositories.find(repo =>
     repo.provider.includes('github')

--- a/static/app/views/organizationContainer.tsx
+++ b/static/app/views/organizationContainer.tsx
@@ -10,7 +10,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 
 interface Props {
-  children: JSX.Element;
+  children: React.JSX.Element;
 }
 
 /**

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -108,7 +108,7 @@ class UsageStatsOrganization<
   }
 
   /** List of components to render on single-project view */
-  get projectDetails(): JSX.Element[] {
+  get projectDetails(): React.JSX.Element[] {
     return [];
   }
 

--- a/static/app/views/performance/landing/widgets/components/dataStateSwitch.tsx
+++ b/static/app/views/performance/landing/widgets/components/dataStateSwitch.tsx
@@ -1,15 +1,15 @@
 import {Fragment} from 'react';
 
 export function DataStateSwitch(props: {
-  dataComponents: JSX.Element[];
-  emptyComponent: JSX.Element;
-  errorComponent: JSX.Element;
+  dataComponents: React.JSX.Element[];
+  emptyComponent: React.JSX.Element;
+  errorComponent: React.JSX.Element;
 
   hasData: boolean;
   isErrored: boolean;
   isLoading: boolean;
-  loadingComponent?: JSX.Element;
-}): JSX.Element {
+  loadingComponent?: React.JSX.Element;
+}): React.JSX.Element {
   if (props.isErrored) {
     return props.errorComponent;
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -289,7 +289,7 @@ const MIN_PCT_DURATION_DIFFERENCE = 10;
 
 type DurationComparison = {
   deltaPct: number;
-  deltaText: JSX.Element;
+  deltaText: React.JSX.Element;
   status: 'faster' | 'slower' | 'equal';
 } | null;
 
@@ -385,10 +385,10 @@ function TableRow({
   toolTipText,
 }: {
   children: React.ReactNode;
-  title: JSX.Element | string | null;
+  title: React.JSX.Element | string | null;
   extra?: React.ReactNode;
   keep?: boolean;
-  prefix?: JSX.Element;
+  prefix?: React.JSX.Element;
   toolTipText?: string;
 }) {
   if (!keep && !children) {

--- a/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
+++ b/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
@@ -10,7 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getTraceDetailsUrl, shouldForceRouteToOldView} from './utils';
 
 type Props = {
-  children: JSX.Element;
+  children: React.JSX.Element;
   event: Event;
 };
 

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -77,7 +77,7 @@ export type ChildProps = {
 };
 
 type Props = {
-  childComponent: (props: ChildProps) => JSX.Element;
+  childComponent: (props: ChildProps) => React.JSX.Element;
   generateEventView: (props: {
     location: Location;
     organization: Organization;

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -957,7 +957,7 @@ class GSBanner extends Component<Props, State> {
     let overquotaPrompt: React.ReactNode;
     let eventTypes: EventType[] = [];
 
-    const eventTypeToElement = (eventType: EventType): JSX.Element => {
+    const eventTypeToElement = (eventType: EventType): React.JSX.Element => {
       const onClick = () => {
         trackGetsentryAnalytics('quota_alert.clicked_link', {
           organization,

--- a/static/gsApp/hooks/orgStatsBanner.tsx
+++ b/static/gsApp/hooks/orgStatsBanner.tsx
@@ -43,7 +43,7 @@ function OrgStatsBanner({organization, subscription, referrer}: Props) {
   const isPaidPlan = subscription.planDetails.price > 0;
   // only show start trial if on a free plan and trial available
   const showStartTrial = !isPaidPlan && subscription.canTrial;
-  const getTextContent = (): [string | JSX.Element, string | JSX.Element] => {
+  const getTextContent = (): [string, string | React.JSX.Element] => {
     const action = getBestActionToIncreaseEventLimits(organization, subscription);
     switch (action) {
       case 'start_trial':


### PR DESCRIPTION
https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript react 19 removes the JSX global type in favor of React.JSX.

part of https://github.com/getsentry/frontend-tsc/issues/68
