### PR TITLE
ref(demo-mode): rename isDemoModeEnabled fn

### DIFF
--- a/static/app/actionCreators/account.tsx
+++ b/static/app/actionCreators/account.tsx
@@ -3,7 +3,7 @@ import {Client} from 'sentry/api';
 import ConfigStore from 'sentry/stores/configStore';
 import type {UserIdentityConfig} from 'sentry/types/auth';
 import type {User} from 'sentry/types/user';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import type {ChangeAvatarUser} from 'sentry/views/settings/account/accountDetails';
 
 export async function disconnectIdentity(
@@ -55,7 +55,7 @@ export async function logout(api: Client, redirectUrl?: string) {
 }
 
 function getRedirectUrl(redirectUrl = '/auth/login/') {
-  return isDemoModeEnabled() ? 'https://sentry.io' : redirectUrl;
+  return isDemoModeActive() ? 'https://sentry.io' : redirectUrl;
 }
 
 export function removeAuthenticator(api: Client, userId: string, authId: string) {

--- a/static/app/actionCreators/guides.tsx
+++ b/static/app/actionCreators/guides.tsx
@@ -6,7 +6,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import GuideStore from 'sentry/stores/guideStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDemoGuides, getTourTask} from 'sentry/utils/demoMode/guides';
 
 import {demoEndModal} from './modal';
@@ -16,7 +16,7 @@ const api = new Client();
 
 export async function fetchGuides() {
   try {
-    if (isDemoModeEnabled()) {
+    if (isDemoModeActive()) {
       GuideStore.fetchSucceeded(getDemoGuides());
       return;
     }
@@ -64,7 +64,7 @@ export function recordFinish(
   orgSlug: string | null,
   org: Organization | null
 ) {
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     api.requestPromise('/assistant/', {
       method: 'PUT',
       data: {
@@ -76,7 +76,7 @@ export function recordFinish(
 
   const tourTask = getTourTask(guide);
 
-  if (isDemoModeEnabled() && tourTask && org) {
+  if (isDemoModeActive() && tourTask && org) {
     const {tour, task} = tourTask;
     updateOnboardingTask(api, org, {task, status: 'complete', completionSeen: true});
     fetchOrganizationDetails(api, org.slug);
@@ -95,7 +95,7 @@ export function recordFinish(
 }
 
 export function recordDismiss(guide: string, step: number, orgId: string | null) {
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     api.requestPromise('/assistant/', {
       method: 'PUT',
       data: {

--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -8,7 +8,7 @@ import {DEFAULT_TOAST_DURATION} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import IndicatorStore from 'sentry/stores/indicatorStore';
 import {space} from 'sentry/styles/space';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 
 type IndicatorType = 'loading' | 'error' | 'success' | 'undo' | '';
 
@@ -82,7 +82,7 @@ export function addLoadingMessage(
 }
 
 export function addErrorMessage(msg: React.ReactNode, options?: Options) {
-  if (isDemoModeEnabled()) {
+  if (isDemoModeActive()) {
     return addMessageWithType('error')(
       t('This action is not allowed in demo mode.'),
       options

--- a/static/app/actionCreators/onboardingTasks.tsx
+++ b/static/app/actionCreators/onboardingTasks.tsx
@@ -3,7 +3,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import type {OnboardingTaskStatus, UpdatedTask} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {updateDemoWalkthroughTask} from 'sentry/utils/demoMode/guides';
 
 /**
@@ -17,7 +17,7 @@ export function updateOnboardingTask(
   organization: Organization,
   updatedTask: UpdatedTask
 ) {
-  if (isDemoModeEnabled()) {
+  if (isDemoModeActive()) {
     updateDemoWalkthroughTask(updatedTask);
     return;
   }

--- a/static/app/components/acl/demoModeDisabled.spec.tsx
+++ b/static/app/components/acl/demoModeDisabled.spec.tsx
@@ -1,11 +1,11 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 
 import DisableInDemoMode from './demoModeDisabled'; // Adjust the import path as necessary
 
 jest.mock('sentry/utils/demoMode', () => ({
-  isDemoModeEnabled: jest.fn(),
+  isDemoModeActive: jest.fn(),
 }));
 
 jest.mock('sentry/locale', () => ({
@@ -14,7 +14,7 @@ jest.mock('sentry/locale', () => ({
 
 describe('DisableInDemoMode', () => {
   it('renders children when demo mode is disabled', () => {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDemoModeActive as jest.Mock).mockReturnValue(false);
 
     render(
       <DisableInDemoMode>
@@ -27,7 +27,7 @@ describe('DisableInDemoMode', () => {
   });
 
   it('renders a tooltip when demo mode is enabled', () => {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
     render(
       <DisableInDemoMode>

--- a/static/app/components/acl/demoModeDisabled.tsx
+++ b/static/app/components/acl/demoModeDisabled.tsx
@@ -1,13 +1,13 @@
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 
 type Props = {
   children?: React.ReactNode;
 };
 
 function DisableInDemoMode({children}: Props) {
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     return children;
   }
 

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -3,13 +3,13 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDemoModeGuides} from 'sentry/utils/demoMode/guides';
 
 export default function getGuidesContent(
   organization: Organization | null
 ): GuidesContent {
-  if (isDemoModeEnabled()) {
+  if (isDemoModeActive()) {
     return getDemoModeGuides();
   }
   return [

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -14,7 +14,7 @@ import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import type EventView from 'sentry/utils/discover/eventView';
 import useApi from 'sentry/utils/useApi';
 import useProjects from 'sentry/utils/useProjects';
@@ -206,7 +206,7 @@ export default function CreateAlertButton({
 
   const showGuide = !organization.alertsMemberWrite && !!showPermissionGuide;
   const canCreateAlert =
-    isDemoModeEnabled() ||
+    isDemoModeActive() ||
     hasEveryAccess(['alerts:write'], {organization}) ||
     projects.some(p => hasEveryAccess(['alerts:write'], {project: p}));
   const hasOrgWrite = hasEveryAccess(['org:write'], {organization});

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -10,7 +10,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   extraQueryParameter,
   extraQueryParameterWithEmail,
-  isDemoModeEnabled,
+  isDemoModeActive,
   openDemoEmailModal,
   urlAttachQueryParams,
 } from 'sentry/utils/demoMode';
@@ -22,7 +22,7 @@ export default function DemoHeader() {
     openDemoEmailModal();
   }, []);
 
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     return null;
   }
 

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -9,7 +9,7 @@ import FormState from 'sentry/components/forms/state';
 import {t} from 'sentry/locale';
 import type {Choice} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 
 export const fieldIsRequiredMessage = t('Field is required');
 
@@ -607,7 +607,7 @@ class FormModel {
     // Check if field needs to handle transforming request object
     const getDataFn = typeof getData === 'function' ? getData : (a: any) => a;
 
-    const defaultErrorMsg = isDemoModeEnabled()
+    const defaultErrorMsg = isDemoModeActive()
       ? t('Editing data is not allowed in demo mode.')
       : t('Failed to save');
 

--- a/static/app/components/modals/demoEmailModal.tsx
+++ b/static/app/components/modals/demoEmailModal.tsx
@@ -61,12 +61,13 @@ export default function Modal({onAddedEmail, closeModal, onFailure}: Props) {
             email,
           },
         });
-        closeModal();
 
         updateTouches(utmState);
       } catch (error) {
         onFailure();
       }
+
+      closeModal();
     },
     [api, closeModal, onFailure, onAddedEmail]
   );

--- a/static/app/components/nav/orgDropdown.tsx
+++ b/static/app/components/nav/orgDropdown.tsx
@@ -15,7 +15,7 @@ import {t, tn} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {localizeDomain, resolveRoute} from 'sentry/utils/resolveRoute';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -133,7 +133,7 @@ export function OrgDropdown({className}: {className?: string}) {
               label: t('Switch Organization'),
               isSubmenu: true,
               disabled: !organizations?.length,
-              hidden: config.singleOrganization || isDemoModeEnabled(),
+              hidden: config.singleOrganization || isDemoModeActive(),
               children: [
                 ...orderBy(organizations, ['status.id', 'name']).map(switchOrg => ({
                   key: switchOrg.id,

--- a/static/app/components/nav/primary/onboarding.tsx
+++ b/static/app/components/nav/primary/onboarding.tsx
@@ -24,7 +24,7 @@ import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {OnboardingTask} from 'sentry/types/onboarding';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -47,7 +47,7 @@ function OnboardingItem({
   const theme = useTheme();
   const {layout} = useNavContext();
   const showLabel = layout === NavLayout.MOBILE;
-  const demoMode = isDemoModeEnabled();
+  const demoMode = isDemoModeActive();
   const label = demoMode ? t('Guided Tours') : t('Onboarding');
   const pendingCompletionSeen = doneTasks.length !== completeTasks.length;
   const {activateSidebar} = useOnboardingSidebar();
@@ -127,7 +127,7 @@ export function PrimaryNavigationOnboarding() {
     false
   );
 
-  const demoMode = isDemoModeEnabled();
+  const demoMode = isDemoModeActive();
 
   const {allTasks, doneTasks, completeTasks, refetch} = useOnboardingTasks({
     disabled: !isActive,

--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -29,7 +29,7 @@ import DemoWalkthroughStore from 'sentry/stores/demoWalkthroughStore';
 import {space} from 'sentry/styles/space';
 import {type OnboardingTask, OnboardingTaskKey} from 'sentry/types/onboarding';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -271,7 +271,7 @@ function Task({task, hidePanel, showWaitingIndicator}: TaskProps) {
 
       e.stopPropagation();
 
-      if (isDemoModeEnabled()) {
+      if (isDemoModeActive()) {
         DemoWalkthroughStore.activateGuideAnchor(task.task);
       }
 

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -20,7 +20,7 @@ import type {
 import {OnboardingTaskGroup, OnboardingTaskKey} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDemoWalkthroughTasks} from 'sentry/utils/demoMode/guides';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
@@ -106,7 +106,7 @@ export function getOnboardingTasks({
     ? `${getPerformanceBaseUrl(organization.slug, 'frontend')}/`
     : `${getPerformanceBaseUrl(organization.slug)}/`;
 
-  if (isDemoModeEnabled()) {
+  if (isDemoModeActive()) {
     return [
       {
         task: OnboardingTaskKey.ISSUE_GUIDE,
@@ -372,7 +372,7 @@ export function getOnboardingTasks({
 
 export function getMergedTasks({organization, projects, onboardingContext}: Options) {
   const taskDescriptors = getOnboardingTasks({organization, projects, onboardingContext});
-  const serverTasks = isDemoModeEnabled()
+  const serverTasks = isDemoModeActive()
     ? getDemoWalkthroughTasks()
     : organization.onboardingTasks;
 

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 
@@ -64,7 +64,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
               >
                 {t('Search Support, Docs and More')}
               </SidebarMenuItem>
-              {!isDemoModeEnabled() && (
+              {!isDemoModeActive() && (
                 // Sentry zendesk is public but we hide it in demo mode to limit the amount of potential spam
                 <SidebarMenuItem href="https://sentry.zendesk.com/hc/en-us">
                   {t('Visit Help Center')}

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -14,7 +14,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import PreferenceStore from 'sentry/stores/preferencesStore';
 import type {Organization} from 'sentry/types/organization';
 import type {StatuspageIncident} from 'sentry/types/system';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
 import * as incidentsHook from 'sentry/utils/useServiceIncidents';
@@ -133,14 +133,14 @@ describe('Sidebar', function () {
   });
 
   it('does not render help center in demo mode', async () => {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
     renderSidebar({organization});
     await userEvent.click(await screen.findByText('Help'));
 
     expect(screen.queryByText('Visit Help Center')).not.toBeInTheDocument();
 
-    (isDemoModeEnabled as jest.Mock).mockReset();
+    (isDemoModeActive as jest.Mock).mockReset();
   });
 
   describe('SidebarDropdown', function () {

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -46,7 +46,7 @@ import PreferencesStore from 'sentry/stores/preferencesStore';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import theme from 'sentry/utils/theme';
@@ -161,7 +161,7 @@ function Sidebar() {
     return () => bcl.remove('collapsed');
   }, [collapsed]);
 
-  const sidebarAnchor = isDemoModeEnabled() ? (
+  const sidebarAnchor = isDemoModeActive() ? (
     <GuideAnchor target="projects" disabled={!DemoWalkthroughStore.get('sidebar')}>
       {t('Projects')}
     </GuideAnchor>

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -16,7 +16,7 @@ import {IconCheckmark} from 'sentry/icons/iconCheckmark';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -47,7 +47,7 @@ export function OnboardingStatus({
   );
 
   const isActive = currentPanel === SidebarPanelKey.ONBOARDING_WIZARD;
-  const demoMode = isDemoModeEnabled();
+  const demoMode = isDemoModeActive();
 
   const {
     allTasks,

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -43,7 +43,7 @@ import type {NewQuery} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {defined, percent} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import EventView from 'sentry/utils/discover/eventView';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
@@ -553,7 +553,7 @@ function StreamGroup({
     <Placeholder height="18px" />
   );
 
-  const issueStreamAnchor = isDemoModeEnabled() ? (
+  const issueStreamAnchor = isDemoModeActive() ? (
     <GuideAnchor target="issue_stream" disabled={!DemoWalkthroughStore.get('issue')} />
   ) : (
     <GuideAnchor target="issue_stream" />

--- a/static/app/utils/demoMode/index.spec.tsx
+++ b/static/app/utils/demoMode/index.spec.tsx
@@ -3,7 +3,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {
   extraQueryParameter,
   extraQueryParameterWithEmail,
-  isDemoModeEnabled,
+  isDemoModeActive,
   urlAttachQueryParams,
 } from './';
 
@@ -60,13 +60,13 @@ describe('Demo Mode Functions', () => {
     });
   });
 
-  describe('isDemoModeEnabled', () => {
+  describe('isDemoModeActive', () => {
     it('returns true if demoMode is enabled and user is not a superuser', () => {
       jest.spyOn(ConfigStore, 'get').mockReturnValue(true);
       jest
         .spyOn(require('sentry/utils/isActiveSuperuser'), 'isActiveSuperuser')
         .mockReturnValue(false);
-      expect(isDemoModeEnabled()).toBe(true);
+      expect(isDemoModeActive()).toBe(true);
     });
 
     it('returns false if demoMode is enabled but user is a superuser', () => {
@@ -74,12 +74,12 @@ describe('Demo Mode Functions', () => {
       jest
         .spyOn(require('sentry/utils/isActiveSuperuser'), 'isActiveSuperuser')
         .mockReturnValue(true);
-      expect(isDemoModeEnabled()).toBe(false);
+      expect(isDemoModeActive()).toBe(false);
     });
 
     it('returns false if demoMode is not enabled', () => {
       jest.spyOn(ConfigStore, 'get').mockReturnValue(false);
-      expect(isDemoModeEnabled()).toBe(false);
+      expect(isDemoModeActive()).toBe(false);
     });
   });
 });

--- a/static/app/utils/demoMode/index.tsx
+++ b/static/app/utils/demoMode/index.tsx
@@ -35,12 +35,12 @@ export function urlAttachQueryParams(url: string, params: URLSearchParams): stri
   return url;
 }
 
-export function isDemoModeEnabled(): boolean {
+export function isDemoModeActive(): boolean {
   return ConfigStore.get('demoMode') && !isActiveSuperuser();
 }
 
 export function openDemoSignupModal() {
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     return;
   }
   setTimeout(() => {
@@ -49,7 +49,7 @@ export function openDemoSignupModal() {
 }
 
 export function openDemoEmailModal() {
-  if (!isDemoModeEnabled()) {
+  if (!isDemoModeActive()) {
     return;
   }
 
@@ -75,7 +75,7 @@ function onAddedEmail(email: string) {
 let inactivityTimeout: number | undefined;
 
 window.addEventListener('blur', () => {
-  if (isDemoModeEnabled()) {
+  if (isDemoModeActive()) {
     inactivityTimeout = window.setTimeout(() => {
       logout(new Client());
     }, INACTIVITY_TIMEOUT_MS);

--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -10,7 +10,7 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useTeams} from 'sentry/utils/useTeams';
 
 interface Props {
@@ -81,7 +81,7 @@ function TeamFilter({
       multiple
       clearable
       searchable
-      disabled={isDemoModeEnabled()}
+      disabled={isDemoModeActive()}
       loading={fetching}
       menuTitle={t('Filter teams')}
       options={[

--- a/static/app/views/monitors/components/ownerFilter.tsx
+++ b/static/app/views/monitors/components/ownerFilter.tsx
@@ -1,6 +1,6 @@
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useOwnerOptions} from 'sentry/utils/useOwnerOptions';
 import {useOwners} from 'sentry/utils/useOwners';
 
@@ -36,7 +36,7 @@ export function OwnerFilter({selectedOwners, onChangeFilter}: OwnerFilterProps) 
       clearable
       searchable
       loading={fetching}
-      disabled={isDemoModeEnabled()}
+      disabled={isDemoModeActive()}
       menuTitle={t('Filter owners')}
       options={[{label: t('Suggested'), options: suggestedOptions}, ...options]}
       value={selectedOwners}

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
@@ -1,7 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import SessionHistory from 'sentry/views/settings/account/accountSecurity/sessionHistory';
 
 const ENDPOINT = '/users/me/ips/';
@@ -48,7 +48,7 @@ describe('AccountSecuritySessionHistory', function () {
   });
 
   it('renders empty in demo mode even if ips exist', async () => {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
     await render(<SessionHistory {...routerProps} />);
 
@@ -56,6 +56,6 @@ describe('AccountSecuritySessionHistory', function () {
     expect(screen.queryByText('192.168.0.1')).not.toBeInTheDocument();
     expect(screen.queryByText('US (CA)')).not.toBeInTheDocument();
 
-    (isDemoModeEnabled as jest.Mock).mockReset();
+    (isDemoModeActive as jest.Mock).mockReset();
   });
 });

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
@@ -11,7 +11,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {InternetProtocol} from 'sentry/types/user';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -30,7 +30,7 @@ function SessionHistory({routes, params, location}: Props) {
     isError,
   } = useApiQuery<IpListType>(['/users/me/ips/'], {
     staleTime: 0,
-    enabled: !isDemoModeEnabled(),
+    enabled: !isDemoModeActive(),
   });
 
   if (isError) {

--- a/static/app/views/settings/account/apiApplications/index.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/index.spec.tsx
@@ -9,7 +9,7 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import ApiApplications from 'sentry/views/settings/account/apiApplications';
 
 jest.mock('sentry/utils/demoMode');
@@ -50,7 +50,7 @@ describe('ApiApplications', function () {
   });
 
   it('renders empty in demo mode even if there are applications', async function () {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
     MockApiClient.addMockResponse({
       url: '/api-applications/',
@@ -63,7 +63,7 @@ describe('ApiApplications', function () {
       await screen.findByText("You haven't created any applications yet.")
     ).toBeInTheDocument();
 
-    (isDemoModeEnabled as jest.Mock).mockReset();
+    (isDemoModeActive as jest.Mock).mockReset();
   });
 
   it('creates application', async function () {

--- a/static/app/views/settings/account/apiApplications/index.tsx
+++ b/static/app/views/settings/account/apiApplications/index.tsx
@@ -15,7 +15,7 @@ import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {ApiApplication} from 'sentry/types/user';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import Row from 'sentry/views/settings/account/apiApplications/row';
@@ -38,7 +38,7 @@ function ApiApplications({router}: Props) {
     refetch,
   } = useApiQuery<ApiApplication[]>([ENDPOINT], {
     staleTime: 0,
-    enabled: !isDemoModeEnabled(),
+    enabled: !isDemoModeActive(),
   });
 
   if (isLoading) {

--- a/static/app/views/settings/account/apiTokens.spec.tsx
+++ b/static/app/views/settings/account/apiTokens.spec.tsx
@@ -7,7 +7,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {ApiTokens} from 'sentry/views/settings/account/apiTokens';
 
 jest.mock('sentry/utils/demoMode');
@@ -46,7 +46,7 @@ describe('ApiTokens', function () {
   });
 
   it('renders empty in demo mode even if there are tokens', async function () {
-    (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
     MockApiClient.addMockResponse({
       url: '/api-tokens/',
@@ -59,7 +59,7 @@ describe('ApiTokens', function () {
       await screen.findByText("You haven't created any authentication tokens yet.")
     ).toBeInTheDocument();
 
-    (isDemoModeEnabled as jest.Mock).mockReset();
+    (isDemoModeActive as jest.Mock).mockReset();
   });
 
   it('can delete token', async function () {

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -14,7 +14,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {InternalAppApiToken} from 'sentry/types/user';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {
   getApiQueryData,
   setApiQueryData,
@@ -41,7 +41,7 @@ export function ApiTokens() {
     refetch,
   } = useApiQuery<InternalAppApiToken[]>(API_TOKEN_QUERY_KEY, {
     staleTime: 0,
-    enabled: !isDemoModeEnabled(),
+    enabled: !isDemoModeActive(),
   });
 
   const {mutate: deleteToken} = useMutation({

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -21,7 +21,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import ModalStore from 'sentry/stores/modalStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
 jest.mock('sentry/utils/analytics');
@@ -654,7 +654,7 @@ describe('OrganizationMembersList', function () {
     });
 
     it('renders only current user in demo mode', async function () {
-      (isDemoModeEnabled as jest.Mock).mockReturnValue(true);
+      (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
       render(<OrganizationMembersList />, {organization, router});
       renderGlobalModal({router});
@@ -663,7 +663,7 @@ describe('OrganizationMembersList', function () {
       expect(screen.getByText(currentUser.name)).toBeInTheDocument();
       expect(screen.queryByText(member.name)).not.toBeInTheDocument();
 
-      (isDemoModeEnabled as jest.Mock).mockReset();
+      (isDemoModeActive as jest.Mock).mockReset();
     });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -25,7 +25,7 @@ import {space} from 'sentry/styles/space';
 import type {OrganizationAuthProvider} from 'sentry/types/auth';
 import type {Member} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {
   type ApiQueryKey,
   setApiQueryData,
@@ -279,7 +279,7 @@ function OrganizationMembersList() {
   const membersPageLinks = getResponseHeader?.('Link');
 
   // hides other users in demo mode
-  const membersToShow = isDemoModeEnabled()
+  const membersToShow = isDemoModeActive()
     ? members.filter(({email}) => email === currentUser.email)
     : members;
 


### PR DESCRIPTION
Renames `isDemoModeEnabled` to  a more appropriate `isDemoModeActive`, since demo mode can be enabled but inactive if the user is a superuser