### PR TITLE
feat(issue-views): Add "+ Add View" button to left nav issue views

### DIFF
--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -106,15 +106,6 @@ const AddViewButton = styled(Button)<{layout: NavLayout}>`
   line-height: 177.75%;
   border-radius: ${p => p.theme.borderRadius};
 
-  &[aria-selected='true'] {
-    color: ${p => p.theme.purple400};
-    font-weight: ${p => p.theme.fontWeightBold};
-
-    &:hover {
-      color: ${p => p.theme.purple400};
-    }
-  }
-
   &:hover {
     color: inherit;
   }

--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -6,6 +6,7 @@ import {motion} from 'framer-motion';
 import {Button} from 'sentry/components/core/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {useNavContext} from 'sentry/components/nav/context';
+import useDefaultProject from 'sentry/components/nav/issueViews/useDefaultProject';
 import {NavLayout} from 'sentry/components/nav/types';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -27,6 +28,8 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
 
   const {layout} = useNavContext();
   const [isLoading, setIsLoading] = useState(false);
+
+  const defaultProject = useDefaultProject();
 
   const {data: groupSearchViews} = useFetchGroupSearchViews({
     orgSlug: organization.slug,
@@ -55,8 +58,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
             name: 'New View',
             query: 'is:unresolved',
             querySort: IssueSortOptions.DATE,
-            // TODO: fix this default projects
-            projects: [],
+            projects: defaultProject,
             isAllProjects: false,
             environments: DEFAULT_ENVIRONMENTS,
             timeFilters: DEFAULT_TIME_FILTERS,

--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -36,7 +36,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
   });
 
   const {mutate: updateViews} = useUpdateGroupSearchViews({
-    onSettled: data => {
+    onSuccess: data => {
       if (data?.length) {
         navigate(
           normalizeUrl({

--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -1,0 +1,140 @@
+import {Fragment, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {Button} from 'sentry/components/core/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {useNavContext} from 'sentry/components/nav/context';
+import {NavLayout} from 'sentry/components/nav/types';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  DEFAULT_ENVIRONMENTS,
+  DEFAULT_TIME_FILTERS,
+} from 'sentry/views/issueList/issueViews/issueViews';
+import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
+  const navigate = useNavigate();
+  const organization = useOrganization();
+
+  const {layout} = useNavContext();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {data: groupSearchViews} = useFetchGroupSearchViews({
+    orgSlug: organization.slug,
+  });
+
+  const {mutate: updateViews} = useUpdateGroupSearchViews({
+    onSettled: data => {
+      if (data?.length) {
+        navigate(
+          normalizeUrl({
+            pathname: `${baseUrl}/views/${data.at(-1)!.id}/`,
+          })
+        );
+        setIsLoading(false);
+      }
+    },
+  });
+
+  const handleOnAddView = () => {
+    if (groupSearchViews) {
+      setIsLoading(true);
+      updateViews({
+        groupSearchViews: [
+          ...groupSearchViews,
+          {
+            name: 'New View',
+            query: 'is:unresolved',
+            querySort: IssueSortOptions.DATE,
+            // TODO: fix this default projects
+            projects: [],
+            isAllProjects: false,
+            environments: DEFAULT_ENVIRONMENTS,
+            timeFilters: DEFAULT_TIME_FILTERS,
+          },
+        ],
+        orgSlug: organization.slug,
+      });
+    }
+  };
+
+  return (
+    <motion.div>
+      <AddViewButton
+        borderless
+        size="zero"
+        layout={layout}
+        onClick={handleOnAddView}
+        disabled={isLoading}
+      >
+        {isLoading ? (
+          <LoadingIndicator mini />
+        ) : (
+          <Fragment>
+            <StyledIconAdd size="xs" />
+            {t('Add View')}
+          </Fragment>
+        )}
+      </AddViewButton>
+    </motion.div>
+  );
+}
+
+const AddViewButton = styled(Button)<{layout: NavLayout}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(0.5)};
+
+  width: 100%;
+  position: relative;
+  height: 34px;
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  line-height: 177.75%;
+  border-radius: ${p => p.theme.borderRadius};
+
+  &[aria-selected='true'] {
+    color: ${p => p.theme.purple400};
+    font-weight: ${p => p.theme.fontWeightBold};
+
+    &:hover {
+      color: ${p => p.theme.purple400};
+    }
+  }
+
+  &:hover {
+    color: inherit;
+  }
+
+  [data-isl] {
+    transform: translate(0, 0);
+    top: 1px;
+    bottom: 1px;
+    right: 0;
+    left: 0;
+    width: initial;
+    height: initial;
+  }
+
+  ${p =>
+    p.layout === NavLayout.MOBILE &&
+    css`
+      padding: 0 ${space(1.5)} 0 48px;
+      border-radius: 0;
+    `}
+`;
+
+const StyledIconAdd = styled(IconAdd)`
+  margin-right: 4px;
+`;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -402,8 +402,8 @@ const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`
   background: ${p => p.theme.purple400};
   border: solid 2px ${p => p.theme.surface200};
   position: absolute;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   top: -3px;
   right: -3px;
 `;

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -3,9 +3,11 @@ import {AnimatePresence, Reorder} from 'framer-motion';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
+import {IssueViewAddViewButton} from 'sentry/components/nav/issueViews/issueViewAddViewButton';
 import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -14,6 +16,7 @@ import {useParams} from 'sentry/utils/useParams';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {generateTempViewId} from 'sentry/views/issueList/issueViews/issueViews';
 import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 interface IssueViewNavItemsProps {
@@ -36,6 +39,13 @@ export function IssueViewNavItems({
 
   const [views, setViews] = useState<IssueView[]>(loadedViews);
   const [isDragging, setIsDragging] = useState(false);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (loadedViews.length !== views.length) {
+      setViews(loadedViews);
+    }
+  }, [loadedViews, views, setViews]);
 
   // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
   // then redirect to the "All Issues" page
@@ -178,8 +188,25 @@ export function IssueViewNavItems({
         leftNav: true,
         organization: organization.slug,
       });
+      setApiQueryData<GroupSearchView[]>(
+        queryClient,
+        makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
+        newViews.map(v => ({
+          ...v,
+          isAllProjects: isEqual(v.projects, [-1]),
+          name: v.label,
+        }))
+      );
     },
