### PR TITLE
fix(rate limits): Handle redis index error gracefully

### DIFF
--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -116,7 +116,7 @@ class RedisRateLimiter(RateLimiter):
         except (RedisError, IndexError):
             # We don't want rate limited endpoints to fail when ratelimits
             # can't be updated. We do want to know when that happens.
-            logger.exception("Failed to retrieve current value from redis")
+            logger.exception("Failed to retrieve current rate limit value from redis")
             return False, 0, reset_time
 
         return result > limit, result, reset_time

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -113,7 +113,7 @@ class RedisRateLimiter(RateLimiter):
             pipe.expire(redis_key, expiration)
             pipeline_result = pipe.execute()
             result = pipeline_result[0]
-        except RedisError:
+        except (RedisError, IndexError):
             # We don't want rate limited endpoints to fail when ratelimits
             # can't be updated. We do want to know when that happens.
             logger.exception("Failed to retrieve current value from redis")


### PR DESCRIPTION
If something goes wrong when we're checking a rate limit in redis, we try to handle it gracefully, capturing the error but not crashing whatever process was doing the rate limit checking. That works, but we missed a potential error type in our `except` statement: If the results come back empty, we'll get an `IndexError` when we to take `pipeline_result[0]`.

This fixes that by adding `IndexError` to the `except`. It also tweaks the resulting error message to make it clearer what redis value couldn't be retrieved.

Fixes https://sentry.sentry.io/issues/6196545340
Fixes https://sentry.sentry.io/issues/6269885170
Fixes https://sentry.sentry.io/issues/5917664708
Fixes https://sentry.sentry.io/issues/6028225463