### PR TITLE
fix(laravel-insights): Highlight selected nav item

### DIFF
--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -113,7 +113,7 @@ SecondaryNav.Item = function SecondaryNavItem({
   ...linkProps
 }: SecondaryNavItemProps) {
   const location = useLocation();
-  const isActive = incomingIsActive || isLinkActive(activeTo, location.pathname, {end});
+  const isActive = incomingIsActive ?? isLinkActive(activeTo, location.pathname, {end});
 
   const {layout} = useNavContext();
 

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -6,14 +6,18 @@ import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import ProjectIcon from 'sentry/components/nav/projectIcon';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
+import {isLinkActive} from 'sentry/components/nav/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {PlatformKey, Project} from 'sentry/types/project';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {
   AI_LANDING_SUB_PATH,
   AI_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/ai/settings';
+import {useIsLaravelInsightsEnabled} from 'sentry/views/insights/pages/backend/laravel/features';
 import {
   BACKEND_LANDING_SUB_PATH,
   BACKEND_SIDEBAR_LABEL,
@@ -35,11 +39,34 @@ type InsightsNavigationProps = {
   children: React.ReactNode;
 };
 
+const platformsUsingOverviewAsProjectDetails: PlatformKey[] = ['php-laravel'];
+
 function InsightsSecondaryNav({children}: InsightsNavigationProps) {
   const organization = useOrganization();
+  const location = useLocation();
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
 
   const {projects} = useProjects();
+
+  const [isLaravelInsightsEnabled] = useIsLaravelInsightsEnabled();
+
+  const isSingleProjectSelected =
+    typeof location.query.project === 'string' && location.query.project !== '-1';
+
+  function isProjectSelectedExclusively(project: Project) {
+    return isSingleProjectSelected && location.query.project === project.id;
+  }
+
+  function isUsingOverviewAsProjectDetails(project: Project) {
+    return (
+      project.platform &&
+      platformsUsingOverviewAsProjectDetails.includes(project.platform) &&
+      isLaravelInsightsEnabled
+    );
+  }
+
+  const isStarredProjectSelected =
+    location.query.starred === '1' && isSingleProjectSelected;
 
   return (
     <Fragment>
@@ -52,7 +79,17 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
             <SecondaryNav.Item to={`${baseUrl}/${FRONTEND_LANDING_SUB_PATH}/`}>
               {FRONTEND_SIDEBAR_LABEL}
             </SecondaryNav.Item>
-            <SecondaryNav.Item to={`${baseUrl}/${BACKEND_LANDING_SUB_PATH}/`}>
+            <SecondaryNav.Item
+              isActive={
+                isLinkActive(
+                  `${baseUrl}/${BACKEND_LANDING_SUB_PATH}/`,
+                  location.pathname
+                ) &&
+                // The starred param indicates that the overview is being accessed via the starred projects nav item
+                (!isStarredProjectSelected || !isLaravelInsightsEnabled)
+              }
+              to={`${baseUrl}/${BACKEND_LANDING_SUB_PATH}/`}
+            >
               {BACKEND_SIDEBAR_LABEL}
             </SecondaryNav.Item>
             <SecondaryNav.Item to={`${baseUrl}/${MOBILE_LANDING_SUB_PATH}/`}>
@@ -70,7 +107,21 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
               .map(project => (
                 <SecondaryNav.Item
                   key={project.id}
-                  to={`${baseUrl}/projects/${project.slug}/`}
+                  to={
+                    isUsingOverviewAsProjectDetails(project)
+                      ? {
+                          pathname: `${baseUrl}/backend/`,
+                          search: `?project=${project.id}&starred=1`,
+                        }
+                      : `${baseUrl}/projects/${project.slug}/`
+                  }
+                  isActive={
+                    isUsingOverviewAsProjectDetails(project)
+                      ? isLinkActive(`${baseUrl}/backend/`, location.pathname) &&
+                        isProjectSelectedExclusively(project) &&
+                        isStarredProjectSelected
+                      : undefined
+                  }
                   leadingItems={
                     <StyledProjectIcon
                       projectPlatforms={project.platform ? [project.platform] : []}

--- a/static/app/views/insights/pages/backend/laravel/index.tsx
+++ b/static/app/views/insights/pages/backend/laravel/index.tsx
@@ -109,7 +109,7 @@ export function LaravelOverviewPage() {
             <ModuleLayout.Full>
               <ToolRibbon>
                 <PageFilterBar condensed>
-                  <ProjectPageFilter />
+                  <ProjectPageFilter resetParamsOnChange={['starred']} />
                   <EnvironmentPageFilter />
                   <DatePageFilter
                     maxPickableDays={maxPickableDays}

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -36,7 +36,7 @@ function ProjectDetailContainer(
   ) {
     return (
       <Redirect
-        to={`/organizations/${organization.slug}/insights/backend?project=${project.id}`}
+        to={`/insights/backend/?project=${project.id}${project.isBookmarked ? '&starred=1' : ''}`}
       />
     );
   }


### PR DESCRIPTION
For larvel projects on EA, the project details are redirected to the BE overview page.
This PR ensures that the starred project menu item is highlighted if it was used for navigation.

- closes https://github.com/getsentry/sentry/issues/87159