### PR TITLE
feat: add gsadmin entrypoint

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -240,6 +240,9 @@ const appConfig: webpack.Configuration = {
      */
     pipeline: ['sentry/utils/statics-setup', 'sentry/views/integrationPipeline'],
 
+    // admin interface
+    gsAdmin: ['sentry/utils/statics-setup', path.join(staticPrefix, 'gsAdmin')],
+
     /**
      * Legacy CSS Webpack appConfig for Django-powered views.
      * This generates a single "sentry.css" file that imports ALL component styles


### PR DESCRIPTION
currently this is being built by getsentry but if i remove getsentry webpack it'll surface as acceptance test errors (the underlying cause of course being a 404 for the gsAdmin.js entrypoint)