### PR TITLE
issues: fix tag width visual regression

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -277,8 +277,6 @@ const DropdownButton = styled(Button)`
 `;
 
 const StyledTag = styled(Tag)`
-  display: flex;
-  align-items: center;
   gap: ${space(0.25)};
   position: relative;
   height: 24px;


### PR DESCRIPTION
Flex grows space, the default for a tag is inline-flex which does not grow the entire width