### PR TITLE
fix(taskworker) Make timed_task accept float

### DIFF
--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -72,6 +72,6 @@ def at_most_once_task() -> None:
 
 
 @exampletasks.register(name="examples.timed")
-def timed_task(sleep_seconds: int) -> None:
-    sleep(int(sleep_seconds))
+def timed_task(sleep_seconds: float | str) -> None:
+    sleep(float(sleep_seconds))
     logger.info("timed_task complete")


### PR DESCRIPTION
Most of our tasks run in <1s and this will let us simulate real workloads better.