### PR TITLE
feat(laravel-insights): Open in explore

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -1,10 +1,8 @@
 import {Fragment, useMemo} from 'react';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
 import {getChartColorPalette} from 'sentry/constants/chartPalette';
-import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -22,6 +20,7 @@ import {
   SeriesColorIndicator,
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/backend/laravel/styles';
+import {Toolbar} from 'sentry/views/insights/pages/backend/laravel/toolbar';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
 
@@ -156,25 +155,19 @@ export function CachesWidget({query}: {query?: string}) {
       Visualization={visualization}
       Actions={
         hasData && (
-          <Widget.WidgetToolbar>
-            <Button
-              size="xs"
-              aria-label={t('Open Full-Screen View')}
-              borderless
-              icon={<IconExpand />}
-              onClick={() => {
-                openInsightChartModal({
-                  title: t('Cache Miss Rates'),
-                  children: (
-                    <Fragment>
-                      <ModalChartContainer>{visualization}</ModalChartContainer>
-                      <ModalTableWrapper>{footer}</ModalTableWrapper>
-                    </Fragment>
-                  ),
-                });
-              }}
-            />
-          </Widget.WidgetToolbar>
+          <Toolbar
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('Cache Miss Rates'),
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
         )
       }
       noFooterPadding

--- a/static/app/views/insights/pages/backend/laravel/durationWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/durationWidget.tsx
@@ -1,17 +1,29 @@
 import {useCallback, useMemo} from 'react';
 
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {ModalChartContainer} from 'sentry/views/insights/pages/backend/laravel/styles';
+import {Toolbar} from 'sentry/views/insights/pages/backend/laravel/toolbar';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
 
 export function DurationWidget({query}: {query?: string}) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
+
+  const fullQuery = `span.op:http.server ${query}`.trim();
 
   const {data, isLoading, error} = useApiQuery<MultiSeriesEventsStats>(
     [
@@ -24,7 +36,7 @@ export function DurationWidget({query}: {query?: string}) {
           orderby: 'avg(span.duration)',
           partial: 1,
           useRpc: 1,
-          query: `span.op:http.server ${query}`.trim(),
+          query: fullQuery,
         },
       },
     ],
@@ -51,19 +63,56 @@ export function DurationWidget({query}: {query?: string}) {
     [data]
   );
 
-  const timeSeries = useMemo(() => {
+  const plottables = useMemo(() => {
     return [
       getTimeSeries('avg(span.duration)', CHART_PALETTE[1][0]),
       getTimeSeries('p95(span.duration)', CHART_PALETTE[1][1]),
-    ].filter(series => !!series);
+    ]
+      .filter(series => !!series)
+      .map(ts => new Line(convertSeriesToTimeseries(ts)));
   }, [getTimeSeries]);
 
-  return (
-    <InsightsLineChartWidget
-      title="Duration"
+  const isEmpty = plottables.every(plottable => plottable.isEmpty);
+
+  const visualization = (
+    <WidgetVisualizationStates
       isLoading={isLoading}
       error={error}
-      series={timeSeries}
+      isEmpty={isEmpty}
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        plottables,
+      }}
+    />
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('Duration')} />}
+      Visualization={visualization}
+      Actions={
+        !isEmpty && (
+          <Toolbar
+            exploreParams={{
+              mode: Mode.SAMPLES,
+              visualize: [
+                {
+                  chartType: ChartType.LINE,
+                  yAxes: ['avg(span.duration)', 'p95(span.duration)'],
+                },
+              ],
+              query: fullQuery,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('Duration'),
+                children: <ModalChartContainer>{visualization}</ModalChartContainer>,
+              });
+            }}
+          />
+        )
+      }
     />
   );
 }

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -2,9 +2,7 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/button';
 import {getChartColorPalette} from 'sentry/constants/chartPalette';
