### PR TITLE
feat(eap-migration): Add initial timeseries comparsion util

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import sentry_sdk
 
@@ -76,7 +76,7 @@ def make_snql_request(
 
 
 def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultForComparison):
-    aligned_results = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
+    aligned_results: dict[str, Any] = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
 
     def fill_aligned_series(data: SnubaTSResult, alias: str, key: str):
         for element in data["data"]:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -5,6 +5,7 @@ from typing import Any, TypedDict
 import sentry_sdk
 
 from sentry import features
+from sentry.api.bases.organization import NoProjects
 from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_eap
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
@@ -79,7 +80,7 @@ def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultFor
     aligned_results: dict[str, Any] = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
 
     def fill_aligned_series(data: SnubaTSResult, alias: str, key: str):
-        for element in data["data"]:
+        for element in data.data:
             element_value = element.get(alias) or 0
             element_time = element["time"]
             aligned_results[element_time][key] = float(element_value)
@@ -131,6 +132,9 @@ def assert_timeseries_close(aligned_timeseries):
 def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
     snuba_query: SnubaQuery = alert_rule.snuba_query
     project = alert_rule.projects.first()
+    if not project:
+        raise NoProjects
+
     organization = Organization.objects.get_from_cache(id=project.organization_id)
 
     on_demand_metrics_enabled = features.has(

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -1,0 +1,168 @@
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import TypedDict
+
+import sentry_sdk
+
+from sentry import features
+from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_eap
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.models.organization import Organization
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.fields import get_function_alias
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.entity_subscription import apply_dataset_query_conditions
+from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.metrics_performance import timeseries_query
+from sentry.snuba.models import SnubaQuery
+from sentry.snuba.spans_rpc import run_timeseries_query
+from sentry.utils.snuba import SnubaTSResult
+
+WINDOW_TO_INTERVAL_MAP = {
+    60: "24h",
+    300: "24h",
+}
+
+
+class TSResultForComparison(TypedDict):
+    result: SnubaTSResult
+    agg_alias: str
+
+
+def make_rpc_request(
+    query: str,
+    aggregate: str,
+    time_window: int,
+    snuba_params: SnubaParams,
+) -> TSResultForComparison:
+    query = apply_dataset_query_conditions(SnubaQuery.Type.PERFORMANCE, query, None)
+
+    query_parts = QueryParts(selected_columns=[aggregate], query=query, equations=[], orderby=[])
+    query_parts = translate_mep_to_eap(query_parts)
+
+    results = run_timeseries_query(
+        snuba_params,
+        query_string=query_parts["query"],
+        y_axes=query_parts["selected_columns"],
+        referrer="job-runner.compare-timeseries",
+        granularity_secs=time_window,
+        config=SearchResolverConfig(),
+    )
+
+    return TSResultForComparison(result=results, agg_alias=query_parts["selected_columns"][0])
+
+
+def make_snql_request(
+    query: str,
+    aggregate: str,
+    time_window: int,
+    on_demand_metrics_enabled: bool,
+    snuba_params: SnubaParams,
+) -> TSResultForComparison:
+    query = apply_dataset_query_conditions(SnubaQuery.Type.PERFORMANCE, query, None)
+
+    results = timeseries_query(
+        [aggregate],
+        query,
+        snuba_params=snuba_params,
+        rollup=time_window,
+        referrer="job-runner.compare-timeseries",
+        on_demand_metrics_enabled=on_demand_metrics_enabled,
+        on_demand_metrics_type=MetricSpecType.SIMPLE_QUERY,
+        zerofill_results=True,
+    )
+
+    return TSResultForComparison(result=results, agg_alias=get_function_alias(aggregate))
+
+
+def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultForComparison):
+    aligned_results = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
+
+    def fill_aligned_series(data: SnubaTSResult, alias: str, key: str):
+        for element in data["data"]:
+            element_value = element.get(alias) or 0
+            element_time = element["time"]
+            aligned_results[element_time][key] = float(element_value)
+
+    fill_aligned_series(snql_result["result"].data, snql_result["agg_alias"], "snql_value")
+    fill_aligned_series(rpc_result["result"].data, rpc_result["agg_alias"], "rpc_value")
+
+    return aligned_results
+
+
+def assert_timeseries_close(aligned_timeseries):
+    mismatches: dict[int, dict[str, float]] = {}
+    missing_buckets = 0
+    for timestamp, values in aligned_timeseries.items():
+        rpc_value = values["rpc_value"]
+        snql_value = values["snql_value"]
+        if rpc_value is None or snql_value is None:
+            missing_buckets += 1
+            continue
+
+        # If the sum is 0, we assume that the numbers must be 0, since we have all positive integers. We still do
+        # check the sum in order to protect the division by zero in case for some reason we have -x + x inside of
+        # the timeseries.
+        if rpc_value + snql_value == 0:
+            continue
+
+        mismatch = abs(rpc_value - snql_value)
+        average = (rpc_value + snql_value) / 2
+        diff = mismatch / average
+
+        if diff > 0.05:
+            mismatches[timestamp] = {
+                "rpc_value": rpc_value,
+                "snql_value": snql_value,
+                "mismatch_percentage": mismatch,
+            }
+
+    if mismatches:
+        with sentry_sdk.isolation_scope() as scope:
+            scope.set_extra("mismatches", mismatches)
+            sentry_sdk.capture_message("Timeseries mismatch", level="info")
+
+    if missing_buckets > 1:
+        sentry_sdk.capture_message("Multiple missing buckets!", level="info")
+
+    return mismatches
+
+
+def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
+    snuba_query: SnubaQuery = alert_rule.snuba_query
+    project = alert_rule.projects.first()
+    organization = Organization.objects.get_from_cache(id=project.organization_id)
+
+    on_demand_metrics_enabled = features.has(
+        "organizations:on-demand-metrics-extraction",
+        organization,
+    )
+
+    # Align time to the nearest hour because RPCs roll up on exact timestamps.
+    now = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
+    snuba_params = SnubaParams(
+        environments=[snuba_query.environment],
+        projects=[project],
+        organization=organization,
+        start=now - timedelta(days=1),
+        end=now,
+    )
+
+    rpc_result = make_rpc_request(
+        snuba_query.query,
+        snuba_query.aggregate,
+        time_window=snuba_query.time_window,
+        snuba_params=snuba_params,
+    )
+
+    snql_result = make_snql_request(
+        snuba_query.query,
+        snuba_query.aggregate,
+        time_window=snuba_query.time_window,
+        on_demand_metrics_enabled=on_demand_metrics_enabled,
+        snuba_params=snuba_params,
+    )
+
+    aligned_timeseries = align_timeseries(snql_result=snql_result, rpc_result=rpc_result)
+
+    return assert_timeseries_close(aligned_timeseries)

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -19,11 +19,6 @@ from sentry.snuba.models import SnubaQuery
 from sentry.snuba.spans_rpc import run_timeseries_query
 from sentry.utils.snuba import SnubaTSResult
 
