### PR TITLE
feat(timeseries): Introduce a new timeseries endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -213,6 +213,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_events_facets.py                     @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_meta.py                       @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_stats.py                      @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_timeseries.py                 @getsentry/visibility
 /src/sentry/api/endpoints/organization_measurements_meta.py                 @getsentry/visibility
 
 /tests/snuba/api/endpoints/*                                                @getsentry/visibility

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -297,7 +297,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         units: dict[str, str | None] = {}
         meta: dict[str, str] = result_meta.copy()
         for key, value in result_meta.items():
-            unit, field_type = self.get_unit_and_type(key, value)
+            units[key], meta[key] = self.get_unit_and_type(key, value)
         return meta, units
 
     def get_unit_and_type(self, field, field_type):

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -297,24 +297,25 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         units: dict[str, str | None] = {}
         meta: dict[str, str] = result_meta.copy()
         for key, value in result_meta.items():
-            if value in SIZE_UNITS:
-                units[key] = value
-                meta[key] = "size"
-            elif value in DURATION_UNITS:
-                units[key] = value
-                meta[key] = "duration"
-            elif value == "rate":
-                if key in ["eps()", "sps()", "tps()"]:
-                    units[key] = "1/second"
-                elif key in ["epm()", "spm()", "tpm()"]:
-                    units[key] = "1/minute"
-                else:
-                    units[key] = None
-            elif value == "duration":
-                units[key] = "millisecond"
-            else:
-                units[key] = None
+            unit, field_type = self.get_unit_and_type(key, value)
         return meta, units
+
+    def get_unit_and_type(self, field, field_type):
+        if field_type in SIZE_UNITS:
+            return field_type, "size"
+        elif field_type in DURATION_UNITS:
+            return field_type, "duration"
+        elif field_type == "rate":
+            if field in ["eps()", "sps()", "tps()"]:
+                return "1/second", field_type
+            elif field in ["epm()", "spm()", "tpm()"]:
+                return "1/minute", field_type
+            else:
+                return None, field_type
+        elif field_type == "duration":
+            return "millisecond", field_type
+        else:
+            return None, field_type
 
     def handle_results_with_meta(
         self,
@@ -418,6 +419,38 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 if readable_value:
                     result["readable"] = readable_value
 
+    def get_rollup(
+        self, request: Request, snuba_params: SnubaParams, top_events: int, use_rpc: bool
+    ) -> int:
+        try:
+            rollup = get_rollup_from_request(
+                request,
+                snuba_params.date_range,
+                default_interval=None,
+                error=InvalidSearchQuery(),
+                top_events=top_events,
+                allow_interval_over_range=not use_rpc,
+            )
+        # If the user sends an invalid interval, use the default instead
+        except InvalidSearchQuery:
+            sentry_sdk.set_tag("user.invalid_interval", request.GET.get("interval"))
+            date_range = snuba_params.date_range
+            stats_period = parse_stats_period(get_interval_from_range(date_range, False))
+            rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600
+        return rollup
+
+    def validate_comparison_delta(
+        self,
+        comparison_delta: timedelta | None,
+        snuba_params: SnubaParams,
+        organization: Organization,
+    ) -> None:
+        if comparison_delta is not None:
+            retention = quotas.backend.get_event_retention(organization=organization)
+            comparison_start = snuba_params.start_date - comparison_delta
+            if retention and comparison_start < timezone.now() - timedelta(days=retention):
+                raise ValidationError("Comparison period is outside your retention window")
+
     def get_event_stats_data(
         self,
         request: Request,
@@ -458,26 +491,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     except NoProjects:
                         return {"data": []}
 
-                try:
-                    rollup = get_rollup_from_request(
-                        request,
-                        snuba_params.date_range,
-                        default_interval=None,
-                        error=InvalidSearchQuery(),
-                        top_events=top_events,
-                        allow_interval_over_range=not use_rpc,
-                    )
-                # If the user sends an invalid interval, use the default instead
-                except InvalidSearchQuery:
-                    sentry_sdk.set_tag("user.invalid_interval", request.GET.get("interval"))
-                    date_range = snuba_params.date_range
-                    stats_period = parse_stats_period(get_interval_from_range(date_range, False))
-                    rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600
-                if comparison_delta is not None:
-                    retention = quotas.backend.get_event_retention(organization=organization)
-                    comparison_start = snuba_params.start_date - comparison_delta
-                    if retention and comparison_start < timezone.now() - timedelta(days=retention):
-                        raise ValidationError("Comparison period is outside your retention window")
+                rollup = self.get_rollup(request, snuba_params, top_events, use_rpc)
+                self.validate_comparison_delta(comparison_delta, snuba_params, organization)
 
                 query_columns = get_query_columns(columns, rollup)
             with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query"):

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -67,8 +67,8 @@ class SeriesMeta(TypedDict):
     order: NotRequired[int]
     groupBy: NotRequired[list[str]]
     isOther: NotRequired[str]
-    unit: NotRequired[str]
-    type: str
+    valueUnit: NotRequired[str]
+    valueType: str
     interval: float
 
 
@@ -336,8 +336,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                             ],
                             axis=axis,
                             meta=SeriesMeta(
-                                unit=unit,
-                                type=field_type,
+                                valueUnit=unit,
+                                valueType=field_type,
                                 interval=rollup * 1000,
                             ),
                         )
@@ -361,8 +361,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                                     order=value.data["order"],
                                     groupBy=value.data.get("groupby", []),
                                     isOther=value.data.get("is_other", False),
-                                    unit=unit,
-                                    type=field_type,
+                                    valueUnit=unit,
+                                    valueType=field_type,
                                     interval=rollup * 1000,
                                 ),
                             )

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -313,8 +313,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         response = StatsResponse(
             meta=StatsMeta(
                 dataset=DATASET_LABELS[dataset],
-                start=snuba_params.start_date.timestamp(),
-                end=snuba_params.end_date.timestamp(),
+                start=snuba_params.start_date.timestamp() * 1000,
+                end=snuba_params.end_date.timestamp() * 1000,
             ),
             timeseries=self.serialize_result(result, axes, rollup),
         )
@@ -331,14 +331,14 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     [
                         TimeSeries(
                             values=[
-                                Row(timestamp=row["time"], value=row.get(axis, 0))
+                                Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
                                 for row in result.data["data"]
                             ],
                             axis=axis,
                             meta=SeriesMeta(
                                 unit=unit,
                                 type=field_type,
-                                interval=rollup,
+                                interval=rollup * 1000,
                             ),
                         )
                     ]
@@ -353,7 +353,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                         [
                             TimeSeries(
                                 values=[
-                                    Row(timestamp=row["time"], value=row.get(axis, 0))
+                                    Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
                                     for row in value.data["data"]
                                 ],
                                 axis=axis,
@@ -363,7 +363,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                                     isOther=value.data.get("is_other", False),
                                     unit=unit,
                                     type=field_type,
-                                    interval=rollup,
+                                    interval=rollup * 1000,
                                 ),
                             )
                         ]

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -1,0 +1,371 @@
+from collections.abc import Mapping
+from datetime import timedelta
+from typing import Any, NotRequired, TypedDict
+
+import sentry_sdk
+from rest_framework.exceptions import ParseError, ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.endpoints.organization_events_stats import (
+    ALLOWED_EVENTS_STATS_REFERRERS,
+    METRICS_ENHANCED_REFERRERS,
+    SENTRY_BACKEND_REFERRERS,
+)
+from sentry.constants import MAX_TOP_EVENTS
+from sentry.models.organization import Organization
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
+from sentry.snuba import (
+    discover,
+    errors,
+    functions,
+    metrics_enhanced_performance,
+    metrics_performance,
+    ourlogs,
+    spans_eap,
+    spans_indexed,
+    spans_metrics,
+    spans_rpc,
+    transactions,
+    uptime_checks,
+)
+from sentry.snuba.query_sources import QuerySource
+from sentry.snuba.referrer import Referrer
+from sentry.snuba.utils import DATASET_LABELS
+from sentry.utils.snuba import SnubaTSResult
+
+TOP_EVENTS_DATASETS = {
+    discover,
+    functions,
+    metrics_performance,
+    metrics_enhanced_performance,
+    spans_indexed,
+    spans_metrics,
+    spans_eap,
+    errors,
+    transactions,
+}
+
+
+class StatsMeta(TypedDict):
+    dataset: str
+    start: float
+    end: float
+
+
+class Row(TypedDict):
+    timestamp: float
+    value: float
+
+
+class SeriesMeta(TypedDict):
+    order: NotRequired[int]
+    groupby: NotRequired[list[str]]
+    isOther: NotRequired[str]
+    unit: NotRequired[str]
+    type: str
+    interval: float
+
+
+class TimeSeries(TypedDict):
+    values: list[Row]
+    axis: str
+    meta: SeriesMeta
+
+
+class StatsResponse(TypedDict):
+    meta: StatsMeta
+    timeseries: list[TimeSeries]
+
+
+@region_silo_endpoint
+class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get_features(
+        self, organization: Organization, request: Request
+    ) -> Mapping[str, bool | None]:
+        feature_names = [
+            "organizations:performance-use-metrics",
+            "organizations:dashboards-mep",
+            "organizations:mep-rollout-flag",
+        ]
+        batch_features = features.batch_has(
+            feature_names,
+            organization=organization,
+            actor=request.user,
+        )
+        return (
+            batch_features.get(f"organization:{organization.id}", {})
+            if batch_features is not None
+            else {
+                feature_name: features.has(
+                    feature_name, organization=organization, actor=request.user
+                )
+                for feature_name in feature_names
+            }
+        )
+
+    def get_request_querysource(self, request: Request, referrer: str) -> QuerySource:
+        if referrer in SENTRY_BACKEND_REFERRERS:
+            return QuerySource.SENTRY_BACKEND
+        else:
+            return self.get_request_source(request)
+
+    def get_top_events(self, request: Request) -> int:
+        if "topEvents" in request.GET:
+            try:
+                top_events = int(request.GET.get("topEvents", 0))
+            except ValueError:
+                raise ParseError(detail="topEvents must be an integer")
+            if top_events > MAX_TOP_EVENTS:
+                raise ParseError(detail=f"Can only get up to {MAX_TOP_EVENTS} top events")
+            elif top_events <= 0:
+                raise ParseError(detail="topEvents needs to be at least 1")
+
+            return top_events
+        else:
+            return 0
+
+    def get_comparison_delta(self, request: Request) -> timedelta | None:
+        if "comparisonDelta" in request.GET:
+            try:
+                return timedelta(seconds=int(request.GET["comparisonDelta"]))
+            except ValueError:
+                raise ParseError(detail="comparisonDelta must be an integer")
+        else:
+            return None
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
+            span.set_data("organization", organization)
+
+            top_events = self.get_top_events(request)
+            comparison_delta = self.get_comparison_delta(request)
+
+            dataset = self.get_dataset(request)
+            # Add more here until top events is supported on all the datasets
+            if top_events > 0:
+                if dataset not in TOP_EVENTS_DATASETS:
+                    raise ParseError(detail=f"{dataset} doesn't support topEvents yet")
+
+            metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
+            use_rpc = dataset in {spans_indexed, ourlogs, uptime_checks}
+
+            sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
+            try:
+                snuba_params = self.get_snuba_params(
+                    # old events-stats had global_check on False for v1, trying it off to see if that works for our
+                    # new usage
+                    request,
+                    organization,
+                    check_global_views=True,
+                )
+            except NoProjects:
+                return Response([], status=200)
+
+        try:
+            self.validate_comparison_delta(comparison_delta, snuba_params, organization)
+            rollup = self.get_rollup(request, snuba_params, top_events, use_rpc)
+            axes = request.GET.getlist("yAxis", ["count()"])
+
+            events_stats = self.get_event_stats(
+                request,
+                organization,
+                top_events,
+                dataset,
+                axes,
+                request.GET.get("query", ""),
+                snuba_params,
+                rollup,
+                comparison_delta,
+            )
+            return Response(
+                self.serialize_stats_data(events_stats, axes, snuba_params, rollup, dataset),
+                status=200,
+            )
+        except ValidationError:
+            return Response({"detail": "Comparison period is outside retention window"}, status=400)
+
+    def get_event_stats(
+        self,
+        request: Request,
+        organization: Organization,
+        top_events: int,
+        dataset: Any,
+        query_columns: list[str],
+        query: str,
+        snuba_params: SnubaParams,
+        rollup: int,
+        comparison_delta: timedelta | None,
+    ) -> SnubaTSResult | dict[str, SnubaTSResult]:
+        allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
+        include_other = request.GET.get("excludeOther") != "1"
+        referrer = request.GET.get("referrer")
+        referrer = (
+            referrer
+            if referrer in ALLOWED_EVENTS_STATS_REFERRERS.union(METRICS_ENHANCED_REFERRERS)
+            else Referrer.API_ORGANIZATION_EVENT_STATS.value
+        )
+        query_source = self.get_request_querysource(request, referrer)
+
+        batch_features = self.get_features(organization, request)
+        use_metrics = (
+            batch_features.get("organizations:performance-use-metrics", False)
+            or batch_features.get("organizations:dashboards-mep", False)
+            or (
+                batch_features.get("organizations:mep-rollout-flag", False)
+                and features.has(
+                    "organizations:dynamic-sampling",
+                    organization=organization,
+                    actor=request.user,
+                )
+            )
+        )
+
+        if top_events > 0:
+            if dataset == spans_indexed:
+                return spans_rpc.run_top_events_timeseries_query(
+                    params=snuba_params,
+                    query_string=query,
+                    y_axes=query_columns,
+                    raw_groupby=self.get_field_list(organization, request),
+                    orderby=self.get_orderby(request),
+                    limit=top_events,
+                    referrer=referrer,
+                    granularity_secs=rollup,
+                    config=SearchResolverConfig(
+                        auto_fields=False,
+                        use_aggregate_conditions=True,
+                    ),
+                )
+            return dataset.top_events_timeseries(
+                timeseries_columns=query_columns,
+                selected_columns=self.get_field_list(organization, request),
+                equations=self.get_equation_list(organization, request),
+                user_query=query,
+                snuba_params=snuba_params,
+                orderby=self.get_orderby(request),
+                rollup=rollup,
+                limit=top_events,
+                organization=organization,
+                referrer=referrer + ".find-topn",
+                allow_empty=False,
+                zerofill_results=True,
+                include_other=include_other,
+                query_source=query_source,
+                transform_alias_to_input_format=True,
+                fallback_to_transactions=features.has(
+                    "organizations:performance-discover-dataset-selector",
+                    organization,
+                    actor=request.user,
+                ),
+            )
+
+        if dataset == spans_indexed:
+            return spans_rpc.run_timeseries_query(
+                params=snuba_params,
+                query_string=query,
+                y_axes=query_columns,
+                granularity_secs=rollup,
+                referrer=referrer,
+                config=SearchResolverConfig(
+                    auto_fields=False,
+                    use_aggregate_conditions=True,
+                ),
+                comparison_delta=comparison_delta,
+            )
+
+        return dataset.timeseries_query(
+            selected_columns=query_columns,
+            query=query,
+            snuba_params=snuba_params,
+            rollup=rollup,
+            referrer=referrer,
+            zerofill_results=True,
+            comparison_delta=comparison_delta,
+            allow_metric_aggregates=allow_metric_aggregates,
+            has_metrics=use_metrics,
+            query_source=query_source,
+            fallback_to_transactions=features.has(
+                "organizations:performance-discover-dataset-selector",
+                organization,
+                actor=request.user,
+            ),
+            transform_alias_to_input_format=True,
+        )
+
+    def serialize_stats_data(
+        self,
+        result: SnubaTSResult | dict[str, SnubaTSResult],
+        axes: list[str],
+        snuba_params: SnubaParams,
+        rollup: int,
+        dataset,
+    ) -> StatsResponse:
+        response = StatsResponse(
+            meta=StatsMeta(
+                dataset=DATASET_LABELS[dataset],
+                start=snuba_params.start_date.timestamp(),
+                end=snuba_params.end_date.timestamp(),
+            ),
+            timeseries=self.serialize_result(result, axes, rollup),
+        )
+        return response
+
+    def serialize_result(
+        self, result: SnubaTSResult | dict[str, SnubaTSResult], axes: list[str], rollup: int
+    ) -> list[TimeSeries]:
+        serialized_result = []
+        if isinstance(result, SnubaTSResult):
+            for axis in axes:
+                unit, field_type = self.get_unit_and_type(axis, result.data["meta"]["fields"][axis])
+                serialized_result.extend(
+                    [
+                        TimeSeries(
+                            values=[
+                                Row(timestamp=row["time"], value=row.get(axis, 0))
+                                for row in result.data["data"]
+                            ],
+                            axis=axis,
+                            meta=SeriesMeta(
+                                unit=unit,
+                                type=field_type,
+                                interval=rollup,
+                            ),
+                        )
+                    ]
+                )
+        else:
+            for key, value in result.items():
+                for axis in axes:
+                    unit, field_type = self.get_unit_and_type(
+                        axis, value.data["meta"]["fields"][axis]
+                    )
+                    serialized_result.extend(
+                        [
+                            TimeSeries(
+                                values=[
+                                    Row(timestamp=row["time"], value=row.get(axis, 0))
+                                    for row in value.data["data"]
+                                ],
+                                axis=axis,
+                                meta=SeriesMeta(
+                                    order=value.data["order"],
+                                    groupby=value.data.get("groupby", []),
+                                    isOther=value.data.get("is_other", False),
+                                    unit=unit,
+                                    type=field_type,
+                                    interval=rollup,
+                                ),
+                            )
+                        ]
+                    )
+        return serialized_result

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -65,7 +65,7 @@ class Row(TypedDict):
 
 class SeriesMeta(TypedDict):
     order: NotRequired[int]
-    groupby: NotRequired[list[str]]
+    groupBy: NotRequired[list[str]]
     isOther: NotRequired[str]
     unit: NotRequired[str]
     type: str
@@ -359,7 +359,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                                 axis=axis,
                                 meta=SeriesMeta(
                                     order=value.data["order"],
-                                    groupby=value.data.get("groupby", []),
+                                    groupBy=value.data.get("groupby", []),
                                     isOther=value.data.get("is_other", False),
                                     unit=unit,
                                     type=field_type,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -65,7 +65,6 @@ class Row(TypedDict):
 
 class SeriesMeta(TypedDict):
     order: NotRequired[int]
-    groupBy: NotRequired[list[str]]
     isOther: NotRequired[str]
     valueUnit: NotRequired[str]
     valueType: str
@@ -75,6 +74,7 @@ class SeriesMeta(TypedDict):
 class TimeSeries(TypedDict):
     values: list[Row]
     axis: str
+    groupBy: NotRequired[list[str]]
     meta: SeriesMeta
 
 
@@ -357,9 +357,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                                     for row in value.data["data"]
                                 ],
                                 axis=axis,
+                                groupBy=value.data.get("groupby", {}),
                                 meta=SeriesMeta(
                                     order=value.data["order"],
-                                    groupBy=value.data.get("groupby", []),
                                     isOther=value.data.get("is_other", False),
                                     valueUnit=unit,
                                     valueType=field_type,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -491,6 +491,7 @@ from .endpoints.organization_events_spans_performance import (
     OrganizationEventsSpansStatsEndpoint,
 )
 from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
+from .endpoints.organization_events_timeseries import OrganizationEventsTimeseriesEndpoint
 from .endpoints.organization_events_trace import (
     OrganizationEventsTraceEndpoint,
     OrganizationEventsTraceLightEndpoint,
@@ -1411,6 +1412,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/events-stats/$",
         OrganizationEventsStatsEndpoint.as_view(),
         name="sentry-api-0-organization-events-stats",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/events-timeseries/$",
+        OrganizationEventsTimeseriesEndpoint.as_view(),
+        name="sentry-api-0-organization-events-timeseries",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/events/anomalies/$",

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -601,7 +601,7 @@ def top_events_timeseries(
                         if zerofill_results
                         else item["data"]
                     ),
-                    "groupby": item["groupby"],
+                    "groupby": item.get("groupby", []),
                     "meta": result["meta"],
                     "order": item["order"],
                 },

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -212,9 +212,9 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "count()"
+        assert timeseries["groupBy"] == {"message": "very bad"}
         assert timeseries["meta"] == {
             "order": 0,
-            "groupBy": ["very bad"],
             "isOther": False,
             "valueUnit": None,
             "valueType": "integer",
@@ -238,9 +238,9 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         timeseries = response.data["timeseries"][1]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "p95()"
+        assert timeseries["groupBy"] == {"message": "very bad"}
         assert timeseries["meta"] == {
             "order": 0,
-            "groupBy": ["very bad"],
             "isOther": False,
             "valueUnit": "millisecond",
             "valueType": "duration",
@@ -264,9 +264,9 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         timeseries = response.data["timeseries"][2]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "count()"
+        assert timeseries["groupBy"] == {"message": "oh my"}
         assert timeseries["meta"] == {
             "order": 1,
-            "groupBy": ["oh my"],
             "isOther": False,
             "valueUnit": None,
             "valueType": "integer",
@@ -290,9 +290,9 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         timeseries = response.data["timeseries"][3]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "p95()"
+        assert timeseries["groupBy"] == {"message": "oh my"}
         assert timeseries["meta"] == {
             "order": 1,
-            "groupBy": ["oh my"],
             "isOther": False,
             "valueUnit": "millisecond",
             "valueType": "duration",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
+from tests.sentry.issues.test_utils import SearchIssueTestMixin
+
+
+class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
+    endpoint = "sentry-api-0-organization-events-timeseries"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.authed_user = self.user
+
+        self.start = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
+        self.end = self.start + timedelta(hours=2)
+
+        self.project = self.create_project()
+        self.project2 = self.create_project()
+        self.user = self.create_user()
+        self.user2 = self.create_user()
+        transaction = load_data(
+            "transaction",
+            start_timestamp=self.start + timedelta(minutes=1),
+            timestamp=self.start + timedelta(minutes=3),
+        )
+        transaction.update(
+            {
+                "transaction": "very bad",
+                "tags": {"sentry:user": self.user.email},
+            }
+        )
+        self.store_event(
+            data=transaction,
+            project_id=self.project.id,
+        )
+        transaction = load_data(
+            "transaction",
+            start_timestamp=self.start + timedelta(hours=1, minutes=1),
+            timestamp=self.start + timedelta(hours=1, minutes=3),
+        )
+        transaction.update(
+            {
+                "transaction": "oh my",
+                "tags": {"sentry:user": self.user2.email},
+            }
+        )
+        self.store_event(
+            data=transaction,
+            project_id=self.project2.id,
+        )
+        transaction = load_data(
+            "transaction",
+            start_timestamp=self.start + timedelta(hours=1, minutes=2),
+            timestamp=self.start + timedelta(hours=1, minutes=4),
+        )
+        transaction.update(
+            {
+                "transaction": "very bad",
+                "tags": {"sentry:user": self.user2.email},
+            }
+        )
+        self.store_event(
+            data=transaction,
+            project_id=self.project2.id,
+        )
+        self.url = reverse(
+            "sentry-api-0-organization-events-timeseries",
+            kwargs={"organization_id_or_slug": self.project.organization.slug},
+        )
+        self.features = {"organizations:global-views": True}
+
+    def do_request(self, data, url=None, features=None):
+        if features is None:
+            features = {"organizations:discover-basic": True}
+        features.update(self.features)
+        with self.feature(features):
+            return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    @pytest.mark.querybuilder
+    def test_simple(self):
+        response = self.do_request(
+            {
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "project": [self.project.id, self.project2.id],
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "discover",
+            "start": self.start.timestamp(),
+            "end": self.end.timestamp(),
+        }
+        assert len(response.data["timeseries"]) == 1
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count()"
+        assert [row["value"] for row in timeseries["values"]] == [1, 2, 0]
+        assert timeseries["meta"] == {
+            "unit": None,
+            "type": "integer",
+            "interval": 3600,
+        }
+
+    def test_simple_multiple_yaxis(self):
+        response = self.do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()", "count_unique(user)"],
+                "project": [self.project.id, self.project2.id],
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "discover",
+            "start": self.start.timestamp(),
+            "end": self.end.timestamp(),
+        }
+        assert len(response.data["timeseries"]) == 2
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count()"
+        assert [row["value"] for row in timeseries["values"]] == [1, 2, 0]
+        assert timeseries["meta"] == {
+            "unit": None,
+            "type": "integer",
+            "interval": 3600,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count_unique(user)"
+        assert [row["value"] for row in timeseries["values"]] == [1, 1, 0]
+        assert timeseries["meta"] == {
+            "unit": None,
+            "type": "integer",
+            "interval": 3600,
+        }
+
+    def test_simple_top_events(self):
+        response = self.do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()", "p95()"],
+                "field": ["count()", "message"],
+                "orderby": ["-count()"],
+                "topEvents": 5,
+                "project": [self.project.id, self.project2.id],
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "discover",
+            "start": self.start.timestamp(),
+            "end": self.end.timestamp(),
+        }
+        assert len(response.data["timeseries"]) == 4
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count()"
+        assert timeseries["meta"] == {
+            "order": 0,
+            "groupby": ["very bad"],
+            "isOther": False,
+            "unit": None,
+            "type": "integer",
+            "interval": 3600,
+        }
+        assert [row["value"] for row in timeseries["values"]] == [1, 1, 0]
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "p95()"
+        assert timeseries["meta"] == {
+            "order": 0,
+            "groupby": ["very bad"],
+            "isOther": False,
+            "unit": "millisecond",
+            "type": "duration",
+            "interval": 3600,
+        }
+        assert [row["value"] for row in timeseries["values"]] == [120000.0, 120000.0, 0]
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count()"
+        assert timeseries["meta"] == {
+            "order": 1,
+            "groupby": ["oh my"],
+            "isOther": False,
+            "unit": None,
+            "type": "integer",
+            "interval": 3600,
+        }
+        assert [row["value"] for row in timeseries["values"]] == [0, 1, 0]
+
+        timeseries = response.data["timeseries"][3]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "p95()"
+        assert timeseries["meta"] == {
+            "order": 1,
+            "groupby": ["oh my"],
+            "isOther": False,
+            "unit": "millisecond",
+            "type": "duration",
+            "interval": 3600,
+        }
+        assert [row["value"] for row in timeseries["values"]] == [0, 120000.0, 0]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -97,18 +97,31 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
             "dataset": "discover",
-            "start": self.start.timestamp(),
-            "end": self.end.timestamp(),
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
         }
         assert len(response.data["timeseries"]) == 1
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "count()"
-        assert [row["value"] for row in timeseries["values"]] == [1, 2, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 2,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
         assert timeseries["meta"] == {
             "unit": None,
             "type": "integer",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
 
     def test_simple_multiple_yaxis(self):
@@ -125,28 +138,54 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
             "dataset": "discover",
-            "start": self.start.timestamp(),
-            "end": self.end.timestamp(),
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
         }
         assert len(response.data["timeseries"]) == 2
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "count()"
-        assert [row["value"] for row in timeseries["values"]] == [1, 2, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 2,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
         assert timeseries["meta"] == {
             "unit": None,
             "type": "integer",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
 
         timeseries = response.data["timeseries"][1]
         assert len(timeseries["values"]) == 3
         assert timeseries["axis"] == "count_unique(user)"
-        assert [row["value"] for row in timeseries["values"]] == [1, 1, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
         assert timeseries["meta"] == {
             "unit": None,
             "type": "integer",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
 
     def test_simple_top_events(self):
@@ -166,8 +205,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
             "dataset": "discover",
-            "start": self.start.timestamp(),
-            "end": self.end.timestamp(),
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
         }
         assert len(response.data["timeseries"]) == 4
         timeseries = response.data["timeseries"][0]
@@ -179,9 +218,22 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "isOther": False,
             "unit": None,
             "type": "integer",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
-        assert [row["value"] for row in timeseries["values"]] == [1, 1, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
 
         timeseries = response.data["timeseries"][1]
         assert len(timeseries["values"]) == 3
@@ -192,9 +244,22 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "isOther": False,
             "unit": "millisecond",
             "type": "duration",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
-        assert [row["value"] for row in timeseries["values"]] == [120000.0, 120000.0, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 120000.0,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 120000.0,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
 
         timeseries = response.data["timeseries"][2]
         assert len(timeseries["values"]) == 3
@@ -205,9 +270,22 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "isOther": False,
             "unit": None,
             "type": "integer",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
-        assert [row["value"] for row in timeseries["values"]] == [0, 1, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 0,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 1,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]
 
         timeseries = response.data["timeseries"][3]
         assert len(timeseries["values"]) == 3
@@ -218,6 +296,19 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "isOther": False,
             "unit": "millisecond",
             "type": "duration",
-            "interval": 3600,
+            "interval": 3_600_000,
         }
-        assert [row["value"] for row in timeseries["values"]] == [0, 120000.0, 0]
+        assert timeseries["values"] == [
+            {
+                "timestamp": self.start.timestamp() * 1000,
+                "value": 0,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
+                "value": 120000.0,
+            },
+            {
+                "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 2,
+                "value": 0,
+            },
+        ]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -119,8 +119,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "unit": None,
-            "type": "integer",
+            "valueUnit": None,
+            "valueType": "integer",
             "interval": 3_600_000,
         }
 
@@ -160,8 +160,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "unit": None,
-            "type": "integer",
+            "valueUnit": None,
+            "valueType": "integer",
             "interval": 3_600_000,
         }
 
@@ -183,8 +183,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "unit": None,
-            "type": "integer",
+            "valueUnit": None,
+            "valueType": "integer",
             "interval": 3_600_000,
         }
 
@@ -216,8 +216,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 0,
             "groupBy": ["very bad"],
             "isOther": False,
-            "unit": None,
-            "type": "integer",
+            "valueUnit": None,
+            "valueType": "integer",
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [
@@ -242,8 +242,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 0,
             "groupBy": ["very bad"],
             "isOther": False,
-            "unit": "millisecond",
-            "type": "duration",
+            "valueUnit": "millisecond",
+            "valueType": "duration",
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [
@@ -268,8 +268,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 1,
             "groupBy": ["oh my"],
             "isOther": False,
-            "unit": None,
-            "type": "integer",
+            "valueUnit": None,
+            "valueType": "integer",
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [
@@ -294,8 +294,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 1,
             "groupBy": ["oh my"],
             "isOther": False,
-            "unit": "millisecond",
-            "type": "duration",
+            "valueUnit": "millisecond",
+            "valueType": "duration",
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -214,7 +214,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["axis"] == "count()"
         assert timeseries["meta"] == {
             "order": 0,
-            "groupby": ["very bad"],
+            "groupBy": ["very bad"],
             "isOther": False,
             "unit": None,
             "type": "integer",
@@ -240,7 +240,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["axis"] == "p95()"
         assert timeseries["meta"] == {
             "order": 0,
-            "groupby": ["very bad"],
+            "groupBy": ["very bad"],
             "isOther": False,
             "unit": "millisecond",
             "type": "duration",
@@ -266,7 +266,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["axis"] == "count()"
         assert timeseries["meta"] == {
             "order": 1,
-            "groupby": ["oh my"],
+            "groupBy": ["oh my"],
             "isOther": False,
             "unit": None,
             "type": "integer",
@@ -292,7 +292,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["axis"] == "p95()"
         assert timeseries["meta"] == {
             "order": 1,
-            "groupby": ["oh my"],
+            "groupBy": ["oh my"],
             "isOther": False,
             "unit": "millisecond",
             "type": "duration",


### PR DESCRIPTION
- This adds a new events-timeseries endpoint that will eventually replace the events-stats endpoint
- Introduces a new stats response as discussed [here](https://www.notion.so/sentry/Events-stats-rewrite-1af8b10e4b5d802d9d84fdd46522196f) with the main consumers of the endpoint
- TODO: I've tested this with discover, but haven't had time to do it to the other datasets. They'll probably still run, but I need to shift focus back to the trace view for now so figure its better to have this working for at least discover and come back later for the other datasets