### PR TITLE
fix(safari): Fix tooltip underlines in Safari

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -250,12 +250,12 @@ type AlertColors = {
 
 export const generateThemeUtils = (colors: Colors, aliases: Aliases) => ({
   tooltipUnderline: (underlineColor: ColorOrAlias = 'gray300') => ({
-    textDecoration: `underline dotted ${
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      colors[underlineColor] ?? aliases[underlineColor]
-    }`,
+    textDecoration: 'underline' as const,
     textDecorationThickness: '0.75px',
     textUnderlineOffset: '1.25px',
+    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    textDecorationColor: colors[underlineColor] ?? aliases[underlineColor],
+    textDecorationStyle: 'dotted' as const,
   }),
   overflowEllipsis: css`
     display: block;


### PR DESCRIPTION
Safari only supports `underline dotted` when [vendor prefixed](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration), so these styles are currently not being applied. There are other usages in the app, but those all go through emotion which probably transform them so that it works correctly. The tooltip styles here are applied directly as an element style in `useHoverOverlay()` which is why this isn't working.