### PR TITLE
test(react19): Fix create org acceptance test

### DIFF
--- a/tests/acceptance/test_create_organization.py
+++ b/tests/acceptance/test_create_organization.py
@@ -15,6 +15,7 @@ class CreateOrganizationTest(AcceptanceTestCase):
         settings.PRIVACY_URL = "https://sentry.io/privacy/"
         settings.TERMS_URL = "https://sentry.io/terms/"
         self.browser.get("/organizations/new/")
+        assert self.browser.wait_until('input[name="name"]')
         assert self.browser.element_exists('input[name="name"]')
         assert self.browser.element_exists('input[name="agreeTerms"]')
         self.browser.element('input[name="name"]').send_keys("new org")


### PR DESCRIPTION
For some reason it needs to wait slightly longer until the form is available. This is the only failing acceptance test in 19.

part of https://github.com/getsentry/frontend-tsc/issues/68
