### PR TITLE
feat(nav): Use default project icon instead of "all projects" icon if platform not found

### DIFF
--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -133,7 +133,7 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
                 }
                 leadingItems={
                   <StyledProjectIcon
-                    projectPlatforms={project.platform ? [project.platform] : []}
+                    projectPlatforms={project.platform ? [project.platform] : ['default']}
                   />
                 }
               >


### PR DESCRIPTION
Updates the project icons for starred projects in the left nav to use the default project icon rather than the all projects icon if the platform isn't found: 

![image](https://github.com/user-attachments/assets/863447ce-d2c7-41f0-b142-f98e311c26e9)
