### PR TITLE
fix(react19): Replace ReactChild with ReactNode

### DIFF
--- a/static/app/components/actions/actionLink.tsx
+++ b/static/app/components/actions/actionLink.tsx
@@ -30,7 +30,7 @@ type CommonProps = Omit<
   ConfirmableActionProps,
   'onConfirm' | 'confirmText' | 'children' | 'stopPropagation' | 'priority'
 > & {
-  children: React.ReactChild;
+  children: React.ReactNode;
   className?: string;
   confirmLabel?: string;
   confirmPriority?: ConfirmableActionProps['priority'];

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -84,7 +84,7 @@ export interface DropdownMenuProps
   /**
    * Title for the current menu.
    */
-  menuTitle?: React.ReactChild;
+  menuTitle?: React.ReactNode;
   /**
    * Reference to the container element that the portal should be rendered into.
    */

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -60,11 +60,11 @@ export interface DropdownMenuListProps
   /**
    * To be displayed below the menu items
    */
-  menuFooter?: React.ReactChild;
+  menuFooter?: React.ReactNode;
   /**
    * Title to display on top of the menu
    */
-  menuTitle?: React.ReactChild;
+  menuTitle?: React.ReactNode;
   /**
    * Minimum menu width
    */

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -91,7 +91,7 @@ export function StackTracePreviewContent({
 }
 
 type StackTracePreviewProps = {
-  children: React.ReactChild;
+  children: React.ReactNode;
   groupId: string;
   eventId?: string;
   groupingCurrentLevel?: number;

--- a/static/app/views/deprecatedAsyncView.tsx
+++ b/static/app/views/deprecatedAsyncView.tsx
@@ -20,7 +20,7 @@ export default abstract class DeprecatedAsyncView<
   render() {
     return (
       <SentryDocumentTitle title={this.getTitle()}>
-        {this.renderComponent() as React.ReactChild}
+        {this.renderComponent()}
       </SentryDocumentTitle>
     );
   }

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -361,7 +361,7 @@ function EventDetailsContent(props: Props) {
       orgSlug={organization.slug}
       projectSlug={projectSlug}
     >
-      {renderContent() as React.ReactChild}
+      {renderContent()}
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/organizationStats/teamInsights/index.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.tsx
@@ -18,7 +18,7 @@ function TeamInsightsContainer({children, organization}: Props) {
           ? cloneElement<any>(children, {
               organization,
             })
-          : (children as React.ReactChild)}
+          : children}
       </NoProjectMessage>
     </Feature>
   );

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -351,7 +351,7 @@ function EventDetailsContent(props: Props) {
       title={t('Performance — Event Details')}
       orgSlug={organization.slug}
     >
-      {renderBody() as React.ReactChild}
+      {renderBody()}
     </SentryDocumentTitle>
   );
 }

--- a/static/gsApp/components/features/learnMoreButton.tsx
+++ b/static/gsApp/components/features/learnMoreButton.tsx
@@ -18,7 +18,7 @@ type Props = React.PropsWithChildren<{
   source: string;
   analyticsData?: Record<string, any>;
   'aria-label'?: string;
-  children?: React.ReactChild;
+  children?: React.ReactNode;
 }> &
   React.ComponentProps<typeof LinkButton>;
 

--- a/static/gsApp/components/labelWithPowerIcon.tsx
+++ b/static/gsApp/components/labelWithPowerIcon.tsx
@@ -65,7 +65,7 @@ function LabelWithPowerIcon({children, id, subscription}: Props) {
   // @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544
 
   if (id === undefined) {
-    return children as React.ReactElement;
+    return children;
   }
 
   const config = POWER_FEATURE_CONFIG.find(c => c.id === id)!;


### PR DESCRIPTION
Some instances were no longer needed. ReactChild is gone in react 19.

part of https://github.com/getsentry/frontend-tsc/issues/68
