### PR TITLE
fix(issues): Hide duplicate client_os context

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -89,9 +89,9 @@ describe('HighlightsIconSummary', function () {
 
   it('renders appropriate icons and text', async function () {
     render(<HighlightsIconSummary event={event} group={group} />);
-    expect(screen.getByText('Mac OS X')).toBeInTheDocument();
-    expect(screen.getByText('10.15')).toBeInTheDocument();
-    await userEvent.hover(screen.getByText('10.15'));
+    expect(screen.getByText('macOS')).toBeInTheDocument();
+    expect(screen.getByText('15.3')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('15.3'));
     expect(await screen.findByText('Operating System Version')).toBeInTheDocument();
     expect(screen.getByText('CPython')).toBeInTheDocument();
     expect(screen.getByText('3.8.13')).toBeInTheDocument();

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -89,15 +89,34 @@ describe('HighlightsIconSummary', function () {
 
   it('renders appropriate icons and text', async function () {
     render(<HighlightsIconSummary event={event} group={group} />);
-    expect(screen.getByText('macOS')).toBeInTheDocument();
-    expect(screen.getByText('15.3')).toBeInTheDocument();
-    await userEvent.hover(screen.getByText('15.3'));
+    expect(screen.getByText('Mac OS X')).toBeInTheDocument();
+    expect(screen.getByText('10.15')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('10.15'));
     expect(await screen.findByText('Operating System Version')).toBeInTheDocument();
     expect(screen.getByText('CPython')).toBeInTheDocument();
     expect(screen.getByText('3.8.13')).toBeInTheDocument();
     await userEvent.hover(screen.getByText('3.8.13'));
     expect(await screen.findByText('Runtime Version')).toBeInTheDocument();
     expect(screen.getAllByRole('img')).toHaveLength(4);
+  });
+
+  it('deduplicates client_os and os contexts', function () {
+    const duplicateOsContextEvent = EventFixture({
+      contexts: {
+        client_os: {
+          type: 'client_os',
+          name: 'macOS',
+        },
+        os: {
+          type: 'os',
+          name: 'macOS',
+          version: '15.3',
+        },
+      },
+    });
+    render(<HighlightsIconSummary event={duplicateOsContextEvent} group={group} />);
+    expect(screen.getByText('macOS')).toBeInTheDocument();
+    expect(screen.getByText('15.3')).toBeInTheDocument();
   });
 
   it('hides device for non mobile/native', function () {

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -66,7 +66,12 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
         },
       }),
     }))
-    .filter(item => {
+    .filter((item, _index, array) => {
+      // Prefer the "os" context for OS information
+      if (item.alias === 'client_os' && array.find(i => i.alias === 'os')) {
+        return false;
+      }
+
       const hasData = item.icon !== null && Boolean(item.title || item.subtitle);
       if (item.alias === 'device') {
         return hasData && shouldDisplayDevice;

--- a/static/app/components/events/highlights/testUtils.tsx
+++ b/static/app/components/events/highlights/testUtils.tsx
@@ -8,10 +8,14 @@ export const TEST_EVENT_CONTEXTS = {
       brand: 'wuque studios',
     },
   },
-  client_os: {
+  os: {
     type: 'os',
-    name: 'Mac OS X',
-    version: '10.15',
+    name: 'macOS',
+    version: '15.3',
+  },
+  client_os: {
+    type: 'client_os',
+    name: 'macOS',
   },
   runtime: {
     type: 'runtime',

--- a/static/app/components/events/highlights/testUtils.tsx
+++ b/static/app/components/events/highlights/testUtils.tsx
@@ -8,14 +8,10 @@ export const TEST_EVENT_CONTEXTS = {
       brand: 'wuque studios',
     },
   },
-  os: {
-    type: 'os',
-    name: 'macOS',
-    version: '15.3',
-  },
   client_os: {
-    type: 'client_os',
-    name: 'macOS',
+    type: 'os',
+    name: 'Mac OS X',
+    version: '10.15',
   },
   runtime: {
     type: 'runtime',


### PR DESCRIPTION
Removes duplicate client_os that mirrors information from os that is parsed from browser user agent.

![image](https://github.com/user-attachments/assets/b978c087-a86b-4741-b297-4a6ca8f4f63c)

fixes https://github.com/getsentry/projects/issues/801