### PR TITLE
chore(issue-details): Fix a few things about issue guide

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -1,6 +1,6 @@
 import {Fragment, type HTMLAttributes, useContext, useEffect, useMemo} from 'react';
 import {createPortal} from 'react-dom';
-import {useTheme} from '@emotion/react';
+import {ClassNames, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ButtonBar from 'sentry/components/buttonBar';
@@ -300,39 +300,44 @@ export function TourGuide({
       {isOpen
         ? createPortal(
             <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
-              <TourOverlay
-                animated
-                arrowProps={{
-                  ...arrowProps,
-                  style: {
-                    ...arrowProps.style,
-                    fill: darkTheme.backgroundElevated,
-                  },
-                }}
-              >
-                <TourBody ref={scrollToElement}>
-                  {isTopRowVisible && (
-                    <TopRow>
-                      <div>{countText}</div>
-                      {isDismissVisible && (
-                        <TourCloseButton
-                          onClick={e => {
-                            trackAnalytics('tour-guide.close', {organization, id});
-                            handleDismiss(e);
-                          }}
-                          icon={<IconClose style={{color: darkTheme.textColor}} />}
-                          aria-label={t('Close')}
-                          borderless
-                          size="sm"
-                        />
+              <ClassNames>
+                {({css}) => (
+                  <TourOverlay
+                    animated
+                    arrowProps={{
+                      ...arrowProps,
+                      className: css`
+                        path.fill {
+                          fill: ${darkTheme.backgroundElevated} !important;
+                        }
+                      `,
+                    }}
+                  >
+                    <TourBody ref={scrollToElement}>
+                      {isTopRowVisible && (
+                        <TopRow>
+                          <div>{countText}</div>
+                          {isDismissVisible && (
+                            <TourCloseButton
+                              onClick={e => {
+                                trackAnalytics('tour-guide.close', {organization, id});
+                                handleDismiss(e);
+                              }}
+                              icon={<IconClose style={{color: darkTheme.textColor}} />}
+                              aria-label={t('Close')}
+                              borderless
+                              size="sm"
+                            />
+                          )}
+                        </TopRow>
                       )}
-                    </TopRow>
-                  )}
-                  {title && <TitleRow>{title}</TitleRow>}
-                  {description && <DescriptionRow>{description}</DescriptionRow>}
-                  {actions && <Flex justify="flex-end">{actions}</Flex>}
-                </TourBody>
-              </TourOverlay>
+                      {title && <TitleRow>{title}</TitleRow>}
+                      {description && <DescriptionRow>{description}</DescriptionRow>}
+                      {actions && <Flex justify="flex-end">{actions}</Flex>}
+                    </TourBody>
+                  </TourOverlay>
+                )}
+              </ClassNames>
             </PositionWrapper>,
             document.body
           )

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -27,6 +27,10 @@ type TourSetStepAction<T extends TourEnumType> = {
 type TourEndAction = {
   type: 'END_TOUR';
 };
+type TourSetAvailabilityAction = {
+  isAvailable: boolean;
+  type: 'SET_AVAILABILITY';
+};
 type TourSetRegistrationAction = {
   isRegistered: boolean;
   type: 'SET_REGISTRATION';
@@ -42,6 +46,7 @@ export type TourAction<T extends TourEnumType> =
   | TourPreviousStepAction
   | TourSetStepAction<T>
   | TourEndAction
+  | TourSetAvailabilityAction
   | TourSetRegistrationAction
   | TourSetCompletionAction;
 
@@ -152,6 +157,8 @@ function tourReducer<T extends TourEnumType>(
       return {...state, isCompleted: action.isCompleted};
     case 'SET_REGISTRATION':
       return {...state, isRegistered: action.isRegistered};
+    case 'SET_AVAILABILITY':
+      return {...state, isAvailable: action.isAvailable};
     default:
       return state;
   }

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -32,15 +32,6 @@ describe('NewIssueExperienceButton', function () {
     jest.clearAllMocks();
   });
 
-  it('does not appear by default', function () {
-    render(
-      <div data-test-id="test-id">
-        <NewIssueExperienceButton />
-      </div>
-    );
-    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
-  });
-
   it('appears correctly when organization has the single interface option', function () {
     const {unmount: unmountOptionTrue} = render(
       <div data-test-id="test-id">
@@ -129,10 +120,13 @@ describe('NewIssueExperienceButton', function () {
     });
 
     await userEvent.click(button);
-    // Text should change immediately
-    expect(
-      screen.getByRole('button', {name: 'Switch to the old issue experience'})
-    ).toBeInTheDocument();
+
+    const dropdownButton = screen.getByRole('button', {name: 'Manage issue experience'});
+    await userEvent.click(dropdownButton);
+    const oldExperienceButton = screen.getByRole('menuitemradio', {
+      name: 'Switch to the old issue experience',
+    });
+    expect(oldExperienceButton).toBeInTheDocument();
     // User option should be saved
     await waitFor(() => {
       expect(mockChangeUserSettings).toHaveBeenCalledWith(
@@ -149,7 +143,7 @@ describe('NewIssueExperienceButton', function () {
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
 
     // Clicking again toggles it off
-    await userEvent.click(button);
+    await userEvent.click(oldExperienceButton);
     // Old text should be back
     expect(
       screen.getByRole('button', {name: 'Switch to the new issue experience'})
@@ -187,17 +181,17 @@ describe('NewIssueExperienceButton', function () {
 
     expect(
       screen.getByRole('button', {
-        name: 'Switch issue experience',
+        name: 'Manage issue experience',
       })
     ).toBeInTheDocument();
 
     const dropdownButton = screen.getByRole('button', {
-      name: 'Switch issue experience',
+      name: 'Manage issue experience',
     });
     await userEvent.click(dropdownButton);
 
     await userEvent.click(
-      await screen.findByRole('menuitemradio', {name: 'Give feedback on new UI'})
+      await screen.findByRole('menuitemradio', {name: 'Give feedback on the UI'})
     );
     expect(mockFeedbackForm).toHaveBeenCalled();
 

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -153,7 +153,7 @@ export function NewIssueExperienceButton() {
       //  - The user is on the old UI
       //  - The org does not have the opt-in flag
       //  - The org has the enforce flag
-      //  - The org has the new UI only flag
+      //  - The org has the new UI only option
       hidden:
         !hasStreamlinedUI ||
         !hasStreamlinedUIFlag ||

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -53,7 +53,7 @@ export function NewIssueExperienceButton() {
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
-  const hasNewUIOnly = organization.streamlineOnly;
+  const hasNewUIOnly = Boolean(organization.streamlineOnly);
 
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
@@ -101,18 +101,6 @@ export function NewIssueExperienceButton() {
     }
   }, [isPromoVisible, tourDispatch, mutateAssistant]);
 
-  // We hide the toggle if the org...
-  if (
-    // doesn't have the 'opt-in' flag,
-    !hasStreamlinedUIFlag ||
-    // has the 'remove opt-out' flag,
-    hasEnforceStreamlinedUIFlag ||
-    // has access to only the updated experience through the experiment
-    hasNewUIOnly
-  ) {
-    return null;
-  }
-
   if (!hasStreamlinedUI) {
     return (
       <TryNewButton
@@ -153,7 +141,16 @@ export function NewIssueExperienceButton() {
     {
       key: 'switch-to-old-ui',
       label: t('Switch to the old issue experience'),
-      hidden: !hasStreamlinedUI,
+      // Do not show the toggle out of the new UI if any of these are true:
+      //  - The user is on the old UI
+      //  - The org does not have the opt-in flag
+      //  - The org has the enforce flag
+      //  - The org has the new UI only flag
+      hidden:
+        !hasStreamlinedUI ||
+        !hasStreamlinedUIFlag ||
+        hasEnforceStreamlinedUIFlag ||
+        hasNewUIOnly,
       onAction: handleToggle,
     },
     {

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -124,7 +124,7 @@ export function NewIssueExperienceButton() {
     },
     {
       key: 'give-feedback',
-      label: t('Give feedback on the new UI'),
+      label: t('Give feedback on the UI'),
       hidden: !openForm,
       onAction: () => {
         openForm?.({

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {motion} from 'framer-motion';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
@@ -10,13 +9,11 @@ import {TourAction, TourGuide} from 'sentry/components/tours/components';
 import {useMutateAssistant} from 'sentry/components/tours/useAssistant';
 import {IconLab} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
@@ -28,10 +25,8 @@ import {
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export function NewIssueExperienceButton() {
-  const user = useUser();
   const organization = useOrganization();
   const isSuperUser = isActiveSuperuser();
-
   const {
     dispatch: tourDispatch,
     currentStepId,
@@ -40,14 +35,6 @@ export function NewIssueExperienceButton() {
     isCompleted: isTourCompleted,
   } = useIssueDetailsTour();
   const {mutate: mutateAssistant} = useMutateAssistant();
-
-  // The promotional modal should only appear if:
-  //  - The tour is available to this user
-  //  - All the steps have been registered
-  //  - The tour has not been completed
-  //  - The tour is not currently active
-  const isPromoVisible =
-    isTourAvailable && isTourRegistered && !isTourCompleted && currentStepId === null;
 
   // XXX: We use a ref to track the previous state of tour completion
   // since we only show the banner when the tour goes from incomplete to complete
@@ -61,13 +48,13 @@ export function NewIssueExperienceButton() {
     isTourCompletedRef.current = isTourCompleted;
   }, [isTourCompleted]);
 
+  const hasStreamlinedUI = useHasStreamlinedUI();
   const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
   const hasNewUIOnly = organization.streamlineOnly;
 
-  const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
 
@@ -78,6 +65,19 @@ export function NewIssueExperienceButton() {
       organization,
     });
   }, [mutateUserOptions, organization, hasStreamlinedUI]);
+
+  // The promotional modal should only appear if:
+  //  - The tour is available to this user
+  //  - All the steps have been registered
+  //  - The tour has not been completed
+  //  - The tour is not currently active
+  //  - The streamline UI is enabled
+  const isPromoVisible =
+    isTourAvailable &&
+    isTourRegistered &&
+    !isTourCompleted &&
+    currentStepId === null &&
+    hasStreamlinedUI;
 
   useEffect(() => {
     if (isPromoVisible) {
@@ -113,57 +113,33 @@ export function NewIssueExperienceButton() {
     return null;
   }
 
-  if (!openForm || !hasStreamlinedUI) {
-    const label = hasStreamlinedUI
-      ? t('Switch to the old issue experience')
-      : t('Switch to the new issue experience');
-    const text = hasStreamlinedUI ? null : t('Try New UI');
-
+  if (!hasStreamlinedUI) {
     return (
-      <ToggleButton
-        enabled={hasStreamlinedUI}
-        size={hasStreamlinedUI ? 'xs' : 'sm'}
-        icon={
-          defined(user?.options?.prefersIssueDetailsStreamlinedUI) ? (
-            <IconLab isSolid={hasStreamlinedUI} />
-          ) : (
-            <motion.div
-              style={{height: 14}}
-              animate={{
-                rotate: [null, 6, -6, 12, -12, 6, -6, 0],
-              }}
-              transition={{
-                duration: 1,
-                delay: 1,
-                repeatDelay: 3,
-                repeat: 3,
-              }}
-            >
-              <IconLab isSolid={hasStreamlinedUI} />
-            </motion.div>
-          )
-        }
-        title={label}
-        aria-label={label}
+      <TryNewButton
+        icon={<IconLab />}
+        size="sm"
+        title={t('Switch to the new issue experience')}
+        aria-label={t('Switch to the new issue experience')}
         onClick={handleToggle}
       >
-        {text}
-      </ToggleButton>
+        {t('Try New UI')}
+      </TryNewButton>
     );
   }
 
   const items = [
     {
-      key: 'switch-to-old-ui',
-      label: t('Switch to the old issue experience'),
-      onAction: handleToggle,
+      key: 'take-tour',
+      label: t('Take a tour'),
+      hidden: !isTourAvailable || !isTourRegistered,
+      onAction: () => tourDispatch({type: 'START_TOUR'}),
     },
     {
       key: 'give-feedback',
-      label: t('Give feedback on new UI'),
+      label: t('Give feedback on thenew UI'),
       hidden: !openForm,
       onAction: () => {
-        openForm({
+        openForm?.({
           messagePlaceholder: t(
             'Excluding bribes, what would make you excited to use the new UI?'
           ),
@@ -174,25 +150,21 @@ export function NewIssueExperienceButton() {
         });
       },
     },
-  ];
-
-  if (isTourAvailable && isTourRegistered) {
-    items.unshift({
-      key: 'start-tour',
-      label: t('Take a tour'),
-      onAction: () => tourDispatch({type: 'START_TOUR'}),
-    });
-  }
-
-  if (isSuperUser && isTourCompleted) {
-    items.push({
+    {
+      key: 'switch-to-old-ui',
+      label: t('Switch to the old issue experience'),
+      hidden: !hasStreamlinedUI,
+      onAction: handleToggle,
+    },
+    {
       key: 'reset-tour-modal',
       label: t('Reset tour modal (Superuser only)'),
+      hidden: !isSuperUser || !isTourCompleted,
       onAction: () => {
         mutateAssistant({guide: ISSUE_DETAILS_TOUR_GUIDE_KEY, status: 'restart'});
       },
-    });
-  }
+    },
+  ];
 
   return (
     <TourGuide
@@ -209,7 +181,6 @@ export function NewIssueExperienceButton() {
         trigger={triggerProps => (
           <StyledDropdownButton
             {...triggerProps}
-            enabled={hasStreamlinedUI}
             size={hasStreamlinedUI ? 'xs' : 'sm'}
             aria-label={t('Switch issue experience')}
           >
@@ -224,18 +195,19 @@ export function NewIssueExperienceButton() {
   );
 }
 
-const StyledDropdownButton = styled(DropdownButton)<{enabled: boolean}>`
-  color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+const StyledDropdownButton = styled(DropdownButton)`
+  color: ${p => p.theme.button.primary.background};
   :hover {
-    color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+    color: ${p => p.theme.button.primary.background};
   }
 `;
 
-const ToggleButton = styled(Button)<{enabled: boolean}>`
-  color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
-  background: ${p =>
-    p.enabled ? 'inherit' : `linear-gradient(90deg, #3468D8, #248574)`};
-  :hover {
-    color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
+const TryNewButton = styled(Button)`
+  background: linear-gradient(90deg, #3468d8, #248574);
+  color: ${p => p.theme.white};
+  &:hover,
+  &:active,
+  &:focus {
+    color: ${p => p.theme.white};
   }
 `;

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -171,6 +171,10 @@ export function NewIssueExperienceButton() {
     },
   ];
 
+  if (items.every(item => item.hidden)) {
+    return null;
+  }
+
   return (
     <TourGuide
       title={t('Come back anytime')}
@@ -187,7 +191,7 @@ export function NewIssueExperienceButton() {
           <StyledDropdownButton
             {...triggerProps}
             size={hasStreamlinedUI ? 'xs' : 'sm'}
-            aria-label={t('Switch issue experience')}
+            aria-label={t('Manage issue experience')}
           >
             {/* Passing icon as child to avoid extra icon margin */}
             <IconLab isSolid={hasStreamlinedUI} />

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -108,7 +108,15 @@ export function NewIssueExperienceButton() {
         size="sm"
         title={t('Switch to the new issue experience')}
         aria-label={t('Switch to the new issue experience')}
-        onClick={handleToggle}
+        onClick={() => {
+          handleToggle();
+          tourDispatch({
+            type: 'SET_AVAILABILITY',
+            isAvailable:
+              location.hash === '#tour' ||
+              organization.features.includes('issue-details-streamline-tour'),
+          });
+        }}
       >
         {t('Try New UI')}
       </TryNewButton>

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -124,7 +124,7 @@ export function NewIssueExperienceButton() {
     },
     {
       key: 'give-feedback',
-      label: t('Give feedback on thenew UI'),
+      label: t('Give feedback on the new UI'),
       hidden: !openForm,
       onAction: () => {
         openForm?.({

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -95,7 +95,7 @@ describe('StreamlinedGroupHeader', () => {
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('button', {name: 'Switch to the old issue experience'})
+        screen.queryByRole('button', {name: 'Manage issue experience'})
       ).not.toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Resolve'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Archive'})).toBeInTheDocument();
@@ -118,7 +118,7 @@ describe('StreamlinedGroupHeader', () => {
         }
       );
       expect(
-        await screen.findByRole('button', {name: 'Switch to the old issue experience'})
+        await screen.findByRole('button', {name: 'Manage issue experience'})
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Fixes include:
- Actually fix the arrow color, it's a bit messy because the prop is ColorOrAlias and we can't rely on the user's theme. Thought my last fix worked, but I was just in dark mode 🤦 
- Show the modal when the user switches from the old UI
- Show the new UI dropdown for feedback and a tour even when the new UI is enforced (e.g. on new orgs)
<img width="233" alt="image" src="https://github.com/user-attachments/assets/a9a41711-6aec-4946-94f9-111114cc17d1" />


I also removed the animation for the icon since the button is now a very bright color and probably doesn't need that flair.