### PR TITLE
fix(ourlogs): Remove 'add to column' when table is frozen

### DIFF
--- a/static/app/components/events/breadcrumbs/combinedBreadcrumbsAndLogsSection.tsx
+++ b/static/app/components/events/breadcrumbs/combinedBreadcrumbsAndLogsSection.tsx
@@ -24,7 +24,7 @@ export function CombinedBreadcrumbsAndLogsSection({
 
   return (
     <LogsPageParamsProvider
-      isIssuesDetailView
+      isOnEmbeddedView
       limitToTraceId={event.contexts?.trace?.trace_id}
     >
       <CombinedBreadcrumbsAndLogsSectionContent
@@ -53,7 +53,7 @@ function CombinedBreadcrumbsAndLogsSectionContent({
       />
       <LogsIssuesSection
         initialCollapse={shouldCollapseLogs}
-        isIssuesDetailView
+        isOnEmbeddedView
         limitToTraceId={event.contexts?.trace?.trace_id}
       />
     </Fragment>

--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -7,7 +7,7 @@ import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/log
 /**
  * These are the default fields that are shown in the logs table. The query will always add other hidden fields required to render details view etc.
  */
-function defaultLogFields(): OurLogKnownFieldKey[] {
+export function defaultLogFields(): OurLogKnownFieldKey[] {
   return [
     OurLogKnownFieldKey.SEVERITY_TEXT,
     OurLogKnownFieldKey.BODY,

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -14,6 +14,7 @@ import {isUrl} from 'sentry/utils/string/isUrl';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {
   useLogsFields,
+  useLogsIsTableEditingFrozen,
   useLogsSearch,
   useSetLogsFields,
   useSetLogsSearch,
@@ -348,6 +349,7 @@ function LogFieldsTreeRowDropdown({content}: {content: AttributeTreeContent}) {
   const search = useLogsSearch();
   const fields = useLogsFields();
   const setLogFields = useSetLogsFields();
+  const isTableEditingFrozen = useLogsIsTableEditingFrozen();
   const [isVisible, setIsVisible] = useState(false);
   const originalAttribute = content.originalAttribute;
 
@@ -391,6 +393,7 @@ function LogFieldsTreeRowDropdown({content}: {content: AttributeTreeContent}) {
     {
       key: 'add-column',
       label: t('Add this as table column'),
+      hidden: isTableEditingFrozen,
       disabled: fields.includes(originalAttribute.original_attribute_key),
       onAction: () => {
         addColumn();

--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -21,7 +21,7 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 
 export function LogsIssuesSection({
   initialCollapse,
-  isIssuesDetailView,
+  isOnEmbeddedView,
   limitToTraceId: traceId,
 }: {
   initialCollapse: boolean;
@@ -45,7 +45,7 @@ export function LogsIssuesSection({
       initialCollapse={initialCollapse}
     >
       <LogsPageParamsProvider
-        isIssuesDetailView={isIssuesDetailView}
+        isOnEmbeddedView={isOnEmbeddedView}
         limitToTraceId={traceId}
       >
         <LogsSectionContent tableData={tableData} />

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -22,7 +22,7 @@ import {
 } from 'sentry/views/explore/components/table';
 import {
   useLogsFields,
-  useLogsIsTableSortFrozen,
+  useLogsIsTableEditingFrozen,
   useLogsSearch,
   useLogsSortBys,
   useSetLogsCursor,
@@ -38,7 +38,7 @@ export function LogsTable({tableData}: {tableData: UseExploreLogsTableResult}) {
   const fields = useLogsFields();
   const search = useLogsSearch();
   const setCursor = useSetLogsCursor();
-  const isTableSortFrozen = useLogsIsTableSortFrozen();
+  const isTableEditingFrozen = useLogsIsTableEditingFrozen();
   const {data, isError, isPending, pageLinks, meta} = tableData;
 
   const tableRef = useRef<HTMLTableElement>(null);
@@ -73,8 +73,10 @@ export function LogsTable({tableData}: {tableData: UseExploreLogsTableResult}) {
                   isFirst={index === 0}
                 >
                   <TableHeadCellContent
-                    onClick={isTableSortFrozen ? undefined : () => setSortBys([{field}])}
-                    isFrozen={isTableSortFrozen}
+                    onClick={
+                      isTableEditingFrozen ? undefined : () => setSortBys([{field}])
+                    }
+                    isFrozen={isTableEditingFrozen}
                   >
                     <Tooltip showOnlyOnOverflow title={headerLabel}>
                       {headerLabel}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -61,6 +61,9 @@ export const LogDetailTableBodyCell = styled(TableBodyCell)`
   ${LogTableRow} & {
     padding: 0;
   }
+  &:last-child {
+    padding: 0;
+  }
 `;
 
 export const DetailsWrapper = styled('div')`


### PR DESCRIPTION
### Summary
This removes 'add to column' when the table is frozen, and switches the prop names to more generic since we're also using it on Trace view soon.

Other:
- Fixed a styling problem with padding being applied due to css specificity rules.
- Frozen log table keeps the default field list (can be changed to a provider prop in the future) since they shouldn't allow column editing.

#### Screenshots
| ![Screenshot 2025-03-12 at 2 22 18 PM](https://github.com/user-attachments/assets/9ef1ade3-296d-4894-8495-42ee8450dbb2)|
|-|