### PR TITLE
fix(ACI): Update Action serializer to only use new models

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -15,8 +15,17 @@ from sentry.notifications.notification_action.group_type_notification_registry.h
 )
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction, DataConditionAlertRuleTrigger, DataConditionGroupAction, DataCondition, DetectorWorkflow, WorkflowDataConditionGroup
+from sentry.workflow_engine.models import (
+    Action,
+    ActionAlertRuleTriggerAction,
+    DataCondition,
+    DataConditionAlertRuleTrigger,
+    DataConditionGroupAction,
+    DetectorWorkflow,
+    WorkflowDataConditionGroup,
+)
 from sentry.workflow_engine.models.data_condition import Condition
+
 
 class WorkflowEngineActionSerializer(Serializer):
     def serialize(
@@ -43,13 +52,24 @@ class WorkflowEngineActionSerializer(Serializer):
             sentry_app_config = obj.data.get("settings")
 
         action_dcga = DataConditionGroupAction.objects.get(action=aarta.action)
-        action_filter_data_condition = DataCondition.objects.filter(condition_group=action_dcga.condition_group, type=Condition.ISSUE_PRIORITY_EQUALS, condition_result=True)
+        action_filter_data_condition = DataCondition.objects.get(
+            condition_group=action_dcga.condition_group,
+            type=Condition.ISSUE_PRIORITY_EQUALS,
+            condition_result=True,
+        )
         # should this actually have a different data condition group? how to differentiate?
         # import pdb; pdb.set_trace()
-        workflow_dcg = WorkflowDataConditionGroup.objects.get(condition_group=action_filter_data_condition.condition_group)
+        workflow_dcg = WorkflowDataConditionGroup.objects.get(
+            condition_group=action_filter_data_condition.condition_group
+        )
         detector_workflow = DetectorWorkflow.objects.get(workflow=workflow_dcg.workflow)
-        detector_trigger = DataCondition.objects.filter(condition_result=action_filter_data_condition.comparison, condition_group=detector_workflow.detector.workflow_condition_group)
-        datacondition_alertruletrigger = DataConditionAlertRuleTrigger.objects.get(data_condition=detector_trigger)
+        detector_trigger = DataCondition.objects.get(
+            condition_result=action_filter_data_condition.comparison,
+            condition_group=detector_workflow.detector.workflow_condition_group,
+        )
+        datacondition_alertruletrigger = DataConditionAlertRuleTrigger.objects.get(
+            data_condition=detector_trigger
+        )
         # it might not be possible to differentiate between a warning and critical trigger / datacondition with the information we have
 
         result = {

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -10,14 +10,13 @@ from sentry.incidents.endpoints.serializers.alert_rule_trigger_action import (
     human_desc,
 )
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler import (
     MetricAlertRegistryHandler,
 )
-from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
-from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.models import Action, DataConditionGroup, DataConditionGroupAction
+from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
 
 
 class WorkflowEngineActionSerializer(Serializer):

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -9,15 +9,14 @@ from sentry.incidents.endpoints.serializers.alert_rule_trigger_action import (
     get_input_channel_id,
     human_desc,
 )
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler import (
     MetricAlertRegistryHandler,
 )
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
-
+from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction, DataConditionAlertRuleTrigger, DataConditionGroupAction, DataCondition, DetectorWorkflow, WorkflowDataConditionGroup
+from sentry.workflow_engine.models.data_condition import Condition
 
 class WorkflowEngineActionSerializer(Serializer):
     def serialize(
@@ -43,11 +42,19 @@ class WorkflowEngineActionSerializer(Serializer):
             sentry_app_id = int(obj.config.get("target_identifier"))
             sentry_app_config = obj.data.get("settings")
 
-        trigger_action = AlertRuleTriggerAction.objects.get(id=aarta.alert_rule_trigger_action_id)
+        action_dcga = DataConditionGroupAction.objects.get(action=aarta.action)
+        action_filter_data_condition = DataCondition.objects.filter(condition_group=action_dcga.condition_group, type=Condition.ISSUE_PRIORITY_EQUALS, condition_result=True)
+        # should this actually have a different data condition group? how to differentiate?
+        # import pdb; pdb.set_trace()
+        workflow_dcg = WorkflowDataConditionGroup.objects.get(condition_group=action_filter_data_condition.condition_group)
+        detector_workflow = DetectorWorkflow.objects.get(workflow=workflow_dcg.workflow)
+        detector_trigger = DataCondition.objects.filter(condition_result=action_filter_data_condition.comparison, condition_group=detector_workflow.detector.workflow_condition_group)
+        datacondition_alertruletrigger = DataConditionAlertRuleTrigger.objects.get(data_condition=detector_trigger)
+        # it might not be possible to differentiate between a warning and critical trigger / datacondition with the information we have
 
         result = {
             "id": str(aarta.alert_rule_trigger_action_id),
-            "alertRuleTriggerId": str(trigger_action.alert_rule_trigger.id),
+            "alertRuleTriggerId": str(datacondition_alertruletrigger.alert_rule_trigger_id),
             "type": obj.type,
             "targetType": ACTION_TARGET_TYPE_TO_STRING[ActionTarget(target_type)],
             "targetIdentifier": get_identifier_from_action(

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -289,6 +289,10 @@ def migrate_metric_data_conditions(
         type=threshold_type,
         condition_group=detector_data_condition_group,
     )
+    DataConditionAlertRuleTrigger.objects.create(
+        data_condition=detector_trigger,
+        alert_rule_trigger_id=alert_rule_trigger.id,
+    )
     # create an "action filter": if the detector's status matches a certain priority level,
     # then the condition result is set to true
     data_condition_group = DataConditionGroup.objects.create(
@@ -307,10 +311,6 @@ def migrate_metric_data_conditions(
         condition_result=True,
         type=Condition.ISSUE_PRIORITY_EQUALS,
         condition_group=data_condition_group,
-    )
-    DataConditionAlertRuleTrigger.objects.create(
-        data_condition=action_filter,
-        alert_rule_trigger_id=alert_rule_trigger.id,
     )
     return detector_trigger, action_filter
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -26,6 +26,7 @@ from sentry.workflow_engine.models import (
     AlertRuleDetector,
     AlertRuleWorkflow,
     DataCondition,
+    DataConditionAlertRuleTrigger,
     DataConditionGroup,
     DataConditionGroupAction,
     DataSource,
@@ -288,7 +289,10 @@ def migrate_metric_data_conditions(
         type=threshold_type,
         condition_group=detector_data_condition_group,
     )
-
+    DataConditionAlertRuleTrigger.objects.create(
+        data_condition=detector_trigger,
+        alert_rule_trigger_id=alert_rule_trigger.id,
+    )
     # create an "action filter": if the detector's status matches a certain priority level,
     # then the condition result is set to true
     data_condition_group = DataConditionGroup.objects.create(

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -289,10 +289,6 @@ def migrate_metric_data_conditions(
         type=threshold_type,
         condition_group=detector_data_condition_group,
     )
-    DataConditionAlertRuleTrigger.objects.create(
-        data_condition=detector_trigger,
-        alert_rule_trigger_id=alert_rule_trigger.id,
-    )
     # create an "action filter": if the detector's status matches a certain priority level,
     # then the condition result is set to true
     data_condition_group = DataConditionGroup.objects.create(
@@ -311,6 +307,10 @@ def migrate_metric_data_conditions(
         condition_result=True,
         type=Condition.ISSUE_PRIORITY_EQUALS,
         condition_group=data_condition_group,
+    )
+    DataConditionAlertRuleTrigger.objects.create(
+        data_condition=action_filter,
+        alert_rule_trigger_id=alert_rule_trigger.id,
     )
     return detector_trigger, action_filter
 

--- a/tests/sentry/incidents/serializers/test_workflow_engine_action.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_action.py
@@ -102,7 +102,7 @@ class TestActionSerializer(TestCase):
             self.sentry_app_action, self.user, WorkflowEngineActionSerializer()
         )
         assert serialized_action["type"] == "sentry_app"
-        assert serialized_action["id"] == str(self.sentry_app_trigger.id)
+        assert serialized_action["id"] == str(self.sentry_app_trigger_action.id)
         assert serialized_action["alertRuleTriggerId"] == str(self.sentry_app_trigger.id)
         assert serialized_action["targetType"] == "sentry_app"
         assert serialized_action["targetIdentifier"] == sentry_app.id
@@ -133,7 +133,7 @@ class TestActionSerializer(TestCase):
             self.slack_action, self.user, WorkflowEngineActionSerializer()
         )
         assert serialized_action["type"] == self.integration.provider
-        assert serialized_action["id"] == str(self.slack_trigger.id)
+        assert serialized_action["id"] == str(self.slack_trigger_action.id)
         assert serialized_action["alertRuleTriggerId"] == str(self.slack_trigger.id)
         assert serialized_action["targetType"] == "specific"
         assert serialized_action["targetIdentifier"] == self.slack_trigger_action.target_display

--- a/tests/sentry/incidents/serializers/test_workflow_engine_action.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_action.py
@@ -6,18 +6,27 @@ from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction, DataConditionAlertRuleTrigger, WorkflowDataConditionGroup
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.models import (
+    Action,
+    ActionAlertRuleTriggerAction,
+    DataConditionAlertRuleTrigger,
+    WorkflowDataConditionGroup,
+)
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @freeze_time("2018-12-11 03:21:34")
 class TestActionSerializer(TestCase):
     def setUp(self) -> None:
         self.alert_rule = self.create_alert_rule()
-        self.critical_trigger = self.create_alert_rule_trigger(alert_rule=self.alert_rule, label="critical")
-        self.critical_trigger_action = self.create_alert_rule_trigger_action(alert_rule_trigger=self.critical_trigger)
+        self.critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.alert_rule, label="critical"
+        )
+        self.critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.critical_trigger
+        )
 
         # create ACI stuff
         self.action = self.create_action(
@@ -32,11 +41,21 @@ class TestActionSerializer(TestCase):
             alert_rule_trigger_action_id=self.critical_trigger_action.id,
         )
 
-        self.detector_data_condition_group = self.create_data_condition_group(organization_id=self.organization.id)
-        self.detector = self.create_detector(name=self.alert_rule.name, project=self.project, workflow_condition_group=self.detector_data_condition_group, owner_user_id=self.alert_rule.user_id)
-        self.workflow = self.create_workflow(name=self.alert_rule.name, organization_id=self.organization.id, owner_user_id=self.alert_rule.user_id)
+        self.detector_data_condition_group = self.create_data_condition_group(
+            organization_id=self.organization.id
+        )
+        self.detector = self.create_detector(
+            name=self.alert_rule.name,
+            project=self.project,
+            workflow_condition_group=self.detector_data_condition_group,
+            owner_user_id=self.alert_rule.user_id,
+        )
+        self.workflow = self.create_workflow(
+            name=self.alert_rule.name,
+            organization_id=self.organization.id,
+            owner_user_id=self.alert_rule.user_id,
+        )
         self.create_detector_workflow(detector=self.detector, workflow=self.workflow)
-        
 
         self.data_condition_group = self.create_data_condition_group(organization=self.organization)
         self.create_data_condition_group_action(
@@ -48,14 +67,19 @@ class TestActionSerializer(TestCase):
             type=Condition.ISSUE_PRIORITY_EQUALS,
             condition_group=self.data_condition_group,
         )
-        WorkflowDataConditionGroup.objects.create(workflow=self.workflow, condition_group=self.data_condition_group)
+        WorkflowDataConditionGroup.objects.create(
+            workflow=self.workflow, condition_group=self.data_condition_group
+        )
 
         self.critical_detector_trigger_data_condition = self.create_data_condition(
             condition_group=self.detector.workflow_condition_group,
             condition_result=self.action_filter_data_condition.comparison,
             comparison=self.critical_trigger.alert_threshold,
         )
-        DataConditionAlertRuleTrigger.objects.create(data_condition=self.critical_detector_trigger_data_condition, alert_rule_trigger_id=self.critical_trigger.id)
+        DataConditionAlertRuleTrigger.objects.create(
+            data_condition=self.critical_detector_trigger_data_condition,
+            alert_rule_trigger_id=self.critical_trigger.id,
+        )
 
     def test_simple(self) -> None:
         serialized_action = serialize(self.action, self.user, WorkflowEngineActionSerializer())
@@ -79,7 +103,9 @@ class TestActionSerializer(TestCase):
             name="Super Awesome App",
             schema={"elements": [self.create_alert_rule_action_schema()]},
         )
-        self.sentry_app_trigger = self.create_alert_rule_trigger(alert_rule=self.alert_rule, label="warning")
+        self.sentry_app_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.alert_rule, label="warning"
+        )
         self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
@@ -127,7 +153,10 @@ class TestActionSerializer(TestCase):
             condition_result=self.sentry_app_action_filter_data_condition.comparison,
             comparison=self.sentry_app_trigger.alert_threshold,
         )
-        DataConditionAlertRuleTrigger.objects.create(data_condition=self.sentry_app_detector_trigger_data_condition, alert_rule_trigger_id=self.sentry_app_trigger.id)
+        DataConditionAlertRuleTrigger.objects.create(
+            data_condition=self.sentry_app_detector_trigger_data_condition,
+            alert_rule_trigger_id=self.sentry_app_trigger.id,
+        )
 
         serialized_action = serialize(
             self.sentry_app_action, self.user, WorkflowEngineActionSerializer()
@@ -146,7 +175,9 @@ class TestActionSerializer(TestCase):
             external_id="TXXXXXXX1",
             user=self.user,
         )
-        self.slack_trigger = self.create_alert_rule_trigger(alert_rule=self.alert_rule, label="warning")
+        self.slack_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.alert_rule, label="warning"
+        )
         self.slack_trigger_action = AlertRuleTriggerAction.objects.create(
             alert_rule_trigger=self.slack_trigger,
             target_identifier="123",


### PR DESCRIPTION
We don't want to read from the old models at all in these serializers as we'll have switched over at this point. This PR updates the new `Action` serializer that's used by the old alert rule endpoint to only read from the newer ACI models.

Closes https://getsentry.atlassian.net/browse/ACI-230