### PR TITLE
fix(releases): Apple-iOS uses mobile session terms

### DIFF
--- a/static/app/views/releases/utils/sessionTerm.spec.tsx
+++ b/static/app/views/releases/utils/sessionTerm.spec.tsx
@@ -655,7 +655,7 @@ describe('Release Health Session Term', function () {
       SessionTerm.CRASHED,
       'apple-ios'
     );
-    expect(crashedSessionTerm).toEqual(desktopTermDescriptions.crashed);
+    expect(crashedSessionTerm).toBe('An error that resulted in the application crashing');
 
     // Crash Free Users
     const crashFreeUsersSessionTerm = getSessionTermDescription(
@@ -676,28 +676,28 @@ describe('Release Health Session Term', function () {
       SessionTerm.ABNORMAL,
       'apple-ios'
     );
-    expect(abnormalSessionTerm).toEqual(desktopTermDescriptions.abnormal);
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
 
     // Healthy
     const healthySessionTerm = getSessionTermDescription(
       SessionTerm.HEALTHY,
       'apple-ios'
     );
-    expect(healthySessionTerm).toEqual(desktopTermDescriptions.healthy);
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
 
     // Errored
     const erroredSessionTerm = getSessionTermDescription(
       SessionTerm.ERRORED,
       'apple-ios'
     );
-    expect(erroredSessionTerm).toEqual(desktopTermDescriptions.errored);
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
 
     // Unhandled
     const unhandledSessionTerm = getSessionTermDescription(
       SessionTerm.UNHANDLED,
       'apple-ios'
     );
-    expect(unhandledSessionTerm).toEqual(desktopTermDescriptions.unhandled);
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
   });
 
   it('minidump terms', function () {

--- a/static/app/views/releases/utils/sessionTerm.tsx
+++ b/static/app/views/releases/utils/sessionTerm.tsx
@@ -87,7 +87,6 @@ function getTermDescriptions(platform: PlatformKey | null) {
   const technology =
     platform === 'react-native' ||
     platform === 'java-spring' ||
-    platform === 'apple-ios' ||
     platform === 'dotnet-aspnetcore'
       ? platform
       : platform?.split('-')[0];
@@ -119,7 +118,6 @@ function getTermDescriptions(platform: PlatformKey | null) {
           'An unhandled exception that resulted in the application crashing'
         ),
       };
-
     case 'apple': {
       return {
         ...commonTermsDescription,
@@ -142,7 +140,6 @@ function getTermDescriptions(platform: PlatformKey | null) {
         [SessionTerm.UNHANDLED]:
           "An error was captured by the global 'onerror' or 'onunhandledrejection' handler.",
       };
-    case 'apple-ios':
     case 'minidump':
     case 'native':
     case 'nintendo-switch':


### PR DESCRIPTION
Apple-iOS used desktop TermDescriptions, but instead, it should use the ones from mobile to align with Android, Cordova, React-Native, and Flutter. Still, we keep the different session term for crashed, cause for Apple platforms you usually have errors and not exceptions.

This came up while working on app hang rate for Apple projects https://github.com/getsentry/sentry/issues/86106.