### PR TITLE
feat(flagpole): Add a project's platform as context

### DIFF
--- a/src/sentry/features/flagpole_context.py
+++ b/src/sentry/features/flagpole_context.py
@@ -78,6 +78,7 @@ def project_context_transformer(data: SentryContextData) -> EvaluationContextDic
         context_data["project_slug"] = proj.slug
         context_data["project_name"] = proj.name
         context_data["project_id"] = proj.id
+        context_data["project_platform"] = proj.platform
 
     return context_data
 

--- a/tests/sentry/features/test_flagpole_context.py
+++ b/tests/sentry/features/test_flagpole_context.py
@@ -21,7 +21,7 @@ from sentry.users.models.useremail import UserEmail
 class TestSentryFlagpoleContext(TestCase):
     def test_sentry_flagpole_context_builder(self):
         org = self.create_organization()
-        project = self.create_project(organization=org)
+        project = self.create_project(organization=org, platform="php")
         sentry_flagpole_builder = get_sentry_flagpole_context_builder()
 
         sentry_context = sentry_flagpole_builder.build(
@@ -32,6 +32,7 @@ class TestSentryFlagpoleContext(TestCase):
         assert sentry_context.get("organization_slug") == org.slug
         assert sentry_context.get("project_slug") == project.slug
         assert sentry_context.get("project_id") == project.id
+        assert sentry_context.get("project_platform") == project.platform
 
 
 class TestSentryOrganizationContextTransformer(TestCase):
@@ -44,7 +45,9 @@ class TestSentryOrganizationContextTransformer(TestCase):
             organization_context_transformer(SentryContextData(organization=1234))  # type: ignore[arg-type]
 
         with pytest.raises(InvalidContextDataException):
-            organization_context_transformer(SentryContextData(organization=self.create_project()))  # type: ignore[arg-type]
+            organization_context_transformer(
+                SentryContextData(organization=self.create_project())
+            )  # type: ignore[arg-type]
 
     def test_with_valid_organization(self):
         org = self.create_organization(slug="foobar", name="Foo Bar")
@@ -127,13 +130,14 @@ class TestProjectContextTransformer(TestCase):
             project_context_transformer(SentryContextData(project=self.create_organization()))
 
     def test_with_valid_project(self):
-        project = self.create_project(slug="foobar", name="Foo Bar")
+        project = self.create_project(slug="foobar", name="Foo Bar", platform="php")
 
         context_data = project_context_transformer(SentryContextData(project=project))
         assert context_data == {
             "project_slug": "foobar",
             "project_name": "Foo Bar",
             "project_id": project.id,
+            "project_platform": "php",
         }
 
 

--- a/tests/sentry/features/test_flagpole_context.py
+++ b/tests/sentry/features/test_flagpole_context.py
@@ -46,8 +46,8 @@ class TestSentryOrganizationContextTransformer(TestCase):
 
         with pytest.raises(InvalidContextDataException):
             organization_context_transformer(
-                SentryContextData(organization=self.create_project())
-            )  # type: ignore[arg-type]
+                SentryContextData(organization=self.create_project())  # type: ignore[arg-type]
+            )
 
     def test_with_valid_organization(self):
         org = self.create_organization(slug="foobar", name="Foo Bar")


### PR DESCRIPTION
I want to enable a cohort based on the platform of the project. This PR will then add the project's platform to the available context for a project.