-WINDOW_TO_INTERVAL_MAP = {
-    60: "24h",
-    300: "24h",
-}
-
 
 class TSResultForComparison(TypedDict):
     result: SnubaTSResult
@@ -115,7 +110,7 @@ def assert_timeseries_close(aligned_timeseries):
             mismatches[timestamp] = {
                 "rpc_value": rpc_value,
                 "snql_value": snql_value,
-                "mismatch_percentage": mismatch,
+                "mismatch_percentage": diff,
             }
 
     if mismatches:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -79,8 +79,8 @@ def make_snql_request(
 def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultForComparison):
     aligned_results: dict[str, Any] = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
 
-    def fill_aligned_series(data: SnubaTSResult, alias: str, key: str):
-        for element in data.data:
+    def fill_aligned_series(data: dict[str, Any], alias: str, key: str):
+        for element in data["data"]:
             element_value = element.get(alias) or 0
             element_time = element["time"]
             aligned_results[element_time][key] = float(element_value)

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -3,6 +3,14 @@ from typing import TypedDict
 from parsimonious import NodeVisitor
 
 from sentry.api.event_search import event_search_grammar
+from sentry.search.events import fields
+
+
+class QueryParts(TypedDict):
+    selected_columns: list[str]
+    query: str
+    equations: list[str] | None
+    orderby: list[str] | None
 
 
 def apply_is_segment_condition(query: str) -> str:
@@ -11,9 +19,16 @@ def apply_is_segment_condition(query: str) -> str:
     return "is_transaction:1"
 
 
-def switcheroo(term):
+def column_switcheroo(term):
     if term == "transaction.duration":
         return "span.duration"
+
+    return term
+
+
+def function_switcheroo(term):
+    if term == "count()":
+        return "count(span.duration)"
 
     return term
 
@@ -23,23 +38,69 @@ class TranslationVisitor(NodeVisitor):
         super().__init__()
 
     def visit_raw_aggregate_param(self, node, children):
-        return switcheroo(node.text)
+        return column_switcheroo(node.text)
+
+    def visit_aggregate_key(self, node, children):
+        if children[0] == "count":
+            return function_switcheroo("count()")
+
+        return children or node.text
 
     def visit_key(self, node, children):
-        return switcheroo(node.text)
+        return column_switcheroo(node.text)
 
     def visit_value(self, node, children):
