### PR TITLE
fix(traceDataSection): don't hide when oneOtherIssueEvent is undef

### DIFF
--- a/static/app/views/issueDetails/traceDataSection.tsx
+++ b/static/app/views/issueDetails/traceDataSection.tsx
@@ -31,7 +31,10 @@ export function TraceDataSection({event}: {event: Event}) {
   }
 
   const noEvents = !isLoading && traceEvents.length === 0;
-  if (hasStreamlinedUI && (!oneOtherIssueEvent || noEvents)) {
+  if (
+    hasStreamlinedUI &&
+    (noEvents || (traceEvents.length === 1 && !oneOtherIssueEvent))
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Noticed on [this feedback](https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A6394168736&project=11276&referrer=feedback_list_page&statsPeriod=24h) the hide logic for issueDetails/traceDataSection doesn't seem right. `oneOtherIssueEvent` is undefined when there are 2 or more timeline events. The current condition is hiding all `TraceTimeline`s 

Same feedback w/this change on dev-ui:
![Screenshot 2025-03-13 at 7 09 43 PM](https://github.com/user-attachments/assets/a104efad-b088-4871-a78f-bef8c1bc5d15)