### PR TITLE
fix(widget-builder): Use portals to render search popovers

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -156,6 +156,7 @@ interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
+  portalTarget?: HTMLElement | null;
   supportedAggregates?: AggregationKey[];
 }
 
@@ -170,6 +171,7 @@ export function EAPSpanSearchQueryBuilder({
   getFilterTokenWarning,
   supportedAggregates = [],
   projects,
+  portalTarget,
 }: EAPSpanSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -247,6 +249,7 @@ export function EAPSpanSearchQueryBuilder({
       disallowUnsupportedFilters
       recentSearches={SavedSearchType.SPAN}
       showUnsubmittedIndicator
+      portalTarget={portalTarget}
     />
   );
 }

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -36,6 +36,7 @@ export type WidgetBuilderSearchBarProps = {
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
   dataset?: DiscoverDatasets;
+  portalTarget?: HTMLElement | null;
 };
 
 export interface DatasetConfig<SeriesResponse, TableResponse> {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -13,9 +13,16 @@ interface Props {
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
   dataset?: DiscoverDatasets;
+  portalTarget?: HTMLElement | null;
 }
 
-export function EventsSearchBar({pageFilters, onClose, widgetQuery, dataset}: Props) {
+export function EventsSearchBar({
+  pageFilters,
+  onClose,
+  widgetQuery,
+  dataset,
+  portalTarget,
+}: Props) {
   const organization = useOrganization();
   const {customMeasurements} = useCustomMeasurements();
   const eventView = eventViewFromWidget('', widgetQuery, pageFilters);
@@ -35,6 +42,7 @@ export function EventsSearchBar({pageFilters, onClose, widgetQuery, dataset}: Pr
       dataset={dataset}
       includeTransactions={hasDatasetSelector(organization) ? false : true}
       searchSource="widget_builder"
+      portalTarget={portalTarget}
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -11,9 +11,10 @@ import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 interface Props {
   onClose: SearchBarProps['onClose'];
   widgetQuery: WidgetQuery;
+  portalTarget?: HTMLElement | null;
 }
 
-function IssuesSearchBar({onClose, widgetQuery}: Props) {
+function IssuesSearchBar({onClose, widgetQuery, portalTarget}: Props) {
   const organization = useOrganization();
   const onChange = useCallback<NonNullable<SearchQueryBuilderProps['onChange']>>(
     (query, state) => {
@@ -29,6 +30,7 @@ function IssuesSearchBar({onClose, widgetQuery}: Props) {
       initialQuery={widgetQuery.conditions || ''}
       onChange={onChange}
       placeholder={t('Search for issues, status, assigned, and more')}
+      portalTarget={portalTarget}
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -34,9 +34,15 @@ interface Props {
   onClose: SearchBarProps['onClose'];
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  portalTarget?: HTMLElement | null;
 }
 
-export function ReleaseSearchBar({pageFilters, widgetQuery, onClose}: Props) {
+export function ReleaseSearchBar({
+  pageFilters,
+  widgetQuery,
+  onClose,
+  portalTarget,
+}: Props) {
   const organization = useOrganization();
   const orgSlug = organization.slug;
   const projectIds = pageFilters.projects;
@@ -79,6 +85,7 @@ export function ReleaseSearchBar({pageFilters, widgetQuery, onClose}: Props) {
       disallowFreeText
       invalidMessages={invalidMessages}
       recentSearches={SavedSearchType.SESSION}
+      portalTarget={portalTarget}
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -11,7 +11,8 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 function SpansSearchBar({
   widgetQuery,
   onSearch,
-}: Pick<WidgetBuilderSearchBarProps, 'widgetQuery' | 'onSearch'>) {
+  portalTarget,
+}: Pick<WidgetBuilderSearchBarProps, 'widgetQuery' | 'onSearch' | 'portalTarget'>) {
   const {
     selection: {projects},
   } = usePageFilters();
@@ -26,6 +27,7 @@ function SpansSearchBar({
       supportedAggregates={ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
       searchSource="dashboards"
       projects={projects}
+      portalTarget={portalTarget}
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -196,6 +196,7 @@ function WidgetBuilderQueryFilterBuilder({
             }}
             widgetQuery={widget.queries[index]!}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
+            portalTarget={document.body}
           />
           {canHaveAlias && (
             <LegendAliasInput

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -125,6 +125,7 @@ type Props = {
   onChange?: (query: string, state: CallbackSearchState) => void;
   onSearch?: (query: string) => void;
   placeholder?: string;
+  portalTarget?: HTMLElement | null;
   projectIds?: number[] | readonly number[];
   query?: string;
   recentSearches?: SavedSearchType;
@@ -144,6 +145,7 @@ function ResultsSearchQueryBuilder(props: Props) {
     dataset,
     includeTransactions = true,
     placeholder,
+    portalTarget,
   } = props;
 
   const api = useApi();
@@ -295,6 +297,7 @@ function ResultsSearchQueryBuilder(props: Props) {
       filterKeySections={filterKeySections}
       getTagValues={getEventFieldValues}
       recentSearches={props.recentSearches ?? SavedSearchType.EVENT}
+      portalTarget={portalTarget}
       showUnsubmittedIndicator
     />
   );


### PR DESCRIPTION
The widget builder needs to pass along a portal target so the popovers render outside of the `overflow: auto` context of the slideout panel.

Updates the search bar interface to accept a portalTarget and passes along `document.body` to render it above everything else.

To test, I was using `span.description` in the spans dataset and `message` in `errors` or `transactions`.