### PR TITLE
fix(integrations): validate new project on code mappings update

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -45,9 +45,14 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         except RepositoryProjectPathConfig.DoesNotExist:
             raise Http404
 
+        if request.data.get("projectId"):
+            kwargs["new_project"] = super().get_project(
+                kwargs["organization"], request.data.get("projectId")
+            )
+
         return (args, kwargs)
 
-    def put(self, request: Request, config_id, organization, config) -> Response:
+    def put(self, request: Request, config_id, organization, config, new_project) -> Response:
         """
         Update a repository project path config
         ``````````````````
@@ -61,7 +66,7 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :param string default_branch:
         :auth: required
         """
-        if not request.access.has_project_access(config.project):
+        if not request.access.has_projects_access([config.project, new_project]):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
@@ -30,6 +30,7 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
             teams=[self.team, self.team2],
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.project2 = self.create_project(organization=self.org, teams=[self.team2], name="Tiger")
         self.integration, self.org_integration = self.create_provider_integration_for(
             self.org, self.user, provider="github", name="Example", external_id="abcd"
         )
@@ -72,6 +73,9 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
         self.create_team_membership(team=self.team, member=non_member_om)
+
+        response = self.make_put({"projectId": self.project2.id, "sourceRoot": "newRoot"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
         response = self.make_put({"sourceRoot": "newRoot"})
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
When updating a code mapping, a user should have project access to the new project of that code mapping.
This PR fixes that.