### PR TITLE
fix(guides): Use a portal for guides to avoid overflow issues

### DIFF
--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -138,7 +138,7 @@ describe('Tour Components', () => {
   describe('TourElement', () => {
     it('renders children regardless of tour state', async () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
-      const {container: inactiveContainer} = render(
+      const {unmount: unmountInactive} = render(
         <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
@@ -156,14 +156,15 @@ describe('Tour Components', () => {
         </TourContextProvider>
       );
 
-      expect(within(inactiveContainer).getByText('Child Element')).toBeInTheDocument();
+      expect(screen.getByText('Child Element')).toBeInTheDocument();
+      unmountInactive();
 
       mockUseTourReducer.mockReturnValue({
         ...emptyTourContext,
         isRegistered: true,
         currentStepId: TestTour.NAME,
       });
-      const {container: activeContainer} = render(
+      render(
         <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
@@ -180,8 +181,8 @@ describe('Tour Components', () => {
           </TourElement>
         </TourContextProvider>
       );
-      expect(await within(activeContainer).findByText('Test Title')).toBeInTheDocument();
-      expect(within(activeContainer).getByText('Child Element')).toBeInTheDocument();
+      expect(await screen.findByText('Test Title')).toBeInTheDocument();
+      expect(screen.getByText('Child Element')).toBeInTheDocument();
     });
 
     it('renders overlay when step is active', async () => {

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -1,4 +1,5 @@
 import {Fragment, type HTMLAttributes, useContext, useEffect, useMemo} from 'react';
+import {createPortal} from 'react-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -299,37 +300,40 @@ export function TourGuide({
       >
         {children}
       </Wrapper>
-      {isOpen ? (
-        <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
-          <TourOverlay
-            animated
-            arrowProps={{...arrowProps, background: 'lightModeBlack'}}
-          >
-            <TourBody id={id}>
-              {isTopRowVisible && (
-                <TopRow>
-                  <div>{countText}</div>
-                  {isDismissVisible && (
-                    <TourCloseButton
-                      onClick={e => {
-                        trackAnalytics('tour-guide.close', {organization, id});
-                        handleDismiss(e);
-                      }}
-                      icon={<IconClose style={{color: theme.inverted.textColor}} />}
-                      aria-label={t('Close')}
-                      borderless
-                      size="sm"
-                    />
+      {isOpen
+        ? createPortal(
+            <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
+              <TourOverlay
+                animated
+                arrowProps={{...arrowProps, background: 'lightModeBlack'}}
+              >
+                <TourBody id={id}>
+                  {isTopRowVisible && (
+                    <TopRow>
+                      <div>{countText}</div>
+                      {isDismissVisible && (
+                        <TourCloseButton
+                          onClick={e => {
+                            trackAnalytics('tour-guide.close', {organization, id});
+                            handleDismiss(e);
+                          }}
+                          icon={<IconClose style={{color: theme.inverted.textColor}} />}
+                          aria-label={t('Close')}
+                          borderless
+                          size="sm"
+                        />
+                      )}
+                    </TopRow>
                   )}
-                </TopRow>
-              )}
-              {title && <TitleRow>{title}</TitleRow>}
-              {description && <DescriptionRow>{description}</DescriptionRow>}
-              {actions && <Flex justify="flex-end">{actions}</Flex>}
-            </TourBody>
-          </TourOverlay>
-        </PositionWrapper>
-      ) : null}
+                  {title && <TitleRow>{title}</TitleRow>}
+                  {description && <DescriptionRow>{description}</DescriptionRow>}
+                  {actions && <Flex justify="flex-end">{actions}</Flex>}
+                </TourBody>
+              </TourOverlay>
+            </PositionWrapper>,
+            document.body
+          )
+        : null}
     </Fragment>
   );
 }


### PR DESCRIPTION
Avoids this issue by using a portal to `document.body`:

![image](https://github.com/user-attachments/assets/fdd716dc-b7e6-4e8d-b267-4ee67cac96f8)

With the fix:

<img width="442" alt="image" src="https://github.com/user-attachments/assets/4c1f3ac1-588c-4470-9588-dd01d94431eb" />
