### PR TITLE
ref(onboarding): Remove 'Sentry.wrap' from react-native auto

### DIFF
--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -164,36 +164,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                         {t('Add debug symbols upload to your build process')}
                       </ListItem>
                     </List>
-                    <p />
-                    <p>
-                      <strong>{t('Wrap Your App')}</strong>
-                    </p>
-                    <p>
-                      {tct(
-                        'After the wizard completes, wrap your app with Sentry to enable automatic [touchEventLink:touch event tracking] and [autoInstrumentationLink:automatic instrumentation]:',
-                        {
-                          touchEventLink: (
-                            <ExternalLink href="https://docs.sentry.io/platforms/react-native/configuration/touchevents/" />
-                          ),
-                          autoInstrumentationLink: (
-                            <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/" />
-                          ),
-                        }
-                      )}
-                    </p>
                   </Fragment>
-                ),
-                code: [
-                  {
-                    label: 'JavaScript',
-                    value: 'javascript',
-                    language: 'javascript',
-                    filename: 'App.js',
-                    code: `export default Sentry.wrap(App);`,
-                  },
-                ],
-                additionalInfo: t(
-                  'This step is not required if your app does not have a single parent "App" component.'
                 ),
               },
             ],
@@ -227,12 +198,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               {
                 language: 'javascript',
                 code: getConfigureSnippet(params),
-                additionalInfo: tct(
-                  'The "sentry-wizard" will try to add it to your [code:App.tsx]',
-                  {
-                    code: <code />,
-                  }
-                ),
               },
               {
                 language: 'javascript',


### PR DESCRIPTION
Update the getting-started docs for react-native, reflecting the new release [https://github.com/getsentry/sentry-wizard/releases/tag/v4.4.0](https://github.com/getsentry/sentry-wizard/releases/tag/v4.4.0
)

**Before**
![Screenshot 2025-03-14 at 07 03 25](https://github.com/user-attachments/assets/d2c545e7-e396-4a50-8faa-6e2dec44ce6e)



**After**
![Screenshot 2025-03-14 at 07 03 56](https://github.com/user-attachments/assets/67715c3a-3799-4d8e-aa93-0a6efa2c4a39)
