### PR TITLE
fix(hc): Truncates organization names that exceed the max field length

### DIFF
--- a/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
@@ -13,7 +13,7 @@ from sentry.hybridcloud.services.region_organization_provisioning import (
     RegionOrganizationProvisioningRpcService,
 )
 from sentry.issues.streamline import apply_streamline_rollout_group
-from sentry.models.organization import Organization
+from sentry.models.organization import ORGANIZATION_NAME_MAX_LENGTH, Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationslugreservation import OrganizationSlugReservationType
@@ -52,7 +52,7 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
         assert (user_id is None and email) or (
             user_id and email is None
         ), "Must set either user_id or email"
-        truncated_name = organization_name[:64]
+        truncated_name = organization_name[:ORGANIZATION_NAME_MAX_LENGTH]
         org = Organization.objects.create(
             id=organization_id, name=truncated_name, slug=slug, is_test=is_test
         )

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
@@ -52,8 +52,9 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
         assert (user_id is None and email) or (
             user_id and email is None
         ), "Must set either user_id or email"
+        truncated_name = organization_name[:64]
         org = Organization.objects.create(
-            id=organization_id, name=organization_name, slug=slug, is_test=is_test
+            id=organization_id, name=truncated_name, slug=slug, is_test=is_test
         )
 
         apply_streamline_rollout_group(organization=org)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 
 SENTRY_USE_SNOWFLAKE = getattr(settings, "SENTRY_USE_SNOWFLAKE", False)
 NON_MEMBER_SCOPES = frozenset(["org:write", "project:write", "team:write"])
+ORGANIZATION_NAME_MAX_LENGTH = 64
 
 
 class OrganizationStatus(IntEnum):
@@ -154,7 +155,7 @@ class Organization(ReplicatedRegionModel):
     replication_version = 4
 
     __relocation_scope__ = RelocationScope.Organization
-    name = models.CharField(max_length=64)
+    name = models.CharField(max_length=ORGANIZATION_NAME_MAX_LENGTH)
     slug: models.Field[str, str] = SentryOrgSlugField(unique=True)
     status = BoundedPositiveIntegerField(
         choices=OrganizationStatus.as_choices(), default=OrganizationStatus.ACTIVE.value


### PR DESCRIPTION
Potential alternative to #87095

Automatically truncates organization names that exceed the maximum length.
