### PR TITLE
feat(ui): Do not close release drawer on location change

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -88,6 +88,7 @@ function createReleaseBubbleMouseListeners({
           />
         ),
         {
+          shouldCloseOnLocationChange: () => false,
           ariaLabel: t('Releases drawer'),
           transitionProps: {stiffness: 1000},
         }

--- a/static/app/views/releases/drawer/commitsList.tsx
+++ b/static/app/views/releases/drawer/commitsList.tsx
@@ -12,6 +12,7 @@ import {space} from 'sentry/styles/space';
 import type {Repository} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {EmptyState} from 'sentry/views/releases/detail/commitsAndFiles/emptyState';
 import {ReleaseCommit} from 'sentry/views/releases/detail/commitsAndFiles/releaseCommit';
 import RepositorySwitcher from 'sentry/views/releases/detail/commitsAndFiles/repositorySwitcher';
@@ -29,6 +30,7 @@ interface CommitsProps {
 
 export function CommitsList({release, releaseRepos, projectSlug}: CommitsProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const activeReleaseRepo =
     releaseRepos.find(repo => repo.name === location.query.activeRepo) ?? releaseRepos[0];
 
@@ -42,8 +44,9 @@ export function CommitsList({release, releaseRepos, projectSlug}: CommitsProps) 
     release,
     projectSlug,
     activeRepository: activeReleaseRepo,
-    // ...query,
+    cursor: location.query.commitsCursor,
   });
+
   const commitsByRepository = getCommitsByRepository(commitList);
   const reposToRender = getReposToRender(Object.keys(commitsByRepository));
   const activeRepoName: string | undefined = activeReleaseRepo
@@ -73,7 +76,15 @@ export function CommitsList({release, releaseRepos, projectSlug}: CommitsProps) 
               ))}
             </PanelBody>
           </Panel>
-          <Pagination pageLinks={getResponseHeader?.('Link')} />
+          <Pagination
+            pageLinks={getResponseHeader?.('Link')}
+            onCursor={(cursor, path, searchQuery) => {
+              navigate({
+                pathname: path,
+                query: {...searchQuery, commitsCursor: cursor},
+              });
+            }}
+          />
         </Fragment>
       ) : (
         <EmptyState>

--- a/static/app/views/releases/drawer/filesChangedList.tsx
+++ b/static/app/views/releases/drawer/filesChangedList.tsx
@@ -11,6 +11,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Repository} from 'sentry/types/integrations';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {EmptyState} from 'sentry/views/releases/detail/commitsAndFiles/emptyState';
 import FileChange from 'sentry/views/releases/detail/commitsAndFiles/fileChange';
 import RepositorySwitcher from 'sentry/views/releases/detail/commitsAndFiles/repositorySwitcher';
@@ -24,6 +25,7 @@ interface FilesChangedProps {
 
 export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const activeReleaseRepo =
     releaseRepos.find(repo => repo.name === location.query.activeRepo) ?? releaseRepos[0];
 
@@ -36,7 +38,7 @@ export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
   } = useReleaseCommitFiles({
     release,
     activeRepository: activeReleaseRepo,
-    // ...query,
+    cursor: location.query.fileCursor,
   });
 
   const filesByRepository = getFilesByRepository(fileList);
@@ -83,7 +85,15 @@ export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
                 </Panel>
               );
             })}
-            <Pagination pageLinks={fileListPageLinks} />
+            <Pagination
+              pageLinks={fileListPageLinks}
+              onCursor={(cursor, path, searchQuery) => {
+                navigate({
+                  pathname: path,
+                  query: {...searchQuery, fileCursor: cursor},
+                });
+              }}
+            />
           </Fragment>
         ) : (
           <EmptyState>

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -57,9 +57,7 @@ export function ReleaseDrawerTable({start, onSelectRelease, end}: Props) {
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const {data, isLoading, isError /* isPending, getResponseHeader */} = useApiQuery<
-    Release[]
-  >(
+  const {data, isLoading, isError, getResponseHeader} = useApiQuery<Release[]>(
     [
       `/organizations/${organization.slug}/releases/`,
       {
@@ -69,16 +67,18 @@ export function ReleaseDrawerTable({start, onSelectRelease, end}: Props) {
               ['project', 'environment'].includes(key)
             )
           ),
+          cursor: location.query.releaseCursor,
           ...normalizeDateTimeParams({
             start,
             end,
           }),
-          per_page: 10,
+          per_page: 15,
         },
       },
     ],
     {staleTime: 0}
   );
+  const pageLinks = getResponseHeader?.('Link');
 
   const releaseData = data?.map(d => ({
     project: d.projects[0]!,
@@ -190,11 +190,11 @@ export function ReleaseDrawerTable({start, onSelectRelease, end}: Props) {
         }}
       />
       <PaginationNoMargin
-        // pageLinks={pageLinks}
+        pageLinks={pageLinks}
         onCursor={(cursor, path, searchQuery) => {
           navigate({
             pathname: path,
-            query: {...searchQuery, cursor},
+            query: {...searchQuery, releaseCursor: cursor},
           });
         }}
       />

--- a/static/app/views/releases/utils/useReleaseCommitFiles.tsx
+++ b/static/app/views/releases/utils/useReleaseCommitFiles.tsx
@@ -10,13 +10,17 @@ type PageFilterUrlParams =
   | 'statsPeriod'
   | 'project'
   | 'environment';
+type OtherUrlParams = 'cursor' | 'perPage';
 
 interface UseReleaseCommitFilesParams
-  extends Partial<Record<PageFilterUrlParams, string>> {
+  extends Partial<
+    Record<
+      PageFilterUrlParams | OtherUrlParams,
+      string | string[] | number | null | undefined
+    >
+  > {
   release: string;
   activeRepository?: Repository;
-  cursor?: string;
-  perPage?: number;
 }
 export function useReleaseCommitFiles(
   {release, activeRepository, perPage = 40, ...query}: UseReleaseCommitFilesParams,

--- a/static/app/views/releases/utils/useReleaseCommits.tsx
+++ b/static/app/views/releases/utils/useReleaseCommits.tsx
@@ -10,13 +10,18 @@ type PageFilterUrlParams =
   | 'statsPeriod'
   | 'project'
   | 'environment';
+type OtherUrlParams = 'cursor' | 'perPage';
 
-interface UseReleaseCommitsParams extends Partial<Record<PageFilterUrlParams, string>> {
+interface UseReleaseCommitsParams
+  extends Partial<
+    Record<
+      PageFilterUrlParams | OtherUrlParams,
+      string | string[] | number | null | undefined
+    >
+  > {
   projectSlug: string;
   release: string;
   activeRepository?: Repository;
-  cursor?: string;
-  perPage?: number;
 }
 
 export function useReleaseCommits(


### PR DESCRIPTION
* do not close release drawer on location change
* add back pagination to releases, commits, and files changed tables

ref https://github.com/getsentry/sentry/issues/85779