### PR TITLE
ref(process-segments): Skip produce flag

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -430,7 +430,14 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "process-segments": {
         "topic": Topic.BUFFERED_SEGMENTS,
         "strategy_factory": "sentry.spans.consumers.process_segments.factory.DetectPerformanceIssuesStrategyFactory",
-        "click_options": multiprocessing_options(default_max_batch_size=100),
+        "click_options": [
+            click.Option(
+                ["--skip-produce", "skip_produce"],
+                is_flag=True,
+                default=False,
+            ),
+            *multiprocessing_options(default_max_batch_size=100),
+        ],
     },
     **settings.SENTRY_KAFKA_CONSUMERS,
 }

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -11,7 +11,7 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.produce import Produce
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.processing.strategies.unfold import Unfold
-from arroyo.types import Commit, Message, Partition, Value
+from arroyo.types import Commit, FilteredPayload, Message, Partition, Value
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import BufferedSegment
 
@@ -87,6 +87,8 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
         commit_step = CommitOffsets(commit)
+
+        produce_step: ProcessingStrategy[FilteredPayload | KafkaPayload]
 
         if self.skip_produce:
             produce_step = Produce(

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -90,7 +90,7 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
 
         produce_step: ProcessingStrategy[FilteredPayload | KafkaPayload]
 
-        if self.skip_produce:
+        if not self.skip_produce:
             produce_step = Produce(
                 producer=self.producer,
                 topic=self.output_topic,

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -44,6 +44,7 @@ def test_segment_deserialized_correctly(mock_process_segment):
         max_batch_size=2,
         max_batch_time=1,
         output_block_size=1,
+        skip_produce=False,
     )
 
     with mock.patch.object(factory, "producer", new=mock.Mock()) as mock_producer:


### PR DESCRIPTION
We need an option to disable producing to snuba-spans for testing
purposes.

Since this option cannot be dynamically changed at runtime (without
adding more filtersteps or similar), we're making it a CLI flag
