### PR TITLE
✨ feat(aci): invoke opsgenie metric alert handler from noa

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -381,6 +381,14 @@ class OpsgenieActionHandler(DefaultActionHandler):
         if metric_value is None:
             metric_value = get_metric_count_from_incident(incident)
 
+        notification_context = NotificationContext.from_alert_rule_trigger_action(action)
+        alert_context = AlertContext.from_alert_rule_incident(incident.alert_rule)
+        metric_issue_context = MetricIssueContext.from_legacy_models(
+            incident=incident,
+            new_status=new_status,
+            metric_value=metric_value,
+        )
+
         success = send_incident_alert_notification(
             notification_context=notification_context,
             alert_context=alert_context,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -370,11 +370,22 @@ class OpsgenieActionHandler(DefaultActionHandler):
     ):
         from sentry.integrations.opsgenie.utils import send_incident_alert_notification
 
-        success = send_incident_alert_notification(
-            action=action,
+        notification_context = NotificationContext.from_alert_rule_trigger_action(action)
+        alert_context = AlertContext.from_alert_rule_incident(incident.alert_rule)
+        metric_issue_context = MetricIssueContext.from_legacy_models(
             incident=incident,
             new_status=new_status,
             metric_value=metric_value,
+        )
+
+        if metric_value is None:
+            metric_value = get_metric_count_from_incident(incident)
+
+        success = send_incident_alert_notification(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            organization=incident.organization,
             notification_uuid=notification_uuid,
         )
         if success:

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -29,10 +29,14 @@ def build_incident_attachment(
     notification_uuid: str | None = None,
 ) -> dict[str, Any]:
 
+    # TODO(iamrajjoshi): Pass down `metric_issue_context`
     data = incident_attachment_info(
         alert_context=alert_context,
-        metric_issue_context=metric_issue_context,
+        open_period_identifier=metric_issue_context.open_period_identifier,
         organization=organization,
+        snuba_query=metric_issue_context.snuba_query,
+        new_status=metric_issue_context.new_status,
+        metric_value=metric_issue_context.metric_value,
         notification_uuid=notification_uuid,
         referrer="metric_alert_opsgenie",
     )

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -29,14 +29,10 @@ def build_incident_attachment(
     notification_uuid: str | None = None,
 ) -> dict[str, Any]:
 
-    # TODO(iamrajjoshi): Pass down `metric_issue_context`
     data = incident_attachment_info(
+        metric_issue_context=metric_issue_context,
         alert_context=alert_context,
-        open_period_identifier=metric_issue_context.open_period_identifier,
         organization=organization,
-        snuba_query=metric_issue_context.snuba_query,
-        new_status=metric_issue_context.new_status,
-        metric_value=metric_issue_context.metric_value,
         notification_uuid=notification_uuid,
         referrer="metric_alert_opsgenie",
     )

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -4,13 +4,13 @@ import logging
 from typing import Any, cast
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
-from sentry.integrations.metric_alerts import (
-    get_metric_count_from_incident,
-    incident_attachment_info,
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
 )
+from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcOrganizationIntegration
@@ -59,13 +59,17 @@ def build_incident_attachment(
 
 
 def attach_custom_priority(
-    data: dict[str, Any], action: AlertRuleTriggerAction, new_status: IncidentStatus
+    data: dict[str, Any], notification_context: NotificationContext, new_status: IncidentStatus
 ) -> dict[str, Any]:
-    app_config = action.get_single_sentry_app_config()
-    if new_status == IncidentStatus.CLOSED or app_config is None:
+    sentry_app_config = notification_context.sentry_app_config
+    # use custom severity (overrides default in build_incident_attachment)
+    if new_status == IncidentStatus.CLOSED or sentry_app_config is None:
         return data
 
-    priority = app_config.get("priority", OPSGENIE_DEFAULT_PRIORITY)
+    if isinstance(sentry_app_config, list):
+        raise ValueError("Sentry app config must be a single dict")
+
+    priority = sentry_app_config.get("priority", OPSGENIE_DEFAULT_PRIORITY)
     data["priority"] = priority
     return data
 
@@ -83,19 +87,16 @@ def get_team(team_id: int | str | None, org_integration: RpcOrganizationIntegrat
 
 
 def send_incident_alert_notification(
-    action: AlertRuleTriggerAction,
-    incident: Incident,
-    new_status: IncidentStatus,
-    metric_value: float | None = None,
+    notification_context: NotificationContext,
+    alert_context: AlertContext,
+    metric_issue_context: MetricIssueContext,
+    organization: Organization,
     notification_uuid: str | None = None,
 ) -> bool:
     from sentry.integrations.opsgenie.integration import OpsgenieIntegration
 
-    if metric_value is None:
-        metric_value = get_metric_count_from_incident(incident)
-
     result = integration_service.organization_context(
-        organization_id=incident.organization_id, integration_id=action.integration_id
+        organization_id=organization.id, integration_id=notification_context.integration_id
     )
     integration = result.integration
     org_integration = result.organization_integration
@@ -103,7 +104,7 @@ def send_incident_alert_notification(
         logger.info("Opsgenie integration removed, but the rule is still active.")
         return False
 
-    team = get_team(org_integration=org_integration, team_id=action.target_identifier)
+    team = get_team(org_integration=org_integration, team_id=notification_context.target_identifier)
     if not team:
         # team removed, but the rule is still active
         logger.info("Opsgenie team removed, but the rule is still active.")
@@ -115,14 +116,14 @@ def send_incident_alert_notification(
     )
     client = install.get_keyring_client(keyid=team["id"])
     attachment = build_incident_attachment(
-        alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-        metric_issue_context=MetricIssueContext.from_legacy_models(
-            incident, new_status, metric_value
-        ),
-        organization=incident.organization,
+        alert_context=alert_context,
+        metric_issue_context=metric_issue_context,
+        organization=organization,
         notification_uuid=notification_uuid,
     )
-    attachment = attach_custom_priority(attachment, action, new_status)
+    attachment = attach_custom_priority(
+        attachment, notification_context, metric_issue_context.new_status
+    )
 
     try:
         resp = client.send_notification(attachment)
@@ -130,12 +131,12 @@ def send_incident_alert_notification(
             "rule.success.opsgenie_incident_alert",
             extra={
                 "status_code": resp.status_code,
-                "organization_id": incident.organization_id,
+                "organization_id": organization.id,
                 "data": attachment,
-                "status": new_status.value,
+                "status": metric_issue_context.new_status.value,
                 "team_name": team["team"],
                 "team_id": team["id"],
-                "integration_id": action.integration_id,
+                "integration_id": notification_context.integration_id,
             },
         )
         return True
@@ -147,7 +148,7 @@ def send_incident_alert_notification(
                 "data": attachment,
                 "team_name": team["team"],
                 "team_id": team["id"],
-                "integration_id": action.integration_id,
+                "integration_id": notification_context.integration_id,
             },
         )
         raise

--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -9,7 +9,12 @@ from sentry.incidents.typings.metric_detector import (
     MetricIssueContext,
     NotificationContext,
 )
-from sentry.integrations.pagerduty.utils import send_incident_alert_notification
+from sentry.integrations.opsgenie.utils import (
+    send_incident_alert_notification as send_opsgenie_incident_alert_notification,
+)
+from sentry.integrations.pagerduty.utils import (
+    send_incident_alert_notification as send_pagerduty_incident_alert_notification,
+)
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
 from sentry.utils.registry import Registry
@@ -84,7 +89,7 @@ class PagerDutyMetricAlertHandler(BaseMetricAlertHandler):
         organization: Organization,
         notification_uuid: str,
     ) -> None:
-        send_incident_alert_notification(
+        send_pagerduty_incident_alert_notification(
             notification_context=notification_context,
             alert_context=alert_context,
             metric_issue_context=metric_issue_context,
@@ -100,20 +105,15 @@ class OpsgenieMetricAlertHandler(BaseMetricAlertHandler):
         cls,
         notification_context: NotificationContext,
         alert_context: AlertContext,
-        job: WorkflowJob,
+        metric_issue_context: MetricIssueContext,
         organization: Organization,
         notification_uuid: str,
     ) -> None:
-        from sentry.integrations.opsgenie.utils import send_incident_alert_notification
 
-        send_incident_alert_notification(
+        send_opsgenie_incident_alert_notification(
             notification_context=notification_context,
             alert_context=alert_context,
-            # TODO(iamrajjoshi): Replace with something once we know how we want to build the link
-            open_period_identifier=job["event"].group.id,
+            metric_issue_context=metric_issue_context,
             organization=organization,
-            snuba_query=cls.get_snuba_query(job),
-            new_status=cls.get_new_status(job),
-            metric_value=cls.get_metric_value(job),
             notification_uuid=notification_uuid,
         )

--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -91,3 +91,29 @@ class PagerDutyMetricAlertHandler(BaseMetricAlertHandler):
             organization=organization,
             notification_uuid=notification_uuid,
         )
+
+
+@metric_alert_handler_registry.register(Action.Type.OPSGENIE)
+class OpsgenieMetricAlertHandler(BaseMetricAlertHandler):
+    @classmethod
+    def send_alert(
+        cls,
+        notification_context: NotificationContext,
+        alert_context: AlertContext,
+        job: WorkflowJob,
+        organization: Organization,
+        notification_uuid: str,
+    ) -> None:
+        from sentry.integrations.opsgenie.utils import send_incident_alert_notification
+
+        send_incident_alert_notification(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            # TODO(iamrajjoshi): Replace with something once we know how we want to build the link
+            open_period_identifier=job["event"].group.id,
+            organization=organization,
+            snuba_query=cls.get_snuba_query(job),
+            new_status=cls.get_new_status(job),
+            metric_value=cls.get_metric_value(job),
+            notification_uuid=notification_uuid,
+        )

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -100,9 +100,6 @@ class OpsgenieActionHandlerTest(FireTest):
                 metric_value=metric_value,
             ),
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -160,15 +157,7 @@ class OpsgenieActionHandlerTest(FireTest):
                 incident, IncidentStatus(incident.status), metric_value
             ),
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            metric_issue_context=MetricIssueContext.from_legacy_models(
-                incident=incident,
-                new_status=IncidentStatus(incident.status),
-                metric_value=metric_value,
-            ),
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -217,15 +206,7 @@ class OpsgenieActionHandlerTest(FireTest):
                     incident, new_status, metric_value=1000
                 ),
                 alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-                metric_issue_context=MetricIssueContext.from_legacy_models(
-                    incident=incident,
-                    new_status=new_status,
-                    metric_value=1000,
-                ),
                 organization=incident.organization,
