### PR TITLE
fix(aci): evaluate only slow conditions correctly

### DIFF
--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -89,6 +89,8 @@ def process_data_condition_group(
     is_fast: bool = True,
 ) -> DataConditionGroupResult:
     invalid_group_result: DataConditionGroupResult = (False, []), []
+    logic_result = False
+    condition_results: list[DataConditionResult] = []
 
     try:
         group = DataConditionGroup.objects.get_from_cache(id=data_condition_group_id)
@@ -115,6 +117,11 @@ def process_data_condition_group(
     else:
         _, conditions = split_conditions_by_speed(conditions)
         remaining_conditions = []
+
+    if not conditions and remaining_conditions:
+        # there are only slow conditions to evaluate, do not evaluate an empty list of conditions
+        # which would evaluate to True
+        return (logic_result, condition_results), remaining_conditions
 
     conditions_to_evaluate = [(condition, value) for condition in conditions]
     logic_result, condition_results = evaluate_data_conditions(conditions_to_evaluate, logic_type)

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -214,6 +214,18 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         assert condition_results == [True]
         assert remaining_conditions == [self.slow_condition]
 
+    def test_basic_only_slow_conditions(self):
+        self.data_condition.delete()
+        (logic_result, condition_results), remaining_conditions = process_data_condition_group(
+            self.data_condition_group.id,
+            10,
+            True,
+        )
+
+        assert logic_result is False
+        assert condition_results == []
+        assert remaining_conditions == [self.slow_condition]
+
     def test_execute_slow_conditions(self):
         (logic_result, condition_results), remaining_conditions = process_data_condition_group(
             self.data_condition_group,


### PR DESCRIPTION
When there only are slow conditions to evaluate, we were previously evaluating the empty list of fast conditions, and an empty list of conditions evaluates to `True`. This should not be the case as we still have the slow conditions to evaluate, and returning `True` means we don't enqueue the workflow.

Instead, we should early return if there are only slow conditions to let the workflow be enqueued for delayed processing.