### PR TITLE
ref(trace): Remove "default" op from trace view rows

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1698,10 +1698,10 @@ const TraceStylingWrapper = styled('div')`
 
   .TraceEmDash {
     margin-left: 4px;
-    margin-right: 4px;
   }
 
   .TraceDescription {
+    margin-left: 4px;
     white-space: nowrap;
   }
 `;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1197,6 +1197,63 @@ describe('TraceTree', () => {
         tree.expand(siblingAutogroup!, expanded);
         expect(TraceTree.HasVisibleChildren(siblingAutogroup!)).toBe(expanded);
       });
+
+      it("doesn't auto-group sibling spans with default op", () => {
+        const siblingSpans = [
+          makeSpan({
+            op: 'pageload',
+            description: 'parent',
+            start_timestamp: start,
+            timestamp: start + 1,
+            span_id: '0000',
+          }),
+          makeSpan({
+            op: 'default',
+            description: 'desc',
+            start_timestamp: start,
+            timestamp: start + 1,
+            parent_span_id: '0000',
+          }),
+          makeSpan({
+            op: 'default',
+            description: 'desc',
+            start_timestamp: start,
+            timestamp: start + 1,
+            parent_span_id: '0000',
+          }),
+          makeSpan({
+            op: 'default',
+            description: 'desc',
+            start_timestamp: start,
+            timestamp: start + 1,
+            parent_span_id: '0000',
+          }),
+          makeSpan({
+            op: 'default',
+            description: 'desc',
+            start_timestamp: start,
+            timestamp: start + 1,
+            parent_span_id: '0000',
+          }),
+          makeSpan({
+            op: 'default',
+            description: 'desc',
+            start_timestamp: start,
+            timestamp: start + 1,
+            parent_span_id: '0000',
+          }),
+        ];
+
+        const tree = TraceTree.FromTrace(trace, traceMetadata);
+        TraceTree.FromSpans(tree.root.children[0]!, siblingSpans, makeEventTransaction());
+
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+
+        const siblingAutogroup = TraceTree.Find(tree.root, node =>
+          isSiblingAutogroupedNode(node)
+        );
+        expect(siblingAutogroup).toBeNull();
+      });
     });
 
     describe('parent autogroup', () => {
@@ -1216,6 +1273,28 @@ describe('TraceTree', () => {
 
         tree.expand(parentAutogroup!, expanded);
         expect(TraceTree.HasVisibleChildren(parentAutogroup!)).toBe(expanded);
+      });
+
+      it("does't auto-group child spans with default op", () => {
+        const childSpans = [
+          makeSpan({op: 'default', description: 'desc1', span_id: '0000'}),
+          makeSpan({
+            op: 'default',
+            description: 'desc2',
+            span_id: '0001',
+            parent_span_id: '0000',
+          }),
+        ];
+
+        const tree = TraceTree.FromTrace(trace, traceMetadata);
+        TraceTree.FromSpans(tree.root.children[0]!, childSpans, makeEventTransaction());
+
+        TraceTree.AutogroupDirectChildrenSpanNodes(tree.root);
+
+        const parentAutogroup = TraceTree.Find(tree.root, node =>
+          isParentAutogroupedNode(node)
+        );
+        expect(parentAutogroup).toBeNull();
       });
     });
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -777,6 +777,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
         tail &&
         tail.children.length === 1 &&
         isSpanNode(tail.children[0]!) &&
