### PR TITLE
fix(jira): fix comment sync

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -134,6 +134,7 @@ class JiraIntegration(IssueSyncIntegration):
     inbound_assignee_key = "sync_reverse_assignment"
     issues_ignored_fields_key = "issues_ignored_fields"
     resolution_strategy_key = "resolution_strategy"
+    comment_key = "sync_comments"
 
     @classproperty
     def use_email_scope(cls):


### PR DESCRIPTION
Turning on comment sync with jira is not working. Frontend sends a request to set it to true but doesn't find the label to set to true:
![Screenshot 2025-03-17 at 1 49 21 PM](https://github.com/user-attachments/assets/c0b4af3c-bd87-4c55-993e-4fa840530f6d)

I think this never worked. All the other integrations set this string except Jira. The parent class is also not setting it. 🤷‍♀️ still need to verify but 95% sure.

Fixes GH-87065