### PR TITLE
issues: fix chonk tag style

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {useTheme} from '@emotion/react';
+import {type DO_NOT_USE_ChonkTheme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Chevron} from 'sentry/components/chevron';
@@ -13,6 +13,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
 import type {SuggestedOwnerReason} from 'sentry/types/group';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 
 type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
@@ -153,13 +154,15 @@ const StyledTag = styled(Tag)`
   color: ${p => p.theme.subText};
 `;
 
-const UnassignedTag = styled(Tag)`
-  border-style: dashed;
-  gap: ${space(0.5)};
-  height: 24px;
-  padding: ${space(0.5)};
-  padding-right: ${space(0.25)};
-`;
+const UnassignedTag = withChonk(
+  styled(StyledTag)`
+    border-style: dashed;
+  `,
+  styled(StyledTag)<{theme: DO_NOT_USE_ChonkTheme}>`
+    border: 1px dashed ${p => p.theme.border};
+    background-color: transparent;
+  `
+);
 
 const TooltipSubtext = styled('div')`
   color: ${p => p.theme.subText};


### PR DESCRIPTION
The default colors are no longer specified on tags, so we need to adjust it directly

![CleanShot 2025-03-12 at 09 53 26@2x](https://github.com/user-attachments/assets/04507c2a-ff30-49b7-aa7d-015c57111e39)
becomes
![CleanShot 2025-03-12 at 09 53 33@2x](https://github.com/user-attachments/assets/e8add8b3-6ef0-4b4d-9bf8-ff36064dbfd8)