-    [views, debounceUpdateViews, viewId, baseUrl, navigate, organization.slug]
+    [
+      views,
+      debounceUpdateViews,
+      viewId,
+      baseUrl,
+      navigate,
+      organization.slug,
+      queryClient,
+    ]
   );
 
   const handleDuplicateView = useCallback(
@@ -202,22 +229,39 @@ export function IssueViewNavItems({
         if (view.id === viewId) {
           navigate(constructViewLink(baseUrl, duplicatedView));
         }
+        setApiQueryData<GroupSearchView[]>(
+          queryClient,
+          makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
+          newViews.map(v => ({
+            ...v,
+            isAllProjects: isEqual(v.projects, [-1]),
+            name: v.label,
+          }))
+        );
       }
     },
-    [views, viewId, baseUrl, navigate, debounceUpdateViews]
+    [
+      views,
+      viewId,
+      baseUrl,
+      navigate,
+      debounceUpdateViews,
+      organization.slug,
+      queryClient,
+    ]
   );
 
   return (
     <Reorder.Group
       as="div"
       axis="y"
-      values={views ?? []}
+      values={views}
       onReorder={newOrder => setViews(newOrder)}
       initial={false}
       ref={sectionRef}
     >
       {views.map(view => (
-        <AnimatePresence key={view.id}>
+        <AnimatePresence key={view.id} mode="sync">
           <IssueViewNavItemContent
             view={view}
             sectionRef={sectionRef}
@@ -232,6 +276,7 @@ export function IssueViewNavItems({
           />
         </AnimatePresence>
       ))}
+      <IssueViewAddViewButton baseUrl={baseUrl} />
     </Reorder.Group>
   );
 }

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -37,6 +37,10 @@ export function IssueViewNavItems({
 
   const queryParams = location.query;
 
+  /**
+   * TODO(msun): Revisit whether we can use the useApiQuery's cache as the
+   * source of truth for the view state, rather than a separate state
+   */
   const [views, setViews] = useState<IssueView[]>(loadedViews);
   const [isDragging, setIsDragging] = useState(false);
   const queryClient = useQueryClient();

--- a/static/app/components/nav/issueViews/useDefaultProject.tsx
+++ b/static/app/components/nav/issueViews/useDefaultProject.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+export default function useDefaultProject(): number[] {
+  const organization = useOrganization();
+  const {projects: allProjects} = useProjects();
+
+  const allowMultipleProjects = organization.features.includes('global-views');
+  const isSuperUser = isActiveSuperuser();
+
+  const memberProjects = useMemo(
+    () => allProjects.filter(project => project.isMember),
+    [allProjects]
+  );
+
+  return useMemo(() => {
+    if (allowMultipleProjects) {
+      return [];
+    }
+
+    if (isSuperUser) {
+      // Return first project ID or empty array if no projects exist
+      if (allProjects.length > 0 && allProjects[0]?.id) {
+        return allowMultipleProjects ? [] : [parseInt(allProjects[0].id, 10)];
+      }
+      return [];
+    }
+
+    // Return first member project ID or empty array if no member projects exist
+    if (memberProjects.length > 0 && memberProjects[0]?.id) {
+      return [parseInt(memberProjects[0].id, 10)];
+    }
+    return [];
+  }, [memberProjects, allowMultipleProjects, isSuperUser, allProjects]);
+}


### PR DESCRIPTION
This PR adds an entry point to creating views (besides just duplicating) via an "+ Add View" button below the starred views. 

Unlike before, hitting the Add View button waits for a response before it generates a _persistent_ view. The persistent view is empty besides a "is:unresolved" query. 