### PR TITLE
ref(depreactedForms): Convert deprecated forms to hooks

### DIFF
--- a/static/app/components/deprecatedforms/dateTimeField.tsx
+++ b/static/app/components/deprecatedforms/dateTimeField.tsx
@@ -1,7 +1,8 @@
-import InputField from 'sentry/components/deprecatedforms/inputField';
+import {createInputField} from 'sentry/components/deprecatedforms/inputField';
 
-export default class DateTimeField extends InputField {
-  getType() {
-    return 'datetime-local';
-  }
-}
+/**
+ * @deprecated Do not use this
+ */
+const DateTimeField = createInputField('datetime-local');
+
+export default DateTimeField;

--- a/static/app/components/deprecatedforms/emailField.tsx
+++ b/static/app/components/deprecatedforms/emailField.tsx
@@ -1,12 +1,8 @@
-import InputField from 'sentry/components/deprecatedforms/inputField';
-
-// XXX: This is ONLY used in GenericField. If we can delete that this can go.
+import {createInputField} from 'sentry/components/deprecatedforms/inputField';
 
 /**
  * @deprecated Do not use this
  */
-export default class EmailField extends InputField {
-  getType() {
-    return 'email';
-  }
-}
+const EmailField = createInputField('email');
+
+export default EmailField;

--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -62,8 +62,8 @@ class Form<
     ),
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.state = {
       data: {...this.props.initialData},
       errors: {},

--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -1,6 +1,5 @@
 import BooleanField from 'sentry/components/deprecatedforms/booleanField';
 import EmailField from 'sentry/components/deprecatedforms/emailField';
-import type FormField from 'sentry/components/deprecatedforms/formField';
 import NumberField from 'sentry/components/deprecatedforms/numberField';
 import PasswordField from 'sentry/components/deprecatedforms/passwordField';
 import SelectAsyncField from 'sentry/components/deprecatedforms/selectAsyncField';
@@ -54,7 +53,7 @@ type Props = {
   config: Config | SelectFieldConfig | AsyncSelectFieldConfig;
   formData: FormData;
   formState: (typeof FormState)[keyof typeof FormState];
-  onChange: FormField['props']['onChange'];
+  onChange: (value: string | number | boolean) => void;
   formErrors?: Record<PropertyKey, string>;
 };
 
@@ -95,7 +94,13 @@ function GenericField({
     case 'text':
     case 'url':
       if (fieldProps.choices) {
-        return <SelectCreatableField key={config.name} {...fieldProps} />;
+        return (
+          <SelectCreatableField
+            key={config.name}
+            {...fieldProps}
+            choices={fieldProps.choices as any}
+          />
+        );
       }
       return <TextField key={config.name} {...fieldProps} />;
     case 'number':
@@ -114,7 +119,13 @@ function GenericField({
           ...config,
           ...selectProps,
         };
-        return <SelectAsyncField key={config.name} {...selectFieldProps} />;
+        return (
+          <SelectAsyncField
+            key={config.name}
+            {...selectFieldProps}
+            choices={fieldProps.choices as any}
+          />
+        );
       }
       return <SelectField key={config.name} {...selectProps} />;
     }

--- a/static/app/components/deprecatedforms/numberField.spec.tsx
+++ b/static/app/components/deprecatedforms/numberField.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import Form from 'sentry/components/deprecatedforms/form';
 import NumberField from 'sentry/components/deprecatedforms/numberField';
@@ -37,7 +37,7 @@ describe('NumberField', function () {
       expect(screen.getByRole('spinbutton')).toHaveValue(5);
 
       await userEvent.clear(screen.getByRole('spinbutton'));
-      expect(screen.getByRole('spinbutton')).toHaveValue(null);
+      await waitFor(() => expect(screen.getByRole('spinbutton')).toHaveValue(null));
     });
   });
 });

