### PR TITLE
fix(spotlight): Fixes to make spotlight work in dev

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -193,7 +193,7 @@ export function initializeSdk(config: Config) {
 
   if (process.env.NODE_ENV !== 'production') {
     if (
-      sentryConfig.environment === 'development' &&
+      sentryConfig.environment?.startsWith('dev') &&
       process.env.SENTRY_SPOTLIGHT &&
       !['false', 'f', 'n', 'no', 'off', '0'].includes(process.env.SENTRY_SPOTLIGHT)
     ) {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -346,6 +346,7 @@ const appConfig: webpack.Configuration = {
       'process.env.SPA_DSN': JSON.stringify(SENTRY_SPA_DSN),
       'process.env.SENTRY_RELEASE_VERSION': JSON.stringify(SENTRY_RELEASE_VERSION),
       'process.env.USE_REACT_QUERY_DEVTOOL': JSON.stringify(USE_REACT_QUERY_DEVTOOL),
+      'process.env.SENTRY_SPOTLIGHT': JSON.stringify(env.SENTRY_SPOTLIGHT),
     }),
 
     /**


### PR DESCRIPTION
The necessary changes to make spotlight work with `sentry` and `getsentry.

The following works for me:
```
SENTRY_SPOTLIGHT=1 getsentry devserver --ingest --pretty --workers
```