### PR TITLE
feat(workflow_engine): Add Validator for BaseActions

### DIFF
--- a/src/sentry/incidents/metric_alert_detector.py
+++ b/src/sentry/incidents/metric_alert_detector.py
@@ -51,6 +51,7 @@ class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
             raise serializers.ValidationError("Too many conditions")
         return attrs
 
+    # TODO - @saponifi3d - we can make this more generic and move it into the base Detector
     def update_data_conditions(self, instance: Detector, data_conditions: list[DataConditionType]):
         """
         Update the data condition if it already exists, create one if it does not
@@ -116,6 +117,7 @@ class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
             event_types=data_source.get("event_types", [event_type for event_type in event_types]),
         )
 
+    # TODO - @saponifi3d - we can make this more generic and move it into the base Detector
     def update(self, instance: Detector, validated_data: dict[str, Any]):
         instance.name = validated_data.get("name", instance.name)
         instance.type = validated_data.get("detector_type", instance.group_type).slug

--- a/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
@@ -1,12 +1,14 @@
 __all__ = [
-    "BaseDataConditionValidator",
+    "BaseActionValidator",
     "BaseDataConditionGroupValidator",
+    "BaseDataConditionValidator",
     "BaseDataSourceValidator",
     "BaseDetectorTypeValidator",
     "DataSourceCreator",
     "NumericComparisonConditionValidator",
 ]
 
+from .action import BaseActionValidator
 from .data_condition import (
     BaseDataConditionGroupValidator,
     BaseDataConditionValidator,

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -11,8 +11,6 @@ from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
-# from sentry.utils.registry import NoRegistrationExistsError
-
 T = TypeVar("T", bound=Model)
 ActionData = dict[str, Any]
 ActionConfig = dict[str, Any]

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -1,0 +1,60 @@
+from typing import Any, Generic, TypeVar
+
+from django.forms import ValidationError
+from jsonschema import ValidationError as JsonValidationError
+from jsonschema import validate
+from rest_framework import serializers
+
+from sentry.api.serializers.rest_framework import CamelSnakeModelSerializer
+from sentry.db.models import Model
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.types import ActionHandler
+
+# from sentry.utils.registry import NoRegistrationExistsError
+
+T = TypeVar("T", bound=Model)
+ActionData = dict[str, Any]
+ActionConfig = dict[str, Any]
+
+
+def validate_json_schema(value, schema):
+    try:
+        validate(value, schema)
+    except JsonValidationError as e:
+        raise ValidationError(str(e))
+
+    return value
+
+
+class BaseActionValidator(CamelSnakeModelSerializer[T], Generic[T]):
+    data: Any = serializers.JSONField()
+    config: Any = serializers.JSONField()
+
+    class Meta:
+        model = T
+        fields = ["config", "data", "integration_id", "type"]
+
+    def _get_action_handler(self) -> ActionHandler:
+        initial_type = self.initial_data.get("type")
+        action_type = self.validate_type(initial_type)
+        return action_handler_registry.get(action_type)
+
+    def validate_type(self, value) -> Action.Type:
+        if not value:
+            raise ValidationError("Action type is required")
+
+        try:
+            Action.Type(value)
+        except ValueError:
+            raise ValidationError("Invalid action type")
+
+        return value
+
+    def validate_data(self, value) -> ActionData:
+        data_schema = self._get_action_handler().data_schema
+        return validate_json_schema(value, data_schema)
+
+    def validate_config(self, value) -> ActionConfig:
+        config_schema = self._get_action_handler().config_schema
+        return validate_json_schema(value, config_schema)

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -75,6 +75,8 @@ class NotificationActionHandler(ActionHandler):
         },
     }
 
+    data_schema = {}
+
     @staticmethod
     def execute(
         job: WorkflowJob,

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -74,7 +74,12 @@ class Action(DefaultFieldsModel, JSONConfigBase):
 @receiver(pre_save, sender=Action)
 def enforce_config_schema(sender, instance: Action, **kwargs):
     handler = instance.get_handler()
-    schema = handler.config_schema
 
-    if schema is not None:
-        instance.validate_config(schema)
+    config_schema = handler.config_schema
+    data_schema = handler.data_schema
+
+    if config_schema is not None:
+        instance.validate_config(config_schema)
+
+    if data_schema is not None:
+        instance.validate_config(data_schema)

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
+from jsonschema import ValidationError, validate
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
@@ -82,4 +83,7 @@ def enforce_config_schema(sender, instance: Action, **kwargs):
         instance.validate_config(config_schema)
 
     if data_schema is not None:
-        instance.validate_config(data_schema)
+        try:
+            validate(instance.data, data_schema)
+        except ValidationError as e:
+            raise ValidationError(f"Invalid config: {e.message}")

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -47,6 +47,7 @@ class WorkflowJob(EventJob, total=False):
 
 class ActionHandler:
     config_schema: ClassVar[dict[str, Any]]
+    data_schema: ClassVar[dict[str, Any]]
 
     @staticmethod
     def execute(job: WorkflowJob, action: Action, detector: Detector) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -27,17 +27,18 @@ from sentry.snuba.models import (
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import (
+    BaseActionValidator,
     BaseDataConditionGroupValidator,
     BaseDataSourceValidator,
     BaseDetectorTypeValidator,
     DataSourceCreator,
     NumericComparisonConditionValidator,
 )
-from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource
+from sentry.workflow_engine.models import Action, DataCondition, DataConditionGroup, DataSource
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.types import ActionHandler, DetectorPriorityLevel
 
 
 class BaseValidatorTest(TestCase):
@@ -546,3 +547,120 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 class MockDetectorValidator(BaseDetectorTypeValidator):
     data_source = MockDataSourceValidator()
     condition_group = MockConditionGroupValidator()
+
+
+class MockActionHandler(ActionHandler):
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Action Configuration",
+        "type": "object",
+        "properties": {
+            "foo": {
+                "type": ["string"],
+            },
+        },
+        "required": ["foo"],
+        "additionalProperties": False,
+    }
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Action Data",
+        "type": "object",
+        "properties": {
+            "baz": {
+                "type": ["string"],
+            },
+        },
+        "required": ["baz"],
+        "additionalProperties": False,
+    }
+
+
+class MockActionValidator(BaseActionValidator[MockModel]):
+    field1 = serializers.CharField()
+
+    class Meta:
+        model = MockModel
+        fields = "__all__"
+
+
+@mock.patch(
+    "sentry.workflow_engine.registry.action_handler_registry.get",
+    return_value=MockActionHandler,
+)
+class TestBaseActionValidator(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.valid_data = {
+            "field1": "test",
+            "type": Action.Type.SLACK,
+            "config": {"foo": "bar"},
+            "data": {"baz": "bar"},
+        }
+
+    def test_validate_type(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "type": Action.Type.SLACK,
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate_type__invalid(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "type": "invalid_test",
+            }
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate_config(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"foo": "bar"},
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate_config__invalid(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"invalid": 1},
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate_data(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "data": {"baz": "foo"},
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate_data__invalid(self, mock_action_handler_get):
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+                "data": {"invalid": 1},
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is False


### PR DESCRIPTION
## Description
Create an ingress validator for Actions, this generic action can be used to validate a portion of an Action from the base Action model.

As I was adding this, I noticed the data blob didn't have a schema, so I added one of those as well -- let me know if you'd like that split out from here to make it easier to review.