### PR TITLE
fix(insights): fix meta type for integers on session health charts

### DIFF
--- a/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
@@ -79,7 +79,7 @@ export default function useReleaseSessionCounts() {
       seriesName: `${release}_total_sessions`,
       meta: {
         fields: {
-          [`${release}_total_sessions`]: 'number' as const,
+          [`${release}_total_sessions`]: 'integer' as const,
           time: 'date' as const,
         },
         units: {},

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -80,7 +80,7 @@ export default function useSessionHealthBreakdown({type}: {type: 'count' | 'rate
     meta: {
       fields: {
         [`${status}_session_${type}`]:
-          type === 'count' ? ('number' as const) : ('percentage' as const),
+          type === 'count' ? ('integer' as const) : ('percentage' as const),
         time: 'date' as const,
       },
       units: {},

--- a/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
@@ -80,7 +80,7 @@ export default function useUserHealthBreakdown({type}: {type: 'count' | 'rate'})
     meta: {
       fields: {
         [`${status}_user_${type}`]:
-          type === 'count' ? ('number' as const) : ('percentage' as const),
+          type === 'count' ? ('integer' as const) : ('percentage' as const),
         time: 'date' as const,
       },
       units: {},


### PR DESCRIPTION
formats the y axis labels

<img width="611" alt="SCR-20250313-lroa" src="https://github.com/user-attachments/assets/1c3fa4ea-2b17-48dc-b0b5-7c400d0404c6" />
