### PR TITLE
ref(onboarding): Load docs on platform click and do not display deletion confirmation

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -33,7 +33,7 @@ import PageCorners from 'sentry/views/onboarding/components/pageCorners';
 import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import Stepper from './components/stepper';
-import {PlatformSelection} from './platformSelection';
+import {hasDocsOnPlatformClickEnabled, PlatformSelection} from './platformSelection';
 import SetupDocs from './setupDocs';
 import type {StepDescriptor} from './types';
 import TargetedOnboardingWelcome from './welcome';
@@ -75,6 +75,7 @@ function Onboarding(props: Props) {
   const onboardingContext = useContext(OnboardingContext);
   const selectedSDK = onboardingContext.data.selectedSDK;
   const selectedProjectSlug = selectedSDK?.key;
+  const docsOnPlatformClickEnabled = hasDocsOnPlatformClickEnabled(organization);
 
   const {
     params: {step: stepId},
@@ -210,30 +211,33 @@ function Onboarding(props: Props) {
       return;
     }
 
-    const newProjects = Object.keys(onboardingContext.data.projects).reduce(
-      (acc, key) => {
-        if (
-          onboardingContext.data.projects[key]!.slug !==
-          onboardingContext.data.selectedSDK?.key
-        ) {
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          acc[key] = onboardingContext.data.projects[key];
-        }
-        return acc;
-      },
-      {}
-    );
+    const currentProjects = {...onboardingContext.data.projects};
+    const newProjects = Object.keys(currentProjects).reduce((acc, key) => {
+      if (currentProjects[key]!.slug !== onboardingContext.data.selectedSDK?.key) {
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        acc[key] = currentProjects[key];
+      }
+      return acc;
+    }, {});
 
     try {
+      if (docsOnPlatformClickEnabled) {
+        onboardingContext.setData({
+          ...onboardingContext.data,
+          projects: newProjects,
+          selectedSDK: undefined,
+        });
+      } else {
+        onboardingContext.setData({
+          ...onboardingContext.data,
+          projects: newProjects,
+        });
+      }
       await removeProject({
         api,
         orgSlug: organization.slug,
         projectSlug: recentCreatedProject.slug,
         origin: 'onboarding',
-      });
-      onboardingContext.setData({
-        ...onboardingContext.data,
-        projects: newProjects,
       });
 
       trackAnalytics('onboarding.data_removed', {
@@ -243,10 +247,20 @@ function Onboarding(props: Props) {
         project_id: recentCreatedProject.id,
       });
     } catch (error) {
+      onboardingContext.setData({
+        ...onboardingContext.data,
+        projects: currentProjects,
+      });
       handleXhrErrorResponse('Unable to delete project in onboarding', error);
       // we don't give the user any feedback regarding this error as this shall be silent
     }
-  }, [api, organization, recentCreatedProject, onboardingContext]);
+  }, [
+    api,
+    organization,
+    recentCreatedProject,
+    onboardingContext,
+    docsOnPlatformClickEnabled,
+  ]);
 
   const handleGoBack = useCallback(
     (goToStepIndex?: number) => {
@@ -390,11 +404,16 @@ function Onboarding(props: Props) {
             currentStepIndex={stepIndex}
             onClick={i => {
               if ((i as number) < stepIndex && shallProjectBeDeleted) {
-                openConfirmModal({
-                  ...goBackDeletionAlertModalProps,
+                if (docsOnPlatformClickEnabled) {
                   // @ts-expect-error TS(2345): Argument of type 'number | MouseEvent<HTMLDivEleme... Remove this comment to see the full error message
-                  onConfirm: () => handleGoBack(i),
-                });
+                  handleGoBack(i);
+                } else {
+                  openConfirmModal({
+                    ...goBackDeletionAlertModalProps,
+                    // @ts-expect-error TS(2345): Argument of type 'number | MouseEvent<HTMLDivEleme... Remove this comment to see the full error message
+                    onConfirm: () => handleGoBack(i),
+                  });
+                }
                 return;
               }
 
@@ -411,9 +430,16 @@ function Onboarding(props: Props) {
         </UpsellWrapper>
       </Header>
       <Container hasFooter={containerHasFooter}>
-        <Confirm bypass={!shallProjectBeDeleted} {...goBackDeletionAlertModalProps}>
-          <Back animate={stepIndex > 0 ? 'visible' : 'hidden'} />
-        </Confirm>
+        {docsOnPlatformClickEnabled ? (
+          <Back
+            animate={stepIndex > 0 ? 'visible' : 'hidden'}
+            onClick={() => handleGoBack()}
+          />
+        ) : (
+          <Confirm bypass={!shallProjectBeDeleted} {...goBackDeletionAlertModalProps}>
+            <Back animate={stepIndex > 0 ? 'visible' : 'hidden'} />
+          </Confirm>
+        )}
         <AnimatePresence mode="wait" onExitComplete={updateAnimationState}>
           <OnboardingStep
             initial="initial"

--- a/static/app/views/onboarding/platformSelection.tsx
+++ b/static/app/views/onboarding/platformSelection.tsx
@@ -7,12 +7,21 @@ import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext'
 import PlatformPicker from 'sentry/components/platformPicker';
 import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import testableTransition from 'sentry/utils/testableTransition';
 import useOrganization from 'sentry/utils/useOrganization';
+import GenericFooter from 'sentry/views/onboarding/components/genericFooter';
 import StepHeading from 'sentry/views/onboarding/components/stepHeading';
+import {useConfigureSdk} from 'sentry/views/onboarding/useConfigureSdk';
 
 import {CreateProjectsFooter} from './components/createProjectsFooter';
 import type {StepProps} from './types';
+
+export function hasDocsOnPlatformClickEnabled(organization: Organization) {
+  return organization.features.includes(
+    'onboarding-load-docs-on-platform-click-and-silent-delete-on-back'
+  );
+}
 
 export function PlatformSelection(props: StepProps) {
   const organization = useOrganization();
@@ -23,6 +32,12 @@ export function PlatformSelection(props: StepProps) {
       ? onboardingContext.data.selectedSDK
       : undefined
     : undefined;
+
+  const {configureSdk} = useConfigureSdk({
+    onComplete: props.onComplete,
+  });
+
+  const docsOnPlatformClickEnabled = hasDocsOnPlatformClickEnabled(organization);
 
   return (
     <Wrapper>
@@ -48,24 +63,37 @@ export function PlatformSelection(props: StepProps) {
           platform={onboardingContext.data.selectedSDK?.key}
           defaultCategory={onboardingContext.data.selectedSDK?.category}
           setPlatform={platform => {
-            onboardingContext.setData({
-              ...onboardingContext.data,
-              selectedSDK: platform
-                ? {...omit(platform, 'id'), key: platform.id}
-                : undefined,
-            });
+            const selectedSDK = platform
+              ? {...omit(platform, 'id'), key: platform.id}
+              : undefined;
+
+            if (docsOnPlatformClickEnabled) {
+              configureSdk(selectedSDK);
+            } else {
+              onboardingContext.setData({
+                ...onboardingContext.data,
+                selectedSDK,
+              });
+            }
           }}
           organization={organization}
         />
       </motion.div>
-      <CreateProjectsFooter
-        {...props}
-        organization={organization}
-        clearPlatform={() => {
-          onboardingContext.setData({...onboardingContext.data, selectedSDK: undefined});
-        }}
-        selectedPlatform={selectedPlatform}
-      />
+      {docsOnPlatformClickEnabled ? (
+        <GenericFooter>{props.genSkipOnboardingLink()}</GenericFooter>
+      ) : (
+        <CreateProjectsFooter
+          {...props}
+          clearPlatform={() => {
+            onboardingContext.setData({
+              ...onboardingContext.data,
+              selectedSDK: undefined,
+            });
+          }}
+          organization={organization}
+          selectedPlatform={selectedPlatform}
+        />
+      )}
     </Wrapper>
   );
 }

--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -1,0 +1,175 @@
+import {useCallback, useContext} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
+import {openModal} from 'sentry/actionCreators/modal';
+import {createProject} from 'sentry/actionCreators/projects';
+import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
+import {t} from 'sentry/locale';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {
+  OnboardingProjectStatus,
+  type OnboardingSelectedSDK,
+} from 'sentry/types/onboarding';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {useTeams} from 'sentry/utils/useTeams';
+
+/**
+ * A custom hook that loads the "Getting Started" documentation for a selected platform.
+ * If the project for the selected platform doesn't exist, it creates a new one.
+ */
+export function useConfigureSdk({
+  onComplete,
+}: {
+  onComplete: (selectedPlatform: OnboardingSelectedSDK) => void;
+}) {
+  const api = useApi();
+  const {teams} = useTeams();
+  const {projects} = useProjects();
+  const organization = useOrganization();
+  const onboardingContext = useContext(OnboardingContext);
+
+  const createPlatformProject = useCallback(
+    async (selectedPlatform?: OnboardingSelectedSDK) => {
+      if (!selectedPlatform) {
+        return;
+      }
+
+      const createProjectForPlatform: OnboardingSelectedSDK | undefined = projects.find(
+        p => p.slug === selectedPlatform.key
+      )
+        ? undefined
+        : selectedPlatform;
+
+      if (!createProjectForPlatform) {
+        onboardingContext.setData({
+          ...onboardingContext.data,
+          selectedSDK: selectedPlatform,
+        });
+
+        trackAnalytics('growth.onboarding_set_up_your_project', {
+          platform: selectedPlatform.key,
+          organization,
+        });
+
+        onComplete(selectedPlatform);
+        return;
+      }
+
+      try {
+        addLoadingMessage(t('Loading SDK configuration\u2026'));
+
+        const response = (await createProject({
+          api,
+          orgSlug: organization.slug,
+          team: teams[0]!.slug,
+          platform: createProjectForPlatform.key,
+          name: createProjectForPlatform.key,
+          options: {
+            defaultRules: true,
+          },
+        })) as Project;
+
+        ProjectsStore.onCreateSuccess(response, organization.slug);
+
+        // Measure to filter out projects that might have been created during the onboarding and not deleted from the session due to an error
+        // Note: in the onboarding flow the projects are created based on the platform slug
+        const newProjects = Object.keys(onboardingContext.data.projects).reduce(
+          (acc, key) => {
+            if (onboardingContext.data.projects[key]!.slug !== response.slug) {
+              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+              acc[key] = onboardingContext.data.projects[key];
+            }
+            return acc;
+          },
+          {}
+        );
+
+        onboardingContext.setData({
+          selectedSDK: createProjectForPlatform,
+          projects: {
+            ...newProjects,
+            [response.id]: {
+              slug: response.slug,
+              status: OnboardingProjectStatus.WAITING,
+            },
+          },
+        });
+
+        trackAnalytics('growth.onboarding_set_up_your_project', {
+          platform: selectedPlatform.key,
+          organization,
+        });
+
+        clearIndicators();
+        setTimeout(() => onComplete(createProjectForPlatform));
+      } catch (err) {
+        addErrorMessage(t('Failed to load SDK configuration'));
+        Sentry.captureException(err);
+      }
+    },
+    [onboardingContext, api, organization, teams, projects, onComplete]
+  );
+
+  const configureSdk = useCallback(
+    async (selectedPlatform?: OnboardingSelectedSDK) => {
+      if (!selectedPlatform) {
+        return;
+      }
+
+      if (
+        selectedPlatform.type !== 'language' ||
+        !Object.values(SupportedLanguages).includes(
+          selectedPlatform.language as SupportedLanguages
+        )
+      ) {
+        createPlatformProject(selectedPlatform);
+        return;
+      }
+
+      const {FrameworkSuggestionModal, modalCss} = await import(
+        'sentry/components/onboarding/frameworkSuggestionModal'
+      );
+
+      openModal(
+        deps => (
+          <FrameworkSuggestionModal
+            {...deps}
+            organization={organization}
+            selectedPlatform={selectedPlatform}
+            onConfigure={selectedFramework => {
+              createPlatformProject(selectedFramework);
+            }}
+            onSkip={() => createPlatformProject(selectedPlatform)}
+            newOrg
+          />
+        ),
+        {
+          modalCss,
+          onClose: () => {
+            trackAnalytics('onboarding.select_framework_modal_close_button_clicked', {
+              platform: selectedPlatform.key,
+              organization,
+            });
+            onboardingContext.setData({
+              ...onboardingContext.data,
+              selectedSDK: undefined,
+            });
+          },
+        }
+      );
+    },
+    [createPlatformProject, onboardingContext, organization]
+  );
+
+  return {configureSdk};
+}


### PR DESCRIPTION
- closes https://github.com/getsentry/projects/issues/792
- everything new is behind the feature flag "onboarding-load-docs-on-platform-click-and-silent-delete-on-back"
- Related PRs: https://github.com/getsentry/sentry/pull/86769 and https://github.com/getsentry/sentry-options-automator/pull/3302

**Preview**

https://github.com/user-attachments/assets/5f37ea7a-6b27-4f30-8602-4f11aa3213ef


