### PR TITLE
fix(ourlogs): Small ux fixes for logs on issues

### DIFF
--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -22,14 +22,19 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 export function LogsIssuesSection({
   initialCollapse,
   isOnEmbeddedView,
-  limitToTraceId: traceId,
+  limitToTraceId,
 }: {
   initialCollapse: boolean;
 } & Omit<LogsPageParamsProviderProps, 'children'>) {
   const organization = useOrganization();
   const feature = organization.features.includes('ourlogs-enabled');
-  const tableData = useExploreLogsTable({enabled: feature});
+  const tableData = useExploreLogsTable({enabled: feature, limit: 10});
   if (!feature) {
+    return null;
+  }
+  if (!limitToTraceId) {
+    // If there isn't a traceId (eg. profiling issue), we shouldn't show logs since they are trace specific.
+    // We may change this in the future if we have a trace-group or we generate trace sids for these issue types.
     return null;
   }
   if (tableData?.data?.length === 0) {
@@ -46,7 +51,7 @@ export function LogsIssuesSection({
     >
       <LogsPageParamsProvider
         isOnEmbeddedView={isOnEmbeddedView}
-        limitToTraceId={traceId}
+        limitToTraceId={limitToTraceId}
       >
         <LogsSectionContent tableData={tableData} />
       </LogsPageParamsProvider>

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -6,6 +6,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {
   useLogsBaseSearch,
+  useLogsCursor,
   useLogsFields,
   useLogsProjectIds,
   useLogsSearch,
@@ -26,6 +27,7 @@ export type UseExploreLogsTableResult = ReturnType<typeof useExploreLogsTable>;
 export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
   const _search = useLogsSearch();
   const baseSearch = useLogsBaseSearch();
+  const cursor = useLogsCursor();
   const fields = useLogsFields();
   const sortBys = useLogsSortBys();
   const projectIds = useLogsProjectIds();
@@ -38,6 +40,7 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
   const {data, meta, isError, isPending, pageLinks} = useOurlogs(
     {
       ...options,
+      cursor,
       sorts: sortBys,
       fields: Array.from(extendedFields),
       search,


### PR DESCRIPTION
### Summary
Limit to 10 rows on issues, make sure cursor is being used, and avoid rendering logs at all if no trace id is set.

