### PR TITLE
fix(aci): fix DataConditionHandler types and add filter groups

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -11,7 +11,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.AGE_COMPARISON)
 class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.ISSUE_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ANOMALY_DETECTION)
 class AnomalyDetectionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.DETECTOR_TRIGGER]
+    type = DataConditionHandler.Type.DETECTOR_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -12,7 +12,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ASSIGNED_TO)
 class AssignedToConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.ISSUE_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -13,7 +13,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.EVENT_ATTRIBUTE)
 class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.EVENT_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.EVENT_CREATED_BY_DETECTOR)
 class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -17,7 +17,8 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionResu
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER, DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.FREQUENCY
 
     comparison_json_schema = {
         "type": "object",
@@ -43,7 +44,8 @@ class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventFrequencyPercentHandler(DataConditionHandler[list[int]]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER, DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.FREQUENCY
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.EVENT_SEEN_COUNT)
 class EventSeenCountConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -8,7 +8,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.EXISTING_HIGH_PRIORITY_ISSUE)
 class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -19,7 +19,7 @@ def is_new_event(job: WorkflowJob) -> bool:
 
 @condition_handler_registry.register(Condition.FIRST_SEEN_EVENT)
 class FirstSeenEventConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -8,7 +8,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ISSUE_CATEGORY)
 class IssueCategoryConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -8,7 +8,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ISSUE_OCCURRENCES)
 class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.ISSUE_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
@@ -7,7 +7,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ISSUE_PRIORITY_EQUALS)
 class IssuePriorityCondition(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER, DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.ISSUE_ATTRIBUTES
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.ISSUE_RESOLUTION_CHANGE)
 class IssueResolutionConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -18,7 +18,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.LATEST_ADOPTED_RELEASE)
 class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.EVENT_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -41,7 +41,8 @@ def get_latest_release_for_env(
 
 @condition_handler_registry.register(Condition.LATEST_RELEASE)
 class LatestReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.EVENT_ATTRIBUTES
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -9,7 +9,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.LEVEL)
 class LevelConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.EVENT_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -9,7 +9,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.NEW_HIGH_PRIORITY_ISSUE)
 class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.REAPPEARED_EVENT)
 class ReappearedEventConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.REGRESSION_EVENT)
 class RegressionEventConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.WORKFLOW_TRIGGER]
+    type = DataConditionHandler.Type.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -9,7 +9,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.TAGGED_EVENT)
 class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
-    type = [DataConditionHandler.Type.ACTION_FILTER]
+    type = DataConditionHandler.Type.ACTION_FILTER
+    filter_group = DataConditionHandler.FilterGroup.EVENT_ATTRIBUTES
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -69,7 +69,13 @@ class DataConditionHandler(Generic[T]):
         WORKFLOW_TRIGGER = "workflow_trigger"
         ACTION_FILTER = "action_filter"
 
-    type: ClassVar[list[Type]]
+    class FilterGroup(StrEnum):
+        ISSUE_ATTRIBUTES = "issue_attributes"
+        FREQUENCY = "frequency"
+        EVENT_ATTRIBUTES = "event_attributes"
+
+    type: ClassVar[Type]
+    filter_group: ClassVar[FilterGroup]
     comparison_json_schema: ClassVar[dict[str, Any]] = {}
 
     @staticmethod


### PR DESCRIPTION
`DataConditionHandlers` will now only ever have one type. Also added a `filter_group` attribute to categorize action filters