### PR TITLE
✨ feat(aci): invoke pagerduty metric alert handler from noa

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -1,7 +1,17 @@
+import uuid
 from abc import ABC
 
 import sentry_sdk
 
+from sentry.eventstore.models import GroupEvent
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+)
+from sentry.integrations.pagerduty.utils import send_incident_alert_notification
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.models.organization import Organization
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.types import WorkflowJob
@@ -9,6 +19,28 @@ from sentry.workflow_engine.types import WorkflowJob
 
 class BaseMetricAlertHandler(ABC):
     @classmethod
+    def build_notification_context(cls, action: Action) -> NotificationContext:
+        return NotificationContext.from_action_model(action)
+
+    @classmethod
+    def build_alert_context(cls, detector: Detector, occurrence: IssueOccurrence) -> AlertContext:
+        return AlertContext.from_workflow_engine_models(detector, occurrence)
+
+    @classmethod
+    def build_metric_issue_context(cls, event: GroupEvent) -> MetricIssueContext:
+        return MetricIssueContext.from_group_event(event)
+
+    @classmethod
+    def send_alert(
+        cls,
+        notification_context: NotificationContext,
+        alert_context: AlertContext,
+        metric_issue_context: MetricIssueContext,
+        organization: Organization,
+        notification_uuid: str,
+    ) -> None:
+        raise NotImplementedError
+
     def invoke_legacy_registry(
         cls,
         job: WorkflowJob,
@@ -19,8 +51,43 @@ class BaseMetricAlertHandler(ABC):
         with sentry_sdk.start_span(
             op="workflow_engine.handlers.action.notification.metric_alert.invoke_legacy_registry"
         ):
-            # TODO: Implement this
-            pass
+            event = job["event"]
+            if not event.occurrence:
+                raise ValueError("Event occurrence is required for alert context")
+
+            notification_context = cls.build_notification_context(action)
+            alert_context = cls.build_alert_context(detector, event.occurrence)
+            metric_issue_context = cls.build_metric_issue_context(event)
+
+            notification_uuid = str(uuid.uuid4())
+
+            cls.send_alert(
+                notification_context=notification_context,
+                alert_context=alert_context,
+                metric_issue_context=metric_issue_context,
+                organization=detector.project.organization,
+                notification_uuid=notification_uuid,
+            )
 
 
 metric_alert_handler_registry = Registry[BaseMetricAlertHandler](enable_reverse_lookup=False)
+
+
+@metric_alert_handler_registry.register(Action.Type.PAGERDUTY)
+class PagerDutyMetricAlertHandler(BaseMetricAlertHandler):
+    @classmethod
+    def send_alert(
+        cls,
+        notification_context: NotificationContext,
+        alert_context: AlertContext,
+        metric_issue_context: MetricIssueContext,
+        organization: Organization,
+        notification_uuid: str,
+    ) -> None:
+        send_incident_alert_notification(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            organization=organization,
+            notification_uuid=notification_uuid,
+        )

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -1,0 +1,390 @@
+import uuid
+from collections.abc import Mapping
+from typing import Any
+from unittest import mock
+
+import pytest
+from django.utils import timezone
+
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+)
+from sentry.issues.grouptype import MetricIssuePOC
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.models.group import GroupStatus
+from sentry.models.organization import Organization
+from sentry.snuba.models import SnubaQuery
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.handlers.action.notification.metric_alert import (
+    BaseMetricAlertHandler,
+    PagerDutyMetricAlertHandler,
+)
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowJob
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class TestHandler(BaseMetricAlertHandler):
+    @classmethod
+    def send_alert(
+        cls,
+        notification_context: NotificationContext,
+        alert_context: AlertContext,
+        metric_issue_context: MetricIssueContext,
+        organization: Organization,
+        notification_uuid: str,
+    ) -> None:
+        pass
+
+
+class MetricAlertHandlerBase(BaseWorkflowTest):
+    def create_issue_occurrence(
+        self,
+        initial_issue_priority: int | None = None,
+        level: str = "error",
+        evidence_data: Mapping[str, Any] | None = None,
+    ):
+        if evidence_data is None:
+            evidence_data = {}
+
+        return IssueOccurrence(
+            id=str(uuid.uuid4()),
+            project_id=self.project.id,
+            event_id=str(uuid.uuid4()),
+            fingerprint=["test_fingerprint"],
+            issue_title="test_issue_title",
+            subtitle="test_subtitle",
+            resource_id="test_resource_id",
+            evidence_data=evidence_data,
+            evidence_display=[],
+            type=MetricIssuePOC,
+            detection_time=timezone.now(),
+            level=level,
+            culprit="test_culprit",
+            initial_issue_priority=initial_issue_priority,
+            assignee=None,
+        )
+
+    def assert_notification_context(
+        self,
+        notification_context: NotificationContext,
+        integration_id: int | None = None,
+        target_identifier: str | None = None,
+        target_display: str | None = None,
+        sentry_app_config: list[dict[str, Any]] | dict[str, Any] | None = None,
+        sentry_app_id: str | None = None,
+    ):
+        assert notification_context.integration_id == integration_id
+        assert notification_context.target_identifier == target_identifier
+        assert notification_context.target_display == target_display
+        assert notification_context.sentry_app_config == sentry_app_config
+        assert notification_context.sentry_app_id == sentry_app_id
+
+    def assert_alert_context(
+        self,
+        alert_context: AlertContext,
+        name: str,
+        action_identifier_id: int,
+        threshold_type: AlertRuleThresholdType | None = None,
+        detection_type: AlertRuleDetectionType | None = None,
+        comparison_delta: int | None = None,
+    ):
+        assert alert_context.name == name
+        assert alert_context.action_identifier_id == action_identifier_id
+        assert alert_context.threshold_type == threshold_type
+        assert alert_context.detection_type == detection_type
+        assert alert_context.comparison_delta == comparison_delta
+
+    def assert_metric_issue_context(
+        self,
+        metric_issue_context: MetricIssueContext,
+        open_period_identifier: int,
+        snuba_query: SnubaQuery,
+        new_status: IncidentStatus,
+        metric_value: float | None = None,
+    ):
+        assert metric_issue_context.open_period_identifier == open_period_identifier
+        assert metric_issue_context.snuba_query == snuba_query
+        assert metric_issue_context.new_status == new_status
+        assert metric_issue_context.metric_value == metric_value
+
+
+class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            config={"target_identifier": "channel456"},
+            data={"tags": "environment,user,my_tag"},
+        )
+        self.snuba_query = self.create_snuba_query()
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.handler = TestHandler()
+
+    def test_missing_occurrence_raises_value_error(self):
+        self.job["event"].occurrence = None
+
+        with pytest.raises(ValueError):
+            self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+    def test_get_incident_status(self):
+        # Initial priority is high -> incident is critical
+        group, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+            ),
+        )
+        assert group_event.occurrence is not None
+        assert (
+            MetricIssueContext._get_new_status(group, group_event.occurrence)
+            == IncidentStatus.CRITICAL
+        )
+
+        # Initial priority is medium -> incident is warning
+        group, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                level="warning",
+            ),
+        )
+        assert group_event.occurrence is not None
+        assert (
+            MetricIssueContext._get_new_status(group, group_event.occurrence)
+            == IncidentStatus.WARNING
+        )
+
+        # Resolved group -> incident is closed
+        group, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                level="warning",
+            ),
+        )
+        assert group_event.occurrence is not None
+        # Set the group to resolved -> incident is closed
+        group.status = GroupStatus.RESOLVED
+        assert (
+            MetricIssueContext._get_new_status(group, group_event.occurrence)
+            == IncidentStatus.CLOSED
+        )
+
+    def test_build_notification_context(self):
+        notification_context = self.handler.build_notification_context(self.action)
+        assert isinstance(notification_context, NotificationContext)
+        assert notification_context.target_identifier == "channel456"
+        assert notification_context.integration_id == "1234567890"
+        assert notification_context.sentry_app_config is None
+
+    def test_build_alert_context(self):
+        assert self.group_event.occurrence is not None
+        alert_context = self.handler.build_alert_context(self.detector, self.group_event.occurrence)
+        assert isinstance(alert_context, AlertContext)
+        assert alert_context.name == self.detector.name
+        assert alert_context.action_identifier_id == self.detector.id
+        assert alert_context.threshold_type is None
+        assert alert_context.comparison_delta is None
+
+    def test_get_snuba_query(self):
+        _, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={"snuba_query_id": self.snuba_query.id},
+            ),
+        )
+        assert group_event.occurrence is not None
+        query = MetricIssueContext._get_snuba_query(group_event.occurrence)
+        assert query == self.snuba_query
+
+    def test_get_new_status(self):
+        assert self.group_event.occurrence is not None
+        status = MetricIssueContext._get_new_status(
+            self.group_event.group, self.group_event.occurrence
+        )
+        assert status == IncidentStatus.CRITICAL
+
+        _, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                level="warning",
+                evidence_data={"snuba_query_id": self.snuba_query.id},
+            ),
+        )
+        assert group_event.occurrence is not None
+        status = MetricIssueContext._get_new_status(group_event.group, group_event.occurrence)
+        assert status == IncidentStatus.WARNING
+
+    def test_get_metric_value(self):
+        _, _, group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                level="warning",
+                evidence_data={"metric_value": 123.45},
+            ),
+        )
+        assert group_event.occurrence is not None
+        value = MetricIssueContext._get_metric_value(group_event.occurrence)
+        assert value == 123.45
+
+    @mock.patch.object(TestHandler, "send_alert")
+    def test_invoke_legacy_registry(self, mock_send_alert):
+        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+
+        _, kwargs = mock_send_alert.call_args
+
+        notification_context = kwargs["notification_context"]
+        alert_context = kwargs["alert_context"]
+        metric_issue_context = kwargs["metric_issue_context"]
+        organization = kwargs["organization"]
+        notification_uuid = kwargs["notification_uuid"]
+
+        assert isinstance(notification_context, NotificationContext)
+        assert isinstance(alert_context, AlertContext)
+        assert metric_issue_context == MetricIssueContext.from_group_event(self.group_event)
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    def test_send_alert_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            BaseMetricAlertHandler().send_alert(
+                notification_context=mock.MagicMock(),
+                alert_context=mock.MagicMock(),
+                metric_issue_context=mock.MagicMock(),
+                organization=mock.MagicMock(),
+                notification_uuid="test-uuid",
+            )
+
+
+class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.PAGERDUTY,
+            integration_id=1234567890,
+            config={"target_identifier": "service123"},
+            data={"priority": "P1"},
+        )
+        self.snuba_query = self.create_snuba_query()
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.handler = PagerDutyMetricAlertHandler()
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.metric_alert.send_incident_alert_notification"
+    )
+    def test_send_alert(self, mock_send_incident_alert_notification):
+        notification_context = NotificationContext.from_action_model(self.action)
+        assert self.group_event.occurrence is not None
+        alert_context = AlertContext.from_workflow_engine_models(
+            self.detector, self.group_event.occurrence
+        )
+        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        notification_uuid = str(uuid.uuid4())
+
+        self.handler.send_alert(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            organization=self.detector.project.organization,
+            notification_uuid=notification_uuid,
+        )
+
+        mock_send_incident_alert_notification.assert_called_once_with(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            organization=self.detector.project.organization,
+            notification_uuid=notification_uuid,
+        )
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.metric_alert.PagerDutyMetricAlertHandler.send_alert"
+    )
+    def test_invoke_legacy_registry(self, mock_send_alert):
+        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        _, kwargs = mock_send_alert.call_args
+
+        notification_context = kwargs["notification_context"]
+        alert_context = kwargs["alert_context"]
+        metric_issue_context = kwargs["metric_issue_context"]
+        organization = kwargs["organization"]
+        notification_uuid = kwargs["notification_uuid"]
+
+        assert isinstance(notification_context, NotificationContext)
+        assert isinstance(alert_context, AlertContext)
+        assert isinstance(metric_issue_context, MetricIssueContext)
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="service123",
+            target_display=None,
+            sentry_app_config={"priority": "P1"},
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=None,
+            detection_type=None,
+            comparison_delta=None,
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.group_event.group.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -274,9 +274,29 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         organization = kwargs["organization"]
         notification_uuid = kwargs["notification_uuid"]
 
