### PR TITLE
feat(issue-views): Use drag handle for dragging views

### DIFF
--- a/static/app/components/nav/issueViews/grabHandleIcon.tsx
+++ b/static/app/components/nav/issueViews/grabHandleIcon.tsx
@@ -1,0 +1,23 @@
+import {forwardRef} from 'react';
+
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {SvgIcon} from 'sentry/icons/svgIcon';
+
+const GrabHandleIcon = forwardRef<SVGSVGElement, SVGIconProps>((props, ref) => {
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <circle cx="5" cy="2" r="1.5" />
+      <circle cx="11" cy="2" r="1.5" />
+
+      <circle cx="5" cy="8" r="1.5" />
+      <circle cx="11" cy="8" r="1.5" />
+
+      <circle cx="5" cy="14" r="1.5" />
+      <circle cx="11" cy="14" r="1.5" />
+    </SvgIcon>
+  );
+});
+
+GrabHandleIcon.displayName = 'GrabHandleIcon';
+
+export {GrabHandleIcon};

--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
@@ -151,7 +151,7 @@ const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
   text-overflow: ellipsis;
   padding-right: 1px;
   cursor: pointer;
-  line-height: 1.45;
+  line-height: 1.5;
 `;
 
 const StyledGrowingInput = styled(GrowingInput)<{
@@ -167,7 +167,7 @@ const StyledGrowingInput = styled(GrowingInput)<{
   border-radius: 0px;
   text-overflow: ellipsis;
   cursor: text;
-  line-height: 1.45;
+  line-height: 1.5;
 
   &,
   &:focus,

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IconEllipsis, IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -89,7 +88,6 @@ export function IssueViewNavEllipsisMenu({
           }}
           size="zero"
         >
-          <InteractionStateLayer />
           <IconEllipsis compact color="gray500" />
         </TriggerWrapper>
       )}

--- a/static/app/components/nav/projectIcon.tsx
+++ b/static/app/components/nav/projectIcon.tsx
@@ -36,7 +36,7 @@ function ProjectIcon({projectPlatforms}: ProjectIconProps) {
       );
   }
 
-  return <IconWrap>{renderedIcons}</IconWrap>;
+  return <IconWrap data-project-icon>{renderedIcons}</IconWrap>;
 }
 
 const IconWrap = styled('div')`
@@ -61,7 +61,6 @@ const BorderOverlay = styled('div')`
   border: 1px solid ${p => p.theme.translucentGray100};
   border-radius: 3px;
   pointer-events: none;
-  z-index: 1;
 `;
 
 const StyledPlatformIcon = styled(PlatformIcon)`
@@ -77,14 +76,12 @@ const PlatformIconWrapper = styled('div')<{index: number}>`
     `
     top: 0;
     left: 0;
-    z-index: 1;
   `}
   ${p =>
     p.index === 1 &&
     `
     bottom: 0;
     right: 0;
-    z-index: 2;
   `}
 `;
 


### PR DESCRIPTION
This PR creates a new dragHandleIcon (2x3 grid of dots) that is used by the issue views components. The icon replaces the project icon on hover, and the view can only be dragged by clicking down on that icon. 