### PR TITLE
fix(dashboards-eap): Add !transaction.span_id:00 to filters

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -87,4 +87,93 @@ describe('SpansConfig', () => {
 
     expect(Object.keys(groupByOptions)).toEqual(['tag:transaction', 'tag:platform']);
   });
+
+  it('appends the transaction.span_id filter to the series request to match the trace explorer', async () => {
+    const eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+    });
+
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          conditions: 'test',
+          name: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    // Trigger request
+    SpansConfig.getSeriesRequest!(
+      api,
+      widget,
+      0,
+      organization,
+      PageFiltersFixture(),
+      undefined,
+      'test-referrer',
+      undefined
+    );
+
+    expect(eventsStatsMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(eventsStatsMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'test !transaction.span_id:00',
+          }),
+        })
+      );
+    });
+  });
+
+  it('appends the transaction.span_id filter to the events request to match the trace explorer', async () => {
+    const eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: [],
+    });
+
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          conditions: 'test',
+          name: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    // Trigger request
+    SpansConfig.getTableRequest!(
+      api,
+      widget,
+      widget.queries[0]!,
+      organization,
+      PageFiltersFixture(),
+      undefined,
+      undefined,
+      'test-referrer',
+      undefined
+    );
+
+    expect(eventsStatsMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(eventsStatsMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'test !transaction.span_id:00',
+          }),
+        })
+      );
+    });
+  });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -220,6 +220,11 @@ function getEventsRequest(
     params.sort = toArray(query.orderby);
   }
 
+  // Filtering out all spans with op like 'ui.interaction*' which aren't
+  // embedded under transactions. The trace view does not support rendering
+  // such spans yet.
+  eventView.query = `${eventView.query} !transaction.span_id:00`;
+
   return doDiscoverQuery<EventsTableData>(
     api,
     url,
@@ -278,6 +283,11 @@ function getSeriesRequest(
 
   requestData.useRpc = true;
   requestData.interval = getInterval(pageFilters.datetime, 'spans');
+
+  // Filtering out all spans with op like 'ui.interaction*' which aren't
+  // embedded under transactions. The trace view does not support rendering
+  // such spans yet.
+  requestData.query = `${requestData.query} !transaction.span_id:00`;
 
   return doEventsRequest<true>(api, requestData);
 }


### PR DESCRIPTION
Explore always sends requests with !transaction.span_id:00 appended to requests. This is required to filter out spans that are not bound to a transaction since the trace view can't support rendering these yet.