### PR TITLE
feat(replays): Remove beta consumer option gating

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from collections.abc import Mapping
 
 import sentry_sdk
@@ -10,13 +9,11 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import Commit, FilteredPayload, Message, Partition
 from django.conf import settings
 
-from sentry import options
 from sentry.filestore.gcs import GCS_RETRYABLE_ERRORS
 from sentry.replays.usecases.ingest import (
     DropSilently,
     ProcessedRecordingMessage,
     commit_recording_message,
-    ingest_recording,
     parse_recording_message,
     process_recording_message,
 )
@@ -55,7 +52,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         return RunTask(
             function=process_message,
             next_step=RunTaskInThreads(
-                processing_function=commit_message,  # type: ignore[arg-type]
+                processing_function=commit_message,
                 concurrency=self.num_threads,
                 max_pending_futures=self.max_pending_futures,
                 next_step=CommitOffsets(commit),
@@ -63,18 +60,10 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         )
 
 
-def process_message(
-    message: Message[KafkaPayload],
-) -> ProcessedRecordingMessage | FilteredPayload | bytes:
-    if random.randint(0, 100) > options.get("replay.consumer.recording.beta-rollout"):
-        sentry_sdk.set_tag("replay.consumer.recording.beta", False)
-        return message.payload.value
-
-    sentry_sdk.set_tag("replay.consumer.recording.beta", True)
-
+def process_message(message: Message[KafkaPayload]) -> ProcessedRecordingMessage | FilteredPayload:
     with sentry_sdk.start_transaction(
         name="replays.consumer.recording_buffered.process_message",
-        op="replays.consumer.recording_buffered",
+        op="replays.consumer.recording_buffered.process_message",
         custom_sampling_context={
             "sample_rate": getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0)
         },
@@ -88,13 +77,10 @@ def process_message(
             return FilteredPayload()
 
 
-def commit_message(message: Message[ProcessedRecordingMessage | bytes]) -> None:
-    if isinstance(message.payload, bytes):
-        return ingest_recording(message.payload)
-
+def commit_message(message: Message[ProcessedRecordingMessage]) -> None:
     with sentry_sdk.start_transaction(
         name="replays.consumer.recording_buffered.commit_message",
-        op="replays.consumer.recording_buffered",
+        op="replays.consumer.recording_buffered.commit_message",
         custom_sampling_context={
             "sample_rate": getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0)
         },

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -16,6 +16,7 @@ from sentry.replays.usecases.ingest import (
     commit_recording_message,
     parse_recording_message,
     process_recording_message,
+    track_recording_metadata,
 )
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def commit_message(message: Message[ProcessedRecordingMessage]) -> None:
     ):
         try:
             commit_recording_message(message.payload)
+            track_recording_metadata(message.payload)
             return None
         except GCS_RETRYABLE_ERRORS:
             raise

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -17,7 +17,6 @@ from sentry.replays.lib.storage import _make_recording_filename, storage_kv
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.usecases.pack import unpack
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class RecordingTestCase(TransactionTestCase):
@@ -469,53 +468,3 @@ class RecordingTestCase(TransactionTestCase):
 
 class ThreadedRecordingTestCase(RecordingTestCase):
     force_synchronous = False
-
-
-# Experimental Two Step Recording Consumer
-
-
-class BetaEnabledRecordingTestCase(RecordingTestCase):
-
-    def test_compressed_segment_ingestion(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_compressed_segment_ingestion()
-
-    def test_event_with_replay_video(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_event_with_replay_video()
-
-    def test_event_with_replay_video_packed(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_event_with_replay_video_packed()
-
-    def test_uncompressed_segment_ingestion(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_uncompressed_segment_ingestion()
-
-    def test_invalid_json(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_json()
-
-    def test_invalid_payload_invalid_headers(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_payload_invalid_headers()
-
-    def test_invalid_payload_invalid_unicode_codepoint(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_payload_invalid_unicode_codepoint()
-
-    def test_invalid_payload_malformed_headers(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_payload_malformed_headers()
-
-    def test_invalid_payload_missing_headers(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_payload_missing_headers()
-
-    def test_invalid_payload_type(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_payload_type()
-
-    def test_invalid_message(self):
-        with override_options({"replay.consumer.recording.beta-rollout": 100}):
-            super().test_invalid_message()


### PR DESCRIPTION
Its rolled out at 100%.  Preserving the option because I plan to use it again later.