### PR TITLE
test(react19): Adjust widgetViewerModal for react 19

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -411,15 +411,18 @@ describe('Modals -> WidgetViewerModal', function () {
           unselectedSeries: [`${mockWidget.id}:Query Name`],
         };
         await renderModal({initialData, widget: mockWidget});
-        expect(ReactEchartsCore).toHaveBeenLastCalledWith(
+
+        const echartsMock = jest.mocked(ReactEchartsCore);
+        const lastCall = echartsMock.mock.calls[echartsMock.mock.calls.length - 1]![0];
+        // TODO(react19): Can change this back to expect(ReactEchartsCore).toHaveBeenLastCalledWith()
+        expect(lastCall).toEqual(
           expect.objectContaining({
             option: expect.objectContaining({
               legend: expect.objectContaining({
                 selected: {[`Query Name;${mockWidget.id}`]: false},
               }),
             }),
-          }),
-          {}
+          })
         );
       });
 


### PR DESCRIPTION
In react 19 the 2nd argument is undefined instead of empty object. expect.anything fails which. Just hardcode it to check the first argument.

part of https://github.com/getsentry/frontend-tsc/issues/68
