### PR TITLE
feat(db): Add metrics to track how often integrity errors happen

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -11,6 +11,8 @@ from django.db.models.expressions import BaseExpression, CombinedExpression, Val
 from django.db.models.fields import Field
 from django.db.models.signals import post_save
 
+from sentry.utils import metrics
+
 if TYPE_CHECKING:
     from sentry.db.models.base import BaseModel
 
@@ -164,6 +166,10 @@ def update_or_create(
         with transaction.atomic(using=using):
             return objects.create(**create_kwargs), True
     except IntegrityError:
+        metrics.incr(
+            "db.models.query.update_or_create.integrity_error",
+            tags={"model": model.__name__},
+        )
         pass
 
     # Retrying the update() here to preserve behavior in a race condition with a concurrent create().
@@ -218,6 +224,10 @@ def create_or_update(
         with transaction.atomic(using=using):
             return objects.create(**create_kwargs), True
     except IntegrityError:
+        metrics.incr(
+            "db.models.query.create_or_update.integrity_error",
+            tags={"model": model.__name__},
+        )
         affected = objects.filter(**kwargs).update(**values)
 
     return affected, False


### PR DESCRIPTION
These metrics will be used to present a case of replacing sentry's in-house `create_or_update` and `update_or_create` with Django's alternatives.