### PR TITLE
chore(ourlogs): Bump sentry SDK version to 2.23.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.62
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.6
-sentry-sdk[http2]>=2.22.0
+sentry-sdk[http2]>=2.23.1
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -192,7 +192,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.62
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.6
-sentry-sdk==2.22.0
+sentry-sdk==2.23.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.62
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.6
-sentry-sdk==2.22.0
+sentry-sdk==2.23.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/integrations/web/organization_integration_setup.py
+++ b/src/sentry/integrations/web/organization_integration_setup.py
@@ -3,7 +3,7 @@ import logging
 import sentry_sdk
 from django.http import Http404, HttpRequest
 from django.http.response import HttpResponseBase
-from sentry_sdk.tracing import TRANSACTION_SOURCE_VIEW
+from sentry_sdk.tracing import TransactionSource
 
 from sentry import features
 from sentry.features.exceptions import FeatureNotRegistered
@@ -22,7 +22,7 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
 
     def handle(self, request: HttpRequest, organization, provider_id) -> HttpResponseBase:
         scope = sentry_sdk.Scope.get_current_scope()
-        scope.set_transaction_name(f"integration.{provider_id}", source=TRANSACTION_SOURCE_VIEW)
+        scope.set_transaction_name(f"integration.{provider_id}", source=TransactionSource.VIEW)
 
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id


### PR DESCRIPTION
The new version of the python SDK supports sending sentry logs - upgrade it so that we can start dogfooding.