### PR TITLE
fix(anomaly detection): Force None to 0

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -40,9 +40,8 @@ def get_anomaly_data_from_seer(
         "project_id": subscription.project_id,
         "alert_rule_id": alert_rule.id,
     }
-    if not snuba_query or not isinstance(aggregation_value, (int, float)):
-        extra_data["aggregation_value"] = aggregation_value
-        logger.warning("Aggregation value not integer or snuba query is empty", extra=extra_data)
+    if not snuba_query:
+        logger.warning("Snuba query is empty", extra=extra_data)
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists
@@ -54,7 +53,7 @@ def get_anomaly_data_from_seer(
     ):
         return None
 
-    if not aggregation_value and aggregation_value != 0:
+    if aggregation_value is None:
         extra_data["threshold_type"] = alert_rule.threshold_type
         extra_data["sensitivity"] = alert_rule.sensitivity
         extra_data["seasonality"] = alert_rule.seasonality
@@ -62,7 +61,7 @@ def get_anomaly_data_from_seer(
 
         metrics.incr("anomaly_detection.aggregation_value.none")
         logger.warning("Aggregation value is none", extra=extra_data)
-        return None
+        aggregation_value = 0
 
     anomaly_detection_config = AnomalyDetectionConfig(
         time_period=int(snuba_query.time_window / 60),

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -745,25 +745,45 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     )
     @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_null_aggregation_value(self, mock_logger, mock_seer_request):
+        seer_return_value: DetectAnomaliesResponse = {
+            "success": True,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.9,
+                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 10,
+                }
+            ],
+        }
+
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         processor = SubscriptionProcessor(self.sub)
+        processor.alert_rule = self.dynamic_rule
         result = get_anomaly_data_from_seer(
             alert_rule=processor.alert_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
-            aggregation_value="NULL_VALUE",  # type: ignore[arg-type]
+            aggregation_value=None,  # type: ignore[arg-type]
         )
         logger_extra = {
             "subscription_id": self.sub.id,
             "organization_id": self.sub.project.organization.id,
             "project_id": self.sub.project_id,
             "alert_rule_id": self.dynamic_rule.id,
-            "aggregation_value": "NULL_VALUE",
+            "threshold_type": self.dynamic_rule.threshold_type,
+            "sensitivity": self.dynamic_rule.sensitivity,
+            "seasonality": self.dynamic_rule.seasonality,
+            "aggregation_value": None,
+            "dataset": "events",
         }
-        assert result is None
         mock_logger.warning.assert_called_with(
-            "Aggregation value not integer or snuba query is empty",
+            "Aggregation value is none",
             extra=logger_extra,
         )
+        assert result is not None
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -766,7 +766,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             alert_rule=processor.alert_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
-            aggregation_value=None,  # type: ignore[arg-type]
+            aggregation_value=None,
         )
         logger_extra = {
             "subscription_id": self.sub.id,


### PR DESCRIPTION
If we see a `None` aggregation value we'll set it to 0 so we can send it to Seer. The null values were causing validation errors and missing data and appear to be originating from [this code](https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/subscription_processor.py#L311-L313. 

Addresses https://github.com/getsentry/seer/issues/2143