### PR TITLE
feat(insights): add back session health onboarding

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import startCase from 'lodash/startCase';
 import {PlatformIcon} from 'platformicons';
 
 import appStartPreviewImg from 'sentry-images/insights/module-upsells/insights-app-starts-module-charts.svg';
@@ -65,28 +66,23 @@ export function ModulesOnboarding({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasData]);
 
-  if (onboardingProject) {
+  // Show onboarding content if:
+  // 1. There's an onboarding project, or
+  // 2. showOnboardingOverride is true, or
+  // 3. There's no span data and showOnboardingOverride is undefined
+  const shouldShowOnboarding =
+    onboardingProject ||
+    showOnboardingOverride === true ||
+    (showOnboardingOverride === undefined && !hasData);
+
+  if (shouldShowOnboarding) {
     return (
       <ModuleLayout.Full>
-        <LegacyOnboarding organization={organization} project={onboardingProject} />
-      </ModuleLayout.Full>
-    );
-  }
-
-  if (showOnboardingOverride !== undefined) {
-    return showOnboardingOverride ? (
-      <ModuleLayout.Full>
-        <ModulesOnboardingPanel moduleName={moduleName} />
-      </ModuleLayout.Full>
-    ) : (
-      children
-    );
-  }
-
-  if (!hasData) {
-    return (
-      <ModuleLayout.Full>
-        <ModulesOnboardingPanel moduleName={moduleName} />
+        {onboardingProject ? (
+          <LegacyOnboarding organization={organization} project={onboardingProject} />
+        ) : (
+          <ModulesOnboardingPanel moduleName={moduleName} />
+        )}
       </ModuleLayout.Full>
     );
   }
@@ -154,7 +150,7 @@ function ModulePreview({moduleName}: ModulePreviewProps) {
           <div>{t('Supported Today: ')}</div>
           <SupportedSdkList>
             {emptyStateContent.supportedSdks.map((sdk: PlatformKey) => (
-              <Tooltip title={getSDKName(sdk) ?? ''} key={sdk} position="top">
+              <Tooltip title={getSDKName(sdk) ?? startCase(sdk)} key={sdk} position="top">
                 <SupportedSdkIconContainer
                   onMouseOver={() => setHoveredIcon(sdk)}
                   onMouseOut={() => setHoveredIcon(null)}

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -40,17 +40,9 @@ import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 type ModuleOnboardingProps = {
   children: React.ReactNode;
   moduleName: ModuleName;
-  /**
-   * Used to override the default logic for rendering module onboarding.
-   */
-  showOnboardingOverride?: boolean;
 };
 
-export function ModulesOnboarding({
-  children,
-  moduleName,
-  showOnboardingOverride,
-}: ModuleOnboardingProps) {
+export function ModulesOnboarding({children, moduleName}: ModuleOnboardingProps) {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const {reloadProjects} = useProjects();
@@ -66,23 +58,18 @@ export function ModulesOnboarding({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasData]);
 
-  // Show onboarding content if:
-  // 1. There's an onboarding project, or
-  // 2. showOnboardingOverride is true, or
-  // 3. There's no span data and showOnboardingOverride is undefined
-  const shouldShowOnboarding =
-    onboardingProject ||
-    showOnboardingOverride === true ||
-    (showOnboardingOverride === undefined && !hasData);
-
-  if (shouldShowOnboarding) {
+  if (onboardingProject) {
     return (
       <ModuleLayout.Full>
-        {onboardingProject ? (
-          <LegacyOnboarding organization={organization} project={onboardingProject} />
-        ) : (
-          <ModulesOnboardingPanel moduleName={moduleName} />
-        )}
+        <LegacyOnboarding organization={organization} project={onboardingProject} />
+      </ModuleLayout.Full>
+    );
+  }
+
+  if (!hasData) {
+    return (
+      <ModuleLayout.Full>
+        <ModulesOnboardingPanel moduleName={moduleName} />
       </ModuleLayout.Full>
     );
   }
@@ -90,7 +77,7 @@ export function ModulesOnboarding({
   return children;
 }
 
-function ModulesOnboardingPanel({moduleName}: {moduleName: ModuleName}) {
+export function ModulesOnboardingPanel({moduleName}: {moduleName: ModuleName}) {
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const emptyStateContent = EMPTY_STATE_CONTENT[moduleName];
   return (

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -36,13 +36,20 @@ import {
 import {ModuleName} from 'sentry/views/insights/types';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 
+type ModuleOnboardingProps = {
+  children: React.ReactNode;
+  moduleName: ModuleName;
+  /**
+   * Used to override the default logic for rendering module onboarding.
+   */
+  showOnboardingOverride?: boolean;
+};
+
 export function ModulesOnboarding({
   children,
   moduleName,
-}: {
-  children: React.ReactNode;
-  moduleName: ModuleName;
-}) {
+  showOnboardingOverride,
+}: ModuleOnboardingProps) {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const {reloadProjects} = useProjects();
@@ -63,6 +70,16 @@ export function ModulesOnboarding({
       <ModuleLayout.Full>
         <LegacyOnboarding organization={organization} project={onboardingProject} />
       </ModuleLayout.Full>
+    );
+  }
+
+  if (showOnboardingOverride !== undefined) {
+    return showOnboardingOverride ? (
+      <ModuleLayout.Full>
+        <ModulesOnboardingPanel moduleName={moduleName} />
+      </ModuleLayout.Full>
+    ) : (
+      children
     );
   }
 

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import startCase from 'lodash/startCase';
 import {PlatformIcon} from 'platformicons';
 
 import appStartPreviewImg from 'sentry-images/insights/module-upsells/insights-app-starts-module-charts.svg';
@@ -18,6 +17,7 @@ import emptyStateImg from 'sentry-images/spot/performance-waiting-for-span.svg';
 import {LinkButton} from 'sentry/components/button';
 import Panel from 'sentry/components/panels/panel';
 import {Tooltip} from 'sentry/components/tooltip';
+import platforms from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PlatformKey} from 'sentry/types/project';
@@ -119,6 +119,11 @@ function ModulesOnboardingPanel({moduleName}: {moduleName: ModuleName}) {
 
 type ModulePreviewProps = {moduleName: ModuleName};
 
+function getSDKName(sdk: PlatformKey) {
+  const currentPlatform = platforms.find(p => p.id === sdk);
+  return currentPlatform?.name;
+}
+
 function ModulePreview({moduleName}: ModulePreviewProps) {
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const emptyStateContent = EMPTY_STATE_CONTENT[moduleName];
@@ -132,7 +137,7 @@ function ModulePreview({moduleName}: ModulePreviewProps) {
           <div>{t('Supported Today: ')}</div>
           <SupportedSdkList>
             {emptyStateContent.supportedSdks.map((sdk: PlatformKey) => (
-              <Tooltip title={startCase(sdk)} key={sdk} position="top">
+              <Tooltip title={getSDKName(sdk) ?? ''} key={sdk} position="top">
                 <SupportedSdkIconContainer
                   onMouseOver={() => setHoveredIcon(sdk)}
                   onMouseOut={() => setHoveredIcon(null)}
@@ -509,8 +514,23 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
     }),
     valuePropPoints: [
       t('Understanding the rate of errored sessions across active releases.'),
+      t('Comparing adoption rates across different releases.'),
+      t('Visualizing user adoption over time.'),
     ],
     imageSrc: screenLoadsPreviewImg, // TODO: need new img
-    supportedSdks: [], // TODO: add supported sdks
+    supportedSdks: [
+      'android',
+      'flutter',
+      'apple-ios',
+      'javascript',
+      'electron',
+      'native',
+      'php',
+      'python',
+      'react-native',
+      'dotnet',
+      'rust',
+      'unity',
+    ], // this techncially isn't the full list - we support JS browser & node but it seems like too many SDKs to list here
   },
 };

--- a/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
@@ -1,0 +1,15 @@
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+
+export default function useProjectHasSessions() {
+  const {selection} = usePageFilters();
+  const {projects: allProjects} = useProjects();
+
+  const projectIds = selection.projects;
+  const projects = projectIds.map(projectId => {
+    return allProjects.find(p => p.id === projectId.toString());
+  });
+  const hasSessionData = projects.some(p => p?.hasSessions);
+
+  return hasSessionData;
+}

--- a/static/app/views/insights/sessions/settings.ts
+++ b/static/app/views/insights/sessions/settings.ts
@@ -6,7 +6,6 @@ export const DATA_TYPE = t('Session');
 export const DATA_TYPE_PLURAL = t('Sessions');
 export const BASE_URL = 'sessions';
 
-// TODO: update this
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/releases/setup/';
 
 export const MODULE_VISIBLE_FEATURES = ['insights-session-health-tab-ui'];

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -9,6 +9,7 @@ import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
@@ -88,24 +89,26 @@ export function SessionsOverview() {
                 </Alert>
               </ToolRibbon>
             </ModuleLayout.Full>
-            {view === MOBILE_LANDING_SUB_PATH && (
-              <Fragment>
-                {SESSION_HEALTH_CHARTS}
-                <ModuleLayout.Half>
-                  <ReleaseSessionCountChart />
-                </ModuleLayout.Half>
-                <ModuleLayout.Half>
-                  <ReleaseSessionPercentageChart />
-                </ModuleLayout.Half>
-                <ModuleLayout.Full>
-                  <FilterWrapper>
-                    <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
-                  </FilterWrapper>
-                  <ReleaseHealth filters={filters} />
-                </ModuleLayout.Full>
-              </Fragment>
-            )}
-            {view === FRONTEND_LANDING_SUB_PATH && SESSION_HEALTH_CHARTS}
+            <ModulesOnboarding moduleName={ModuleName.SESSIONS}>
+              {view === MOBILE_LANDING_SUB_PATH && (
+                <Fragment>
+                  {SESSION_HEALTH_CHARTS}
+                  <ModuleLayout.Half>
+                    <ReleaseSessionCountChart />
+                  </ModuleLayout.Half>
+                  <ModuleLayout.Half>
+                    <ReleaseSessionPercentageChart />
+                  </ModuleLayout.Half>
+                  <ModuleLayout.Full>
+                    <FilterWrapper>
+                      <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
+                    </FilterWrapper>
+                    <ReleaseHealth filters={filters} />
+                  </ModuleLayout.Full>
+                </Fragment>
+              )}
+              {view === FRONTEND_LANDING_SUB_PATH && SESSION_HEALTH_CHARTS}
+            </ModulesOnboarding>
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -29,6 +29,7 @@ import UserHealthCountChart from 'sentry/views/insights/sessions/charts/userHeal
 import UserHealthRateChart from 'sentry/views/insights/sessions/charts/userHealthRateChart';
 import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
+import useProjectHasSessions from 'sentry/views/insights/sessions/queries/useProjectHasSessions';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export function SessionsOverview() {
@@ -37,7 +38,12 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
+
   const [filters, setFilters] = useState<string[]>(['']);
+
+  // only show onboarding if the project does not have session data
+  const hasSessionData = useProjectHasSessions();
+  const showOnboarding = !hasSessionData;
 
   const SESSION_HEALTH_CHARTS = (
     <Fragment>
@@ -89,7 +95,10 @@ export function SessionsOverview() {
                 </Alert>
               </ToolRibbon>
             </ModuleLayout.Full>
-            <ModulesOnboarding moduleName={ModuleName.SESSIONS}>
+            <ModulesOnboarding
+              moduleName={ModuleName.SESSIONS}
+              showOnboardingOverride={showOnboarding}
+            >
               {view === MOBILE_LANDING_SUB_PATH && (
                 <Fragment>
                   {SESSION_HEALTH_CHARTS}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -9,7 +9,7 @@ import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
-import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
+import {ModulesOnboardingPanel} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
@@ -95,29 +95,35 @@ export function SessionsOverview() {
                 </Alert>
               </ToolRibbon>
             </ModuleLayout.Full>
-            <ModulesOnboarding
-              moduleName={ModuleName.SESSIONS}
-              showOnboardingOverride={showOnboarding}
-            >
-              {view === MOBILE_LANDING_SUB_PATH && (
-                <Fragment>
-                  {SESSION_HEALTH_CHARTS}
-                  <ModuleLayout.Half>
-                    <ReleaseSessionCountChart />
-                  </ModuleLayout.Half>
-                  <ModuleLayout.Half>
-                    <ReleaseSessionPercentageChart />
-                  </ModuleLayout.Half>
-                  <ModuleLayout.Full>
-                    <FilterWrapper>
-                      <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
-                    </FilterWrapper>
-                    <ReleaseHealth filters={filters} />
-                  </ModuleLayout.Full>
-                </Fragment>
-              )}
-              {view === FRONTEND_LANDING_SUB_PATH && SESSION_HEALTH_CHARTS}
-            </ModulesOnboarding>
+            {showOnboarding ? (
+              <ModuleLayout.Full>
+                <ModulesOnboardingPanel moduleName={ModuleName.SESSIONS} />
+              </ModuleLayout.Full>
+            ) : (
+              <Fragment>
+                {view === MOBILE_LANDING_SUB_PATH && (
+                  <Fragment>
+                    {SESSION_HEALTH_CHARTS}
+                    <ModuleLayout.Half>
+                      <ReleaseSessionCountChart />
+                    </ModuleLayout.Half>
+                    <ModuleLayout.Half>
+                      <ReleaseSessionPercentageChart />
+                    </ModuleLayout.Half>
+                    <ModuleLayout.Full>
+                      <FilterWrapper>
+                        <FilterReleaseDropdown
+                          filters={filters}
+                          setFilters={setFilters}
+                        />
+                      </FilterWrapper>
+                      <ReleaseHealth filters={filters} />
+                    </ModuleLayout.Full>
+                  </Fragment>
+                )}
+                {view === FRONTEND_LANDING_SUB_PATH && SESSION_HEALTH_CHARTS}
+              </Fragment>
+            )}
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>


### PR DESCRIPTION
the onboarding SDK icons for insights were just mapping the SDK name (the `PlatformKey`) to an uppercase version of it, which doesn't work super well for iOS or .NET for example. we already have access to the `PlatformIntegration` type which gives us a handy name reference, so use that instead.

before:

https://github.com/user-attachments/assets/478c43b7-facd-447a-b7a8-15537ae4d255


after:


https://github.com/user-attachments/assets/73870aab-8373-48bd-a259-0fe799c05a4d

the SDKs shown in the session health onboarding are based on the docs: https://docs.sentry.io/product/releases/setup/


closes https://github.com/getsentry/sentry/issues/86837