### PR TITLE
fix(aci): allow creating issue alerts with no triggers

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -191,13 +191,18 @@ class IssueAlertMigrator:
 
         # the only time the data_conditions list will be empty is if somebody only has EveryEventCondition in their conditions list.
         # if it's empty and this is not the case, we should not migrate
-        no_conditions = len(data_conditions) == 0
+        no_conditions = len(conditions) == 0
+        no_data_conditions = len(data_conditions) == 0
         only_has_every_event_cond = (
             len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
         )
 
-        if not self.is_dry_run and no_conditions and not only_has_every_event_cond:
-            raise Exception("No valid conditions, skipping migration")
+        if not self.is_dry_run:
+            if no_data_conditions and no_conditions:
+                # originally no conditions and we expect no data conditions
+                pass
+            elif no_data_conditions and not only_has_every_event_cond:
+                raise Exception("No valid conditions, skipping migration")
 
         enabled = True
         rule_snooze = RuleSnooze.objects.filter(rule=self.rule, user_id=None).first()

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -202,7 +202,7 @@ class IssueAlertMigrator:
                 # originally no conditions and we expect no data conditions
                 pass
             elif no_data_conditions and not only_has_every_event_cond:
-                raise Exception("No valid conditions, skipping migration")
+                raise Exception("No valid trigger conditions, skipping migration")
 
         enabled = True
         rule_snooze = RuleSnooze.objects.filter(rule=self.rule, user_id=None).first()

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -290,6 +290,20 @@ class IssueAlertMigratorTest(TestCase):
 
         assert Workflow.objects.all().count() == 0
 
+    def test_run__no_triggers(self):
+        conditions = []
+        self.issue_alert.data["conditions"] = conditions
+        self.issue_alert.save()
+
+        IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
+
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+
+        assert workflow.when_condition_group
+        conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
+        assert conditions.count() == 0
+
     def test_run__no_double_migrate(self):
         IssueAlertMigrator(self.issue_alert, self.user.id).run()
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -291,8 +291,7 @@ class IssueAlertMigratorTest(TestCase):
         assert Workflow.objects.all().count() == 0
 
     def test_run__no_triggers(self):
-        conditions = []
-        self.issue_alert.data["conditions"] = conditions
+        self.issue_alert.data["conditions"] = []
         self.issue_alert.save()
 
         IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
@@ -301,8 +300,9 @@ class IssueAlertMigratorTest(TestCase):
         workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
 
         assert workflow.when_condition_group
-        conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
-        assert conditions.count() == 0
+        assert (
+            DataCondition.objects.filter(condition_group=workflow.when_condition_group).count() == 0
+        )
 
     def test_run__no_double_migrate(self):
         IssueAlertMigrator(self.issue_alert, self.user.id).run()


### PR DESCRIPTION
We have many rows in the Rule table where there are no conditions (triggers):
```
select * from sentry_rule where data LIKE '%conditions":[]%'
```
This is the replacement for `EveryEventCondition` so this should be allowed when migrating issue alerts to workflow engine.