### PR TITLE
feat(react19): Remove context from lifecycle methods

### DIFF
--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
 import {Button} from 'sentry/components/button';
-import type {FormContextData} from 'sentry/components/deprecatedforms/formContext';
 import FormContext from 'sentry/components/deprecatedforms/formContext';
 import FormState from 'sentry/components/forms/state';
 import {t} from 'sentry/locale';
@@ -41,9 +40,6 @@ type FormClassState = {
   state: FormState;
 };
 
-// Re-export for compatibility alias.
-export type Context = FormContextData;
-
 class Form<
   Props extends FormProps = FormProps,
   State extends FormClassState = FormClassState,
@@ -62,8 +58,8 @@ class Form<
     ),
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.state = {
       data: {...this.props.initialData},
       errors: {},

--- a/static/app/components/deprecatedforms/formField.tsx
+++ b/static/app/components/deprecatedforms/formField.tsx
@@ -45,21 +45,21 @@ export default abstract class FormField<
     required: false,
   };
 
-  constructor(props: Props, context?: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.state = {
       error: null,
-      value: this.getValue(props, context),
+      value: this.getValue(props, this.context),
     } as State;
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props, nextContext: FormContextData) {
-    const newError = this.getError(nextProps, nextContext);
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    const newError = this.getError(nextProps, this.context);
     if (newError !== this.state.error) {
       this.setState({error: newError});
     }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      const newValue = this.getValue(nextProps, nextContext);
+    if (this.props.value !== nextProps.value || defined(this.context.form)) {
+      const newValue = this.getValue(nextProps, this.context);
       if (newValue !== this.state.value) {
         this.setValue(newValue);
       }

--- a/static/app/components/deprecatedforms/passwordField.tsx
+++ b/static/app/components/deprecatedforms/passwordField.tsx
@@ -1,4 +1,3 @@
-import type {Context} from 'sentry/components/deprecatedforms/form';
 import InputField from 'sentry/components/deprecatedforms/inputField';
 import FormState from 'sentry/components/forms/state';
 
@@ -21,8 +20,8 @@ export default class PasswordField extends InputField<Props, State> {
     prefix: '',
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     this.state = {...this.state, editing: false};
   }

--- a/static/app/components/deprecatedforms/selectCreatableField.tsx
+++ b/static/app/components/deprecatedforms/selectCreatableField.tsx
@@ -19,8 +19,8 @@ import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
 export default class SelectCreatableField extends SelectField {
   options: Array<SelectValue<any>> | undefined;
 
-  constructor(props: any, context: any) {
-    super(props, context);
+  constructor(props: any) {
+    super(props);
 
     // We only want to parse options once because react-select relies
     // on `options` mutation when you create a new option
@@ -29,13 +29,13 @@ export default class SelectCreatableField extends SelectField {
     this.options = this.getOptions(props);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: any, nextContext: any) {
-    const newError = this.getError(nextProps, nextContext);
+  UNSAFE_componentWillReceiveProps(nextProps: any) {
+    const newError = this.getError(nextProps, this.context);
     if (newError !== this.state.error) {
       this.setState({error: newError});
     }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      const newValue = this.getValue(nextProps, nextContext);
+    if (this.props.value !== nextProps.value || defined(this.context.form)) {
+      const newValue = this.getValue(nextProps, this.context);
       // This is the only thing that is different from parent, we compare newValue against coerced value in state
       // To remain compatible with react-select, we need to store the option object that
       // includes `value` and `label`, but when we submit the format, we need to coerce it

--- a/static/app/components/deprecatedforms/selectField.tsx
+++ b/static/app/components/deprecatedforms/selectField.tsx
@@ -19,13 +19,13 @@ export default class SelectField extends FormField<Props> {
     multiple: false,
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps: any, nextContext: any) {
-    const newError = this.getError(nextProps, nextContext);
+  UNSAFE_componentWillReceiveProps(nextProps: any) {
+    const newError = this.getError(nextProps, this.context);
     if (newError !== this.state.error) {
       this.setState({error: newError});
     }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      const newValue = this.getValue(nextProps, nextContext);
+    if (this.props.value !== nextProps.value || defined(this.context.form)) {
+      const newValue = this.getValue(nextProps, this.context);
       // This is the only thing that is different from parent, we compare newValue against coerced value in state
       // To remain compatible with react-select, we need to store the option object that
       // includes `value` and `label`, but when we submit the format, we need to coerce it

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -56,8 +56,8 @@ type State = {
 } & PluginComponentBase['state'];
 
 class IssueActions extends PluginComponentBase<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     this.createIssue = this.onSave.bind(this, this.createIssue.bind(this));
     this.linkIssue = this.onSave.bind(this, this.linkIssue.bind(this));

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -39,8 +39,8 @@ class PluginSettings<
   P extends Props = Props,
   S extends State = State,
 > extends PluginComponentBase<P, S> {
-  constructor(props: P, context: any) {
-    super(props, context);
+  constructor(props: P) {
+    super(props);
 
     Object.assign(this.state, {
       fieldList: null,

--- a/static/app/plugins/jira/components/settings.tsx
+++ b/static/app/plugins/jira/components/settings.tsx
@@ -25,8 +25,8 @@ const PAGE_FIELD_LIST = {
 };
 
 class Settings extends DefaultSettings<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     Object.assign(this.state, {
       page: 0,

--- a/static/app/plugins/pluginComponentBase.tsx
+++ b/static/app/plugins/pluginComponentBase.tsx
@@ -26,8 +26,8 @@ class PluginComponentBase<
   P extends Props = Props,
   S extends State = State,
 > extends Component<P, S> {
-  constructor(props: P, context: any) {
-    super(props, context);
+  constructor(props: P) {
+    super(props);
 
     [
       'onLoadSuccess',

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -26,8 +26,8 @@ export default class Subscriptions extends Component<Props> {
     webhookDisabled: false,
   };
 
-  constructor(props: Props, context: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.context.form.setValue('events', this.props.events);
   }
 


### PR DESCRIPTION
Context is static, no longer supported in react 19 types

part of https://github.com/getsentry/frontend-tsc/issues/68
