### PR TITLE
feat(eap-spans): add count_op function

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -172,18 +172,17 @@ class ResolvedAggregate(ResolvedFunction):
 
 @dataclass(frozen=True, kw_only=True)
 class ResolvedConditionalAggregate(ResolvedFunction):
-    """
-    An aggregate is the most primitive type of function, these are the ones that are availble via the RPC directly and contain no logic
-    Examples of this are `sum()` and `avg()`.
-    """
 
     # The internal rpc alias for this column
     internal_name: Function.ValueType
     # Whether to enable extrapolation
     extrapolation: bool = True
-    is_aggregate: bool = field(default=True, init=False)
+    # The condition to filter on
     filter: TraceItemFilter
+    # The attribute to conditionally aggregate on
     key: AttributeKey
+
+    is_aggregate: bool = field(default=True, init=False)
 
     @property
     def proto_definition(self) -> AttributeConditionalAggregation:
@@ -260,8 +259,11 @@ class ConditionalAggregateDefinition(FunctionDefinition):
     The `filter` is returned by the `filter_resolver` function which takes in the args from the user and returns a `TraceItemFilter`.
     """
 
+    # The type of aggregation (ex. sum, avg)
     internal_function: Function.ValueType
+    # The attribute to conditionally aggregate on
     key: AttributeKey
+    # A function that takes in the resolved argument and returns the condition to filter on
     filter_resolver: Callable[..., TraceItemFilter]
 
     def resolve(

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -16,11 +16,11 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Function,
     VirtualColumnContext,
 )
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.events.types import SnubaParams
-from sentry.snuba.spans_rpc import TraceItemFilter
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/sentry/search/eap/ourlogs/definitions.py
+++ b/src/sentry/search/eap/ourlogs/definitions.py
@@ -8,6 +8,7 @@ from sentry.search.eap.ourlogs.attributes import (
 
 OURLOG_DEFINITIONS = ColumnDefinitions(
     aggregates={},
+    conditional_aggregates={},
     formulas={},
     columns=OURLOG_ATTRIBUTE_DEFINITIONS,
     contexts=OURLOG_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -17,7 +17,7 @@ def count_processor(count_value: int | None) -> int:
 
 
 def resolve_count_op_filter(op_value: str) -> TraceItemFilter:
-    TraceItemFilter(
+    return TraceItemFilter(
         comparison_filter=ComparisonFilter(
             key=AttributeKey(
                 name="sentry.op",
@@ -34,6 +34,7 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         internal_function=Function.FUNCTION_COUNT,
         default_search_type="integer",
         arguments=[ArgumentDefinition(argument_types={"string"}, is_attribute=False)],
+        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.op"),
         filter_resolver=resolve_count_op_filter,
     )
 }

--- a/src/sentry/search/eap/spans/definitions.py
+++ b/src/sentry/search/eap/spans/definitions.py
@@ -1,12 +1,16 @@
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.search.eap.columns import ColumnDefinitions
-from sentry.search.eap.spans.aggregates import SPAN_AGGREGATE_DEFINITIONS
+from sentry.search.eap.spans.aggregates import (
+    SPAN_AGGREGATE_DEFINITIONS,
+    SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS,
+)
 from sentry.search.eap.spans.attributes import SPAN_ATTRIBUTE_DEFINITIONS, SPAN_VIRTUAL_CONTEXTS
 from sentry.search.eap.spans.formulas import SPAN_FORMULA_DEFINITIONS
 
 SPAN_DEFINITIONS = ColumnDefinitions(
     aggregates=SPAN_AGGREGATE_DEFINITIONS,
+    conditional_aggregates=SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS,
     formulas=SPAN_FORMULA_DEFINITIONS,
     columns=SPAN_ATTRIBUTE_DEFINITIONS,
     contexts=SPAN_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/uptime_checks/definitions.py
+++ b/src/sentry/search/eap/uptime_checks/definitions.py
@@ -8,6 +8,7 @@ from sentry.search.eap.uptime_checks.attributes import (
 
 UPTIME_CHECK_DEFINITIONS = ColumnDefinitions(
     aggregates={},
+    conditional_aggregates={},
     formulas={},
     columns=UPTIME_CHECK_ATTRIBUTE_DEFINITIONS,
     contexts=UPTIME_CHECK_VIRTUAL_CONTEXTS,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -5,7 +5,12 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceIt
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
-from sentry.search.eap.columns import ResolvedAggregate, ResolvedAttribute, ResolvedFormula
+from sentry.search.eap.columns import (
+    ResolvedAggregate,
+    ResolvedAttribute,
+    ResolvedConditionalAggregate,
+    ResolvedFormula,
+)
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
 from sentry.search.events.fields import get_function_alias
@@ -16,7 +21,9 @@ from sentry.utils.snuba import process_value
 logger = logging.getLogger("sentry.snuba.spans_rpc")
 
 
-def categorize_column(column: ResolvedAttribute | ResolvedAggregate | ResolvedFormula) -> Column:
+def categorize_column(
+    column: ResolvedAttribute | ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula,
+) -> Column:
     if isinstance(column, ResolvedFormula):
         return Column(formula=column.proto_definition, label=column.public_alias)
     if isinstance(column, ResolvedAggregate):

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -28,6 +28,8 @@ def categorize_column(
         return Column(formula=column.proto_definition, label=column.public_alias)
     if isinstance(column, ResolvedAggregate):
         return Column(aggregation=column.proto_definition, label=column.public_alias)
+    if isinstance(column, ResolvedConditionalAggregate):
+        return Column(conditional_aggregation=column.proto_definition, label=column.public_alias)
     else:
         return Column(key=column.proto_definition, label=column.public_alias)
 

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,7 +13,12 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, OrFilter, Tr
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.columns import ResolvedAggregate, ResolvedAttribute, ResolvedFormula
+from sentry.search.eap.columns import (
+    ResolvedAggregate,
+    ResolvedAttribute,
+    ResolvedConditionalAggregate,
+    ResolvedFormula,
+)
 from sentry.search.eap.constants import DOUBLE, INT, MAX_ROLLUP_POINTS, STRING, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
@@ -76,7 +81,11 @@ def get_timeseries_query(
     config: SearchResolverConfig,
     granularity_secs: int,
     extra_conditions: TraceItemFilter | None = None,
-) -> tuple[TimeSeriesRequest, list[ResolvedFormula | ResolvedAggregate], list[ResolvedAttribute]]:
+) -> tuple[
+    TimeSeriesRequest,
+    list[ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate],
+    list[ResolvedAttribute],
+]:
     resolver = get_resolver(params=params, config=config)
     meta = resolver.resolve_meta(referrer=referrer)
     query, _, query_contexts = resolver.resolve_query(query_string)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2826,7 +2826,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["trace_status_rate(unauthenticated)"] == 0.2
 
         assert meta["dataset"] == self.dataset
-        
+
     def test_count_op(self):
         self.store_spans(
             [

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2827,6 +2827,46 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
 
         assert meta["dataset"] == self.dataset
 
+    def test_count_op(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.process"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.process"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"op": "queue.publish", "sentry_tags": {"op": "queue.publish"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "count_op(queue.process)",
+                    "count_op(queue.publish)",
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert len(data) == 1
+        assert data[0]["count_op(queue.process)"] == 2
+        assert data[0]["count_op(queue.publish)"] == 1
+
+        assert meta["dataset"] == self.dataset
+
     @pytest.mark.skip(reason="replay id alias not migrated over")
     def test_replay_id(self):
         super().test_replay_id()


### PR DESCRIPTION
1. Add the last type of column supported by RPC, conditional_aggregation
2. Adds `count_op` function

Closes https://github.com/getsentry/team-visibility/issues/32 and https://github.com/getsentry/team-visibility/issues/28