### PR TITLE
fix(ui): Update coloring of priority signal icon for better visibility

### DIFF
--- a/static/app/components/badge/iconCellSignal.tsx
+++ b/static/app/components/badge/iconCellSignal.tsx
@@ -8,9 +8,9 @@ interface Props extends SVGIconProps {
 }
 const IconCellSignal = forwardRef<SVGSVGElement, Props>(({bars = 3, ...props}, ref) => {
   const theme = useTheme();
-  const firstBarColor = bars > 0 ? theme.gray300 : theme.gray100;
-  const secondBarColor = bars > 1 ? theme.gray300 : theme.gray100;
-  const thirdBarColor = bars > 2 ? theme.gray300 : theme.gray100;
+  const firstBarColor = bars > 0 ? theme.gray300 : theme.gray200;
+  const secondBarColor = bars > 1 ? theme.gray300 : theme.gray200;
+  const thirdBarColor = bars > 2 ? theme.gray300 : theme.gray200;
 
   return (
     <SvgIcon {...props} ref={ref}>


### PR DESCRIPTION
Gray100 is barely visible, so bumping up the faded signal coloring to gray200.

Before:

![CleanShot 2025-03-12 at 10 40 56@2x](https://github.com/user-attachments/assets/ddd1cda0-8666-46b3-ba4d-593b5c0b4aba)

After:

![CleanShot 2025-03-12 at 10 41 06@2x](https://github.com/user-attachments/assets/0c563704-4f85-48b3-a8f7-a2eb7bcb1c1a)
