### PR TITLE
fix(routes): Add trailing slash to /issues route for better logging

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2110,7 +2110,7 @@ function buildRoutes() {
   );
 
   const issueRoutes = (
-    <Route path="/issues" component={errorHandler(IssueNavigation)} withOrgPath>
+    <Route path="/issues/" component={errorHandler(IssueNavigation)} withOrgPath>
       <IndexRoute component={errorHandler(OverviewWrapper)} />
       <Route path="views/:viewId/" component={errorHandler(OverviewWrapper)} />
       <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />


### PR DESCRIPTION
The lack of a trailing slash was causing some analytics and sentry logging to use a badly formed route name:

![CleanShot 2025-03-17 at 12 06 05](https://github.com/user-attachments/assets/757bf2b5-a914-4e57-858e-e63a2f121df4)
