### PR TITLE
fix(widget-viewer): Fetch correct widget using the URL param

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -817,7 +817,7 @@ describe('Dashboards > Detail', function () {
       expect(window.confirm).not.toHaveBeenCalled();
     });
 
-    it('opens the widget viewer modal using the widget id specified in the url', async () => {
+    it('opens the widget viewer modal using the widget index specified in the url', async () => {
       const router = RouterFixture({
         location: {...initialData.router.location, pathname: '/widget/123/'},
         params: {orgId: 'org-slug', dashboardId: '1'},
@@ -848,9 +848,9 @@ describe('Dashboards > Detail', function () {
         <ViewEditDashboard
           {...RouteComponentPropsFixture()}
           organization={initialData.organization}
-          params={{orgId: 'org-slug', dashboardId: '1', widgetId: '1'}}
+          params={{orgId: 'org-slug', dashboardId: '1', widgetId: '0'}}
           router={initialData.router}
-          location={{...initialData.router.location, pathname: '/widget/123/'}}
+          location={{...initialData.router.location, pathname: '/widget/0/'}}
         >
           {null}
         </ViewEditDashboard>,

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -308,18 +308,10 @@ class DashboardDetail extends Component<Props, State> {
       confidence,
       sampleCount,
       isSampled,
+      modifiedDashboard,
     } = this.state;
     if (isWidgetViewerPath(location.pathname)) {
-      const widget =
-        defined(widgetId) &&
-        (dashboard.widgets.find(({id}) => {
-          // This ternary exists because widgetId is in some places typed as string, while
-          // in other cases it is typed as number. Instead of changing the type everywhere,
-          // we check for both cases at runtime as I am not sure which is the correct type.
-          return typeof widgetId === 'number' ? id === String(widgetId) : id === widgetId;
-        }) ??
-          // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
-          dashboard.widgets[widgetId]);
+      const widget = (modifiedDashboard ?? dashboard).widgets[Number(widgetId)];
       if (widget) {
         openWidgetViewerModal({
           organization,


### PR DESCRIPTION
The URL param `widgetId` is actually never the real ID of the widget, but rather the index. The way we were looking up widgets for the widget viewer posed two problems:

1. The way we were looking up the widget (by `id === widgetId`) would fail 99% of the time because IDs are incremented globally, so it would only ever work on the first widgets ever
2. We maintain a dirty state of a dashboard, and the code was not accounting for this so while a request was in flight to update the dashboard, a user could not open the widget viewer for a new widget. They would get an error toast saying the widget was not found.

I fixed this by using the `widgetId` as an index and biasing towards a `modifiedDashboard` if it exists. In the future we should refactor the routes so `widgetId` uses `widgetIndex` which is something we already seem to use for widget builder. We could argue that we should use IDs sometime but we'll need to account for the edit state where widgets don't have IDs yet