### PR TITLE
feat(schema-hints): Add default ordering to displayed hints

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -12,7 +12,12 @@ import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {prettifyTagKey} from 'sentry/utils/discover/fields';
-import {type AggregationKey, FieldKind} from 'sentry/utils/fields';
+import {
+  type AggregationKey,
+  FieldKind,
+  FieldValueType,
+  getFieldDefinition,
+} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import SchemaHintsDrawer from 'sentry/views/explore/components/schemaHintsDrawer';
 import {SCHEMA_HINTS_LIST_ORDER_KEYS} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
@@ -164,9 +169,12 @@ function SchemaHintsList({
       }
 
       const newSearchQuery = new MutableSearch(exploreQuery);
+      const isBoolean =
+        getFieldDefinition(hint.key, 'span', hint.kind)?.valueType ===
+        FieldValueType.BOOLEAN;
       newSearchQuery.addFilterValue(
         hint.key,
-        hint.kind === FieldKind.MEASUREMENT ? '>0' : ''
+        isBoolean ? 'True' : hint.kind === FieldKind.MEASUREMENT ? '>0' : ''
       );
       setExploreQuery(newSearchQuery.formatString());
     },

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -10,7 +10,6 @@ import {getFunctionTags} from 'sentry/components/performance/spanSearchQueryBuil
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
-import {defined} from 'sentry/utils';
 import {prettifyTagKey} from 'sentry/utils/discover/fields';
 import {
   type AggregationKey,
@@ -66,18 +65,18 @@ function SchemaHintsList({
     const filterTags: TagCollection = {...functionTags, ...numberTags, ...stringTags};
     filterTags.has = getHasTag({...stringTags});
 
-    const schemaHintsPresetKeys = SCHEMA_HINTS_LIST_ORDER_KEYS.filter(key =>
-      defined(filterTags[key])
+    const schemaHintsPresetTags = getTagsFromKeys(
+      SCHEMA_HINTS_LIST_ORDER_KEYS,
+      filterTags
     );
-    const schemaHintsPresetTags = getTagsFromKeys(schemaHintsPresetKeys, filterTags);
 
     const sectionKeys = SPANS_FILTER_KEY_SECTIONS.flatMap(
       section => section.children
-    ).filter(key => !schemaHintsPresetKeys.includes(key));
+    ).filter(key => !SCHEMA_HINTS_LIST_ORDER_KEYS.includes(key));
     const sectionSortedTags = getTagsFromKeys(sectionKeys, filterTags);
 
     const otherKeys = Object.keys(filterTags).filter(
-      key => !sectionKeys.includes(key) && !schemaHintsPresetKeys.includes(key)
+      key => !sectionKeys.includes(key) && !SCHEMA_HINTS_LIST_ORDER_KEYS.includes(key)
     );
     const otherTags = getTagsFromKeys(otherKeys, filterTags);
 

--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -1,0 +1,25 @@
+import {FieldKey} from 'sentry/utils/fields';
+import {SpanIndexedField} from 'sentry/views/insights/types';
+
+const FRONTEND_HINT_KEYS = [SpanIndexedField.BROWSER_NAME, SpanIndexedField.USER];
+
+const MOBILE_HINT_KEYS = [
+  FieldKey.OS_NAME,
+  FieldKey.DEVICE_FAMILY,
+  SpanIndexedField.USER,
+];
+
+const COMMON_HINT_KEYS = [
+  SpanIndexedField.IS_TRANSACTION,
+  SpanIndexedField.SPAN_OP,
+  SpanIndexedField.SPAN_DESCRIPTION,
+  SpanIndexedField.SPAN_DURATION,
+  SpanIndexedField.TRANSACTION,
+  FieldKey.HTTP_STATUS_CODE,
+  SpanIndexedField.RELEASE,
+  'url',
+];
+
+export const SCHEMA_HINTS_LIST_ORDER_KEYS = [
+  ...new Set([...FRONTEND_HINT_KEYS, ...MOBILE_HINT_KEYS, ...COMMON_HINT_KEYS]),
+];


### PR DESCRIPTION
Dhrumil and Dora gave me a [list of hints](https://www.notion.so/sentry/Schema-Hints-Onboarding-Guide-18a8b10e4b5d8016a64ec3e763001abe?pvs=4#18a8b10e4b5d80af98b1e1325cbd6bfe) that should display first (if they exist in the list of tags) so i've adjusted the sorting to have these show up at the beginning of the list. Here's what it looks like (it varies from project to project):

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/8b90e8b4-597b-4502-bb97-b8a359caf382" />

Closes https://github.com/getsentry/sentry/issues/86480