-        assert isinstance(notification_context, NotificationContext)
-        assert isinstance(alert_context, AlertContext)
-        assert metric_issue_context == MetricIssueContext.from_group_event(self.group_event)
+        self.assert_notification_context(
+            notification_context,
+            integration_id=self.action.integration_id,
+            target_identifier=self.action.config["target_identifier"],
+            target_display=None,
+            sentry_app_config=None,
+            sentry_app_id=None,
+        )
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=None,
+            detection_type=None,
+            comparison_delta=None,
+        )
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.group_event.group.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+        )
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
 
@@ -361,9 +381,6 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         organization = kwargs["organization"]
         notification_uuid = kwargs["notification_uuid"]
 
-        assert isinstance(notification_context, NotificationContext)
-        assert isinstance(alert_context, AlertContext)
-        assert isinstance(metric_issue_context, MetricIssueContext)
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
 
@@ -392,6 +409,3 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,
         )
-
-        assert organization == self.detector.project.organization
-        assert isinstance(notification_uuid, str)

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Mapping
+from dataclasses import asdict
 from typing import Any
 from unittest import mock
 
@@ -93,11 +94,13 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         detection_type: AlertRuleDetectionType | None = None,
         comparison_delta: int | None = None,
     ):
-        assert alert_context.name == name
-        assert alert_context.action_identifier_id == action_identifier_id
-        assert alert_context.threshold_type == threshold_type
-        assert alert_context.detection_type == detection_type
-        assert alert_context.comparison_delta == comparison_delta
+        assert asdict(alert_context) == {
+            "name": name,
+            "action_identifier_id": action_identifier_id,
+            "threshold_type": threshold_type,
+            "detection_type": detection_type,
+            "comparison_delta": comparison_delta,
+        }
 
     def assert_metric_issue_context(
         self,
@@ -107,10 +110,12 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         new_status: IncidentStatus,
         metric_value: float | None = None,
     ):
