### PR TITLE
feat(nav): Add org dropdown in mobile nav

### DIFF
--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -223,7 +223,9 @@ describe('Nav', function () {
       renderNav();
 
       // Should have a top-level header element with a home link and menu button
-      expect(screen.getByRole('link', {name: 'Sentry Home'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Toggle organization menu'})
+      ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Open main menu'})).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', {name: 'Open main menu'}));

--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -4,12 +4,13 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import Link from 'sentry/components/links/link';
+import Hook from 'sentry/components/hook';
 import {useNavContext} from 'sentry/components/nav/context';
+import {OrgDropdown} from 'sentry/components/nav/orgDropdown';
 import {PrimaryNavigationItems} from 'sentry/components/nav/primary/index';
 import {SecondaryMobile} from 'sentry/components/nav/secondaryMobile';
 import {TOPBAR_MOBILE_HEIGHT} from 'sentry/components/sidebar/constants';
-import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
+import {IconClose, IconMenu} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
@@ -45,14 +46,13 @@ function MobileTopbar() {
     isActiveSuperuser() && !ConfigStore.get('isSelfHosted') && !isExcludedOrg;
 
   return (
-    <Topbar>
-      <HomeLink
-        to={`/organizations/${organization.slug}/issues/`}
-        aria-label={t('Sentry Home')}
-        showSuperuserWarning={showSuperuserWarning}
-      >
-        <IconSentry />
-      </HomeLink>
+    <Topbar showSuperuserWarning={showSuperuserWarning}>
+      <Left>
+        <OrgDropdown />
+        {showSuperuserWarning && (
+          <Hook name="component:superuser-warning" organization={organization} />
+        )}
+      </Left>
       <Button
         onClick={handleClick}
         icon={view === 'closed' ? <IconMenu /> : <IconClose />}
@@ -107,9 +107,10 @@ function NavigationOverlayPortal({
   );
 }
 
-const Topbar = styled('header')`
+const Topbar = styled('header')<{showSuperuserWarning: boolean}>`
   height: ${TOPBAR_MOBILE_HEIGHT};
   width: 100vw;
+  padding-left: ${space(1.5)};
   padding-right: ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.translucentGray200};
   background: ${p => p.theme.surface300};
@@ -120,39 +121,18 @@ const Topbar = styled('header')`
   position: sticky;
   top: 0;
   z-index: ${p => p.theme.zIndex.sidebar};
-`;
-
-const HomeLink = styled(Link, {
-  shouldForwardProp: prop => prop !== 'showSuperuserWarning',
-})<{showSuperuserWarning: boolean}>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 ${space(2)};
-  height: 100%;
-  position: relative;
-
-  svg {
-    color: ${p => p.theme.textColor};
-    width: ${space(3)};
-    height: ${space(3)};
-  }
 
   ${p =>
     p.showSuperuserWarning &&
     css`
-      &:before {
-        content: '';
-        position: absolute;
-        height: 34px;
-        width: 42px;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        border-radius: ${p.theme.borderRadius};
-        background: ${p.theme.sidebar.superuser};
-      }
+      background: ${p.theme.sidebar.superuser};
     `}
+`;
+
+const Left = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
 const NavigationOverlay = styled('nav')`

--- a/static/app/components/nav/orgDropdown.tsx
+++ b/static/app/components/nav/orgDropdown.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import orderBy from 'lodash/orderBy';
 
@@ -7,6 +8,8 @@ import {Button} from 'sentry/components/core/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import OrganizationBadge from 'sentry/components/idBadge/organizationBadge';
 import UserBadge from 'sentry/components/idBadge/userBadge';
+import {useNavContext} from 'sentry/components/nav/context';
+import {NavLayout} from 'sentry/components/nav/types';
 import {IconAdd} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -44,7 +47,7 @@ function createOrganizationMenuItem(): MenuItemProps {
   };
 }
 
-export function OrgDropdown() {
+export function OrgDropdown({className}: {className?: string}) {
   const api = useApi();
 
   const config = useLegacyStore(ConfigStore);
@@ -62,20 +65,29 @@ export function OrgDropdown() {
 
   const {projects} = useProjects();
 
+  const {layout} = useNavContext();
+  const isMobile = layout === NavLayout.MOBILE;
+
   function handleLogout() {
     logout(api);
   }
 
   return (
     <DropdownMenu
+      className={className}
       trigger={props => (
         <OrgDropdownTrigger
+          isMobile={isMobile}
           size="zero"
           borderless
           aria-label={t('Toggle organization menu')}
           {...props}
         >
-          <StyledOrganizationAvatar size={32} round={false} organization={organization} />
+          <StyledOrganizationAvatar
+            size={isMobile ? 24 : 32}
+            round={false}
+            organization={organization}
+          />
         </OrgDropdownTrigger>
       )}
       minMenuWidth={200}
@@ -175,9 +187,16 @@ export function OrgDropdown() {
   );
 }
 
-const OrgDropdownTrigger = styled(Button)`
+const OrgDropdownTrigger = styled(Button)<{isMobile: boolean}>`
   height: 44px;
   width: 44px;
+
+  ${p =>
+    p.isMobile &&
+    css`
+      width: 32px;
+      height: 32px;
+    `}
 `;
 
 const StyledOrganizationAvatar = styled(OrganizationAvatar)`

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -37,7 +37,9 @@ export function Sidebar() {
         <SidebarHeader isSuperuser={showSuperuserWarning}>
           <OrgDropdown />
           {showSuperuserWarning && (
-            <Hook name="component:superuser-warning" organization={organization} />
+            <SuperuserBadgeContainer>
+              <Hook name="component:superuser-warning" organization={organization} />
+            </SuperuserBadgeContainer>
           )}
         </SidebarHeader>
         <PrimaryNavigationItems />
@@ -98,4 +100,13 @@ const SidebarHeader = styled('header')<{isSuperuser: boolean}>`
         background: ${p.theme.sidebar.superuser};
       }
     `}
+`;
+
+const SuperuserBadgeContainer = styled('div')`
+  position: absolute;
+  top: -8px;
+  left: 2px;
+  right: 2px;
+  font-size: 12px;
+  margin: 0;
 `;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -439,7 +439,9 @@ function Sidebar() {
             <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
             {showSuperuserWarning() && !isExcludedOrg() && (
-              <Hook name="component:superuser-warning" organization={organization} />
+              <SuperuserBadgeContainer>
+                <Hook name="component:superuser-warning" organization={organization} />
+              </SuperuserBadgeContainer>
             )}
           </DropdownSidebarSection>
           <PrimaryItems>
@@ -753,6 +755,17 @@ const DropdownSidebarSection = styled(SidebarSection)<{
 
 const SidebarCollapseItem = styled(SidebarItem)`
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+const SuperuserBadgeContainer = styled('div')`
+  position: absolute;
+  top: -5px;
+  right: 5px;
+
+  /* Hiding on smaller screens because it looks misplaced */
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
     display: none;
   }
 `;

--- a/static/gsApp/components/superuser/superuserWarning.tsx
+++ b/static/gsApp/components/superuser/superuserWarning.tsx
@@ -1,11 +1,8 @@
 import {Fragment, useEffect} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import type {Client} from 'sentry/api';
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
-import {prefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {Tooltip} from 'sentry/components/tooltip';
 import AlertStore from 'sentry/stores/alertStore';
 import {space} from 'sentry/styles/space';
@@ -59,10 +56,11 @@ function ExitSuperuserButton() {
 }
 
 type Props = {
+  className?: string;
   organization?: Organization;
 };
 
-function SuperuserWarning({organization}: Props) {
+function SuperuserWarning({organization, className}: Props) {
   const isExcludedOrg = shouldExcludeOrg(organization);
 
   useEffect(() => {
@@ -87,7 +85,7 @@ function SuperuserWarning({organization}: Props) {
   }
 
   return (
-    <SuperuserBadge type="warning" stackedNav={prefersStackedNav()}>
+    <Badge type="warning" className={className}>
       <Tooltip
         isHoverable
         title={
@@ -101,29 +99,8 @@ function SuperuserWarning({organization}: Props) {
       >
         Superuser
       </Tooltip>
-    </SuperuserBadge>
+    </Badge>
   );
 }
 
 export default SuperuserWarning;
-
-const SuperuserBadge = styled(Badge)<{stackedNav: boolean}>`
-  position: absolute;
-  top: -5px;
-  right: 5px;
-
-  ${p =>
-    p.stackedNav &&
-    css`
-      top: -8px;
-      left: 2px;
-      right: 2px;
-      font-size: 10px;
-      margin: 0;
-    `}
-
-  /* Hiding on smaller screens because it looks misplaced */
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    display: none;
-  }
-`;


### PR DESCRIPTION
Adds the new org dropdown to the mobile nav so users can switch orgs in this experience.

![CleanShot 2025-03-14 at 10 09 02@2x](https://github.com/user-attachments/assets/6f7c0f2b-91b7-4e71-9daa-125400d7d03d)
