### PR TITLE
ref: implement missing to_query_string for AggregateFilter

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -371,15 +371,14 @@ class SearchBoolean(namedtuple("SearchBoolean", "left_term operator right_term")
         return value == SearchBoolean.BOOLEAN_AND or SearchBoolean.is_or_operator(value)
 
 
-class ParenExpression(namedtuple("ParenExpression", "children")):
-    def to_query_string(self):
-        children = ""
-        for child in self.children:
-            if isinstance(child, str):
-                children += f" {child}"
-            else:
-                children += f" {child.to_query_string()}"
-        return f"({children})"
+class ParenExpression(NamedTuple):
+    children: Sequence[QueryToken]
+
+    def to_query_string(self) -> str:
+        inner = " ".join(
+            child if isinstance(child, str) else child.to_query_string() for child in self.children
+        )
+        return f"({inner})"
 
 
 class SearchKey(NamedTuple):
@@ -516,7 +515,7 @@ class SearchFilter(NamedTuple):
     def __str__(self):
         return f"{self.key.name}{self.operator}{self.value.raw_value}"
 
-    def to_query_string(self):
+    def to_query_string(self) -> str:
         if self.operator == "IN":
             return f"{self.key.name}:{self.value.to_query_string()}"
         elif self.operator == "NOT IN":
@@ -558,12 +557,18 @@ if TYPE_CHECKING:
         value: SearchValue
         DO_NOT_USE_ME_I_AM_FOR_MYPY: bool = True
 
+        def to_query_string(self) -> str:
+            return ""
+
 else:  # real implementation here!
 
     class AggregateFilter(NamedTuple):
         key: AggregateKey
         operator: str
         value: SearchValue
+
+        def to_query_string(self) -> str:
+            return f"{self.key.name}:{self.operator}{self.value.to_query_string()}"
 
         def __str__(self) -> str:
             return f"{self.key.name}{self.operator}{self.value.raw_value}"
@@ -1324,7 +1329,7 @@ default_config = SearchConfig(
 )
 
 QueryOp = Literal["AND", "OR"]
-QueryToken = Union[SearchFilter, QueryOp, ParenExpression]
+QueryToken = Union[SearchFilter, AggregateFilter, QueryOp, ParenExpression]
 
 
 def parse_search_query(

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -9,6 +9,8 @@ from django.contrib.auth.models import AnonymousUser
 from sentry.api.event_search import (
     AggregateFilter,
     ParenExpression,
+    QueryOp,
+    QueryToken,
     SearchConfig,
     SearchFilter,
     SearchKey,
@@ -28,7 +30,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERATORS
-from sentry.search.events.filter import ParsedTerm, ParsedTerms, to_list
+from sentry.search.events.filter import to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
     get_teams_for_users,
@@ -273,23 +275,23 @@ def convert_query_values(
 
 @overload
 def convert_query_values(
-    search_filters: ParsedTerms,
+    search_filters: Sequence[QueryToken],
     projects: Sequence[Project],
     user: User | RpcUser | AnonymousUser | None,
     environments: Sequence[Environment] | None,
     value_converters=value_converters,
     allow_aggregate_filters=False,
-) -> ParsedTerms: ...
+) -> Sequence[QueryToken]: ...
 
 
 def convert_query_values(
-    search_filters: ParsedTerms,
+    search_filters: Sequence[QueryToken],
     projects: Sequence[Project],
     user: User | RpcUser | AnonymousUser | None,
     environments: Sequence[Environment] | None,
     value_converters=value_converters,
     allow_aggregate_filters=False,
-) -> ParsedTerms:
+) -> Sequence[QueryToken]:
     """
     Accepts a collection of SearchFilter objects and converts their values into
     a specific format, based on converters specified in `value_converters`.
@@ -317,9 +319,9 @@ def convert_query_values(
     ) -> ParenExpression: ...
 
     @overload
-    def convert_search_filter(search_filter: str, organization: Organization) -> str: ...
+    def convert_search_filter(search_filter: QueryOp, organization: Organization) -> QueryOp: ...
 
-    def convert_search_filter(search_filter: ParsedTerm, organization: Organization) -> ParsedTerm:
+    def convert_search_filter(search_filter: QueryToken, organization: Organization) -> QueryToken:
         if isinstance(search_filter, ParenExpression):
             return search_filter._replace(
                 children=[
@@ -351,8 +353,8 @@ def convert_query_values(
         return search_filter
 
     def expand_substatus_query_values(
-        search_filters: ParsedTerms, org: Organization
-    ) -> ParsedTerms:
+        search_filters: Sequence[QueryToken], org: Organization
+    ) -> Sequence[QueryToken]:
         first_status_incl = None
         first_status_excl = None
         includes_status_filter = False

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -27,7 +27,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
-from sentry.api.event_search import ParenExpression, SearchFilter, parse_search_query
+from sentry.api.event_search import QueryToken, parse_search_query
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.replay_examples import ReplayExamples
@@ -187,7 +187,7 @@ def query_selector_dataset(
     project_ids: list[int],
     start: datetime,
     end: datetime,
-    search_filters: list[SearchFilter | ParenExpression | str],
+    search_filters: list[QueryToken],
     environment: list[str],
     pagination: Paginators | None,
     sort: str | None,

--- a/src/sentry/replays/endpoints/project_replay_clicks_index.py
+++ b/src/sentry/replays/endpoints/project_replay_clicks_index.py
@@ -29,7 +29,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.event_search import ParenExpression, SearchFilter, parse_search_query
+from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.replay_examples import ReplayExamples
@@ -128,7 +128,7 @@ def query_replay_clicks(
     end: datetime.datetime,
     limit: int,
     offset: int,
-    search_filters: Sequence[SearchFilter | str | ParenExpression],
+    search_filters: Sequence[QueryToken],
     organization_id: int,
 ):
     """Query replay clicks.
@@ -196,7 +196,7 @@ def query_replay_clicks(
 # transformed into `Or` operations.
 def handle_search_filters(
     search_config: dict[str, FieldProtocol],
-    search_filters: Sequence[SearchFilter | str | ParenExpression],
+    search_filters: Sequence[QueryToken],
 ) -> list[Condition]:
     """Convert search filters to snuba conditions."""
     result: list[Condition] = []

--- a/src/sentry/replays/usecases/query/configs/scalar.py
+++ b/src/sentry/replays/usecases/query/configs/scalar.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import datetime, timezone
 
-from sentry.api.event_search import ParenExpression, SearchFilter
+from sentry.api.event_search import ParenExpression, QueryToken
 from sentry.replays.lib.new_query.conditions import (
     NonEmptyStringScalar,
     StringArray,
@@ -96,7 +96,7 @@ scalar_search_config = {**static_search_config, **varying_search_config}
 
 
 def can_scalar_search_subquery(
-    search_filters: Sequence[ParenExpression | SearchFilter | str],
+    search_filters: Sequence[QueryToken],
     started_at: datetime,
 ) -> bool:
     """Return "True" if a scalar event search can be performed."""

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Generator, Sequence
 from typing import Any
 
-from sentry.api.event_search import ParenExpression, SearchFilter, parse_search_query
+from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
 from sentry.search.events.types import SnubaParams
@@ -184,7 +184,7 @@ def _get_select_column(query: str) -> tuple[str, Sequence[Any]]:
     return condition.key.name, condition.value.raw_value
 
 
-def extract_columns_recursive(query: list[Any]) -> Generator[SearchFilter]:
+def extract_columns_recursive(query: Sequence[QueryToken]) -> Generator[SearchFilter]:
     for condition in query:
         if isinstance(condition, SearchFilter):
             if condition.key.name in ("issue.id", "transaction", "replay_id"):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -298,6 +298,11 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             )
         ]
 
+    def test_paren_expression_to_query_string(self):
+        (val,) = parse_search_query("(has:1 random():<5)")
+        assert isinstance(val, ParenExpression)
+        assert val.to_query_string() == "(has:=1 random():<5.0)"  # type: ignore[unreachable]  # will be fixed once parse_search_query is fixed!
+
     def test_bool_operator_with_bool_disabled(self):
         config = SearchConfig.create_from(default_config, allow_boolean=False)
         with pytest.raises(InvalidSearchQuery) as excinfo:


### PR DESCRIPTION
new test previously failed with:

```
______ ParseSearchQueryBackendTest.test_paren_expression_to_query_string _______
tests/sentry/api/test_event_search.py:304: in test_paren_expression_to_query_string
    assert val.to_query_string() == '(has:1 random():<5)'
src/sentry/api/event_search.py:381: in to_query_string
    children += f" {child.to_query_string()}"
E   AttributeError: 'AggregateFilter' object has no attribute 'to_query_string'
```

<!-- Describe your PR here. -->