### PR TITLE
fix(ourlogs): Better clickability for expanding rows

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -16,7 +16,7 @@ import {
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
 
-const DEFAULT_HOVER_TIMEOUT = 300;
+const DEFAULT_HOVER_TIMEOUT = 200;
 
 /**
  * ProjectTraceItemDetailsEndpoint currently only supports ourlogs dataset

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -37,7 +37,6 @@ import {
   LogDetailTableBodyCell,
   LogFirstCellContent,
   LogTableBodyCell,
-  LogTableBodyCellContent,
   LogTableRow,
   StyledChevronButton,
 } from './styles';
@@ -60,7 +59,7 @@ export function LogRowContent({
   const organization = useOrganization();
   const fields = useLogsFields();
   const [expanded, setExpanded] = useState<boolean>(false);
-  const onClickExpand = useCallback(() => setExpanded(e => !e), [setExpanded]);
+  const onClickExpand = useCallback(() => setExpanded(e => !e), []);
   const theme = useTheme();
 
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
@@ -123,13 +122,11 @@ export function LogRowContent({
 
           return (
             <LogTableBodyCell key={field}>
-              <LogTableBodyCellContent onClick={e => e.stopPropagation()}>
-                <LogFieldRenderer
-                  item={getLogRowItem(field, dataRow, meta)}
-                  meta={meta}
-                  extra={rendererExtra}
-                />
-              </LogTableBodyCellContent>
+              <LogFieldRenderer
+                item={getLogRowItem(field, dataRow, meta)}
+                meta={meta}
+                extra={rendererExtra}
+              />
             </LogTableBodyCell>
           );
         })}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -1,7 +1,6 @@
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {TableCell} from 'sentry/components/charts/simpleTableChart';
 import {Button} from 'sentry/components/core/button';
 import {GRID_BODY_ROW_HEIGHT} from 'sentry/components/gridEditable/styles';
 import {HighlightComponent} from 'sentry/components/highlight';
@@ -48,10 +47,6 @@ export const LogTableRow = styled(TableRow)`
   cursor: pointer;
 `;
 
-export const LogTableCell = styled(TableCell)`
-  pointer-events: none;
-`;
-
 export const LogTableBodyCell = styled(TableBodyCell)`
   min-height: ${GRID_BODY_ROW_HEIGHT - 8}px;
 `;
@@ -86,11 +81,8 @@ export const DetailsGrid = styled(StyledPanel)`
   padding: ${space(1)} ${space(2)};
 `;
 
-export const CenteredRow = styled('div')<{align?: 'left' | 'center' | 'right'}>`
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-  justify-content: ${p => p.align || 'left'};
+export const NonClickableCell = styled('div')`
+  cursor: auto;
 `;
 
 export const LogDetailsTitle = styled('div')`
@@ -99,11 +91,7 @@ export const LogDetailsTitle = styled('div')`
   user-select: none;
 `;
 
-export const LogTableBodyCellContent = styled('div')`
-  cursor: default;
-`;
-
-export const LogFirstCellContent = styled(LogTableBodyCellContent)`
+export const LogFirstCellContent = styled('div')`
   display: flex;
   align-items: center;
 `;
@@ -178,9 +166,20 @@ export const LogsHighlight = styled(HighlightComponent)`
 `;
 
 export const WrappingText = styled('div')<{wrap?: boolean}>`
-  width: 100%;
-  ${p => p.theme.overflowEllipsis};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   ${p => p.wrap && 'text-wrap: auto;'}
+  cursor: auto;
+`;
+
+export const AlignedCellContent = styled('div')<{
+  align?: 'left' | 'center' | 'right';
+}>`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  justify-content: ${p => p.align || 'left'};
 `;
 
 export function getLogColors(level: SeverityLevel, theme: Theme) {


### PR DESCRIPTION
### Summary
This wraps content so that the row expand is blocked (for text selecting), but all of the row that isn't content should now be clickable. 

#### Other
- Lowered hover timeout for prefetch to 200ms.