### PR TITLE
chore(aci): emit metrics for successfully instantiated actions in post process

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -9,7 +9,7 @@ from typing import Any, DefaultDict, NamedTuple
 from celery import Task
 from django.db.models import OuterRef, Subquery
 
-from sentry import buffer, features, nodestore
+from sentry import buffer, nodestore
 from sentry.buffer.base import BufferField
 from sentry.db import models
 from sentry.eventstore.models import Event, GroupEvent
@@ -466,17 +466,8 @@ def fire_rules(
             rule_fire_history = history.record(rule, group, groupevent.event_id, notification_uuid)
 
             callback_and_futures = activate_downstream_actions(
-                rule, groupevent, notification_uuid, rule_fire_history
+                rule, groupevent, notification_uuid, rule_fire_history, is_post_process=False
             ).values()
-            if features.has(
-                "organizations:workflow-engine-process-workflows",
-                project.organization,
-            ):
-                metrics.incr(
-                    "post_process.delayed_processing.triggered_actions",
-                    amount=len(callback_and_futures),
-                    tags={"event_type": groupevent.group.type},
-                )
 
             # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
             for callback, futures in callback_and_futures:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -11,7 +11,7 @@ from typing import Any
 from django.core.cache import cache
 from django.utils import timezone
 
-from sentry import analytics, buffer
+from sentry import analytics, buffer, features
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -149,6 +149,7 @@ def activate_downstream_actions(
     event: GroupEvent,
     notification_uuid: str | None = None,
     rule_fire_history: RuleFireHistory | None = None,
+    is_post_process: bool | None = True,
 ) -> MutableMapping[
     str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
 ]:
@@ -156,10 +157,14 @@ def activate_downstream_actions(
         str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
     ] = {}
 
+    instantiated_actions = 0
+
     for action in rule.data.get("actions", ()):
         action_inst = instantiate_action(rule, action, rule_fire_history)
         if not action_inst:
             continue
+
+        instantiated_actions += 1
 
         results = safe_execute(
             action_inst.after,
@@ -178,6 +183,21 @@ def activate_downstream_actions(
                 grouped_futures[key] = (future.callback, [rule_future])
             else:
                 grouped_futures[key][1].append(rule_future)
+
+    if features.has(
+        "organizations:workflow-engine-process-workflows",
+        rule.project.organization,
+    ):
+        if is_post_process:
+            logger_name = "post_process.process_rules.triggered_actions"
+        else:
+            logger_name = "post_process.delayed_processing.triggered_actions"
+
+        metrics.incr(
+            logger_name,
+            amount=instantiated_actions,
+            tags={"event_type": event.group.type},
+        )
 
     return grouped_futures
 

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -149,7 +149,7 @@ def activate_downstream_actions(
     event: GroupEvent,
     notification_uuid: str | None = None,
     rule_fire_history: RuleFireHistory | None = None,
-    is_post_process: bool | None = None,
+    is_post_process: bool | None = True,
 ) -> MutableMapping[
     str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
 ]:
@@ -184,7 +184,7 @@ def activate_downstream_actions(
             else:
                 grouped_futures[key][1].append(rule_future)
 
-    if is_post_process is not None and features.has(
+    if features.has(
         "organizations:workflow-engine-process-workflows",
         rule.project.organization,
     ):
@@ -399,7 +399,7 @@ class RuleProcessor:
         notification_uuid = str(uuid.uuid4())
         rule_fire_history = history.record(rule, self.group, self.event.event_id, notification_uuid)
         grouped_futures = activate_downstream_actions(
-            rule, self.event, notification_uuid, rule_fire_history, is_post_process=True
+            rule, self.event, notification_uuid, rule_fire_history
         )
 
         if not self.grouped_futures:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -149,7 +149,7 @@ def activate_downstream_actions(
     event: GroupEvent,
     notification_uuid: str | None = None,
     rule_fire_history: RuleFireHistory | None = None,
-    is_post_process: bool | None = True,
+    is_post_process: bool | None = None,
 ) -> MutableMapping[
     str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
 ]:
@@ -184,7 +184,7 @@ def activate_downstream_actions(
             else:
                 grouped_futures[key][1].append(rule_future)
 
-    if features.has(
+    if is_post_process is not None and features.has(
         "organizations:workflow-engine-process-workflows",
         rule.project.organization,
     ):
@@ -399,7 +399,7 @@ class RuleProcessor:
         notification_uuid = str(uuid.uuid4())
         rule_fire_history = history.record(rule, self.group, self.event.event_id, notification_uuid)
         grouped_futures = activate_downstream_actions(
-            rule, self.event, notification_uuid, rule_fire_history
+            rule, self.event, notification_uuid, rule_fire_history, is_post_process=True
         )
 
         if not self.grouped_futures:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -993,16 +993,6 @@ def process_rules(job: PostProcessJob) -> None:
             has_alert = True
             safe_execute(callback, group_event, futures)
 
-        if features.has(
-            "organizations:workflow-engine-process-workflows",
-            group_event.project.organization,
-        ):
-            metrics.incr(
-                "post_process.process_rules.triggered_actions",
-                amount=len(callback_and_futures),
-                tags={"event_type": group_event.group.type},
-            )
-
     job["has_alert"] = has_alert
     return
 


### PR DESCRIPTION
A more accurate representation of how many actions we will attempt to fire in post process / delayed processing comes from the number of instantiated actions. Previously I was counting the number of futures, which does not work in the case where there are no futures returned (see example below where for a `NotifyEventAction`)
https://github.com/getsentry/sentry/blob/9939ec1fec27dd4e78bcb6457aaba89e97ae95a9/src/sentry/rules/actions/notify_event.py#L30-L42

Workflow engine is currently counting the number of triggered actions (there's no "instantiating" of them as they are stored as rows in the `Action` table). This should still be accurate as we will attempt to fire all of them with a different function, and we only migrate `Actions` that have everything we need (not guaranteed with legacy `Rule` actions).
https://github.com/getsentry/sentry/blob/9939ec1fec27dd4e78bcb6457aaba89e97ae95a9/src/sentry/workflow_engine/processors/workflow.py#L164-L172