### PR TITLE
:recycle: ref(aci): sentry_app_id and sentry_app_installation_uuid in NOA

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -29,6 +29,7 @@ from sentry.workflow_engine.typings.notification_action import (
     OnCallDataBlob,
     SentryAppDataBlob,
     SentryAppFormConfigDataBlob,
+    SentryAppIdentifier,
     SlackDataBlob,
     TicketFieldMappingKeys,
     TicketingActionDataBlobHelper,
@@ -374,9 +375,23 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
             if target_identifier is None:
                 raise ValueError(f"No target identifier found for action type: {action.type}")
 
-            sentry_app_installations = app_service.get_many(
-                filter=dict(app_ids=[target_identifier], organization_id=organization_id)
-            )
+            # Figure out what type of key we are dealing with
+            sentry_app_installations = None
+            if (
+                action.config.get("sentry_app_identifier")
+                == SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+            ):
+                # It is a sentry app installation uuid
+                sentry_app_installations = app_service.get_many(
+                    filter=dict(
+                        uuids=[target_identifier],
+                    )
+                )
+            else:
+                # It is a sentry app id
+                sentry_app_installations = app_service.get_many(
+                    filter=dict(app_ids=[target_identifier], organization_id=organization_id)
+                )
 
             if len(sentry_app_installations) != 1:
                 raise ValueError(

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -393,7 +393,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
                     filter=dict(app_ids=[target_identifier], organization_id=organization_id)
                 )
 
-            if len(sentry_app_installations) != 1:
+            if sentry_app_installations is None or len(sentry_app_installations) != 1:
                 raise ValueError(
                     f"Expected 1 sentry app installation for action type: {action.type}, target_identifier: {target_identifier}, but got {len(sentry_app_installations)}"
                 )

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -21,6 +21,7 @@ from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     OpsgenieIssueAlertHandler,
     PagerDutyIssueAlertHandler,
     PluginIssueAlertHandler,
+    SentryAppIdentifier,
     SentryAppIssueAlertHandler,
     SlackIssueAlertHandler,
     TicketingIssueAlertHandler,
@@ -569,7 +570,10 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
             data={"settings": data_blob},
-            config={"target_identifier": target_id},
+            config={
+                "target_identifier": target_id,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+            },
         )
         blob = self.handler.build_rule_action_blob(action, self.organization.id)
 
@@ -586,7 +590,56 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             data={
                 "settings": data_blob,
             },
-            config={"target_identifier": target_id},
+            config={
+                "target_identifier": target_id,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+            },
+        )
+        blob = self.handler.build_rule_action_blob(action, self.org2.id)
+
+        assert blob == {
+            "id": ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP]["id"],
+            "settings": cleaned_data_blob,
+            "sentryAppInstallationUuid": self.sentry_app_installation2.uuid,
+        }
+
+        action_2_uuid = blob["sentryAppInstallationUuid"]
+
+        # Both orgs should have different sentry app installations
+        assert action_1_uuid != action_2_uuid
+
+    def test_build_rule_action_blob_sentry_app_sentry_app_installation_uuid(self):
+        data_blob = self.build_sentry_app_form_config_data_blob()
+        cleaned_data_blob = self.build_sentry_app_form_config_data_blob(include_null_label=False)
+
+        # sentry app with settings
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            data={"settings": data_blob},
+            config={
+                "target_identifier": self.sentry_app_installation.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            },
+        )
+        blob = self.handler.build_rule_action_blob(action, self.organization.id)
+
+        assert blob == {
+            "id": ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP]["id"],
+            "settings": cleaned_data_blob,
+            "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
+        }
+
+        action_1_uuid = blob["sentryAppInstallationUuid"]
+
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            data={
+                "settings": data_blob,
+            },
+            config={
+                "target_identifier": self.sentry_app_installation2.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            },
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
 

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -21,7 +21,6 @@ from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     OpsgenieIssueAlertHandler,
     PagerDutyIssueAlertHandler,
     PluginIssueAlertHandler,
-    SentryAppIdentifier,
     SentryAppIssueAlertHandler,
     SlackIssueAlertHandler,
     TicketingIssueAlertHandler,
@@ -35,6 +34,7 @@ from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
     ActionFieldMappingKeys,
     EmailActionHelper,
+    SentryAppIdentifier,
 )
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 


### PR DESCRIPTION
because we can't convert all `sentry_app_installation_uuids` to `sentry_app_id` during migration, we need to handle this in the NOA. 

i already made a PR to add the `sentry_app_identifier` key here: https://github.com/getsentry/sentry/pull/86864

now i use the key to figure out how to fetch the sentry app