### PR TITLE
ref(feedback): improve evidence test coverage and post process logging

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1288,7 +1288,10 @@ def should_postprocess_feedback(job: PostProcessJob) -> bool:
 
     feedback_source = event.occurrence.evidence_data.get("source")
 
-    if feedback_source in FeedbackCreationSource.new_feedback_category_values():
+    if (
+        feedback_source is None
+        or feedback_source in FeedbackCreationSource.new_feedback_category_values()
+    ):
         return True
 
     should_notify_on_old_feedbacks = job["event"].project.get_option(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1287,11 +1287,11 @@ def should_postprocess_feedback(job: PostProcessJob) -> bool:
         return False
 
     feedback_source = event.occurrence.evidence_data.get("source")
+    if feedback_source is None:
+        logger.error("Feedback source is missing, skipped alert processing")
+        return False
 
-    if (
-        feedback_source is None
-        or feedback_source in FeedbackCreationSource.new_feedback_category_values()
-    ):
+    if feedback_source in FeedbackCreationSource.new_feedback_category_values():
         return True
 
     should_notify_on_old_feedbacks = job["event"].project.get_option(


### PR DESCRIPTION
Relates to https://getsentry.atlassian.net/browse/INC-1077 where we stopped sending alerts after `source` was removed from evidence