### PR TITLE
fix(sentry apps): Remove extraneous wrapping of response dict

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -121,7 +121,7 @@ class IntegrationPlatformEndpoint(Endpoint):
 
         elif isinstance(exception, SentryAppSentryError):
             return Response(
-                {exception.to_public_dict()},
+                exception.to_public_dict(),
                 status=500,
             )
         # If not an audited sentry app error then default to using default error handler


### PR DESCRIPTION
For some reason we're wrapping our response dict again, which causes a `TypeError` because python thinks we're trying to cast this dict into a set.

Fixes: https://sentry.sentry.io/issues/6390248938/?project=1&query=issue.category%3Aerror%20assigned_or_suggested%3Amy_teams%20firstSeen%3A-7d%20is%3Aunresolved&referrer=issue-stream&sort=date&stream_index=1