### PR TITLE
input: do not export component with shouldForwardProps

### DIFF
--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -83,7 +83,8 @@ export interface InputProps
  * To add leading/trailing items (e.g. a search icon on the left side), use
  * InputControl (components/inputControl) instead.
  */
-export const Input = styled(
+
+const StyledInput = styled(
   forwardRef<HTMLInputElement, InputProps>(
     (
       {
@@ -100,6 +101,15 @@ export const Input = styled(
     ) => <input {...props} ref={ref} size={nativeSize} />
   ),
   {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
+)``;
+
+// This is a hack - emotion does not support overriding the shouldForwardProp
+// for styled components, but if we wrap it inside another component, we can
+// prevent it from doing that while still applying the styles.
+export const Input = styled(
+  forwardRef<HTMLInputElement, InputProps>((props: InputProps, ref) => (
+    <StyledInput {...props} ref={ref} />
+  ))
 )`
   ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}
 `;


### PR DESCRIPTION
Emotion lies to us about props, and in this instance, will not forward any props, as the final props set seems to be an intersection of the [two](https://github.com/emotion-js/emotion/blob/main/packages/styled/src/utils.ts#L17) component prop sets. Since it only does this one level deep, it means we can wrap it