### PR TITLE
feat(laravel-insights): Redirect feedback

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -35,12 +35,10 @@ import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnbo
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {LaravelOverviewPage} from 'sentry/views/insights/pages/backend/laravel';
-import {
-  hasLaravelInsightsFeature,
-  useIsLaravelInsightsEnabled,
-} from 'sentry/views/insights/pages/backend/laravel/features';
+import {useIsLaravelInsightsEnabled} from 'sentry/views/insights/pages/backend/laravel/features';
 import {LaravelInsightsProvider} from 'sentry/views/insights/pages/backend/laravel/laravelInsightsContext';
 import {NewLaravelExperienceButton} from 'sentry/views/insights/pages/backend/laravel/newLaravelExperienceButton';
+import {useIsLaravelPageActive} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {
   BACKEND_LANDING_TITLE,
   OVERVIEW_PAGE_ALLOWED_OPS,
@@ -95,34 +93,8 @@ export const BACKEND_COLUMN_TITLES = [
 ];
 
 function BackendOverviewPage() {
-  const organization = useOrganization();
-  const {projects} = useProjects();
-  const {selection} = usePageFilters();
-  const [isLaravelInsightsEnabled, setIsLaravelInsightsEnabled] =
-    useIsLaravelInsightsEnabled();
-
-  const selectedProjects: Project[] = useMemo(
-    () => getSelectedProjectList(selection.projects, projects),
-    [projects, selection.projects]
-  );
-
-  let renderLaravelInsights = false;
-  const selectedProject = selectedProjects.length === 1 ? selectedProjects[0] : null;
-  if (
-    selectedProject?.platform === 'php-laravel' &&
-    hasLaravelInsightsFeature(organization) &&
-    isLaravelInsightsEnabled
-  ) {
-    renderLaravelInsights = true;
-  }
-
-  return (
-    <LaravelInsightsProvider
-      value={{isLaravelInsightsEnabled, setIsLaravelInsightsEnabled}}
-    >
-      {renderLaravelInsights ? <LaravelOverviewPage /> : <GenericBackendOverviewPage />}
-    </LaravelInsightsProvider>
-  );
+  const isLaravelPageActive = useIsLaravelPageActive();
+  return isLaravelPageActive ? <LaravelOverviewPage /> : <GenericBackendOverviewPage />;
 }
 
 function GenericBackendOverviewPage() {
@@ -341,9 +313,15 @@ function GenericBackendOverviewPage() {
 }
 
 function BackendOverviewPageWithProviders() {
+  const [isLaravelInsightsEnabled, setIsLaravelInsightsEnabled] =
+    useIsLaravelInsightsEnabled();
   return (
     <DomainOverviewPageProviders>
-      <BackendOverviewPage />
+      <LaravelInsightsProvider
+        value={{isLaravelInsightsEnabled, setIsLaravelInsightsEnabled}}
+      >
+        <BackendOverviewPage />
+      </LaravelInsightsProvider>
     </DomainOverviewPageProviders>
   );
 }

--- a/static/app/views/insights/pages/backend/laravel/utils.tsx
+++ b/static/app/views/insights/pages/backend/laravel/utils.tsx
@@ -2,7 +2,13 @@ import {useMemo} from 'react';
 
 import {type Fidelity, getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {Project} from 'sentry/types/project';
+import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {hasLaravelInsightsFeature} from 'sentry/views/insights/pages/backend/laravel/features';
+import {useLaravelInsightsContext} from 'sentry/views/insights/pages/backend/laravel/laravelInsightsContext';
 
 export function usePageFilterChartParams({
   granularity = 'spans',
@@ -21,4 +27,29 @@ export function usePageFilterChartParams({
     interval: getInterval(selection.datetime, granularity),
     project: selection.projects,
   };
+}
+
+export function useIsLaravelSelected() {
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+
+  const selectedProjects: Project[] = useMemo(
+    () => getSelectedProjectList(selection.projects, projects),
+    [projects, selection.projects]
+  );
+
+  const selectedProject = selectedProjects.length === 1 ? selectedProjects[0] : null;
+  return selectedProject?.platform === 'php-laravel';
+}
+
+export function useIsLaravelPageActive() {
+  const organization = useOrganization();
+  const isLaravelSelected = useIsLaravelSelected();
+  const {isLaravelInsightsEnabled} = useLaravelInsightsContext();
+
+  return (
+    isLaravelSelected &&
+    isLaravelInsightsEnabled &&
+    hasLaravelInsightsFeature(organization)
+  );
 }

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -19,6 +19,7 @@ import {
   type RoutableModuleNames,
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
+import {useIsLaravelPageActive} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   isModuleConsideredNew,
@@ -56,6 +57,7 @@ export function DomainViewHeader({
   const organization = useOrganization();
   const location = useLocation();
   const moduleURLBuilder = useModuleURLBuilder();
+  const isLaravelPageActive = useIsLaravelPageActive();
 
   const crumbs: Crumb[] = [
     {
@@ -103,7 +105,18 @@ export function DomainViewHeader({
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
-            <FeedbackWidgetButton />
+            <FeedbackWidgetButton
+              optionOverrides={
+                isLaravelPageActive
+                  ? {
+                      tags: {
+                        ['feedback.source']: 'laravel-insights',
+                        ['feedback.owner']: 'telemetry-experience',
+                      },
+                    }
+                  : undefined
+              }
+            />
             {additonalHeaderActions}
           </ButtonBar>
         </Layout.HeaderActions>


### PR DESCRIPTION
Apply team tags to feedback if on laravel page.
`feedback.source:laravel-insights` `feedback.owner:telemetry-experience`

- closes https://github.com/getsentry/projects/issues/809