### PR TITLE
:wrench: chore(aci): update action serializer to return config

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any
+from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.grouping.grouptype import ErrorGroupType
@@ -20,13 +20,23 @@ from sentry.workflow_engine.models.data_condition_group_action import DataCondit
 from sentry.workflow_engine.types import DataSourceTypeHandler
 
 
+class ActionSerializerResponse(TypedDict):
+    id: str
+    type: str
+    integration_id: int | None
+    data: str
+    config: str
+
+
 @register(Action)
 class ActionSerializer(Serializer):
-    def serialize(self, obj: Action, *args, **kwargs):
+    def serialize(self, obj: Action, *args, **kwargs) -> ActionSerializerResponse:
         return {
             "id": str(obj.id),
             "type": obj.type,
+            "integration_id": obj.integration_id,
             "data": json.dumps(obj.data),
+            "config": json.dumps(obj.config),
         }
 
 

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -3,14 +3,11 @@ from datetime import timedelta
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
-from sentry.integrations.models.integration import Integration
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode
 from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import data_source_type_registry
@@ -121,6 +118,8 @@ class TestDetectorSerializer(TestCase):
                         "id": str(action.id),
                         "type": "email",
                         "data": '{"foo":"bar"}',
+                        "integration_id": None,
+                        "config": "{}",
                     }
                 ],
             },
@@ -240,12 +239,24 @@ class TestDataConditionGroupSerializer(TestCase):
                     "id": str(action.id),
                     "type": "email",
                     "data": '{"foo":"bar"}',
+                    "integration_id": None,
+                    "config": "{}",
                 }
             ],
         }
 
 
 class TestActionSerializer(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            provider="slack",
+            name="example-integration",
+            external_id="123-id",
+            metadata={},
+            organization=self.organization,
+        )
+
     def test_serialize_simple(self):
         action = self.create_action(
             type=Action.Type.EMAIL,
@@ -254,30 +265,54 @@ class TestActionSerializer(TestCase):
 
         result = serialize(action)
 
-        assert result == {"id": str(action.id), "type": "email", "data": '{"foo":"bar"}'}
+        assert result == {
+            "id": str(action.id),
+            "type": "email",
+            "data": '{"foo":"bar"}',
+            "integration_id": None,
+            "config": "{}",
+        }
 
-    def test_serialize_with_legacy_fields(self):
-        """
-        Legacy fields should not be serialized.
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="slack", name="example-integration", external_id="123-id", metadata={}
-            )
+    def test_serialize_with_integration(self):
 
         action = self.create_action(
-            type=Action.Type.SLACK,
+            type=Action.Type.EMAIL,
             data={"foo": "bar"},
-            integration_id=integration.id,
-            config={
-                "target_display": "freddy frog",
-                "target_type": ActionTarget.USER,
-            },
+            integration_id=self.integration.id,
         )
 
         result = serialize(action)
 
-        assert result == {"id": str(action.id), "type": "slack", "data": '{"foo":"bar"}'}
+        assert result == {
+            "id": str(action.id),
+            "type": "email",
+            "data": '{"foo":"bar"}',
+            "integration_id": self.integration.id,
+            "config": "{}",
+        }
+
+    def test_serialize_with_integration_and_config(self):
+
+        action2 = self.create_action(
+            type=Action.Type.SLACK,
+            data={"foo": "bar"},
+            integration_id=self.integration.id,
+            config={
+                "target_type": ActionTarget.USER,
+                "target_display": "freddy frog",
+                "target_identifier": "123-id",
+            },
+        )
+
+        result2 = serialize(action2)
+
+        assert result2 == {
+            "id": str(action2.id),
+            "type": "slack",
+            "data": '{"foo":"bar"}',
+            "integration_id": self.integration.id,
+            "config": '{"target_type":1,"target_display":"freddy frog","target_identifier":"123-id"}',
+        }
 
 
 class TestWorkflowSerializer(TestCase):
@@ -378,6 +413,8 @@ class TestWorkflowSerializer(TestCase):
                             "id": str(action.id),
                             "type": "email",
                             "data": '{"foo":"bar"}',
+                            "integration_id": None,
+                            "config": "{}",
                         }
                     ],
                 },


### PR DESCRIPTION
after introducing the `config` field on `Action`,  we need to return it in the serializer for actions since the frontend will need fields contained inside of it such as `target_identifier` or `target_display` to fill in the actions UI.

also serializing `integration_id`, which we can possibly move inside `config` as well.

i also made a `TypedDict` for the serializer response since it will help us in the future if/when we publish the actions endpoint.