### PR TITLE
fix(taskworker) Improve retry backoff when broker is unavailable

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -266,7 +266,9 @@ class TaskWorker:
         self._shutdown_event = mp_context.Event()
         self._task_receive_timing: dict[str, float] = {}
         self._result_thread: threading.Thread | None = None
-        self.backoff_sleep_seconds = 0
+
+        self._gettask_backoff_seconds = 0
+        self._setstatus_backoff_seconds = 0
 
     def __del__(self) -> None:
         self.shutdown()
@@ -388,10 +390,6 @@ class TaskWorker:
             if not self._child_tasks.full():
                 fetch_next = FetchNextTask(namespace=self._namespace)
 
-            logger.debug(
-                "taskworker.workers._send_result",
-                extra={"task_id": result.task_id, "next": fetch_next is not None},
-            )
             next_task = self._send_update_task(result, fetch_next)
             if next_task:
                 self._task_receive_timing[next_task.id] = time.time()
@@ -413,14 +411,22 @@ class TaskWorker:
         """
         Do the RPC call to this worker's taskbroker, and handle errors
         """
+        logger.debug(
+            "taskworker.workers._send_result",
+            extra={"task_id": result.task_id, "next": fetch_next is not None},
+        )
+        # Use the shutdown_event as a sleep mechanism
+        self._shutdown_event.wait(self._setstatus_backoff_seconds)
         try:
             next_task = self.client.update_task(
                 task_id=result.task_id,
                 status=result.status,
                 fetch_next_task=fetch_next,
             )
+            self._setstatus_backoff_seconds = 0
             return next_task
         except grpc.RpcError as e:
+            self._setstatus_backoff_seconds = min(self._setstatus_backoff_seconds + 1, 10)
             if e.code() == grpc.StatusCode.UNAVAILABLE:
                 self._processed_tasks.put(result)
             logger.exception(
@@ -450,19 +456,22 @@ class TaskWorker:
         self._children = active_children
 
     def fetch_task(self) -> TaskActivation | None:
+        # Use the shutdown_event as a sleep mechanism
+        self._shutdown_event.wait(self._gettask_backoff_seconds)
         try:
             activation = self.client.get_task(self._namespace)
         except grpc.RpcError as e:
             logger.info("taskworker.fetch_task.failed", extra={"error": e})
+
+            self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 1, 10)
             return None
 
         if not activation:
             logger.debug("taskworker.fetch_task.not_found")
 
-            self.backoff_sleep_seconds = min(self.backoff_sleep_seconds + 1, 10)
-            time.sleep(self.backoff_sleep_seconds)
+            self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 1, 10)
             return None
 
-        self.backoff_sleep_seconds = 0
+        self._gettask_backoff_seconds = 0
         self._task_receive_timing[activation.id] = time.time()
         return activation


### PR DESCRIPTION
When a broker is restarted we'll lose GRPC connectivity, and should incrementally backoff until the broker comes back. This will reduce log spam and reduce the thundering herd when the broker comes back.