### PR TITLE
fix(autofix): Attempt fix at trace connected queries

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -80,12 +80,19 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 ["trace_id", "=", event.trace_id],
             ],
         )
-        results = eventstore.backend.get_events(
+        transactions = eventstore.backend.get_events(
             filter=event_filter,
-            dataset=Dataset.Discover,
+            dataset=Dataset.Transactions,
             referrer=Referrer.API_GROUP_AI_AUTOFIX,
             tenant_ids={"organization_id": project.organization_id},
         )
+        errors = eventstore.backend.get_events(
+            filter=event_filter,
+            dataset=Dataset.Events,
+            referrer=Referrer.API_GROUP_AI_AUTOFIX,
+            tenant_ids={"organization_id": project.organization_id},
+        )
+        results = transactions + errors
 
         if not results:
             return None
@@ -95,14 +102,14 @@ class GroupAutofixEndpoint(GroupEndpoint):
         root_events: list[dict] = []
 
         # First pass: collect all events and their relationships
-        for result in results:
-            event_data = result.data
+        for event in results:
+            event_data = event.data
             is_transaction = event_data.get("spans") is not None
             is_error = not is_transaction
 
             event_node = {
-                "event_id": event_data.get("event_id"),
-                "datetime": event_data.get("datetime"),
+                "event_id": event.event_id,
+                "datetime": event.datetime,
                 "span_id": event_data.get("contexts", {}).get("trace", {}).get("span_id"),
                 "parent_span_id": event_data.get("contexts", {})
                 .get("trace", {})
@@ -114,7 +121,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
             if is_transaction:
                 op = event_data.get("contexts", {}).get("trace", {}).get("op")
-                transaction_title = event_data.get("title")
+                transaction_title = event.title
                 duration_obj = event_data.get("breakdowns", {}).get("total.time", {})
                 duration_str = (
                     f"{duration_obj.get('value', 0)} {duration_obj.get('unit', 'millisecond')}s"
@@ -123,8 +130,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 event_node.update(
                     {
                         "title": f"{op} - {transaction_title}" if op else transaction_title,
-                        "platform": event_data.get("platform"),
-                        "is_current_project": int(event_data.get("project", -1)) == project.id,
+                        "platform": event.platform,
+                        "is_current_project": event.project_id == project.id,
                         "duration": duration_str,
                         "profile_id": profile_id,
                         "children_span_ids": [
@@ -135,9 +142,9 @@ class GroupAutofixEndpoint(GroupEndpoint):
             else:
                 event_node.update(
                     {
-                        "title": event_data.get("title"),
-                        "platform": event_data.get("platform"),
-                        "is_current_project": int(event_data.get("project", -1)) == project.id,
+                        "title": event.title,
+                        "platform": event.platform,
+                        "is_current_project": event.project_id == project.id,
                     }
                 )
 
@@ -158,7 +165,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
             # Handle case where this event's span is a parent for events we've already seen
             if span_id and span_id in children_by_parent_span_id:
-                event_node["children"] = children_by_parent_span_id[span_id]
+                event_node["children"].extend(children_by_parent_span_id[span_id])
+                children_by_parent_span_id[span_id] = event_node["children"]
 
         # Second pass: add children from spans to parent events
         for span_id, event_node in events_by_span_id.items():
@@ -170,6 +178,14 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         and events_by_span_id[child_span_id] not in event_node["children"]
                     ):
                         event_node["children"].append(events_by_span_id[child_span_id])
+
+        # Third pass: connect any remaining children to their parents
+        for parent_span_id, children in children_by_parent_span_id.items():
+            if parent_span_id in events_by_span_id:
+                parent_node = events_by_span_id[parent_span_id]
+                for child in children:
+                    if child not in parent_node["children"]:
+                        parent_node["children"].append(child)
 
         # Function to recursively sort children by datetime
         def sort_tree(node):
@@ -198,73 +214,76 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
         return {"trace_id": event.trace_id, "events": cleaned_tree}
 
-    def _get_profile_for_event(
-        self, event: Event | GroupEvent, project: Project
+    def _get_profile_from_trace_tree(
+        self, trace_tree: dict[str, Any] | None, event: Event | GroupEvent | None, project: Project
     ) -> dict[str, Any] | None:
-        profile_matches_event = False
-        transaction_name = event.transaction
-        if not transaction_name:
+        """
+        Finds the profile for the transaction that is a parent of our error event.
+        """
+        if not trace_tree or not event:
             return None
 
-        event_filter = eventstore.Filter(
-            project_ids=[project.id],
-            conditions=[
-                ["transaction", "=", transaction_name],
-                ["trace_id", "=", event.trace_id],
-                ["profile_id", "IS NOT NULL", None],
-            ],
-        )
-        results = eventstore.backend.get_events(
-            filter=event_filter,
-            dataset=Dataset.Transactions,
-            referrer=Referrer.API_GROUP_AI_AUTOFIX,
-            tenant_ids={"organization_id": project.organization_id},
-            limit=10,
-        )
+        events = trace_tree.get("events", [])
+        event_id = event.event_id
 
-        # iterate through each transaction's spans and find the one that contains the span corresponding to our error event
-        span_id = event.data.get("contexts", {}).get("trace", {}).get("span_id")
+        # First, find our error event in the tree and track parent transactions
+        # 1. Find the error event node and also build a map of parent-child relationships
+        # 2. Walk up from the error event to find a transaction with a profile
+
+        child_to_parent = {}
+
+        def build_parent_map(node, parent=None):
+            node_id = node.get("event_id")
+
+            if parent:
+                child_to_parent[node_id] = parent
+
+            for child in node.get("children", []):
+                build_parent_map(child, node)
+
+        # Build the parent-child map for the entire tree
+        for root_node in events:
+            build_parent_map(root_node)
+
+        # Find our error node in the flattened tree
+        error_node = None
+        all_nodes = []
+
+        def collect_all_nodes(node):
+            all_nodes.append(node)
+            for child in node.get("children", []):
+                collect_all_nodes(child)
+
+        for root_node in events:
+            collect_all_nodes(root_node)
+
+        for node in all_nodes:
+            if node.get("event_id") == event_id:
+                error_node = node
+                break
+
+        if not error_node:
+            return None
+
+        # Now walk up the tree to find a transaction with a profile
         profile_id = None
-        if results and span_id:
-            for result in results:
-                spans = result.data.get("spans", [])
-                for span in spans:
-                    if span.get("span_id") == span_id:
-                        profile_matches_event = True
-                        profile_id = (
-                            result.data.get("contexts", {}).get("profile", {}).get("profile_id")
-                        )
-                        break
-                if profile_id:
-                    break
-        if not profile_id and results:  # fallback to a similar transaction in the trace
-            profile_matches_event = False
-            profile_id = results[0].data.get("contexts", {}).get("profile", {}).get("profile_id")
-        if (
-            not profile_id
-        ):  # fallback to any profile in that kind of transaction, not just the same trace
-            event_filter = eventstore.Filter(
-                project_ids=[project.id],
-                conditions=[
-                    ["transaction", "=", transaction_name],
-                    ["profile_id", "IS NOT NULL", None],
-                ],
-            )
-            results = eventstore.backend.get_events(
-                filter=event_filter,
-                dataset=Dataset.Transactions,
-                referrer=Referrer.API_GROUP_AI_AUTOFIX,
-                tenant_ids={"organization_id": project.organization_id},
-                limit=1,
-            )
-            if results:
-                profile_id = (
-                    results[0].data.get("contexts", {}).get("profile", {}).get("profile_id")
-                )
+        current_node = error_node
+        while current_node:
+            if current_node.get("profile_id"):
+                profile_id = current_node.get("profile_id")
+                break
+
+            # Move up to parent - child_to_parent maps child event IDs to parent node objects
+            parent_node = child_to_parent.get(current_node.get("event_id"))
+            if not parent_node:
+                # Reached the root without finding a suitable transaction
+                return None
+            current_node = parent_node
 
         if not profile_id:
             return None
 
+        # Fetch the profile data
         response = get_from_profiling_service(
             "GET",
             f"/organizations/{project.organization_id}/projects/{project.id}/profiles/{profile_id}",
@@ -278,7 +297,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 None
                 if not execution_tree
                 else {
-                    "profile_matches_issue": profile_matches_event,
+                    "profile_matches_issue": True,  # we don't have a fallback for now
                     "execution_tree": execution_tree,
                 }
             )
@@ -500,19 +519,23 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
         repos = get_autofix_repos_from_project_code_mappings(group.project)
 
-        # find best profile for this event
-        try:
-            profile = self._get_profile_for_event(event, group.project) if event else None
-        except Exception:
-            logger.exception("Failed to get profile for event")
-            profile = None
-
-        # get trace tree for this event
+        # get trace tree of transactions and errors for this event
         try:
             trace_tree = self._get_trace_tree_for_event(event, group.project) if event else None
         except Exception:
             logger.exception("Failed to get trace tree for event")
             trace_tree = None
+
+        # find the profile containing our error event
+        try:
+            profile = (
+                self._get_profile_from_trace_tree(trace_tree, event, group.project)
+                if event
+                else None
+            )
+        except Exception:
+            logger.exception("Failed to get profile from trace tree")
+            profile = None
 
         try:
             run_id = self._call_autofix(

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -1,9 +1,12 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import ANY, Mock, patch
+
+import orjson
 
 from sentry.api.endpoints.group_ai_autofix import TIMEOUT_SECONDS, GroupAutofixEndpoint
 from sentry.autofix.utils import AutofixState, AutofixStatus, CodebaseState
 from sentry.models.group import Group
+from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
@@ -257,20 +260,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Should have empty repositories list since there are no codebases
         assert len(response.data["autofix"]["repositories"]) == 0
 
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._get_profile_for_event")
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
-    def test_ai_autofix_post_endpoint(
-        self, mock_check_autofix_status, mock_call, mock_get_profile, mock_profiling_service
-    ):
-        # Mock profile data
-        mock_get_profile.return_value = {"profile_data": "test"}
-        mock_profiling_service.return_value.status = 200
-        mock_profiling_service.return_value.data = (
-            b'{"profile": {"frames": [], "stacks": [], "samples": [], "thread_metadata": {}}}'
-        )
-
+    def test_ai_autofix_post_endpoint(self, mock_check_autofix_status, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
@@ -316,7 +308,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                 }
             ],
             ANY,
-            {"profile_data": "test"},
+            None,
             None,
             "Yes",
             TIMEOUT_SECONDS,
@@ -334,20 +326,13 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._get_profile_for_event")
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
     def test_ai_autofix_post_without_code_mappings(
-        self, mock_check_autofix_status, mock_call, mock_get_profile, mock_profiling_service
+        self,
+        mock_check_autofix_status,
+        mock_call,
     ):
-        # Mock profile data
-        mock_get_profile.return_value = {"profile_data": "test"}
-        mock_profiling_service.return_value.status = 200
-        mock_profiling_service.return_value.data = (
-            b'{"profile": {"frames": [], "stacks": [], "samples": [], "thread_metadata": {}}}'
-        )
-
         release = self.create_release(project=self.project, version="1.0.0")
 
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -378,7 +363,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             group,
             [],
             ANY,
-            {"profile_data": "test"},
+            None,
             None,
             "Yes",
             TIMEOUT_SECONDS,
@@ -396,24 +381,13 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._get_profile_for_event")
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
     def test_ai_autofix_post_without_event_id(
         self,
         mock_check_autofix_status,
         mock_call,
-        mock_get_profile,
-        mock_profiling_service,
     ):
-        # Mock profile data
-        mock_get_profile.return_value = {"profile_data": "test"}
-        mock_profiling_service.return_value.status = 200
-        mock_profiling_service.return_value.data = (
-            b'{"profile": {"frames": [], "stacks": [], "samples": [], "thread_metadata": {}}}'
-        )
-
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
@@ -457,7 +431,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                 }
             ],
             ANY,
-            {"profile_data": "test"},
+            None,
             None,
             "Yes",
             TIMEOUT_SECONDS,
@@ -476,24 +450,14 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._get_profile_for_event")
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
     def test_ai_autofix_post_without_event_id_no_recommended_event(
         self,
         mock_check_autofix_status,
         mock_call,
-        mock_get_profile,
-        mock_profiling_service,
         mock_event,
     ):
-        # Mock profile data
-        mock_get_profile.return_value = {"profile_data": "test"}
-        mock_profiling_service.return_value.status = 200
-        mock_profiling_service.return_value.data = (
-            b'{"profile": {"frames": [], "stacks": [], "samples": [], "thread_metadata": {}}}'
-        )
 
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -538,7 +502,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                 }
             ],
             ANY,
-            {"profile_data": "test"},
+            None,
             None,
             "Yes",
             TIMEOUT_SECONDS,
@@ -744,346 +708,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert len(execution_tree) == 1
         assert execution_tree[0]["function"] == "main"
 
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    def test_get_profile_for_event(self, mock_get_from_profiling_service):
-        # Create a test event with transaction and trace data
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "a" * 16,
-                    }
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        # Mock the profile service response
-        mock_get_from_profiling_service.return_value.status = 200
-        mock_get_from_profiling_service.return_value.data = b"""{
-            "profile": {
-                "frames": [
-                    {
-                        "function": "main",
-                        "module": "app.main",
-                        "filename": "main.py",
-                        "lineno": 10,
-                        "in_app": true
-                    }
-                ],
-                "stacks": [[0]],
-                "samples": [{"stack_id": 0, "thread_id": "1"}],
-                "thread_metadata": {"1": {"name": "MainThread"}}
-            }
-        }"""
-
-        timestamp = before_now(minutes=1)
-        profile_id = "0" * 32
-        # Create a transaction event with profile_id
-        self.store_event(
-            data={
-                "type": "transaction",
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "b" * 16,
-                    },
-                    "profile": {"profile_id": profile_id},
-                },
-                "spans": [
-                    {
-                        "span_id": "a" * 16,
-                        "trace_id": "a" * 32,
-                        "op": "test",
-                        "description": "test span",
-                        "start_timestamp": timestamp.timestamp(),
-                        "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-                    }
-                ],
-                "start_timestamp": timestamp.timestamp(),
-                "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-            },
-            project_id=self.project.id,
-        )
-
-        profile = GroupAutofixEndpoint()._get_profile_for_event(event, self.project)
-
-        # Verify profile was fetched and processed correctly
-        assert profile is not None
-        assert profile["profile_matches_issue"] is True
-        assert len(profile["execution_tree"]) == 1
-        assert profile["execution_tree"][0]["function"] == "main"
-        assert profile["execution_tree"][0]["module"] == "app.main"
-        assert profile["execution_tree"][0]["filename"] == "main.py"
-        assert profile["execution_tree"][0]["lineno"] == 10
-
-        # Verify profiling service was called with correct parameters
-        mock_get_from_profiling_service.assert_called_once_with(
-            "GET",
-            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
-            params={"format": "sample"},
-        )
-
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    def test_get_profile_for_event_no_matching_transaction(self, mock_get_from_profiling_service):
-        # Create a test event with transaction and trace data but no matching transaction event
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "a" * 16,
-                    }
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        profile = GroupAutofixEndpoint()._get_profile_for_event(event, self.project)
-
-        # Verify no profile was returned when no matching transaction is found
-        assert profile is None
-        mock_get_from_profiling_service.assert_not_called()
-
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    def test_get_profile_for_event_profile_service_error(self, mock_get_from_profiling_service):
-        # Create test event and transaction
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "a" * 16,
-                    }
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        timestamp = before_now(minutes=1)
-        profile_id = "0" * 32
-        self.store_event(
-            data={
-                "type": "transaction",
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "b" * 16,
-                    },
-                    "profile": {"profile_id": profile_id},
-                },
-                "spans": [
-                    {
-                        "span_id": "a" * 16,
-                        "trace_id": "a" * 32,
-                        "op": "test",
-                        "description": "test span",
-                        "start_timestamp": timestamp.timestamp(),
-                        "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-                    }
-                ],
-                "start_timestamp": timestamp.timestamp(),
-                "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-            },
-            project_id=self.project.id,
-        )
-
-        # Mock profile service error response
-        mock_get_from_profiling_service.return_value.status = 500
-
-        profile = GroupAutofixEndpoint()._get_profile_for_event(event, self.project)
-
-        # Verify no profile is returned on service error
-        assert profile is None
-
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    def test_get_profile_for_event_fallback_profile(self, mock_get_from_profiling_service):
-        # Create a test event with transaction and trace data
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "a" * 16,  # Different span_id than the transaction event
-                    }
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        # Mock the profile service response
-        mock_get_from_profiling_service.return_value.status = 200
-        mock_get_from_profiling_service.return_value.data = b"""{
-            "profile": {
-                "frames": [
-                    {
-                        "function": "main",
-                        "module": "app.main",
-                        "filename": "main.py",
-                        "lineno": 10,
-                        "in_app": true
-                    }
-                ],
-                "stacks": [[0]],
-                "samples": [{"stack_id": 0, "thread_id": "1"}],
-                "thread_metadata": {"1": {"name": "MainThread"}}
-            }
-        }"""
-
-        timestamp = before_now(minutes=1)
-        profile_id = "0" * 32
-        # Create a transaction event with profile_id but different span_id
-        self.store_event(
-            data={
-                "type": "transaction",
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,
-                        "span_id": "b"
-                        * 16,  # Different span_id than both error event and transaction
-                    },
-                    "profile": {"profile_id": profile_id},
-                },
-                "spans": [
-                    {
-                        "span_id": "c"
-                        * 16,  # Different span_id than both error event and transaction
-                        "trace_id": "a" * 32,
-                        "op": "test",
-                        "description": "test span",
-                        "start_timestamp": timestamp.timestamp(),
-                        "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-                    }
-                ],
-                "start_timestamp": timestamp.timestamp(),
-                "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-            },
-            project_id=self.project.id,
-        )
-
-        profile = GroupAutofixEndpoint()._get_profile_for_event(event, self.project)
-
-        # Verify profile was fetched and processed correctly
-        assert profile is not None
-        # Should indicate that this is a fallback profile that doesn't exactly match the error
-        assert profile["profile_matches_issue"] is False
-        assert len(profile["execution_tree"]) == 1
-        assert profile["execution_tree"][0]["function"] == "main"
-        assert profile["execution_tree"][0]["module"] == "app.main"
-        assert profile["execution_tree"][0]["filename"] == "main.py"
-        assert profile["execution_tree"][0]["lineno"] == 10
-
-        # Verify profiling service was called with correct parameters
-        mock_get_from_profiling_service.assert_called_once_with(
-            "GET",
-            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
-            params={"format": "sample"},
-        )
-
-    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
-    def test_get_profile_for_event_fallback_to_transaction_name(
-        self, mock_get_from_profiling_service
-    ):
-        # Create a test event with transaction and trace data
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "transaction": "test_transaction",
-                "contexts": {
-                    "trace": {
-                        "trace_id": "a" * 32,  # Different trace_id than the transaction event
-                        "span_id": "a" * 16,
-                    }
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        # Mock the profile service response
-        mock_get_from_profiling_service.return_value.status = 200
-        mock_get_from_profiling_service.return_value.data = b"""{
-            "profile": {
-                "frames": [
-                    {
-                        "function": "main",
-                        "module": "app.main",
-                        "filename": "main.py",
-                        "lineno": 10,
-                        "in_app": true
-                    }
-                ],
-                "stacks": [[0]],
-                "samples": [{"stack_id": 0, "thread_id": "1"}],
-                "thread_metadata": {"1": {"name": "MainThread"}}
-            }
-        }"""
-
-        timestamp = before_now(minutes=1)
-        profile_id = "0" * 32
-        # Create a transaction event with profile_id but different trace_id
-        self.store_event(
-            data={
-                "type": "transaction",
-                "transaction": "test_transaction",  # Same transaction name
-                "contexts": {
-                    "trace": {
-                        "trace_id": "b" * 32,  # Different trace_id than the error event
-                        "span_id": "b" * 16,
-                    },
-                    "profile": {"profile_id": profile_id},
-                },
-                "spans": [
-                    {
-                        "span_id": "c" * 16,
-                        "trace_id": "b" * 32,
-                        "op": "test",
-                        "description": "test span",
-                        "start_timestamp": timestamp.timestamp(),
-                        "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-                    }
-                ],
-                "start_timestamp": timestamp.timestamp(),
-                "timestamp": (timestamp + timedelta(seconds=1)).timestamp(),
-            },
-            project_id=self.project.id,
-        )
-
-        profile = GroupAutofixEndpoint()._get_profile_for_event(event, self.project)
-
-        # Verify profile was fetched and processed correctly
-        assert profile is not None
-        # Should indicate that this is a fallback profile that doesn't exactly match the error
-        assert profile["profile_matches_issue"] is False
-        assert len(profile["execution_tree"]) == 1
-        assert profile["execution_tree"][0]["function"] == "main"
-        assert profile["execution_tree"][0]["module"] == "app.main"
-        assert profile["execution_tree"][0]["filename"] == "main.py"
-        assert profile["execution_tree"][0]["lineno"] == 10
-
-        # Verify profiling service was called with correct parameters
-        mock_get_from_profiling_service.assert_called_once_with(
-            "GET",
-            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
-            params={"format": "sample"},
-        )
-
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
     @patch("sentry.api.endpoints.group_ai_autofix.cache")
     def test_ai_autofix_get_endpoint_cache_miss(self, mock_cache, mock_get_autofix_state):
@@ -1210,25 +834,15 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         Note: Events are ordered chronologically at each level.
         """
-        # Create a test event with a trace ID
         event_data = load_data("python")
         trace_id = "1234567890abcdef1234567890abcdef"
-        test_span_id = "abcdef0123456789"  # Add a span_id for the test event
-        event_data.update(
-            {
-                "contexts": {
-                    "trace": {"trace_id": trace_id, "span_id": test_span_id}  # Add the span_id
-                }
-            }
-        )
+        test_span_id = "abcdef0123456789"
+        event_data.update({"contexts": {"trace": {"trace_id": trace_id, "span_id": test_span_id}}})
         event = self.store_event(data=event_data, project_id=self.project.id)
-
-        # Create mock data for the results from eventstore.backend.get_events
-        mock_results = []
 
         # Root event (a transaction)
         root_tx_span_id = "aaaaaaaaaaaaaaaa"
-        root_tx_event = {
+        root_tx_event_data = {
             "event_id": "root-tx-id",
             "datetime": "2023-01-01T10:00:00Z",
             "spans": [{"span_id": "child1-span-id"}, {"span_id": "child2-span-id"}],
@@ -1237,12 +851,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Root Transaction",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
 
         # Child 1 - transaction that happens before child 2
         child1_span_id = "child1-span-id"
-        child1_tx_event = {
+        child1_tx_event_data = {
             "event_id": "child1-tx-id",
             "datetime": "2023-01-01T10:00:10Z",
             "spans": [{"span_id": "grandchild1-span-id"}],
@@ -1256,12 +870,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Database Query",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
 
         # Child 2 - error that happens after child 1
         child2_span_id = "child2-span-id"
-        child2_error_event = {
+        child2_error_event_data = {
             "event_id": "child2-error-id",
             "datetime": "2023-01-01T10:00:20Z",
             "contexts": {
@@ -1273,12 +887,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Division by zero",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
 
         # Grandchild 1 - error event (child of child1)
         grandchild1_span_id = "grandchild1-span-id"
-        grandchild1_error_event = {
+        grandchild1_error_event_data = {
             "event_id": "grandchild1-error-id",
             "datetime": "2023-01-01T10:00:15Z",
             "contexts": {
@@ -1290,12 +904,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Database Error",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
 
         # Add another root event that happens earlier
         another_root_span_id = "bbbbbbbbbbbbbbbb"
-        another_root_tx_event = {
+        another_root_tx_event_data = {
             "event_id": "another-root-id",
             "datetime": "2023-01-01T09:59:00Z",
             "spans": [],
@@ -1304,27 +918,55 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Earlier Transaction",
             "platform": "javascript",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
 
-        # Create mocks for the result objects
-        for event_data in [
-            root_tx_event,
-            child1_tx_event,
-            child2_error_event,
-            grandchild1_error_event,
-            another_root_tx_event,
-        ]:
-            mock_result = Mock()
-            mock_result.data = event_data
-            mock_results.append(mock_result)
+        # Create proper event objects instead of just mocks
+        tx_events = []
+        error_events = []
 
-        # Test the trace tree function with mock data - shuffle to ensure ordering doesn't matter
-        import random
+        # Create transaction events
+        for event_data in [root_tx_event_data, child1_tx_event_data, another_root_tx_event_data]:
+            mock_event = Mock()
+            # Set attributes directly instead of using data property
+            mock_event.event_id = event_data["event_id"]
+            mock_event.datetime = datetime.fromisoformat(
+                event_data["datetime"].replace("Z", "+00:00")
+            )
+            mock_event.data = event_data
+            mock_event.title = event_data["title"]
+            mock_event.platform = event_data["platform"]
+            mock_event.project_id = event_data["project_id"]
+            mock_event.trace_id = trace_id
+            tx_events.append(mock_event)
 
-        random.shuffle(mock_results)
+        # Create error events
+        for event_data in [child2_error_event_data, grandchild1_error_event_data]:
+            mock_event = Mock()
+            # Set attributes directly instead of using data property
+            mock_event.event_id = event_data["event_id"]
+            mock_event.datetime = datetime.fromisoformat(
+                event_data["datetime"].replace("Z", "+00:00")
+            )
+            mock_event.data = event_data
+            mock_event.title = event_data["title"]
+            mock_event.platform = event_data["platform"]
+            mock_event.project_id = event_data["project_id"]
+            mock_event.trace_id = trace_id
+            error_events.append(mock_event)
 
-        with patch("sentry.eventstore.backend.get_events", return_value=mock_results):
+        # Update to patch both Transactions and Events dataset calls
+        with patch("sentry.eventstore.backend.get_events") as mock_get_events:
+
+            def side_effect(filter, dataset, **kwargs):
+                if dataset == Dataset.Transactions:
+                    return tx_events
+                elif dataset == Dataset.Events:
+                    return error_events
+                return []
+
+            mock_get_events.side_effect = side_effect
+
             endpoint = GroupAutofixEndpoint()
             trace_tree = endpoint._get_trace_tree_for_event(event, self.project)
 
@@ -1339,7 +981,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         first_root = trace_tree["events"][0]
         assert first_root["event_id"] == "another-root-id"
         assert first_root["title"] == "browser - Earlier Transaction"
-        assert first_root["datetime"] == "2023-01-01T09:59:00Z"
+        assert first_root["datetime"].isoformat() == "2023-01-01T09:59:00+00:00"
         assert first_root["is_transaction"] is True
         assert first_root["is_error"] is False
         assert len(first_root["children"]) == 0
@@ -1348,7 +990,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         second_root = trace_tree["events"][1]
         assert second_root["event_id"] == "root-tx-id"
         assert second_root["title"] == "http.server - Root Transaction"
-        assert second_root["datetime"] == "2023-01-01T10:00:00Z"
+        assert second_root["datetime"].isoformat() == "2023-01-01T10:00:00+00:00"
         assert second_root["is_transaction"] is True
         assert second_root["is_error"] is False
 
@@ -1359,7 +1001,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         child1 = second_root["children"][0]
         assert child1["event_id"] == "child1-tx-id"
         assert child1["title"] == "db - Database Query"
-        assert child1["datetime"] == "2023-01-01T10:00:10Z"
+        assert child1["datetime"].isoformat() == "2023-01-01T10:00:10+00:00"
         assert child1["is_transaction"] is True
         assert child1["is_error"] is False
 
@@ -1368,7 +1010,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         grandchild1 = child1["children"][0]
         assert grandchild1["event_id"] == "grandchild1-error-id"
         assert grandchild1["title"] == "Database Error"
-        assert grandchild1["datetime"] == "2023-01-01T10:00:15Z"
+        assert grandchild1["datetime"].isoformat() == "2023-01-01T10:00:15+00:00"
         assert grandchild1["is_transaction"] is False
         assert grandchild1["is_error"] is True
         assert len(grandchild1["children"]) == 0
@@ -1377,10 +1019,17 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         child2 = second_root["children"][1]
         assert child2["event_id"] == "child2-error-id"
         assert child2["title"] == "Division by zero"
-        assert child2["datetime"] == "2023-01-01T10:00:20Z"
+        assert child2["datetime"].isoformat() == "2023-01-01T10:00:20+00:00"
         assert child2["is_transaction"] is False
         assert child2["is_error"] is True
         assert len(child2["children"]) == 0
+
+        # Verify that get_events was called twice - once for transactions and once for errors
+        assert mock_get_events.call_count == 2
+        # Check that the first call used the Transactions dataset
+        assert mock_get_events.call_args_list[0][1]["dataset"] == Dataset.Transactions
+        # Check that the second call used the Events dataset
+        assert mock_get_events.call_args_list[1][1]["dataset"] == Dataset.Events
 
     @patch("sentry.eventstore.backend.get_events")
     def test_get_trace_tree_empty_results(self, mock_get_events):
@@ -1391,26 +1040,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         This test checks the behavior when no events are found for a trace.
         """
-        # Test when no trace events are found
         mock_get_events.return_value = []
 
         event_data = load_data("python")
         trace_id = "1234567890abcdef1234567890abcdef"
-        test_span_id = "abcdef0123456789"  # Add a span_id for the test event
-        event_data.update(
-            {
-                "contexts": {
-                    "trace": {"trace_id": trace_id, "span_id": test_span_id}  # Add the span_id
-                }
-            }
-        )
+        test_span_id = "abcdef0123456789"
+        event_data.update({"contexts": {"trace": {"trace_id": trace_id, "span_id": test_span_id}}})
         event = self.store_event(data=event_data, project_id=self.project.id)
 
         endpoint = GroupAutofixEndpoint()
         trace_tree = endpoint._get_trace_tree_for_event(event, self.project)
 
         assert trace_tree is None
-        mock_get_events.assert_called_once()
+        # Should be called twice - once for transactions and once for errors
+        assert mock_get_events.call_count == 2
 
     @patch("sentry.eventstore.backend.get_events")
     def test_get_trace_tree_out_of_order_processing(self, mock_get_events):
@@ -1424,24 +1067,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         This test verifies that the correct tree structure is built even when
         events are processed out of order (child before parent).
         """
-        # Test that we can correctly build the tree even when child events come before parents
         trace_id = "1234567890abcdef1234567890abcdef"
-        test_span_id = "abcdef0123456789"  # Add a span_id for the test event
+        test_span_id = "abcdef0123456789"
         event_data = load_data("python")
-        event_data.update(
-            {
-                "contexts": {
-                    "trace": {"trace_id": trace_id, "span_id": test_span_id}  # Add the span_id
-                }
-            }
-        )
+        event_data.update({"contexts": {"trace": {"trace_id": trace_id, "span_id": test_span_id}}})
         event = self.store_event(data=event_data, project_id=self.project.id)
 
         # Child event that references a parent we haven't seen yet
         child_span_id = "cccccccccccccccc"
         parent_span_id = "pppppppppppppppp"
 
+        # Create proper child event object
         child_event = Mock()
+        child_event.event_id = "child-id"
+        child_event.datetime = datetime.fromisoformat("2023-01-01T10:00:10+00:00")
         child_event.data = {
             "event_id": "child-id",
             "datetime": "2023-01-01T10:00:10Z",
@@ -1454,11 +1093,17 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Child First",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
+        child_event.title = "Child First"
+        child_event.platform = "python"
+        child_event.project_id = self.project.id
+        child_event.trace_id = trace_id
 
-        # Parent event that comes after in the results
+        # Create proper parent event object
         parent_event = Mock()
+        parent_event.event_id = "parent-id"
+        parent_event.datetime = datetime.fromisoformat("2023-01-01T10:00:00+00:00")
         parent_event.data = {
             "event_id": "parent-id",
             "datetime": "2023-01-01T10:00:00Z",
@@ -1468,11 +1113,22 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             },
             "title": "Parent Last",
             "platform": "python",
-            "project": self.project.id,
+            "project_id": self.project.id,
         }
+        parent_event.title = "Parent Last"
+        parent_event.platform = "python"
+        parent_event.project_id = self.project.id
+        parent_event.trace_id = trace_id
 
-        # Provide events with child before parent
-        mock_get_events.return_value = [child_event, parent_event]
+        # Set up the mock to return different results for different dataset calls
+        def side_effect(filter, dataset, **kwargs):
+            if dataset == Dataset.Transactions:
+                return [parent_event]  # Parent is a transaction
+            elif dataset == Dataset.Events:
+                return [child_event]  # Child is an error
+            return []
+
+        mock_get_events.side_effect = side_effect
 
         endpoint = GroupAutofixEndpoint()
         trace_tree = endpoint._get_trace_tree_for_event(event, self.project)
@@ -1490,3 +1146,208 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         child = root["children"][0]
         assert child["event_id"] == "child-id"
         assert child["span_id"] == child_span_id
+
+        # Verify that get_events was called twice
+        assert mock_get_events.call_count == 2
+
+    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree(self, mock_get_from_profiling_service):
+        """
+        Test the _get_profile_from_trace_tree method which finds a profile for a transaction
+        that is a parent of an error event in a trace tree.
+        """
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+
+        # Create a mock trace tree with a transaction that has a profile_id
+        profile_id = "profile123456789"
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "tx-root-id",
+                    "span_id": "root-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": profile_id,
+                    "children": [
+                        {
+                            "event_id": "error-event-id",
+                            "span_id": "event-span-id",
+                            "is_transaction": False,
+                            "is_error": True,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Mock the profile data response
+        mock_profile_data = {
+            "profile": {
+                "frames": [
+                    {
+                        "function": "main",
+                        "module": "app.main",
+                        "filename": "main.py",
+                        "lineno": 10,
+                        "in_app": True,
+                    }
+                ],
+                "stacks": [[0]],
+                "samples": [{"stack_id": 0, "thread_id": "1"}],
+                "thread_metadata": {"1": {"name": "MainThread"}},
+            }
+        }
+
+        # Configure the mock response
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.data = orjson.dumps(mock_profile_data)
+        mock_get_from_profiling_service.return_value = mock_response
+
+        endpoint = GroupAutofixEndpoint()
+        profile_result = endpoint._get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is not None
+        assert profile_result["profile_matches_issue"] is True
+        assert "execution_tree" in profile_result
+        assert len(profile_result["execution_tree"]) == 1
+        assert profile_result["execution_tree"][0]["function"] == "main"
+
+        mock_get_from_profiling_service.assert_called_once_with(
+            "GET",
+            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
+            params={"format": "sample"},
+        )
+
+    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree_api_error(self, mock_get_from_profiling_service):
+        """
+        Test the _get_profile_from_trace_tree method when the profiling service API returns an error.
+        """
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+
+        # Create a mock trace tree with a transaction that has a profile_id
+        profile_id = "profile123456789"
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "tx-root-id",
+                    "span_id": "root-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": profile_id,
+                    "children": [
+                        {
+                            "event_id": "error-event-id",
+                            "span_id": "event-span-id",
+                            "is_transaction": False,
+                            "is_error": True,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Configure the mock response to simulate an API error
+        mock_response = Mock()
+        mock_response.status = 404
+        mock_get_from_profiling_service.return_value = mock_response
+
+        endpoint = GroupAutofixEndpoint()
+        profile_result = endpoint._get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is None
+
+        mock_get_from_profiling_service.assert_called_once_with(
+            "GET",
+            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
+            params={"format": "sample"},
+        )
+
+    @patch("sentry.api.endpoints.group_ai_autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree_multi_level(self, mock_get_from_profiling_service):
+        """
+        Test the _get_profile_from_trace_tree method with a multi-level trace tree
+        where the profile is found in a grandparent transaction.
+        """
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+
+        # Create a mock trace tree with multiple levels
+        profile_id = "profile123456789"
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "root-tx-id",
+                    "span_id": "root-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": profile_id,  # Profile is at the root level
+                    "children": [
+                        {
+                            "event_id": "mid-tx-id",
+                            "span_id": "mid-span-id",
+                            "is_transaction": True,
+                            "is_error": False,
+                            # No profile_id at this level
+                            "children": [
+                                {
+                                    "event_id": "error-event-id",
+                                    "span_id": "event-span-id",
+                                    "is_transaction": False,
+                                    "is_error": True,
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Mock the profile data response
+        mock_profile_data = {
+            "profile": {
+                "frames": [
+                    {
+                        "function": "main",
+                        "module": "app.main",
+                        "filename": "main.py",
+                        "lineno": 10,
+                        "in_app": True,
+                    }
+                ],
+                "stacks": [[0]],
+                "samples": [{"stack_id": 0, "thread_id": "1"}],
+                "thread_metadata": {"1": {"name": "MainThread"}},
+            }
+        }
+
+        # Configure the mock response
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.data = orjson.dumps(mock_profile_data)
+        mock_get_from_profiling_service.return_value = mock_response
+
+        endpoint = GroupAutofixEndpoint()
+        profile_result = endpoint._get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is not None
+        assert profile_result["profile_matches_issue"] is True
+        assert "execution_tree" in profile_result
+
+        mock_get_from_profiling_service.assert_called_once_with(
+            "GET",
+            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
+            params={"format": "sample"},
+        )


### PR DESCRIPTION
The query wasn't working before. This _should_ work. Also use the results from the trace tree to identify the profile id instead of making a redundant query.

(luckily everything is safe in prod because all errors are handled)