### PR TITLE
feat(ourlogs): Allow logs to appear cross-project in trace

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -7,6 +7,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {
   useLogsBaseSearch,
   useLogsFields,
+  useLogsProjectIds,
   useLogsSearch,
   useLogsSortBys,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -27,7 +28,7 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
   const baseSearch = useLogsBaseSearch();
   const fields = useLogsFields();
   const sortBys = useLogsSortBys();
-
+  const projectIds = useLogsProjectIds();
   const extendedFields = new Set([...AlwaysPresentLogFields, ...fields]);
 
   const search = baseSearch ? _search.copy() : _search;
@@ -40,6 +41,7 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
       sorts: sortBys,
       fields: Array.from(extendedFields),
       search,
+      projectIds,
     },
     'api.logs-tab.view'
   );

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -26,8 +26,10 @@ interface UseDiscoverOptions<Fields> {
   noPagination?: boolean;
   pageFilters?: PageFilters;
   projectIds?: number[];
+  /**
+   * TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
+   */
   search?: MutableSearch | string;
-  // TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
   sorts?: Sort[];
 }
 

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -18,19 +18,21 @@ import type {
   SpanMetricsResponse,
 } from 'sentry/views/insights/types';
 
-interface UseMetricsOptions<Fields> {
+interface UseDiscoverOptions<Fields> {
   cursor?: string;
   enabled?: boolean;
   fields?: Fields;
   limit?: number;
   noPagination?: boolean;
   pageFilters?: PageFilters;
-  search?: MutableSearch | string; // TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
+  projectIds?: number[];
+  search?: MutableSearch | string;
+  // TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
   sorts?: Sort[];
 }
 
 export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
-  options: UseMetricsOptions<Fields> = {},
+  options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
   // Indexed spans dataset always returns an `id`
@@ -42,7 +44,7 @@ export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
 };
 
 export const useOurlogs = <Fields extends OurLogFieldKey[]>(
-  options: UseMetricsOptions<Fields> = {},
+  options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
   const {data, ...rest} = useDiscover<Fields, OurLogsResponseItem>(
@@ -55,7 +57,7 @@ export const useOurlogs = <Fields extends OurLogFieldKey[]>(
 };
 
 export const useEAPSpans = <Fields extends EAPSpanProperty[]>(
-  options: UseMetricsOptions<Fields> = {},
+  options: UseDiscoverOptions<Fields> = {},
   referrer: string,
   useRpc?: boolean
 ) => {
@@ -67,7 +69,7 @@ export const useEAPSpans = <Fields extends EAPSpanProperty[]>(
 };
 
 export const useSpanMetrics = <Fields extends SpanMetricsProperty[]>(
-  options: UseMetricsOptions<Fields> = {},
+  options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
   return useDiscover<Fields, SpanMetricsResponse>(
@@ -78,7 +80,7 @@ export const useSpanMetrics = <Fields extends SpanMetricsProperty[]>(
 };
 
 export const useMetrics = <Fields extends MetricsProperty[]>(
-  options: UseMetricsOptions<Fields> = {},
+  options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
   return useDiscover<Fields, MetricsResponse>(
@@ -89,7 +91,7 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
 };
 
 const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, ResponseType>(
-  options: UseMetricsOptions<T> = {},
+  options: UseDiscoverOptions<T> = {},
   dataset: DiscoverDatasets,
   referrer: string
 ) => {
@@ -101,6 +103,7 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     cursor,
     pageFilters: pageFiltersFromOptions,
     noPagination,
+    projectIds,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -110,7 +113,8 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     fields,
     sorts,
     pageFiltersFromOptions ?? pageFilters.selection,
-    dataset
+    dataset,
+    projectIds
   );
 
   const result = useWrappedDiscoverQuery({
@@ -138,7 +142,8 @@ function getEventView(
   fields: string[] = [],
   sorts: Sort[] = [],
   pageFilters: PageFilters,
-  dataset: DiscoverDatasets
+  dataset: DiscoverDatasets,
+  projectIds?: number[]
 ) {
   const query = typeof search === 'string' ? search : (search?.formatString() ?? '');
 
@@ -152,6 +157,10 @@ function getEventView(
     },
     pageFilters
   );
+
+  if (projectIds) {
+    eventView.project = projectIds;
+  }
 
   if (sorts.length > 0) {
     eventView.sorts = sorts;


### PR DESCRIPTION
### Summary
When using 'useDiscover', it's own eventview is created, which normally decodes project directly from location. Since we may be on an issues detail view with an error specific project in the url, we want to be able to bypass using location and make cross-project queries instead.

Also in this PR, renamed the 'UseMetricsOptions' interface as it doesn't quite fit.
