### PR TITLE
fix(perf): Tags page `Add to filter` button in table

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -119,8 +119,6 @@ export function TagValueTable({
 
     conditions.addFilterValues(tagKey ?? '', [tagValue]);
 
-    // const query = conditions.formatString();
-
     navigate(
       {
         ...location,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/78725

The Add to filter button was not working due to it using an older link component which does not work as well using the react-router version we are on now. This PR updates it use a simple clickable div with the `useNavigate` hook to achieve the intended functionality. The page had to be converted from a Class component to a FC as well, in order to make use of hooks.

![image](https://github.com/user-attachments/assets/c0f76e45-1b96-4f97-8a54-509fb83099c1)
