### PR TITLE
feat(devenv): Skip `devenv sync` call when we have FE changes and env var is set

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -11,7 +11,12 @@ trap "rm -f $files_changed_upstream" EXIT
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD >"$files_changed_upstream"
 
-if grep --quiet 'requirements-dev-frozen.txt' "$files_changed_upstream" || grep --quiet 'yarn.lock' "$files_changed_upstream" || grep --quiet 'migrations' "$files_changed_upstream"; then
+grep_pattern="requirements-dev-frozen.txt|migrations"
+if [[ "$SENTRY_DEVENV_SKIP_FRONTEND" != "1" ]]; then
+  grep_pattern+="|yarn.lock"
+fi
+
+if grep -E --quiet "$grep_pattern" "$files_changed_upstream"; then
   cat <<EOF
 
 [${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed. Run devenv sync to resync your environment.${reset}


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/84885

`devenv sync` is a lot quicker now for BE folks since it skips the yarn updates. However, it takes a while to run in general, and it gets triggered whenever `yarn.lock` is updated. Modiyfing `post-merge` to also skip `devenv_sync` if `$SENTRY_DEVENV_SKIP_FRONTEND=1` and we only have changes in `yarn.lock`.