### PR TITLE
profiling: update colors for flamegraph

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -57,15 +57,13 @@ export function FlamegraphUIFramesTooltip({
     >
       {uiFramesInConfigSpace.map((frame, i) => {
         const rect = frame.rect.transformRect(uiFramesView.configSpaceTransform);
+        const color = uiFramesRenderer.getColorForFrame(frame.type);
+        const cssColor = toRGBAString(color[0]!, color[1]!, color[2]!, color[3] ?? 1);
 
         return (
           <React.Fragment key={i}>
             <FlamegraphTooltipFrameMainInfo>
-              <FlamegraphTooltipColorIndicator
-                backgroundColor={toRGBAString(
-                  ...uiFramesRenderer.getColorForFrame(frame.type)
-                )}
-              />
+              <FlamegraphTooltipColorIndicator backgroundColor={cssColor} />
               {uiFrames.formatter(rect.width)}{' '}
               {frame.type === 'frozen' ? t('frozen frame') : t('slow frame')}
             </FlamegraphTooltipFrameMainInfo>

--- a/static/app/utils/profiling/colors/utils.spec.tsx
+++ b/static/app/utils/profiling/colors/utils.spec.tsx
@@ -5,15 +5,10 @@ import {
   makeColorMapBySymbolName,
   makeStackToColor,
 } from 'sentry/utils/profiling/colors/utils';
-import {
-  LCH_LIGHT,
-  makeLightFlamegraphTheme,
-} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {makeLightFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {Frame} from 'sentry/utils/profiling/frame';
 import {lightTheme} from 'sentry/utils/theme';
-
-import {makeColorBucketTheme} from '../speedscope';
 
 const theme = makeLightFlamegraphTheme(lightTheme);
 
@@ -56,7 +51,7 @@ describe('makeStackToColor', () => {
     const {colorBuffer} = makeFn(
       frames,
       () => new Map(),
-      makeColorBucketTheme(LCH_LIGHT),
+      theme.COLORS.COLOR_BUCKET,
       theme
     );
     expect(colorBuffer.slice(0, 4)).toEqual(fallback);
@@ -73,7 +68,7 @@ describe('makeStackToColor', () => {
     const {colorBuffer} = makeFn(
       frames,
       makeColorMapBySymbolName,
-      makeColorBucketTheme(LCH_LIGHT),
+      theme.COLORS.COLOR_BUCKET,
       theme
     );
     expect(colorBuffer.slice(0, 4)).toEqual([0.9625, 0.7125, 0.7125, 1]);
@@ -98,7 +93,7 @@ describe('makeStackToColor', () => {
         m.set('a', [1, 0, 0]);
         return m;
       },
-      makeColorBucketTheme(LCH_LIGHT),
+      theme.COLORS.COLOR_BUCKET,
       theme
     );
     expect(colorBuffer.slice(0, 4)).toEqual([1, 0, 0, 1]);
@@ -114,14 +109,14 @@ describe('makeColorMap', () => {
 
     b.frame = a.frame;
 
-    const map = makeColorMapBySymbolName([a, b], makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMapBySymbolName([a, b], theme.COLORS.COLOR_BUCKET);
     expect(map.get(a.key)).toEqual(map.get(b.key));
   });
   it('default colors by frame name', () => {
     // Reverse order to ensure we actually sort
     const frames = [f(1, 'c'), f(2, 'b'), f(3, 'a')];
 
-    const map = makeColorMapBySymbolName(frames, makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMapBySymbolName(frames, theme.COLORS.COLOR_BUCKET);
 
     expect(getDominantColor(map.get(3))).toBe('red');
     expect(getDominantColor(map.get(2))).toBe('green');
@@ -136,7 +131,7 @@ describe('makeColorMap', () => {
       f(3, 'a', undefined, 'a'),
     ];
 
-    const map = makeColorMapByLibrary(frames, makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMapByLibrary(frames, theme.COLORS.COLOR_BUCKET);
 
     expect(getDominantColor(map.get(3))).toBe('red');
     expect(getDominantColor(map.get(2))).toBe('green');
@@ -150,7 +145,7 @@ describe('makeColorMap', () => {
     frames[1]!.node.recursive = frames[0]!.node;
     frames[2]!.node.recursive = frames[1]!.node;
 
-    const map = makeColorMapByRecursion(frames, makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMapByRecursion(frames, theme.COLORS.COLOR_BUCKET);
 
     expect(getDominantColor(map.get(1))).toBe('red');
     expect(map.get(3)).toBeUndefined();

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -1,4 +1,4 @@
-import type {Theme} from '@emotion/react';
+import type {DO_NOT_USE_ChonkTheme, Theme} from '@emotion/react';
 
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {
@@ -25,7 +25,7 @@ const MONOSPACE_FONT = `ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI 
 
 const FRAME_FONT = lightTheme.text.familyMono;
 
-// Luma chroma hue settings
+// Luma chroma settings
 export interface LCH {
   C_0: number;
   C_d: number;
@@ -63,7 +63,7 @@ export interface FlamegraphTheme {
     FRAME_SYSTEM_COLOR: ColorChannels;
     GRID_FRAME_BACKGROUND_COLOR: string;
     GRID_LINE_COLOR: string;
-    HIGHLIGHTED_LABEL_COLOR: ColorChannels;
+    HIGHLIGHTED_LABEL_COLOR: string;
     HOVERED_FRAME_BORDER_COLOR: string;
     LABEL_FONT_COLOR: string;
     MEMORY_CHART_COLORS: ColorChannels[];
@@ -88,13 +88,14 @@ export interface FlamegraphTheme {
       colorBuffer: number[];
       colorMap: Map<Frame['key'], ColorChannels>;
     };
-    UI_FRAME_COLOR_FROZEN: [number, number, number, number];
-    UI_FRAME_COLOR_SLOW: [number, number, number, number];
+    UI_FRAME_COLOR_FROZEN: ColorChannels;
+    UI_FRAME_COLOR_SLOW: ColorChannels;
   };
   FONTS: {
     FONT: string;
     FRAME_FONT: string;
   };
+  LCH: LCH;
   SIZES: {
     AGGREGATE_FLAMEGRAPH_DEPTH_OFFSET: number;
     BAR_FONT_SIZE: number;
@@ -125,16 +126,16 @@ export interface FlamegraphTheme {
   };
 }
 
-// Luma chroma hue settings for light theme
-export const LCH_LIGHT = {
+// Luma chroma settings for light theme
+const LCH_LIGHT = {
   C_0: 0.25,
   C_d: 0.2,
   L_0: 0.8,
   L_d: 0.15,
 };
 
-// Luma chroma hue settings for dark theme
-export const LCH_DARK = {
+// Luma chroma settings for dark theme
+const LCH_DARK = {
   C_0: 0.2,
   C_d: 0.1,
   L_0: 0.2,
@@ -189,9 +190,12 @@ const FONTS: FlamegraphTheme['FONTS'] = {
   FRAME_FONT,
 };
 
+/** Legacy theme definitions */
 export function makeLightFlamegraphTheme(_theme: Theme): FlamegraphTheme {
   return {
+    LCH: LCH_LIGHT,
     SIZES,
+    FONTS,
     COLORS: {
       BAR_LABEL_FONT_COLOR: '#000',
       BATTERY_CHART_COLORS: [[0.4, 0.56, 0.9, 0.65]],
@@ -223,7 +227,7 @@ export function makeLightFlamegraphTheme(_theme: Theme): FlamegraphTheme {
       SPAN_FALLBACK_COLOR: [0, 0, 0, 0.1],
       GRID_FRAME_BACKGROUND_COLOR: 'rgb(250, 249, 251, 1)', // theme.backgroundSecondary
       GRID_LINE_COLOR: '#e5e7eb',
-      HIGHLIGHTED_LABEL_COLOR: [240, 240, 0, 1],
+      HIGHLIGHTED_LABEL_COLOR: 'rgba(240, 240, 0, 1)',
       HOVERED_FRAME_BORDER_COLOR: 'rgba(0, 0, 0, 0.8)',
       LABEL_FONT_COLOR: '#1f233a',
       MINIMAP_POSITION_OVERLAY_BORDER_COLOR: 'rgba(0,0,0, 0.2)',
@@ -241,13 +245,14 @@ export function makeLightFlamegraphTheme(_theme: Theme): FlamegraphTheme {
       SPAN_FRAME_BORDER: 'rgba(200, 200, 200, 1)',
       STACK_TO_COLOR: makeStackToColor([0, 0, 0, 0.035]),
     },
-    FONTS,
   };
 }
 
 export function makeDarkFlamegraphTheme(_theme: Theme): FlamegraphTheme {
   return {
+    LCH: LCH_DARK,
     SIZES,
+    FONTS,
     COLORS: {
       BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
       BATTERY_CHART_COLORS: [[0.4, 0.56, 0.9, 0.5]],
@@ -279,11 +284,11 @@ export function makeDarkFlamegraphTheme(_theme: Theme): FlamegraphTheme {
       SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
       GRID_FRAME_BACKGROUND_COLOR: 'rgb(26, 20, 31,1)',
       GRID_LINE_COLOR: '#222227',
-      HIGHLIGHTED_LABEL_COLOR: [136, 50, 0, 1],
+      HIGHLIGHTED_LABEL_COLOR: 'rgba(136, 50, 0, 1)',
       HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',
       LABEL_FONT_COLOR: 'rgba(255, 255, 255, 0.8)',
       MINIMAP_POSITION_OVERLAY_BORDER_COLOR: 'rgba(255,255,255, 0.35)',
-      MINIMAP_POSITION_OVERLAY_COLOR: 'rgba(255,255,255,0.1)',
+      MINIMAP_POSITION_OVERLAY_COLOR: 'rgba(82, 25, 25, 0.1)',
       SAMPLE_TICK_COLOR: [255, 0, 0, 0.5],
       // Yellow 200
       UI_FRAME_COLOR_SLOW: [0.96, 0.69, 0.0, 0.6],
@@ -297,6 +302,184 @@ export function makeDarkFlamegraphTheme(_theme: Theme): FlamegraphTheme {
       SPAN_FRAME_BORDER: '#57575b',
       STACK_TO_COLOR: makeStackToColor([1, 1, 1, 0.1]),
     },
-    FONTS,
   };
 }
+
+/** Chonk theme definitions */
+
+const LCH_LIGHT_CHONK = {
+  C_0: 0.35,
+  C_d: 0.3,
+  L_0: 0.8,
+  L_d: 0.15,
+};
+
+const SPAN_LCH_LIGHT_CHONK = {
+  C_0: 0.3,
+  C_d: 0.25,
+  L_0: 0.8,
+  L_d: 0.15,
+};
+
+export const makeLightChonkFlamegraphTheme = (
+  theme: DO_NOT_USE_ChonkTheme
+): FlamegraphTheme => {
+  return {
+    LCH: LCH_LIGHT_CHONK,
+    SIZES,
+    FONTS,
+    COLORS: {
+      COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT_CHONK),
+      SPAN_COLOR_BUCKET: makeColorBucketTheme(SPAN_LCH_LIGHT_CHONK, 140, 220),
+      COLOR_MAPS: {
+        'by symbol name': makeColorMapBySymbolName,
+        'by system frame': makeColorMapBySystemFrame,
+        'by application frame': makeColorMapByApplicationFrame,
+        'by library': makeColorMapByLibrary,
+        'by recursion': makeColorMapByRecursion,
+        'by frequency': makeColorMapByFrequency,
+        'by system vs application frame': makeColorMapBySystemVsApplicationFrame,
+      },
+
+      // Charts
+      CPU_CHART_COLORS: CHART_PALETTE[12].map(c => hexToColorChannels(c, 0.8)),
+      MEMORY_CHART_COLORS: [
+        hexToColorChannels(theme.colors.yellow400, 0.5),
+        hexToColorChannels(theme.colors.red400, 0.5),
+      ],
+      UI_FRAME_COLOR_SLOW: hexToColorChannels(theme.colors.yellow300, 1),
+      UI_FRAME_COLOR_FROZEN: hexToColorChannels(theme.colors.red400, 1),
+      BATTERY_CHART_COLORS: [hexToColorChannels(theme.colors.blue400, 1)],
+
+      // Preset colors
+      FRAME_APPLICATION_COLOR: hexToColorChannels(theme.colors.blue400, 0.4),
+      FRAME_SYSTEM_COLOR: hexToColorChannels(theme.colors.red400, 0.3),
+      DIFFERENTIAL_DECREASE: hexToColorChannels(theme.colors.yellow200, 1),
+      DIFFERENTIAL_INCREASE: hexToColorChannels(theme.colors.red300, 1),
+      SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
+
+      // Cursors and labels
+      LABEL_FONT_COLOR: theme.textColor,
+      BAR_LABEL_FONT_COLOR: theme.textColor,
+      CHART_CURSOR_INDICATOR: theme.subText,
+      CHART_LABEL_COLOR: theme.subText,
+      CURSOR_CROSSHAIR: theme.border,
+
+      // Special states
+      FOCUSED_FRAME_BORDER_COLOR: lightTheme.focus,
+      HIGHLIGHTED_LABEL_COLOR: `rgba(240, 240, 0, 1)`,
+      HOVERED_FRAME_BORDER_COLOR: theme.colors.gray400,
+      SELECTED_FRAME_BORDER_COLOR: lightTheme.blue400,
+
+      // Search results
+      SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 1.0)',
+      SEARCH_RESULT_SPAN_COLOR: '#fdb359',
+
+      // Patterns
+      SPAN_FRAME_LINE_PATTERN_BACKGROUND: theme.colors.grayTransparent100,
+      SPAN_FRAME_LINE_PATTERN: theme.colors.grayTransparent200,
+
+      // Fallbacks
+      SPAN_FALLBACK_COLOR: [0, 0, 0, 0.1],
+      FRAME_FALLBACK_COLOR: [0.5, 0.5, 0.6, 0.1],
+
+      // Layout colors
+      GRID_LINE_COLOR: theme.colors.surface200,
+      GRID_FRAME_BACKGROUND_COLOR: theme.colors.surface400,
+
+      MINIMAP_POSITION_OVERLAY_BORDER_COLOR: theme.colors.gray300,
+      MINIMAP_POSITION_OVERLAY_COLOR: theme.colors.gray200,
+
+      SPAN_FRAME_BORDER: theme.colors.grayTransparent300,
+      STACK_TO_COLOR: makeStackToColor([0, 0, 0, 0.035]),
+    },
+  };
+};
+
+const LCH_DARK_CHONK = {
+  C_0: 0.35,
+  C_d: 0.25,
+  L_0: 0.25,
+  L_d: 0.15,
+};
+
+const SPANS_LCH_DARK_CHONK = {
+  C_0: 0.4,
+  C_d: 0.25,
+  L_0: 0.3,
+  L_d: 0.2,
+};
+
+export const makeDarkChonkFlamegraphTheme = (
+  theme: DO_NOT_USE_ChonkTheme
+): FlamegraphTheme => {
+  return {
+    LCH: LCH_DARK_CHONK,
+    SIZES,
+    FONTS,
+    COLORS: {
+      COLOR_BUCKET: makeColorBucketTheme(LCH_DARK_CHONK),
+      SPAN_COLOR_BUCKET: makeColorBucketTheme(SPANS_LCH_DARK_CHONK, 140, 220),
+      COLOR_MAPS: {
+        'by symbol name': makeColorMapBySymbolName,
+        'by system frame': makeColorMapBySystemFrame,
+        'by application frame': makeColorMapByApplicationFrame,
+        'by library': makeColorMapByLibrary,
+        'by recursion': makeColorMapByRecursion,
+        'by frequency': makeColorMapByFrequency,
+        'by system vs application frame': makeColorMapBySystemVsApplicationFrame,
+      },
+
+      // Charts
+      CPU_CHART_COLORS: CHART_PALETTE[12].map(c => hexToColorChannels(c, 0.8)),
+      MEMORY_CHART_COLORS: [
+        hexToColorChannels(theme.colors.yellow400, 1),
+        hexToColorChannels(theme.colors.red400, 1),
+      ],
+      UI_FRAME_COLOR_SLOW: hexToColorChannels(theme.colors.yellow300, 1),
+      UI_FRAME_COLOR_FROZEN: hexToColorChannels(theme.colors.red400, 1),
+      BATTERY_CHART_COLORS: [hexToColorChannels(theme.colors.blue400, 1)],
+
+      // Preset colors
+      FRAME_APPLICATION_COLOR: hexToColorChannels(theme.colors.blue400, 0.6),
+      FRAME_SYSTEM_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
+      DIFFERENTIAL_DECREASE: hexToColorChannels(theme.colors.yellow200, 1),
+      DIFFERENTIAL_INCREASE: hexToColorChannels(theme.colors.red300, 1),
+      SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
+
+      // Cursors and labels
+      LABEL_FONT_COLOR: theme.textColor,
+      BAR_LABEL_FONT_COLOR: theme.textColor,
+      CHART_CURSOR_INDICATOR: theme.subText,
+      CHART_LABEL_COLOR: theme.subText,
+      CURSOR_CROSSHAIR: theme.border,
+
+      // Special states
+      FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
+      HIGHLIGHTED_LABEL_COLOR: theme.colors.yellow400,
+      HOVERED_FRAME_BORDER_COLOR: theme.colors.gray400,
+      SELECTED_FRAME_BORDER_COLOR: lightTheme.blue400,
+
+      // Search results
+      SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 1.0)',
+      SEARCH_RESULT_SPAN_COLOR: '#fdb359',
+
+      // Patterns
+      SPAN_FRAME_LINE_PATTERN: theme.colors.grayTransparent200,
+      SPAN_FRAME_LINE_PATTERN_BACKGROUND: theme.colors.grayTransparent100,
+
+      // Fallbacks
+      FRAME_FALLBACK_COLOR: [0.5, 0.5, 0.5, 0.4],
+      SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
+
+      // Layout colors
+      GRID_LINE_COLOR: theme.colors.surface200,
+      GRID_FRAME_BACKGROUND_COLOR: theme.colors.surface400,
+      MINIMAP_POSITION_OVERLAY_BORDER_COLOR: theme.colors.gray300,
+      MINIMAP_POSITION_OVERLAY_COLOR: theme.colors.gray200,
+
+      SPAN_FRAME_BORDER: theme.colors.grayTransparent300,
+      STACK_TO_COLOR: makeStackToColor([1, 1, 1, 0.18]),
+    },
+  };
+};

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -344,8 +344,8 @@ export const makeLightChonkFlamegraphTheme = (
       // Charts
       CPU_CHART_COLORS: CHART_PALETTE[12].map(c => hexToColorChannels(c, 0.8)),
       MEMORY_CHART_COLORS: [
-        hexToColorChannels(theme.colors.yellow400, 0.5),
-        hexToColorChannels(theme.colors.red400, 0.5),
+        hexToColorChannels(theme.colors.yellow400, 1),
+        hexToColorChannels(theme.colors.red400, 1),
       ],
       UI_FRAME_COLOR_SLOW: hexToColorChannels(theme.colors.yellow300, 1),
       UI_FRAME_COLOR_FROZEN: hexToColorChannels(theme.colors.red400, 1),

--- a/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
@@ -1,12 +1,14 @@
 import {createContext, useCallback, useMemo, useState} from 'react';
-import {useTheme} from '@emotion/react';
+import {type DO_NOT_USE_ChonkTheme, useTheme} from '@emotion/react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {
+  makeDarkChonkFlamegraphTheme,
   makeDarkFlamegraphTheme,
+  makeLightChonkFlamegraphTheme,
   makeLightFlamegraphTheme,
 } from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 
@@ -37,10 +39,17 @@ function FlamegraphThemeProvider(
   }, []);
 
   const activeFlamegraphTheme = useMemo(() => {
-    const flamegraphTheme =
+    let flamegraphTheme =
       colorMode === 'light'
         ? makeLightFlamegraphTheme(theme)
         : makeDarkFlamegraphTheme(theme);
+
+    if (theme.isChonk) {
+      flamegraphTheme =
+        colorMode === 'light'
+          ? makeLightChonkFlamegraphTheme(theme as unknown as DO_NOT_USE_ChonkTheme)
+          : makeDarkChonkFlamegraphTheme(theme as unknown as DO_NOT_USE_ChonkTheme);
+    }
 
     if (!mutation) {
       return flamegraphTheme;

--- a/static/app/utils/profiling/renderers/UIFramesRenderer.tsx
+++ b/static/app/utils/profiling/renderers/UIFramesRenderer.tsx
@@ -1,6 +1,9 @@
 import type {mat3, vec2} from 'gl-matrix';
 
-import type {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import type {
+  ColorChannels,
+  FlamegraphTheme,
+} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import type {Rect} from 'sentry/utils/profiling/speedscope';
 import type {UIFrameNode, UIFrames} from 'sentry/utils/profiling/uiFrames';
 
@@ -68,9 +71,7 @@ export abstract class UIFramesRenderer {
     return null;
   }
 
-  getColorForFrame(
-    type: UIFrames['frames'][0]['type']
-  ): [number, number, number, number] {
+  getColorForFrame(type: UIFrames['frames'][0]['type']): ColorChannels {
     if (type === 'frozen') {
       return this.theme.COLORS.UI_FRAME_COLOR_FROZEN;
     }

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
@@ -51,9 +51,7 @@ class FlamegraphTextRenderer extends TextRenderer {
       (this.theme.SIZES.BAR_HEIGHT - this.theme.SIZES.BAR_FONT_SIZE / 2) *
       window.devicePixelRatio;
 
-    const HIGHLIGHT_BACKGROUND_COLOR = `rgb(${this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR.join(
-      ', '
-    )})`;
+    const HIGHLIGHT_BACKGROUND_COLOR = this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR;
 
     const TOP_BOUNDARY = configView.top - 1;
     const BOTTOM_BOUNDARY = configView.bottom + 1;

--- a/static/app/utils/profiling/renderers/spansTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansTextRenderer.tsx
@@ -51,9 +51,7 @@ class SpansTextRenderer extends TextRenderer {
 
     const TOP_BOUNDARY = configView.top - 1;
     const BOTTOM_BOUNDARY = configView.bottom + 1;
-    const HIGHLIGHT_BACKGROUND_COLOR = `rgb(${this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR.join(
-      ', '
-    )})`;
+    const HIGHLIGHT_BACKGROUND_COLOR = this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR;
     const HAS_SEARCH_RESULTS = flamegraphSearchResults.size > 0;
     const TEXT_Y_POSITION = FONT_SIZE / 2 - BASELINE_OFFSET;
 

--- a/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
@@ -229,7 +229,7 @@ class UIFramesRendererWebGL extends UIFramesRenderer {
     this.ctx.useProgram(this.program);
   }
 
-  getColorForFrame(type: 'frozen' | 'slow'): [number, number, number, number] {
+  getColorForFrame(type: 'frozen' | 'slow') {
     if (type === 'frozen') {
       return this.theme.COLORS.UI_FRAME_COLOR_FROZEN;
     }


### PR DESCRIPTION
Our flamegraphs are pretty broken with the chonk theme changes, so I've taken the liberty of updating them :)

Before:
![CleanShot 2025-03-12 at 09 05 58@2x](https://github.com/user-attachments/assets/c7724113-41ae-49ce-95d6-020ed46213e2)

After:
![CleanShot 2025-03-12 at 09 09 14@2x](https://github.com/user-attachments/assets/b18d71a2-c3d7-4307-ada2-e234a4d9429c)

