### PR TITLE
ref(views): Do not use saved search/issue view default query when stacked nav is enabled

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -316,9 +316,10 @@ function IssueListOverview({router}: Props) {
       ...getEndpointParams(),
       limit: MAX_ITEMS,
       shortIdLookup: 1,
-      savedSearch: savedSearchLoading
-        ? savedSearchLookupEnabled
-        : savedSearchLookupDisabled,
+      savedSearch:
+        savedSearchLoading && !prefersStackedNav
+          ? savedSearchLookupEnabled
+          : savedSearchLookupDisabled,
     };
 
     if (selectedSearchId) {
@@ -343,7 +344,13 @@ function IssueListOverview({router}: Props) {
     params.collapse = ['stats', 'unhandled'];
 
     return params;
-  }, [getEndpointParams, location.query, savedSearchLoading, selectedSearchId]);
+  }, [
+    getEndpointParams,
+    location.query,
+    savedSearchLoading,
+    selectedSearchId,
+    prefersStackedNav,
+  ]);
 
   const loadFromCache = useCallback((): boolean => {
     const cache = IssueListCacheStore.getFromCache(requestParams);


### PR DESCRIPTION
This PR disables the `savedSearch` query param (confusingly, by setting it to '1') if the stacked nav user setting is enabled. 

This is because hitting issues always puts you into the "Feed" section, which always has the default, prioritized query. 