### PR TITLE
ref: remove config_overrides= argument to parse_search_query

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1332,7 +1332,6 @@ def parse_search_query(
     *,
     config: SearchConfig | None = None,
     params=None,
-    config_overrides=None,
     get_field_type: Callable[[str], str | None] | None = None,
     get_function_result_type: Callable[[str], str | None] | None = None,
 ) -> list[
@@ -1353,9 +1352,6 @@ def parse_search_query(
                 "This is commonly caused by unmatched parentheses. Enclose any text in double quotes.",
             )
         )
-
-    if config_overrides:
-        config = SearchConfig.create_from(config, **config_overrides)
 
     return SearchVisitor(
         config,

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -206,8 +206,6 @@ class BaseQueryBuilder:
             self.builder_config = QueryBuilderConfig()
         else:
             self.builder_config = config
-        if self.builder_config.parser_config_overrides is None:
-            self.builder_config.parser_config_overrides = {}
 
         self.dataset = dataset
 
@@ -1168,9 +1166,12 @@ class BaseQueryBuilder:
             parsed_terms = event_search.parse_search_query(
                 query,
                 params=self.filter_params,
+                config=event_search.SearchConfig.create_from(
+                    event_search.default_config,
+                    **self.builder_config.parser_config_overrides,
+                ),
                 get_field_type=self.get_field_type,
                 get_function_result_type=self.get_function_result_type,
-                config_overrides=self.builder_config.parser_config_overrides,
             )
         except ParseError as e:
             if e.expr is not None:

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -224,7 +224,7 @@ class QueryBuilderConfig:
     # This allows queries to be resolved without adding time constraints. Currently this is just
     # used to allow metric alerts to be built and validated before creation in snuba.
     skip_time_conditions: bool = False
-    parser_config_overrides: Mapping[str, Any] | None = None
+    parser_config_overrides: Mapping[str, Any] = field(default_factory=dict)
     has_metrics: bool = False
     transform_alias_to_input_format: bool = False
     use_metrics_layer: bool = False


### PR DESCRIPTION
only used in one place -- difficult to type properly, and the caller can just do the right thing instead

<!-- Describe your PR here. -->