### PR TITLE
:recycle: ref(aci): don't use `bulk_create` when creating actions

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -114,8 +114,8 @@ def build_notification_actions_from_rule_data_actions(
         actions, skip_failures=not is_dry_run
     )
 
-    # Bulk create the actions if not a dry run
+    # Create the actions if not a dry run
     if not is_dry_run:
-        Action.objects.bulk_create(notification_actions)
-
+        for action in notification_actions:
+            action.save()
     return notification_actions

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -517,10 +517,12 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
     def target_identifier(self) -> str | None:
         target_type = self.action.get(EmailFieldMappingKeys.TARGET_TYPE_KEY.value)
         if target_type in [ActionTargetType.MEMBER.value, ActionTargetType.TEAM.value]:
-            return self.action.get(
-                ACTION_FIELD_MAPPINGS[Action.Type.EMAIL][
-                    ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
-                ]
+            return str(
+                self.action.get(
+                    ACTION_FIELD_MAPPINGS[Action.Type.EMAIL][
+                        ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
+                    ]
+                )
             )
         return None
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -170,7 +170,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             if compare_val in ["None", None, ""]:
                 assert action.config.get("target_identifier") is None
             else:
-                assert action.config.get("target_identifier") == compare_val
+                assert action.config.get("target_identifier") == str(compare_val)
 
         # Assert target_display matches if specified
         if target_display_key:


### PR DESCRIPTION
after we started using `config` to save identifiers on the `Action` model, we need to make sure we don't use `bulk_create` so that the `pre_save` signal works correctly and enforces the schema.

i verified that `save` will also call the signal according to the docs: https://docs.djangoproject.com/en/5.1/ref/models/instances/#what-happens-when-you-save