### PR TITLE
fix(symbol sources): Correct schema and validate builtin sources

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2866,7 +2866,7 @@ SENTRY_BUILTIN_SOURCES = {
             "filetypes": ["pdb", "breakpad", "sourcebundle"],
             # These file paths were empirically determined by examining
             # logs of successful downloads from the Electron symbol server.
-            "file_paths": [
+            "path_patterns": [
                 "*electron*",
                 "*ffmpeg*",
                 "*libEGL*",

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -34,7 +34,23 @@ VALID_LAYOUTS = (
     "slashsymbols",
 )
 
-VALID_FILE_TYPES = ("pe", "pdb", "mach_debug", "mach_code", "elf_debug", "elf_code", "breakpad")
+VALID_FILE_TYPES = (
+    "pe",
+    "pdb",
+    "portablepdb",
+    "mach_debug",
+    "mach_code",
+    "elf_debug",
+    "elf_code",
+    "wasm_debug",
+    "wasm_code",
+    "breakpad",
+    "sourcebundle",
+    "uuidmap",
+    "bcsymbolmap",
+    "il2cpp",
+    "proguard",
+)
 
 VALID_CASINGS = ("lowercase", "uppercase", "default")
 
@@ -48,11 +64,22 @@ LAYOUT_SCHEMA = {
     "additionalProperties": False,
 }
 
+FILTERS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "filetypes": {"type": "array", "items": {"type": "string", "enum": list(VALID_FILE_TYPES)}},
+        "path_patterns": {"type": "array", "items": {"type": "string"}},
+        "requires_checksum": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+
 COMMON_SOURCE_PROPERTIES = {
     "id": {"type": "string", "minLength": 1},
     "name": {"type": "string"},
     "layout": LAYOUT_SCHEMA,
-    "filetypes": {"type": "array", "items": {"type": "string", "enum": list(VALID_FILE_TYPES)}},
+    "filters": FILTERS_SCHEMA,
+    "is_public": {"type": "boolean"},
 }
 
 APP_STORE_CONNECT_SCHEMA = {

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1127,7 +1127,7 @@ class ProjectUpdateTest(APITestCase):
                 "layout": {
                     "type": "native",
                 },
-                "filetypes": ["pe"],
+                "filters": {"filetypes": ["pe"]},
                 "type": "http",
                 "url": "http://honk.beep",
                 "username": "honkhonk",
@@ -1180,7 +1180,7 @@ class ProjectUpdateTest(APITestCase):
                 "layout": {
                     "type": "native",
                 },
-                "filetypes": ["pe"],
+                "filters": {"filetypes": ["pe"]},
                 "type": "http",
                 "url": "http://honk.beep",
                 "username": "honkhonk",
@@ -1215,7 +1215,7 @@ class ProjectUpdateTest(APITestCase):
             "layout": {
                 "type": "native",
             },
-            "filetypes": ["pe"],
+            "filters": {"filetypes": ["pe"]},
             "type": "http",
             "url": "http://honk.beep",
             "username": "honkhonk",
@@ -1228,7 +1228,7 @@ class ProjectUpdateTest(APITestCase):
             "layout": {
                 "type": "native",
             },
-            "filetypes": ["pe"],
+            "filters": {"filetypes": ["pe"]},
             "type": "http",
             "url": "http://honk.beep",
             "username": "honkhonk",

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -1,8 +1,16 @@
+import jsonschema
 import pytest
+from django.conf import settings
 
-from sentry.lang.native.sources import filter_ignored_sources
+from sentry.lang.native.sources import SOURCE_SCHEMA, filter_ignored_sources
 from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+def test_validate_builtin_sources():
+    for source in settings.SENTRY_BUILTIN_SOURCES.values():
+        jsonschema.validate(source, SOURCE_SCHEMA)
 
 
 class TestIgnoredSourcesFiltering:


### PR DESCRIPTION
Validating the builtin symbol sources against the schema revealed that it was incorrect in several ways (missing file types, filters, `is_public`).

I also added the validation of the builtin sources as a test so that in the future a mistake like #86873 fails in CI.