### PR TITLE
test(react19): Modify tests for react 19

### DIFF
--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -52,7 +52,7 @@ function Tokens(props: TokensProp) {
 }
 
 function getLastInput() {
-  const input = screen.getAllByRole('combobox', {name: 'Add a term'}).at(-1);
+  const input = screen.getAllByLabelText('Add a term').at(-1);
 
   expect(input).toBeInTheDocument();
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -831,12 +831,12 @@ describe('SearchQueryBuilder', function () {
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
 
       // New token should be added with the correct key and default value
-      expect(screen.getByRole('row', {name: 'browser.name:""'})).toBeInTheDocument();
+      expect(screen.getByLabelText('browser.name:""')).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('option', {name: 'Firefox'}));
+      await userEvent.click(await screen.findByLabelText('Firefox'));
 
       // New token should have a value
-      expect(screen.getByRole('row', {name: 'browser.name:Firefox'})).toBeInTheDocument();
+      expect(screen.getByLabelText('browser.name:Firefox')).toBeInTheDocument();
     });
 
     it('can add free text by typing', async function () {
@@ -868,7 +868,7 @@ describe('SearchQueryBuilder', function () {
       jest.restoreAllMocks();
 
       // Filter value should have focus
-      expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      expect(await screen.findByLabelText('Edit filter value')).toHaveFocus();
       await userEvent.keyboard('foo{enter}');
 
       // Should have a free text token "some free text"
@@ -877,7 +877,7 @@ describe('SearchQueryBuilder', function () {
       ).toBeInTheDocument();
 
       // Should have a filter token "browser.name:foo"
-      expect(screen.getByRole('row', {name: 'browser.name:foo'})).toBeInTheDocument();
+      expect(screen.getByLabelText('browser.name:foo')).toBeInTheDocument();
     });
 
     it('can add parens by typing', async function () {
@@ -2077,9 +2077,7 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(screen.getByRole('option', {name: 'duration'}));
 
         // Should start with the > operator and a value of 10ms
-        expect(
-          await screen.findByRole('row', {name: 'duration:>10ms'})
-        ).toBeInTheDocument();
+        expect(await screen.findByLabelText('duration:>10ms')).toBeInTheDocument();
       });
 
       it('duration filters have the correct operator options', async function () {
@@ -2214,9 +2212,7 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(screen.getByRole('option', {name: 'size'}));
 
         // Should start with the > operator and a value of 10ms
-        expect(
-          await screen.findByRole('row', {name: 'size:>10bytes'})
-        ).toBeInTheDocument();
+        expect(await screen.findByLabelText('size:>10bytes')).toBeInTheDocument();
       });
 
       it('size filters have the correct operator options', async function () {
@@ -2349,7 +2345,7 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(screen.getByRole('option', {name: 'rate'}));
 
         // Should start with the > operator and a value of 50%
-        expect(await screen.findByRole('row', {name: 'rate:>0.5'})).toBeInTheDocument();
+        expect(await screen.findByLabelText('rate:>0.5')).toBeInTheDocument();
       });
 
       it('percentage filters have the correct operator options', async function () {
@@ -2826,9 +2822,9 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(screen.getByRole('option', {name: 'count_if(...)'}));
 
         expect(
-          await screen.findByRole('row', {
-            name: 'count_if(transaction.duration,greater,300ms):>100',
-          })
+          await screen.findByLabelText(
+            'count_if(transaction.duration,greater,300ms):>100'
+          )
         ).toBeInTheDocument();
       });
 

--- a/static/app/utils/withApi.spec.tsx
+++ b/static/app/utils/withApi.spec.tsx
@@ -22,9 +22,8 @@ describe('withApi', function () {
     const MyComponentWithApi = withApi(MyComponent);
     render(<MyComponentWithApi />);
 
-    expect(MyComponent).toHaveBeenCalledWith(
-      expect.objectContaining({api: apiInstance}),
-      expect.anything()
+    expect(MyComponent.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({api: apiInstance})
     );
   });
 

--- a/static/app/utils/withSentryAppComponents.spec.tsx
+++ b/static/app/utils/withSentryAppComponents.spec.tsx
@@ -13,7 +13,7 @@ describe('withSentryAppComponents HoC', function () {
     const Container = withSentryAppComponents(MyComponent);
     render(<Container />);
 
-    expect(MyComponent).toHaveBeenCalledWith({components: []}, {});
+    expect((MyComponent.mock.calls[0] as any)[0]).toEqual({components: []});
 
     MyComponent.mockClear();
 
@@ -34,15 +34,12 @@ describe('withSentryAppComponents HoC', function () {
       ])
     );
 
-    expect(MyComponent).toHaveBeenCalledWith(
-      {
-        components: [
-          expect.objectContaining({type: 'issue-link'}),
-          expect.objectContaining({type: 'stacktrace-link'}),
-        ],
-      },
-      {}
-    );
+    expect((MyComponent.mock.calls[0] as any)[0]).toEqual({
+      components: [
+        expect.objectContaining({type: 'issue-link'}),
+        expect.objectContaining({type: 'stacktrace-link'}),
+      ],
+    });
   });
 
   it('handles components of a certain type', function () {
@@ -52,7 +49,7 @@ describe('withSentryAppComponents HoC', function () {
     });
     render(<Container />);
 
-    expect(MyComponent).toHaveBeenCalledWith({components: []}, {});
+    expect((MyComponent.mock.calls[0] as any)[0]).toEqual({components: []});
 
     act(() =>
       SentryAppComponentsStore.loadComponents([
@@ -71,18 +68,15 @@ describe('withSentryAppComponents HoC', function () {
       ])
     );
 
-    expect(MyComponent).toHaveBeenCalledWith(
-      {
-        components: [
-          {
-            type: 'issue-link',
-            sentryApp: {uuid: 'uuid', name: '', slug: '', avatars: []},
-            uuid: '',
-            schema: {uri: '', url: '', type: 'stacktrace-link'},
-          },
-        ],
-      },
-      {}
-    );
+    expect((MyComponent.mock.calls[1] as any)[0]).toEqual({
+      components: [
+        {
+          type: 'issue-link',
+          sentryApp: {uuid: 'uuid', name: '', slug: '', avatars: []},
+          uuid: '',
+          schema: {uri: '', url: '', type: 'stacktrace-link'},
+        },
+      ],
+    });
   });
 });

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -517,9 +517,8 @@ describe('Dashboards > WidgetCard', function () {
     await waitFor(() => expect(eventsMock).toHaveBeenCalled());
 
     await waitFor(() =>
-      expect(SimpleTableChart).toHaveBeenCalledWith(
-        expect.objectContaining({stickyHeaders: true}),
-        expect.anything()
+      expect((SimpleTableChart as jest.Mock).mock.calls[0][0]).toEqual(
+        expect.objectContaining({stickyHeaders: true})
       )
     );
   });

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -169,7 +169,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
         },
       })
     );
