### PR TITLE
fix(tokenizeSearch): formatString should account for bracket format

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -500,7 +500,7 @@ describe('utils/tokenizeSearch', function () {
         string: 'release:"4.9.0 build (0.0.01)" error.handled:0',
       },
       {
-        name: 'should not enclose the entire query in quotes if there are no spaces',
+        name: 'should not enclose the entire query in quotes if there are no spaces in brackets shorthand',
         object: new MutableSearch(['transaction:[alpha,beta]']),
         string: 'transaction:[alpha,beta]',
       },
@@ -510,12 +510,12 @@ describe('utils/tokenizeSearch', function () {
         string: 'transaction:["alpha","beta"]',
       },
       {
-        name: 'should not enclose the entire query in quotes if there are quotes around args',
+        name: 'should not enclose the entire query in quotes if some args are quoted in brackets',
         object: new MutableSearch(['transaction:["alpha",beta]']),
         string: 'transaction:["alpha",beta]',
       },
       {
-        name: 'should not enclose the entire query in quotes if there are spaces',
+        name: 'should not enclose the entire query in quotes if there are spaces in quoted args',
         object: new MutableSearch(['transaction:["this has a space",thisdoesnot]']),
         string: 'transaction:["this has a space",thisdoesnot]',
       },

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -499,6 +499,26 @@ describe('utils/tokenizeSearch', function () {
         object: new MutableSearch(['release:4.9.0 build (0.0.01)', 'error.handled:0']),
         string: 'release:"4.9.0 build (0.0.01)" error.handled:0',
       },
+      {
+        name: 'should not enclose the entire query in quotes if there are no spaces',
+        object: new MutableSearch(['transaction:[alpha,beta]']),
+        string: 'transaction:[alpha,beta]',
+      },
+      {
+        name: 'should not enclose the entire query in quotes if there are quotes around args',
+        object: new MutableSearch(['transaction:["alpha","beta"]']),
+        string: 'transaction:["alpha","beta"]',
+      },
+      {
+        name: 'should not enclose the entire query in quotes if there are quotes around args',
+        object: new MutableSearch(['transaction:["alpha",beta]']),
+        string: 'transaction:["alpha",beta]',
+      },
+      {
+        name: 'should not enclose the entire query in quotes if there are spaces',
+        object: new MutableSearch(['transaction:["this has a space",thisdoesnot]']),
+        string: 'transaction:["this has a space",thisdoesnot]',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -156,7 +156,19 @@ export class MutableSearch {
         case TokenType.FILTER:
           if (token.value === '' || token.value === null) {
             formattedTokens.push(`${token.key}:""`);
-          } else if (/[\s\(\)\\"]/g.test(token.value)) {
+          } else if (
+            // Don't quote if it's already a properly formatted bracket expression
+            /^\[.*\]$/.test(token.value) ||
+            // Don't quote if it's already properly quoted
+            /^".*"$/.test(token.value)
+          ) {
+            formattedTokens.push(`${token.key}:${token.value}`);
+          } else if (
+            // Quote if contains spaces, parens, quotes, commas, or brackets
+            /[\s\(\)\\"',\[\]]/g.test(token.value) ||
+            // Also quote if contains colons but not at the start (to handle timestamps)
+            (token.value.includes(':') && !token.value.startsWith('id:'))
+          ) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(`${token.key}:${token.value}`);

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -165,9 +165,7 @@ export class MutableSearch {
             formattedTokens.push(`${token.key}:${token.value}`);
           } else if (
             // Quote if contains spaces, parens, quotes, commas, or brackets
-            /[\s\(\)\\"',\[\]]/g.test(token.value) ||
-            // Also quote if contains colons but not at the start (to handle timestamps)
-            (token.value.includes(':') && !token.value.startsWith('id:'))
+            /[\s\(\)\\"',\[\]]/g.test(token.value)
           ) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -164,8 +164,8 @@ export class MutableSearch {
           ) {
             formattedTokens.push(`${token.key}:${token.value}`);
           } else if (
-            // Quote if contains spaces, parens, quotes, commas, or brackets
-            /[\s\(\)\\"',\[\]]/g.test(token.value)
+            // Quote if contains spaces, parens, or quotes
+            /[\s\(\)\\"]/g.test(token.value)
           ) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {


### PR DESCRIPTION
Fixes a bug where quotes in `tag:[a,b,...]` format were triggering the entire filter value to get enclosed in quotes, see tests.

e.g. for `'transaction:["alpha","beta"]'`, `.formatString()` would output something along the lines of `'transaction:"[\"alpha\",\"beta\"]"'`, which is not the same because it is taking the OR'd values and turning into one string value