### PR TITLE
🔧 chore(aci): move alert context out of workflow engine

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -27,7 +27,7 @@ from sentry.incidents.models.incident import (
     IncidentStatus,
     TriggerStatus,
 )
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, NotificationContext
 from sentry.integrations.metric_alerts import get_metric_count_from_incident
 from sentry.integrations.types import ExternalProviders
 from sentry.models.project import Project
@@ -43,7 +43,6 @@ from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.users.services.user_option import RpcUserOption, user_option_service
 from sentry.utils.email import MessageBuilder, get_email_addresses
-from sentry.workflow_engine.typings.notification_action import NotificationContext
 
 
 class ActionHandler(metaclass=abc.ABCMeta):

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -77,7 +77,7 @@ class NotificationContext:
                 target_display=action.config.get("target_display"),
                 sentry_app_config=action.data.get("settings"),
                 sentry_app_id=action.data.get("target_identifier"),
-                # Does not need data
+                # For Sentry Apps, we use `sentry_app_config` and don't pass `data`
             )
         elif action.type == Action.Type.OPSGENIE or action.type == Action.Type.PAGERDUTY:
             return cls(

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -7,7 +7,7 @@ from django.db import router, transaction
 from django.http import Http404
 
 from sentry.incidents.models.incident import IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, NotificationContext
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
@@ -19,7 +19,6 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import control_silo_function
 from sentry.snuba.models import SnubaQuery
 from sentry.utils import metrics
-from sentry.workflow_engine.typings.notification_action import NotificationContext
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict
 
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
@@ -733,33 +732,3 @@ class EmailDataBlob(DataBlob):
     """
 
     fallthroughType: str = ""
-
-
-@dataclass
-class NotificationContext:
-    """
-    NotificationContext is a dataclass that represents the context required send a notification.
-    """
-
-    integration_id: int | None = None
-    target_identifier: str | None = None
-    target_display: str | None = None
-    sentry_app_config: list[dict[str, Any]] | dict[str, Any] | None = None
-
-    @classmethod
-    def from_alert_rule_trigger_action(cls, action: AlertRuleTriggerAction) -> NotificationContext:
-        return cls(
-            integration_id=action.integration_id,
-            target_identifier=action.target_identifier,
-            target_display=action.target_display,
-            sentry_app_config=action.sentry_app_config,
-        )
-
-    @classmethod
-    def from_action_model(cls, action: Action) -> NotificationContext:
-        return cls(
-            integration_id=action.integration_id,
-            target_identifier=action.config.get("target_identifier"),
-            target_display=action.config.get("target_display"),
-            sentry_app_config=action.data,
-        )


### PR DESCRIPTION
breaking apart changes from https://github.com/getsentry/sentry/pull/86767/, this time moving `NotificationContext` out of workflow engine