### PR TITLE
ref(flags/tagsDrawer): Add empty state to issue flags and tags drawer

### DIFF
--- a/static/app/views/issueDetails/groupFeatureFlags/groupFeatureFlagsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/groupFeatureFlagsDrawerContent.tsx
@@ -1,12 +1,15 @@
 import {useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import useGroupFeatureFlags from 'sentry/views/issueDetails/groupFeatureFlags/useGroupFeatureFlags';
+import {
+  Container,
+  StyledEmptyStateWarning,
+  Wrapper,
+} from 'sentry/views/issueDetails/groupTags/groupTagsDrawer';
 import {TagDistribution} from 'sentry/views/issueDetails/groupTags/tagDistribution';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
@@ -65,6 +68,10 @@ export default function GroupFeatureFlagsDrawerContent({
       message={t('There was an error loading feature flags.')}
       onRetry={refetch}
     />
+  ) : displayTags.length === 0 ? (
+    <StyledEmptyStateWarning withIcon>
+      {t('No feature flags were found for this issue')}
+    </StyledEmptyStateWarning>
   ) : (
     <Wrapper>
       <Container>
@@ -75,16 +82,3 @@ export default function GroupFeatureFlagsDrawerContent({
     </Wrapper>
   );
 }
-
-const Wrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(2)};
-`;
-
-const Container = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: ${space(2)};
-  margin-bottom: ${space(2)};
-`;

--- a/static/app/views/issueDetails/groupFeatureFlags/groupFeatureFlagsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/groupFeatureFlagsDrawerContent.tsx
@@ -70,7 +70,9 @@ export default function GroupFeatureFlagsDrawerContent({
     />
   ) : displayTags.length === 0 ? (
     <StyledEmptyStateWarning withIcon>
-      {t('No feature flags were found for this issue')}
+      {data.length === 0
+        ? t('No feature flags were found for this issue')
+        : t('No feature flags were found for this search')}
     </StyledEmptyStateWarning>
   ) : (
     <Wrapper>

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -326,4 +326,5 @@ export const StyledEmptyStateWarning = styled(EmptyStateWarning)`
   display: flex;
   flex-direction: column;
   align-items: center;
+  font-size: ${p => p.theme.fontSizeLarge};
 `;

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -278,7 +278,9 @@ export function GroupTagsDrawer({
           />
         ) : displayTags.length === 0 ? (
           <StyledEmptyStateWarning withIcon>
-            {t('No tags were found for this issue')}
+            {data.length === 0
+              ? t('No tags were found for this issue')
+              : t('No tags were found for this search')}
           </StyledEmptyStateWarning>
         ) : (
           <Wrapper>

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {ExportQueryType, useDataExport} from 'sentry/components/dataExport';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {
   CrumbContainer,
   EventDrawerBody,
@@ -260,14 +261,14 @@ export function GroupTagsDrawer({
         {headerActions}
       </EventNavigator>
       <EventDrawerBody>
-        {tagKey ? (
-          <TagDetailsDrawerContent group={group} />
-        ) : tab === FEATURE_FLAGS_TAB ? (
+        {tab === FEATURE_FLAGS_TAB ? (
           <GroupFeatureFlagsDrawerContent
             group={group}
             environments={environments}
             search={search}
           />
+        ) : tagKey ? (
+          <TagDetailsDrawerContent group={group} />
         ) : isPending || isHighlightsPending ? (
           <LoadingIndicator />
         ) : isError ? (
@@ -275,6 +276,10 @@ export function GroupTagsDrawer({
             message={t('There was an error loading issue tags.')}
             onRetry={refetch}
           />
+        ) : displayTags.length === 0 ? (
+          <StyledEmptyStateWarning withIcon>
+            {t('No tags were found for this issue')}
+          </StyledEmptyStateWarning>
         ) : (
           <Wrapper>
             <Container>
@@ -293,22 +298,30 @@ export function GroupTagsDrawer({
   );
 }
 
-const Wrapper = styled('div')`
+export const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(2)};
 `;
 
-const Container = styled('div')`
+export const Container = styled('div')`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: ${space(2)};
   margin-bottom: ${space(2)};
 `;
 
-const Header = styled('h3')`
+export const Header = styled('h3')`
   ${p => p.theme.overflowEllipsis};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: ${p => p.theme.fontWeightBold};
   margin: 0;
+`;
+
+export const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  border: ${p => p.theme.border} solid 1px;
+  border-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -313,7 +313,7 @@ export const Container = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-export const Header = styled('h3')`
+const Header = styled('h3')`
   ${p => p.theme.overflowEllipsis};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: ${p => p.theme.fontWeightBold};


### PR DESCRIPTION
<img width="1293" alt="SCR-20250314-rsdo" src="https://github.com/user-attachments/assets/f766b111-d47b-4610-9be9-49c81dbf8a40" />
<img width="1294" alt="SCR-20250314-rstz" src="https://github.com/user-attachments/assets/42897526-cda4-4966-81c8-bb2bd64932d3" />

See https://github.com/getsentry/sentry/pull/86359#issuecomment-2725405753 for error and loading states

**3/17 update**
![Screenshot 2025-03-17 at 11 14 52 AM](https://github.com/user-attachments/assets/45532a21-e00a-4f08-bc22-3c0612a45699)
Updated font size (16px) and text for no search results