### PR TITLE
feat(insights): remove perf sidebar link

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -65,22 +65,18 @@ describe('Sidebar', function () {
 
   const renderSidebarWithFeatures = (features: string[] = []) => {
     return renderSidebar({
-      organization: {
-        ...organization,
-        features: [...organization.features, ...features],
-      },
+      organization: {...organization, features: [...organization.features, ...features]},
     });
   };
 
   beforeEach(function () {
     ConfigStore.set('user', user);
     mockUseLocation.mockReturnValue(LocationFixture());
-    jest.spyOn(incidentsHook, 'useServiceIncidents').mockImplementation(
-      () =>
-        ({
-          data: [ServiceIncidentFixture()],
-        }) as UseQueryResult<StatuspageIncident[]>
-    );
+    jest
+      .spyOn(incidentsHook, 'useServiceIncidents')
+      .mockImplementation(
+        () => ({data: [ServiceIncidentFixture()]}) as UseQueryResult<StatuspageIncident[]>
+      );
 
     apiMocks.broadcasts = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/broadcasts/`,
@@ -97,9 +93,7 @@ describe('Sidebar', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/onboarding-tasks/`,
       method: 'GET',
-      body: {
-        onboardingTasks: [],
-      },
+      body: {onboardingTasks: []},
     });
   });
 
@@ -123,9 +117,7 @@ describe('Sidebar', function () {
   });
 
   it('has can logout', async function () {
-    renderSidebar({
-      organization: OrganizationFixture({access: ['member:read']}),
-    });
+    renderSidebar({organization: OrganizationFixture({access: ['member:read']})});
 
     await userEvent.click(await screen.findByTestId('sidebar-dropdown'));
     await userEvent.click(screen.getByTestId('sidebar-signout'));
@@ -161,9 +153,7 @@ describe('Sidebar', function () {
       expect(orgSettingsLink).toBeInTheDocument();
     });
     it('has link to Members settings with `member:write`', async function () {
-      renderSidebar({
-        organization: OrganizationFixture({access: ['member:read']}),
-      });
+      renderSidebar({organization: OrganizationFixture({access: ['member:read']})});
 
       await userEvent.click(await screen.findByTestId('sidebar-dropdown'));
 
@@ -201,9 +191,7 @@ describe('Sidebar', function () {
     });
 
     it('can have onboarding feature', async function () {
-      renderSidebar({
-        organization: {...organization, features: ['onboarding']},
-      });
+      renderSidebar({organization: {...organization, features: ['onboarding']}});
 
       const quickStart = await screen.findByText('Onboarding');
 
@@ -259,10 +247,7 @@ describe('Sidebar', function () {
       await waitFor(() => {
         expect(apiMocks.broadcastsMarkAsSeen).toHaveBeenCalledWith(
           '/broadcasts/',
-          expect.objectContaining({
-            data: {hasSeen: '1'},
-            query: {id: ['8']},
-          })
+          expect.objectContaining({data: {hasSeen: '1'}, query: {id: ['8']}})
         );
       });
       jest.useRealTimers();
@@ -377,7 +362,7 @@ describe('Sidebar', function () {
       });
 
       const links = screen.getAllByRole('link');
-      expect(links).toHaveLength(24);
+      expect(links).toHaveLength(23);
 
       [
         'Issues',
@@ -392,7 +377,6 @@ describe('Sidebar', function () {
         'Backend',
         'Mobile',
         'AI',
-        'Performance',
         'User Feedback',
         'Crons',
         'Alerts',

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -27,7 +27,6 @@ import {
   IconDashboard,
   IconGraph,
   IconIssues,
-  IconLightning,
   IconMegaphone,
   IconProject,
   IconReleases,
@@ -54,8 +53,6 @@ import theme from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
@@ -78,10 +75,6 @@ import {
   DOMAIN_VIEW_BASE_TITLE,
   DOMAIN_VIEW_BASE_URL,
 } from 'sentry/views/insights/pages/settings';
-import {
-  getPerformanceBaseUrl,
-  platformToDomainView,
-} from 'sentry/views/performance/utils';
 
 import {LegacyProfilingOnboardingSidebar} from '../profiling/profilingOnboardingSidebar';
 
@@ -108,8 +101,6 @@ function Sidebar() {
   const activePanel = useLegacyStore(SidebarPanelStore);
   const organization = useOrganization({allowNull: true});
   const {shouldAccordionFloat} = useContext(ExpandedContext);
-  const {selection} = usePageFilters();
-  const {projects: projectList} = useProjects();
   const hasOrganization = !!organization;
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
 
@@ -119,12 +110,7 @@ function Sidebar() {
   const hasPanel = !!activePanel;
   const orientation: SidebarOrientation = horizontal ? 'top' : 'left';
 
-  const sidebarItemProps = {
-    orientation,
-    collapsed,
-    hasPanel,
-    organization,
-  };
+  const sidebarItemProps = {orientation, collapsed, hasPanel, organization};
   // Avoid showing superuser UI on self-hosted instances
   const showSuperuserWarning = () => {
     return isActiveSuperuser() && !ConfigStore.get('isSelfHosted');
@@ -249,25 +235,6 @@ function Sidebar() {
   const hasPerfLandingRemovalFlag = organization?.features.includes(
     'insights-performance-landing-removal'
   );
-  const view = hasPerfLandingRemovalFlag
-    ? platformToDomainView(projectList, selection.projects)
-    : undefined;
-  const performance = hasOrganization && (
-    <Feature
-      hookName="feature-disabled:performance-sidebar-item"
-      features="performance-view"
-      organization={organization}
-    >
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconLightning />}
-        label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
-        active={hasPerfLandingRemovalFlag ? false : undefined}
-        to={`${getPerformanceBaseUrl(organization.slug, view)}/`}
-        id="performance"
-      />
-    </Feature>
-  );
 
   const releases = hasOrganization && (
     <SidebarItem
@@ -309,10 +276,7 @@ function Sidebar() {
       {...sidebarItemProps}
       icon={<IconSiren />}
       label={t('Alerts')}
-      to={makeAlertsPathname({
-        path: '/rules/',
-        organization,
-      })}
+      to={makeAlertsPathname({path: '/rules/', organization})}
       id="alerts"
     />
   );

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -458,7 +458,6 @@ function Sidebar() {
                     </SidebarSection>
 
                     <SidebarSection>
-                      {performance}
                       {feedback}
                       {monitors}
                       {alerts}


### PR DESCRIPTION
closes [#performance sidebar ](https://github.com/getsentry/sentry/issues/84021)

We've had redirects from performance -> insights for about 2 weeks. Now it's time to remove the performance sidebar link for good.