### PR TITLE
feat(replay): Fix MemoryChart to not re-render as often

### DIFF
--- a/static/app/components/charts/areaChart.tsx
+++ b/static/app/components/charts/areaChart.tsx
@@ -1,6 +1,7 @@
+import {forwardRef} from 'react';
 import type {LineSeriesOption} from 'echarts';
 
-import type {Series} from 'sentry/types/echarts';
+import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
 
 import AreaSeries from './series/areaSeries';
 import type {BaseChartProps} from './baseChart';
@@ -46,13 +47,16 @@ export function transformToAreaSeries({
   );
 }
 
-export function AreaChart({series, stacked, colors, ...props}: AreaChartProps) {
-  return (
-    <BaseChart
-      {...props}
-      data-test-id="area-chart"
-      colors={colors}
-      series={transformToAreaSeries({series, stacked, colors})}
-    />
-  );
-}
+export const AreaChart = forwardRef<ReactEchartsRef, AreaChartProps>(
+  ({series, stacked, colors, ...props}, ref) => {
+    return (
+      <BaseChart
+        {...props}
+        ref={ref}
+        data-test-id="area-chart"
+        colors={colors}
+        series={transformToAreaSeries({series, stacked, colors})}
+      />
+    );
+  }
+);

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -1,5 +1,5 @@
 import type {Dispatch, SetStateAction} from 'react';
