### PR TITLE
fix(jira): Add a 'key_id' block list for JIRA installed webhook endpoint

### DIFF
--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -6,16 +6,18 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.jira.integration import JiraIntegrationProvider
 from sentry.integrations.jira.tasks import sync_metadata
+from sentry.integrations.jira.webhooks.base import JiraWebhookBase
 from sentry.integrations.pipeline import ensure_integration
+from sentry.integrations.project_management.metrics import ProjectManagementFailuresReason
 from sentry.integrations.utils.atlassian_connect import authenticate_asymmetric_jwt, verify_claims
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.utils import jwt
-
-from ...base import IntegrationDomain
-from ...project_management.metrics import ProjectManagementFailuresReason
-from ...utils.metrics import IntegrationPipelineViewEvent, IntegrationPipelineViewType
-from ..integration import JiraIntegrationProvider
-from .base import JiraWebhookBase
 
 # Atlassian sends scanner bots to "test" Atlassian apps and they often hit this endpoint with a bad kid causing errors
 INVALID_KEY_IDS = ["fake-kid"]

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -49,9 +49,9 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
             lifecycle.add_extras(
                 {
                     "key_id": key_id,
-                    "base_url": state.get("baseUrl"),
-                    "description": state.get("description"),
-                    "clientKey": state.get("clientKey"),
+                    "base_url": state.get("baseUrl", ""),
+                    "description": state.get("description", ""),
+                    "clientKey": state.get("clientKey", ""),
                 }
             )
 

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -8,11 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.integrations.jira.tasks import sync_metadata
 from sentry.integrations.pipeline import ensure_integration
-from sentry.integrations.utils.atlassian_connect import (
-    AtlassianConnectValidationError,
-    authenticate_asymmetric_jwt,
-    verify_claims,
-)
+from sentry.integrations.utils.atlassian_connect import authenticate_asymmetric_jwt, verify_claims
 from sentry.utils import jwt
 
 from ...base import IntegrationDomain
@@ -20,6 +16,9 @@ from ...project_management.metrics import ProjectManagementFailuresReason
 from ...utils.metrics import IntegrationPipelineViewEvent, IntegrationPipelineViewType
 from ..integration import JiraIntegrationProvider
 from .base import JiraWebhookBase
+
+# Atlassian sends scanner bots to "test" Atlassian apps and they often hit this endpoint with a bad kid causing errors
+INVALID_KEY_IDS = ["fake-kid"]
 
 
 @control_silo_endpoint
@@ -45,14 +44,22 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                 return self.respond(status=status.HTTP_400_BAD_REQUEST)
 
             key_id = jwt.peek_header(token).get("kid")
-            if key_id:
-                try:
-                    decoded_claims = authenticate_asymmetric_jwt(token, key_id)
-                except AtlassianConnectValidationError as e:
-                    sentry_sdk.capture_exception(e)
-                    lifecycle.record_halt(e)
-                    return self.respond(status=status.HTTP_400_BAD_REQUEST)
+            lifecycle.add_extras(
+                {
+                    "key_id": key_id,
+                    "base_url": state.get("baseUrl"),
+                    "description": state.get("description"),
+                    "clientKey": state.get("clientKey"),
+                }
+            )
 
