### PR TITLE
fix(integrations): Handle missing default org owner in metric

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -262,10 +262,16 @@ def sync_status_inbound(
                 )
                 if not created:
                     resolution.update(datetime=django_timezone.now(), **resolution_params)
+
+            try:
+                default_user_id = str(organizations[0].get_default_owner().id)
+            except IndexError:
+                logger.exception("Error getting default user")
+                default_user_id = "<unknown>"
             analytics.record(
                 "issue.resolved",
                 project_id=group.project.id,
-                default_user_id=organizations[0].get_default_owner().id,
+                default_user_id=default_user_id,
                 organization_id=organization_id,
                 group_id=group.id,
                 resolution_type="with_third_party_app",

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -320,6 +320,7 @@ class Organization(ReplicatedRegionModel):
 
     def get_default_owner(self) -> RpcUser:
         if not hasattr(self, "_default_owner"):
+            # TODO: Investigate how an org can have no owners
             self._default_owner = self.get_owners()[0]
         return self._default_owner
 


### PR DESCRIPTION
In our `sync_status_inbound` integrations task, we record a metric which includes the user id of the org's owner. This can crash if we can't find an owner - in `Organization.get_default_owner`, we try to return the first owner, but that raises an index error if the owner list is empty. 

Since the value is only being used for a metric, we don't want retrieving it to make the whole task error out. This therefore wraps the code getting the value in a `try-except`, and sets the value to `None` if the index error is raised. Since this is really just a bandaid (orgs should always have an owner, shouldn't they?), it also adds a TODO for investigating how there can be no owners.

Fixes https://sentry.sentry.io/issues/4069184744.