### PR TITLE
fix(issues): Show "90D" when at max issue retention

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -95,6 +95,17 @@ describe('EventDetailsHeader', () => {
     expect(screen.getByRole('button', {name: 'Close sidebar'})).toBeInTheDocument();
   });
 
+  it('renders 90d instead of "Since First Seen" when the issue is older than 90d', async function () {
+    const oldGroup = GroupFixture({
+      firstSeen: new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    render(<EventDetailsHeader {...defaultProps} group={oldGroup} />, {
+      organization,
+      router,
+    });
+    expect(await screen.findByRole('button', {name: '90D'})).toBeInTheDocument();
+  });
+
   it('updates the query params with search tokens', async function () {
     const [tagKey, tagValue] = ['user.email', 'leander.rodrigues@sentry.io'];
     const locationQuery = {

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -142,7 +142,9 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                   });
                 }}
                 triggerLabel={
-                  period === defaultStatsPeriod ? t('Since First Seen') : undefined
+                  period === defaultStatsPeriod && !defaultStatsPeriod.isMaxRetention
+                    ? t('Since First Seen')
+                    : undefined
                 }
                 triggerProps={{
                   borderless: true,


### PR DESCRIPTION
Instead of displaying "Since First Seen" it will display the max retention period. Usually 90d.