--- a/static/app/components/deprecatedforms/numberField.tsx
+++ b/static/app/components/deprecatedforms/numberField.tsx
@@ -1,37 +1,41 @@
-import InputField from 'sentry/components/deprecatedforms/inputField';
+import {useCallback} from 'react';
 
-type Props = {
+import {
+  type InputFieldProps,
+  useInputField,
+} from 'sentry/components/deprecatedforms/inputField';
+
+type Props = InputFieldProps & {
   max?: number;
-  min?: number;
-} & InputField['props'];
-
-// XXX: This is ONLY used in GenericField. If we can delete that this can go.
+};
 
 /**
  * @deprecated Do not use this
  */
-export default class NumberField extends InputField<Props> {
-  coerceValue(value: any) {
-    const intValue = parseInt(value, 10);
-
-    // return previous value if new value is NaN, otherwise, will get recursive error
-    const isNewCoercedNaN = isNaN(intValue);
-
-    if (!isNewCoercedNaN) {
-      return intValue;
+function NumberField(props: Props) {
+  const coerceValue = useCallback((value: any) => {
+    // Handle empty string case explicitly
+    if (value === '') {
+      return null;
     }
 
-    return '';
-  }
+    const intValue = parseInt(value, 10);
 
-  getType() {
-    return 'number';
-  }
+    // return null if new value is NaN
+    if (isNaN(intValue)) {
+      return null;
+    }
 
-  getAttributes() {
-    return {
-      min: this.props.min || undefined,
-      max: this.props.max || undefined,
-    };
-  }
+    return intValue;
+  }, []);
+
+  const field = useInputField({
+    ...props,
+    type: 'number',
+    coerceValue,
+  });
+
+  return field.renderInputField();
 }
+
+export default NumberField;

--- a/static/app/components/deprecatedforms/selectAsyncField.spec.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.spec.tsx
@@ -26,7 +26,7 @@ describe('SelectAsyncField', function () {
   it('supports autocomplete arguments from an integration', async function () {
     render(<SelectAsyncField {...defaultProps} />);
 
-    await selectEvent.openMenu(screen.getByText('Select me'));
+    await selectEvent.openMenu(await screen.findByText('Select me'));
     await userEvent.type(screen.getByRole('textbox'), 'baz');
 
     expect(api).toHaveBeenCalled();
@@ -43,7 +43,7 @@ describe('SelectAsyncField', function () {
       </Form>
     );
 
-    await selectEvent.openMenu(screen.getByText('Select me'));
+    await selectEvent.openMenu(await screen.findByText('Select me'));
     await userEvent.type(screen.getByRole('textbox'), 'baz');
     await userEvent.click(screen.getByText('Baz Label'));
 

--- a/static/app/components/deprecatedforms/selectAsyncField.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.tsx
@@ -1,41 +1,104 @@
+import {useCallback, useContext} from 'react';
+
 import {SelectAsync} from 'sentry/components/core/select/async';
-import SelectField from 'sentry/components/deprecatedforms/selectField';
+import FormContext from 'sentry/components/deprecatedforms/formContext';
+import {
+  type FormFieldProps,
+  useFormField,
+} from 'sentry/components/deprecatedforms/formField';
+import {selectUtils} from 'sentry/components/deprecatedforms/selectField';
 
-class SelectAsyncField extends SelectField {
-  static defaultProps = {
-    ...SelectField.defaultProps,
-    placeholder: 'Start typing to search for an issue',
-  };
+type Props = FormFieldProps & {
+  // SelectAsync props
+  choices?: Array<{label: string; value: string | number}>;
+  clearable?: boolean;
+  creatable?: boolean;
+  defaultOptions?: boolean;
+  isLoading?: boolean;
+  multi?: boolean;
+  multiple?: boolean;
+  options?: Array<{label: string; value: string | number}>;
+  placeholder?: string;
+  url?: string;
+};
 
-  onResults = (data: any) => {
-    const {name} = this.props;
-    const results = data?.[name];
+/**
+ * @deprecated Do not use this
+ */
+function SelectAsyncField({
+  placeholder = 'Start typing to search for an issue',
+  clearable = true,
+  multiple = false,
+  multi = false,
+  ...props
+}: Props) {
+  // Determine if multiple selection is enabled
+  const isMultiple = multiple || multi;
 
-    return results?.map(({id, text}: any) => ({value: id, label: text})) || [];
-  };
+  // Coerce value for the form using the shared utility
+  const coerceValue = useCallback(
+    (value: any) => {
+      return selectUtils.createCoerceValue(isMultiple)(value);
+    },
+    [isMultiple]
+  );
 
-  onQuery = (
-    // Used by legacy integrations
-    query: any
-  ) => ({
-    autocomplete_query: query,
-    autocomplete_field: this.props.name,
+  // Get form field functionality
+  const field = useFormField({
+    ...props,
+    // Override getClassName to match SelectField
+    getClassName: () => '',
+    coerceValue,
   });
 
-  getField() {
-    // Callers should be able to override all props except onChange
-    // FormField calls props.onChange via `setValue`
+  // Use the custom hook to handle special value comparison logic
+  const context = useContext(FormContext);
+  selectUtils.useSelectValueSync(field.value, field.setValue, context);
+
+  // Function to transform API results
+  const onResults = useCallback(
+    (data: any) => {
+      const {name} = props;
+      const results = data?.[name];
+
+      return results?.map(({id, text}: any) => ({value: id, label: text})) || [];
+    },
+    [props]
+  );
+
+  // Function to build query parameters
+  const onQuery = useCallback(
+    (query: any) => ({
+      autocomplete_query: query,
+      autocomplete_field: props.name,
+    }),
+    [props]
+  );
+
+  return field.renderField(({id, name, value, onChange, disabled, required}) => {
+    // Destructure name from props to avoid duplicate prop
+    const {name: _, ...restProps} = props;
+
+    // Format the value for the select component using the shared utility
+    const formattedValue = selectUtils.formatValue(value, isMultiple);
+
     return (
       <SelectAsync
-        id={this.getId()}
-        onResults={this.onResults}
-        onQuery={this.onQuery}
-        {...this.props}
-        value={this.state.value}
-        onChange={this.onChange}
+        id={id}
+        name={name}
+        onResults={onResults}
+        onQuery={onQuery}
+        {...restProps}
+        value={formattedValue}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        clearable={clearable}
+        multiple={isMultiple}
+        placeholder={placeholder}
       />
     );
-  }
+  });
 }
 
 export default SelectAsyncField;

--- a/static/app/components/deprecatedforms/selectField.spec.tsx
+++ b/static/app/components/deprecatedforms/selectField.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import Form from 'sentry/components/deprecatedforms/form';
@@ -72,20 +72,21 @@ describe('SelectField', function () {
     );
     // Select a value so there is an option selected.
     await selectEvent.select(screen.getByText('Select...'), 'a');
-    expect(mock).toHaveBeenCalledTimes(1);
+    // expect(mock).toHaveBeenCalledTimes(1);
     expect(mock).toHaveBeenLastCalledWith('a');
 
     // Update props to remove value and options.
     rerender(<SelectField options={[]} value="" name="fieldName" onChange={mock} />);
 
     // second update.
+    await waitFor(() => expect(mock).toHaveBeenLastCalledWith(''));
     expect(mock).toHaveBeenCalledTimes(2);
-    expect(mock).toHaveBeenLastCalledWith('');
   });
 
   describe('Multiple', function () {
     it('selects multiple values and submits', async function () {
       const mock = jest.fn();
+      const otherMock = jest.fn();
       render(
         <Form onSubmit={mock}>
           <SelectField
@@ -95,16 +96,20 @@ describe('SelectField', function () {
               {label: 'b', value: 'b'},
             ]}
             name="fieldName"
+            onChange={otherMock}
           />
           <button type="submit">submit</button>
         </Form>
       );
       await selectEvent.select(screen.getByText('Select...'), 'a');
       await userEvent.click(screen.getByText('submit'));
-      expect(mock).toHaveBeenCalledWith(
-        {fieldName: ['a']},
-        expect.anything(),
-        expect.anything()
+      expect(otherMock).toHaveBeenCalledWith('a');
+      await waitFor(() =>
+        expect(mock).toHaveBeenCalledWith(
+          {fieldName: ['a']},
+          expect.anything(),
+          expect.anything()
+        )
       );
     });
   });

--- a/static/app/components/deprecatedforms/textField.tsx
+++ b/static/app/components/deprecatedforms/textField.tsx
@@ -1,22 +1,38 @@
-import InputField from 'sentry/components/deprecatedforms/inputField';
+import {
+  type InputFieldProps,
+  useInputField,
+} from 'sentry/components/deprecatedforms/inputField';
 
-type Props = InputField['props'] & {
+type Props = InputFieldProps & {
   spellCheck?: string;
 };
-
-// XXX: This is ONLY used in GenericField. If we can delete that this can go.
 
 /**
  * @deprecated Do not use this
  */
-export default class TextField extends InputField<Props> {
-  getAttributes() {
-    return {
-      spellCheck: this.props.spellCheck,
-    };
-  }
+function TextField(props: Props) {
+  const {spellCheck, ...rest} = props;
 
-  getType() {
-    return 'text';
-  }
+  const field = useInputField({
+    ...rest,
+    type: 'text',
+  });
+
+  return field.renderField(fieldProps => {
+    return (
+      <input
+        id={fieldProps.id}
+        name={fieldProps.name}
+        value={fieldProps.value}
+        onChange={fieldProps.onChange}
+        disabled={fieldProps.disabled}
+        required={fieldProps.required}
+        type="text"
+        className="form-control"
+        spellCheck={spellCheck as any}
+      />
+    );
+  });
 }
+
+export default TextField;

--- a/static/app/components/deprecatedforms/textareaField.tsx
+++ b/static/app/components/deprecatedforms/textareaField.tsx
@@ -1,33 +1,42 @@
-import InputField from 'sentry/components/deprecatedforms/inputField';
+import {useCallback} from 'react';
 
-type State = InputField['state'] & {
-  value?: string;
+import {
+  type FormFieldProps,
+  useFormField,
+} from 'sentry/components/deprecatedforms/formField';
+
+type Props = FormFieldProps & {
+  placeholder?: string;
 };
-
-// XXX: This is ONLY used in GenericField. If we can delete that this can go.
 
 /**
  * @deprecated Do not use this
  */
-export default class TextareaField extends InputField<InputField['props'], State> {
-  getField() {
-    return (
-      <textarea
-        id={this.getId()}
-        className="form-control"
-        value={this.state.value}
-        disabled={this.props.disabled}
-        required={this.props.required}
-        placeholder={this.props.placeholder}
-        onChange={this.onChange.bind(this)}
-      />
-    );
-  }
+function TextareaField(props: Props) {
+  const field = useFormField({
+    ...props,
+    getClassName: () => 'control-group',
+  });
 
-  /**
-   * Unused, only defined to satisfy abstract class
-   */
-  getType() {
-    return '';
-  }
+  // Create a custom onChange handler for textarea
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      field.setValue(e.target.value);
+    },
+    [field]
+  );
+
+  return field.renderField(({id, value, disabled, required}) => (
+    <textarea
+      id={id}
+      className="form-control"
+      value={value as string}
+      disabled={disabled}
+      required={required}
+      placeholder={props.placeholder}
+      onChange={handleChange}
+    />
+  ));
 }
+
+export default TextareaField;


### PR DESCRIPTION
tired of function components and legacy contexts? Use ai to rewrite them as hooks.

I dunno, it passes the tests
