### PR TITLE
fix(issues): Shorten long runtime & ruby versions

### DIFF
--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -463,11 +463,14 @@ export function getFormattedContextData({
 }
 
 function shortRuntimeVersion(version: string) {
-  // Ruby runtime version looks like `ruby 3.2.6 (2024-10-30 revision 63aeb018eb) [arm64-darwin23]`
+  // Ruby runtime version looks like:
+  // - `ruby 3.2.6 (2024-10-30 revision 63aeb018eb) [arm64-darwin23]`
+  // - `ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin24]`
   if (version.startsWith('ruby') && version.length > 25) {
-    const match = version.match(/ruby\s+(\d+\.\d+\.\d+)/);
-    // Return just the version number
-    return match ? match[1] : version;
+    // Extract everything from "ruby" until the first opening parenthesis
+    // This will include both the version number and any patch level
+    const match = version.match(/ruby\s+(.*?)(?:\s+\(|$)/);
+    return match ? match[1]?.trim() : version;
   }
   // TODO: handle other long runtime versions
 

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -461,6 +461,31 @@ export function getFormattedContextData({
       }));
   }
 }
+
+function shortRuntimeVersion(version: string) {
+  // Ruby runtime version looks like `ruby 3.2.6 (2024-10-30 revision 63aeb018eb) [arm64-darwin23]`
+  if (version.startsWith('ruby') && version.length > 25) {
+    const match = version.match(/ruby\s+(\d+\.\d+\.\d+)/);
+    // Return just the version number
+    return match ? match[1] : version;
+  }
+  // TODO: handle other long runtime versions
+
+  return version;
+}
+
+function shortOperatingSystemVersion(version: string) {
+  // Darwin version looks like `Darwin Kernel Version 24.3.0: Thu Jan 2 20:24:24 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6030`
+  if (version.startsWith('Darwin Kernel Version') && version.length > 25) {
+    const match = version.match(/Darwin Kernel Version (\d+\.\d+\.\d+).+RELEASE_(.+)/);
+    // Return just the version number and release type
+    return match ? `${match[1]} (RELEASE_${match[2]})` : version;
+  }
+  // TODO: handle other long operating system versions
+
+  return version;
+}
+
 /**
  * Reimplemented as util function from legacy summaries deleted in this PR - https://github.com/getsentry/sentry/pull/71695/files
  * Consildated into one function and neglects any meta annotations since those will be rendered in the proper contexts section.
@@ -507,8 +532,8 @@ export function getContextSummary({
     case 'os':
     case 'client_os':
       title = data?.name ?? null;
-      if (defined(data?.version) && typeof data?.version === 'string') {
-        subtitle = data?.version;
+      if (typeof data?.version === 'string') {
+        subtitle = shortOperatingSystemVersion(data?.version);
         subtitleType = t('Version');
       } else if (defined(data?.kernel_version)) {
         subtitle = data?.kernel_version;
@@ -541,6 +566,12 @@ export function getContextSummary({
       }
       break;
     case 'runtime':
+      title = data?.name ?? null;
+      if (typeof data?.version === 'string') {
+        subtitle = shortRuntimeVersion(data?.version);
+        subtitleType = t('Version');
+      }
+      break;
     case 'browser':
       title = data?.name ?? null;
       if (defined(data?.version)) {

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -469,7 +469,7 @@ function shortRuntimeVersion(version: string) {
   if (version.startsWith('ruby') && version.length > 25) {
     // Extract everything from "ruby" until the first opening parenthesis
     // This will include both the version number and any patch level
-    const match = version.match(/ruby\s+(.*?)(?:\s+\(|$)/);
+    const match = version.match(/^ruby\s+(.*?)(?:\s+\(|$)/);
     return match ? match[1]?.trim() : version;
   }
   // TODO: handle other long runtime versions

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -158,4 +158,33 @@ describe('HighlightsIconSummary', function () {
     });
     expect(await screen.findByRole('button', {name: 'Screenshot'})).toBeInTheDocument();
   });
+
+  it('shortens long runtime versions', async function () {
+    const eventWithLongRuntime = EventFixture({
+      contexts: {
+        runtime: {
+          name: 'ruby',
+          version: 'ruby 3.2.6 (2024-10-30 revision 63aeb018eb) [arm64-darwin23]',
+          type: 'runtime',
+        },
+      },
+    });
+    render(<HighlightsIconSummary event={eventWithLongRuntime} group={group} />);
+    expect(await screen.findByText('3.2.6')).toBeInTheDocument();
+  });
+
+  it('shortens long operating system versions', async function () {
+    const eventWithLongOperatingSystem = EventFixture({
+      contexts: {
+        os: {
+          name: 'Darwin',
+          version:
+            'Darwin Kernel Version 24.3.0: Thu Jan 2 20:24:24 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6030',
+          type: 'os',
+        },
+      },
+    });
+    render(<HighlightsIconSummary event={eventWithLongOperatingSystem} group={group} />);
+    expect(await screen.findByText('24.3.0 (RELEASE_ARM64_T6030)')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -159,7 +159,7 @@ describe('HighlightsIconSummary', function () {
     expect(await screen.findByRole('button', {name: 'Screenshot'})).toBeInTheDocument();
   });
 
-  it('shortens long runtime versions', async function () {
+  it('shortens long ruby runtime versions', async function () {
     const eventWithLongRuntime = EventFixture({
       contexts: {
         runtime: {
@@ -171,6 +171,21 @@ describe('HighlightsIconSummary', function () {
     });
     render(<HighlightsIconSummary event={eventWithLongRuntime} group={group} />);
     expect(await screen.findByText('3.2.6')).toBeInTheDocument();
+  });
+
+  it('shortens long ruby runtime versions with patch', async function () {
+    const eventWithLongRuntime = EventFixture({
+      contexts: {
+        runtime: {
+          name: 'ruby',
+          version:
+            'ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin24]',
+          type: 'runtime',
+        },
+      },
+    });
+    render(<HighlightsIconSummary event={eventWithLongRuntime} group={group} />);
+    expect(await screen.findByText('2.6.10p210')).toBeInTheDocument();
   });
 
   it('shortens long operating system versions', async function () {


### PR DESCRIPTION
Ruby and darwin based operating systems have really long versions, we can display something shorter at the top of the issues page. The full version still appears lower on the page.

before
![image](https://github.com/user-attachments/assets/135a438a-fbc7-4163-9c5e-375737945a58)

after
![image](https://github.com/user-attachments/assets/c3a09a33-d2fd-4cb8-be5f-4b1c0ac823a1)