+        // skip `op: default` spans as `default` is added to op-less spans:
+        tail.children[0].value.op !== 'default' &&
         tail.children[0].value.op === head.value.op
       ) {
         start = Math.min(start, tail.space[0]);
@@ -922,6 +924,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
           isSpanNode(next) &&
           next.children.length === 0 &&
           current.children.length === 0 &&
+          // skip `op: default` spans as `default` is added to op-less spans
+          next.value.op !== 'default' &&
           next.value.op === current.value.op &&
           next.value.description === current.value.description
         ) {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {SpanProjectIcon} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
 
@@ -69,8 +71,12 @@ export function TraceSpanRow(
           <SpanProjectIcon
             platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
           />
-          <span className="TraceOperation">{props.node.value.op ?? '<unknown>'}</span>
-          <strong className="TraceEmDash"> — </strong>
+          {props.node.value.op && props.node.value.op !== 'default' && (
+            <React.Fragment>
+              <span className="TraceOperation">{props.node.value.op}</span>
+              <strong className="TraceEmDash"> — </strong>
+            </React.Fragment>
+          )}
           <span className="TraceDescription" title={props.node.value.description}>
             {props.node.value.description
               ? props.node.value.description.length > 100

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {TraceIcons} from '../traceIcons';
@@ -72,8 +73,12 @@ export function TraceTransactionRow(
           <PlatformIcon
             platform={props.projects[props.node.value.project_slug] ?? 'default'}
           />
-          <span className="TraceOperation">{props.node.value['transaction.op']}</span>
-          <strong className="TraceEmDash"> — </strong>
+          {props.node.value['transaction.op'] !== 'default' && (
+            <React.Fragment>
+              <span className="TraceOperation">{props.node.value['transaction.op']}</span>
+              <strong className="TraceEmDash"> — </strong>
+            </React.Fragment>
+          )}
           <span className="TraceDescription">{props.node.value.transaction}</span>
         </div>
       </div>


### PR DESCRIPTION
This PR removes the **default** op from individual span and transaction rows in the trace view. 

Update: Additionally, after some internal discussion, this PR also skips  `default` spans when auto-grouping child and sibling spans. The reason for avoiding auto-grouping is that grouping on an invisible op is confusing and in general, `default` is a fallback value for op-less spans. So potentially unrelated spans could be auto-grouped. 

This came up [internally in Notion](https://www.notion.so/sentry/70bb8caf18204f02adeb204485e49f73?v=c58014ff2b3a4b4886b83694af5df85a&p=3cae022e150e4c8b9110818b9906e5a4&pm=s). To summarize:

- Given that the `op` is purely a Sentry concept and not part of any Otel specification, I think we should just not show it rather than falling back to **default**. 
  - Especially with spans ingested via our OTLP endpoint, such op-less spans will become more frequent 
- Other tracing providers (e.g. Jaeger, Grafana) also just show the name
- Removing the fallback declutters the UI, which is especially apparent in traces consisting of largely manual instrumentation (see wizard trace at the bottom)

## Some examples:

### Transaction without op

Before:
![image](https://github.com/user-attachments/assets/852dd70e-cf2c-4974-a371-add184d0455f)

After:
![image](https://github.com/user-attachments/assets/4ff61866-d587-4e8b-82d9-15e97ada3973)

### Span without op

Before:
![image](https://github.com/user-attachments/assets/55c4531f-70d8-497e-8953-e0beb9137d1a)

After:
![image](https://github.com/user-attachments/assets/d779b685-81f0-4321-9310-08a2b2592ed1)


### Transactions and spans without op

[Example Trace](https://sentry.sentry.io/explore/discover/trace/04cc44d97eb14ee08352a383cf0b2496/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&field=transaction.duration&name=All%20Errors&node=ag-b98d73ab1d96f007&node=txn-b606e7e02ed24bdfbdc6cb0d86486b70&project=6690737&query=transaction%3Adebug-id-sourcemap-upload&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=24h&timestamp=1742555445&yAxis=count%28%29)

Before:
![image](https://github.com/user-attachments/assets/b15f15e9-531f-4135-86c0-4e2f8e1cc3e5)


After:
![image](https://github.com/user-attachments/assets/39732d49-b04d-4502-b05b-c37b77776506)


### NextJS Example

[Example Trace](https://sentry.sentry.io/explore/discover/trace/e810c48ef4b611a462c6befc1319030a/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&fov=0%2C448&name=All%20Errors&node=ag-3ad78cd3b26e71d3&node=txn-d15f4046ad934d01b3e9f8d63d1db3e6&project=4507657212592128&query=transaction%3A%22GET%20%2Fchangelog%2F%5Bslug%5D%22&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=30d&timestamp=1742558675&yAxis=count%28%29)

Before:
![image](https://github.com/user-attachments/assets/733242fb-4eda-4214-afdf-77aadffdfe05)

After:
![image](https://github.com/user-attachments/assets/da0b4822-d742-4a7b-92d2-28f531e90eee)

