### PR TITLE
fix(issue-details): Use correct nav height for issue details top bar

### DIFF
--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -8,6 +8,7 @@ import Link from 'sentry/components/links/link';
 import {useNavContext} from 'sentry/components/nav/context';
 import {PrimaryNavigationItems} from 'sentry/components/nav/primary/index';
 import {SecondaryMobile} from 'sentry/components/nav/secondaryMobile';
+import {TOPBAR_MOBILE_HEIGHT} from 'sentry/components/sidebar/constants';
 import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -107,7 +108,7 @@ function NavigationOverlayPortal({
 }
 
 const Topbar = styled('header')`
-  height: 40px;
+  height: ${TOPBAR_MOBILE_HEIGHT};
   width: 100vw;
   padding-right: ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.translucentGray200};

--- a/static/app/components/sidebar/constants.tsx
+++ b/static/app/components/sidebar/constants.tsx
@@ -2,3 +2,5 @@ export const SIDEBAR_COLLAPSED_WIDTH = '70px';
 export const SIDEBAR_SEMI_COLLAPSED_WIDTH = '100px';
 export const SIDEBAR_EXPANDED_WIDTH = '220px';
 export const SIDEBAR_MOBILE_HEIGHT = '54px';
+
+export const TOPBAR_MOBILE_HEIGHT = '40px';

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -3,7 +3,11 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {SIDEBAR_MOBILE_HEIGHT} from 'sentry/components/sidebar/constants';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
+import {
+  SIDEBAR_MOBILE_HEIGHT,
+  TOPBAR_MOBILE_HEIGHT,
+} from 'sentry/components/sidebar/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -47,19 +51,21 @@ function StickyEventNav({event, group}: {event: Event; group: Group}) {
   const isStuck = useIsStuck(nav);
   const isScreenMedium = useMedia(`(max-width: ${theme.breakpoints.medium})`);
   const {dispatch} = useIssueDetails();
+  const prefersStackedNav = usePrefersStackedNav();
+  const sidebarHeight = isScreenMedium
+    ? parseInt(prefersStackedNav ? TOPBAR_MOBILE_HEIGHT : SIDEBAR_MOBILE_HEIGHT, 10)
+    : 0;
 
   useLayoutEffect(() => {
     if (!nav) {
       return;
     }
     const navHeight = nav.offsetHeight ?? 0;
-    const sidebarHeight = isScreenMedium ? parseInt(SIDEBAR_MOBILE_HEIGHT, 10) : 0;
-
     dispatch({
       type: 'UPDATE_NAV_SCROLL_MARGIN',
       margin: navHeight + sidebarHeight,
     });
-  }, [nav, isScreenMedium, dispatch]);
+  }, [nav, isScreenMedium, dispatch, sidebarHeight]);
 
   return (
     <FloatingEventNavigation
@@ -67,16 +73,13 @@ function StickyEventNav({event, group}: {event: Event; group: Group}) {
       group={group}
       ref={setNav}
       data-stuck={isStuck}
+      style={{top: sidebarHeight}}
     />
   );
 }
 
 const FloatingEventNavigation = styled(EventTitle)`
   position: sticky;
-  top: 0;
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    top: ${SIDEBAR_MOBILE_HEIGHT};
-  }
   background: ${p => p.theme.background};
   z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;


### PR DESCRIPTION
Working in the old UI:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/d2c569af-90a5-49d5-9715-b9dd1923d8f6" />



New UI w Fix:
<img width="961" alt="image" src="https://github.com/user-attachments/assets/20796db8-8445-41e8-a2ed-2878d4ddecfb" />


