### PR TITLE
feat(ui): Make release bubble padding configurable

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -5,4 +5,4 @@ export const DEFAULT_BUBBLE_SIZE = 12;
 // "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
 // to move into `renderReleaseBubble` if it needs to be customizable
 export const RELEASE_BUBBLE_Y_PADDING = 8;
-export const RELEASE_BUBBLE_X_PADDING = 1;
+export const RELEASE_BUBBLE_X_PADDING = 2;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -5,6 +5,4 @@ export const DEFAULT_BUBBLE_SIZE = 12;
 // "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
 // to move into `renderReleaseBubble` if it needs to be customizable
 export const RELEASE_BUBBLE_Y_PADDING = 8;
-export const RELEASE_BUBBLE_Y_HALF_PADDING = RELEASE_BUBBLE_Y_PADDING / 2;
 export const RELEASE_BUBBLE_X_PADDING = 1;
-export const RELEASE_BUBBLE_X_HALF_PADDING = RELEASE_BUBBLE_X_PADDING / 2;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -1,8 +1,8 @@
 export const BUBBLE_SERIES_ID = '__release_bubble__';
 export const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';
-export const DEFAULT_BUBBLE_SIZE = 12;
+export const DEFAULT_BUBBLE_SIZE = 4;
 
 // "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
 // to move into `renderReleaseBubble` if it needs to be customizable
-export const RELEASE_BUBBLE_Y_PADDING = 8;
-export const RELEASE_BUBBLE_X_PADDING = 2;
+export const RELEASE_BUBBLE_Y_PADDING = 2;
+export const RELEASE_BUBBLE_X_PADDING = 1;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -1,8 +1,2 @@
 export const BUBBLE_SERIES_ID = '__release_bubble__';
 export const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';
-export const DEFAULT_BUBBLE_SIZE = 4;
-
-// "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
-// to move into `renderReleaseBubble` if it needs to be customizable
-export const RELEASE_BUBBLE_Y_PADDING = 2;
-export const RELEASE_BUBBLE_X_PADDING = 1;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -369,6 +369,8 @@ export function useReleaseBubbles({
     };
   }
 
