### PR TITLE
fix(integrations): disallow Opsgenie integration if no business plan

### DIFF
--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -235,7 +235,12 @@ class OpsgenieIntegrationProvider(IntegrationProvider):
     name = "Opsgenie"
     metadata = metadata
     integration_cls = OpsgenieIntegration
-    features = frozenset([IntegrationFeatures.INCIDENT_MANAGEMENT, IntegrationFeatures.ALERT_RULE])
+    features = frozenset(
+        [
+            IntegrationFeatures.ENTERPRISE_INCIDENT_MANAGEMENT,
+            IntegrationFeatures.ENTERPRISE_ALERT_RULE,
+        ]
+    )
 
     def get_pipeline_views(self) -> list[PipelineView]:
         return [InstallationConfigView()]

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -17,6 +17,7 @@ from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 
@@ -221,6 +222,20 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
 
         with pytest.raises(ApiUnauthorized):
             installation.update_organization_config(data)
+
+    @with_feature(
+        {
+            "organizations:integrations-enterprise-alert-rule": False,
+            "organizations:integrations-enterprise-incident-management": False,
+        }
+    )
+    def test_disallow_when_no_business_plan(self):
+        resp = self.client.get(self.init_path)
+        assert resp.status_code == 200
+        assert (
+            b"At least one feature from this list has to be enabled in order to setup the integration"
+            in resp.content
+        )
 
 
 class OpsgenieMigrationIntegrationTest(APITestCase):


### PR DESCRIPTION
The intent of https://github.com/getsentry/sentry/pull/55300 + https://github.com/getsentry/getsentry/pull/11504 was to disallow adding Opsgenie integration on Free or Team plan.

Later, we added backend check for the feature flags https://github.com/getsentry/sentry/pull/63737 but it failed to implement this gate for Opsgenie since that integration had mismatching `OpsgenieIntegrationProvider.metadata.features` and `OpsgenieIntegrationProvider.features`.