-import {useMemo, useRef} from 'react';
+import {forwardRef, memo, useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 
 import type {AreaChartProps, AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -11,6 +11,7 @@ import YAxis from 'sentry/components/charts/components/yAxis';
 import type {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {ReactEchartsRef} from 'sentry/types/echarts';
 import toArray from 'sentry/utils/array/toArray';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {getFormattedDate} from 'sentry/utils/dates';
@@ -19,51 +20,140 @@ import formatDuration from 'sentry/utils/duration/formatDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
 interface Props
-  extends Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
+  extends MemoryChartSeriesProps,
+    Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
   currentHoverTime: undefined | number;
-  durationMs: number;
-  memoryFrames: MemoryFrame[];
   setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;
-  startTimestampMs: number;
 }
 
 export default function MemoryChart({
   currentHoverTime,
   currentTime,
-  durationMs,
-  memoryFrames,
   setCurrentHoverTime,
   setCurrentTime,
-  startTimestampMs,
+  ...props
 }: Props) {
-  const theme = useTheme();
-  const idRef = useRef(domId('replay-memory-chart-'));
+  const chartRef = useRef<ReactEchartsRef | null>(null);
 
-  const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
-    () => ({
-      autoHeightResize: true,
-      height: 'auto',
-      grid: Grid({
-        left: space(1),
-        right: space(1),
-      }),
-      tooltip: computeChartTooltip(
+  const handleRef = useCallback(
+    (e: ReactEchartsRef | null) => {
+      chartRef.current = e;
+
+      if (!e) {
+        return;
+      }
+
+      const echarts = e.getEchartsInstance();
+
+      echarts.on('mousemove', params => {
+        if (!params.event) {
+          return;
+        }
+
+        const pointInGrid = echarts.convertFromPixel('grid', [
+          params.event.offsetX,
+          params.event.offsetY,
+        ]);
+        if (pointInGrid[0] !== undefined) {
+          setCurrentHoverTime(pointInGrid[0]);
+        }
+      });
+      echarts.on('mouseout', () => {
+        setCurrentHoverTime(undefined);
+      });
+
+      echarts.on('click', params => {
+        if (!params.event) {
+          return;
+        }
+
+        const pointInGrid = echarts.convertFromPixel('grid', [
+          params.event.offsetX,
+          params.event.offsetY,
+        ]);
+        if (pointInGrid[0] !== undefined) {
+          setCurrentTime(pointInGrid[0]);
+        }
+      });
+    },
+    [setCurrentTime, setCurrentHoverTime]
+  );
+
+  useEffect(() => {
+    if (!chartRef.current) {
+      return;
+    }
+
+    const echarts = chartRef.current.getEchartsInstance();
+    echarts.setOption({
+      series: [
         {
-          appendToBody: true,
-          trigger: 'axis',
-          renderMode: 'html',
-          chartId: idRef.current,
-          formatter: values => {
-            const firstValue = Array.isArray(values) ? values[0] : values;
-            const seriesTooltips = toArray(values).map(
-              value => `
+          id: 'currentTime',
+          markLine: {
+            data: [{xAxis: currentTime}],
+          },
+        },
+      ],
+    });
+  }, [currentTime]);
+
+  useEffect(() => {
+    if (!chartRef.current) {
+      return;
+    }
+
+    const echarts = chartRef.current.getEchartsInstance();
+    echarts.setOption({
+      series: [
+        {
+          id: 'hoverTime',
+          markLine: {
+            data: currentHoverTime ? [{xAxis: currentHoverTime}] : [],
+          },
+        },
+      ],
+    });
+  }, [currentHoverTime]);
+
+  return <MemoryChartSeries {...props} ref={handleRef} />;
+}
+
+interface MemoryChartSeriesProps {
+  durationMs: number;
+  memoryFrames: MemoryFrame[];
+  startTimestampMs: number;
+}
+
+const MemoryChartSeries = memo(
+  forwardRef<ReactEchartsRef, MemoryChartSeriesProps>(
+    ({durationMs, memoryFrames, startTimestampMs}, ref) => {
+      const theme = useTheme();
+      const idRef = useRef(domId('replay-memory-chart-'));
+      const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
+        () => ({
+          autoHeightResize: true,
+          height: 'auto',
+          grid: Grid({
+            left: space(1),
+            right: space(1),
+          }),
+          tooltip: computeChartTooltip(
+            {
+              appendToBody: true,
+              trigger: 'axis',
+              renderMode: 'html',
+              chartId: idRef.current,
+              formatter: values => {
+                const firstValue = Array.isArray(values) ? values[0] : values;
+                const seriesTooltips = toArray(values).map(
+                  value => `
               <div>
                 <span className="tooltip-label">${value.marker}<strong>${value.seriesName}</strong></span>
                 ${formatBytesBase2((value.data as any)[1])}
               </div>
             `
-            );
-            return `
+                );
+                return `
             <div class="tooltip-series">${seriesTooltips.join('')}</div>
               <div class="tooltip-footer">
                 ${t('Date: %s', getFormattedDate(startTimestampMs + (firstValue as any).axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
@@ -80,113 +170,104 @@ export default function MemoryChart({
               </div>
             <div class="tooltip-arrow"></div>
           `;
+              },
+            },
+            theme
+          ),
+          xAxis: XAxis({
+            type: 'time',
+            axisLabel: {
+              formatter: (time: number) =>
+                formatDuration({
+                  duration: [time, 'ms'],
+                  precision: 'sec',
+                  style: 'hh:mm:ss',
+                }),
+            },
+            theme,
+          }),
+          yAxis: YAxis({
+            type: 'value',
+            theme,
+            minInterval: 1024 * 1024, // input is in bytes, minInterval is a megabyte
+            maxInterval: Math.pow(1024, 4), // maxInterval is a terabyte
+            axisLabel: {
+              // format the axis labels to be whole number values
+              formatter: (value: any) => formatBytesBase2(value, 0),
+            },
+          }),
+        }),
+        [startTimestampMs, theme]
+      );
+
+      const staticSeries = useMemo<AreaChartSeries[]>(
+        () => [
+          {
+            id: 'usedMemory',
+            seriesName: t('Used Heap Memory'),
+            data: memoryFrames.map(frame => ({
+              value: frame.data.memory.usedJSHeapSize,
+              name: frame.offsetMs,
+            })),
+            emphasis: {disabled: true},
+            stack: 'heap-memory',
+            triggerLineEvent: true,
+            lineStyle: {opacity: 0, width: 2},
           },
-        },
-        theme
-      ),
-      xAxis: XAxis({
-        type: 'time',
-        axisLabel: {
-          formatter: (time: number) =>
-            formatDuration({
-              duration: [time, 'ms'],
-              precision: 'sec',
-              style: 'hh:mm:ss',
-            }),
-        },
-        theme,
-      }),
-      yAxis: YAxis({
-        type: 'value',
-        theme,
-        minInterval: 1024 * 1024, // input is in bytes, minInterval is a megabyte
-        maxInterval: Math.pow(1024, 4), // maxInterval is a terabyte
-        axisLabel: {
-          // format the axis labels to be whole number values
-          formatter: (value: any) => formatBytesBase2(value, 0),
-        },
-      }),
-      onMouseOver: ({data}) => {
-        if (data[0]) {
-          setCurrentHoverTime(data[0]);
-        }
-      },
-      onMouseOut: () => {
-        setCurrentHoverTime(undefined);
-      },
-      onClick: ({data}) => {
-        if (data.value) {
-          setCurrentTime(data.value);
-        }
-      },
-    }),
-    [setCurrentHoverTime, setCurrentTime, startTimestampMs, theme]
-  );
+          {
+            id: 'replayStart',
+            seriesName: 'Replay Start',
+            data: [{value: 0, name: 0}],
+            lineStyle: {opacity: 0, width: 0},
+          },
+          {
+            id: 'replayEnd',
+            seriesName: 'Replay End',
+            data: [{value: 0, name: durationMs}],
+            lineStyle: {opacity: 0, width: 0},
+          },
+        ],
+        [durationMs, memoryFrames]
+      );
 
-  const staticSeries = useMemo<AreaChartSeries[]>(
-    () => [
-      {
-        id: 'usedMemory',
-        seriesName: t('Used Heap Memory'),
-        data: memoryFrames.map(frame => ({
-          value: frame.data.memory.usedJSHeapSize,
-          name: frame.offsetMs,
-        })),
-        stack: 'heap-memory',
-        lineStyle: {opacity: 0, width: 2},
-      },
-      {
-        id: 'replayStart',
-        seriesName: 'Replay Start',
-        data: [{value: 0, name: 0}],
-        lineStyle: {opacity: 0, width: 0},
-      },
-      {
-        id: 'replayEnd',
-        seriesName: 'Replay End',
-        data: [{value: 0, name: durationMs}],
-        lineStyle: {opacity: 0, width: 0},
-      },
-    ],
-    [durationMs, memoryFrames]
-  );
+      const dynamicSeries = useMemo<AreaChartSeries[]>(
+        () => [
+          {
+            id: 'currentTime',
+            seriesName: t('Current player time'),
+            data: [],
+            markLine: {
+              symbol: ['', ''],
+              data: [],
+              label: {show: false},
+              lineStyle: {type: 'solid', color: theme.purple300, width: 2},
+            },
+          },
+          {
+            id: 'hoverTime',
+            seriesName: t('Hover player time'),
+            data: [],
+            markLine: {
+              symbol: ['', ''],
+              data: [],
+              label: {show: false},
+              lineStyle: {type: 'solid', color: theme.purple200, width: 2},
+            },
+          },
+        ],
+        [theme.purple200, theme.purple300]
+      );
 
-  const dynamicSeries = useMemo<AreaChartSeries[]>(
-    () => [
-      {
-        id: 'currentTime',
-        seriesName: t('Current player time'),
-        data: [],
-        markLine: {
-          symbol: ['', ''],
-          data: [{xAxis: currentTime}],
-          label: {show: false},
-          lineStyle: {type: 'solid', color: theme.purple300, width: 2},
-        },
-      },
-      {
-        id: 'hoverTime',
-        seriesName: t('Hover player time'),
-        data: [],
-        markLine: {
-          symbol: ['', ''],
-          data: currentHoverTime ? [{xAxis: currentHoverTime}] : [],
-          label: {show: false},
-          lineStyle: {type: 'solid', color: theme.purple200, width: 2},
-        },
-      },
-    ],
-    [currentTime, currentHoverTime, theme.purple200, theme.purple300]
-  );
+      const series = useMemo(
+        () => staticSeries.concat(dynamicSeries),
+        [dynamicSeries, staticSeries]
+      );
 
-  const series = useMemo(
-    () => staticSeries.concat(dynamicSeries),
-    [dynamicSeries, staticSeries]
-  );
-
-  return (
-    <div id={idRef.current}>
-      <AreaChart series={series} {...chartOptions} />
-    </div>
-  );
-}
+      return (
+        <div id={idRef.current}>
+          <AreaChart ref={ref} {...chartOptions} series={series} />
+        </div>
+      );
+    }
+  )
+);


### PR DESCRIPTION
Split `<MemoryChart>` into 2 components:

* The outer component handles mouse events and setting hover/current time
* The inner component renders the chart and is now memoized so that it does not re-render as often

This fixes the issue where a playing replay re-renders the chart and makes the tooltip flicker. Additionally, we define `triggerLineEvent: true` on the series so that mousemove events work on the chart to update hover time.

Closes https://github.com/getsentry/sentry/issues/51465
Closes https://github.com/getsentry/sentry/issues/68785
