### PR TITLE
fix(settings): Change `formPanel` to expand when clicked anywhere

### DIFF
--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -6,6 +6,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
 import {sanitizeQuerySelector} from 'sentry/utils/sanitizeQuerySelector';
 
@@ -66,6 +67,9 @@ function FormPanel({
       id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}
       onClick={collapsible ? handleCollapseToggle : undefined}
       style={collapsible ? {cursor: 'pointer'} : undefined}
+      role={collapsible ? 'button' : undefined}
+      aria-label={collapsible ? t('Expand Options') : t('Panel')}
+      aria-expanded={!collapsed}
     >
       {title && (
         <PanelHeader>

--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -62,12 +62,21 @@ function FormPanel({
   const handleCollapseToggle = useCallback(() => setCollapse(current => !current), []);
 
   return (
-    <Panel id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}>
+    <Panel
+      id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}
+      onClick={collapsible ? handleCollapseToggle : undefined}
+      style={collapsible ? {cursor: 'pointer'} : undefined}
+    >
       {title && (
         <PanelHeader>
           {title}
           {collapsible && (
-            <Collapse onClick={handleCollapseToggle}>
+            <Collapse
+              onClick={e => {
+                e.stopPropagation();
+                handleCollapseToggle();
+              }}
+            >
               <IconChevron
                 data-test-id="form-panel-collapse-chevron"
                 direction={collapsed ? 'down' : 'up'}


### PR DESCRIPTION
Adjusts `formPanel.tsx` by changing it so that the expand/collapse function can be activated by clicking anywhere on the component instead of just on the chevron, which felt like too small of an area. 

Fixes https://github.com/getsentry/sentry/issues/54146