### PR TITLE
fix(timeseries-visualization): Percentage y axis max

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
@@ -35,8 +35,19 @@ export function TimeSeriesWidgetYAxis(
         // the Y axis will be from 0% to 120%, instead of from 0% to 100%. To
         // prevent this case, if the maximum value is _just slightly above 1_,
         // force it to be exactly 1. Only for percentages!
-        if (yAxisFieldType === 'percentage' && value.max - 1 < Y_AXIS_INTEGER_TOLERANCE) {
+        if (
+          yAxisFieldType === 'percentage' &&
+          value.max > 1 &&
+          value.max - 1 < Y_AXIS_INTEGER_TOLERANCE
+        ) {
           return 1;
+        }
+
+        // We show at most 2 decimal places for percentages (e.g. 0.01%).
+        // If the maximum value is _just slightly above 0_, force it to be
+        // exactly 0.01% to avoid showing only 0% on the Y axis.
+        if (yAxisFieldType === 'percentage' && value.max < 0.001) {
+          return 0.001;
         }
 
         return null;


### PR DESCRIPTION
### Problem
According to the comment, we only want to force the yAxis max to be 1 if the max value is slightly above 1 (defined by a threshold). The current implementation does not check if the max value is bigger than null, therefore forcing 0 - 1 as the range for most charts using percentage.

![Screenshot 2025-03-13 at 14 00 14](https://github.com/user-attachments/assets/cce51740-b802-467c-a459-c18dbf2907d4)

### Solution

Check if the max value is actually > 1.

![Screenshot 2025-03-13 at 14 01 35](https://github.com/user-attachments/assets/b6b31e80-986d-4b7d-bda2-23c80a9b71d0)

Additionally, I added `0.001` as the smallest possible maximum to avoid that all axis ticks are formatted as `0%` for very small values.
