### PR TITLE
fix: Sentry Stats page does not respect 24 hour clock format

### DIFF
--- a/static/app/views/organizationStats/usageChart/utils.spec.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.spec.tsx
@@ -36,6 +36,18 @@ describe('getDateFromMoment', () => {
       'Jul 9 12:00 AM - 12:05 AM (+00:00)'
     );
   });
+
+  it('shows the date and time in 24 hour format if 24 hour format is enabled', () => {
+    expect(getDateFromMoment(start, '6h', false, true)).toBe(
+      'Jul 9 00:00 - 06:00 (+00:00)'
+    );
+    expect(getDateFromMoment(start, '1h', false, true)).toBe(
+      'Jul 9 00:00 - 01:00 (+00:00)'
+    );
+    expect(getDateFromMoment(start, '5m', false, true)).toBe(
+      'Jul 9 00:00 - 00:05 (+00:00)'
+    );
+  });
 });
 
 describe('getXAxisDates', () => {

--- a/static/app/views/organizationStats/usageChart/utils.spec.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.spec.tsx
@@ -39,13 +39,13 @@ describe('getDateFromMoment', () => {
 
   it('shows the date and time in 24 hour format if 24 hour format is enabled', () => {
     expect(getDateFromMoment(start, '6h', false, true)).toBe(
-      'Jul 9 00:00 - 06:00 (+00:00)'
+      'Jul 8 20:00 - 02:00 (-04:00)'
     );
     expect(getDateFromMoment(start, '1h', false, true)).toBe(
-      'Jul 9 00:00 - 01:00 (+00:00)'
+      'Jul 8 20:00 - 21:00 (-04:00)'
     );
     expect(getDateFromMoment(start, '5m', false, true)).toBe(
-      'Jul 9 00:00 - 00:05 (+00:00)'
+      'Jul 8 20:00 - 20:05 (-04:00)'
     );
   });
 });

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 
 import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/parse';
 import type {DataCategoryInfo, IntervalPeriod} from 'sentry/types/core';
+import {shouldUse24Hours} from 'sentry/utils/dates';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 
 import {formatUsageWithUnits} from '../utils';
@@ -26,7 +27,7 @@ export function getDateFromMoment(
   m: moment.Moment,
   interval: IntervalPeriod = '1d',
   useUtc = false,
-  use24HourFormat = true
+  use24Hours = shouldUse24Hours()
 ) {
   // Convert interval to days
   const days = parsePeriodToHours(interval) / 24;
@@ -41,20 +42,13 @@ export function getDateFromMoment(
   const parsedInterval = parseStatsPeriod(interval);
   const datetime = useUtc ? moment(m).utc() : moment(m).local();
 
-  const intervalFormat = use24HourFormat
-    ? FORMAT_DATETIME_HOURLY_24H
-    : FORMAT_DATETIME_HOURLY;
+  const intervalFormat = use24Hours ? FORMAT_DATETIME_HOURLY_24H : FORMAT_DATETIME_HOURLY;
 
   return parsedInterval
     ? `${datetime.format(intervalFormat)} - ${datetime
         .add(parsedInterval.period, parsedInterval.periodLength)
-        .format(use24HourFormat ? 'HH:mm (Z)' : 'LT (Z)')}`
+        .format(use24Hours ? 'HH:mm (Z)' : 'LT (Z)')}`
     : datetime.format(intervalFormat);
-}
-
-export function getDateFromUnixTimestamp(timestamp: number) {
-  const date = moment.unix(timestamp);
-  return getDateFromMoment(date);
 }
 
 export function getXAxisDates(

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -28,6 +28,7 @@ import type {DataCategoryInfo, IntervalPeriod} from 'sentry/types/core';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {shouldUse24Hours} from 'sentry/utils/dates';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 
@@ -216,7 +217,7 @@ class UsageStatsOrganization<
     chartDateUtc: boolean;
   } {
     const {orgStats} = this.state;
-    const {dataDatetime, clock24Hours = true} = this.props;
+    const {dataDatetime} = this.props;
 
     const interval = getSeriesApiInterval(dataDatetime);
 
@@ -250,7 +251,7 @@ class UsageStatsOrganization<
     if (intervalHours >= 24) {
       // Daily format doesn't have time, so no change needed
       FORMAT_DATETIME = FORMAT_DATETIME_DAILY;
-    } else if (clock24Hours) {
+    } else if (shouldUse24Hours()) {
       FORMAT_DATETIME = FORMAT_DATETIME_HOURLY_24H;
     } else {
       FORMAT_DATETIME = FORMAT_DATETIME_HOURLY;


### PR DESCRIPTION
This PR aims to fix a bug where if a user had their account settings set to use the 24 hour clock, we wouldn't respect their choice on the stats page and still end up showing the 12h clock instead. 

In this PR I use the existing util for getting the user's 24 hour clock setting from the ConfigStore to generate a boolean value that we then use to update the format of the date timestamp if needed.

I saw in the file I was working in that one of the fns was unused so I just removed it as well.

Closes https://github.com/getsentry/sentry/issues/43423


**Setting Off**
<img width="517" alt="Screenshot 2025-03-12 at 3 34 37 PM" src="https://github.com/user-attachments/assets/b165ebf7-feb0-44b7-a4bb-0606df6c52f9" />



**Setting On**
<img width="484" alt="Screenshot 2025-03-12 at 3 34 22 PM" src="https://github.com/user-attachments/assets/0f6f12ee-3dd4-4bb0-a227-9c9ac04b71b2" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