+            if key_id:
+                if key_id in INVALID_KEY_IDS:
+                    lifecycle.record_halt(halt_reason="JWT contained invalid key_id (kid)")
+                    return self.respond(
+                        {"detail": "Invalid key id"}, status=status.HTTP_400_BAD_REQUEST
+                    )
+                decoded_claims = authenticate_asymmetric_jwt(token, key_id)
                 verify_claims(decoded_claims, request.path, request.GET, method="POST")
 
             data = JiraIntegrationProvider().build_integration(state)

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -125,11 +125,18 @@ def authenticate_asymmetric_jwt(token: str | None, key_id: str) -> dict[str, str
     headers = jwt.peek_header(token)
     key_response = requests.get(f"https://connect-install-keys.atlassian.com/{key_id}")
     public_key = key_response.content.decode("utf-8").strip()
-    decoded_claims = jwt.decode(
-        token, public_key, audience=absolute_uri(), algorithms=[headers.get("alg")]
-    )
-    if not decoded_claims:
-        raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
+
+    try:
+        decoded_claims = jwt.decode(
+            token, public_key, audience=absolute_uri(), algorithms=[headers.get("alg")]
+        )
+        if not decoded_claims:
+            raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
+    except ValueError as e:
+        raise AtlassianConnectValidationError(
+            "Unable to decode given token with Atlassian Connect"
+        ) from e
+
     return decoded_claims
 
 

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -125,17 +125,11 @@ def authenticate_asymmetric_jwt(token: str | None, key_id: str) -> dict[str, str
     headers = jwt.peek_header(token)
     key_response = requests.get(f"https://connect-install-keys.atlassian.com/{key_id}")
     public_key = key_response.content.decode("utf-8").strip()
-
-    try:
-        decoded_claims = jwt.decode(
-            token, public_key, audience=absolute_uri(), algorithms=[headers.get("alg")]
-        )
-        if not decoded_claims:
-            raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
-    except ValueError as e:
-        raise AtlassianConnectValidationError(
-            "Unable to decode given token with Atlassian Connect"
-        ) from e
+    decoded_claims = jwt.decode(
+        token, public_key, audience=absolute_uri(), algorithms=[headers.get("alg")]
+    )
+    if not decoded_claims:
+        raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
 
     return decoded_claims
 

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -130,7 +130,6 @@ def authenticate_asymmetric_jwt(token: str | None, key_id: str) -> dict[str, str
     )
     if not decoded_claims:
         raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
-
     return decoded_claims
 
 

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -16,6 +16,7 @@ from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     get_query_hash,
 )
+from sentry.testutils.asserts import assert_count_of_metric, assert_halt_metric
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.http import absolute_uri
@@ -135,3 +136,24 @@ class JiraInstalledTest(APITestCase):
 
         mock_set_tag.assert_any_call("integration_id", integration.id)
         assert integration.status == ObjectStatus.ACTIVE
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_with_invalid_key_id(self, mock_record_event: MagicMock):
+        self.get_error_response(
+            **self.body(),
+            extra_headers=dict(
+                HTTP_AUTHORIZATION="JWT "
+                + self._jwt_token("RS256", RS256_KEY, headers={"kid": "fake-kid"})
+            ),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        # SLO metric asserts
+        # ENSURE_CONTROL_SILO (success) -> VERIFY_INSTALLATION (halt) -> GET_CONTROL_RESPONSE (success)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.STARTED, 3)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.HALTED, 1)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.HALTED, 2)
+        assert_halt_metric(
+            mock_record_event,
+            "JWT contained invalid key_id (kid)",
+        )

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -152,7 +152,7 @@ class JiraInstalledTest(APITestCase):
         # ENSURE_CONTROL_SILO (success) -> VERIFY_INSTALLATION (halt) -> GET_CONTROL_RESPONSE (success)
         assert_count_of_metric(mock_record_event, EventLifecycleOutcome.STARTED, 3)
         assert_count_of_metric(mock_record_event, EventLifecycleOutcome.HALTED, 1)
-        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.HALTED, 2)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.SUCCESS, 2)
         assert_halt_metric(
             mock_record_event,
             "JWT contained invalid key_id (kid)",


### PR DESCRIPTION
Our Jira installation SLO was failing, because Atlassian sends bots/scanners to "test" their integrators and check if they're working. Some of these bots were hitting our installed webhook endpoint and providing JWTs with a bad `key_id`(kid) ([relevant Sentry issue with details](https://sentry.sentry.io/issues/6084811020/events/oldest/?end=2025-03-11T15%3A10%3A04&project=1&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20ValueError&referrer=oldest-event&sort=date&start=2025-03-11T06%3A45%3A20&stream_index=3)). We would then reach out to Atlassian using the bad kid for the public key and we would get back some 403 Unauthorized HTML. The JWT module would then raise an `ValueError` when we tried to verify the token using the 403 HTML and cause our metric/SLO to fail.

We're just adding a blocklist, since 1. This module is going to get nuked soon with the Atlassian forge changes and 2. so we only filter out the atlassian bots since they all use the same kid.