### PR TITLE
chore(aci milestone 3): refactor dual update to have SPE

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -770,7 +770,6 @@ def update_alert_rule(
     :param detection_type: the type of metric alert; defaults to AlertRuleDetectionType.STATIC
     :return: The updated `AlertRule`
     """
-    from sentry.workflow_engine.migration_helpers.alert_rule import dual_update_migrated_alert_rule
 
     snuba_query = _unpack_snuba_query(alert_rule)
     organization = _unpack_organization(alert_rule)
@@ -907,8 +906,6 @@ def update_alert_rule(
 
         with transaction.atomic(router.db_for_write(AlertRule)):
             alert_rule.update(**updated_fields)
-            # if an exception occurs in this helper, don't catch it so we can see the full stack trace
-            dual_update_migrated_alert_rule(alert_rule, updated_fields)
 
         AlertRuleActivity.objects.create(
             alert_rule=alert_rule,
@@ -1115,10 +1112,6 @@ def update_alert_rule_trigger(
     alert rule
     :return: The updated AlertRuleTrigger
     """
-    from sentry.workflow_engine.migration_helpers.alert_rule import (
-        dual_update_migrated_alert_rule_trigger,
-    )
-
     if (
         AlertRuleTrigger.objects.filter(alert_rule=trigger.alert_rule, label=label)
         .exclude(id=trigger.id)
@@ -1137,8 +1130,6 @@ def update_alert_rule_trigger(
 
     with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
         if updated_fields:
-            # exceptions from this helper are purposely uncaught
-            dual_update_migrated_alert_rule_trigger(trigger, updated_fields)
             trigger.update(**updated_fields)
 
     return trigger
@@ -1367,9 +1358,6 @@ def update_alert_rule_trigger_action(
     :param input_channel_id: (Optional) Slack channel ID. If provided skips lookup
     :return:
     """
-    from sentry.workflow_engine.migration_helpers.alert_rule import (
-        dual_update_migrated_alert_rule_trigger_action,
-    )
 
     updated_fields: dict[str, Any] = {}
     if type is not None:
@@ -1423,8 +1411,6 @@ def update_alert_rule_trigger_action(
 
     with transaction.atomic(router.db_for_write(AlertRuleTriggerAction)):
         trigger_action.update(**updated_fields)
-        # exceptions from this helper are purposely left uncaught
-        dual_update_migrated_alert_rule_trigger_action(trigger_action, updated_fields)
     return trigger_action
 
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -656,7 +656,8 @@ def dual_update_migrated_alert_rule(alert_rule: AlertRule) -> (
         raise MissingDataConditionGroup
     data_conditions = DataCondition.objects.filter(condition_group=data_condition_group)
 
-    # update the data condition types in case the threshold type was updated
+    # update the data condition types if the threshold type was updated
+
     threshold_type = (
         Condition.GREATER
         if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -449,13 +449,14 @@ def create_workflow(
 
 def get_detector_field_values(
     alert_rule: AlertRule,
+    data_condition_group: DataConditionGroup,
     project_id: int | None = None,
-    data_condition_group: DataConditionGroup | None = None,
     user: RpcUser | None = None,
-) -> dict[str:Any]:
+) -> dict[str, Any]:
     detector_field_values = {
         "name": alert_rule.name,
         "description": alert_rule.description,
+        "workflow_condition_group": data_condition_group,
         "owner_user_id": alert_rule.user_id,
         "owner_team": alert_rule.team,
         "config": {
@@ -476,14 +477,6 @@ def get_detector_field_values(
                 "type": MetricAlertFire.slug,
             }
         )
-    if data_condition_group is not None:
-        # this field is only set on create and not update
-        # the separate check is for typing purposes
-        detector_field_values.update(
-            {
-                "workflow_condition_group": data_condition_group,
-            }
-        )
     return detector_field_values
 
 
@@ -494,7 +487,7 @@ def create_detector(
     user: RpcUser | None = None,
 ) -> Detector:
     detector_field_values = get_detector_field_values(
-        alert_rule, project_id, data_condition_group, user
+        alert_rule, data_condition_group, project_id, user
     )
     return Detector.objects.create(**detector_field_values)
 
@@ -503,7 +496,9 @@ def update_detector(
     alert_rule: AlertRule,
     detector: Detector,
 ):
-    detector_field_values = get_detector_field_values(alert_rule)
+    if detector.workflow_condition_group is None:
+        raise MissingDataConditionGroup
+    detector_field_values = get_detector_field_values(alert_rule, detector.workflow_condition_group)
     detector.update(**detector_field_values)
     return detector
 
@@ -740,6 +735,10 @@ def dual_update_migrated_alert_rule_trigger(
 ) -> tuple[DataCondition, DataCondition] | None:
     priority = PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH)
     detector_trigger = get_detector_trigger(alert_rule_trigger, priority)
+    if detector_trigger is None:
+        # we will have already verified that that alert rule was dual written, so
+        # we won't reach this path
+        return None
     action_filter = get_action_filter(alert_rule_trigger, priority)
 
     updated_detector_trigger_fields: dict[str, Any] = {}
@@ -780,12 +779,12 @@ def dual_update_migrated_alert_rule_trigger_action(
         target_identifier,
         trigger_action.target_type,
     )
-    updated_action_fields = {
-        "type": Action.Type(action_type),
-        "data": data,
-        "integration_id": trigger_action.integration_id,
-        "config": action_config,
-    }
+    updated_action_fields: dict[str, Any] = {}
+    updated_action_fields["type"] = Action.Type(action_type)
+    updated_action_fields["data"] = data
+    updated_action_fields["integration_id"] = trigger_action.integration_id
+    updated_action_fields["config"] = action_config
+
     action.update(**updated_action_fields)
     return action
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -447,30 +447,65 @@ def create_workflow(
     )
 
 
-def create_detector(
+def get_detector_field_values(
     alert_rule: AlertRule,
-    project_id: int,
-    data_condition_group: DataConditionGroup,
+    project_id: int | None = None,
+    data_condition_group: DataConditionGroup | None = None,
     user: RpcUser | None = None,
-) -> Detector:
-    return Detector.objects.create(
-        project_id=project_id,
-        enabled=True,
-        created_by_id=user.id if user else None,
-        name=alert_rule.name,
-        workflow_condition_group=data_condition_group,
-        type=MetricAlertFire.slug,
-        description=alert_rule.description,
-        owner_user_id=alert_rule.user_id,
-        owner_team=alert_rule.team,
-        config={
+) -> dict[str:Any]:
+    detector_field_values = {
+        "name": alert_rule.name,
+        "description": alert_rule.description,
+        "owner_user_id": alert_rule.user_id,
+        "owner_team": alert_rule.team,
+        "config": {
             "threshold_period": alert_rule.threshold_period,
             "sensitivity": alert_rule.sensitivity,
             "seasonality": alert_rule.seasonality,
             "comparison_delta": alert_rule.comparison_delta,
             "detection_type": alert_rule.detection_type,
         },
+    }
+    if project_id is not None:
+        # these fields are only set on create, not update
+        detector_field_values.update(
+            {
+                "project_id": project_id,
+                "enabled": True,
+                "created_by_id": user.id if user else None,
+                "type": MetricAlertFire.slug,
+            }
+        )
+    if data_condition_group is not None:
+        # this field is only set on create and not update
+        # the separate check is for typing purposes
+        detector_field_values.update(
+            {
+                "workflow_condition_group": data_condition_group,
+            }
+        )
+    return detector_field_values
+
+
+def create_detector(
+    alert_rule: AlertRule,
+    project_id: int,
+    data_condition_group: DataConditionGroup,
+    user: RpcUser | None = None,
+) -> Detector:
+    detector_field_values = get_detector_field_values(
+        alert_rule, project_id, data_condition_group, user
     )
+    return Detector.objects.create(**detector_field_values)
+
+
+def update_detector(
+    alert_rule: AlertRule,
+    detector: Detector,
+):
+    detector_field_values = get_detector_field_values(alert_rule)
+    detector.update(**detector_field_values)
+    return detector
 
 
 def migrate_alert_rule(
@@ -551,22 +586,23 @@ def dual_write_alert_rule(alert_rule: AlertRule, user: RpcUser | None = None) ->
         for trigger in triggers:
             migrate_metric_data_conditions(trigger)
             trigger_actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger=trigger)
-            # step 3: for each trigger, migrate the actions
+            # step 3: migrate this trigger's actions
             for trigger_action in trigger_actions:
                 migrate_metric_action(trigger_action)
         # step 4: migrate alert rule resolution
         migrate_resolve_threshold_data_conditions(alert_rule)
 
 
-def dual_update_migrated_alert_rule(alert_rule: AlertRule, updated_fields: dict[str, Any]) -> (
-    tuple[
-        DetectorState,
-        Detector,
-    ]
-    | None
-):
+def dual_update_alert_rule(alert_rule: AlertRule) -> None:
+    """
+    Comprehensively dual update the ACI objects corresponding to an alert rule, its triggers, and
+    its actions. All of these objects will have been created/updated prior to calling this method.
+    If an alert was not dual written, then quit early. If a trigger/trigger action on a dual written
+    alert rule has no ACI equivalent, then create the corresponding ACI objects. Otherwise, update
+    the corresponding ACI objects.
+    """
     try:
-        alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=alert_rule)
+        AlertRuleDetector.objects.get(alert_rule=alert_rule)
     except AlertRuleDetector.DoesNotExist:
         logger.info(
             "alert rule was not dual written, returning early",
@@ -575,64 +611,84 @@ def dual_update_migrated_alert_rule(alert_rule: AlertRule, updated_fields: dict[
         # This alert rule was not dual written
         return None
 
-    detector: Detector = alert_rule_detector.detector
+    with transaction.atomic(router.db_for_write(Detector)):
+        # step 1: update the alert rule
+        dual_update_migrated_alert_rule(alert_rule)
+        triggers = AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
+        # step 2: create/update the ACI objects for triggers
+        for trigger in triggers:
+            try:
+                get_detector_trigger(trigger, PRIORITY_MAP[trigger.label])
+            except DataCondition.DoesNotExist:
+                # we need to migrate this trigger
+                migrate_metric_data_conditions(trigger)
+            dual_update_migrated_alert_rule_trigger(trigger)
+            trigger_actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger=trigger)
+            # step 3: create/update the ACI objects for this trigger's actions
+            for trigger_action in trigger_actions:
+                try:
+                    ActionAlertRuleTriggerAction.objects.get(
+                        alert_rule_trigger_action=trigger_action
+                    )
+                except ActionAlertRuleTriggerAction.DoesNotExist:
+                    # we need to migrate this action
+                    migrate_metric_action(trigger_action)
+                dual_update_migrated_alert_rule_trigger_action(trigger_action)
+        # step 4: update alert rule resolution
+        dual_update_resolve_condition(alert_rule)
 
+
+def dual_update_migrated_alert_rule(alert_rule: AlertRule) -> (
+    tuple[
+        DetectorState,
+        Detector,
+    ]
+    | None
+):
+    alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=alert_rule)
+    detector: Detector = alert_rule_detector.detector
     detector_state = DetectorState.objects.get(detector=detector)
 
-    updated_detector_fields: dict[str, Any] = {}
-    config = detector.config.copy()
+    update_detector(alert_rule, detector)
 
-    for field, detector_field in FIELDS_TO_DETECTOR_FIELDS.items():
-        if updated_field := updated_fields.get(field):
-            updated_detector_fields[detector_field] = updated_field
-    # update config fields
-    config_fields = MetricAlertFire.detector_config_schema["properties"].keys()
-    for field in config_fields:
-        if field in updated_fields:
-            config[field] = updated_fields[field]
-    updated_detector_fields["config"] = config
+    data_condition_group = detector.workflow_condition_group
+    if data_condition_group is None:
+        # this shouldn't be possible due to the way we dual write
+        logger.error(
+            "AlertRuleDetector has no associated DataConditionGroup",
+            extra={"alert_rule_id": alert_rule.id},
+        )
+        raise MissingDataConditionGroup
+    data_conditions = DataCondition.objects.filter(condition_group=data_condition_group)
 
-    # if the user updated resolve_threshold or threshold_type, then we also need to update the detector triggers
-    if "threshold_type" in updated_fields or "resolve_threshold" in updated_fields:
-        data_condition_group = detector.workflow_condition_group
-        if data_condition_group is None:
-            # this shouldn't be possible due to the way we dual write
-            logger.error(
-                "AlertRuleDetector has no associated DataConditionGroup",
-                extra={"alert_rule_id": alert_rule.id},
-            )
-            raise MissingDataConditionGroup
-        data_conditions = DataCondition.objects.filter(condition_group=data_condition_group)
-        if "threshold_type" in updated_fields:
-            threshold_type = (
-                Condition.GREATER
-                if updated_fields["threshold_type"] == AlertRuleThresholdType.ABOVE.value
-                else Condition.LESS
-            )
-            resolve_threshold_type = (
-                Condition.LESS_OR_EQUAL
-                if updated_fields["threshold_type"] == AlertRuleThresholdType.ABOVE.value
-                else Condition.GREATER_OR_EQUAL
-            )
-            for dc in data_conditions:
-                if dc.condition_result == DetectorPriorityLevel.OK:
-                    dc.update(type=resolve_threshold_type)
-                else:
-                    dc.update(type=threshold_type)
+    # update the data condition types in case the threshold type was updated
+    threshold_type = (
+        Condition.GREATER
+        if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value
+        else Condition.LESS
+    )
+    resolve_threshold_type = (
+        Condition.LESS_OR_EQUAL
+        if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value
+        else Condition.GREATER_OR_EQUAL
+    )
+    for dc in data_conditions:
+        if dc.condition_result == DetectorPriorityLevel.OK:
+            dc.update(type=resolve_threshold_type)
+        else:
+            dc.update(type=threshold_type)
 
-        if "resolve_threshold" in updated_fields:
-            resolve_condition = data_conditions.get(condition_result=DetectorPriorityLevel.OK)
-            if updated_fields["resolve_threshold"] is None:
-                # we need to figure out the resolve threshold ourselves
-                resolve_threshold = get_resolve_threshold(data_condition_group)
-                if resolve_threshold != -1:
-                    resolve_condition.update(comparison=resolve_threshold)
-                else:
-                    raise UnresolvableResolveThreshold
-            else:
-                resolve_condition.update(comparison=updated_fields["resolve_threshold"])
-
-    detector.update(**updated_detector_fields)
+    # update the resolution data condition threshold in case the resolve threshold was updated
+    resolve_condition = data_conditions.get(condition_result=DetectorPriorityLevel.OK)
+    if alert_rule.resolve_threshold is None:
+        # we need to figure out the resolve threshold ourselves
+        resolve_threshold = get_resolve_threshold(data_condition_group)
+        if resolve_threshold != -1:
+            resolve_condition.update(comparison=resolve_threshold)
+        else:
+            raise UnresolvableResolveThreshold
+    else:
+        resolve_condition.update(comparison=alert_rule.resolve_threshold)
 
     # reset detector status, as the rule was updated
     detector_state.update(active=False, state=DetectorPriorityLevel.OK)
@@ -680,32 +736,20 @@ def dual_update_resolve_condition(alert_rule: AlertRule) -> DataCondition | None
 
 
 def dual_update_migrated_alert_rule_trigger(
-    alert_rule_trigger: AlertRuleTrigger, updated_fields: dict[str, Any]
+    alert_rule_trigger: AlertRuleTrigger,
 ) -> tuple[DataCondition, DataCondition] | None:
-    # NOTE: update the trigger *AFTER* calling this helper so that we can get the right data conditions
     priority = PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH)
     detector_trigger = get_detector_trigger(alert_rule_trigger, priority)
-    if detector_trigger is None:
-        logger.info(
-            "alert rule was not dual written, returning early",
-            extra={"alert_rule": alert_rule_trigger.alert_rule},
-        )
-        return None
     action_filter = get_action_filter(alert_rule_trigger, priority)
 
-    # Fields have already been validated in logic.py, so we can update without validating here
     updated_detector_trigger_fields: dict[str, Any] = {}
     updated_action_filter_fields: dict[str, Any] = {}
-    if "label" in updated_fields:
-        label = updated_fields["label"]
-        updated_detector_trigger_fields["condition_result"] = PRIORITY_MAP.get(
-            label, DetectorPriorityLevel.HIGH
-        )
-        updated_action_filter_fields["comparison"] = PRIORITY_MAP.get(
-            label, DetectorPriorityLevel.HIGH
-        )
-    if "alert_threshold" in updated_fields:
-        updated_detector_trigger_fields["comparison"] = updated_fields["alert_threshold"]
+    label = alert_rule_trigger.label
+    updated_detector_trigger_fields["condition_result"] = PRIORITY_MAP.get(
+        label, DetectorPriorityLevel.HIGH
+    )
+    updated_action_filter_fields["comparison"] = PRIORITY_MAP.get(label, DetectorPriorityLevel.HIGH)
+    updated_detector_trigger_fields["comparison"] = alert_rule_trigger.alert_threshold
 
     detector_trigger.update(**updated_detector_trigger_fields)
     if updated_action_filter_fields:
@@ -715,23 +759,11 @@ def dual_update_migrated_alert_rule_trigger(
 
 
 def dual_update_migrated_alert_rule_trigger_action(
-    trigger_action: AlertRuleTriggerAction, updated_fields: dict[str, Any]
+    trigger_action: AlertRuleTriggerAction,
 ) -> Action | None:
-    # NOTE: update the action *BEFORE* calling this method so that we can reuse the get_action_type method
-    alert_rule_trigger = trigger_action.alert_rule_trigger
-    # Check that we dual wrote this action
-    priority = PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH)
-    detector_trigger = get_detector_trigger(alert_rule_trigger, priority)
-    if detector_trigger is None:
-        logger.info(
-            "alert rule was not dual written, returning early",
-            extra={"alert_rule": alert_rule_trigger.alert_rule},
-        )
-        return None
     aarta = ActionAlertRuleTriggerAction.objects.get(alert_rule_trigger_action=trigger_action)
     action = aarta.action
 
-    updated_action_fields: dict[str, Any] = {}
     action_type = get_action_type(trigger_action)
     if not action_type:
         logger.error(
@@ -743,18 +775,17 @@ def dual_update_migrated_alert_rule_trigger_action(
         )
     data = build_action_data_blob(trigger_action, action_type)
     target_identifier = get_target_identifier(trigger_action, action_type)
-    updated_action_fields["type"] = action_type
-    updated_action_fields["data"] = data
-    updated_action_fields["config"] = {
-        "target_display": updated_fields.get("target_display", None),
-        "target_type": updated_fields.get("target_type", None),
-        "target_identifier": target_identifier,
+    action_config = build_action_config(
+        trigger_action.target_display,
+        target_identifier,
+        trigger_action.target_type,
+    )
+    updated_action_fields = {
+        "type": Action.Type(action_type),
+        "data": data,
+        "integration_id": trigger_action.integration_id,
+        "config": action_config,
     }
-
-    for field in LEGACY_ACTION_FIELDS:
-        if field in updated_fields and field not in updated_action_fields["config"].keys():
-            updated_action_fields[field] = updated_fields[field]
-
     action.update(**updated_action_fields)
     return action
 
@@ -849,6 +880,10 @@ def dual_delete_migrated_alert_rule_trigger(
     priority = PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH)
     detector_trigger = get_detector_trigger(alert_rule_trigger, priority)
     if detector_trigger is None:
+        logger.info(
+            "alert rule was not dual written, returning early",
+            extra={"alert_rule": alert_rule_trigger.alert_rule},
+        )
         return None
     action_filter = get_action_filter(alert_rule_trigger, priority)
     action_filter_dcg = action_filter.condition_group

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -859,25 +859,6 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert self.alert_rule.projects.all().count() == 2
         assert self.alert_rule.projects.all()[0] == updated_projects[0]
 
-    @mock.patch(
-        "sentry.workflow_engine.migration_helpers.alert_rule.dual_update_migrated_alert_rule"
-    )
-    def test_dual_update(self, mock_dual_update):
-        # test that we call the ACI dual update helpers-will be removed after dual write period ends
-        name = "hojicha"
-
-        updated_rule = update_alert_rule(
-            self.alert_rule,
-            name=name,
-        )
-        assert self.alert_rule.id == updated_rule.id
-        assert self.alert_rule.name == name
-
-        assert mock_dual_update.call_count == 1
-        call_args = mock_dual_update.call_args_list[0][0]
-        assert call_args[0] == self.alert_rule
-        assert call_args[1]["name"] == name
-
     def test_update_subscription(self):
         old_subscription_id = self.alert_rule.snuba_query.subscriptions.get().subscription_id
         with self.tasks():
@@ -2232,22 +2213,6 @@ class UpdateAlertRuleTriggerTest(TestCase):
         assert trigger.label == label
         assert trigger.alert_threshold == alert_threshold
 
-    @mock.patch(
-        "sentry.workflow_engine.migration_helpers.alert_rule.dual_update_migrated_alert_rule_trigger"
-    )
-    def test_dual_update(self, mock_dual_update):
-        # test that we can call the ACI dual update helpers—will be removed after dual write period ends
-        trigger = create_alert_rule_trigger(self.alert_rule, "hello", 1000)
-
-        label = "matcha"
-        trigger = update_alert_rule_trigger(trigger, label=label)
-        assert trigger.label == label
-
-        assert mock_dual_update.call_count == 1
-        call_args = mock_dual_update.call_args_list[0][0]
-        assert call_args[0] == trigger
-        assert call_args[1]["label"] == label
-
     def test_name_used(self):
         label = "uh oh"
         create_alert_rule_trigger(self.alert_rule, label, 1000)
@@ -2675,20 +2640,6 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest):
         assert self.action.type == type.value
         assert self.action.target_type == target_type.value
         assert self.action.target_identifier == target_identifier
-
-    @mock.patch(
-        "sentry.workflow_engine.migration_helpers.alert_rule.dual_update_migrated_alert_rule_trigger_action"
-    )
-    def test_dual_update(self, mock_dual_update):
-        # test that we call the ACI dual update helpers—will be removed after dual wrie period ends
-        type = AlertRuleTriggerAction.Type.EMAIL
-        update_alert_rule_trigger_action(self.action, type=type)
-        assert self.action.type == type.value
-
-        assert mock_dual_update.call_count == 1
-        call_args = mock_dual_update.call_args_list[0][0]
-        assert call_args[0] == self.action
-        assert call_args[1]["type"] == type
 
     @responses.activate
     def test_slack(self):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -32,9 +32,11 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule,
     dual_delete_migrated_alert_rule_trigger,
     dual_delete_migrated_alert_rule_trigger_action,
+    dual_update_alert_rule,
     dual_update_migrated_alert_rule,
     dual_update_migrated_alert_rule_trigger,
     dual_update_migrated_alert_rule_trigger_action,
+    dual_write_alert_rule,
     get_action_filter,
     get_detector_trigger,
     get_resolve_threshold,
@@ -118,7 +120,13 @@ def assert_alert_rule_resolve_trigger_migrated(alert_rule):
     assert detector_trigger.condition_result == DetectorPriorityLevel.OK
     assert detector_trigger.condition_group == detector.workflow_condition_group
 
-    data_condition = DataCondition.objects.get(comparison=DetectorPriorityLevel.OK)
+    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=alert_rule)
+    workflow = alert_rule_workflow.workflow
+    workflow_dcgs = DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow=workflow)
+
+    data_condition = DataCondition.objects.get(
+        comparison=DetectorPriorityLevel.OK, condition_group__in=workflow_dcgs
+    )
 
     assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
     assert data_condition.comparison == DetectorPriorityLevel.OK
@@ -159,7 +167,14 @@ def assert_alert_rule_trigger_migrated(alert_rule_trigger):
     )
     assert detector_trigger.condition_result == condition_result
 
-    data_condition = DataCondition.objects.get(comparison=condition_result, condition_result=True)
+    alert_rule = alert_rule_trigger.alert_rule
+    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=alert_rule)
+    workflow = alert_rule_workflow.workflow
+    workflow_dcgs = DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow=workflow)
+
+    data_condition = DataCondition.objects.get(
+        comparison=condition_result, condition_result=True, condition_group__in=workflow_dcgs
+    )
     assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
     assert data_condition.condition_result is True
     assert WorkflowDataConditionGroup.objects.filter(
@@ -1269,3 +1284,82 @@ class DataConditionLookupHelpersTest(BaseMetricAlertMigrationTest):
 
         with pytest.raises(DataCondition.DoesNotExist):
             get_action_filter(self.alert_rule_trigger, DetectorPriorityLevel.HIGH)
+
+
+class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
+    """
+    Test that the SPE create/update methods properly create and update all relevant ACI
+    objects for an alert rule, its triggers, and its actions.
+    """
+
+    def setUp(self):
+        # rule for testing SPE create
+        self.metric_alert = self.create_alert_rule(resolve_threshold=100)
+        self.alert_rule_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="critical", alert_threshold=200
+        )
+        self.alert_rule_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger
+        )
+
+        # rule for testing SPE update
+        resolve_threshold = 50
+        self.dual_written_alert = self.create_alert_rule(resolve_threshold=resolve_threshold)
+        self.dual_written_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.dual_written_alert, label="critical", alert_threshold=100
+        )
+        self.dual_written_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.dual_written_trigger
+        )
+        # dual write him
+        self.create_migrated_metric_alert_objects(self.dual_written_alert)
+        self.detector_trigger, self.action_filter = (
+            self.create_migrated_metric_alert_rule_trigger_objects(
+                self.dual_written_trigger, DetectorPriorityLevel.HIGH, Condition.GREATER
+            )
+        )
+        self.action, self.data_condition_group_action, self.aarta = (
+            self.create_migrated_metric_alert_rule_action_objects(self.dual_written_trigger_action)
+        )
+        self.create_migrated_metric_alert_rule_resolve_objects(
+            self.dual_written_alert, resolve_threshold, Condition.LESS_OR_EQUAL
+        )
+
+    def test_spe_create(self):
+        dual_write_alert_rule(self.metric_alert)
+        assert_alert_rule_migrated(self.metric_alert, self.project.id)
+        assert_alert_rule_trigger_migrated(self.alert_rule_trigger)
+        assert ActionAlertRuleTriggerAction.objects.filter(
+            alert_rule_trigger_action=self.alert_rule_trigger_action
+        ).exists()
+        assert_alert_rule_resolve_trigger_migrated(self.metric_alert)
+
+    def test_spe_update(self):
+        # do some updates on all legacy objects
+        user_2 = self.create_user()
+        self.dual_written_alert.update(name="sencha")
+        self.dual_written_trigger.update(alert_threshold=95)
+        self.dual_written_trigger_action.update(target_identifier=user_2.id)
+
+        dual_update_alert_rule(self.dual_written_alert)
+        detector = AlertRuleDetector.objects.get(alert_rule=self.dual_written_alert).detector
+        self.detector_trigger.refresh_from_db()
+        self.action.refresh_from_db()
+
+        assert detector.name == "sencha"
+        assert self.detector_trigger.comparison == 95
+        assert self.action.config["target_identifier"] == str(user_2.id)
+
+    def test_spe_update_new_objects(self):
+        # create new trigger and action on migrated alert rule
+        new_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.dual_written_alert, label="warning", alert_threshold=75
+        )
+        new_trigger_action = self.create_alert_rule_trigger_action(alert_rule_trigger=new_trigger)
+
+        dual_update_alert_rule(self.dual_written_alert)
+
+        assert_alert_rule_trigger_migrated(new_trigger)
+        assert ActionAlertRuleTriggerAction.objects.filter(
+            alert_rule_trigger_action=new_trigger_action
+        ).exists()

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -1311,7 +1311,7 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         self.dual_written_trigger_action = self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.dual_written_trigger
         )
-        # dual write him
+
         self.create_migrated_metric_alert_objects(self.dual_written_alert)
         self.detector_trigger, self.action_filter = (
             self.create_migrated_metric_alert_rule_trigger_objects(
@@ -1329,9 +1329,7 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         dual_write_alert_rule(self.metric_alert)
         assert_alert_rule_migrated(self.metric_alert, self.project.id)
         assert_alert_rule_trigger_migrated(self.alert_rule_trigger)
-        assert ActionAlertRuleTriggerAction.objects.filter(
-            alert_rule_trigger_action=self.alert_rule_trigger_action
-        ).exists()
+        assert_alert_rule_trigger_action_migrated(self.alert_rule_trigger_action, Action.Type.EMAIL)
         assert_alert_rule_resolve_trigger_migrated(self.metric_alert)
 
     def test_spe_update(self):
@@ -1360,6 +1358,4 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         dual_update_alert_rule(self.dual_written_alert)
 
         assert_alert_rule_trigger_migrated(new_trigger)
-        assert ActionAlertRuleTriggerAction.objects.filter(
-            alert_rule_trigger_action=new_trigger_action
-        ).exists()
+        assert_alert_rule_trigger_action_migrated(new_trigger_action, Action.Type.EMAIL)

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -583,6 +583,19 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
             self.detector_workflow,
             self.data_source_detector,
         ) = self.create_migrated_metric_alert_objects(self.metric_alert)
+        self.alert_rule_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="critical", alert_threshold=200
+        )
+        self.critical_detector_trigger, self.critical_action_filter = (
+            self.create_migrated_metric_alert_rule_trigger_objects(
+                self.alert_rule_trigger, DetectorPriorityLevel.HIGH, Condition.GREATER
+            )
+        )
+        self.resolve_detector_trigger, self.resolve_action_filter = (
+            self.create_migrated_metric_alert_rule_resolve_objects(
+                self.metric_alert, 200, Condition.LESS_OR_EQUAL
+            )
+        )
 
     def test_dual_update_metric_alert(self):
         detector_state = self.detector_state
@@ -592,7 +605,8 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
             "description": "a Japanese green tea roasted over charcoal",
         }
 
-        dual_update_migrated_alert_rule(self.metric_alert, updated_fields)
+        self.metric_alert.update(**updated_fields)
+        dual_update_migrated_alert_rule(self.metric_alert)
         self.detector.refresh_from_db()
         detector_state.refresh_from_db()
 
@@ -603,18 +617,21 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
         assert detector_state.active is False
 
     def test_dual_update_metric_alert_owner(self):
+        updated_fields: dict[str, Any] = {}
         updated_fields = {
             "user_id": self.user.id,
             "team_id": None,
         }
 
-        dual_update_migrated_alert_rule(self.metric_alert, updated_fields)
+        self.metric_alert.update(**updated_fields)
+        dual_update_migrated_alert_rule(self.metric_alert)
         self.detector.refresh_from_db()
 
         assert self.detector.owner_user_id == self.user.id
         assert self.detector.owner_team_id is None
 
     def test_update_metric_alert_config(self):
+        updated_fields: dict[str, Any] = {}
         updated_fields = {
             "detection_type": "percent",
             "threshold_period": 1,
@@ -623,7 +640,8 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
             "comparison_delta": 3600,
         }
 
-        dual_update_migrated_alert_rule(self.metric_alert, updated_fields)
+        self.metric_alert.update(**updated_fields)
+        dual_update_migrated_alert_rule(self.metric_alert)
         self.detector.refresh_from_db()
 
         assert self.detector.config == updated_fields
@@ -786,8 +804,10 @@ class DualUpdateAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
 
     def test_dual_update_metric_alert_threshold_type(self):
         # This field affects the data conditions, but it lives on the alert rule.
-        updated_fields = {"threshold_type": AlertRuleThresholdType.BELOW}
-        dual_update_migrated_alert_rule(self.metric_alert, updated_fields)
+        updated_fields: dict[str, Any] = {}
+        updated_fields = {"threshold_type": AlertRuleThresholdType.BELOW.value}
+        self.metric_alert.update(**updated_fields)
+        dual_update_migrated_alert_rule(self.metric_alert)
 
         self.critical_detector_trigger.refresh_from_db()
         self.resolve_detector_trigger.refresh_from_db()
@@ -797,25 +817,18 @@ class DualUpdateAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
 
     def test_dual_update_metric_alert_resolve_threshold(self):
         # This field affects the data conditions, but it lives on the alert rule.
+        updated_fields: dict[str, Any] = {}
         updated_fields = {"resolve_threshold": 10}
-        dual_update_migrated_alert_rule(self.metric_alert, updated_fields)
+        self.metric_alert.update(**updated_fields)
+        dual_update_migrated_alert_rule(self.metric_alert)
         self.resolve_detector_trigger.refresh_from_db()
 
         assert self.resolve_detector_trigger.comparison == 10
 
-    def test_dual_update_trigger_label(self):
-        updated_fields = {"label": "warning"}
-        dual_update_migrated_alert_rule_trigger(self.alert_rule_trigger, updated_fields)
-        # these are now the *warning* dataconditions
-        self.critical_detector_trigger.refresh_from_db()
-        self.critical_action_filter.refresh_from_db()
-
-        assert self.critical_detector_trigger.condition_result == PRIORITY_MAP["warning"]
-        assert self.critical_action_filter.comparison == PRIORITY_MAP["warning"]
-
     def test_dual_update_trigger_threshold(self):
         updated_fields = {"alert_threshold": 314}
-        dual_update_migrated_alert_rule_trigger(self.alert_rule_trigger, updated_fields)
+        self.alert_rule_trigger.update(**updated_fields)
+        dual_update_migrated_alert_rule_trigger(self.alert_rule_trigger)
         self.critical_detector_trigger.refresh_from_db()
 
         assert self.critical_detector_trigger.comparison == 314
@@ -1067,9 +1080,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app_id=sentry_app.id,
         )
-        dual_update_migrated_alert_rule_trigger_action(
-            self.alert_rule_trigger_action, updated_fields={}
-        )  # don't care about updated fields in this test
+        dual_update_migrated_alert_rule_trigger_action(self.alert_rule_trigger_action)
 
         self.action.refresh_from_db()
         assert self.action.type == Action.Type.SENTRY_APP
@@ -1077,19 +1088,9 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
     def test_dual_update_trigger_action_type_invalid(self):
         self.alert_rule_trigger_action.update(type=12345)
         with pytest.raises(ValidationError):
-            dual_update_migrated_alert_rule_trigger_action(
-                self.alert_rule_trigger_action, updated_fields={}
-            )  # don't care about updated fields in this test
+            dual_update_migrated_alert_rule_trigger_action(self.alert_rule_trigger_action)
 
     def test_dual_update_trigger_action_legacy_fields(self):
-        updated_fields = {
-            "integration_id": self.integration.id,
-            "target_display": "cool-team",
-            "target_identifier": "123-id",
-            "target_type": ActionTarget.USER,
-        }
-        # XXX: This is a bit of a hack, but we update the action's data blob based on the
-        # updated trigger action. So we need to update the trigger action first.
         update_alert_rule_trigger_action(
             self.alert_rule_trigger_action,
             type=ActionService.OPSGENIE,
@@ -1097,9 +1098,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             target_identifier="123-id",
             target_type=ActionTarget.USER,
         )
-        dual_update_migrated_alert_rule_trigger_action(
-            self.alert_rule_trigger_action, updated_fields
-        )
+        dual_update_migrated_alert_rule_trigger_action(self.alert_rule_trigger_action)
 
         self.action.refresh_from_db()
         assert self.action.integration_id == self.integration.id
@@ -1111,14 +1110,6 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
         """
         Test that we update the data blob correctly when changing action type
         """
-        updated_fields = {
-            "integration_id": self.integration.id,
-            "target_display": "cool-team",
-            "target_identifier": "123-id",
-            "target_type": ActionTarget.USER,
-        }
-        # XXX: This is a bit of a hack, but we update the action's data blob based on the
-        # updated trigger action. So we need to update the trigger action first.
         update_alert_rule_trigger_action(
             self.alert_rule_trigger_action,
             type=ActionService.OPSGENIE,
@@ -1126,9 +1117,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             target_identifier="123-id",
             target_type=ActionTarget.USER,
         )
-        dual_update_migrated_alert_rule_trigger_action(
-            self.alert_rule_trigger_action, updated_fields
-        )
+        dual_update_migrated_alert_rule_trigger_action(self.alert_rule_trigger_action)
 
         self.action.refresh_from_db()
         assert self.action.data == {"priority": "P3"}
@@ -1151,20 +1140,6 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             alert_rule_trigger=self.alert_rule_trigger,
         )
         action, _, _ = migrate_metric_action(sentry_app_trigger_action)
-        updated_fields = {
-            "sentry_app_config": [
-                {
-                    "name": "mifu",
-                    "value": "matcha",
-                },
-            ],
-            "target_display": "oolong",
-            "target_identifier": str(sentry_app.id),
-            "target_type": ActionTarget.SENTRY_APP,
-        }
-
-        # XXX: This is a bit of a hack, but we update the action's data blob based on the
-        # updated trigger action. So we need to update the trigger action first.
         update_alert_rule_trigger_action(
             sentry_app_trigger_action,
             sentry_app_config=[
@@ -1174,7 +1149,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
                 },
             ],
         )
-        dual_update_migrated_alert_rule_trigger_action(sentry_app_trigger_action, updated_fields)
+        dual_update_migrated_alert_rule_trigger_action(sentry_app_trigger_action)
 
         action.refresh_from_db()
         assert action.data["settings"] == [


### PR DESCRIPTION
Refactor the dual update helpers so that they don't rely on `updated_fields` and now have one SPE within the alert rule serializer. `dual_update_alert_rule`, the SPE method, will update the alert rule, then create or update its associated triggers and trigger actions. See the comments on the function for more information.