### PR TITLE
fix(autofix): Fix polling w/ comment thread on sidebar + lower poll rate

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -76,7 +76,11 @@ const makeErrorAutofixData = (errorMessage: string): AutofixResponse => {
 };
 
 /** Will not poll when the autofix is in an error state or has completed */
-const isPolling = (autofixData: AutofixData | null, runStarted: boolean) => {
+const isPolling = (
+  autofixData: AutofixData | null,
+  runStarted: boolean,
+  isSidebar?: boolean
+) => {
   if (!autofixData && !runStarted) {
     return false;
   }
@@ -106,7 +110,7 @@ const isPolling = (autofixData: AutofixData | null, runStarted: boolean) => {
   }
 
   // Continue polling if there's an active comment thread, even if the run is completed
-  if (hasActiveCommentThread) {
+  if (!isSidebar && hasActiveCommentThread) {
     return true;
   }
 
@@ -131,7 +135,14 @@ export const useAutofixData = ({groupId}: {groupId: string}) => {
   return {data: data?.autofix ?? null, isPending};
 };
 
-export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {
+export const useAiAutofix = (
+  group: GroupWithAutofix,
+  event: Event,
+  options: {
+    isSidebar?: boolean;
+    pollInterval?: number;
+  } = {}
+) => {
   const api = useApi();
   const queryClient = useQueryClient();
 
@@ -146,10 +157,11 @@ export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {
       if (
         isPolling(
           query.state.data?.[0]?.autofix || null,
-          !!currentRunId || waitingForNextRun
+          !!currentRunId || waitingForNextRun,
+          options.isSidebar
         )
       ) {
-        return POLL_INTERVAL;
+        return options.pollInterval ?? POLL_INTERVAL;
       }
       return false;
     },

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
@@ -43,7 +43,10 @@ export function SolutionsSectionCtaButton({
   const openButtonRef = useRef<HTMLButtonElement>(null);
 
   const {isPending: isAutofixPending} = useAutofixData({groupId: group.id});
-  const {autofixData} = useAiAutofix(group, event);
+  const {autofixData} = useAiAutofix(group, event, {
+    isSidebar: true,
+    pollInterval: 1500,
+  });
 
   const openSolutionsDrawer = useOpenSolutionsDrawer(
     group,


### PR DESCRIPTION
When on the sidebar and there's a comment thread we shouldn't still be polling. Also reduces the poll rate when on the sidebar.