### PR TITLE
feat(ui): Add "Releases" to chart legend for release bubbles

### DIFF
--- a/static/app/utils/analytics/releasesAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/releasesAnalyticsEvents.tsx
@@ -1,6 +1,7 @@
 import type {ReleaseComparisonChartType} from 'sentry/types/release';
 
 export type ReleasesEventParameters = {
+  'releases.bubbles_legend': {selected: boolean};
   'releases.change_chart_type': {chartType: ReleaseComparisonChartType};
   'releases.quickstart_copied': {project_id: string};
   'releases.quickstart_create_integration.success': {
@@ -21,4 +22,5 @@ export const releasesEventMap: Record<ReleasesEventKey, string | null> = {
   'releases.quickstart_create_integration_modal.close':
     'Releases: Quickstart Create Integration Modal Exit',
   'releases.change_chart_type': 'Releases: Change Chart Type',
+  'releases.bubbles_legend': 'Releases: Toggle Legend for Bubble',
 };

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -1,9 +1,26 @@
 import type {ElementEvent} from 'echarts';
 import type {EChartsInstance} from 'echarts-for-react';
+import debounce from 'lodash/debounce';
 
 import type {Series} from 'sentry/types/echarts';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
+
+interface LegendSelectChangedParams {
+  name: string;
+  selected: Record<string, boolean>;
+}
+
+// This needs to be debounced because some charts (e.g. in TimeseriesWidgets)
+// are in a group and share events. Thus on a page with 4 widgets, clicking on
+// a legend item would result in 4 events.
+const trackLegend = debounce((params: LegendSelectChangedParams) => {
+  trackAnalytics('releases.bubbles_legend', {
+    organization: null,
+    selected: params.selected.Releases,
+  });
+});
 
 /**
  * Attaches an event listener to eCharts that will "highlight" a release bubble
@@ -70,4 +87,12 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
   }
 
   echartsInstance.getZr().on('mousemove', handleMouseMove);
+
+  echartsInstance.on('legendselectchanged', (params: LegendSelectChangedParams) => {
+    if (params.name !== 'Releases' || !('Releases' in params.selected)) {
+      return;
+    }
+
+    trackLegend(params);
+  });
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -18,7 +18,7 @@ interface LegendSelectChangedParams {
 const trackLegend = debounce((params: LegendSelectChangedParams) => {
   trackAnalytics('releases.bubbles_legend', {
     organization: null,
-    selected: params.selected.Releases,
+    selected: Boolean(params.selected.Releases),
   });
 });
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -256,6 +256,7 @@ function ReleaseBubbleSeries({
     id: BUBBLE_SERIES_ID,
     type: 'custom',
     renderItem: renderReleaseBubble,
+    name: t('Releases'),
     data,
     tooltip: {
       trigger: 'item',


### PR DESCRIPTION
This adds a legend item to charts that use release bubbles. We also add an analytics event `releases.bubbles_legend` when this is clicked.

ref https://github.com/getsentry/sentry/issues/85775
