### PR TITLE
feat(flags): add flag suggestions to discover searchbox

### DIFF
--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -328,8 +328,8 @@ function ResultsSearchQueryBuilder(props: Props) {
     };
 
     const featureFlagsSection: FilterKeySection = {
-      value: 'feature_flags',
-      label: 'Feature Flags',
+      value: FieldKind.FEATURE_FLAG,
+      label: t('Feature Flags'),
       children: Object.keys(featureFlagTags),
     };
 

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -1,7 +1,12 @@
 import {useCallback, useMemo} from 'react';
 import omit from 'lodash/omit';
 
-import {fetchSpanFieldValues, fetchTagValues} from 'sentry/actionCreators/tags';
+import {
+  fetchFeatureFlagValues,
+  fetchSpanFieldValues,
+  fetchTagValues,
+  useFetchOrganizationTags,
+} from 'sentry/actionCreators/tags';
 import {
   STATIC_FIELD_TAGS,
   STATIC_FIELD_TAGS_SET,
@@ -47,6 +52,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useTags from 'sentry/utils/useTags';
+import {Dataset as AlertsDatasets} from 'sentry/views/alerts/rules/metric/types';
 import {isCustomMeasurement} from 'sentry/views/dashboards/utils';
 
 const getFunctionTags = (fields: readonly Field[] | undefined) => {
@@ -148,9 +154,20 @@ function ResultsSearchQueryBuilder(props: Props) {
 
   const api = useApi();
   const organization = useOrganization();
+  const projectIdStrings = useMemo(
+    () => (projectIds as Array<Readonly<number>>)?.map(String),
+    [projectIds]
+  );
   const {selection} = usePageFilters();
-  const tags = useTags();
+  const dateTimeParams = useMemo(
+    () => normalizeDateTimeParams(selection.datetime),
+    [selection.datetime]
+  );
+  const includeFeatureFlags =
+    (!dataset || dataset === DiscoverDatasets.ERRORS) &&
+    organization.features.includes('feature-flag-autocomplete');
 
+  const tags = useTags();
   const filteredTags = useMemo(() => {
     return omitTags && omitTags.length > 0
       ? omit(tags, omitTags, EXCLUDED_FILTER_KEYS)
@@ -163,64 +180,27 @@ function ResultsSearchQueryBuilder(props: Props) {
   const measurements = useMemo(() => getMeasurements(), []);
   const functionTags = useMemo(() => getFunctionTags(fields), [fields]);
 
-  // Returns array of tag values that substring match `query`; invokes `callback`
-  // with data when ready
-  const getEventFieldValues = useCallback(
-    async (tag: any, query: any): Promise<string[]> => {
-      const projectIdStrings = (projectIds as Array<Readonly<number>>)?.map(String);
-
-      if (isAggregateField(tag.key) || isMeasurement(tag.key)) {
-        // We can't really auto suggest values for aggregate fields
-        // or measurements, so we simply don't
-        return Promise.resolve([]);
-      }
-
-      // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
-      // and low search filter values because discover maps device.class to these values.
-      if (isDeviceClass(tag.key)) {
-        return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
-      }
-      const fetchPromise =
-        dataset === DiscoverDatasets.SPANS_INDEXED
-          ? fetchSpanFieldValues({
-              api,
-              endpointParams: normalizeDateTimeParams(selection.datetime),
-              orgSlug: organization.slug,
-              fieldKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-            })
-          : fetchTagValues({
-              api,
-              endpointParams: normalizeDateTimeParams(selection.datetime),
-              orgSlug: organization.slug,
-              tagKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-              // allows searching for tags on transactions as well
-              includeTransactions,
-              // allows searching for tags on sessions as well
-              includeSessions: includeSessionTagsValues,
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
-            });
-
-      try {
-        const results = await fetchPromise;
-        return results.filter(({name}) => defined(name)).map(({name}) => name);
-      } catch (error) {
-        throw new Error('Unable to fetch event field values');
-      }
+  const featureFlagQuery = useFetchOrganizationTags(
+    {
+      orgSlug: organization.slug,
+      projectIds: projectIdStrings,
+      dataset: AlertsDatasets.ERRORS,
+      useCache: true,
+      useFlagsBackend: true,
+      enabled: includeFeatureFlags,
+      ...dateTimeParams,
     },
-    [
-      api,
-      organization,
-      selection.datetime,
-      projectIds,
-      includeTransactions,
-      includeSessionTagsValues,
-      dataset,
-    ]
+    {}
+  );
+  const featureFlagTags: TagCollection = useMemo(
+    () =>
+      featureFlagQuery.data?.reduce<TagCollection>((acc, tag) => {
+        // Wrap with flags[""]. flags[] is required for the search endpoint and "" is used to escape special characters.
+        const key = `flags["${tag.key}"]`;
+        acc[key] = {...tag, kind: FieldKind.FEATURE_FLAG, key};
+        return acc;
+      }, {}) || {},
+    [featureFlagQuery.data]
   );
 
   const getTagList: TagCollection = useMemo(() => {
@@ -249,7 +229,7 @@ function ResultsSearchQueryBuilder(props: Props) {
               )
             : Object.assign({}, STATIC_FIELD_TAGS_WITHOUT_TRACING);
 
-    Object.assign(combinedTags, filteredTags, STATIC_SEMVER_TAGS);
+    Object.assign(combinedTags, filteredTags, STATIC_SEMVER_TAGS, featureFlagTags);
 
     combinedTags.has = getHasTag(combinedTags);
 
@@ -261,7 +241,84 @@ function ResultsSearchQueryBuilder(props: Props) {
     functionTags,
     filteredTags,
     organization.features,
+    featureFlagTags,
   ]);
+
+  // Returns array of tag values that substring match `query`; invokes `callback`
+  // with data when ready
+  const getEventFieldValues = useCallback(
+    async (tag: any, query: any): Promise<string[]> => {
+      if (getTagList[tag.key]?.kind === FieldKind.FEATURE_FLAG) {
+        if (dataset && dataset !== DiscoverDatasets.ERRORS) {
+          return Promise.resolve([]);
+        }
+
+        const results = await fetchFeatureFlagValues({
+          api,
+          tagKey: tag.key,
+          search: query,
+          projectIds: projectIdStrings,
+          endpointParams: dateTimeParams,
+          sort: '-count' as const,
+          organization,
+        });
+        return results.map(({value}) => value);
+      }
+
+      if (isAggregateField(tag.key) || isMeasurement(tag.key)) {
+        // We can't really auto suggest values for aggregate fields
+        // or measurements, so we simply don't
+        return Promise.resolve([]);
+      }
+
+      // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
+      // and low search filter values because discover maps device.class to these values.
+      if (isDeviceClass(tag.key)) {
+        return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
+      }
+      const fetchPromise =
+        dataset === DiscoverDatasets.SPANS_INDEXED
+          ? fetchSpanFieldValues({
+              api,
+              endpointParams: dateTimeParams,
+              orgSlug: organization.slug,
+              fieldKey: tag.key,
+              search: query,
+              projectIds: projectIdStrings,
+            })
+          : fetchTagValues({
+              api,
+              endpointParams: dateTimeParams,
+              orgSlug: organization.slug,
+              tagKey: tag.key,
+              search: query,
+              projectIds: projectIdStrings,
+              // allows searching for tags on transactions as well
+              includeTransactions,
+              // allows searching for tags on sessions as well
+              includeSessions: includeSessionTagsValues,
+              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+              dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
+            });
+
+      try {
+        const results = await fetchPromise;
+        return results.filter(({name}) => defined(name)).map(({name}) => name);
+      } catch (error) {
+        throw new Error('Unable to fetch event field values');
+      }
+    },
+    [
+      api,
+      organization,
+      dateTimeParams,
+      includeTransactions,
+      includeSessionTagsValues,
+      dataset,
+      getTagList,
+      projectIdStrings,
+    ]
+  );
 
   const filterKeySections = useMemo(() => {
     const customTagsSection: FilterKeySection = {
@@ -270,19 +327,30 @@ function ResultsSearchQueryBuilder(props: Props) {
       children: Object.keys(filteredTags),
     };
 
+    const featureFlagsSection: FilterKeySection = {
+      value: 'feature_flags',
+      label: 'Feature Flags',
+      children: Object.keys(featureFlagTags),
+    };
+
+    const tagsAndFlagsSections = [
+      customTagsSection,
+      ...(includeFeatureFlags && featureFlagTags ? [featureFlagsSection] : []),
+    ];
+
     if (
       dataset === DiscoverDatasets.TRANSACTIONS ||
       dataset === DiscoverDatasets.METRICS_ENHANCED
     ) {
-      return [...ALL_INSIGHTS_FILTER_KEY_SECTIONS, customTagsSection];
+      return [...ALL_INSIGHTS_FILTER_KEY_SECTIONS, ...tagsAndFlagsSections];
     }
 
     if (dataset === DiscoverDatasets.ERRORS) {
-      return [...ERRORS_DATASET_FILTER_KEY_SECTIONS, customTagsSection];
+      return [...ERRORS_DATASET_FILTER_KEY_SECTIONS, ...tagsAndFlagsSections];
     }
 
-    return [...COMBINED_DATASET_FILTER_KEY_SECTIONS, customTagsSection];
-  }, [filteredTags, dataset]);
+    return [...COMBINED_DATASET_FILTER_KEY_SECTIONS, ...tagsAndFlagsSections];
+  }, [filteredTags, dataset, includeFeatureFlags, featureFlagTags]);
 
   return (
     <SearchQueryBuilder


### PR DESCRIPTION
Queries for feature flag keys (sorted by count) and values from discover searchbar. Suggestions are only displayed if
- dataset=ERRORS or undefined. Flags only exist on the errors dataset.
- feature-flag-autocomplete flag is enabled
- there are >0 flags in the org

As in issues stream, flag keys are wrapped w/`flags[""]` to escape special characters reserved by the searchbox. They're unwrapped for value queries (for suggestions), but not for the search.

![Screenshot 2025-03-11 at 2 21 34 PM](https://github.com/user-attachments/assets/4d703c00-0963-4ea7-a70b-c9a0b6ffcf04)

Sample search in prod: 0 results for [session-replay-ui = false](https://sentry.sentry.io/discover/homepage/?dataset=errors&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=11276&query=flags%5B%22feature.organizations%3Asession-replay-ui%22%5D%3Afalse&queryDataset=error-events&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) (a flag that is 100% true everywhere). This suggests the syntax already works w/discover search backend                     

Closes https://github.com/getsentry/team-replay/issues/552