### PR TITLE
fix(API): Ensure issue stats rollup is at least 1

### DIFF
--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -155,7 +155,7 @@ class GroupStatsMixin:
                 query_params = {
                     "start": stats_query_args.stats_period_start,
                     "end": stats_query_args.stats_period_end,
-                    "rollup": int(rollup),
+                    "rollup": max(int(rollup), 1),  # Zero is a bad thing to divide by
                 }
             else:
                 segments, interval = self.STATS_PERIOD_CHOICES[stats_query_args.stats_period]


### PR DESCRIPTION
When we're serializing an issue, and go to retrieve its stats, the size of the buckets we use depends on the size of the interval the stats should cover. But if the interval is too short, the bucket size ends up rounding to 0, and when we later try to divide by it we end up with predictably bad results.

This fixes that by making sure the bucket size is at least 1.

Fixes https://sentry.sentry.io/issues/5012594968