### PR TITLE
fix(dashboards): Prevent `TimeSeriesWidgetVisualization` crash if axis meta is missing

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -182,7 +182,17 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const fieldTypeCounts = mapValues(plottablesByType, plottables => plottables.length);
 
   // Sort the field types by how many plottables use each one
-  const axisTypes = (Object.keys(fieldTypeCounts) as AggregationOutputType[])
+  const axisTypes = (
+    Object.keys(fieldTypeCounts).filter(key => {
+      // JavaScript objects cannot have `undefined` or `null` as keys. lodash
+      // `groupBy` casts those cases to strings. This is _very_ rare, since it
+      // indicates a backend failure to provide the correct data type, but it
+      // happens sometimes. Filter those out. It would be cleaner to use a type
+      // predicate here, but consistently enforcing plottable values is a lot of
+      // work
+      return !['undefined', 'null'].includes(key);
+    }) as AggregationOutputType[]
+  )
     .toSorted(
       // `dataTypes` is extracted from `dataTypeCounts`, so the counts are guaranteed to exist
       (a, b) => fieldTypeCounts[b]! - fieldTypeCounts[a]!


### PR DESCRIPTION
In rare cases (e.g., bad sets of feature flags) time series data might have malformed `meta`. This causes `TimeSeriesWidgetVisualization` to get confused and crash.

This PR adds a bit of error handling for that case, by making sure that `null` and `undefined` types are handled. There's a cleaner solution out there, but this is a hotfix. I will return to improving this when we switch to an updated `TimeSeries` format.
