### PR TITLE
chore(aci): shadow rollout feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -473,8 +473,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable issue alert metrics for shadow rollout (see: alerts create issues)
-    manager.add("organizations:workflow-engine-issue-alert-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow engine for issue alerts
     manager.add("organizations:workflow-engine-issue-alert-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable firing actions for workflow engine issue alerts

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -475,6 +475,10 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable issue alert metrics for shadow rollout (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable workflow engine for issue alerts
+    manager.add("organizations:workflow-engine-issue-alert-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable firing actions for workflow engine issue alerts
+    manager.add("organizations:workflow-engine-issue-alert-fire-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -474,9 +474,9 @@ def register_temporary_features(manager: FeatureManager):
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow engine for issue alerts
-    manager.add("organizations:workflow-engine-issue-alert-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable firing actions for workflow engine issue alerts
-    manager.add("organizations:workflow-engine-issue-alert-fire-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-trigger-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -478,6 +478,7 @@ def fire_rules(
                     tags={"event_type": groupevent.group.type},
                 )
 
+            # TODO(cathy): add opposite of the FF organizations:workflow-engine-issue-alert-fire-actions
             for callback, futures in callback_and_futures:
                 safe_execute(callback, groupevent, futures)
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -469,7 +469,7 @@ def fire_rules(
                 rule, groupevent, notification_uuid, rule_fire_history
             ).values()
             if features.has(
-                "organizations:workflow-engine-issue-alert-rollout",
+                "organizations:workflow-engine-process-workflows",
                 project.organization,
             ):
                 metrics.incr(
@@ -478,7 +478,7 @@ def fire_rules(
                     tags={"event_type": groupevent.group.type},
                 )
 
-            # TODO(cathy): add opposite of the FF organizations:workflow-engine-issue-alert-fire-actions
+            # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
             for callback, futures in callback_and_futures:
                 safe_execute(callback, groupevent, futures)
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -469,7 +469,7 @@ def fire_rules(
                 rule, groupevent, notification_uuid, rule_fire_history
             ).values()
             if features.has(
-                "organizations:workflow-engine-issue-alert-metrics",
+                "organizations:workflow-engine-issue-alert-rollout",
                 project.organization,
             ):
                 metrics.incr(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -994,7 +994,7 @@ def process_rules(job: PostProcessJob) -> None:
             safe_execute(callback, group_event, futures)
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-metrics",
+            "organizations:workflow-engine-issue-alert-rollout",
             group_event.project.organization,
         ):
             metrics.incr(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -939,7 +939,7 @@ def process_workflow_engine(job: PostProcessJob) -> None:
 
     # TODO: only fire one system. to test, fire from both systems and observe metrics
     if not features.has(
-        "organizations:workflow-engine-issue-alert-rollout", job["event"].project.organization
+        "organizations:workflow-engine-process-workflows", job["event"].project.organization
     ):
         return
 
@@ -988,13 +988,13 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        # TODO(cathy): add opposite of the FF organizations:workflow-engine-issue-alert-fire-actions
+        # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
         for callback, futures in callback_and_futures:
             has_alert = True
             safe_execute(callback, group_event, futures)
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-rollout",
+            "organizations:workflow-engine-process-workflows",
             group_event.project.organization,
         ):
             metrics.incr(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -414,7 +414,7 @@ def fire_actions_for_groups(
         organization = group.project.organization
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-rollout",
+            "organizations:workflow-engine-process-workflows",
             organization,
         ):
             metrics.incr(
@@ -424,7 +424,7 @@ def fire_actions_for_groups(
             )
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-fire-actions",
+            "organizations:workflow-engine-trigger-actions",
             organization,
         ):
             for action in filtered_actions:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -13,7 +13,6 @@ from sentry.db import models
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.rules.conditions.event_frequency import COMPARISON_INTERVALS
 from sentry.rules.processing.buffer_processing import (
@@ -412,8 +411,7 @@ def fire_actions_for_groups(
         filtered_actions.extend(list(evaluate_workflows_action_filters(workflows, job)))
 
         # temporary fetching of organization, so not passing in as parameter
-        if organization is None:
-            organization = group.project.organization
+        organization = group.project.organization
 
         if features.has(
             "organizations:workflow-engine-issue-alert-metrics",

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -414,7 +414,7 @@ def fire_actions_for_groups(
         organization = group.project.organization
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-metrics",
+            "organizations:workflow-engine-issue-alert-rollout",
             organization,
         ):
             metrics.incr(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -390,7 +390,6 @@ def fire_actions_for_groups(
     trigger_type_to_dcg_model: dict[DataConditionHandler.Type, dict[int, int]],
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
-    organization: Organization | None = None
     for group, group_event in group_to_groupevent.items():
         job = WorkflowJob({"event": group_event})
         detector = get_detector_by_event(job)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -157,7 +157,7 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
         actions = evaluate_workflows_action_filters(triggered_workflows, job)
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-rollout",
+            "organizations:workflow-engine-process-workflows",
             organization,
         ):
             metrics.incr(
@@ -168,7 +168,7 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):
         if features.has(
-            "organizations:workflow-engine-issue-alert-fire-actions",
+            "organizations:workflow-engine-trigger-actions",
             organization,
         ):
             for action in actions:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -157,7 +157,7 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
         actions = evaluate_workflows_action_filters(triggered_workflows, job)
 
         if features.has(
-            "organizations:workflow-engine-issue-alert-metrics",
+            "organizations:workflow-engine-issue-alert-rollout",
             organization,
         ):
             metrics.incr(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -12,7 +12,7 @@ from sentry.models.project import Project
 from sentry.rules.conditions.event_frequency import ComparisonType
 from sentry.rules.processing.buffer_processing import process_in_batches
 from sentry.rules.processing.delayed_processing import fetch_project
-from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
@@ -738,6 +738,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert group_to_groupevent == self.group_to_groupevent
 
     @patch("sentry.workflow_engine.models.action.Action.trigger")
+    @with_feature("organizations:workflow-engine-issue-alert-fire-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
         fire_actions_for_groups(
             self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -738,7 +738,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert group_to_groupevent == self.group_to_groupevent
 
     @patch("sentry.workflow_engine.models.action.Action.trigger")
-    @with_feature("organizations:workflow-engine-issue-alert-fire-actions")
+    @with_feature("organizations:workflow-engine-trigger-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
         fire_actions_for_groups(
             self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -153,7 +153,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             tags={"detector_type": self.error_detector.type},
         )
 
-    @with_feature("organizations:workflow-engine-issue-alert-metrics")
+    @with_feature("organizations:workflow-engine-issue-alert-rollout")
     @patch("sentry.utils.metrics.incr")
     def test_metrics_triggered_actions(self, mock_incr):
         # add actions to the workflow

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -153,7 +153,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             tags={"detector_type": self.error_detector.type},
         )
 
-    @with_feature("organizations:workflow-engine-issue-alert-rollout")
+    @with_feature("organizations:workflow-engine-process-workflows")
     @patch("sentry.utils.metrics.incr")
     def test_metrics_triggered_actions(self, mock_incr):
         # add actions to the workflow

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -128,6 +128,7 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
     @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @with_feature("organizations:workflow-engine-issue-alert-rollout")
     def test_workflow_engine__workflows(self):
         """
         This test ensures that the workflow engine is correctly hooked up to tasks/post_process.py.

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -128,7 +128,7 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
     @with_feature("organizations:workflow-engine-metric-alert-processing")
-    @with_feature("organizations:workflow-engine-issue-alert-rollout")
+    @with_feature("organizations:workflow-engine-process-workflows")
     def test_workflow_engine__workflows(self):
         """
         This test ensures that the workflow engine is correctly hooked up to tasks/post_process.py.


### PR DESCRIPTION
`organizations:workflow-engine-process-workflows`
- FF for sending events through workflow engine
- When turned on, will be processing events at the same time as the existing system
- I also removed the distinct flag for metrics, so we always emit metrics for the orgs this is rolled out to

`organizations:workflow-engine-trigger-actions`
- FF for firing actions in workflow engine
- TODO: use the opposite of this flag to gate firing actions in the existing system

The plan (test org)
- Create a new project with 1 dually written issue alert in test org
- Turn on `organizations:workflow-engine-issue-alert-rollout` flag for test org
- Ingest some events to that new project