### PR TITLE
fix(projects): Show ANR Rate when feature enabled

### DIFF
--- a/static/app/views/projectDetail/projectCharts.spec.tsx
+++ b/static/app/views/projectDetail/projectCharts.spec.tsx
@@ -81,9 +81,7 @@ describe('ProjectDetail > ProjectCharts', () => {
   });
 
   it('renders App Hang options for apple projects when the feature flag is enabled', async () => {
-    renderProjectCharts('apple', undefined, [
-      'projects:project-detail-apple-app-hang-rate',
-    ]);
+    renderProjectCharts('apple', undefined, ['project-detail-apple-app-hang-rate']);
 
     await userEvent.click(
       screen.getByRole('button', {name: 'Display Crash Free Sessions'})
@@ -94,9 +92,7 @@ describe('ProjectDetail > ProjectCharts', () => {
   });
 
   it('renders App Hang options for apple-ios projects when the feature flag is enabled', async () => {
-    renderProjectCharts('apple-ios', undefined, [
-      'projects:project-detail-apple-app-hang-rate',
-    ]);
+    renderProjectCharts('apple-ios', undefined, ['project-detail-apple-app-hang-rate']);
 
     await userEvent.click(
       screen.getByRole('button', {name: 'Display Crash Free Sessions'})

--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -61,7 +61,7 @@ function ProjectScoreCards({
         query={query}
       />
 
-      {isPlatformANRCompatible(project?.platform) ? (
+      {isPlatformANRCompatible(project?.platform, project?.features) ? (
         <ProjectAnrScoreCard
           organization={organization}
           selection={selection}

--- a/static/app/views/projectDetail/utils.spec.tsx
+++ b/static/app/views/projectDetail/utils.spec.tsx
@@ -9,13 +9,11 @@ describe('ProjectDetail Utils', function () {
 
     it('returns true for apple projects when the feature flag is enabled', function () {
       expect(
-        isPlatformANRCompatible('apple', ['projects:project-detail-apple-app-hang-rate'])
+        isPlatformANRCompatible('apple', ['project-detail-apple-app-hang-rate'])
       ).toBe(true);
 
       expect(
-        isPlatformANRCompatible('apple-ios', [
-          'projects:project-detail-apple-app-hang-rate',
-        ])
+        isPlatformANRCompatible('apple-ios', ['project-detail-apple-app-hang-rate'])
       ).toBe(true);
     });
 

--- a/static/app/views/projectDetail/utils.tsx
+++ b/static/app/views/projectDetail/utils.tsx
@@ -14,7 +14,7 @@ export function isPlatformANRCompatible(platform?: PlatformKey, features?: strin
     return true;
   }
   if (platform === 'apple' || platform === 'apple-ios') {
-    if (features?.includes('projects:project-detail-apple-app-hang-rate')) {
+    if (features?.includes('project-detail-apple-app-hang-rate')) {
       return true;
     }
   }


### PR DESCRIPTION
Remove the projects: prefix for checking the features' whether to show the ANR rate or not when the feature project-detail-apple-app-hang-rate is enabled.


