### PR TITLE
feat(autofix): Send trace-connected error and transaction tree in Autofix payload

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -90,9 +90,9 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if not results:
             return None
 
-        events_by_span_id = {}
-        children_by_parent_span_id = {}
-        root_events = []
+        events_by_span_id: dict[str, dict] = {}
+        children_by_parent_span_id: dict[str, list[dict]] = {}
+        root_events: list[dict] = []
 
         # First pass: collect all events and their relationships
         for result in results:
@@ -518,7 +518,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
         # get trace tree for this event
         try:
-            trace_tree = self._get_trace_tree_for_event(event, group.project)
+            trace_tree = self._get_trace_tree_for_event(event, group.project) if event else None
         except Exception as e:
             logger.exception(
                 "Failed to get trace tree for event",


### PR DESCRIPTION
Finds all transactions and errors in a trace for the event we're running Autofix on, and returns a tree with the important fields. We'll be able to use this tree as context in prompts, and use it as a starting point for tools to access profiles, trace-connected issues, and spans.

I have no way to test locally, so I made this safe enough to test in prod.

One annoying note is that transactions are planned to be deprecated eventually, but if I were to only dump spans, there would be way too much noise. Once the deprecation happens, we can update this logic then to use span segments and whatever else is available.