### PR TITLE
feat(billing): Generate txt emails from html templates

### DIFF
--- a/bin/generate_email_text.py
+++ b/bin/generate_email_text.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python
+"""
+Script to generate text versions (body.txt) of email templates from HTML versions (body.html).
+
+This script converts HTML email templates to text format, preserving Django template
+tags and maintaining the structure of the content. It can optionally use djlint to
+check for and fix formatting issues in both the HTML source and generated text files.
+
+Features:
+- Preserves Django template tags ({% %}, {{ }}, {# #})
+- Converts HTML formatting to Markdown-style text
+- Replaces include paths from .html to .txt
+- Fixes common template formatting issues
+- Optionally checks/fixes templates with djlint
+- Substitutes specific template tags for text-specific versions
+
+Usage:
+    python bin/generate_email_text.py --html path/to/template.html
+    python bin/generate_email_text.py --html path/to/template.html --fix-html --fix-text
+    python bin/generate_email_text.py --html path/to/template.html --all
+
+Dependencies and setup:
+    devenv sync
+    source .venv/bin/activate
+    pip install html2text djlint
+"""
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+
+from html2text import HTML2Text
+
+# Define tag substitutions for HTML to text conversion
+# These tags will be replaced when converting from HTML to text templates
+TAG_SUBSTITUTIONS = {
+    "spend_visibility_billing_usage_table": "spend_visibility_billing_usage_table_text",
+    # Add more substitutions here as needed
+}
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def extract_django_tags(text):
+    """Extract Django template tags from text.
+
+    This function identifies and extracts all Django template tags in a given text.
+    Tags include:
+    - Block tags: {% ... %}
+    - Variable tags: {{ ... }}
+    - Comment tags: {# ... #}
+
+    Args:
+        text (str): The template text to search for Django tags
+
+    Returns:
+        iterator: An iterator of re.Match objects containing the positions and content
+                 of each Django tag found in the text
+    """
+    return re.finditer(r"({%.*?%}|{{.*?}}|{#.*?#})", text, re.DOTALL)
+
+
+def process_with_djlint(file_path, check=False, fix=False, file_type="html"):
+    """Process a file with djlint to check for issues and/or fix them.
+
+    djlint is a linter/formatter for Django/Jinja templates that can identify
+    common formatting issues and fix them automatically.
+
+    Args:
+        file_path (str): Path to the file to process
+        check (bool): Whether to check the file for issues
+        fix (bool): Whether to fix issues in the file
+        file_type (str): Type of file being processed ('html' or 'text')
+
+    Returns:
+        bool: True if no issues found or fixes applied successfully,
+              False if issues found and not fixed
+    """
+    if not check and not fix:
+        return True
+
+    file_type_display = "HTML" if file_type == "html" else "Text"
+
+    def _run_djlint_command(cmd, description, check_mode=True):
+        """Helper function to run djlint commands and handle output consistently.
+
+        Args:
+            cmd (list): Command to run
+            description (str): Description of what the command does
+            check_mode (bool): Whether to use check=True in subprocess.run
+
+        Returns:
+            tuple: (success, result) - success is boolean, result is subprocess result
+        """
+        logger.info("Running command: %s", " ".join(cmd))
+        try:
+            result = subprocess.run(
+                cmd, check=check_mode, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            return True, result
+        except subprocess.CalledProcessError as e:
+            if check_mode:
+                logger.debug("Command stderr: %s", e.stderr)
+                logger.debug("Command stdout: %s", e.stdout)
+                logger.debug("Command exit code: %d", e.returncode)
+                return False, e
+            return False, e
+
+    # Handle text files differently since djlint may have issues with them
+    if file_type == "text" and fix:
+        # Read file content before processing to detect actual changes
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content_before = f.read()
+        except OSError as e:
+            logger.warning("Error reading file before formatting: %s", str(e))
+            return False
+
+        logger.info("Running djlint on text file: %s", file_path)
+
+        # Run djlint without using check=True since we expect exit code 1 for text files
+        success, result = _run_djlint_command(
+            ["djlint", "--reformat", "--profile=django", file_path],
+            "format text file",
+            check_mode=False,
+        )
+
+        # Log output at debug level to hide diff
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
+
+        # Check if file content actually changed
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content_after = f.read()
+        except OSError as e:
+            logger.warning("Error reading file after formatting: %s", str(e))
+            return False
+
+        actually_changed = content_before != content_after
+
+        # Interpret djlint exit codes for text files
+        if result.returncode == 0:
+            logger.info(
+                "djlint completed successfully (exit code: 0) - No formatting issues found in %s",
+                file_path,
+            )
+            return True
+        elif result.returncode == 1:
+            if actually_changed:
+                logger.info(
+                    "djlint completed with exit code 1 - The file needed formatting and was updated"
+                )
+                logger.info("Fixed formatting in %s", file_path)
+            else:
+                logger.info(
+                    "djlint completed with exit code 1 - The file needed formatting but no actual changes were made"
+                )
+                logger.info("No actual changes made to %s (formatting already correct)", file_path)
+            return True
+        else:
+            logger.warning(
+                "djlint encountered an error (exit code: %d) with %s",
+                result.returncode,
+                file_path,
+            )
+            return False
+
+    # Handle HTML files or check-only operations
+    if fix:
+        success, result = _run_djlint_command(
+            ["djlint", file_path, "--reformat", "--profile=django"],
+            f"reformat {file_type_display} file",
+        )
+
+        if success:
+            logger.info(
+                "djlint completed successfully - Formatting fixed in %s file: %s",
+                file_type_display,
+                file_path,
+            )
+        else:
+            logger.error(
+                "djlint failed with exit code %d - Failed to fix %s issues in %s",
+                result.returncode,
+                file_type_display,
+                file_path,
+            )
+
+    if check:
+        success, result = _run_djlint_command(
+            ["djlint", file_path, "--check", "--profile=django"], f"check {file_type_display} file"
+        )
+
+        if success:
+            logger.info(
+                "djlint check completed successfully (exit code: 0) - No %s issues found in %s",
+                file_type_display,
+                file_path,
+            )
+        else:
+            logger.warning(
+                "djlint check failed with exit code %d - Found %s issues in %s",
+                result.returncode,
+                file_type_display,
+                file_path,
+            )
+            return False
+
+    return True
+
+
+def convert_html_to_text(html):
+    """Convert HTML to plain text while preserving Django template tags.
+
+    This function converts HTML markup to plain text with Markdown-like formatting
+    while ensuring that Django template tags remain intact and functional.
+
+    The conversion process:
+    1. Replaces Django tags with unique placeholders
+    2. Converts HTML to text using html2text
+    3. Restores the original Django tags from placeholders
+    4. Adds newlines between adjacent links for better readability
+    5. Cleans up formatting issues in the text
+
+    Args:
+        html (str): HTML content with Django tags to convert
+
+    Returns:
+        str: Text version of the HTML with Django tags preserved
+    """
+    # First, replace Django tags with placeholders
+    tags = list(extract_django_tags(html))
+    placeholders = {}
+
+    modified_html = html
+    offset = 0
+
+    for match in tags:
+        start, end = match.span()
+        tag = match.group()
+        placeholder = f"__DJANGO_TAG_{len(placeholders)}__"
+        placeholders[placeholder] = tag
+
+        adjusted_start = start + offset
+        adjusted_end = end + offset
+        modified_html = modified_html[:adjusted_start] + placeholder + modified_html[adjusted_end:]
+        offset += len(placeholder) - (end - start)
+
+    # Configure html2text options
+    h = HTML2Text()
+    h.body_width = 0  # Don't wrap lines
+    h.ignore_links = False  # Keep links as text
+    h.ignore_images = True  # Skip image placeholders
+    h.ignore_tables = False  # Preserve table structure
+    h.unicode_snob = True  # Use Unicode characters instead of ASCII
+    h.ignore_emphasis = True  # Don't convert * to ** in text
+
+    # Convert to plain text
+    text = h.handle(modified_html)
+
+    # Restore Django tags
+    for placeholder, tag in placeholders.items():
+        text = text.replace(placeholder, tag)
+
+    # Improve handling of links with better spacing
+    # 1. Standard markdown links pattern: [text](url) [text2](url2)
+    text = re.sub(r"(\]\([^)]+\)) (\[[^\]]+\])", r"\1\n\n\2", text)
+
+    # 2. Links with Django template tags between them
+    text = re.sub(
+        r"(\]\([^)]+\))(.*?)(\[[^\]]+\])",
+        lambda m: (
+            m.group(1) + "\n\n" + m.group(2) + m.group(3)
+            if not re.search(r"\n", m.group(2))
+            else m.group(0)
+        ),
+        text,
+    )
+
+    # 3. Special case: handle links at the end of a line followed by links at start of next line
+    text = re.sub(r"(\]\([^)]+\))\n(\[[^\]]+\])", r"\1\n\n\2", text)
+
+    # 4. Add newlines between links in direct sequence (no space between closing ] and opening [)
+    text = re.sub(r"(\]\([^)]+\))(\[[^\]]+\])", r"\1\n\n\2", text)
+
+    # 5. Handle template tag URLs: [text]({% tag %}) [text2](url2)
+    text = re.sub(r"(\]\([^)]+\)) (\[[^\]]+\])", r"\1\n\n\2", text)
+
+    # 6. Additional spacing after a link followed by text
+    text = re.sub(
+        r"(\]\([^)]+\))([^\[\n])",
+        lambda m: m.group(1) + "\n\n" + m.group(2) if not m.group(2).isspace() else m.group(0),
+        text,
+    )
+
+    # Clean up some common formatting issues
+    text = re.sub(r"\n\s*\n", "\n\n", text)  # Remove extra blank lines
+    text = re.sub(r" +", " ", text)  # Remove repeated spaces
+
+    # Final clean up: ensure we don't have more than two consecutive newlines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+
+    return text
+
+
+def remove_block_tags(text):
+    """Remove block tags from the text template while preserving their content.
+
+    This function extracts the content from within block tags and places it directly
+    in the text, removing the block directives themselves. This makes the text template
+    more readable and direct, without the need for block inheritance.
+
+    Args:
+        text (str): Text with Django block tags to process
+
+    Returns:
+        str: Text with block tags removed but their content preserved
+    """
+    # Define a pattern to match block tags and their content
+    block_pattern = r"{%\s*block\s+([^%]*?)\s*%}(.*?){%\s*endblock\s*(?:[^%]*?)\s*%}"
+
+    # Find all block tags and their content in the text
+    blocks = re.finditer(block_pattern, text, re.DOTALL)
+
+    # Make a copy of the text to modify
+    modified_text = text
+
+    # Process each block, replacing the entire block (including tags) with just its content
+    offset = 0
+    for match in blocks:
+        block_name = match.group(1).strip()
+        block_content = match.group(2)
+
+        # Log the block being processed
+        logger.debug("Processing block: %s", block_name)
+
+        # Get the span of the entire block including tags
+        start, end = match.span()
+        adjusted_start = start + offset
+        adjusted_end = end + offset
+
+        # Replace the entire block with just its content in the text
+        modified_text = (
+            modified_text[:adjusted_start] + block_content.strip() + modified_text[adjusted_end:]
+        )
+
+        # Update offset for subsequent replacements
+        original_length = end - start
+        replacement_length = len(block_content.strip())
+        offset += replacement_length - original_length
+
+    # Clean up formatting issues that might have been introduced
+    modified_text = re.sub(r"\n\s*\n\s*\n", "\n\n", modified_text)  # Remove triple newlines
+
+    return modified_text
+
+
+def remove_block_super(text):
+    """Remove {{ block.super }} occurrences from text templates.
+
+    Since we're removing the block structure, {{ block.super }} references
+    (which include content from parent template blocks) are no longer relevant.
+
+    Args:
+        text (str): Text with potential {{ block.super }} references
+
+    Returns:
+        str: Text with {{ block.super }} references removed
+    """
+    # Define pattern to match {{ block.super }} with potential whitespace variations
+    super_pattern = r"{{\s*block\.super\s*}}"
+
+    # Remove block.super occurrences
+    modified_text = re.sub(super_pattern, "", text)
+
+    # Clean up any blank lines that might have been created by the removal
+    modified_text = re.sub(r"\n\s*\n\s*\n", "\n\n", modified_text)
+
+    return modified_text
+
+
+def substitute_template_tags(text):
+    """Substitute specific template tags with their text-appropriate versions.
+
+    This function replaces template tags according to the TAG_SUBSTITUTIONS dictionary,
+    which defines mappings from HTML template tags to their text-specific equivalents.
+
+    Args:
+        text (str): Template text containing Django tags to substitute
+
+    Returns:
+        str: Text with template tags substituted according to TAG_SUBSTITUTIONS
+    """
+    # Skip if no substitutions defined
+    if not TAG_SUBSTITUTIONS:
+        return text
+
+    modified_text = text
+
+    # Process each tag substitution
+    for html_tag, text_tag in TAG_SUBSTITUTIONS.items():
+        # Create a pattern that matches the tag in template syntax: {% tag ... %}
+        # This captures any parameters that might be part of the tag
+        pattern = r"{%\s*" + re.escape(html_tag) + r"\s+([^%]*?)%}"
+        replacement = r"{% " + text_tag + r" \1%}"
+
+        # Replace all occurrences of the tag
+        modified_text = re.sub(pattern, replacement, modified_text)
+
+        logger.debug("Replaced template tag '%s' with '%s'", html_tag, text_tag)
+
+    return modified_text
+
+
+def add_linebreaks_after_tags(text):
+    """Add line breaks after template tags to improve readability.
+
+    This function ensures that certain template tags (like include) are followed
+    by a line break for better formatting and readability of text templates.
+
+    Args:
+        text (str): Text with Django template tags
+
+    Returns:
+        str: Text with added line breaks after specified template tags
+    """
+    # Tags that should be followed by a line break
+    tags_needing_breaks = ["include", "load", "if", "else", "endif", "for", "endfor"]
+
+    # Create a pattern that matches tags that need line breaks
+    # The pattern captures the tag and any whitespace/newline after it
+    pattern = r"({%\s*(?:" + "|".join(tags_needing_breaks) + r").*?%})(\s*)"
+
+    # Replace matched tags, ensuring they're followed by at least one newline
+    def add_break(match):
+        tag = match.group(1)
+        whitespace = match.group(2)
+
+        # If no newline after tag, add one
+        if not whitespace or "\n" not in whitespace:
+            return tag + "\n"
+        # If already has newline, keep as is
+        return tag + whitespace
+
+    modified_text = re.sub(pattern, add_break, text)
+
+    # Ensure there aren't excessive newlines (no more than 2 consecutive)
+    modified_text = re.sub(r"\n{3,}", "\n\n", modified_text)
+
+    return modified_text
+
+
+def generate_text_template(
+    html_path, text_path=None, check_html=False, fix_html=False, check_text=False, fix_text=False
+):
+    """Generate a text template from an HTML template.
+
+    This is the main function that processes an HTML template and generates a text version.
+    The function can optionally check/fix both the HTML source and text output with djlint.
+
+    The process:
+    1. Optionally processes the HTML with djlint
+    2. Reads the HTML content
+    3. Extracts load tags for preservation
+    4. Converts HTML to text preserving templates
+    5. Removes extends tags as they're handled differently in text
+    6. Adds load tags at the beginning if not already present
+    7. Updates include paths to reference .txt files instead of .html
+    8. Removes block tags while preserving their content
+    9. Removes {{ block.super }} references
+    10. Substitutes template tags according to TAG_SUBSTITUTIONS
+    11. Adds line breaks after specific template tags
+    12. Writes the text content to the output file
+    13. Optionally processes the text output with djlint
+
+    Args:
+        html_path (str): Path to the HTML template
+        text_path (str, optional): Path for the output text template.
+                                   Defaults to same path with .html replaced by .txt
+        check_html (bool): Whether to check HTML for issues with djlint
+        fix_html (bool): Whether to fix HTML issues with djlint
+        check_text (bool): Whether to check generated text for issues with djlint
+        fix_text (bool): Whether to fix issues in generated text files using djlint
+
+    Returns:
+        str: Path to the generated text template
+    """
+    if text_path is None:
+        text_path = html_path.replace(".html", ".txt")
+
+    # Ensure the output directory exists
+    output_dir = os.path.dirname(text_path)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    # Process HTML with djlint if requested
+    process_with_djlint(html_path, check=check_html, fix=fix_html, file_type="html")
+
+    try:
+        with open(html_path, "r", encoding="utf-8") as f:
+            html = f.read()
+    except OSError:
+        logger.exception("Error reading HTML file %s", html_path)
+        sys.exit(1)
+
+    # Extract load tags from the HTML template
+    load_tags = re.findall(r"{%\s*load\s+[^%]*%}", html)
+    load_tags_str = "\n".join(load_tags)
+
+    # Convert HTML to text
+    text = convert_html_to_text(html)
+
+    # Remove extends tag (handled differently in text templates)
+    text = re.sub(r"{%\s*extends\s+[^%]*%}", "", text)
+
+    # Check if load tags already exist in the text
+    # If they do, don't add them again to avoid duplication
+    load_tags_exist = any(re.search(re.escape(tag), text) for tag in load_tags)
+
+    # Add load tags at the beginning only if they don't already exist
+    if load_tags and not load_tags_exist:
+        text = load_tags_str + "\n\n" + text
+
+    # Replace any include tags that reference HTML with text
+    text = re.sub(r'({%\s*include\s+"[^"]*).html([^%]*%})', r"\1.txt\2", text)
+    text = re.sub(
+        r"({%\s*include\s+'[^']*).html([^%]*%})", r"\1.txt\2", text
+    )  # Handle single quotes too
+
+    # Remove block tags while preserving their content
+    text = remove_block_tags(text)
+
+    # Remove {{ block.super }} references
+    text = remove_block_super(text)
+
+    # Substitute template tags according to TAG_SUBSTITUTIONS
+    text = substitute_template_tags(text)
+
+    # Add line breaks after specific template tags
+    text = add_linebreaks_after_tags(text)
+
+    # Write the text to the output file and ensure it's fully written
+    try:
+        with open(text_path, "w", encoding="utf-8") as f:
+            f.write(text)
+            # Explicitly flush to disk
+            f.flush()
+            os.fsync(f.fileno())
+    except OSError:
+        logger.exception("Error writing text file %s", text_path)
+        sys.exit(1)
+
+    # Process the generated text file with djlint if requested
+    if check_text or fix_text:
+        process_with_djlint(text_path, check=check_text, fix=fix_text, file_type="text")
+
+    return text_path
+
+
+def main():
+    """Main entry point for the script.
+
+    Parses command-line arguments and runs the template conversion process.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate text email templates from HTML templates.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate text version of a single template
+  python generate_email_text.py --html templates/email/welcome.html
+
+  # Check and fix issues in HTML, then generate text
+  python generate_email_text.py --html templates/email/welcome.html --check-html --fix-html
+
+  # Process all templates matching the base name pattern
+  python generate_email_text.py --html templates/email/welcome.html --all
+
+  # Fix HTML and text formatting issues
+  python generate_email_text.py --html templates/email/welcome.html --fix-html --fix-text
+""",
+    )
+    parser.add_argument("--html", required=True, help="Path to the HTML template")
+    parser.add_argument(
+        "--text", help="Path to write the text template (defaults to same name with .txt extension)"
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="Process all matching templates in the directory"
+    )
+    parser.add_argument(
+        "--check-html", action="store_true", help="Check HTML files for issues using djlint"
+    )
+    parser.add_argument(
+        "--fix-html", action="store_true", help="Fix HTML issues using djlint before conversion"
+    )
+    parser.add_argument(
+        "--check-text",
+        action="store_true",
+        help="Check generated text files for issues using djlint",
+    )
+    parser.add_argument(
+        "--fix-text", action="store_true", help="Fix issues in generated text files using djlint"
+    )
+
+    args = parser.parse_args()
+
+    if args.all:
+        # Find all HTML templates in the directory
+        directory = os.path.dirname(args.html)
+        base_name = os.path.basename(args.html).replace(".html", "")
+
+        for root, _, files in os.walk(directory):
+            for file in files:
+                if file.endswith(".html") and base_name in file:
+                    html_path = os.path.join(root, file)
+                    text_path = html_path.replace(".html", ".txt")
+                    generate_text_template(
+                        html_path,
+                        text_path,
+                        args.check_html,
+                        args.fix_html,
+                        args.check_text,
+                        args.fix_text,
+                    )
+                    logger.info("Generated %s", text_path)
+    else:
+        text_path = generate_text_template(
+            args.html, args.text, args.check_html, args.fix_html, args.check_text, args.fix_text
+        )
+        logger.info("Generated %s", text_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,8 @@ pytest-xdist>=3
 responses>=0.23.1
 selenium>=4.16.0
 sentry-cli>=2.16.0
+html2text==2024.2.26
+djlint==1.36.4
 
 # pre-commit dependencies
 pre-commit>=4

--- a/tests/bin/test_generate_email_text.py
+++ b/tests/bin/test_generate_email_text.py
@@ -1,0 +1,817 @@
+import os
+import subprocess
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from bin.generate_email_text import (
+    add_linebreaks_after_tags,
+    convert_html_to_text,
+    extract_django_tags,
+    generate_text_template,
+    main,
+    process_with_djlint,
+    remove_block_super,
+    remove_block_tags,
+    substitute_template_tags,
+)
+
+# Test data for HTML templates
+HTML_SIMPLE = """
+<html>
+<body>
+<h1>Hello {{ user.name }}</h1>
+<p>Welcome to our service!</p>
+</body>
+</html>
+"""
+
+HTML_WITH_BLOCKS = """
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}Welcome Email{% endblock %}
+{% block content %}
+<h1>Hello {{ user.name }}</h1>
+<p>Welcome to our service!</p>
+{% include "footer.html" %}
+{% endblock %}
+"""
+
+HTML_WITH_SUPER = """
+{% extends "base.html" %}
+{% block content %}
+{{ block.super }}
+<p>Additional content.</p>
+{% endblock %}
+"""
+
+HTML_WITH_TAGS_TO_SUBSTITUTE = """
+{% extends "base.html" %}
+{% block content %}
+<h1>Billing Report</h1>
+{% spend_visibility_billing_usage_table order_id=1234 %}
+{% endblock %}
+"""
+
+# Additional test data for edge cases
+HTML_WITH_UNICODE = """
+<html>
+<body>
+<h1>Hello {{ user.name }}</h1>
+<p>Unicode characters: äöüß ñ é 你好 こんにちは</p>
+</body>
+</html>
+"""
+
+HTML_EMPTY = """
+{% extends "base.html" %}
+{% block content %}
+{% endblock %}
+"""
+
+HTML_MALFORMED = """
+<html>
+<body>
+<h1>Malformed HTML
+<p>This tag is not closed.
+<div>
+    {% if condition %}
+    <span>More unclosed tags
+    {% endif %}
+</body>
+</html>
+"""
+
+HTML_DEEPLY_NESTED = """
+{% extends "base.html" %}
+{% block level1 %}
+    Level 1 content
+    {% block level2 %}
+        Level 2 content
+        {% block level3 %}
+            Level 3 content
+            {% block level4 %}
+                Level 4 content
+            {% endblock %}
+        {% endblock %}
+    {% endblock %}
+{% endblock %}
+"""
+
+
+class TestExtractDjangoTags:
+    """Test the extract_django_tags function."""
+
+    def test_extract_block_tags(self):
+        """Test extraction of block tags."""
+        text = "{% block content %}Hello{% endblock %}"
+        tags = list(extract_django_tags(text))
+        assert len(tags) == 2
+        assert tags[0].group() == "{% block content %}"
+        assert tags[1].group() == "{% endblock %}"
+
+    def test_extract_variable_tags(self):
+        """Test extraction of variable tags."""
+        text = "Hello {{ user.name }}"
+        tags = list(extract_django_tags(text))
+        assert len(tags) == 1
+        assert tags[0].group() == "{{ user.name }}"
+
+    def test_extract_comment_tags(self):
+        """Test extraction of comment tags."""
+        text = "{# This is a comment #}"
+        tags = list(extract_django_tags(text))
+        assert len(tags) == 1
+        assert tags[0].group() == "{# This is a comment #}"
+
+    def test_extract_mixed_tags(self):
+        """Test extraction of mixed tag types."""
+        text = "{% if user %}{{ user.name }}{# User exists #}{% endif %}"
+        tags = list(extract_django_tags(text))
+        assert len(tags) == 4
+        assert [tag.group() for tag in tags] == [
+            "{% if user %}",
+            "{{ user.name }}",
+            "{# User exists #}",
+            "{% endif %}",
+        ]
+
+    def test_extract_from_empty_string(self):
+        """Test extraction from an empty string."""
+        tags = list(extract_django_tags(""))
+        assert len(tags) == 0
+
+    def test_extract_with_nested_tags(self):
+        """Test extraction of nested template tags."""
+        text = "{% if user.is_active %}{% if user.name %}{{ user.name }}{% endif %}{% endif %}"
+        tags = list(extract_django_tags(text))
+        assert len(tags) == 5
+        assert tags[0].group() == "{% if user.is_active %}"
+        assert tags[1].group() == "{% if user.name %}"
+        assert tags[2].group() == "{{ user.name }}"
+        assert tags[3].group() == "{% endif %}"
+        assert tags[4].group() == "{% endif %}"
+
+
+@patch("bin.generate_email_text.subprocess.run")
+class TestProcessWithDjlint:
+    """Test the process_with_djlint function."""
+
+    def test_process_html_check_only_success(self, mock_run):
+        """Test successful HTML check with djlint."""
+        # Mock successful subprocess run
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "No issues found"
+        mock_process.stderr = ""
+        mock_run.return_value = mock_process
+
+        result = process_with_djlint("test.html", check=True, fix=False, file_type="html")
+        assert result is True
+        mock_run.assert_called_once()
+        assert "--check" in mock_run.call_args[0][0]
+
+    def test_process_html_fix_success(self, mock_run):
+        """Test successful HTML fix with djlint."""
+        # Mock successful subprocess run
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "Fixed issues"
+        mock_process.stderr = ""
+        mock_run.return_value = mock_process
+
+        result = process_with_djlint("test.html", check=False, fix=True, file_type="html")
+        assert result is True
+        mock_run.assert_called_once()
+        assert "--reformat" in mock_run.call_args[0][0]
+
+    def test_process_text_fix_with_changes(self, mock_run):
+        """Test fixing text with changes."""
+        # This test mocks file read operations and subprocess execution
+        # to simulate a file that changes during formatting
+        with patch("builtins.open", create=True) as mock_file:
+            # Mock file content before and after formatting
+            mock_file.side_effect = [
+                MagicMock(read=MagicMock(return_value="Text before")),
+                MagicMock(read=MagicMock(return_value="Text after")),
+            ]
+
+            # Mock subprocess execution with a return code of 1 (issues found and fixed)
+            mock_process = MagicMock()
+            mock_process.returncode = 1
+            mock_process.stdout = "Fixed issues"
+            mock_process.stderr = ""
+            mock_run.return_value = mock_process
+
+            result = process_with_djlint("test.txt", check=False, fix=True, file_type="text")
+            assert result is True
+
+    def test_process_with_subprocess_error(self, mock_run):
+        """Test handling of subprocess errors."""
+        # Mock subprocess raising CalledProcessError
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="djlint", output="Error output", stderr="Error stderr"
+        )
+
+        result = process_with_djlint("test.html", check=True, fix=False, file_type="html")
+        assert result is False
+
+    def test_process_text_file_read_error(self, mock_run):
+        """Test handling of file read errors."""
+        with patch("builtins.open", create=True) as mock_file:
+            # Mock open raising OSError for the first call
+            mock_file.side_effect = OSError("File read error")
+
+            result = process_with_djlint("test.txt", check=False, fix=True, file_type="text")
+            assert result is False
+
+
+class TestConvertHtmlToText:
+    """Test the convert_html_to_text function."""
+
+    def test_convert_simple_html(self):
+        """Test conversion of simple HTML to text."""
+        text = convert_html_to_text("<h1>Title</h1><p>Paragraph</p>")
+        assert "Title" in text
+        assert "Paragraph" in text
+        # No HTML tags should remain
+        assert "<h1>" not in text
+        assert "</h1>" not in text
+        assert "<p>" not in text
+        assert "</p>" not in text
+
+    def test_preserve_django_tags(self):
+        """Test preservation of Django tags during conversion."""
+        html = "<h1>Hello {{ user.name }}</h1>"
+        text = convert_html_to_text(html)
+        assert "{{ user.name }}" in text
+
+    def test_preserve_complex_django_tags(self):
+        """Test preservation of complex Django tags during conversion."""
+        html = """
+        <div>
+            {% if user.is_active %}
+                <p>Welcome back!</p>
+            {% else %}
+                <p>Please activate your account.</p>
+            {% endif %}
+        </div>
+        """
+        text = convert_html_to_text(html)
+        assert "{% if user.is_active %}" in text
+        assert "{% else %}" in text
+        assert "{% endif %}" in text
+
+    def test_convert_html_with_unicode(self):
+        """Test conversion of HTML with unicode characters."""
+        text = convert_html_to_text(HTML_WITH_UNICODE)
+        assert "Unicode characters: äöüß ñ é 你好 こんにちは" in text
+
+    def test_convert_malformed_html(self):
+        """Test conversion of malformed HTML."""
+        text = convert_html_to_text(HTML_MALFORMED)
+        assert "Malformed HTML" in text
+        assert "This tag is not closed" in text
+        assert "{% if condition %}" in text
+        assert "{% endif %}" in text
+
+    def test_convert_empty_html(self):
+        """Test conversion of empty HTML."""
+        text = convert_html_to_text("")
+        # html2text can add a newline, which is acceptable
+        assert text.strip() == ""
+
+    def test_convert_html_with_links(self):
+        """Test conversion of HTML with links."""
+        html = '<a href="https://example.com">Example</a> <a href="https://test.com">Test</a>'
+        text = convert_html_to_text(html)
+        # Links should be preserved but with proper spacing
+        assert "Example" in text
+        assert "Test" in text
+        assert "https://example.com" in text
+        assert "https://test.com" in text
+
+
+class TestRemoveBlockTags:
+    """Test the remove_block_tags function."""
+
+    def test_remove_simple_block(self):
+        """Test removal of simple block tags."""
+        template = "{% block content %}Block content{% endblock %}"
+        result = remove_block_tags(template)
+        assert result == "Block content"
+
+    def test_remove_nested_blocks(self):
+        """Test removal of nested block tags."""
+        # The expected behavior is that this function recursively removes all block tags
+        # If this fails, it might indicate that the function only processes blocks at one level
+        template = """
+        {% block outer %}
+            Outer content
+            {% block inner %}Inner content{% endblock %}
+        {% endblock %}
+        """
+
+        # First process to remove outer block
+        intermediate = remove_block_tags(template)
+        assert "block outer" not in intermediate
+        assert "block inner" in intermediate
+
+        # Then apply again to remove inner block (simulating the recursive behavior)
+        result = remove_block_tags(intermediate)
+        assert "block outer" not in result
+        assert "block inner" not in result
+
+        assert "Outer content" in result
+        assert "Inner content" in result
+        assert "{% block" not in result
+        assert "{% endblock" not in result
+
+    def test_remove_block_with_name_in_endblock(self):
+        """Test removal of blocks with name in endblock."""
+        template = "{% block content %}Block content{% endblock content %}"
+        result = remove_block_tags(template)
+        assert result == "Block content"
+        assert "{% block" not in result
+        assert "{% endblock" not in result
+
+    def test_remove_deeply_nested_blocks(self):
+        """Test removal of deeply nested blocks."""
+        result = HTML_DEEPLY_NESTED
+        # Apply remove_block_tags multiple times to remove nested blocks
+        for _ in range(4):  # Assuming maximum nesting level of 4
+            result = remove_block_tags(result)
+
+        # All block tags should be removed
+        assert "{% block" not in result
+        assert "{% endblock" not in result
+        # Content should be preserved
+        assert "Level 1 content" in result
+        assert "Level 2 content" in result
+        assert "Level 3 content" in result
+        assert "Level 4 content" in result
+
+    def test_remove_empty_block(self):
+        """Test removal of empty block."""
+        template = "{% block empty %}{% endblock %}"
+        result = remove_block_tags(template)
+        assert result == ""
+
+    def test_handle_mismatched_blocks(self):
+        """Test handling of mismatched block tags."""
+        template = "{% block content %}Content{% endblock other %}"
+        result = remove_block_tags(template)
+        assert "Content" in result
+        assert "{% block" not in result
+        assert "{% endblock" not in result
+
+
+class TestRemoveBlockSuper:
+    """Test the remove_block_super function."""
+
+    def test_remove_block_super(self):
+        """Test removal of block.super tags."""
+        template = "{{ block.super }}\nAdditional content"
+        result = remove_block_super(template)
+        assert result == "\nAdditional content"
+        assert "{{ block.super }}" not in result
+
+    def test_remove_block_super_with_whitespace(self):
+        """Test removal of block.super tags with whitespace variations."""
+        template = "{{  block.super  }}\nAdditional content"
+        result = remove_block_super(template)
+        assert result == "\nAdditional content"
+        assert "{{  block.super  }}" not in result
+
+    def test_remove_multiple_block_super(self):
+        """Test removal of multiple block.super tags."""
+        template = "{{ block.super }}\nMiddle content\n{{ block.super }}"
+        result = remove_block_super(template)
+        assert result == "\nMiddle content\n"
+        assert "{{ block.super }}" not in result
+
+    def test_no_block_super(self):
+        """Test with template having no block.super."""
+        template = "Content without block.super"
+        result = remove_block_super(template)
+        assert result == template
+
+
+class TestSubstituteTemplateTags:
+    """Test the substitute_template_tags function."""
+
+    def test_substitute_tags(self):
+        """Test substitution of template tags."""
+        template = "{% spend_visibility_billing_usage_table order_id=1234 %}"
+        result = substitute_template_tags(template)
+        assert "{% spend_visibility_billing_usage_table_text order_id=1234 %}" in result
+        assert "{% spend_visibility_billing_usage_table " not in result
+
+    def test_no_substitution_for_unknown_tags(self):
+        """Test that unknown tags are not substituted."""
+        template = "{% unknown_tag order_id=1234 %}"
+        result = substitute_template_tags(template)
+        assert result == template
+
+    def test_substitute_multiple_tags(self):
+        """Test substitution of multiple template tags."""
+        template = """
+        {% spend_visibility_billing_usage_table order_id=1234 %}
+        Some content
+        {% spend_visibility_billing_usage_table order_id=5678 %}
+        """
+        result = substitute_template_tags(template)
+        assert "{% spend_visibility_billing_usage_table_text order_id=1234 %}" in result
+        assert "{% spend_visibility_billing_usage_table_text order_id=5678 %}" in result
+        assert "{% spend_visibility_billing_usage_table " not in result
+
+    @patch("bin.generate_email_text.TAG_SUBSTITUTIONS", {})
+    def test_empty_substitutions_dict(self):
+        """Test behavior with empty substitutions dictionary."""
+        template = "{% spend_visibility_billing_usage_table order_id=1234 %}"
+        result = substitute_template_tags(template)
+        # No substitutions should occur with empty dict
+        assert result == template
+
+
+class TestAddLinebreaksAfterTags:
+    """Test the add_linebreaks_after_tags function."""
+
+    def test_add_linebreaks_after_include(self):
+        """Test adding linebreaks after include tags."""
+        template = "{% include 'file.html' %}Next line"
+        result = add_linebreaks_after_tags(template)
+        assert result == "{% include 'file.html' %}\nNext line"
+
+    def test_no_additional_linebreaks_if_already_present(self):
+        """Test that no additional linebreaks are added if already present."""
+        template = "{% include 'file.html' %}\nNext line"
+        result = add_linebreaks_after_tags(template)
+        assert result == template
+
+    def test_add_linebreaks_after_multiple_tags(self):
+        """Test adding linebreaks after multiple tags."""
+        template = "{% if condition %}{% include 'file.html' %}{% endif %}Next line"
+        result = add_linebreaks_after_tags(template)
+        # Each tag should have a linebreak after it
+        assert "{% if condition %}\n" in result
+        assert "{% include 'file.html' %}\n" in result
+        assert "{% endif %}\nNext line" in result
+
+    def test_preserve_existing_multiple_linebreaks(self):
+        """Test preservation of multiple existing linebreaks."""
+        template = "{% include 'file.html' %}\n\nNext line"
+        result = add_linebreaks_after_tags(template)
+        assert result == template
+
+    def test_excessive_linebreaks_reduced(self):
+        """Test excessive linebreaks are reduced to two."""
+        template = "{% include 'file.html' %}\n\n\n\nNext line"
+        result = add_linebreaks_after_tags(template)
+        assert "{% include 'file.html' %}\n\nNext line" in result
+
+    def test_handle_empty_input(self):
+        """Test handling of empty input."""
+        result = add_linebreaks_after_tags("")
+        assert result == ""
+
+
+class TestGenerateTextTemplate:
+    """Test the generate_text_template function."""
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_basic_conversion(self, mock_process_djlint):
+        """Test basic HTML to text conversion."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_SIMPLE)
+
+            text_path = generate_text_template(html_path)
+            assert os.path.exists(text_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                text = f.read()
+                assert "Hello {{ user.name }}" in text
+                assert "Welcome to our service!" in text
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_exact_text_output(self, mock_process_djlint):
+        """Test exact text output from HTML conversion."""
+        # Create a very simple HTML template with predictable output
+        simple_html = """
+        <html>
+        <head><title>Simple Title</title></head>
+        <body>
+            <h1>Main Heading</h1>
+            <p>This is a paragraph.</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2</li>
+            </ul>
+            <p>{{ variable }}</p>
+            {% if condition %}
+                <p>Conditional content</p>
+            {% endif %}
+        </body>
+        </html>
+        """
+
+        expected_text = """# Main Heading
+
+This is a paragraph.
+
+ * List item 1
+ * List item 2
+
+{{ variable }}
+
+{% if condition %}
+
+Conditional content
+
+{% endif %}"""
+
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "simple.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(simple_html)
+
+            text_path = generate_text_template(html_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                actual_text = f.read().strip()
+
+            # Account for potential extra space after if condition tag
+            actual_text = actual_text.replace("{% if condition %} ", "{% if condition %}")
+            assert actual_text == expected_text.strip()
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_conversion_with_blocks(self, mock_process_djlint):
+        """Test conversion of HTML with block tags."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_WITH_BLOCKS)
+
+            text_path = generate_text_template(html_path)
+            assert os.path.exists(text_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                text = f.read()
+                assert "{% load i18n %}" in text
+                assert "Hello {{ user.name }}" in text
+                assert "Welcome to our service!" in text
+                assert '{% include "footer.txt" %}' in text
+                assert "{% extends" not in text
+                assert "{% block" not in text
+                assert "{% endblock" not in text
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_conversion_with_super(self, mock_process_djlint):
+        """Test conversion of HTML with block.super."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_WITH_SUPER)
+
+            text_path = generate_text_template(html_path)
+            assert os.path.exists(text_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                text = f.read()
+                assert "Additional content" in text
+                assert "{{ block.super }}" not in text
+                assert "{% extends" not in text
+                assert "{% block" not in text
+                assert "{% endblock" not in text
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_conversion_with_tag_substitution(self, mock_process_djlint):
+        """Test conversion of HTML with tags to substitute."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_WITH_TAGS_TO_SUBSTITUTE)
+
+            text_path = generate_text_template(html_path)
+            assert os.path.exists(text_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                text = f.read()
+                assert "Billing Report" in text
+                assert "{% spend_visibility_billing_usage_table_text order_id=1234 %}" in text
+                assert "{% spend_visibility_billing_usage_table " not in text
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_custom_text_path(self, mock_process_djlint):
+        """Test specifying a custom output path."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            custom_text_path = os.path.join(tmp_dir, "custom_output.txt")
+
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_SIMPLE)
+
+            result_path = generate_text_template(html_path, custom_text_path)
+            assert result_path == custom_text_path
+            assert os.path.exists(custom_text_path)
+
+    def test_djlint_options(self):
+        """Test that djlint options are correctly passed."""
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "template.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(HTML_SIMPLE)
+
+            # Use side_effect to ensure each call returns True
+            with patch(
+                "bin.generate_email_text.process_with_djlint", side_effect=[True, True]
+            ) as mock_process_djlint:
+                generate_text_template(
+                    html_path, check_html=True, fix_html=True, check_text=True, fix_text=True
+                )
+
+                # Verify process_with_djlint was called with correct options
+                assert mock_process_djlint.call_count == 2
+
+                # First call should be for HTML with check=True, fix=True
+                html_call = mock_process_djlint.call_args_list[0]
+                assert html_call[1]["check"] is True
+                assert html_call[1]["fix"] is True
+                assert html_call[1]["file_type"] == "html"
+
+                # Second call should be for text with check=True, fix=True
+                text_call = mock_process_djlint.call_args_list[1]
+                assert text_call[1]["check"] is True
+                assert text_call[1]["fix"] is True
+                assert text_call[1]["file_type"] == "text"
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_exact_complex_output(self, mock_process_djlint):
+        """Test exact text output for HTML with tables and links."""
+        # Create HTML with tables and links which are often tricky to convert
+        complex_html = """
+        <html>
+        <body>
+            <h1>Table and Link Test</h1>
+            <p>Here's a <a href="https://example.com">link to example.com</a> and <a href="{{ variable_url }}">dynamic link</a>.</p>
+
+            <table border="1">
+                <tr>
+                    <th>Header 1</th>
+                    <th>Header 2</th>
+                </tr>
+                <tr>
+                    <td>Cell 1,1</td>
+                    <td>Cell 1,2</td>
+                </tr>
+                <tr>
+                    <td>Cell 2,1</td>
+                    <td>{{ table_variable }}</td>
+                </tr>
+            </table>
+
+            <p>{% if table_condition %}Show this text{% endif %}</p>
+        </body>
+        </html>
+        """
+
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "complex.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(complex_html)
+
+            text_path = generate_text_template(html_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                actual_text = f.read().strip()
+
+            # Verify links are formatted correctly
+            assert "link to example.com" in actual_text
+            assert "https://example.com" in actual_text
+            assert "dynamic link" in actual_text
+            assert "{{ variable_url }}" in actual_text
+
+            # Verify table structure is preserved in some form
+            assert "Header 1" in actual_text
+            assert "Header 2" in actual_text
+            assert "Cell 1,1" in actual_text
+            assert "Cell 1,2" in actual_text
+            assert "Cell 2,1" in actual_text
+            assert "{{ table_variable }}" in actual_text
+
+            # Verify template tags are preserved
+            assert "{% if table_condition %}" in actual_text
+            assert "Show this text" in actual_text
+            assert "{% endif %}" in actual_text
+
+            # Check that table cells are separated logically
+            # This ensures the table structure is somewhat maintained
+            header_idx = actual_text.find("Header 1")
+            cell_1_idx = actual_text.find("Cell 1,1")
+            assert header_idx >= 0
+            assert cell_1_idx >= 0
+            assert header_idx < cell_1_idx, "Headers should appear before cell data in the output"
+
+    @patch("bin.generate_email_text.process_with_djlint", return_value=True)
+    def test_template_tags_in_html_attributes(self, mock_process_djlint):
+        """Test handling of template tags within HTML attributes and structure."""
+        # HTML with Django template tags inside attributes and HTML structure
+        html_with_embedded_tags = """
+        <html>
+        <body>
+            <h1 class="{% if heading_class %}{{ heading_class }}{% else %}default-heading{% endif %}">Dynamic Heading</h1>
+
+            <a href="{% url 'view_name' object.id %}" class="{{ link_class }}">Dynamic Link</a>
+
+            <div>
+                Content with {% cycle 'odd' 'even' %} cycle
+            </div>
+
+            <ul>
+                {% for item in items %}
+                <li>{{ item.name }}</li>
+                {% endfor %}
+            </ul>
+
+            <img src="{% static 'path/to/image.jpg' %}" alt="{% trans 'Image description' %}">
+        </body>
+        </html>
+        """
+
+        expected_text = """# Dynamic Heading\n\n[Dynamic Link]({% url 'view_name' object.id %})\n\nContent with {% cycle 'odd' 'even' %} cycle \n\n{% for item in items %} \n * {{ item.name }}\n{% endfor %}"""
+
+        with TemporaryDirectory() as tmp_dir:
+            html_path = os.path.join(tmp_dir, "embedded_tags.html")
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(html_with_embedded_tags)
+
+            text_path = generate_text_template(html_path)
+
+            with open(text_path, "r", encoding="utf-8") as f:
+                actual_text = f.read().strip()
+
+            assert actual_text == expected_text
+
+
+@patch("bin.generate_email_text.generate_text_template")
+@patch("bin.generate_email_text.os.walk")
+@patch("bin.generate_email_text.argparse.ArgumentParser.parse_args")
+class TestMainFunction:
+    """Test the main function."""
+
+    def test_single_file_processing(self, mock_parse_args, mock_walk, mock_generate):
+        """Test processing of a single file."""
+        # Mock arguments
+        args = MagicMock()
+        args.html = "templates/email/welcome.html"
+        args.text = None
+        args.all = False
+        args.check_html = False
+        args.fix_html = False
+        args.check_text = False
+        args.fix_text = False
+        mock_parse_args.return_value = args
+
+        # Mock generate_text_template return value to avoid file access
+        mock_generate.return_value = "templates/email/welcome.txt"
+
+        # Call main function with proper mocking to avoid SystemExit
+        with patch(
+            "sys.argv", ["generate_email_text.py", "--html", "templates/email/welcome.html"]
+        ):
+            main()
+
+        # Verify generate_text_template was called with correct arguments
+        mock_generate.assert_called_once_with(
+            "templates/email/welcome.html", None, False, False, False, False
+        )
+
+    def test_all_flag_processing(self, mock_parse_args, mock_walk, mock_generate):
+        """Test processing with --all flag."""
+        # Mock arguments
+        args = MagicMock()
+        args.html = "templates/email/welcome.html"
+        args.text = None
+        args.all = True
+        args.check_html = True
+        args.fix_html = True
+        args.check_text = True
+        args.fix_text = True
+        mock_parse_args.return_value = args
+
+        # Mock os.walk to return multiple HTML files
+        mock_walk.return_value = [
+            ("templates/email", [], ["welcome.html", "confirm.html", "other.html"]),
+        ]
+
+        # Mock os.path.basename to extract base name correctly
+        with patch("os.path.basename", return_value="welcome.html"):
+            # Mock os.path.join to construct paths properly
+            with patch("os.path.join", side_effect=lambda *args: "/".join(args)):
+                # Call main function
+                main()
+
+        # Should be called for each matching file (welcome.html and confirm.html)
+        # Assuming base_name "welcome" is in both of these files
+        assert mock_generate.call_count >= 1


### PR DESCRIPTION
Moving this into `sentry` from https://github.com/getsentry/getsentry/pull/16645 as it applies to all emails, not just billing emails.

----

Maintaining two email copies for billing notifications is a burden (`body.txt` and `body.html`).
The HTML version is the most well-maintained, and we use `body.txt` for copy assertions in our tests.

Ideally, the HTML version would be the source of truth, and we would "generate" `body.txt` from their `body.html` counterparts.

This pull request adds `bin/generate_email_text.py` to do exactly that.

**Usage:**

```
python3 bin/generate_email_text.py --html getsentry/templates/emails/depleted-quota-capacity/body.html --fix-html --fix-text
```

The `bin/generate_email_text.py` script uses `html2text` to convert the HTML files into a txt version, and formats the txt version with djlint.

-------

The proof of concept of what this script generates is in https://github.com/getsentry/getsentry/pull/16645.



