### PR TITLE
feat(toolbar): Indicate when a FF override is in place

### DIFF
--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -20,7 +20,7 @@ import PanelLayout from '../panelLayout';
 
 import CustomOverride from './customOverride';
 import FeatureFlagItem from './featureFlagItem';
-import {FeatureFlagsContextProvider, useFeatureFlagsContext} from './featureFlagsContext';
+import {useFeatureFlagsContext} from './featureFlagsContext';
 
 type Prefilter = 'all' | 'overrides';
 
@@ -30,90 +30,88 @@ export default function FeatureFlagsPanel() {
   const [isAddFlagActive, setIsAddFlagActive] = useState(false);
 
   return (
-    <FeatureFlagsContextProvider>
-      <PanelLayout
-        title="Feature Flags"
-        titleRight={
-          <button
-            aria-label="Override Flag"
-            css={[resetButtonCss, panelHeadingRightCss]}
-            title="Override Flag"
-            onClick={() => setIsAddFlagActive(!isAddFlagActive)}
-          >
-            <span css={buttonRightCss}>
-              {isAddFlagActive ? (
-                <IconChevron direction="up" size="xs" />
-              ) : (
-                <IconChevron direction="down" size="xs" />
-              )}
-              Override
-            </span>
-          </button>
-        }
+    <PanelLayout
+      title="Feature Flags"
+      titleRight={
+        <button
+          aria-label="Override Flag"
+          css={[resetButtonCss, panelHeadingRightCss]}
+          title="Override Flag"
+          onClick={() => setIsAddFlagActive(!isAddFlagActive)}
+        >
+          <span css={buttonRightCss}>
+            {isAddFlagActive ? (
+              <IconChevron direction="up" size="xs" />
+            ) : (
+              <IconChevron direction="down" size="xs" />
+            )}
+            Override
+          </span>
+        </button>
+      }
+    >
+      {isAddFlagActive && (
+        <div
+          css={[
+            smallCss,
+            panelSectionCss,
+            panelInsetContentCss,
+            css`
+              background: var(--surface200);
+              padding: var(--space150);
+            `,
+          ]}
+        >
+          <AnalyticsProvider keyVal="custom-override" nameVal="Custom Override">
+            <CustomOverride setComponentActive={setIsAddFlagActive} />
+          </AnalyticsProvider>
+        </div>
+      )}
+      <div
+        css={css`
+          display: grid;
+          grid-template-rows: auto auto 1fr auto;
+          flex-grow: 1;
+        `}
       >
-        {isAddFlagActive && (
-          <div
-            css={[
-              smallCss,
-              panelSectionCss,
-              panelInsetContentCss,
-              css`
-                background: var(--surface200);
-                padding: var(--space150);
-              `,
-            ]}
-          >
-            <AnalyticsProvider keyVal="custom-override" nameVal="Custom Override">
-              <CustomOverride setComponentActive={setIsAddFlagActive} />
-            </AnalyticsProvider>
-          </div>
-        )}
+        <IsDirtyMessage />
+        <div
+          css={[
+            smallCss,
+            panelSectionCssNoBorder,
+            panelInsetContentCss,
+            css`
+              display: grid;
+              grid-template-areas: 'search segments';
+              gap: var(--space100);
+            `,
+          ]}
+        >
+          <Filters
+            setPrefilter={setPrefilter}
+            prefilter={prefilter}
+            setSearchTerm={setSearchTerm}
+          />
+        </div>
         <div
           css={css`
-            display: grid;
-            grid-template-rows: auto auto 1fr auto;
-            flex-grow: 1;
+            contain: strict;
+            flex-direction: column;
+            align-items: stretch;
           `}
         >
-          <IsDirtyMessage />
-          <div
-            css={[
-              smallCss,
-              panelSectionCssNoBorder,
-              panelInsetContentCss,
-              css`
-                display: grid;
-                grid-template-areas: 'search segments';
-                gap: var(--space100);
-              `,
-            ]}
-          >
-            <Filters
-              setPrefilter={setPrefilter}
-              prefilter={prefilter}
-              setSearchTerm={setSearchTerm}
-            />
-          </div>
           <div
             css={css`
-              contain: strict;
-              flex-direction: column;
-              align-items: stretch;
+              overflow: auto;
             `}
           >
-            <div
-              css={css`
-                overflow: auto;
-              `}
-            >
-              <AnalyticsProvider keyVal="flag-table" nameVal="Flag Table">
-                <FlagTable searchTerm={searchTerm} prefilter={prefilter} />
-              </AnalyticsProvider>
-            </div>
+            <AnalyticsProvider keyVal="flag-table" nameVal="Flag Table">
+              <FlagTable searchTerm={searchTerm} prefilter={prefilter} />
+            </AnalyticsProvider>
           </div>
         </div>
-      </PanelLayout>
-    </FeatureFlagsContextProvider>
+      </div>
+    </PanelLayout>
   );
 }
 

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -21,6 +21,7 @@ import PanelLayout from '../panelLayout';
 import CustomOverride from './customOverride';
 import FeatureFlagItem from './featureFlagItem';
 import {useFeatureFlagsContext} from './featureFlagsContext';
+import FlagOverridesBadge from './flagOverridesBadge';
 
 type Prefilter = 'all' | 'overrides';
 
