### PR TITLE
feat(shared-views): Use starred table for group index endpoint

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -20,6 +20,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
 from sentry.models.group import Group, looks_like_short_id
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release
@@ -104,11 +105,12 @@ def build_query_params_from_request(
             if selected_view_id:
                 default_view = GroupSearchView.objects.filter(id=int(selected_view_id)).first()
             else:
-                default_view = GroupSearchView.objects.filter(
+                first_starred_view = GroupSearchViewStarred.objects.filter(
                     organization=organization,
                     user_id=request.user.id,
                     position=0,
                 ).first()
+                default_view = first_starred_view.group_search_view if first_starred_view else None
 
             if default_view:
                 query_kwargs["sort_by"] = default_view.query_sort

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -40,6 +40,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import GROUP_OWNER_TYPE, GroupOwner, GroupOwnerType
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsnooze import GroupSnooze
@@ -2373,13 +2374,19 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             owner_id=self.user.id,
             visibility=Visibility.OWNER_PINNED,
         )
-        GroupSearchView.objects.create(
+        default_view = GroupSearchView.objects.create(
             organization=self.organization,
             user_id=self.user.id,
             position=0,
             name="Default View",
             query="ZeroDivisionError",
             query_sort="date",
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            position=0,
+            group_search_view=default_view,
         )
         event = self.store_event(
             data={


### PR DESCRIPTION
This PR updates the default query in the group index endpoint to use the first starred view's query, rather than the first groupsearchview. This also removes (I think) the last usage of the position column in the groupsearchview, which is necessary to drop the column 