### PR TITLE
fix(integrations): Allow clicking on disabled linked issues

### DIFF
--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -132,13 +132,13 @@ function SentryAppExternalIssueActions({
           title={tct('Unable to connect to [provider].', {
             provider: sentryAppComponent.sentryApp.name,
           })}
-          disabled={!disabled}
+          disabled={!disabled && !!externalIssue}
           skipWrapper
         >
           <StyledIntegrationLink
             onClick={e =>
               disabled
-                ? e.preventDefault()
+                ? !externalIssue && e.preventDefault()
                 : doOpenSentryAppIssueModal({
                     organization,
                     group,
@@ -147,8 +147,8 @@ function SentryAppExternalIssueActions({
                     sentryAppInstallation,
                   })
             }
-            href={disabled ? undefined : url}
-            disabled={disabled}
+            href={disabled && !externalIssue ? undefined : url}
+            disabled={disabled && !externalIssue}
           >
             {displayName}
           </StyledIntegrationLink>

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {Body, Hovercard} from 'sentry/components/hovercard';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {IconAdd, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -135,7 +136,7 @@ export const IssueSyncListElementContainer = styled('div')`
   }
 `;
 
-export const IntegrationLink = styled('a')<{disabled?: boolean}>`
+export const IntegrationLink = styled(ExternalLink)<{disabled?: boolean}>`
   text-decoration: none;
   margin-left: ${space(1)};
   color: ${p => p.theme.textColor};


### PR DESCRIPTION
On the old ui, when an integration is disabled we don't allow you to click on an existing linked issue. This changes it to allow clicking on the link which opens in whatever external url.

Changes it to open in a new tab.
