### PR TITLE
chore(alerts): Remove unused logging

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -411,18 +411,6 @@ class SubscriptionProcessor:
             )
 
         aggregation_value = self.get_aggregation_value(subscription_update)
-        if features.has(
-            "organizations:failure-rate-metric-alert-logging",
-            self.subscription.project.organization,
-        ):
-            logger.info(
-                "Update value in subscription processor",
-                extra={
-                    "result": subscription_update,
-                    "aggregation_value": aggregation_value,
-                    "rule_id": self.alert_rule.id,
-                },
-            )
 
         has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization
@@ -443,18 +431,6 @@ class SubscriptionProcessor:
                     subscription=self.subscription,
                     last_update=self.last_update.timestamp(),
                     aggregation_value=aggregation_value,
-                )
-            # XXX (mifu67): log problematic rule, to be deleted later
-            if features.has(
-                "feature.organizations:failure-rate-metric-alert-logging",
-                self.subscription.project.organization,
-            ):
-                logger.info(
-                    "Received this response from Seer",
-                    extra={
-                        "potential_anomalies": potential_anomalies,
-                        "alert_rule_id": self.alert_rule.id,
-                    },
                 )
             if potential_anomalies is None:
                 logger.info(


### PR DESCRIPTION
Remove some logging we're not using anymore - while there is still an open GH issue about failure rate alerting, we have not been able to dedicate the time to investigating it and collecting logs we don't look at for 6 months is wasteful. The more recent part @mifu67 added we have solved, but we kind of piggybacked on the feature flag for a different problem.