### PR TITLE
ui(subscription): Show reserved budget categories in one usage card

### DIFF
--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -72,6 +72,7 @@ type CategoryNameProps = {
   capitalize?: boolean;
   hadCustomDynamicSampling?: boolean;
   plan?: Plan;
+  title?: boolean;
 };
 
 /**
@@ -82,6 +83,7 @@ export function getPlanCategoryName({
   category,
   hadCustomDynamicSampling = false,
   capitalize = true,
+  title = false,
 }: CategoryNameProps) {
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const displayNames = plan?.categoryDisplayNames?.[category];
@@ -91,7 +93,11 @@ export function getPlanCategoryName({
       : displayNames
         ? displayNames.plural
         : category;
-  return capitalize ? upperFirst(categoryName) : categoryName;
+  return title
+    ? titleCase(categoryName)
+    : capitalize
+      ? upperFirst(categoryName)
+      : categoryName;
 }
 
 /**

--- a/static/gsApp/views/subscriptionPage/overview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.spec.tsx
@@ -124,13 +124,17 @@ describe('Subscription > Overview', () => {
       ).not.toBeInTheDocument();
     } else if (isAm3DsPlan(subscription.plan) && !subscription.isEnterpriseTrial) {
       if (subscription.hadCustomDynamicSampling) {
-        expect(screen.getByText('Accepted spans spend this period')).toBeInTheDocument();
-        expect(screen.getByText('Stored spans spend this period')).toBeInTheDocument();
-      } else {
         expect(screen.getByText('Spans spend this period')).toBeInTheDocument();
         expect(
-          screen.queryByText('Stored spans spend this period')
-        ).not.toBeInTheDocument();
+          screen.getByText('Accepted Spans Included in Subscription')
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText('Stored Spans Included in Subscription')
+        ).toBeInTheDocument();
+      } else {
+        expect(screen.getByText('Spans spend this period')).toBeInTheDocument();
+        expect(screen.queryByText('Accepted spans')).not.toBeInTheDocument();
+        expect(screen.queryByText('Stored spans')).not.toBeInTheDocument();
       }
     } else {
       expect(screen.getByText('Spans usage this period')).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -190,13 +190,14 @@ function Overview({api, location, subscription, organization, promotionData}: Pr
       nonPlanProductTrials?.filter(pt => pt.category === DataCategory.PROFILES).length >
         0 || false;
 
+    const showAllBudgetTotals = subscription.hadCustomDynamicSampling ? true : false;
     if (
       !subscription.hadCustomDynamicSampling &&
       isAm3DsPlan(subscription.plan) &&
       !subscription.isEnterpriseTrial
     ) {
-      // if the customer has not yet used custom DS in the current period, just show
-      // one spans card
+      // if the customer has not yet stated using custom DS in the current period,
+      // just show one spans UsageTotalsTable
       reservedBudgetCategoryInfo[DataCategory.SPANS]!.reservedSpend +=
         reservedBudgetCategoryInfo[DataCategory.SPANS_INDEXED]!.reservedSpend ?? 0;
     }
@@ -205,10 +206,8 @@ function Overview({api, location, subscription, organization, promotionData}: Pr
       <TotalsWrapper>
         {sortCategories(subscription.categories).map(categoryHistory => {
           const category = categoryHistory.category;
-          if (
-            category === DATA_CATEGORY_INFO.spanIndexed.plural &&
-            !subscription.hadCustomDynamicSampling
-          ) {
+          // Stored spans are combined into the accepted spans category's table
+          if (category === DATA_CATEGORY_INFO.spanIndexed.plural) {
             return null;
           }
 
@@ -269,6 +268,9 @@ function Overview({api, location, subscription, organization, promotionData}: Pr
               prepaidBudget={reservedBudgetCategoryInfo[category]?.prepaidBudget}
               reservedSpend={reservedBudgetCategoryInfo[category]?.reservedSpend}
               freeBudget={reservedBudgetCategoryInfo[category]?.freeBudget}
+              // If there are reserved budgets and all the budgets should have separate breakdowns
+              // we need to be able to access other categories' usageData.totals
+              allTotalsByCategory={showAllBudgetTotals ? usageData.totals : undefined}
             />
           );
         })}

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -174,7 +174,7 @@ describe('Subscription > UsageTotals', function () {
     expect(screen.getByTestId('reserved-spans')).toHaveTextContent(
       '$100,000.00 Reserved'
     );
-    expect(screen.getByText('$40,000')).toBeInTheDocument();
+    expect(screen.getByText('$60,000')).toBeInTheDocument();
     expect(screen.getByText('40% of $100,000')).toBeInTheDocument();
 
     // Expand usage table

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -163,10 +163,14 @@ describe('Subscription > UsageTotals', function () {
         subscription={dsSubscription}
         organization={organization}
         displayMode="usage"
+        allTotalsByCategory={{
+          spans: totals,
+          spansIndexed: totals,
+        }}
       />
     );
 
-    expect(screen.getByText('Accepted spans spend this period')).toBeInTheDocument();
+    expect(screen.getByText('Spans spend this period')).toBeInTheDocument();
     expect(screen.getByTestId('reserved-spans')).toHaveTextContent(
       '$100,000.00 Reserved'
     );
@@ -182,6 +186,7 @@ describe('Subscription > UsageTotals', function () {
     expect(
       screen.getByRole('columnheader', {name: 'Accepted Spans'})
     ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Stored Spans'})).toBeInTheDocument();
   });
 
   it('renders spans with reserved budgets without dynamic sampling', async function () {
@@ -241,13 +246,22 @@ describe('Subscription > UsageTotals', function () {
         subscription={dsSubscription}
         organization={organization}
         displayMode="usage"
+        allTotalsByCategory={{
+          spans: totals,
+          spansIndexed: totals,
+        }}
       />
     );
 
     expect(screen.getByTestId('gifted-spans')).toHaveTextContent(
       '$100,000.00 Reserved + $10,000.00 Gifted'
     );
-    expect(screen.getByText('55% of $110,000')).toBeInTheDocument();
+    expect(
+      screen.getByText('Accepted Spans Included in Subscription')
+    ).toBeInTheDocument();
+    expect(screen.getByText('40% of $110,000')).toBeInTheDocument();
+    expect(screen.getByText('Stored Spans Included in Subscription')).toBeInTheDocument();
+    expect(screen.getByText('20% of $110,000')).toBeInTheDocument();
   });
 
   it('renders reserved budget categories with soft cap', function () {

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -197,7 +197,7 @@ export function calculateCategoryPrepaidUsage(
   }
   const hasReservedBudget = reservedCpe || typeof reservedSpend === 'number'; // reservedSpend can be 0
   const prepaidUsed = hasReservedBudget
-    ? reservedSpend ?? totals.accepted * (reservedCpe ?? 0)
+    ? (reservedSpend ?? totals.accepted * (reservedCpe ?? 0))
     : totals.accepted;
   const prepaidPercentUsed = getPercentage(prepaidUsed, prepaidTotal);
 
@@ -357,7 +357,7 @@ function UsageTotals({
   const hasReservedBudget = reservedUnits === RESERVED_BUDGET_QUOTA;
   const free = hasReservedBudget ? freeBudget : freeUnits;
   const reserved = hasReservedBudget ? reservedBudget : reservedUnits;
-  const prepaid = hasReservedBudget ? prepaidBudget ?? 0 : prepaidUnits;
+  const prepaid = hasReservedBudget ? (prepaidBudget ?? 0) : prepaidUnits;
 
   const displayGifts = (free || freeBudget) && !isUnlimitedReserved(reservedUnits);
   const reservedTestId = displayGifts ? `gifted-${category}` : `reserved-${category}`;
@@ -432,8 +432,8 @@ function UsageTotals({
     reserved !== 0 || subscription.isTrial ? 100 - prepaidPercentUsed : 0;
   const totalCategorySpend =
     (hasReservedBudget
-      ? subscription.reservedBudgets?.find(budget => category in budget.categories)
-          ?.totalReservedSpend ?? 0
+      ? (subscription.reservedBudgets?.find(budget => category in budget.categories)
+          ?.totalReservedSpend ?? 0)
       : prepaidPrice) + categoryOnDemandSpent;
 
   // Shared on demand spend is gone, another category has spent all of it

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -197,7 +197,7 @@ export function calculateCategoryPrepaidUsage(
   }
   const hasReservedBudget = reservedCpe || typeof reservedSpend === 'number'; // reservedSpend can be 0
   const prepaidUsed = hasReservedBudget
-    ? (reservedSpend ?? totals.accepted * (reservedCpe ?? 0))
+    ? reservedSpend ?? totals.accepted * (reservedCpe ?? 0)
     : totals.accepted;
   const prepaidPercentUsed = getPercentage(prepaidUsed, prepaidTotal);
 
@@ -357,7 +357,7 @@ function UsageTotals({
   const hasReservedBudget = reservedUnits === RESERVED_BUDGET_QUOTA;
   const free = hasReservedBudget ? freeBudget : freeUnits;
   const reserved = hasReservedBudget ? reservedBudget : reservedUnits;
-  const prepaid = hasReservedBudget ? (prepaidBudget ?? 0) : prepaidUnits;
+  const prepaid = hasReservedBudget ? prepaidBudget ?? 0 : prepaidUnits;
 
   const displayGifts = (free || freeBudget) && !isUnlimitedReserved(reservedUnits);
   const reservedTestId = displayGifts ? `gifted-${category}` : `reserved-${category}`;
@@ -431,7 +431,10 @@ function UsageTotals({
   const unusedPrepaidWidth =
     reserved !== 0 || subscription.isTrial ? 100 - prepaidPercentUsed : 0;
   const totalCategorySpend =
-    (hasReservedBudget ? (reservedSpend ?? 0) : prepaidPrice) + categoryOnDemandSpent;
+    (hasReservedBudget
+      ? subscription.reservedBudgets?.find(budget => category in budget.categories)
+          ?.totalReservedSpend ?? 0
+      : prepaidPrice) + categoryOnDemandSpent;
 
   // Shared on demand spend is gone, another category has spent all of it
   // It is confusing to show on demand spend when the category did not spend any and the budget is gone
@@ -617,19 +620,17 @@ function UsageTotals({
                 )}
                 {isDisplayingSpend ? (
                   prepaidPrice === 0 ? (
-                    !hasReservedBudget && (
-                      <div>
-                        <LegendTitle>{t('Included in Subscription')}</LegendTitle>
-                        <LegendPriceSubText>
-                          <ReservedUsage
-                            prepaidUsage={prepaidUsage}
-                            reserved={reserved}
-                            category={category}
-                            productTrial={productTrial}
-                          />
-                        </LegendPriceSubText>
-                      </div>
-                    )
+                    <div>
+                      <LegendTitle>{t('Included in Subscription')}</LegendTitle>
+                      <LegendPriceSubText>
+                        <ReservedUsage
+                          prepaidUsage={prepaidUsage}
+                          reserved={reserved}
+                          category={category}
+                          productTrial={productTrial}
+                        />
+                      </LegendPriceSubText>
+                    </div>
                   ) : // Show reserved budget breakdown by category with the spans category first if DS was active
                   // Otherwise we show a combined table for both accepted and stored spans
                   subscription?.reservedBudgets &&

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -61,6 +61,7 @@ const EMPTY_STAT_TOTAL = {
 const COLORS = {
   reserved: CHART_PALETTE[5]![0]!,
   ondemand: CHART_PALETTE[5]![1]!,
+  secondary_reserved: CHART_PALETTE[5]![2]!,
 } as const;
 
 function getPercentage(quantity: number, total: number | null) {
@@ -84,11 +85,15 @@ type UsageProps = {
   organization: Organization;
   subscription: Subscription;
   /**
+   * All category totals when needed for reserved budgets.
+   */
+  allTotalsByCategory?: {[key: string]: BillingStatTotal};
+  /**
    * Do not allow the table to be expansded
    */
   disableTable?: boolean;
   /**
-   * Event breakdown totals
+   * Event breakdown totals used by Performance Units
    */
   eventTotals?: {[key: string]: BillingStatTotal};
   /**
@@ -340,6 +345,7 @@ function UsageTotals({
   showEventBreakdown = false,
   disableTable,
   displayMode,
+  allTotalsByCategory,
 }: UsageProps) {
   const [state, setState] = useState<State>({expanded: false, trialButtonBusy: false});
 
@@ -481,7 +487,7 @@ function UsageTotals({
                 {getPlanCategoryName({
                   plan: subscription.planDetails,
                   category,
-                  hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+                  // intentionally not passing hadCustomDynamicSampling as we only show a combined card under "spans" regardless
                 })}{' '}
                 {getTitle()}
                 {productTrial && (
@@ -539,12 +545,38 @@ function UsageTotals({
           <PlanUseBarContainer>
             <PlanUseBarGroup style={{width: `${reservedMaxWidth}%`}}>
               {prepaidPercentUsed >= 1 && (
-                <PlanUseBar
-                  style={{
-                    width: `${prepaidPercentUsed}%`,
-                    backgroundColor: COLORS.reserved,
-                  }}
-                />
+                <Fragment>
+                  {subscription?.reservedBudgets &&
+                  subscription.hadCustomDynamicSampling &&
+                  subscription.reservedBudgets.some(rb => category in rb.categories) ? (
+                    // Show breakdown by category with the spans category first
+                    subscription.reservedBudgets.map(rb =>
+                      Object.entries(rb.categories)
+                        .sort(([cat1], [cat2]) =>
+                          cat1 === category ? -1 : cat2 === category ? 1 : 0
+                        )
+                        .map(([rbCategory, rbInfo]) => (
+                          <PlanUseBar
+                            key={rbCategory}
+                            style={{
+                              width: `${(rbInfo.reservedSpend / rb.reservedBudget) * 100}%`,
+                              backgroundColor:
+                                rbCategory === category
+                                  ? COLORS.reserved
+                                  : COLORS.secondary_reserved,
+                            }}
+                          />
+                        ))
+                    )
+                  ) : (
+                    <PlanUseBar
+                      style={{
+                        width: `${prepaidPercentUsed}%`,
+                        backgroundColor: COLORS.reserved,
+                      }}
+                    />
+                  )}
+                </Fragment>
               )}
               {unusedPrepaidWidth >= 1 && (
                 <PlanUseBar
@@ -580,32 +612,96 @@ function UsageTotals({
           <LegendFooterWrapper>
             <LegendPriceWrapper>
               <LegendContainer>
-                <LegendDot style={{backgroundColor: COLORS.reserved}} />
-
+                {!hasReservedBudget && (
+                  <LegendDot style={{backgroundColor: COLORS.reserved}} />
+                )}
                 {isDisplayingSpend ? (
                   prepaidPrice === 0 ? (
-                    // No reserved price, included in plan
-                    <div>
-                      <LegendTitle>{t('Included in Subscription')}</LegendTitle>
-                      <LegendPriceSubText>
-                        <ReservedUsage
-                          prepaidUsage={prepaidUsage}
-                          reserved={reserved}
-                          category={category}
-                          productTrial={productTrial}
-                        />
-                      </LegendPriceSubText>
-                    </div>
+                    !hasReservedBudget && (
+                      <div>
+                        <LegendTitle>{t('Included in Subscription')}</LegendTitle>
+                        <LegendPriceSubText>
+                          <ReservedUsage
+                            prepaidUsage={prepaidUsage}
+                            reserved={reserved}
+                            category={category}
+                            productTrial={productTrial}
+                          />
+                        </LegendPriceSubText>
+                      </div>
+                    )
+                  ) : // Show reserved budget breakdown by category with the spans category first if DS was active
+                  // Otherwise we show a combined table for both accepted and stored spans
+                  subscription?.reservedBudgets &&
+                    subscription.hadCustomDynamicSampling ? (
+                    subscription.reservedBudgets.map(rb =>
+                      Object.entries(rb.categories)
+                        .sort(([cat1], [cat2]) =>
+                          // Sort to put the matching category first
+                          cat1 === category ? -1 : cat2 === category ? 1 : 0
+                        )
+                        .map(([categoryKey]) => (
+                          <Fragment key={categoryKey}>
+                            <LegendBudgetContainer>
+                              <LegendDot
+                                style={{
+                                  backgroundColor:
+                                    categoryKey === category
+                                      ? COLORS.reserved
+                                      : COLORS.secondary_reserved,
+                                }}
+                              />
+                              <LegendTitle>
+                                {getPlanCategoryName({
+                                  plan: subscription.planDetails,
+                                  category: categoryKey,
+                                  hadCustomDynamicSampling:
+                                    subscription.hadCustomDynamicSampling,
+                                  title: true,
+                                  capitalize: false,
+                                })}
+                                {t(' Included in Subscription')}
+                              </LegendTitle>
+                            </LegendBudgetContainer>
+
+                            <LegendPriceSubText>
+                              <div>
+                                <LegendPrice>
+                                  {formatPercentage(
+                                    Math.round(
+                                      ((subscription.reservedBudgets?.[0]?.categories?.[
+                                        categoryKey as keyof (typeof subscription.reservedBudgets)[0]['categories']
+                                      ]?.reservedSpend ?? 0) /
+                                        (subscription.reservedBudgets?.[0]
+                                          ?.reservedBudget ?? 1)) *
+                                        100
+                                    ) / 100
+                                  )}{' '}
+                                  of{' '}
+                                  {prepaidPrice === 0
+                                    ? reserved
+                                    : formatCurrency(
+                                        roundUpToNearestDollar(prepaidPrice)
+                                      )}
+                                </LegendPrice>
+                              </div>
+                            </LegendPriceSubText>
+                          </Fragment>
+                        ))
+                    )
                   ) : (
-                    <div>
-                      <LegendTitle>{t('Included in Subscription')}</LegendTitle>
-                      <LegendPrice>
-                        {formatPercentage(prepaidPercentUsed / 100)} of{' '}
-                        {prepaidPrice === 0
-                          ? reserved
-                          : formatCurrency(roundUpToNearestDollar(prepaidPrice))}
-                      </LegendPrice>
-                    </div>
+                    <LegendContainer>
+                      <LegendDot style={{backgroundColor: COLORS.reserved}} />
+                      <div>
+                        <LegendTitle>{t('Included in Subscription')}</LegendTitle>
+                        <LegendPrice>
+                          {formatPercentage(prepaidPercentUsed / 100)} of{' '}
+                          {prepaidPrice === 0
+                            ? reserved
+                            : formatCurrency(roundUpToNearestDollar(prepaidPrice))}
+                        </LegendPrice>
+                      </div>
+                    </LegendContainer>
                   )
                 ) : (
                   <div>
@@ -695,6 +791,23 @@ function UsageTotals({
             totals={totals}
             subscription={subscription}
           />
+          {/* Show additional tables for shared reserved budget categories */}
+          {hasReservedBudget &&
+            subscription.hadCustomDynamicSampling &&
+            allTotalsByCategory &&
+            subscription.reservedBudgets?.map(budget =>
+              Object.entries(budget.categories)
+                // Filter out the current category since it's already shown from logic above
+                .filter(([categoryKey]) => categoryKey !== category)
+                .map(([categoryKey]) => (
+                  <UsageTotalsTable
+                    key={categoryKey}
+                    category={categoryKey}
+                    totals={allTotalsByCategory?.[categoryKey] ?? EMPTY_STAT_TOTAL}
+                    subscription={subscription}
+                  />
+                ))
+            )}
 
           {showEventBreakdown &&
             Object.entries(eventTotals).map(([key, eventTotal]) => {
@@ -802,6 +915,7 @@ const LegendContainer = styled('div')`
 const LegendTitle = styled('div')`
   font-weight: 700;
   font-size: ${p => p.theme.fontSizeSmall};
+  white-space: nowrap;
 `;
 
 const LegendPrice = styled('div')`
@@ -812,6 +926,12 @@ const LegendPriceSubText = styled(LegendPrice)`
   color: ${p => p.theme.subText};
 `;
 
+const LegendBudgetContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  white-space: nowrap;
+`;
 const PlanUseBarContainer = styled('div')`
   display: flex;
   height: 16px;


### PR DESCRIPTION
Combines the usage details for Reserved Budget categories into one usage card. If dynamic sampling is active for the current usage period, it will show a breakdown by Accepted Spans and Stored Spans. If not, it will combine the two categories into one set of totals. 

When dynamic sampling is active for the usage period:
![Screenshot 2025-03-13 at 10 56 40 AM](https://github.com/user-attachments/assets/12ba7a9f-6661-4049-b0b8-64cd58e574fc)
![Screenshot 2025-03-13 at 10 56 54 AM](https://github.com/user-attachments/assets/bce67998-a360-4906-88b9-984b06702757)


When dynamic sampling is not active for the usage period:
![Screenshot 2025-03-12 at 6 22 25 PM](https://github.com/user-attachments/assets/5cfd403f-452b-4076-9aea-649addd8519a)
![Screenshot 2025-03-12 at 6 22 32 PM](https://github.com/user-attachments/assets/bf3f2f1d-0ac9-4109-bdcb-b109a951b0d8)
