### PR TITLE
fix(eap-spans): count_op should use `score.total`

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -68,6 +68,8 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
 def resolve_count_scores(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
     score_column = cast(str, args[0])
     ratio_column_name = score_column.replace("measurements.score", "score.ratio")
+    if ratio_column_name == "score.ratio.total":
+        ratio_column_name = "score.total"
     attribute_key = AttributeKey(name=ratio_column_name, type=AttributeKey.TYPE_DOUBLE)
     filter = TraceItemFilter(exists_filter=ExistsFilter(key=attribute_key))
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2985,7 +2985,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
                     {
                         "measurements": {
                             "score.ratio.lcp": {"value": 0.03},
-                            "score.ratio.total": {"value": 0.43},
+                            "score.total": {"value": 0.43},
                         }
                     },
                     start_ts=self.ten_mins_ago,
@@ -2993,7 +2993,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
                 self.create_span(
                     {
                         "measurements": {
-                            "score.ratio.total": {"value": 1.0},
+                            "score.total": {"value": 1.0},
                         }
                     },
                     start_ts=self.ten_mins_ago,
@@ -3001,7 +3001,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
                 self.create_span(
                     {
                         "measurements": {
-                            "score.ratio.total": {"value": 0.0},
+                            "score.total": {"value": 0.0},
                         }
                     },
                     start_ts=self.ten_mins_ago,


### PR DESCRIPTION
There is no `score.ratio.total`, only `score.total` (as they would be the same anyways)