### PR TITLE
ref(inbound-filters): Remove option to control generic inbound filters

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1190,9 +1190,6 @@ register("relay.metric-bucket-distribution-encodings", default={}, flags=FLAG_AU
 # Controls the rollout rate in percent (`0.0` to `1.0`) for metric stats.
 register("relay.metric-stats.rollout-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Controls whether generic inbound filters are sent to Relay.
-register("relay.emit-generic-inbound-filters", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -158,18 +158,17 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
     if csp_disallowed_sources:
         filter_settings["csp"] = {"disallowedSources": csp_disallowed_sources}
 
-    if options.get("relay.emit-generic-inbound-filters"):
-        try:
-            # At the end we compute the generic inbound filters, which are inbound filters expressible with a
-            # conditional DSL that Relay understands.
-            generic_filters = get_generic_filters(project)
-            if generic_filters is not None:
-                filter_settings["generic"] = generic_filters
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-            logger.exception(
-                "Exception while building Relay project config: error building generic filters"
-            )
+    try:
+        # At the end we compute the generic inbound filters, which are inbound filters expressible with a
+        # conditional DSL that Relay understands.
+        generic_filters = get_generic_filters(project)
+        if generic_filters is not None:
+            filter_settings["generic"] = generic_filters
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        logger.exception(
+            "Exception while building Relay project config: error building generic filters"
+        )
 
     return filter_settings
 

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-12T13:41:06.264032+00:00'
+created: '2025-03-13T12:25:04.085418+00:00'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -78,6 +78,53 @@ config:
       - hoholikik.club
       - smartlink.cool
       - promfflinkdev.com
+    generic:
+      filters:
+      - condition:
+          inner:
+            inner:
+            - inner:
+              - name: ty
+                op: glob
+                value:
+                - ChunkLoadError
+              - name: value
+                op: glob
+                value:
+                - Loading chunk *
+              op: and
+            - inner:
+              - name: ty
+                op: glob
+                value:
+                - '*Uncaught *'
+              - name: value
+                op: glob
+                value:
+                - 'ChunkLoadError: Loading chunk *'
+              op: and
+            op: or
+          name: event.exception.values
+          op: any
+        id: chunk-load-error
+        isEnabled: true
+      - condition:
+          inner:
+            inner:
+            - name: value
+              op: glob
+              value:
+              - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
+            - name: value
+              op: glob
+              value:
+              - '*https://react.dev/errors/{418,419,422,423,425}*'
+            op: or
+          name: event.exception.values
+          op: any
+        id: react-hydration-errors
+        isEnabled: true
+      version: 1
     ignoreTransactions:
       isEnabled: true
       patterns:

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1217,7 +1217,6 @@ def test_project_config_cardinality_limits_organization_options_override_options
 
 @django_db_all
 @region_silo_test
-@override_options({"relay.emit-generic-inbound-filters": True})
 def test_project_config_with_generic_filters(default_project):
     config = get_project_config(default_project).to_dict()
     _validate_project_config(config["config"])


### PR DESCRIPTION
This PR removes the `relay.emit-generic-inbound-filters` option, which was controlling whether generic inbound filters were emitted. It is being removed now since we have fully adopted the new mechanism for the past few months, and the flag, when set to `False`, was disabling chunk load error and hydration error filters for self-hosted customers.