### PR TITLE
ref(guide): Remove `to` from guideAnchor

### DIFF
--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import type {Query} from 'history';
 
 import {
   closeGuide,
@@ -37,10 +36,6 @@ type Props = {
    */
   onStepComplete?: (e: React.MouseEvent) => void;
   position?: React.ComponentProps<typeof Hovercard>['position'];
-  to?: {
-    pathname: string;
-    query: Query;
-  };
   wrapperComponent?: React.ComponentType<{
     'aria-expanded': React.AriaAttributes['aria-expanded'];
     children: React.ReactNode;
@@ -151,8 +146,7 @@ class BaseGuideAnchor extends Component<Props, State> {
   };
 
   render() {
-    const {children, position, offset, containerClassName, to, wrapperComponent} =
-      this.props;
+    const {children, position, offset, containerClassName, wrapperComponent} = this.props;
     const {active, currentGuide, step} = this.state;
 
     if (!active) {
@@ -180,12 +174,12 @@ class BaseGuideAnchor extends Component<Props, State> {
         actions={
           <ButtonBar gap={1}>
             {lastStep ? (
-              <TourAction size="xs" to={to} onClick={this.handleFinish}>
+              <TourAction size="xs" onClick={this.handleFinish}>
                 {currentStep.nextText ||
                   (hasManySteps ? t('Enough Already') : t('Got It'))}
               </TourAction>
             ) : (
-              <TourAction size="xs" onClick={this.handleNextStep} to={to}>
+              <TourAction size="xs" onClick={this.handleNextStep}>
                 {currentStep.nextText || t('Next')}
               </TourAction>
             )}


### PR DESCRIPTION
This appears to be unused.

This is part of cleaning up LinkButton and button