### PR TITLE
feat(new-trace): Prevent trace view page content from overflowing

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -116,6 +116,8 @@ const TraceInnerLayout = styled('div')`
   flex-direction: column;
   flex: 1 1 100%;
   padding: ${space(2)} ${space(3)};
+  overflow-y: scroll;
+  margin-bottom: ${space(1)};
 
   background-color: ${p => p.theme.surface100};
 `;


### PR DESCRIPTION
<img width="774" alt="Screenshot 2025-03-17 at 3 06 08 PM" src="https://github.com/user-attachments/assets/382bd500-5b6b-4768-b76d-67fb2eba44e6" />