-        return switcheroo(node.text)
+        return column_switcheroo(node.text)
 
     def generic_visit(self, node, children):
         return children or node.text
 
 
-class QueryParts(TypedDict):
-    selected_columns: list[str]
-    query: str
-    equations: list[str] | None
-    orderby: list[str] | None
+def translate_query(query: str):
+    flattened_query = []
+
+    def _flatten(seq):
+        for item in seq:
+            if isinstance(item, list):
+                _flatten(item)
+            else:
+                flattened_query.append(item)
+
+    tree = event_search_grammar.parse(query)
+    parsed = TranslationVisitor().visit(tree)
+    _flatten(parsed)
+
+    return apply_is_segment_condition("".join(flattened_query))
+
+
+def translate_columns(columns):
+    translated_columns = []
+
+    for column in columns:
+        match = fields.is_function(column)
+
+        if not match:
+            translated_columns.append(column_switcheroo(column))
+            continue
+
+        translated_func = function_switcheroo(column)
+        if translated_func != column:
+            translated_columns.append(translated_func)
+            continue
+
+        match = fields.is_function(column)
+
+        raw_function = match.group("function")
+        arguments = fields.parse_arguments(raw_function, match.group("columns"))
+        translated_arguments = []
+
+        for argument in arguments:
+            translated_arguments.append(column_switcheroo(argument))
+
+        new_arg = ",".join(translated_arguments)
+        translated_columns.append(f"{raw_function}({new_arg})")
+
+    return translated_columns
 
 
 def translate_mep_to_eap(query_parts: QueryParts):
