### PR TITLE
deps(react19): Pin react-is to specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,8 @@
     "webpack-dev-server": "5.2.0"
   },
   "resolutions": {
-    "react-mentions/@babel/runtime": "*"
+    "react-mentions/@babel/runtime": "*",
+    "**/react-is": "18.3.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10505,20 +10505,10 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.13.1, react-is@^16.7.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-is@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+react-is@18.3.1, react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-lazyload@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Some of our legacy dependencies are holding back the version of react-is we have installed. It is used in prop-types and pretty-format which is used in the few snapshot tests we have.

Pins to the same version of react we're using. Will need to be upgraded to 19.

Otherwise causes the issue seen in https://github.com/jestjs/jest/issues/15402

part of https://github.com/getsentry/frontend-tsc/issues/68
