### PR TITLE
fix(issues): Add hash location to url from jump to links

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -195,7 +195,11 @@ function EventNavigationLink({
         hash: `#${config.key}`,
       }}
       onClick={event => {
-        event.preventDefault();
+        // If command click do nothing, assume user wants to open in new tab
+        if (event.metaKey || event.ctrlKey) {
+          return;
+        }
+
         setIsCollapsed(false);
         document
           .getElementById(config.key)


### PR DESCRIPTION
When clicking the "Jump To" links on issue details, add the `#trace` to the url to focus the section on page refresh or when sharing.

these links
![image](https://github.com/user-attachments/assets/a54b7d16-bfb5-462d-8abc-a2d52f3255e8)
