### PR TITLE
fix(query-builder): Place focus in correct location after deleting a token with mouse

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -115,13 +115,6 @@ export type QueryBuilderActions =
   | MultiSelectFilterValueAction
   | DeleteLastMultiSelectFilterValueAction;
 
-function removeQueryToken(query: string, token: TokenResult<Token>): string {
-  return removeExcessWhitespaceFromParts(
-    query.substring(0, token.location.start.offset),
-    query.substring(token.location.end.offset)
-  );
-}
-
 function removeQueryTokensFromQuery(
   query: string,
   tokens: Array<TokenResult<Token>>
@@ -318,21 +311,38 @@ function updateFreeText(
 
 function replaceTokensWithText(
   state: QueryBuilderState,
-  action: ReplaceTokensWithTextAction,
-  getFieldDefinition: FieldDefinitionGetter
+  {
+    getFieldDefinition,
+    text,
+    tokens,
+    focusOverride: incomingFocusOverride,
+  }: {
+    getFieldDefinition: FieldDefinitionGetter;
+    text: string;
+    tokens: Array<TokenResult<Token>>;
+    focusOverride?: FocusOverride;
+  }
 ): QueryBuilderState {
-  const newQuery = replaceTokensWithPadding(state.query, action.tokens, action.text);
-  const cursorPosition =
-    (action.tokens[0]?.location.start.offset ?? 0) + action.text.length; // TODO: Ensure this is sorted
+  const newQuery = replaceTokensWithPadding(state.query, tokens, text);
+
+  if (incomingFocusOverride) {
+    return {
+      ...state,
+      query: newQuery,
+      focusOverride: incomingFocusOverride,
+    };
+  }
+
+  const cursorPosition = (tokens[0]?.location.start.offset ?? 0) + text.length; // TODO: Ensure this is sorted
   const newParsedQuery = parseQueryBuilderValue(newQuery, getFieldDefinition);
   const focusedToken = newParsedQuery?.find(
     (token: any) =>
       token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
   );
 
-  const focusOverride =
-    action.focusOverride ??
-    (focusedToken ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)} : null);
+  const focusOverride = focusedToken
+    ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)}
+    : null;
 
   return {
     ...state,
@@ -499,16 +509,22 @@ export function useQueryBuilderState({
             focusOverride: null,
           };
         case 'DELETE_TOKEN':
-          return {
-            ...state,
-            query: removeQueryToken(state.query, action.token),
-          };
+          return replaceTokensWithText(state, {
+            tokens: [action.token],
+            text: '',
+            getFieldDefinition,
+          });
         case 'DELETE_TOKENS':
           return deleteQueryTokens(state, action);
         case 'UPDATE_FREE_TEXT':
           return updateFreeText(state, action);
         case 'REPLACE_TOKENS_WITH_TEXT':
-          return replaceTokensWithText(state, action, getFieldDefinition);
+          return replaceTokensWithText(state, {
+            tokens: action.tokens,
+            text: action.text,
+            focusOverride: action.focusOverride,
+            getFieldDefinition,
+          });
         case 'UPDATE_FILTER_KEY':
           return {
             ...state,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -612,6 +612,11 @@ describe('SearchQueryBuilder', function () {
         screen.queryByRole('row', {name: 'browser.name:firefox'})
       ).not.toBeInTheDocument();
 
+      // Focus should be at the beginning of the query
+      expect(
+        screen.getAllByRole('combobox', {name: 'Add a search term'})[0]
+      ).toHaveFocus();
+
       // Custom tag token should still be present
       expect(screen.getByRole('row', {name: 'custom_tag_name:123'})).toBeInTheDocument();
     });


### PR DESCRIPTION
Previously, clicking the 'x' on a token near the beginning of the query would sometimes cause the focus to go to the remove button on the following token. This reuses another util function which does a better job of moving the focus to the nearest text input instead.