### PR TITLE
feat(shared-views): Add visibility param to groupsearchview endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -54,7 +54,7 @@ class MemberPermission(OrganizationPermission):
 
 class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
     visibility = serializers.MultipleChoiceField(
-        choices=[v[0] for v in GroupSearchViewVisibility.as_choices()],
+        choices=GroupSearchViewVisibility.as_choices(),
         required=False,
     )
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -58,9 +58,6 @@ class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
         required=False,
     )
 
-    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
-        return data
-
 
 @region_silo_endpoint
 class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,3 +1,6 @@
+from functools import reduce
+from operator import or_
+
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
 from rest_framework import serializers, status
@@ -11,7 +14,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.groupsearchview import GroupSearchViewStarredSerializer
+from sentry.api.serializers.models.groupsearchview import (
+    GroupSearchViewSerializer,
+    GroupSearchViewStarredSerializer,
+)
 from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidator,
     GroupSearchViewValidatorResponse,

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -137,8 +137,8 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
             ).prefetch_related("projects")
 
             param_query_map = {
-                "organization": org_query,
-                "owner": owner_query,
+                GroupSearchViewVisibility.ORGANIZATION: org_query,
+                GroupSearchViewVisibility.OWNER: owner_query,
             }
 
             query_list = [param_query_map[v] for v in visibility]

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -112,7 +112,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                     data={"detail": "You do not have access to any projects."},
                 )
 
-        visibility = request.GET.getlist("visibility", [])
+        visibility = request.GET.getlist("visibility")
         valid_visibility_options = [v[0] for v in GroupSearchViewVisibility.as_choices()]
         if visibility:
             if any(v not in valid_visibility_options for v in visibility):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -59,13 +59,6 @@ class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
     )
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
-        if "visibility" in data:
-            valid_visibility_options = [v[0] for v in GroupSearchViewVisibility.as_choices()]
-            if any(v not in valid_visibility_options for v in data["visibility"]):
-                raise serializers.ValidationError(
-                    f"Unsupported visibility query parameter: {data['visibility']}"
-                )
-
         return data
 
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -53,10 +53,8 @@ class MemberPermission(OrganizationPermission):
 
 
 class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
-    visibility = serializers.ListField(
-        child=serializers.ChoiceField(
-            choices=[v[0] for v in GroupSearchViewVisibility.as_choices()]
-        ),
+    visibility = serializers.MultipleChoiceField(
+        choices=[v[0] for v in GroupSearchViewVisibility.as_choices()],
         required=False,
     )
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1074,11 +1074,12 @@ class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
         assert response.data[2]["name"] == self.organization_view.name
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_get_views_with_invalid_visibility(self) -> None:
         self.login_as(user=self.user_1)
         response = self.client.get(self.url, {"visibility": ["random"]})
         assert response.status_code == 400
-        assert response.data == {"detail": "Invalid visibility query parameter."}
+        assert str(response.data["visibility"][0]) == '"random" is not a valid choice.'
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
 from sentry.issues.endpoints.organization_group_search_views import DEFAULT_VIEWS
-from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.testutils.cases import APITestCase, TransactionTestCase
@@ -961,6 +961,124 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         response = self.client.get(self.url)
         assert response.status_code == 400
         assert response.data["detail"] == "You do not have access to any projects."
+
+
+class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-views"
+    method = "get"
+
+    def setUp(self) -> None:
+        self.user_1 = self.user
+        self.user_2 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_2)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-views",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+        self.starred_view = GroupSearchView.objects.create(
+            name="User 1's Starred View",
+            organization=self.organization,
+            user_id=self.user_1.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+            visibility=GroupSearchViewVisibility.OWNER,
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_1.id,
+            group_search_view=self.starred_view,
+            position=0,
+        )
+
+        self.unstarred_view = GroupSearchView.objects.create(
+            name="User 1's Unstarred View",
+            organization=self.organization,
+            user_id=self.user_1.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=1,
+            visibility=GroupSearchViewVisibility.OWNER,
+        )
+
+        GroupSearchView.objects.create(
+            name="User 2's Unstarred View",
+            organization=self.organization,
+            user_id=self.user_2.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+            visibility=GroupSearchViewVisibility.OWNER,
+        )
+
+        self.organization_view = GroupSearchView.objects.create(
+            name="Organization View",
+            organization=self.organization,
+            user_id=self.user_2.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=1,
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_get_views_no_visibility(self) -> None:
+        self.login_as(user=self.user_1)
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.starred_view.id)
+        assert response.data[0]["name"] == self.starred_view.name
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_get_views_owner_visibility(self) -> None:
+        self.login_as(user=self.user_1)
+        response = self.client.get(self.url, {"visibility": "owner"})
+
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == str(self.starred_view.id)
+        assert response.data[0]["name"] == self.starred_view.name
+        assert response.data[1]["id"] == str(self.unstarred_view.id)
+        assert response.data[1]["name"] == self.unstarred_view.name
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_get_views_organization_visibility(self) -> None:
+        self.login_as(user=self.user_2)
+        response = self.client.get(self.url, {"visibility": "organization"})
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.organization_view.id)
+        assert response.data[0]["name"] == self.organization_view.name
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_get_views_with_user_organization_visibility(self) -> None:
+        self.login_as(user=self.user_1)
+        response = self.client.get(self.url, {"visibility": ["owner", "organization"]})
+
+        assert response.status_code == 200
+        assert len(response.data) == 3
+        assert response.data[0]["id"] == str(self.starred_view.id)
+        assert response.data[0]["name"] == self.starred_view.name
+        assert response.data[1]["id"] == str(self.unstarred_view.id)
+        assert response.data[1]["name"] == self.unstarred_view.name
+        assert response.data[2]["id"] == str(self.organization_view.id)
+        assert response.data[2]["name"] == self.organization_view.name
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_get_views_with_invalid_visibility(self) -> None:
+        self.login_as(user=self.user_1)
+        response = self.client.get(self.url, {"visibility": ["random"]})
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid visibility query parameter."}
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -983,7 +983,6 @@ class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
             user_id=self.user_1.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             visibility=GroupSearchViewVisibility.OWNER,
         )
         GroupSearchViewStarred.objects.create(
@@ -999,7 +998,6 @@ class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
             user_id=self.user_1.id,
             query="is:unresolved",
             query_sort="date",
-            position=1,
             visibility=GroupSearchViewVisibility.OWNER,
         )
 
@@ -1009,7 +1007,6 @@ class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
             user_id=self.user_2.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             visibility=GroupSearchViewVisibility.OWNER,
         )
 
@@ -1019,7 +1016,6 @@ class OrganizationGroupSearchViewsGetVisibilityTest(APITestCase):
             user_id=self.user_2.id,
             query="is:unresolved",
             query_sort="date",
-            position=1,
             visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
 


### PR DESCRIPTION
Adds a new visibility query param to the groupsearchview endpoint.

As of now this query param can be "Owner", "Organization" or both, and it will return the issue views that have the given visibility. 

There are no usages of this on the frontend, so no behavior should change immediately after this PR is merged. 

