### PR TITLE
ref(getting-started-docs): Remove skip and comment from tests

### DIFF
--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -360,9 +360,7 @@ describe('Onboarding Setup Docs', function () {
   });
 
   describe('JS Loader Script', function () {
-    // TODO: This test does not play well with deselected products by default
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('renders Loader Script setup', async function () {
+    it('renders Loader Script setup', async function () {
       const {router, organization, project} = initializeOrg({
         router: {
           location: {

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -535,13 +535,6 @@ describe('ProductSelectionAvailability', function () {
         organization: {
           features: ['performance-view', 'profiling-view'],
         },
-        router: {
-          location: {
-            query: {
-              product: [ProductSolution.PROFILING],
-            },
-          },
-        },
       });
 
       renderMockRequests({planTier: PlanTier.AM2, organization});
@@ -556,14 +549,16 @@ describe('ProductSelectionAvailability', function () {
         }
       );
 
+      await userEvent.click(screen.getByRole('button', {name: 'Profiling'}));
+
       // Performance is added to the query string, so it will be checked
       await waitFor(() => {
         expect(router.replace).toHaveBeenCalledWith(
           expect.objectContaining({
             query: expect.objectContaining({
               product: [
-                ProductSolution.PERFORMANCE_MONITORING,
                 ProductSolution.PROFILING,
+                ProductSolution.PERFORMANCE_MONITORING,
               ],
             }),
           })

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -530,9 +530,7 @@ describe('ProductSelectionAvailability', function () {
       ).toBeInTheDocument();
     });
 
-    // TODO: This test does not play well with deselected products by default
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('enabling Profiling, shall check and "disabled" Tracing', async function () {
+    it('enabling Profiling, shall check and "disabled" Tracing', async function () {
       const {router, organization} = initializeOrg({
         organization: {
           features: ['performance-view', 'profiling-view'],


### PR DESCRIPTION
- Skips and comments were introduced in the PR https://github.com/getsentry/sentry/pull/86395
- With the [[PR](https://github.com/getsentry/sentry/pull/86677)](https://github.com/getsentry/sentry/pull/86677) merged, the tests for "enabling Profiling" and "disabling Tracing" were updated to work with products that aren’t selected by default. This PR updates them and removes the `.skip` + comment.
- The PR also removes the `.skip` from the "renders Loader Script setup" test, as it should work now.