### PR TITLE
fix(onboarding): Do not display selection styles in the new changes

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -333,7 +333,7 @@ const PlatformCard = styled(
   cursor: pointer;
 
   ${p =>
-    p.selected && p.visibleSelection && `background: ${p.theme.alert.info.background};`}
+    p.selected && p.visibleSelection && `background: ${p.theme.alert.info.backgroundLight};`}
 
   &:hover {
     background: ${p => p.theme.alert.muted.backgroundLight};

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -333,7 +333,9 @@ const PlatformCard = styled(
   cursor: pointer;
 
   ${p =>
-    p.selected && p.visibleSelection && `background: ${p.theme.alert.info.backgroundLight};`}
+    p.selected &&
+    p.visibleSelection &&
+    `background: ${p.theme.alert.info.backgroundLight};`}
 
   &:hover {
     background: ${p => p.theme.alert.muted.backgroundLight};

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -59,6 +59,10 @@ interface PlatformPickerProps {
   showFilterBar?: boolean;
   showOther?: boolean;
   source?: string;
+  /**
+   * When `false`, hides the close button and does not display a custom background color.
+   */
+  visibleSelection?: boolean;
 }
 
 type State = {
@@ -69,6 +73,7 @@ type State = {
 class PlatformPicker extends Component<PlatformPickerProps, State> {
   static defaultProps = {
     showOther: true,
+    visibleSelection: true,
   };
 
   state: State = {
@@ -192,6 +197,7 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
           {platformList.map(platform => {
             return (
               <PlatformCard
+                visibleSelection={this.props.visibleSelection}
                 data-test-id={`platform-${platform.id}`}
                 key={platform.id}
                 platform={platform}
@@ -295,35 +301,39 @@ const ClearButton = styled(Button)`
   color: ${p => p.theme.textColor};
 `;
 
-const PlatformCard = styled(({platform, selected, onClear, ...props}: any) => (
-  <div {...props}>
-    <StyledPlatformIcon
-      platform={platform.id}
-      size={56}
-      radius={5}
-      withLanguageIcon
-      format="lg"
-    />
-    <h3>{platform.name}</h3>
-    {selected && (
-      <ClearButton
-        icon={<IconClose isCircled />}
-        borderless
-        size="xs"
-        onClick={onClear}
-        aria-label={t('Clear')}
+const PlatformCard = styled(
+  ({platform, selected, visibleSelection, onClear, ...props}: any) => (
+    <div {...props}>
+      <StyledPlatformIcon
+        platform={platform.id}
+        size={56}
+        radius={5}
+        withLanguageIcon
+        format="lg"
       />
-    )}
-  </div>
-))`
+      <h3>{platform.name}</h3>
+      {selected && visibleSelection && (
+        <ClearButton
+          icon={<IconClose isCircled />}
+          borderless
+          size="xs"
+          onClick={onClear}
+          aria-label={t('Clear')}
+        />
+      )}
+    </div>
+  )
+)`
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 0 0 14px;
   border-radius: 4px;
-  background: ${p => p.selected && p.theme.alert.info.backgroundLight};
   cursor: pointer;
+
+  ${p =>
+    p.selected && p.visibleSelection && `background: ${p.theme.alert.info.background};`}
 
   &:hover {
     background: ${p => p.theme.alert.muted.backgroundLight};

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -251,6 +251,18 @@ function Onboarding(props: Props) {
         ...onboardingContext.data,
         projects: currentProjects,
       });
+      if (docsOnPlatformClickEnabled) {
+        onboardingContext.setData({
+          ...onboardingContext.data,
+          projects: currentProjects,
+          selectedSDK: undefined,
+        });
+      } else {
+        onboardingContext.setData({
+          ...onboardingContext.data,
+          projects: currentProjects,
+        });
+      }
       handleXhrErrorResponse('Unable to delete project in onboarding', error);
       // we don't give the user any feedback regarding this error as this shall be silent
     }

--- a/static/app/views/onboarding/platformSelection.tsx
+++ b/static/app/views/onboarding/platformSelection.tsx
@@ -59,6 +59,7 @@ export function PlatformSelection(props: StepProps) {
         </p>
         <PlatformPicker
           noAutoFilter
+          visibleSelection={!docsOnPlatformClickEnabled}
           source="targeted-onboarding"
           platform={onboardingContext.data.selectedSDK?.key}
           defaultCategory={onboardingContext.data.selectedSDK?.category}


### PR DESCRIPTION
**Problem**

As part of the new onboarding changes ([see](https://github.com/getsentry/sentry/pull/86777)), we no longer want to display a 'close' button when a platform is selected. This is because by clicking on the platform, we directly load the getting started docs, and users can then not click on the close button. Currently users can see it for a few seconds, until the docs are loaded, and we redirect them to the new page.


https://github.com/user-attachments/assets/b587d756-6989-4371-9f5e-0fce7cfd0466

**Solution**
A new prop, visibleSelection, has been added to the platformPicker component. By default, this prop is set to true, ensuring that existing functionality remains unchanged. When enabled, it disables the close button and background styles for the new onboarding experience. 


**Note**
These changes will only take effect in the onboarding if the feature flag `onboarding-load-docs-on-platform-click-and-silent-delete-on-back` is enabled.