-                snuba_query=incident.alert_rule.snuba_query,
-                new_status=new_status,
-                metric_value=1000,
             )
             expected_payload = attach_custom_priority(expected_payload, self.action, new_status)
 

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -95,9 +95,14 @@ class OpsgenieActionHandlerTest(FireTest):
         data = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
             metric_issue_context=MetricIssueContext.from_legacy_models(
-                incident, IncidentStatus(incident.status), metric_value
+                incident=incident,
+                new_status=IncidentStatus(incident.status),
+                metric_value=metric_value,
             ),
             organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -155,7 +160,15 @@ class OpsgenieActionHandlerTest(FireTest):
                 incident, IncidentStatus(incident.status), metric_value
             ),
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident=incident,
+                new_status=IncidentStatus(incident.status),
+                metric_value=metric_value,
+            ),
             organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -204,7 +217,15 @@ class OpsgenieActionHandlerTest(FireTest):
                     incident, new_status, metric_value=1000
                 ),
                 alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+                metric_issue_context=MetricIssueContext.from_legacy_models(
+                    incident=incident,
+                    new_status=new_status,
+                    metric_value=1000,
+                ),
                 organization=incident.organization,
+                snuba_query=incident.alert_rule.snuba_query,
+                new_status=new_status,
+                metric_value=1000,
             )
             expected_payload = attach_custom_priority(expected_payload, self.action, new_status)
 

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -22,6 +22,7 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.action.notification.metric_alert import (
     BaseMetricAlertHandler,
+    OpsgenieMetricAlertHandler,
     PagerDutyMetricAlertHandler,
 )
 from sentry.workflow_engine.models import Action
