### PR TITLE
feat(ui): Use formatted release names inside drawer

### DIFF
--- a/static/app/views/releases/drawer/releasesDrawer.tsx
+++ b/static/app/views/releases/drawer/releasesDrawer.tsx
@@ -12,6 +12,7 @@ import {
 import {PlatformList} from 'sentry/components/platformList';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {ReleasesDrawerDetails} from 'sentry/views/releases/drawer/releasesDrawerDetails';
 import {ReleasesDrawerList} from 'sentry/views/releases/drawer/releasesDrawerList';
 import {useReleaseDetails} from 'sentry/views/releases/utils/useReleaseDetails';
@@ -48,7 +49,7 @@ export function ReleasesDrawer({
   );
   const crumbs = [
     {label: t('Releases'), to: '#'},
-    ...(releaseOrSelected ? [{label: releaseOrSelected, to: '#'}] : []),
+    ...(releaseOrSelected ? [{label: formatVersion(releaseOrSelected), to: '#'}] : []),
   ];
   const title =
     releaseOrSelected && releaseDetailsQuery.data ? (
@@ -56,7 +57,7 @@ export function ReleasesDrawer({
         <PlatformList
           platforms={releaseDetailsQuery.data.projects.map(({platform}) => platform)}
         />
-        {releaseOrSelected}
+        {formatVersion(releaseOrSelected)}
       </ReleaseWithPlatform>
     ) : (
       tn('%s Release', '%s Releases', releases.length ?? 0)

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -22,6 +22,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {getReleaseNewIssuesUrl} from 'sentry/views/releases/utils';
 
 type ReleaseHealthItem = {
@@ -42,7 +43,7 @@ type ReleaseHealthGridItem = Pick<ReleaseHealthItem, 'date' | 'release' | 'error
 type Column = GridColumnHeader<keyof ReleaseHealthGridItem>;
 
 const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseHealthGridItem>> = [
-  {key: 'release', name: 'version', width: 400},
+  {key: 'release', name: 'release', width: 400},
   {key: 'error_count', name: 'new issues'},
   {key: 'date', name: 'created'},
 ];
@@ -82,7 +83,7 @@ export function ReleaseDrawerTable({start, onSelectRelease, end}: Props) {
 
   const releaseData = data?.map(d => ({
     project: d.projects[0]!,
-    release: d.shortVersion ?? d.version,
+    release: d.version,
     date: d.dateCreated,
     error_count: d.projects[0]?.newGroups ?? 0,
     project_id: d.projects[0]?.id ?? 0,
@@ -128,7 +129,7 @@ export function ReleaseDrawerTable({start, onSelectRelease, end}: Props) {
             }}
           >
             <ProjectBadge project={dataRow.project} disableLink hideName />
-            <TextOverflow>{value}</TextOverflow>
+            <TextOverflow>{formatVersion(value)}</TextOverflow>
           </ReleaseLink>
         );
       }


### PR DESCRIPTION
Use formatted/short release names everywhere inside of releases drawer

refs https://github.com/getsentry/sentry/issues/85779
