### PR TITLE
feat(search-builder): Allow rendering popovers with portals

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -27,6 +27,10 @@ export interface SearchQueryBuilderContextData {
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement>;
   placeholder?: string;
+  /**
+   * The element to render the combobox popovers into.
+   */
+  portalTarget?: HTMLElement | null;
   recentSearches?: SavedSearchType;
 }
 
@@ -51,4 +55,5 @@ export const SearchQueryBuilderContext = createContext<SearchQueryBuilderContext
   disabled: false,
   disallowFreeText: false,
   disallowWildcard: false,
+  portalTarget: null,
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -102,6 +102,10 @@ export interface SearchQueryBuilderProps {
    */
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
+  /**
+   * If provided, will render the combobox popovers into the given element.
+   */
+  portalTarget?: HTMLElement | null;
   queryInterface?: QueryInterfaceType;
   /**
    * If provided, saves and displays recent searches of the given type.
@@ -197,6 +201,7 @@ export function SearchQueryBuilder({
   showUnsubmittedIndicator,
   trailingItems,
   getFilterTokenWarning,
+  portalTarget,
 }: SearchQueryBuilderProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -270,6 +275,7 @@ export function SearchQueryBuilder({
       recentSearches,
       searchSource,
       size,
+      portalTarget,
     };
   }, [
     state,
@@ -288,6 +294,7 @@ export function SearchQueryBuilder({
     recentSearches,
     searchSource,
     size,
+    portalTarget,
   ]);
 
   return (

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -104,6 +104,9 @@ export interface SearchQueryBuilderProps {
   placeholder?: string;
   /**
    * If provided, will render the combobox popovers into the given element.
+   * This is useful when the search query builder is rendered as a child of an
+   * element that has CSS styling that prevents popovers from overflowing, e.g.
+   * a scrollable container.
    */
   portalTarget?: HTMLElement | null;
   queryInterface?: QueryInterfaceType;

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -120,6 +120,7 @@ export type CustomComboboxMenuProps<T> = {
   overlayProps: OverlayProps;
   popoverRef: React.RefObject<HTMLDivElement>;
   state: ComboBoxState<T>;
+  portalTarget?: HTMLElement | null;
 };
 
 export type CustomComboboxMenu<T> = (
@@ -247,6 +248,7 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   popoverRef,
   state,
   overlayProps,
+  portalTarget,
 }: {
   filterValue: string;
   hiddenOptions: Set<SelectKey>;
@@ -257,6 +259,7 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   popoverRef: React.RefObject<HTMLDivElement>;
   state: ComboBoxState<any>;
   customMenu?: CustomComboboxMenu<T>;
+  portalTarget?: HTMLElement | null;
 }) {
   if (customMenu) {
     return customMenu({
@@ -268,6 +271,7 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
       state,
       overlayProps,
       filterValue,
+      portalTarget,
     });
   }
 
@@ -322,7 +326,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   }: SearchQueryBuilderComboboxProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) {
-  const {disabled} = useSearchQueryBuilder();
+  const {disabled, portalTarget} = useSearchQueryBuilder();
   const listBoxRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -546,6 +550,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
         popoverRef={popoverRef}
         state={state}
         overlayProps={overlayProps}
+        portalTarget={portalTarget}
       />
     </Wrapper>
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {isMac} from '@react-aria/utils';
 
@@ -16,6 +17,7 @@ interface ValueListBoxProps<T> extends CustomComboboxMenuProps<T> {
   isLoading: boolean;
   isMultiSelect: boolean;
   items: T[];
+  portalTarget?: HTMLElement | null;
 }
 
 function Footer({
@@ -52,6 +54,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
   isMultiSelect,
   items,
   canUseWildcard,
+  portalTarget,
 }: ValueListBoxProps<T>) {
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
@@ -63,7 +66,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
     return null;
   }
 
-  return (
+  const valueListBoxContent = (
     <StyledPositionWrapper {...overlayProps} visible={isOpen}>
       <SectionedOverlay ref={popoverRef}>
         {isLoading && hiddenOptions.size >= totalOptions ? (
@@ -90,6 +93,12 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
       </SectionedOverlay>
     </StyledPositionWrapper>
   );
+
+  if (portalTarget) {
+    return createPortal(valueListBoxContent, portalTarget);
+  }
+
+  return valueListBoxContent;
 }
 
 const SectionedOverlay = styled(Overlay)`

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -290,7 +290,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   setSelectedSection,
   overlayProps,
 }: FilterKeyListBoxProps<T>) {
-  const {filterKeyMenuWidth, wrapperRef, query} = useSearchQueryBuilder();
+  const {filterKeyMenuWidth, wrapperRef, query, portalTarget} = useSearchQueryBuilder();
 
   // Add recent filters to hiddenOptions so they don't show up the ListBox component.
   // We render recent filters manually in the RecentFiltersPane component.
@@ -360,7 +360,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
     );
   }
 
-  return (
+  const filterKeyListBoxContent = (
     <StyledPositionWrapper {...overlayProps} visible={isOpen}>
       <SectionedOverlay ref={popoverRef} width={filterKeyMenuWidth}>
         {isOpen ? (
@@ -379,6 +379,12 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
       </SectionedOverlay>
     </StyledPositionWrapper>
   );
+
+  if (portalTarget) {
+    return createPortal(filterKeyListBoxContent, portalTarget);
+  }
+
+  return filterKeyListBoxContent;
 }
 
 const SectionedOverlay = styled(Overlay, {


### PR DESCRIPTION
Exposes a portalTarget prop in the context so popovers can render out of the current DOM hierarchy. This is useful because if a search component is part of a child that has overflow: auto, we can render the popover through a different part of the DOM (e.g. document.body), so the popover isn't affected by overflow issues.
