### PR TITLE
ref(insights): update session health chart titles, help text, and legends

### DIFF
--- a/static/app/views/dashboards/widgets/widget/widgetDescription.tsx
+++ b/static/app/views/dashboards/widgets/widget/widgetDescription.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 export interface WidgetDescriptionProps {
-  description?: React.ReactElement | string;
+  description?: React.ReactNode;
   revealTooltip?: 'hover' | 'always';
   title?: string;
 }

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -38,6 +38,7 @@ export interface InsightsTimeSeriesWidgetProps {
   title: string;
   visualizationType: 'line' | 'area' | 'bar';
   aliases?: Aliases;
+  description?: string;
   stacked?: boolean;
 }
 
@@ -120,6 +121,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
         }
         Actions={
           <Widget.WidgetToolbar>
+            {props.description && (
+              <Widget.WidgetDescription description={props.description} />
+            )}
             <Button
               size="xs"
               aria-label={t('Open Full-Screen View')}

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -38,7 +38,7 @@ export interface InsightsTimeSeriesWidgetProps {
   title: string;
   visualizationType: 'line' | 'area' | 'bar';
   aliases?: Aliases;
-  description?: string;
+  description?: React.ReactNode;
   stacked?: boolean;
 }
 

--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -11,7 +11,7 @@ export default function CrashFreeSessionsChart() {
 
   return (
     <InsightsLineChartWidget
-      title={t('Crash Free Session Rate')}
+      title={t('Crash Free Sessions')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -12,6 +12,7 @@ export default function CrashFreeSessionsChart() {
   return (
     <InsightsLineChartWidget
       title={t('Crash Free Sessions')}
+      description={t('Percent of healthy sessions out of total sessions.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useCrashFreeSessions from 'sentry/views/insights/sessions/queries/useCrashFreeSessions';
 
@@ -12,7 +13,14 @@ export default function CrashFreeSessionsChart() {
   return (
     <InsightsLineChartWidget
       title={t('Crash Free Sessions')}
-      description={t('Percent of healthy sessions out of total sessions.')}
+      description={tct(
+        'The percent of sessions terminating without a crash. See [link:session status].',
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -14,7 +14,7 @@ export default function ErrorFreeSessionsChart() {
     <InsightsLineChartWidget
       title={t('Error Free Sessions')}
       description={tct(
-        'The percent of sessions that finished without a single error occurring. See [link:session status].',
+        'The percent of sessions terminating without a single error occurring. See [link:session status].',
         {
           link: (
             <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -11,7 +11,7 @@ export default function ErrorFreeSessionsChart() {
 
   return (
     <InsightsLineChartWidget
-      title={t('Error Free Session Rate')}
+      title={t('Error Free Sessions')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useErrorFreeSessions from 'sentry/views/insights/sessions/queries/useErrorFreeSessions';
 
@@ -12,7 +13,14 @@ export default function ErrorFreeSessionsChart() {
   return (
     <InsightsLineChartWidget
       title={t('Error Free Sessions')}
-      description={t('Percent of healthy sessions out of total sessions.')}
+      description={tct(
+        'The percent of sessions that finished without a single error occurring. See [link:session status].',
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -12,6 +12,7 @@ export default function ErrorFreeSessionsChart() {
   return (
     <InsightsLineChartWidget
       title={t('Error Free Sessions')}
+      description={t('Percent of healthy sessions out of total sessions.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
@@ -12,6 +12,9 @@ export default function ReleaseSessionCountChart() {
   return (
     <InsightsLineChartWidget
       title={t('Total Sessions by Release')}
+      description={t(
+        'The total number of sessions per release. The 5 most recent releases are shown.'
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
@@ -12,6 +12,9 @@ export default function ReleaseSessionPercentageChart() {
   return (
     <InsightsAreaChartWidget
       title={t('Percent Sessions by Release')}
+      description={t(
+        'The percentage of total sessions that each release accounted for. The 5 most recent releases are shown.'
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
@@ -21,6 +21,7 @@ export default function SessionHealthCountChart({view}: {view: string}) {
   return (
     <InsightsLineChartWidget
       title={t('Sessions')}
+      description={t('The percent of sessions with each health status.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
@@ -1,20 +1,26 @@
 import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 
-export default function SessionHealthCountChart() {
+export default function SessionHealthCountChart({view}: {view: string}) {
   const {series, isPending, error} = useSessionHealthBreakdown({type: 'count'});
+  const frontendPath = view === FRONTEND_LANDING_SUB_PATH;
 
   const aliases = {
     healthy_session_count: t('Healthy session count'),
-    crashed_session_count: t('Crashed session count'),
-    errored_session_count: t('Errored session count'),
+    crashed_session_count: frontendPath
+      ? t('Unhandled error session count')
+      : t('Crashed session count'),
+    errored_session_count: frontendPath
+      ? t('Handled error session count')
+      : t('Errored session count'),
     abnormal_session_count: t('Abnormal session count'),
   };
 
   return (
     <InsightsLineChartWidget
-      title={t('Session Health Count')}
+      title={t('Sessions')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
@@ -21,7 +22,14 @@ export default function SessionHealthCountChart({view}: {view: string}) {
   return (
     <InsightsLineChartWidget
       title={t('Sessions')}
-      description={t('The percent of sessions with each health status.')}
+      description={tct(
+        'The count of sessions with each health status. See [link:session status].',
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
@@ -1,20 +1,26 @@
 import {t} from 'sentry/locale';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 
-export default function SessionHealthRateChart() {
+export default function SessionHealthRateChart({view}: {view: string}) {
   const {series, isPending, error} = useSessionHealthBreakdown({type: 'rate'});
+  const frontendPath = view === FRONTEND_LANDING_SUB_PATH;
 
   const aliases = {
     healthy_session_rate: t('Healthy session rate'),
-    crashed_session_rate: t('Crashed session rate'),
-    errored_session_rate: t('Errored session rate'),
+    crashed_session_rate: frontendPath
+      ? t('Unhandled error session rate')
+      : t('Crashed session rate'),
+    errored_session_rate: frontendPath
+      ? t('Handled error session rate')
+      : t('Errored session rate'),
     abnormal_session_rate: t('Abnormal session rate'),
   };
 
   return (
     <InsightsAreaChartWidget
-      title={t('Session Health Rate')}
+      title={t('Session Health')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
@@ -21,7 +22,14 @@ export default function SessionHealthRateChart({view}: {view: string}) {
   return (
     <InsightsAreaChartWidget
       title={t('Session Health')}
-      description={t('The percent of sessions with each health status.')}
+      description={tct(
+        'The percent of sessions with each health status. See [link:session status].',
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
@@ -21,6 +21,7 @@ export default function SessionHealthRateChart({view}: {view: string}) {
   return (
     <InsightsAreaChartWidget
       title={t('Session Health')}
+      description={t('The percent of sessions with each health status.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
@@ -1,22 +1,28 @@
 import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
 
-export default function UserHealthCountChart() {
+export default function UserHealthCountChart({view}: {view: string}) {
   const {series, isPending, error} = useUserHealthBreakdown({
     type: 'count',
   });
+  const frontendPath = view === FRONTEND_LANDING_SUB_PATH;
 
   const aliases = {
     healthy_user_count: t('Healthy user count'),
-    crashed_user_count: t('Crashed user count'),
-    errored_user_count: t('Errored user count'),
+    crashed_user_count: frontendPath
+      ? t('Unhandled error user count')
+      : t('Crashed user count'),
+    errored_user_count: frontendPath
+      ? t('Handled error user count')
+      : t('Errored user count'),
     abnormal_user_count: t('Abnormal user count'),
   };
 
   return (
     <InsightsLineChartWidget
-      title={t('User Health Count')}
+      title={t('Users')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
@@ -23,7 +24,17 @@ export default function UserHealthCountChart({view}: {view: string}) {
   return (
     <InsightsLineChartWidget
       title={t('Users')}
-      description={t('Breakdown of total users, grouped by health status.')}
+      description={tct(
+        'Breakdown of total [linkUsers:users], grouped by [linkStatus:health status].',
+        {
+          linkUsers: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#user-modeapplication-mode-sessions" />
+          ),
+          linkStatus: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
@@ -23,6 +23,7 @@ export default function UserHealthCountChart({view}: {view: string}) {
   return (
     <InsightsLineChartWidget
       title={t('Users')}
+      description={t('Breakdown of total users, grouped by health status.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
@@ -1,22 +1,28 @@
 import {t} from 'sentry/locale';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
 
-export default function UserHealthRateChart() {
+export default function UserHealthRateChart({view}: {view: string}) {
   const {series, isPending, error} = useUserHealthBreakdown({
     type: 'rate',
   });
+  const frontendPath = view === FRONTEND_LANDING_SUB_PATH;
 
   const aliases = {
     healthy_user_rate: t('Healthy user rate'),
-    crashed_user_rate: t('Crashed user rate'),
-    errored_user_rate: t('Errored user rate'),
+    crashed_user_rate: frontendPath
+      ? t('Unhandled error user rate')
+      : t('Crashed user rate'),
+    errored_user_rate: frontendPath
+      ? t('Handled error user rate')
+      : t('Errored user rate'),
     abnormal_user_rate: t('Abnormal user rate'),
   };
 
   return (
     <InsightsAreaChartWidget
-      title={t('User Health Rate')}
+      title={t('User Health')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
@@ -23,6 +23,7 @@ export default function UserHealthRateChart({view}: {view: string}) {
   return (
     <InsightsAreaChartWidget
       title={t('User Health')}
+      description={t('The percent of users with each health status.')}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
@@ -1,4 +1,5 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
@@ -23,7 +24,17 @@ export default function UserHealthRateChart({view}: {view: string}) {
   return (
     <InsightsAreaChartWidget
       title={t('User Health')}
-      description={t('The percent of users with each health status.')}
+      description={tct(
+        'The percent of [linkUsers:users] with each [linkStatus:health status].',
+        {
+          linkUsers: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#user-modeapplication-mode-sessions" />
+          ),
+          linkStatus: (
+            <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />
+          ),
+        }
+      )}
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -37,7 +37,7 @@ export function SessionsOverview() {
     module: ModuleName.SESSIONS,
   };
 
-  const {view} = useDomainViewFilters();
+  const {view = ''} = useDomainViewFilters();
 
   const [filters, setFilters] = useState<string[]>(['']);
 
@@ -57,16 +57,16 @@ export function SessionsOverview() {
         </ModuleLayout.Third>
       ) : undefined}
       <ModuleLayout.Third>
-        <SessionHealthCountChart />
+        <SessionHealthCountChart view={view} />
       </ModuleLayout.Third>
       <ModuleLayout.Third>
-        <SessionHealthRateChart />
+        <SessionHealthRateChart view={view} />
       </ModuleLayout.Third>
       <ModuleLayout.Half>
-        <UserHealthCountChart />
+        <UserHealthCountChart view={view} />
       </ModuleLayout.Half>
       <ModuleLayout.Half>
-        <UserHealthRateChart />
+        <UserHealthRateChart view={view} />
       </ModuleLayout.Half>
     </Fragment>
   );


### PR DESCRIPTION
### changes the wording on the session health charts for frontend: crashed -> unhandled error, errored -> handled error

<img width="903" alt="SCR-20250312-mkgg" src="https://github.com/user-attachments/assets/6e3194f0-44bf-4779-a289-ade4d8e0095b" />

###  title tweaks for all charts (remove unit since it's obvious what the unit is after hovering)

<img width="1218" alt="SCR-20250312-mkah" src="https://github.com/user-attachments/assets/27e069bc-a0cb-4091-865b-8410e2b8d4ea" />
<img width="1205" alt="SCR-20250312-mkbq" src="https://github.com/user-attachments/assets/0f4fde9d-2e7d-4c60-83c8-d5d48c4d3993" />

### add help icons with descriptions on each chart

https://github.com/user-attachments/assets/b853fc07-5ca9-4cf7-98f6-a570b3f38cf7



