### PR TITLE
fix(widget-builder): Fix overflowing select dropdowns

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -21,8 +21,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
-import type {SortDirection} from 'sentry/views/dashboards/widgetBuilder/utils';
-import {sortDirections} from 'sentry/views/dashboards/widgetBuilder/utils';
+import {
+  type SortDirection,
+  sortDirections,
+} from 'sentry/views/dashboards/widgetBuilder/utils';
 import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
 import {QueryField} from 'sentry/views/discover/table/queryField';
 
@@ -167,6 +169,9 @@ export function SortBySelectors({
                 sortDirection: values.sortDirection,
               });
             }}
+            useMenuPortal={organization.features.includes(
+              'dashboards-widget-builder-redesign'
+            )}
           />
         )}
       </Tooltip>


### PR DESCRIPTION
Similar to the search field dropdowns, the select field dropdowns were also being clipped off. You can see this the most with the sort field. e.g.

<img width="710" alt="Screenshot 2025-03-11 at 2 44 32 PM" src="https://github.com/user-attachments/assets/8287d874-490b-4f37-886d-3a95c565927c" />

Now the fields will properly overflow

<img width="873" alt="Screenshot 2025-03-11 at 2 44 51 PM" src="https://github.com/user-attachments/assets/17b6bbb4-0ab4-45e8-ac93-f357685648d3" />
