### PR TITLE
feat(laravel-insights): Improve empty states

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -24,6 +24,7 @@ import {
 import {Toolbar} from 'sentry/views/insights/pages/backend/laravel/toolbar';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
+import {HighestCacheMissRateTransactionsWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 function isCacheHitError(error: RequestError | null) {
   return (
@@ -126,6 +127,7 @@ export function CachesWidget({query}: {query?: string}) {
       isLoading={isLoading}
       error={error}
       isEmpty={!hasData}
+      emptyMessage={<HighestCacheMissRateTransactionsWidgetEmptyStateWarning />}
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables: timeSeries.map(

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -26,6 +26,7 @@ import {Toolbar} from 'sentry/views/insights/pages/backend/laravel/toolbar';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
 import {ModuleName} from 'sentry/views/insights/types';
+import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 interface QueriesDiscoverQueryResponse {
   data: Array<{
@@ -135,6 +136,7 @@ export function QueriesWidget({query}: {query?: string}) {
       isEmpty={!hasData}
       isLoading={isLoading}
       error={error}
+      emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         aliases: Object.fromEntries(

--- a/static/app/views/insights/pages/backend/laravel/widgetVisualizationStates.tsx
+++ b/static/app/views/insights/pages/backend/laravel/widgetVisualizationStates.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
-import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {WidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 type WidgetVisualization = React.ComponentType<any> & {
   LoadingPlaceholder: React.ComponentType<any>;
@@ -11,6 +11,7 @@ export function WidgetVisualizationStates<T extends WidgetVisualization>({
   isLoading,
   isEmpty,
   error,
+  emptyMessage,
   VisualizationType,
   visualizationProps,
 }: {
@@ -19,6 +20,7 @@ export function WidgetVisualizationStates<T extends WidgetVisualization>({
   isEmpty: boolean;
   isLoading: boolean;
   visualizationProps: React.ComponentProps<T>;
+  emptyMessage?: React.ReactNode;
 }) {
   if (isLoading) {
     return <VisualizationType.LoadingPlaceholder />;
@@ -27,7 +29,7 @@ export function WidgetVisualizationStates<T extends WidgetVisualization>({
     return <Widget.WidgetError error={error} />;
   }
   if (isEmpty) {
-    return <Widget.WidgetError error={MISSING_DATA_MESSAGE} />;
+    return emptyMessage ? emptyMessage : <WidgetEmptyStateWarning />;
   }
   return <VisualizationType {...visualizationProps} />;
 }


### PR DESCRIPTION
Re-use existing empty states for new widgets.
<img width="1146" alt="Screenshot 2025-03-14 at 10 37 52" src="https://github.com/user-attachments/assets/ea27dfa8-3d42-4bd2-9f7b-7ea93889c64e" />

Jobs uses the generic one that will also be used for every other widget. Queries and caches have a specific one.

- closes https://github.com/getsentry/projects/issues/824