@@ -51,24 +112,12 @@ def translate_mep_to_eap(query_parts: QueryParts):
     and also allow us to migrate all our Discover/Dashboard/Alert
     datamodels to store EAP compatible EQS queries.
     """
-    flattened_query = []
-
-    def _flatten(seq):
-        for item in seq:
-            if isinstance(item, list):
-                _flatten(item)
-            else:
-                flattened_query.append(item)
-
-    tree = event_search_grammar.parse(query_parts["query"])
-    parsed = TranslationVisitor().visit(tree)
-    _flatten(parsed)
-
-    new_query = apply_is_segment_condition("".join(flattened_query))
+    new_query = translate_query(query_parts["query"])
+    new_columns = translate_columns(query_parts["selected_columns"])
 
     eap_query = QueryParts(
         query=new_query,
-        selected_columns=query_parts["selected_columns"],
+        selected_columns=new_columns,
         equations=query_parts["equations"],
         orderby=query_parts["orderby"],
     )

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -88,8 +88,6 @@ def translate_columns(columns):
             translated_columns.append(translated_func)
             continue
 
-        match = fields.is_function(column)
-
         raw_function = match.group("function")
         arguments = fields.parse_arguments(raw_function, match.group("columns"))
         translated_arguments = []

--- a/tests/sentry/discover/test_compare_timeseries.py
+++ b/tests/sentry/discover/test_compare_timeseries.py
@@ -1,0 +1,146 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from sentry.discover.compare_timeseries import compare_timeseries_for_alert_rule
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleProjects
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.models import SnubaQuery
+from sentry.testutils.cases import BaseMetricsLayerTestCase, BaseSpansTestCase, TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.users.models.user import User
+from sentry.utils.samples import load_data
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+@freeze_time()
+class CompareAlertsTimeseriesTestCase(BaseMetricsLayerTestCase, TestCase, BaseSpansTestCase):
+    @property
+    def now(self):
+        return datetime.now(UTC).replace(microsecond=0)
+
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization()
+        with assume_test_silo_mode_of(User):
+            self.user = User.objects.create(email="test@sentry.io")
+
+        project_1 = self.create_project(organization=self.org)
+
+        snuba_query = SnubaQuery.objects.create(
+            type=SnubaQuery.Type.PERFORMANCE.value,
+            dataset=Dataset.PerformanceMetrics.value,
+            query="has:transaction.duration",
+            aggregate="avg(transaction.duration)",
+            time_window=3600,
+            resolution=60,
+        )
+
+        self.alert_rule = AlertRule.objects.create(
+            snuba_query=snuba_query,
+            threshold_period=1,
+            organization=project_1.organization,
+        )
+
+        AlertRuleProjects.objects.create(alert_rule=self.alert_rule, project=project_1)
+
+        self.double_write_segment(
+            project=project_1,
+            trace_id=uuid4().hex,
+            transaction_id=uuid4().hex,
+            span_id="1" + uuid4().hex[:15],
+            transaction="foo",
+            duration=50,
+            exclusive_time=50,
+            days_before_now=1,
+        )
+
+        self.double_write_segment(
+            project=project_1,
+            trace_id=uuid4().hex,
+            transaction_id=uuid4().hex,
+            span_id="1" + uuid4().hex[:15],
+            transaction="bar",
+            duration=100,
+            exclusive_time=100,
+            days_before_now=2,
+        )
+
+    def double_write_segment(
+        self,
+        *,
+        project,
+        trace_id,
+        transaction_id,
+        span_id,
+        duration,
+        days_before_now: int = 0,
+        hours_before_now: int = 0,
+        minutes_before_now: int = 0,
+        seconds_before_now: int = 0,
+        **kwargs,
+    ):
+        kwargs.setdefault("measurements", {})
+        if "lcp" not in kwargs["measurements"]:
+            kwargs["measurements"]["lcp"] = duration
+        if "client_sample_rate" not in kwargs["measurements"]:
+            kwargs["measurements"]["client_sample_rate"] = 0.1
+
+        timestamp = self.adjust_timestamp(
+            self.now
+            - timedelta(
+                days=days_before_now,
+                hours=hours_before_now,
+                minutes=minutes_before_now,
+                seconds=seconds_before_now,
+            )
+        )
+        end_timestamp = timestamp + timedelta(microseconds=duration * 1000)
+
+        data = load_data(
+            "transaction",
+            start_timestamp=timestamp,
+            timestamp=end_timestamp,
+            trace=trace_id,
+            span_id=span_id,
+            spans=[],
+            event_id=transaction_id,
+        )
+
+        for measurement, value in kwargs.get("measurements", {}).items():
+            data["measurements"][measurement] = {"value": value}
+
+        if tags := kwargs.get("tags", {}):
+            data["tags"] = [[key, val] for key, val in tags.items()]
+
+        self.store_segment(
+            project_id=project.id,
+            trace_id=trace_id,
+            transaction_id=transaction_id,
+            span_id=span_id,
+            timestamp=timestamp,
+            duration=duration,
+            organization_id=project.organization.id,
+            is_eap=True,
+            **kwargs,
+        )
+
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction.status": "unknown"},
+            project_id=project.id,
+            org_id=project.organization.id,
+            value=duration,
+            days_before_now=days_before_now,
+            hours_before_now=hours_before_now,
+            minutes_before_now=minutes_before_now,
+            seconds_before_now=seconds_before_now,
+        )
+
+    def test_compare_simple(self):
+        mismatches = compare_timeseries_for_alert_rule(self.alert_rule)
+        assert mismatches == {}

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -26,11 +26,15 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "(tags[foo]:10 OR transaction.duration:11) AND (p95(span.duration):<10)",
             "((tags[foo]:10 OR span.duration:11) AND (p95(span.duration):<10)) AND is_transaction:1",
         ),
+        pytest.param(
+            "count(   ):<10",
+            "(count(span.duration):<10) AND is_transaction:1",
+        ),
     ],
 )
-def test_mep_to_eap_simple(input: str, expected: str):
+def test_mep_to_eap_simple_query(input: str, expected: str):
     old = QueryParts(
-        selected_columns=["id", "transaction.duration"],
+        selected_columns=["id"],
         query=input,
         equations=[],
         orderby=[],
@@ -38,3 +42,32 @@ def test_mep_to_eap_simple(input: str, expected: str):
     translated = translate_mep_to_eap(old)
 
     assert translated["query"] == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        pytest.param(
+            ["transaction.duration"],
+            ["span.duration"],
+        ),
+        pytest.param(
+            ["count()", "avg(transaction.duration)"],
+            ["count(span.duration)", "avg(span.duration)"],
+        ),
+        pytest.param(
+            ["avgIf(transaction.duration,greater,300)"],
+            ["avgIf(span.duration,greater,300)"],
+        ),
+    ],
+)
+def test_mep_to_eap_simple_selected_columns(input: str, expected: str):
+    old = QueryParts(
+        selected_columns=input,
+        query="",
+        equations=[],
+        orderby=[],
+    )
+    translated = translate_mep_to_eap(old)
+
+    assert translated["selected_columns"] == expected

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -61,7 +61,7 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
         ),
     ],
 )
-def test_mep_to_eap_simple_selected_columns(input: str, expected: str):
+def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str]):
     old = QueryParts(
         selected_columns=input,
         query="",


### PR DESCRIPTION
Add some initial timeseries comparison code:
1. Take transaction/mep EQS, run timeseries query
2. Translate transaction/mep EQS -> eap EQS, run EAP query
3. Compare timeseries buckets

Also adds some basic translation for selected columns

Starting with basic functionality to see how far we can get for alerts,
will continue to layer on more