### PR TITLE
fix(ui): Fix grid lines left border in crons / uptime

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -273,7 +273,6 @@ const LabelsContainer = styled('div')<{labelPosition: LabelPosition}>`
     p.labelPosition === 'left-top' &&
     css`
       height: 50px;
-      box-shadow: -1px 0 0 0 ${p.theme.translucentInnerBorder};
     `}
   ${p =>
     p.labelPosition === 'center-bottom' &&

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -102,6 +102,7 @@ const AlignedGridLineOverlay = styled(GridLineOverlay)`
 `;
 
 const AlignedGridLineLabels = styled(GridLineLabels)`
+  box-shadow: -1px 0 0 0 ${p => p.theme.translucentInnerBorder};
   grid-row: 1;
   grid-column: 2/-1;
 `;

--- a/static/app/views/monitors/components/detailsTimeline.tsx
+++ b/static/app/views/monitors/components/detailsTimeline.tsx
@@ -145,6 +145,10 @@ const Header = styled('div')`
   grid-template-columns: subgrid;
   border-bottom: 1px solid ${p => p.theme.border};
   z-index: 1;
+
+  > :last-child {
+    box-shadow: -1px 0 0 0 ${p => p.theme.translucentInnerBorder};
+  }
 `;
 
 const TimelineWidthTracker = styled('div')`

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -208,6 +208,7 @@ const AlignedGridLineOverlay = styled(GridLineOverlay)`
 `;
 
 const AlignedGridLineLabels = styled(GridLineLabels)`
+  box-shadow: -1px 0 0 0 ${p => p.theme.translucentInnerBorder};
   grid-row: 1;
   grid-column: 3/-1;
 `;


### PR DESCRIPTION
This border is dependant on how we're rendering the timeline, so let's
just keep it on the styled components where it's needed, otherwise it
will render in places we don't want.