### PR TITLE
fix(autofix): add missing project filter in trace tree query

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -17,6 +17,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings, get_autofix_state
+from sentry.constants import ObjectStatus
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
@@ -74,7 +75,15 @@ class GroupAutofixEndpoint(GroupEndpoint):
         """
         Returns a tree of errors and transactions in the trace for a given event. Does not include non-transaction/non-error spans to reduce noise.
         """
+        project_ids = list(
+            dict(
+                Project.objects.filter(
+                    organization=project.organization, status=ObjectStatus.ACTIVE
+                ).values_list("id", "slug")
+            ).keys()
+        )
         event_filter = eventstore.Filter(
+            project_ids=project_ids,
             conditions=[
                 ["trace_id", "=", event.trace_id],
             ],


### PR DESCRIPTION
Listing project ids to search across so the query will work