### PR TITLE
fix(dashboards): Add limit validation for chart widgets

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -397,6 +397,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     def validate(self, data):
         query_errors = []
         all_columns: set[str] = set()
+        has_columns = False
         has_query_error = False
         self.query_warnings = {"queries": [], "columns": {}}
         max_cardinality_allowed = options.get("on_demand.max_widget_cardinality.on_query_count")
@@ -410,6 +411,8 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         if data.get("queries"):
             # Check each query to see if they have an issue or discover error depending on the type of the widget
             for query in data.get("queries"):
+                if len(query.get("columns")) > 0:
+                    has_columns = True
                 if (
                     data.get("widget_type") == DashboardWidgetTypes.ISSUE
                     and "issue_query_error" in query
@@ -478,6 +481,14 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                     {"displayType": "displayType is required during creation."}
                 )
 
+        # Validate limit on chart widgets
+        if (
+            data.get("display_type") != DashboardWidgetDisplayTypes.TABLE
+            and data.get("display_type") != DashboardWidgetDisplayTypes.BIG_NUMBER
+            and data.get("limit") is None
+            and has_columns
+        ):
+            raise serializers.ValidationError({"limit": "limit is required."})
         # Validate widget thresholds
         thresholds = data.get("thresholds")
         if thresholds:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -481,7 +481,9 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                     {"displayType": "displayType is required during creation."}
                 )
 
-        # Validate limit on chart widgets
+        # Validate limit on chart widgets with group-by columns:
+        # if there are too many groups the server cannot serve the
+        # request to get widget data and hence the chart fails to load.
         if (
             data.get("display_type") != DashboardWidgetDisplayTypes.TABLE
             and data.get("display_type") != DashboardWidgetDisplayTypes.BIG_NUMBER

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -2034,6 +2034,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "displayType": "line",
                     "interval": "5m",
                     "title": f"Widget {i}",
+                    "limit": 5,
                     "queries": [
                         {
                             "name": "Transactions",
@@ -2541,6 +2542,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                 {
                     "title": "EPM line",
                     "displayType": "line",
+                    "limit": 3,
                     "queries": [
                         {
                             "name": "",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1129,3 +1129,150 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             data=data,
         )
         assert response.status_code == 200, response.data
+
+    def test_has_group_by_and_no_limit_on_creation(self):
+        data = {
+            "title": "Test Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": ["count()"],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 400, response.data
+
+    def test_has_group_by_and_limit_on_creation(self):
+        data = {
+            "title": "Test Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "limit": 5,
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": ["count()"],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 200, response.data
+
+    def test_edit_widget_with_group_by_and_no_limit(self):
+        # First create a valid widget
+        self.widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=1,
+            title="Test Query",
+            id="1",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            limit=5,
+        )
+        self.widget_query = DashboardWidgetQuery.objects.create(
+            order=0,
+            widget=self.widget,
+            name="",
+            conditions="",
+            columns=["transaction"],
+            fields=[],
+            aggregates=["count()"],
+            orderby="-transaction",
+        )
+
+        # Now try to edit it without a limit
+        data = {
+            "id": self.widget.id,
+            "title": "Updated Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": ["count()"],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 400, response.data
+
+    def test_edit_widget_with_group_by_and_limit(self):
+        # First create a valid widget
+        self.widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=1,
+            title="Test Query",
+            id="1",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+        )
+        self.widget_query = DashboardWidgetQuery.objects.create(
+            order=0,
+            widget=self.widget,
+            name="",
+            conditions="",
+            columns=[],
+            fields=[],
+            aggregates=["count()"],
+            orderby="-transaction",
+        )
+
+        # Now try to edit it without a limit
+        data = {
+            "id": self.widget.id,
+            "title": "Updated Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "limit": 5,
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": ["count()"],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 200, response.data

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1187,7 +1187,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             dashboard=self.dashboard,
             order=1,
             title="Test Query",
-            id="1",
+            id=1,
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
             limit=5,
@@ -1235,7 +1235,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             dashboard=self.dashboard,
             order=1,
             title="Test Query",
-            id="1",
+            id=1,
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
         )

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1019,6 +1019,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "displayType": "line",
                     "interval": "5m",
                     "title": "Transaction count()",
+                    "limit": 5,
                     "queries": [
                         {
                             "name": "Transactions",
@@ -1056,6 +1057,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "displayType": "line",
                     "interval": "5m",
                     "title": "Transaction count()",
+                    "limit": 5,
                     "queries": [
                         {
                             "name": "Transactions",
@@ -1093,6 +1095,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "displayType": "line",
                     "interval": "5m",
                     "title": f"Widget {i}",
+                    "limit": 5,
                     "queries": [
                         {
                             "name": "Transactions",


### PR DESCRIPTION
Adds validation to dashboard widget api to ensure that chart widgets have a limit when they have a group by. This eliminates the possibility of the server not serving the request and the chart failing.

Closes https://github.com/getsentry/sentry/issues/82039
