### PR TITLE
fix(insights): Display dash for missing HTTP methods

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -393,6 +393,11 @@ class _Table extends Component<Props, State> {
       );
     }
 
+    // Display a placeholder for empty http.method values instead of the default `(empty string)`, which is confusing
+    if (field === 'http.method' && (dataRow[field] === '' || dataRow[field] === null)) {
+      return <span>{'\u2014'}</span>;
+    }
+
     return (
       <CellAction
         column={column}


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/e013fb20-6c6d-4fe1-bb22-8927f9706b63)


## After
![image](https://github.com/user-attachments/assets/e400a230-cb0f-454c-9dfa-35e1d9a1348f)


Fixes https://github.com/getsentry/sentry/issues/81391