### PR TITLE
fix(nav): Fix links to trace pages embedded in other product areas

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -60,7 +60,8 @@ const TRACE_SOURCE_TO_INSIGHTS_MODULE: Partial<Record<TraceViewSources, ModuleNa
   mobile_screens_module: ModuleName.MOBILE_VITALS,
 };
 
-export const TRACE_SOURCE_TO_NON_INSIGHT_ROUTES: Partial<
+// Remove this when the new navigation is GA'd
+export const TRACE_SOURCE_TO_NON_INSIGHT_ROUTES_LEGACY: Partial<
   Record<TraceViewSources, string>
 > = {
   traces: 'traces',
@@ -70,6 +71,19 @@ export const TRACE_SOURCE_TO_NON_INSIGHT_ROUTES: Partial<
   performance_transaction_summary: 'traces',
   issue_details: 'issues',
   feedback_details: 'feedback',
+  dashboards: 'dashboards',
+};
+
+export const TRACE_SOURCE_TO_NON_INSIGHT_ROUTES: Partial<
+  Record<TraceViewSources, string>
+> = {
+  traces: 'explore/traces',
+  metrics: 'metrics',
+  discover: 'explore/discover',
+  profiling_flamegraph: 'explore/profiling',
+  performance_transaction_summary: 'explore/traces',
+  issue_details: 'issues',
+  feedback_details: 'issues/feedback',
   dashboards: 'dashboards',
 };
 

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -20,6 +20,7 @@ import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 import {
   TRACE_SOURCE_TO_NON_INSIGHT_ROUTES,
+  TRACE_SOURCE_TO_NON_INSIGHT_ROUTES_LEGACY,
   type TraceViewSources,
 } from '../newTraceDetails/traceHeader/breadcrumbs';
 
@@ -35,12 +36,11 @@ function getBaseTraceUrl(
     return getPerformanceBaseUrl(organization.slug, view);
   }
 
-  const url =
-    source && source in TRACE_SOURCE_TO_NON_INSIGHT_ROUTES
-      ? TRACE_SOURCE_TO_NON_INSIGHT_ROUTES[source]
-      : 'traces';
+  const routesMap = prefersStackedNav()
+    ? TRACE_SOURCE_TO_NON_INSIGHT_ROUTES
+    : TRACE_SOURCE_TO_NON_INSIGHT_ROUTES_LEGACY;
 
-  const routeSuffix = url === 'traces' && prefersStackedNav() ? 'explore/traces' : url;
+  const routeSuffix = source && source in routesMap ? routesMap[source] : 'traces';
 
   return normalizeUrl(`/organizations/${organization.slug}/${routeSuffix}`);
 }


### PR DESCRIPTION
The util that generates the route to trace views within product areas was only modified to work for `/traces/trace/<trace>`, not for other pages like `/discover/traces/<trace>`. This creates a duplicate mapping that is updated for the new nav routes.