### PR TITLE
feat(releases): Tweak release bubbles hitbox + area alignment

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -143,7 +143,7 @@ function createReleaseBubbleMouseListeners({
 }
 
 interface ReleaseBubbleSeriesProps {
-  bubblePadding: {x: number; y: number};
+  bubblePadding: number;
   bubbleSize: number;
   buckets: Bucket[];
   chartRef: React.RefObject<ReactEchartsRef | null>;
@@ -230,34 +230,24 @@ function ReleaseBubbleSeries({
       //  ----------------  ----------------
       //                 ^  ^
       //                 |--|
-      //                 bubblePadding.x
+      //                 bubblePadding
 
-      // No left-padding on first bubble
-      x: bubbleStartX + (params.dataIndex === 0 ? 0 : bubblePadding.x),
-
-      // No right-padding on last bubble
-      // We don't decrease width on first bubble to make up for lack of
-      // left-padding
-      width:
-        width -
-        (params.dataIndex === 0 || params.dataIndex === data.length - 1
-          ? 0
-          : bubblePadding.x),
-
+      x: bubbleStartX + bubblePadding / 2,
+      width: width - bubblePadding,
       // We configure base chart's grid and xAxis to create a gap size of
       // `bubbleSize`. We then have to configure `y` and `height` to fit within this
       //
       // ----------------- grid bottom
-      //   | bubblePadding.y
+      //   | bubblePadding
       //   | bubbleSize
-      //   | bubblePadding.y
+      //   | bubblePadding
       // ----------------- = xAxis offset
 
       // idk exactly what's happening but we need a 1 pixel buffer to make it
       // properly centered. I want to guess because we are drawing below the
       // xAxis, and we have to account for the pixel being drawn in the other
       // direction. You can see this if you set the x-axis offset to 0 and compare.
-      y: bubbleStartY + bubblePadding.y + 1,
+      y: bubbleStartY + bubblePadding,
       height: bubbleSize,
 
       // border radius
@@ -269,13 +259,19 @@ function ReleaseBubbleSeries({
       transition: ['shape'],
       shape,
       style: {
+        // Use lineWidth to "fake" padding so that mouse events are triggered
+        // in the "padding" areas (i.e. so tooltips open)
+        lineWidth: bubblePadding,
+        stroke: 'transparent',
         fill: theme.blue400,
         // TODO: figure out correct opacity calculations
         opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
       },
       emphasis: {
         style: {
-          stroke: theme.blue300,
+          opacity: 1,
+          stroke: 'transparent',
+          fill: theme.blue400,
         },
       },
     } satisfies CustomSeriesRenderItemReturn;
@@ -325,7 +321,7 @@ ${t('Click to expand')}
 
 interface UseReleaseBubblesParams {
   chartRef: React.RefObject<ReactEchartsRef | null>;
-  bubblePadding?: {x: number; y: number};
+  bubblePadding?: number;
   bubbleSize?: number;
   chartRenderer?: (rendererProps: {
     end: Date;
@@ -343,7 +339,7 @@ export function useReleaseBubbles({
   minTime,
   maxTime,
   bubbleSize = 4,
-  bubblePadding = {x: 2, y: 1},
+  bubblePadding = 2,
 }: UseReleaseBubblesParams) {
   const organization = useOrganization();
   const {openDrawer} = useDrawer();
@@ -368,8 +364,7 @@ export function useReleaseBubbles({
     };
   }
 
-  // Read comments in `renderReleaseBubble()` regarding the +1
-  const totalBubblePaddingY = 1 + bubblePadding.y * 2;
+  const totalBubblePaddingY = bubblePadding * 2;
 
   return {
     createReleaseBubbleHighlighter,
@@ -406,7 +401,7 @@ export function useReleaseBubbles({
       // configure `axisLine` and `offset` to move axis line below 0 so that
       // bubbles sit between bottom of the main chart and the axis line
       axisLine: {onZero: false},
-      offset: bubbleSize + totalBubblePaddingY,
+      offset: bubbleSize + totalBubblePaddingY - 1,
     },
 
     /**
@@ -415,7 +410,7 @@ export function useReleaseBubbles({
     releaseBubbleGrid: {
       // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are
       // drawn below grid (but above x axis label)
-      bottom: bubbleSize + totalBubblePaddingY,
+      bottom: bubbleSize + totalBubblePaddingY + 1,
     },
   };
 }


### PR DESCRIPTION
This tweaks the bubbles hitbox a bit by using stroke width of the box as "padding". This makes it a bit easier to trigger the tooltip when hovering over a bubble as the whitespace around the bubble will now trigger.

Also fixes some alignment issues and tweaks on hover

ref https://github.com/getsentry/sentry/issues/85775
