### PR TITLE
fix(issues): Filter to comments from issues stream

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -100,7 +100,13 @@ function EventOrGroupExtraDetails({
     ) : null,
     hasNewLayout && subtitle ? <Location>{subtitle}</Location> : null,
     numComments > 0 ? (
-      <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
+      <CommentsLink
+        to={{
+          pathname: `${issuesPath}${id}/activity/`,
+          // Filter activity to only show comments
+          query: {filter: 'comments'},
+        }}
+      >
         <IconChat
           size="xs"
           color={subscriptionDetails?.reason === 'mentioned' ? 'successText' : undefined}


### PR DESCRIPTION
After clicking the comment icon from the issues stream, filter issue activity to show only the comments in the new ui. Does nothing in the old ui.

![image](https://github.com/user-attachments/assets/3f1f3ce6-3ba6-4fae-acb9-47e33ad2e5da)
