### PR TITLE
fix(widget-viewer): Only apply arbitrary sort to table widget

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1410,7 +1410,7 @@ describe('Modals -> WidgetViewerModal', function () {
       expect(await screen.findByText('Open in Explore')).toBeInTheDocument();
     });
 
-    it('does not make an events-stats request with the table sort as an aggregate', async function () {
+    it('does not make an events-stats request with an arbitrary table sort as a y-axis', async function () {
       const eventsStatsMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events-stats/',
         body: {},

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -297,21 +297,19 @@ function WidgetViewerModal(props: Props) {
     !fields.map(getAggregateAlias).includes(getAggregateAlias(rawOrderby))
   ) {
     fields.push(rawOrderby);
-    [tableWidget, primaryWidget].forEach(aggregatesAndColumns => {
-      if (isAggregateField(rawOrderby) || isEquation(rawOrderby)) {
-        aggregatesAndColumns.queries.forEach(query => {
-          if (!query.aggregates.includes(rawOrderby)) {
-            query.aggregates.push(rawOrderby);
-          }
-        });
-      } else {
-        aggregatesAndColumns.queries.forEach(query => {
-          if (!query.columns.includes(rawOrderby)) {
-            query.columns.push(rawOrderby);
-          }
-        });
-      }
-    });
+    if (isAggregateField(rawOrderby) || isEquation(rawOrderby)) {
+      tableWidget.queries.forEach(query => {
+        if (!query.aggregates.includes(rawOrderby)) {
+          query.aggregates.push(rawOrderby);
+        }
+      });
+    } else {
+      tableWidget.queries.forEach(query => {
+        if (!query.columns.includes(rawOrderby)) {
+          query.columns.push(rawOrderby);
+        }
+      });
+    }
   }
 
   // Need to set the orderby of the eventsv2 query to equation[index] format


### PR DESCRIPTION
If a user is sorting by something that is not in the yAxis, we append that column to the widget viewer table, but we should not show it in the chart.

e.g. you can test with this widget: https://sentry.sentry.io/dashboard/122183/widget/15/?project=1&statsPeriod=24h

The widget plots `p90`, but sorts by `-count`, we shouldn't see the count series in the UI.

It seems like this was intentional but possible could just be a long standing bug. @edwardgou-sentry can you let me know if there's some behaviour I'm misunderstanding here?