### PR TITLE
fix(ourlogs): Logs section appears despite no data

### DIFF
--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -12,7 +12,10 @@ import {
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
-import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
+import {
+  useExploreLogsTable,
+  type UseExploreLogsTableResult,
+} from 'sentry/views/explore/logs/useLogsQuery';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
@@ -23,6 +26,11 @@ export function LogsIssuesSection({
 }: {
   initialCollapse: boolean;
 } & Omit<LogsPageParamsProviderProps, 'children'>) {
+  const tableData = useExploreLogsTable({});
+  if (tableData?.data?.length === 0) {
+    // Like breadcrumbs, we don't show the logs section if there are no logs.
+    return null;
+  }
   return (
     <Feature features={['ourlogs-enabled']}>
       <InterimSection
@@ -36,21 +44,16 @@ export function LogsIssuesSection({
           isIssuesDetailView={isIssuesDetailView}
           limitToTraceId={traceId}
         >
-          <LogsSectionContent />
+          <LogsSectionContent tableData={tableData} />
         </LogsPageParamsProvider>
       </InterimSection>
     </Feature>
   );
 }
 
-function LogsSectionContent() {
+function LogsSectionContent({tableData}: {tableData: UseExploreLogsTableResult}) {
   const setLogsQuery = useSetLogsQuery();
   const logsSearch = useLogsSearch();
-  const tableData = useExploreLogsTable({});
-  if (tableData?.data?.length === 0) {
-    // Like breadcrumbs, we don't show the logs section if there are no logs.
-    return null;
-  }
   return (
     <Fragment>
       <SearchQueryBuilder

--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -1,10 +1,10 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   LogsPageParamsProvider,
   type LogsPageParamsProviderProps,
@@ -26,28 +26,31 @@ export function LogsIssuesSection({
 }: {
   initialCollapse: boolean;
 } & Omit<LogsPageParamsProviderProps, 'children'>) {
-  const tableData = useExploreLogsTable({});
+  const organization = useOrganization();
+  const feature = organization.features.includes('ourlogs-enabled');
+  const tableData = useExploreLogsTable({enabled: feature});
+  if (!feature) {
+    return null;
+  }
   if (tableData?.data?.length === 0) {
     // Like breadcrumbs, we don't show the logs section if there are no logs.
     return null;
   }
   return (
-    <Feature features={['ourlogs-enabled']}>
-      <InterimSection
-        key="logs"
-        type={SectionKey.LOGS}
-        title={t('Logs')}
-        data-test-id="logs-data-section"
-        initialCollapse={initialCollapse}
+    <InterimSection
+      key="logs"
+      type={SectionKey.LOGS}
+      title={t('Logs')}
+      data-test-id="logs-data-section"
+      initialCollapse={initialCollapse}
+    >
+      <LogsPageParamsProvider
+        isIssuesDetailView={isIssuesDetailView}
+        limitToTraceId={traceId}
       >
-        <LogsPageParamsProvider
-          isIssuesDetailView={isIssuesDetailView}
-          limitToTraceId={traceId}
-        >
-          <LogsSectionContent tableData={tableData} />
-        </LogsPageParamsProvider>
-      </InterimSection>
-    </Feature>
+        <LogsSectionContent tableData={tableData} />
+      </LogsPageParamsProvider>
+    </InterimSection>
   );
 }
 


### PR DESCRIPTION
### Summary
We want the section to not appear (like breadcrumbs) if there is no log data, this previously was keeping the section but removing the content.