-        assert metric_issue_context.open_period_identifier == open_period_identifier
-        assert metric_issue_context.snuba_query == snuba_query
-        assert metric_issue_context.new_status == new_status
-        assert metric_issue_context.metric_value == metric_value
+        assert asdict(metric_issue_context) == {
+            "open_period_identifier": open_period_identifier,
+            "snuba_query": snuba_query,
+            "new_status": new_status,
+            "metric_value": metric_value,
+        }
 
 
 class TestBaseMetricAlertHandler(MetricAlertHandlerBase):

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -79,11 +79,13 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         sentry_app_config: list[dict[str, Any]] | dict[str, Any] | None = None,
         sentry_app_id: str | None = None,
     ):
-        assert notification_context.integration_id == integration_id
-        assert notification_context.target_identifier == target_identifier
-        assert notification_context.target_display == target_display
-        assert notification_context.sentry_app_config == sentry_app_config
-        assert notification_context.sentry_app_id == sentry_app_id
+        assert asdict(notification_context) == {
+            "integration_id": integration_id,
+            "target_identifier": target_identifier,
+            "target_display": target_display,
+            "sentry_app_config": sentry_app_config,
+            "sentry_app_id": sentry_app_id,
+        }
 
     def assert_alert_context(
         self,

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -188,6 +188,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         event: Event | None = None,
         occurrence: IssueOccurrence | None = None,
         fingerprint="test_fingerprint",
+        group_type_id: int | None = None,
     ) -> tuple[Group, Event, GroupEvent]:
         project = project or self.project
         event = event or self.create_event(
@@ -196,7 +197,11 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             fingerprint,
         )
 
-        group = self.create_group(project=project)
+        if group_type_id:
+            group = self.create_group(project=project, type=group_type_id)
+        else:
+            group = self.create_group(project=project)
+
         event.for_group(group)
 
         group_event = GroupEvent(


### PR DESCRIPTION
this pr wires up the metric alert pagerduty handler into NOA.
it allows the NOA to build context dataclasses from `Action`, `Detector`, and `WorkflowJob` and pass them down the handler to fire a notification.

i expanded upon the base class, added some utility methods, moved some code around to prevent circular imports.

i also took an attempt in defining roughly on how the data in `evidence_data` will be structured,

still need to update the tests.