### PR TITLE
fix(laravel-insights): Handle wrong return type

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -88,7 +88,11 @@ export function CachesWidget({query}: {query?: string}) {
   });
 
   const timeSeries = useMemo<DiscoverSeries[]>(() => {
-    if (!timeSeriesRequest.data && timeSeriesRequest.meta) {
+    if (
+      (!timeSeriesRequest.data && timeSeriesRequest.meta) ||
+      // There are no-data cases, for which the endpoint returns a single empty series with meta containing an explanation
+      'data' in timeSeriesRequest.data
+    ) {
       return [];
     }
 

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -97,19 +97,24 @@ export function QueriesWidget({query}: {query?: string}) {
   );
 
   const timeSeries = useMemo<DiscoverSeries[]>(() => {
-    if (!timeSeriesRequest.data) {
+    if (
+      !timeSeriesRequest.data ||
+      // There are no-data cases, for which the endpoint returns a single empty series with meta containing an explanation
+      'data' in timeSeriesRequest.data
+    ) {
       return [];
     }
 
     return Object.keys(timeSeriesRequest.data)
       .filter(key => key !== 'Other')
       .map(key => {
-        const seriesData = timeSeriesRequest.data[key]!;
+        const seriesData = timeSeriesRequest.data[key];
         return {
-          data: seriesData.data.map(([time, value]) => ({
-            name: new Date(time * 1000).toISOString(),
-            value: value?.[0]?.count || 0,
-          })),
+          data:
+            seriesData?.data.map(([time, value]) => ({
+              name: new Date(time * 1000).toISOString(),
+              value: value?.[0]?.count || 0,
+            })) ?? [],
           seriesName: key,
           meta: {
             fields: {

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -108,13 +108,12 @@ export function QueriesWidget({query}: {query?: string}) {
     return Object.keys(timeSeriesRequest.data)
       .filter(key => key !== 'Other')
       .map(key => {
-        const seriesData = timeSeriesRequest.data[key];
+        const seriesData = timeSeriesRequest.data[key]!;
         return {
-          data:
-            seriesData?.data.map(([time, value]) => ({
-              name: new Date(time * 1000).toISOString(),
-              value: value?.[0]?.count || 0,
-            })) ?? [],
+          data: seriesData.data.map(([time, value]) => ({
+            name: new Date(time * 1000).toISOString(),
+            value: value?.[0]?.count || 0,
+          })),
           seriesName: key,
           meta: {
             fields: {


### PR DESCRIPTION
In some cases when the backend cannot find any data, it changes the return structure from a multi-series object to a single empty series containing a meta object with an explanation why the response is empty.