+  const totalBubblePaddingY = bubblePadding.y * 2;
+
   return {
     createReleaseBubbleHighlighter,
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -221,21 +221,22 @@ function ReleaseBubbleSeries({
     // Width between two timestamps for timeSeries
     const width = bubbleEndX - bubbleStartX;
 
-    // Padding is on both left/right sides to try to center the bubble
-    //
-    //  bubbleStartX   bubbleEndX
-    //  |              |
-    //  v              v
-    //  ----------------  ----------------
-    //  |              |  |              |
-    //  ----------------  ----------------
-    //                 ^  ^
-    //                 |--|
-    //                 bubblePadding.x
     const shape = {
+      // Padding is on both left/right sides to try to center the bubble
+      //
+      //  bubbleStartX   bubbleEndX
+      //  |              |
+      //  v              v
+      //  ----------------  ----------------
+      //  |              |  |              |
+      //  ----------------  ----------------
+      //                 ^  ^
+      //                 |--|
+      //                 bubblePadding.x
+
       // No left-padding on first bubble
-      x: bubbleStartX + (params.dataIndex === 0 ? 0 : bubblePadding.x / 2),
-      y: bubbleStartY + bubblePadding.y / 2,
+      x: bubbleStartX + (params.dataIndex === 0 ? 0 : bubblePadding.x),
+
       // No right-padding on last bubble
       // We don't decrease width on first bubble to make up for lack of
       // left-padding
@@ -243,8 +244,23 @@ function ReleaseBubbleSeries({
         width -
         (params.dataIndex === 0 || params.dataIndex === data.length - 1
           ? 0
-          : bubblePadding.x / 2),
-      height: bubbleSize - bubblePadding.y,
+          : bubblePadding.x),
+
+      // We configure base chart's grid and xAxis to create a gap size of
+      // `bubbleSize`. We then have to configure `y` and `height` to fit within this
+      //
+      // ----------------- grid bottom
+      //   ^
+      //   | bubbleSize
+      //   v
+      // ----------------- = xAxis offset
+
+      // idk exactly what's happening but we need a 1 pixel buffer to make it
+      // properly centered. I want to guess because we are drawing below the
+      // xAxis, and we have to account for the pixel being drawn in the other
+      // direction. You can see this if you set the x-axis offset to 0 and compare.
+      y: bubbleStartY + bubblePadding.y + 1,
+      height: bubbleSize,
 
       // border radius
       r: 0,
@@ -388,7 +404,9 @@ export function useReleaseBubbles({
       // configure `axisLine` and `offset` to move axis line below 0 so that
       // bubbles sit between bottom of the main chart and the axis line
       axisLine: {onZero: false},
-      offset: bubbleSize,
+      // The +1 is needed because we add 1 pixel when drawing the bubbles in
+      // renderReleaseBubble (read comments there)
+      offset: bubbleSize + totalBubblePaddingY + 1,
     },
 
     /**
@@ -397,7 +415,7 @@ export function useReleaseBubbles({
     releaseBubbleGrid: {
       // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are
       // drawn below grid (but above x axis label)
-      bottom: bubbleSize,
+      bottom: bubbleSize + totalBubblePaddingY + 1,
     },
   };
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -250,9 +250,9 @@ function ReleaseBubbleSeries({
       // `bubbleSize`. We then have to configure `y` and `height` to fit within this
       //
       // ----------------- grid bottom
-      //   ^
+      //   | bubblePadding.y
       //   | bubbleSize
-      //   v
+      //   | bubblePadding.y
       // ----------------- = xAxis offset
 
       // idk exactly what's happening but we need a 1 pixel buffer to make it

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -28,9 +28,6 @@ import {useUser} from 'sentry/utils/useUser';
 import {
   BUBBLE_AREA_SERIES_ID,
   BUBBLE_SERIES_ID,
-  DEFAULT_BUBBLE_SIZE,
-  RELEASE_BUBBLE_X_PADDING,
-  RELEASE_BUBBLE_Y_PADDING,
 } from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
 import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
@@ -343,8 +340,8 @@ export function useReleaseBubbles({
   releases,
   minTime,
   maxTime,
-  bubbleSize = DEFAULT_BUBBLE_SIZE,
-  bubblePadding = {x: RELEASE_BUBBLE_X_PADDING, y: RELEASE_BUBBLE_Y_PADDING},
+  bubbleSize = 4,
+  bubblePadding = {x: 2, y: 1},
 }: UseReleaseBubblesParams) {
   const organization = useOrganization();
   const {openDrawer} = useDrawer();

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -369,7 +369,8 @@ export function useReleaseBubbles({
     };
   }
 
-  const totalBubblePaddingY = bubblePadding.y * 2;
+  // Read comments in `renderReleaseBubble()` regarding the +1
+  const totalBubblePaddingY = 1 + bubblePadding.y * 2;
 
   return {
     createReleaseBubbleHighlighter,
@@ -406,9 +407,7 @@ export function useReleaseBubbles({
       // configure `axisLine` and `offset` to move axis line below 0 so that
       // bubbles sit between bottom of the main chart and the axis line
       axisLine: {onZero: false},
-      // The +1 is needed because we add 1 pixel when drawing the bubbles in
-      // renderReleaseBubble (read comments there)
-      offset: bubbleSize + totalBubblePaddingY + 1,
+      offset: bubbleSize + totalBubblePaddingY,
     },
 
     /**
@@ -417,7 +416,7 @@ export function useReleaseBubbles({
     releaseBubbleGrid: {
       // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are
       // drawn below grid (but above x axis label)
-      bottom: bubbleSize + totalBubblePaddingY + 1,
+      bottom: bubbleSize + totalBubblePaddingY,
     },
   };
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -237,9 +237,13 @@ function ReleaseBubbleSeries({
       x: bubbleStartX + (params.dataIndex === 0 ? 0 : bubblePadding.x / 2),
       y: bubbleStartY + bubblePadding.y / 2,
       // No right-padding on last bubble
-      width: width - (params.dataIndex === 0 ? 0 : bubblePadding.x),
-      // currently we have a static height, but this may need to change since
-      // we have charts of different dimensions
+      // We don't decrease width on first bubble to make up for lack of
+      // left-padding
+      width:
+        width -
+        (params.dataIndex === 0 || params.dataIndex === data.length - 1
+          ? 0
+          : bubblePadding.x / 2),
       height: bubbleSize - bubblePadding.y,
 
       // border radius


### PR DESCRIPTION
We may need to configure different bubble styles when on different charts. This PR makes the padding configurable if needed. It also removes left padding from first bubble and right padding from last padding and fixes the vertical alignment of the bubble as well.

ref https://github.com/getsentry/sentry/issues/85775
