### PR TITLE
:wrench: chore(aci): add sentry app identifier to action config

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -155,7 +155,7 @@ def build_action_config(
         "target_type": target_type,
     }
     if target_type == ActionTarget.SENTRY_APP.value:
-        base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+        base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_ID
     return base_config
 
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -15,7 +15,7 @@ from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
-from sentry.notifications.models.notificationaction import ActionService
+from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.models import (
@@ -35,7 +35,11 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
-from sentry.workflow_engine.typings.notification_action import OnCallDataBlob, SentryAppDataBlob
+from sentry.workflow_engine.typings.notification_action import (
+    OnCallDataBlob,
+    SentryAppDataBlob,
+    SentryAppIdentifier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +146,19 @@ def get_target_identifier(
     return alert_rule_trigger_action.target_identifier
 
 
+def build_action_config(
+    target_display: str | None, target_identifier: str | None, target_type: int
+) -> dict[str, str | int | None]:
+    base_config = {
+        "target_display": target_display,
+        "target_identifier": target_identifier,
+        "target_type": target_type,
+    }
+    if target_type == ActionTarget.SENTRY_APP.value:
+        base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+    return base_config
+
+
 def get_detector_trigger(
     alert_rule_trigger: AlertRuleTrigger, priority: DetectorPriorityLevel
 ) -> DataCondition | None:
@@ -216,16 +233,17 @@ def migrate_metric_action(
     action_type_enum = Action.Type(action_type)
     data = build_action_data_blob(alert_rule_trigger_action, action_type_enum)
     target_identifier = get_target_identifier(alert_rule_trigger_action, action_type_enum)
+    action_config = build_action_config(
+        alert_rule_trigger_action.target_display,
+        target_identifier,
+        alert_rule_trigger_action.target_type,
+    )
 
     action = Action.objects.create(
         type=action_type_enum,
         data=data,
         integration_id=alert_rule_trigger_action.integration_id,
-        config={
-            "target_display": alert_rule_trigger_action.target_display,
-            "target_identifier": target_identifier,
-            "target_type": alert_rule_trigger_action.target_type,
-        },
+        config=action_config,
     )
     data_condition_group_action = DataConditionGroupAction.objects.create(
         condition_group_id=action_filter.condition_group.id,

--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -75,11 +75,7 @@ def translate_rule_data_actions_to_notification_actions(
                 type=translator.action_type,
                 data=translator.get_sanitized_data(),
                 integration_id=translator.integration_id,
-                config={
-                    "target_identifier": translator.target_identifier,
-                    "target_display": translator.target_display,
-                    "target_type": translator.target_type,
-                },
+                config=translator.action_config,
             )
 
             notification_actions.append(notification_action)

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -18,6 +18,16 @@ from sentry.workflow_engine.models.action import Action
 EXCLUDED_ACTION_DATA_KEYS = ["uuid", "id"]
 
 
+class SentryAppIdentifier(StrEnum):
+    """
+    SentryAppIdentifier is an enum that represents the identifier for a Sentry app.
+    """
+
+    SENTRY_APP_INSTALLATION_UUID = "sentry_app_installation_uuid"
+    SENTRY_APP_SLUG = "sentry_app_slug"
+    SENTRY_APP_ID = "sentry_app_id"
+
+
 @dataclass
 class FieldMapping:
     """
@@ -183,6 +193,18 @@ class BaseActionTranslator(ABC):
             if ActionFieldMappingKeys.TARGET_DISPLAY_KEY in mapping:
                 return self.action.get(mapping[ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value])
         return None
+
+    @property
+    def action_config(self) -> dict[str, str | int | None]:
+        base_config = {
+            "target_identifier": self.target_identifier,
+            "target_display": self.target_display,
+            "target_type": self.target_type.value if self.target_type is not None else None,
+        }
+        if self.action_type == Action.Type.SENTRY_APP:
+            base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+
+        return base_config
 
     @property
     def blob_type(self) -> type[DataBlob] | None:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -181,10 +181,7 @@ def assert_sentry_app_action_migrated(
 ):
     # Verify target_identifier is the string representation of sentry_app_id
     assert action.config.get("target_identifier") == str(alert_rule_trigger_action.sentry_app_id)
-    assert (
-        action.config.get("sentry_app_identifier")
-        == SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
-    )
+    assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
 
     # Verify data blob has correct structure for Sentry apps
     if not alert_rule_trigger_action.sentry_app_config:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -61,6 +61,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -180,6 +181,10 @@ def assert_sentry_app_action_migrated(
 ):
     # Verify target_identifier is the string representation of sentry_app_id
     assert action.config.get("target_identifier") == str(alert_rule_trigger_action.sentry_app_id)
+    assert (
+        action.config.get("sentry_app_identifier")
+        == SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+    )
 
     # Verify data blob has correct structure for Sentry apps
     if not alert_rule_trigger_action.sentry_app_config:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -21,6 +21,7 @@ from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
     SentryAppDataBlob,
+    SentryAppIdentifier,
     TicketDataBlob,
     TicketFieldMappingKeys,
     issue_alert_action_translator_registry,
@@ -177,7 +178,10 @@ class TestNotificationActionMigrationUtils(TestCase):
             assert action.config.get("target_display") == compare_dict.get(target_display_key)
 
         # Assert target_type matches
-        assert action.config.get("target_type") == translator.target_type
+        if translator.target_type is not None:
+            assert action.config.get("target_type") == translator.target_type.value
+        else:
+            assert action.config.get("target_type") is None
 
     def assert_actions_migrated_correctly(
         self,
@@ -1096,6 +1100,10 @@ class TestNotificationActionMigrationUtils(TestCase):
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
             assert action.config.get("target_identifier") == install.uuid
+            assert (
+                action.config.get("sentry_app_identifier")
+                == SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+            )
 
     def test_dry_run_flag(self):
         """Test that the dry_run flag prevents database writes."""


### PR DESCRIPTION
because we can't convert `sentry_app_installation_uuid` or `sentry_app.slug ` to `sentry_app.id` during migration, we must determine this inside the NOA. in order to do so, we need to save the identifier type in the `Action.config`. This PR allows for that to happen.