### PR TITLE
feat(ourlogs): Make traceids linkable

### DIFF
--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -9,6 +9,7 @@ import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
@@ -24,7 +25,11 @@ import type {
 } from 'sentry/views/explore/logs/fieldRenderers';
 import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import type {OurLogsTableRowDetails} from 'sentry/views/explore/logs/useLogsQuery';
-import {getLogAttributeItem, removeSentryPrefix} from 'sentry/views/explore/logs/utils';
+import {
+  adjustLogTraceID,
+  getLogAttributeItem,
+  removeSentryPrefix,
+} from 'sentry/views/explore/logs/utils';
 
 const MAX_TREE_DEPTH = 4;
 const INVALID_BRANCH_REGEX = /\.{2,}/;
@@ -449,21 +454,28 @@ function LogFieldsTreeValue({
   // Check if we have a custom renderer for this attribute
   const attributeKey = originalAttribute.original_attribute_key;
   const renderer = renderers[attributeKey];
+  const basicRenderer = getFieldRenderer(attributeKey, {}, false);
+  const adjustedValue =
+    attributeKey === OurLogKnownFieldKey.TRACE_ID
+      ? adjustLogTraceID(content.value as string)
+      : content.value;
 
-  const defaultValue = <span>{String(content.value)}</span>;
+  const basicRendered = basicRenderer({[attributeKey]: adjustedValue}, renderExtra);
+  const defaultValue = <span>{String(adjustedValue)}</span>;
 
   if (config?.disableRichValue) {
-    return defaultValue;
+    return String(adjustedValue);
   }
 
   if (renderer) {
     return renderer({
-      item: getLogAttributeItem(attributeKey, content.value),
+      item: getLogAttributeItem(attributeKey, adjustedValue),
       extra: renderExtra,
+      basicRendered,
     });
   }
 
-  return isUrl(String(content.value)) ? (
+  return isUrl(String(adjustedValue)) ? (
     <AttributeLinkText>
       <ExternalLink
         onClick={e => {
@@ -471,7 +483,7 @@ function LogFieldsTreeValue({
           openNavigateToExternalLinkModal({linkText: String(content.value)});
         }}
       >
-        {String(content.value)}
+        {basicRendered}
       </ExternalLink>
     </AttributeLinkText>
   ) : (

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -34,6 +34,7 @@ import {
   LogDetailTableBodyCell,
   LogFirstCellContent,
   LogTableBodyCell,
+  LogTableBodyCellContent,
   LogTableRow,
   StyledChevronButton,
 } from './styles';
@@ -108,11 +109,13 @@ export function LogRowContent({dataRow, highlightTerms, meta}: LogsRowProps) {
 
           return (
             <LogTableBodyCell key={field}>
-              <LogFieldRenderer
-                item={getLogRowItem(field, dataRow, meta)}
-                meta={meta}
-                extra={rendererExtra}
-              />
+              <LogTableBodyCellContent onClick={e => e.stopPropagation()}>
+                <LogFieldRenderer
+                  item={getLogRowItem(field, dataRow, meta)}
+                  meta={meta}
+                  extra={rendererExtra}
+                />
+              </LogTableBodyCellContent>
             </LogTableBodyCell>
           );
         })}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -96,7 +96,11 @@ export const LogDetailsTitle = styled('div')`
   user-select: none;
 `;
 
-export const LogFirstCellContent = styled('div')`
+export const LogTableBodyCellContent = styled('div')`
+  cursor: default;
+`;
+
+export const LogFirstCellContent = styled(LogTableBodyCellContent)`
   display: flex;
   align-items: center;
 `;


### PR DESCRIPTION
### Summary
There isn't much to see on a trace w.r.t logs at the moment, but at least for debugging you can get to the trace without having to copy+paste traceids.

Other:
- Also fixes trying to select text on a log row causing the row to expand or collapse.

#### Screenshots
|![Screenshot 2025-03-12 at 5 04 17 PM](https://github.com/user-attachments/assets/423585ff-7b5a-4451-b1ef-5ad48779defe)|
|-|