### PR TITLE
feat(insights): add most related issues to backend

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -176,12 +176,12 @@ function GenericBackendOverviewPage() {
   const doubleChartRowCharts = [
     PerformanceWidgetSetting.SLOW_HTTP_OPS,
     PerformanceWidgetSetting.SLOW_DB_OPS,
+    PerformanceWidgetSetting.MOST_RELATED_ISSUES,
   ];
   const tripleChartRowCharts = filterAllowedChartsMetrics(
     organization,
     [
       PerformanceWidgetSetting.TPM_AREA,
-      PerformanceWidgetSetting.MOST_RELATED_ISSUES,
       PerformanceWidgetSetting.DURATION_HISTOGRAM,
       PerformanceWidgetSetting.P50_DURATION_AREA,
       PerformanceWidgetSetting.P75_DURATION_AREA,

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -181,6 +181,7 @@ function GenericBackendOverviewPage() {
     organization,
     [
       PerformanceWidgetSetting.TPM_AREA,
+      PerformanceWidgetSetting.MOST_RELATED_ISSUES,
       PerformanceWidgetSetting.DURATION_HISTOGRAM,
       PerformanceWidgetSetting.P50_DURATION_AREA,
       PerformanceWidgetSetting.P75_DURATION_AREA,


### PR DESCRIPTION
We've had some requests to add this back after removing the performance sidebar link, so let's add it back!
<img width="651" alt="image" src="https://github.com/user-attachments/assets/e9216dea-b546-494b-a747-9dbd922b4711" />