-import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
@@ -13,6 +11,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
@@ -22,6 +22,7 @@ import {
   SeriesColorIndicator,
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/backend/laravel/styles';
+import {Toolbar} from 'sentry/views/insights/pages/backend/laravel/toolbar';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -48,6 +49,8 @@ export function QueriesWidget({query}: {query?: string}) {
     granularity: 'spans',
   });
 
+  const fullQuery = `has:db.system ${query}`;
+
   const queriesRequest = useApiQuery<QueriesDiscoverQueryResponse>(
     [
       `/organizations/${organization.slug}/events/`,
@@ -63,7 +66,7 @@ export function QueriesWidget({query}: {query?: string}) {
             'avg(span.duration)',
             'transaction',
           ],
-          query: `has:db.system !transaction.span_id:00 ${query}`,
+          query: fullQuery,
           sort: '-avg(span.duration)',
           per_page: 3,
           useRpc: 1,
@@ -180,25 +183,31 @@ export function QueriesWidget({query}: {query?: string}) {
       Visualization={visualization}
       Actions={
         hasData && (
-          <Widget.WidgetToolbar>
-            <Button
-              size="xs"
-              aria-label={t('Open Full-Screen View')}
-              borderless
-              icon={<IconExpand />}
-              onClick={() => {
-                openInsightChartModal({
-                  title: t('Slow Queries'),
-                  children: (
-                    <Fragment>
-                      <ModalChartContainer>{visualization}</ModalChartContainer>
-                      <ModalTableWrapper>{footer}</ModalTableWrapper>
-                    </Fragment>
-                  ),
-                });
-              }}
-            />
-          </Widget.WidgetToolbar>
+          <Toolbar
+            exploreParams={{
+              mode: Mode.AGGREGATE,
+              visualize: [
+                {
+                  chartType: ChartType.LINE,
+                  yAxes: ['avg(span.duration)'],
+                },
+              ],
+              groupBy: ['sentry.normalized_description'],
+              query: fullQuery,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('Slow Queries'),
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
         )
       }
       noFooterPadding

--- a/static/app/views/insights/pages/backend/laravel/toolbar.tsx
+++ b/static/app/views/insights/pages/backend/laravel/toolbar.tsx
@@ -1,0 +1,56 @@
+import {Button} from 'sentry/components/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconEllipsis, IconExpand} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+type ExploreParams = Parameters<typeof getExploreUrl>[0];
+
+interface ToolbarProps {
+  onOpenFullScreen: () => void;
+  exploreParams?: Omit<ExploreParams, 'organization' | 'selection'>;
+}
+
+export function Toolbar({exploreParams, onOpenFullScreen}: ToolbarProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const exploreUrl =
+    exploreParams && getExploreUrl({...exploreParams, organization, selection});
+
+  return (
+    <Widget.WidgetToolbar>
+      {exploreUrl ? (
+        <DropdownMenu
+          size="xs"
+          position="bottom-end"
+          trigger={triggerProps => (
+            <Button
+              {...triggerProps}
+              size="xs"
+              borderless
+              icon={<IconEllipsis />}
+              aria-label={t('More actions')}
+            />
+          )}
+          items={[
+            {
+              key: 'open-in-explore',
+              label: t('Open in Explore'),
+              to: exploreUrl,
+            },
+          ]}
+        />
+      ) : null}
+      <Button
+        size="xs"
+        aria-label={t('Open Full-Screen View')}
+        borderless
+        icon={<IconExpand />}
+        onClick={onOpenFullScreen}
+      />
+    </Widget.WidgetToolbar>
+  );
+}


### PR DESCRIPTION
Add context menu with `Open in Explore` to widgets.
Note: The caches widget is not querying from EAP yet and therefore cannot be displayed in explore.

<img width="397" alt="Screenshot 2025-03-12 at 11 53 38" src="https://github.com/user-attachments/assets/cde8f044-0c1d-4259-ac91-88d33ed27835" />

- closes https://github.com/getsentry/sentry/issues/86674
