### PR TITLE
chore(ppf): Stop sending group states from the post process forwarder

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -69,7 +69,6 @@ class EventStream(Service):
         primary_hash: str | None,
         queue: str,
         skip_consume: bool = False,
-        group_states: GroupStates | None = None,
         occurrence_id: str | None = None,
         eventstream_type: str | None = None,
     ) -> None:
@@ -86,7 +85,6 @@ class EventStream(Service):
                     "primary_hash": primary_hash,
                     "cache_key": cache_key,
                     "group_id": group_id,
-                    "group_states": group_states,
                     "occurrence_id": occurrence_id,
                     "project_id": project_id,
                     "eventstream_type": eventstream_type,
@@ -136,7 +134,6 @@ class EventStream(Service):
             primary_hash,
             self._get_queue_for_post_process(event),
             skip_consume,
-            group_states,
             occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
             eventstream_type=eventstream_type,
         )

--- a/src/sentry/eventstream/kafka/dispatch.py
+++ b/src/sentry/eventstream/kafka/dispatch.py
@@ -8,7 +8,6 @@ from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.types import Message
 
 from sentry import options
-from sentry.eventstream.base import GroupStates
 from sentry.eventstream.kafka.protocol import (
     get_task_kwargs_for_message,
     get_task_kwargs_for_message_from_headers,
@@ -43,7 +42,6 @@ def dispatch_post_process_group_task(
     primary_hash: str | None,
     queue: str,
     skip_consume: bool = False,
-    group_states: GroupStates | None = None,
     occurrence_id: str | None = None,
     eventstream_type: str | None = None,
 ) -> None:
@@ -60,7 +58,6 @@ def dispatch_post_process_group_task(
                 "primary_hash": primary_hash,
                 "cache_key": cache_key,
                 "group_id": group_id,
-                "group_states": group_states,
                 "occurrence_id": occurrence_id,
                 "project_id": project_id,
                 "eventstream_type": eventstream_type,

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -186,9 +186,11 @@ def get_task_kwargs_for_message_from_headers(
                 "is_new": is_new,
                 "is_regression": is_regression,
                 "is_new_group_environment": is_new_group_environment,
-                "queue": decode_str(_required("queue"))
-                if "queue" in header_data
-                else "post_process_errors",
+                "queue": (
+                    decode_str(_required("queue"))
+                    if "queue" in header_data
+                    else "post_process_errors"
+                ),
             }
 
         else:

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -472,7 +472,6 @@ class SnubaEventStream(SnubaProtocolEventStream):
             primary_hash,
             self._get_queue_for_post_process(event),
             skip_consume,
-            group_states,
             occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
             eventstream_type=eventstream_type,
         )

--- a/tests/sentry/eventstream/kafka/test_dispatch.py
+++ b/tests/sentry/eventstream/kafka/test_dispatch.py
@@ -90,7 +90,6 @@ def test_dispatch_task(mock_dispatch: Mock) -> None:
         is_regression=None,
         is_new_group_environment=False,
         queue="post_process_errors",
-        group_states=None,
         occurrence_id=None,
         eventstream_type=None,
     )
@@ -119,7 +118,6 @@ def test_dispatch_task_with_occurrence(mock_post_process_group: Mock) -> None:
             "cache_key": "e:066f15fe1cd2406aaa7c6a07471d7aef:2",
             "eventstream_type": None,
             "group_id": 44,
-            "group_states": None,
             "is_new": False,
             "is_new_group_environment": False,
             "is_regression": None,

--- a/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
+++ b/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
@@ -148,7 +148,6 @@ class PostProcessForwarderTest(TestCase):
                 is_regression=None,
                 queue="post_process_errors",
                 is_new_group_environment=False,
-                group_states=None,
                 occurrence_id=None,
                 eventstream_type=EventStreamEventType.Error.value,
             )


### PR DESCRIPTION
We stop relying on `group_states` in https://github.com/getsentry/sentry/pull/63130. Once this has merged and is in production, we can stop sending `group_states` entirely via the ppf.

We can stop including the `group_states` info in the Kafka messages in a later pr

<!-- Describe your PR here. -->