### PR TITLE
fix(symbol sources): Use correct field name

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2866,7 +2866,7 @@ SENTRY_BUILTIN_SOURCES = {
             "filetypes": ["pdb", "breakpad", "sourcebundle"],
             # These file paths were empirically determined by examining
             # logs of successful downloads from the Electron symbol server.
-            "file_paths": [
+            "path_patterns": [
                 "*electron*",
                 "*ffmpeg*",
                 "*libEGL*",


### PR DESCRIPTION
Fixup of #86678.

The field for debug file paths is called `path_patterns`, not `file_paths`.