### PR TITLE
fix(spans): Handle optional release and op in segments consumer

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -64,6 +64,7 @@ def _find_segment_span(spans: list[Span]) -> Span | None:
 DEFAULT_SPAN_OP = "default"
 
 
+@metrics.wraps("spans.consumers.process_segments.enrich_spans")
 def _enrich_spans(segment: Span | None, spans: list[Span]) -> None:
     for span in spans:
         span["op"] = span.get("sentry_tags", {}).get("op") or DEFAULT_SPAN_OP
@@ -76,6 +77,7 @@ def _enrich_spans(segment: Span | None, spans: list[Span]) -> None:
     groupings.write_to_spans(spans)
 
 
+@metrics.wraps("spans.consumers.process_segments.create_models")
 def _create_models(segment: Span, project: Project) -> None:
     """
     Creates the Environment and Release models, along with the necessary
@@ -121,6 +123,7 @@ def _create_models(segment: Span, project: Project) -> None:
     record_release_received(project, release.version)
 
 
+@metrics.wraps("spans.consumers.process_segments.detect_performance_problems")
 def _detect_performance_problems(segment_span: Span, spans: list[Span], project: Project) -> None:
     if not options.get("standalone-spans.detect-performance-problems.enable"):
         return
@@ -215,6 +218,7 @@ def _build_shim_event_data(segment_span: Span, spans: list[Span]) -> dict[str, A
     return event
 
 
+@metrics.wraps("spans.consumers.process_segments.record_signals")
 def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> None:
     # TODO: Make transaction name clustering work again
     # record_transaction_name_for_clustering(project, event.data)
@@ -242,7 +246,7 @@ def process_segment(spans: list[Span]) -> list[Span]:
         # functions are refactored to a span interface.
         return spans
 
-    with metrics.timer("tasks.spans.project.get_from_cache"):
+    with metrics.timer("spans.consumers.process_segments.get_project"):
         project = Project.objects.get_from_cache(id=segment_span["project_id"])
 
     _enrich_spans(segment_span, spans)

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -5,6 +5,8 @@ from unittest import mock
 import pytest
 
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
+from sentry.models.environment import Environment
+from sentry.models.release import Release
 from sentry.spans.consumers.process_segments.message import process_segment
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
@@ -14,6 +16,20 @@ from tests.sentry.spans.consumers.process import build_mock_span
 class TestSpansTask(TestCase):
     def setUp(self):
         self.project = self.create_project()
+
+    def generate_basic_spans(self):
+        segment_span = build_mock_span(project_id=self.project.id)
+        child_span = build_mock_span(
+            project_id=self.project.id,
+            description="mock_test",
+            is_segment=False,
+            parent_span_id=segment_span["span_id"],
+            span_id="940ce942561548b5",
+            start_timestamp_ms=1707953018867,
+            start_timestamp_precise=1707953018.867,
+        )
+
+        return [child_span, segment_span]
 
     def generate_n_plus_one_spans(self):
         segment_span = build_mock_span(project_id=self.project.id)
@@ -54,6 +70,35 @@ class TestSpansTask(TestCase):
         spans = [segment_span, child_span, cause_span] + repeating_spans
 
         return spans
+
+    def test_create_models(self):
+        spans = self.generate_basic_spans()
+        assert process_segment(spans)
+
+        Environment.objects.get(
+            organization_id=self.organization.id,
+            name="development",
+        )
+
+        release = Release.objects.get(
+            organization_id=self.organization.id,
+            version="backend@24.2.0.dev0+699ce0cd1281cc3c7275d0a474a595375c769ae8",
+        )
+        assert release.date_added.timestamp() == spans[0]["end_timestamp_precise"]
+
+    def test_empty_defaults(self):
+        spans = self.generate_basic_spans()
+        for span in spans:
+            del span["sentry_tags"]
+
+        processed_spans = process_segment(spans)
+        assert len(processed_spans) == len(spans)
+        assert processed_spans[0]["span_id"] == spans[0]["span_id"]
+        assert processed_spans[1]["span_id"] == spans[1]["span_id"]
+
+        # double-check that we actually ran through processing. The "op"
+        # attribute does not exist in the original spans.
+        assert processed_spans[0]["op"]
 
     @override_options(
         {


### PR DESCRIPTION
The new segments consumer could not handle spans without a release and spans without an `op`. While the op is usually ensured by Relay, we add a defensive default. Releases are in fact optional and this is fixed now.