### PR TITLE
fix(nav): Fix horizontal overflow on issue details

### DIFF
--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -122,6 +122,7 @@ const BodyContainer = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-width: 0;
 `;
 
 export default OrganizationLayout;


### PR DESCRIPTION
At certain widths, while using the new nav, the content would overflow. This was visible on the issue details page at ~1100px 