### PR TITLE
feat(uptime): Rename `Intermittent` -> `Failure`

### DIFF
--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -60,7 +60,7 @@ export function UptimeDetailsSidebar({
               isHoverable
               size="sm"
               title={tct(
-                'A check status is marked as intermittent when it fails but has not yet met the threshold to be considered downtime. [link:Learn more].',
+                'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
                 {
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
@@ -78,7 +78,7 @@ export function UptimeDetailsSidebar({
               isHoverable
               size="sm"
               title={tct(
-                'A check status is considered downtime when it fails 3 consecutive times, meeting the downtime threshold. [link:Learn more].',
+                'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
                 {
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -16,7 +16,7 @@ export const checkStatusPrecedent: CheckStatus[] = [
 
 export const statusToText: Record<CheckStatus, string> = {
   [CheckStatus.SUCCESS]: t('Uptime'),
-  [CheckStatus.FAILURE]: t('Intermittent'),
+  [CheckStatus.FAILURE]: t('Failure'),
   [CheckStatus.FAILURE_INCIDENT]: t('Downtime'),
   [CheckStatus.MISSED_WINDOW]: t('Unknown'),
 };
@@ -39,8 +39,9 @@ export const tickStyle: Record<CheckStatus, TickStyle> = {
     tickColor: 'green300',
   },
   [CheckStatus.FAILURE]: {
-    labelColor: 'green300',
-    tickColor: 'green200',
+    labelColor: 'red400',
+    tickColor: 'red300',
+    hatchTick: 'red200',
   },
   [CheckStatus.FAILURE_INCIDENT]: {
     labelColor: 'red400',


### PR DESCRIPTION
This adjusts the color of the failure ticks as well to a hatched red