### PR TITLE
fix(dashboards-eap): Ensure groupBy is still sent when empty array

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -37,7 +37,7 @@ describe('getWidgetExploreUrl', () => {
       displayType: DisplayType.AREA,
       queries: [
         {
-          fields: ['span.description', 'avg(span.duration)'],
+          fields: [],
           aggregates: ['avg(span.duration)'],
           columns: ['span.description'],
           conditions: '',
@@ -53,6 +53,30 @@ describe('getWidgetExploreUrl', () => {
     // The chart type is set to 1 for area charts
     expect(url).toBe(
       '/organizations/org-slug/traces/?dataset=spansRpc&field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+    );
+  });
+
+  it('returns the correct url for timeseries widgets without grouping', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.AREA,
+      queries: [
+        {
+          fields: [],
+          aggregates: ['avg(span.duration)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, selection, organization);
+
+    // Note: for line widgets the mode is set to aggregate
+    // The chart type is set to 1 for area charts
+    expect(url).toBe(
+      '/organizations/org-slug/traces/?dataset=spansRpc&field=avg%28span.duration%29&groupBy=&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
     );
   });
 });

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -86,6 +86,15 @@ export function getWidgetExploreUrl(
     utc: decodeBoolean(locationQueryParams.utc) ?? null,
   };
 
+  let groupBy = fields?.filter(field => !isAggregateFieldOrEquation(field));
+  if (groupBy && groupBy.length === 0) {
+    // Force the groupBy to be an array with a single empty string
+    // so that qs.stringify appends the key to the URL. If the key
+    // is not present, the Explore UI will assign a default groupBy
+    // which we do not want if the user has not specified a groupBy.
+    groupBy = [''];
+  }
+
   const queryParams = {
     // Page filters should propagate
     selection: {
@@ -100,7 +109,7 @@ export function getWidgetExploreUrl(
         yAxes: locationQueryParams.yAxes,
       },
     ],
-    groupBy: fields?.filter(field => !isAggregateFieldOrEquation(field)),
+    groupBy,
     field: decodeList(locationQueryParams.field),
     query: decodeScalar(locationQueryParams.query),
     sort:

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -67,9 +67,10 @@ export function getWidgetExploreUrl(
       : [locationQueryParams.field];
 
   const query = widget.queries[0]!;
-  const queryFields = defined(query.fields)
-    ? query.fields
-    : [...query.columns, ...query.aggregates];
+  const queryFields =
+    defined(query.fields) && widget.displayType === DisplayType.TABLE
+      ? query.fields
+      : [...query.columns, ...query.aggregates];
 
   // Updates fields by adding any individual terms from equation fields as a column
   getFieldsFromEquations(queryFields).forEach(term => {
@@ -86,7 +87,7 @@ export function getWidgetExploreUrl(
     utc: decodeBoolean(locationQueryParams.utc) ?? null,
   };
 
-  let groupBy = fields?.filter(field => !isAggregateFieldOrEquation(field));
+  let groupBy = queryFields?.filter(field => !isAggregateFieldOrEquation(field));
   if (groupBy && groupBy.length === 0) {
     // Force the groupBy to be an array with a single empty string
     // so that qs.stringify appends the key to the URL. If the key


### PR DESCRIPTION
qs.stringify doesn't support empty arrays in URLs. Any keys that map to an empty array will be ignored, but the Explore UI will add a default if the key isn't present in the URL. Enforce that the groupBy is added to make sure the chart is rendered properly when there is no grouping in dashboards by adding an empty string so the key is pushed to the URL params
