### PR TITLE
fix(event_manager): Resolve TypeError while recording first insight span

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -375,7 +375,6 @@ def record_first_cron_checkin(project, monitor_id, **kwargs):
     )
 
 
-@first_insight_span_received.connect(weak=False)
 def record_first_insight_span(project, module, **kwargs):
     flag = None
     if module == InsightModules.HTTP:
@@ -408,6 +407,9 @@ def record_first_insight_span(project, module, **kwargs):
         platform=project.platform,
         module=module,
     )
+
+
+first_insight_span_received.connect(record_first_insight_span, weak=False)
 
 
 @member_invited.connect(weak=False)


### PR DESCRIPTION
Fixes a regression introduced in #86604 that resulted in a captured
`TypeError` when recording the first insight span for a project.

We switched from using signals, which are prohibited in
`EventManager.save`, to directly calling the onboarding receiver
function. In this specific instance, we missed that the function was
decorated, and the import resulted in `None`. For an unknown reason, the
resulting `TypeError` did not show up in Sentry.

Projects that have not recorded these flags since the regression was
rolled out will be flagged when they ingest the next span of the
corresponding insights module.