### PR TITLE
feat(login): Default login banner back to discord

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -95,7 +95,7 @@
   {% elif show_login_banner %}
   <div class="alert-banner default">
     <div class="alert-message">
-      Ship it, break it, fix it—live! Hands-on workshop debugging with Lazar. &nbsp<a target="_blank" href="https://sentry.io/resources/instrument-monitor-fix-workshop/">RSVP for March 12.</a>
+      Want to connect with the folks building Sentry? &nbsp<a target="_blank" href="https://discord.com/invite/sentry">Join us on Discord.</a>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Webinar date is now in the past so defaulting the login banner back to normal.

Relates to https://github.com/getsentry/sentry/pull/85486