### PR TITLE
chore(aci milestone 3): refactor dual write helpers to support new workflow name

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1294,8 +1294,6 @@ def create_alert_rule_trigger_action(
     :param input_channel_id: (Optional) Slack channel ID. If provided skips lookup
     :return: The created action
     """
-    from sentry.workflow_engine.migration_helpers.alert_rule import migrate_metric_action
-
     target_display: str | None = None
     if type.value in AlertRuleTriggerAction.EXEMPT_SERVICES:
         raise InvalidTriggerActionError("Selected notification service is exempt from alert rules")
@@ -1340,15 +1338,6 @@ def create_alert_rule_trigger_action(
             sentry_app_id=sentry_app_id,
             sentry_app_config=sentry_app_config,
         )
-        # NOTE (mifu67): skip dual writing anomaly detection alerts until we figure out how to handle them
-        if (
-            features.has(
-                "organizations:workflow-engine-metric-alert-dual-write",
-                trigger.alert_rule.organization,
-            )
-            and trigger.alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC
-        ):
-            migrate_metric_action(trigger_action)
     return trigger_action
 
 

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -34,8 +34,7 @@ from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule_trigger,
     dual_update_resolve_condition,
-    migrate_alert_rule,
-    migrate_resolve_threshold_data_conditions,
+    dual_write_alert_rule,
 )
 
 from .alert_rule_trigger import AlertRuleTriggerSerializer
@@ -270,6 +269,8 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 )
                 raise BadRequest
 
+            self._handle_triggers(alert_rule, triggers)
+
             # NOTE (mifu67): skip dual writing anomaly detection alerts until we figure out how to handle them
             should_dual_write = (
                 features.has(
@@ -278,12 +279,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 and alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC
             )
             if should_dual_write:
-                migrate_alert_rule(alert_rule, user)
-
-            self._handle_triggers(alert_rule, triggers)
-            if should_dual_write:
-                migrate_resolve_threshold_data_conditions(alert_rule)
-
+                dual_write_alert_rule(alert_rule, user)
             return alert_rule
 
     def update(self, instance, validated_data):

--- a/src/sentry/incidents/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger.py
@@ -2,7 +2,6 @@ from django import forms
 from django.db import router, transaction
 from rest_framework import serializers
 
-from sentry import features
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.incidents.logic import (
@@ -13,14 +12,9 @@ from sentry.incidents.logic import (
     rewrite_trigger_action_fields,
     update_alert_rule_trigger,
 )
-from sentry.incidents.models.alert_rule import (
-    AlertRuleDetectionType,
-    AlertRuleTrigger,
-    AlertRuleTriggerAction,
-)
+from sentry.incidents.models.alert_rule import AlertRuleTrigger, AlertRuleTriggerAction
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule_trigger_action,
-    migrate_metric_data_conditions,
 )
 
 from .alert_rule_trigger_action import AlertRuleTriggerActionSerializer
@@ -63,15 +57,6 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                     "This label is already in use for this alert rule"
                 )
 
-            # NOTE (mifu67): skip dual writing anomaly detection alerts until we figure out how to handle them
-            if (
-                features.has(
-                    "organizations:workflow-engine-metric-alert-dual-write",
-                    alert_rule_trigger.alert_rule.organization,
-                )
-                and alert_rule_trigger.alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC
-            ):
-                migrate_metric_data_conditions(alert_rule_trigger)
         self._handle_actions(alert_rule_trigger, actions)
         return alert_rule_trigger
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -495,7 +495,8 @@ def migrate_alert_rule(
     detector_data_condition_group = create_data_condition_group(organization_id)
     detector = create_detector(alert_rule, project.id, detector_data_condition_group, user)
 
-    workflow = create_workflow(alert_rule.name, organization_id, user)
+    workflow_name = get_workflow_name(alert_rule)
+    workflow = create_workflow(workflow_name, organization_id, user)
 
     open_incident = Incident.objects.get_active_incident(alert_rule, project)
     if open_incident:
@@ -526,6 +527,33 @@ def migrate_alert_rule(
         alert_rule_workflow,
         detector_workflow,
     )
+
+
+def get_workflow_name(alert_rule: AlertRule) -> str:
+    # max length of name is 256 characters
+    # get triggers -> get actions
+    # this is a placeholder replicating the existing behavior; changes to the workflow
+    # name will come in a subsequent PR
+    return alert_rule.name
+
+
+def dual_write_alert_rule(alert_rule: AlertRule, user: RpcUser | None = None) -> None:
+    """
+    Comprehensively dual write the ACI objects corresponding to an alert rule, its triggers, and
+    its actions. All these objects will have been created before calling this method.
+    """
+    # step 1: migrate the alert rule
+    migrate_alert_rule(alert_rule)
+    triggers = AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
+    # step 2: migrate each trigger
+    for trigger in triggers:
+        migrate_metric_data_conditions(trigger)
+        trigger_actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger=trigger)
+        # step 3: for each trigger, migrate the actions
+        for trigger_action in trigger_actions:
+            migrate_metric_action(trigger_action)
+    # step 4: migrate alert rule resolution
+    migrate_resolve_threshold_data_conditions(alert_rule)
 
 
 def dual_update_migrated_alert_rule(alert_rule: AlertRule, updated_fields: dict[str, Any]) -> (


### PR DESCRIPTION
Refactor the dual write helper calls so that they're all called within one function. This function (`dual_write_alert_rule`) is called within the serializer after the alert rule, its triggers, and its actions have been successfully created, so that there is one point of entry for dual write. Also create a placeholder method for getting the new workflow name; this currently replicates the old functionality and will be built out later.