### PR TITLE
badge: forward avatarsize under props

### DIFF
--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -60,7 +60,7 @@ export const BaseBadge = memo(
             organization={organization}
             project={project}
             actor={actor}
-            avatarProps={avatarProps}
+            avatarProps={{...avatarProps, size: avatarSize}}
           />
         )}
 


### PR DESCRIPTION
Not sure why we have avatarSize and separate avatarProps here, but I must have overlooked this when changing the implementation