### PR TITLE
fix(relocation) Relax step ordering for relocations

### DIFF
--- a/src/sentry/relocation/api/endpoints/abort.py
+++ b/src/sentry/relocation/api/endpoints/abort.py
@@ -15,7 +15,7 @@ ERR_NOT_ABORTABLE_STATUS = (
     "Relocations can only be cancelled if they are not yet complete; this relocation is `SUCCESS`."
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/cancel.py
+++ b/src/sentry/relocation/api/endpoints/cancel.py
@@ -26,7 +26,7 @@ ERR_COULD_NOT_CANCEL_RELOCATION_AT_STEP = Template(
     started."""
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/details.py
+++ b/src/sentry/relocation/api/endpoints/details.py
@@ -11,7 +11,7 @@ from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.relocation.models.relocation import Relocation
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/index.py
+++ b/src/sentry/relocation/api/endpoints/index.py
@@ -47,7 +47,7 @@ ERR_THROTTLED_RELOCATION = (
 )
 ERR_UNKNOWN_RELOCATION_STATUS = Template("`$status` is not a valid relocation status.")
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 RELOCATION_FILE_SIZE_SMALL = 10 * 1024**2
 RELOCATION_FILE_SIZE_MEDIUM = 100 * 1024**2

--- a/src/sentry/relocation/api/endpoints/pause.py
+++ b/src/sentry/relocation/api/endpoints/pause.py
@@ -26,7 +26,7 @@ ERR_COULD_NOT_PAUSE_RELOCATION = (
     "Could not pause relocation, perhaps because it is no longer in-progress."
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/public_key.py
+++ b/src/sentry/relocation/api/endpoints/public_key.py
@@ -13,7 +13,7 @@ from sentry.backup.crypto import GCPKMSEncryptor, get_default_crypto_key_version
 from sentry.relocation.api.endpoints import ERR_FEATURE_DISABLED
 from sentry.utils.env import log_gcp_credentials_details
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/recover.py
+++ b/src/sentry/relocation/api/endpoints/recover.py
@@ -28,7 +28,7 @@ ERR_COULD_NOT_RECOVER_RELOCATION = (
     "Could not recover relocation, perhaps because it is no longer in a failed state."
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/retry.py
+++ b/src/sentry/relocation/api/endpoints/retry.py
@@ -34,7 +34,7 @@ ERR_FILE_NO_LONGER_EXISTS = (
     "The relocation file no longer exists, probably due to data retention requirements."
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/api/endpoints/unpause.py
+++ b/src/sentry/relocation/api/endpoints/unpause.py
@@ -23,7 +23,7 @@ ERR_NOT_UNPAUSABLE_STATUS = Template(
     `$status`."""
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 @region_silo_endpoint

--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -29,7 +29,7 @@ from sentry.relocation.tasks.transfer import process_relocation_transfer_control
 from sentry.relocation.utils import RELOCATION_BLOB_SIZE, RELOCATION_FILE_TYPE
 from sentry.utils.db import atomic_transaction
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation")
 
 
 class DBBackedRelocationExportService(RegionRelocationExportService):

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -83,7 +83,7 @@ from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 from sentry.utils.env import gcp_project_id, log_gcp_credentials_details
 
-logger = logging.getLogger("sentry.relocation.tasks")
+logger = logging.getLogger("sentry.relocation")
 
 # Time limits for various steps in the process.
 RETRY_BACKOFF = 60  # So the 1st retry is after ~1 min, 2nd after ~2 min, 3rd after ~4 min, etc.

--- a/src/sentry/relocation/tasks/transfer.py
+++ b/src/sentry/relocation/tasks/transfer.py
@@ -22,7 +22,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.region import get_local_region
 
-logger = logging.getLogger("sentry.relocation.tasks")
+logger = logging.getLogger("sentry.relocation")
 
 
 @instrumented_task(
@@ -98,6 +98,8 @@ def process_relocation_transfer_control(transfer_id: int) -> None:
         return
     log_context["state"] = transfer.state
     log_context["relocation_uuid"] = str(transfer.relocation_uuid)
+
+    logger.info("relocation.transfer.processing", extra=log_context)
 
     if transfer.state == RelocationTransferState.Request:
         public_key = transfer.public_key or b""
@@ -191,6 +193,8 @@ def process_relocation_transfer_region(transfer_id: int) -> None:
 
     log_context["state"] = transfer.state
     log_context["relocation_uuid"] = uuid
+
+    logger.info("relocation.transfer.processing", extra=log_context)
 
     if transfer.state == RelocationTransferState.Reply:
         relocation_storage = get_relocation_storage()


### PR DESCRIPTION
Instead of failing a relocation when a task is retried out of order, we should leave the relocation alone as it could still make progress.

I've also aligned all the logger names so that debugging relocations is less tedious.