### PR TITLE
fix(taskworker) Consolidate and expand client metrics

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -387,7 +387,6 @@ class TaskWorker:
             if not self._child_tasks.full():
                 fetch_next = FetchNextTask(namespace=self._namespace)
 
-            metrics.incr("taskworker.worker.fetch_next", tags={"next": fetch_next is not None})
             logger.debug(
                 "taskworker.workers._send_result",
                 extra={"task_id": result.task_id, "next": fetch_next is not None},
@@ -453,22 +452,16 @@ class TaskWorker:
         try:
             activation = self.client.get_task(self._namespace)
         except grpc.RpcError as e:
-            metrics.incr("taskworker.worker.fetch_task", tags={"status": "failed"})
             logger.info("taskworker.fetch_task.failed", extra={"error": e})
             return None
 
         if not activation:
-            metrics.incr("taskworker.worker.fetch_task", tags={"status": "notfound"})
             logger.debug("taskworker.fetch_task.not_found")
 
             self.backoff_sleep_seconds = min(self.backoff_sleep_seconds + 1, 10)
             time.sleep(self.backoff_sleep_seconds)
             return None
 
-        metrics.incr(
-            "taskworker.worker.fetch_task",
-            tags={"status": "success", "namespace": activation.namespace},
-        )
         self.backoff_sleep_seconds = 0
         self._task_receive_timing[activation.id] = time.time()
         return activation


### PR DESCRIPTION
We want to know how many RPC operations are failing from the worker perspective as this will feed into an SLO for taskbrokers.