### PR TITLE
feat(laravel-insights): Modals and color indicator

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -1,8 +1,11 @@
 import {Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
 
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
-import {space} from 'sentry/styles/space';
+import {getChartColorPalette} from 'sentry/constants/chartPalette';
+import {IconExpand} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,6 +16,12 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useSpanMetricsTopNSeries} from 'sentry/views/insights/common/queries/useSpanMetricsTopNSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/backend/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 
 export function CachesWidget({query}: {query?: string}) {
@@ -90,68 +99,75 @@ export function CachesWidget({query}: {query?: string}) {
   const hasData =
     cachesRequest.data && cachesRequest.data.data.length > 0 && timeSeries.length > 0;
 
+  const colorPalette = getChartColorPalette(timeSeries.length - 2);
+
+  const visualization = isLoading ? (
+    <TimeSeriesWidgetVisualization.LoadingPlaceholder />
+  ) : error ? (
+    <Widget.WidgetError error={error} />
+  ) : !hasData ? (
+    <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
+  ) : (
+    <TimeSeriesWidgetVisualization
+      plottables={timeSeries
+        .map(convertSeriesToTimeseries)
+        .map((ts, index) => new Line(ts, {color: colorPalette[index]}))}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {cachesRequest.data?.data.map((item, index) => (
+        <Fragment key={item.transaction}>
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <div>
+            <Link
+              to={`/insights/backend/caches?project=${item['project.id']}&transaction=${item.transaction}`}
+            >
+              {item.transaction}
+            </Link>
+          </div>
+          <span>{(item['cache_miss_rate()'] * 100).toFixed(2)}%</span>
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
   return (
     <Widget
-      Title={<Widget.WidgetTitle title="Cache Miss Rates" />}
-      Visualization={
-        isLoading ? (
-          <TimeSeriesWidgetVisualization.LoadingPlaceholder />
-        ) : error ? (
-          <Widget.WidgetError error={error} />
-        ) : !hasData ? (
-          <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
-        ) : (
-          <TimeSeriesWidgetVisualization
-            plottables={timeSeries.map(convertSeriesToTimeseries).map(ts => new Line(ts))}
-          />
-        )
-      }
-      Footer={
+      Title={<Widget.WidgetTitle title={t('Cache Miss Rates')} />}
+      Visualization={visualization}
+      Actions={
         hasData && (
-          <WidgetFooterTable>
-            {cachesRequest.data?.data.map(item => (
-              <Fragment key={item.transaction}>
-                <OverflowCell>
-                  <Link
-                    to={`/insights/backend/caches?project=${item['project.id']}&transaction=${item.transaction}`}
-                  >
-                    {item.transaction}
-                  </Link>
-                </OverflowCell>
-                <span>{(item['cache_miss_rate()'] * 100).toFixed(2)}%</span>
-              </Fragment>
-            ))}
-          </WidgetFooterTable>
+          <Widget.WidgetToolbar>
+            <Button
+              size="xs"
+              aria-label={t('Open Full-Screen View')}
+              borderless
+              icon={<IconExpand />}
+              onClick={() => {
+                openInsightChartModal({
+                  title: t('Cache Miss Rates'),
+                  children: (
+                    <Fragment>
+                      <ModalChartContainer>{visualization}</ModalChartContainer>
+                      <ModalTableWrapper>{footer}</ModalTableWrapper>
+                    </Fragment>
+                  ),
+                });
+              }}
+            />
+          </Widget.WidgetToolbar>
         )
       }
+      noFooterPadding
+      Footer={footer}
     />
   );
 }
-
-const OverflowCell = styled('div')`
-  ${p => p.theme.overflowEllipsis};
-  min-width: 0px;
-`;
-
-const WidgetFooterTable = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  margin: -${space(1)} -${space(2)};
-  font-size: ${p => p.theme.fontSizeSmall};
-
-  & > * {
-    padding: ${space(1)} ${space(1)};
-  }
-
-  & > *:nth-child(2n + 1) {
-    padding-left: ${space(2)};
-  }
-
-  & > *:nth-child(2n) {
-    padding-right: ${space(2)};
-  }
-
-  & > *:not(:nth-last-child(-n + 2)) {
-    border-bottom: 1px solid ${p => p.theme.border};
-  }
-`;

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -1,7 +1,11 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {space} from 'sentry/styles/space';
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
+import {getChartColorPalette} from 'sentry/constants/chartPalette';
+import {IconExpand} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -13,19 +17,29 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/backend/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {ModuleName} from 'sentry/views/insights/types';
 
 interface QueriesDiscoverQueryResponse {
   data: Array<{
+    'avg(span.duration)': number;
     'project.id': string;
     'sentry.normalized_description': string;
     'span.group': string;
     'span.op': string;
-    'sum(span.duration)': number;
     'time_spent_percentage()': number;
     transaction: string;
   }>;
+}
+
+function getSeriesName(item: {'span.group': string; transaction: string}) {
+  return `${item.transaction},${item['span.group']}`;
 }
 
 export function QueriesWidget({query}: {query?: string}) {
@@ -46,11 +60,11 @@ export function QueriesWidget({query}: {query?: string}) {
             'span.group',
             'project.id',
             'sentry.normalized_description',
-            'sum(span.duration)',
+            'avg(span.duration)',
             'transaction',
           ],
           query: `has:db.system !transaction.span_id:00 ${query}`,
-          sort: '-sum(span.duration)',
+          sort: '-avg(span.duration)',
           per_page: 3,
           useRpc: 1,
         },
@@ -66,10 +80,10 @@ export function QueriesWidget({query}: {query?: string}) {
         query: {
           ...pageFilterChartParams,
           dataset: 'spans',
-          field: ['transaction', 'span.group', 'sum(span.duration)'],
-          yAxis: ['sum(span.duration)'],
+          field: ['transaction', 'span.group', 'avg(span.duration)'],
+          yAxis: ['avg(span.duration)'],
           query: `span.group:[${queriesRequest.data?.data.map(item => `"${item['span.group']}"`).join(',')}]`,
-          sort: '-sum(span.duration)',
+          sort: '-avg(span.duration)',
           topEvents: 3,
           useRpc: 1,
         },
@@ -111,82 +125,86 @@ export function QueriesWidget({query}: {query?: string}) {
   const hasData =
     queriesRequest.data && queriesRequest.data.data.length > 0 && timeSeries.length > 0;
 
+  const colorPalette = getChartColorPalette(timeSeries.length - 2);
+
+  const visualization = isLoading ? (
+    <TimeSeriesWidgetVisualization.LoadingPlaceholder />
+  ) : error ? (
+    <Widget.WidgetError error={error} />
+  ) : !hasData ? (
+    <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
+  ) : (
+    <TimeSeriesWidgetVisualization
+      aliases={Object.fromEntries(
+        queriesRequest.data?.data.map(item => [
+          getSeriesName(item),
+          item['sentry.normalized_description'],
+        ]) ?? []
+      )}
+      plottables={timeSeries
+        .map(convertSeriesToTimeseries)
+        .map((ts, index) => new Line(ts, {color: colorPalette[index]}))}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {queriesRequest.data?.data.map((item, index) => (
+        <Fragment key={item['sentry.normalized_description']}>
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <div>
+            <SpanDescriptionCell
+              projectId={Number(item['project.id'])}
+              group={item['span.group']}
+              description={item['sentry.normalized_description']}
+              moduleName={ModuleName.DB}
+            />
+            <ControllerText>{item.transaction}</ControllerText>
+          </div>
+          <span>{getDuration((item['avg(span.duration)'] ?? 0) / 1000, 2, true)}</span>
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
   return (
     <Widget
-      Title={<Widget.WidgetTitle title="Slow Queries" />}
-      Visualization={
-        isLoading ? (
-          <TimeSeriesWidgetVisualization.LoadingPlaceholder />
-        ) : error ? (
-          <Widget.WidgetError error={error} />
-        ) : !hasData ? (
-          <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
-        ) : (
-          <TimeSeriesWidgetVisualization
-            aliases={Object.fromEntries(
-              queriesRequest.data?.data.map(item => [
-                `${item.transaction},${item['span.group']}`,
-                item['sentry.normalized_description'],
-              ]) ?? []
-            )}
-            plottables={timeSeries.map(convertSeriesToTimeseries).map(ts => new Line(ts))}
-          />
+      Title={<Widget.WidgetTitle title={t('Slow Queries')} />}
+      Visualization={visualization}
+      Actions={
+        hasData && (
+          <Widget.WidgetToolbar>
+            <Button
+              size="xs"
+              aria-label={t('Open Full-Screen View')}
+              borderless
+              icon={<IconExpand />}
+              onClick={() => {
+                openInsightChartModal({
+                  title: t('Slow Queries'),
+                  children: (
+                    <Fragment>
+                      <ModalChartContainer>{visualization}</ModalChartContainer>
+                      <ModalTableWrapper>{footer}</ModalTableWrapper>
+                    </Fragment>
+                  ),
+                });
+              }}
+            />
+          </Widget.WidgetToolbar>
         )
       }
       noFooterPadding
-      Footer={
-        hasData && (
-          <WidgetFooterTable>
-            {queriesRequest.data?.data.map(item => (
-              <Fragment key={item['sentry.normalized_description']}>
-                <OverflowCell>
-                  <SpanDescriptionCell
-                    projectId={Number(item['project.id'])}
-                    group={item['span.group']}
-                    description={item['sentry.normalized_description']}
-                    moduleName={ModuleName.DB}
-                  />
-                  <ControllerText>{item.transaction}</ControllerText>
-                </OverflowCell>
-                <span>
-                  {getDuration((item['sum(span.duration)'] ?? 0) / 1000, 2, true)}
-                </span>
-              </Fragment>
-            ))}
-          </WidgetFooterTable>
-        )
-      }
+      Footer={footer}
     />
   );
 }
-
-const OverflowCell = styled('div')`
-  ${p => p.theme.overflowEllipsis};
-  min-width: 0px;
-`;
-
-const WidgetFooterTable = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  font-size: ${p => p.theme.fontSizeSmall};
-
-  & > * {
-    padding: ${space(1)} ${space(1)};
-  }
-
-  & > *:nth-child(2n + 1) {
-    padding-left: ${space(2)};
-  }
-
-  & > *:nth-child(2n) {
-    padding-right: ${space(2)};
-    text-align: right;
-  }
-
-  & > *:not(:nth-last-child(-n + 2)) {
-    border-bottom: 1px solid ${p => p.theme.border};
-  }
-`;
 
 const ControllerText = styled('div')`
   ${p => p.theme.overflowEllipsis};

--- a/static/app/views/insights/pages/backend/laravel/styles.tsx
+++ b/static/app/views/insights/pages/backend/laravel/styles.tsx
@@ -21,11 +21,12 @@ export const WidgetFooterTable = styled('div')`
   }
 
   & > *:nth-child(3n + 1) {
-    padding-left: ${space(1.5)};
+    position: relative;
   }
 
   & > *:nth-child(3n + 2) {
     ${p => p.theme.overflowEllipsis};
+    padding-left: ${space(1.5)};
     min-width: 0px;
   }
 
@@ -40,7 +41,9 @@ export const WidgetFooterTable = styled('div')`
 `;
 
 export const SeriesColorIndicator = styled('div')`
-  width: 3px;
-  height: 100%;
-  flex-shrink: 0;
+  position: absolute;
+  left: -1px;
+  width: 8px;
+  height: 16px;
+  border-radius: 0 3px 3px 0;
 `;

--- a/static/app/views/insights/pages/backend/laravel/styles.tsx
+++ b/static/app/views/insights/pages/backend/laravel/styles.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+import Panel from 'sentry/components/panels/panel';
+import {space} from 'sentry/styles/space';
+
+export const ModalChartContainer = styled('div')`
+  height: 280px;
+`;
+
+export const ModalTableWrapper = styled(Panel)`
+  margin-top: ${space(2)};
+`;
+
+export const WidgetFooterTable = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  & > * {
+    padding: ${space(1)} ${space(0.5)};
+  }
+
+  & > *:nth-child(3n + 1) {
+    padding-left: ${space(1.5)};
+  }
+
+  & > *:nth-child(3n + 2) {
+    ${p => p.theme.overflowEllipsis};
+    min-width: 0px;
+  }
+
+  & > *:nth-child(3n) {
+    padding-right: ${space(2)};
+    text-align: right;
+  }
+
+  & > *:not(:nth-last-child(-n + 3)) {
+    border-bottom: 1px solid ${p => p.theme.border};
+  }
+`;
+
+export const SeriesColorIndicator = styled('div')`
+  width: 3px;
+  height: 100%;
+  flex-shrink: 0;
+`;


### PR DESCRIPTION
Add modals to queries and caches widgets.
Add color indicators to entries in tables to ease matching them with the series in the chart.

<img width="735" alt="Screenshot 2025-03-11 at 09 08 26" src="https://github.com/user-attachments/assets/e6302d19-9564-477f-a374-689f58bacc32" />

![Screenshot 2025-03-11 at 11 34 14](https://github.com/user-attachments/assets/d6465529-7bb8-4185-adb4-fb679fef450e)

- part of https://github.com/getsentry/projects/issues/791