@@ -413,3 +414,97 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,
         )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+
+class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow(environment=self.environment)
+        self.action = self.create_action(
+            type=Action.Type.OPSGENIE,
+            integration_id=1234567890,
+            config={"target_identifier": "team123"},
+            data={"priority": "P1"},
+        )
+        self.snuba_query = self.create_snuba_query()
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.handler = OpsgenieMetricAlertHandler()
+
+    @mock.patch("sentry.integrations.opsgenie.utils.send_incident_alert_notification")
+    def test_send_alert(self, mock_send_incident_alert_notification):
+        notification_context = NotificationContext.from_action_model(self.action)
+        assert self.group_event.occurrence is not None
+        alert_context = AlertContext.from_workflow_engine_models(
+            self.detector, self.group_event.occurrence
+        )
+        notification_uuid = str(uuid.uuid4())
+
+        self.handler.send_alert(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            job=self.job,
+            organization=self.detector.project.organization,
+            notification_uuid=notification_uuid,
+        )
+
+        mock_send_incident_alert_notification.assert_called_once_with(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            open_period_identifier=self.job["event"].group.id,
+            organization=self.detector.project.organization,
+            snuba_query=self.handler.get_snuba_query(self.job),
+            new_status=self.handler.get_new_status(self.job),
+            metric_value=self.handler.get_metric_value(self.job),
+            notification_uuid=notification_uuid,
+        )
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.metric_alert.OpsgenieMetricAlertHandler.send_alert"
+    )
+    def test_invoke_legacy_registry(self, mock_send_alert):
+        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        args, _ = mock_send_alert.call_args
+        notification_context, alert_context, job, organization, notification_uuid = args
+
+        assert isinstance(notification_context, NotificationContext)
+        assert isinstance(alert_context, AlertContext)
+
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="team123",
+            target_display=None,
+            sentry_app_config={"priority": "P1"},
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=None,
+            detection_type=None,
+            comparison_delta=None,
+        )
+
+        assert job == self.job
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)


### PR DESCRIPTION
invoking the opsgenie metric alert handler from NOA.

similar to the support for pagerduty i added in https://github.com/getsentry/sentry/pull/86767. 

moves up the fk lookups 1 level and pass in data classes to the handler.