-    expect(mock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/metrics/data/',
       expect.objectContaining({

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1088,7 +1088,9 @@ describe('Results', function () {
         {router, organization}
       );
 
-      expect(await screen.findByText('this is a tip')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('this is a tip')).toBeInTheDocument();
+      });
     });
 
     it('renders metric fallback alert', async function () {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -375,6 +375,12 @@ describe('GroupReplays', () => {
         },
       });
 
+      const mockReplayRecord = mockReplay?.getReplay();
+      MockApiClient.addMockResponse({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${mockReplayRecord?.project_id}/replays/${mockReplayRecord?.id}/viewed-by/`,
+      });
+
       // Mock the system date to be 2022-09-28
       setMockDate(new Date('Sep 28, 2022 11:29:13 PM UTC'));
 
@@ -476,6 +482,12 @@ describe('GroupReplays', () => {
             finished_at: hydrated.finished_at.toString(),
           })),
         },
+      });
+
+      const mockReplayRecord = mockReplay?.getReplay();
+      MockApiClient.addMockResponse({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${mockReplayRecord?.project_id}/replays/${mockReplayRecord?.id}/viewed-by/`,
       });
 
       render(<GroupReplays />, {

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -55,6 +55,11 @@ function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatfor
     method: 'PUT',
     body: {},
   });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sdks/`,
+    body: {},
+  });
 }
 
 describe('ProjectInstallPlatform', function () {

--- a/static/app/views/projectInstall/platformOrIntegration.spec.tsx
+++ b/static/app/views/projectInstall/platformOrIntegration.spec.tsx
@@ -43,6 +43,11 @@ function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatfor
     method: 'PUT',
     body: {},
   });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sdks/`,
+    body: {},
+  });
 }
 
 describe('ProjectInstallPlatform', function () {

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -43,7 +43,7 @@ describe('OrganizationAuditLog', function () {
     expect(screen.getByText('IP')).toBeInTheDocument();
     expect(screen.getByText('Time')).toBeInTheDocument();
     expect(screen.queryByText('No audit entries available')).not.toBeInTheDocument();
-    expect(screen.getByText('edited project ludic-science')).toBeInTheDocument();
+    expect(await screen.findByText('edited project ludic-science')).toBeInTheDocument();
   });
 
   it('renders empty', async function () {

--- a/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
@@ -9,6 +9,7 @@ import {
   renderGlobalModal,
   screen,
   userEvent,
+  waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
 
@@ -297,7 +298,9 @@ describe('Subscription > BillingDetails', function () {
 
     renderGlobalModal();
     const modal = await screen.findByRole('dialog');
-    expect(modal).toHaveTextContent('Unable to initialize payment setup');
+    await waitFor(() => {
+      expect(modal).toHaveTextContent('Unable to initialize payment setup');
+    });
   });
 
   it('shows an error when confirmSetup fails', async function () {


### PR DESCRIPTION
Some getByRoles stop working for some reason. It does reproduce locally with react 19 installed.

you can see other broken tests here https://github.com/getsentry/sentry/actions/runs/13815562399/job/38647774882?pr=86531

part of https://github.com/getsentry/frontend-tsc/issues/68
