### PR TITLE
feat(releases): Change release bubbles series color to match bubbles

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -287,6 +287,7 @@ function ReleaseBubbleSeries({
     renderItem: renderReleaseBubble,
     name: t('Releases'),
     data,
+    color: theme.blue300,
     tooltip: {
       trigger: 'item',
       position: 'bottom',


### PR DESCRIPTION
Give the release _series_ the same color as the bubbles (or at least close enough).

Before:
![image](https://github.com/user-attachments/assets/b9c7af79-0db9-4e1a-99e5-a877adab03a3)

After:
![image](https://github.com/user-attachments/assets/6c0a7197-a845-4539-b915-6c4d61cdb53f)