@@ -152,10 +153,22 @@ function Filters({
           grid-area: segments;
         `}
       >
-        <SegmentedControl<Prefilter> onChange={setPrefilter} size="xs" value={prefilter}>
-          <SegmentedControl.Item key="all">All</SegmentedControl.Item>
-          <SegmentedControl.Item key="overrides">Overrides</SegmentedControl.Item>
-        </SegmentedControl>
+        <div
+          css={css`
+            position: relative;
+            display: grid;
+          `}
+        >
+          <SegmentedControl<Prefilter>
+            onChange={setPrefilter}
+            size="xs"
+            value={prefilter}
+          >
+            <SegmentedControl.Item key="all">All</SegmentedControl.Item>
+            <SegmentedControl.Item key="overrides">Overrides</SegmentedControl.Item>
+          </SegmentedControl>
+          <FlagOverridesBadge />
+        </div>
       </div>
       <Input
         css={css`

--- a/static/app/components/devtoolbar/components/featureFlags/flagOverridesBadge.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/flagOverridesBadge.tsx
@@ -1,0 +1,12 @@
+import IndicatorBadge from 'sentry/components/devtoolbar/components/indicatorBadge';
+
+import useHasCustomFlagOverrides from './useHasCustomFlagOverrides';
+
+export default function FlagOverridesBadge() {
+  const hasOverrides = useHasCustomFlagOverrides();
+
+  if (hasOverrides) {
+    return <IndicatorBadge variant="red" />;
+  }
+  return null;
+}

--- a/static/app/components/devtoolbar/components/featureFlags/useHasCustomFlagOverrides.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/useHasCustomFlagOverrides.tsx
@@ -1,0 +1,10 @@
+import {useFeatureFlagsContext} from 'sentry/components/devtoolbar/components/featureFlags/featureFlagsContext';
+
+export default function useHasCustomFlagOverrides(): boolean {
+  const {featureFlagMap} = useFeatureFlagsContext();
+  return (
+    Object.entries(featureFlagMap)?.filter(
+      ([_name, {value, override}]) => override !== undefined && value !== override
+    ).length > 0
+  );
+}

--- a/static/app/components/devtoolbar/components/indicatorBadge.tsx
+++ b/static/app/components/devtoolbar/components/indicatorBadge.tsx
@@ -6,6 +6,7 @@ const variants = {
   red: css`
     background: var(--red400);
     color: var(--gray100);
+    z-index: 1;
   `,
 };
 
@@ -27,7 +28,7 @@ const badgeCss = css`
   line-height: 1rem;
   position: absolute;
   right: 2px;
-  top: 18px;
+  bottom: 2px;
   width: 0.55rem;
   display: flex;
   align-items: center;

--- a/static/app/components/devtoolbar/components/navigation.tsx
+++ b/static/app/components/devtoolbar/components/navigation.tsx
@@ -19,6 +19,7 @@ import {navigationCss} from '../styles/navigation';
 import {resetDialogCss} from '../styles/reset';
 
 import AlertBadge from './alerts/alertBadge';
+import FlagOverridesBadge from './featureFlags/flagOverridesBadge';
 import IconButton from './navigation/iconButton';
 
 export default function Navigation({
@@ -57,7 +58,9 @@ export default function Navigation({
       <NavButton panelName="alerts" label="Active Alerts" icon={<IconSiren />}>
         <AlertBadge />
       </NavButton>
-      <NavButton panelName="featureFlags" label="Feature Flags" icon={<IconFlag />} />
+      <NavButton panelName="featureFlags" label="Feature Flags" icon={<IconFlag />}>
+        <FlagOverridesBadge />
+      </NavButton>
       <NavButton panelName="releases" label="Releases" icon={<IconReleases />}>
         <SessionStatusBadge />
       </NavButton>

--- a/static/app/components/devtoolbar/components/providers.tsx
+++ b/static/app/components/devtoolbar/components/providers.tsx
@@ -10,6 +10,8 @@ import {ToolbarRouterContextProvider} from '../hooks/useToolbarRoute';
 import {VisibilityContextProvider} from '../hooks/useVisibility';
 import type {Configuration} from '../types';
 
+import {FeatureFlagsContextProvider} from './featureFlags/featureFlagsContext';
+
 interface Props {
   children: React.ReactNode;
   config: Configuration;
@@ -38,7 +40,9 @@ export default function Providers({children, config, container}: Props) {
         <ConfigurationContextProvider config={config}>
           <QueryClientProvider client={queryClient}>
             <VisibilityContextProvider>
-              <ToolbarRouterContextProvider>{children}</ToolbarRouterContextProvider>
+              <ToolbarRouterContextProvider>
+                <FeatureFlagsContextProvider>{children}</FeatureFlagsContextProvider>
+              </ToolbarRouterContextProvider>
             </VisibilityContextProvider>
           </QueryClientProvider>
         </ConfigurationContextProvider>


### PR DESCRIPTION
A little red indicator shows up in the Nav when something is overridden

This change only applie to the prototype toolbar on sentry.io, not the production one (https://github.com/getsentry/sentry-toolbar/pull/233)

<img width="382" alt="SCR-20250314-nouq" src="https://github.com/user-attachments/assets/75ac7387-7c78-41a7-b97e-4a51332e007c" />


Related to https://github.com/getsentry/sentry/issues/86991