### PR TITLE
perf(releases): bulk query for PRs in CommitSerializer

### DIFF
--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -50,7 +50,10 @@ class CommitSerializer(Serializer):
             )
         )
 
-        pull_request_by_commit = {pr.merge_commit_sha: serialize(pr) for pr in pull_requests}
+        pull_request_by_commit = {
+            pr.merge_commit_sha: serialized_pr
+            for (pr, serialized_pr) in zip(pull_requests, serialize(pull_requests))
+        }
 
         result = {}
         for item in item_list:

--- a/tests/sentry/api/serializers/test_commit.py
+++ b/tests/sentry/api/serializers/test_commit.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from sentry.api.serializers import serialize
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
@@ -70,3 +71,67 @@ class CommitSerializerTest(TestCase):
         result = serialize(commit, user)
 
         assert result["author"] == {}
+
+    def test_pull_requests(self):
+        """Test we can correctly match pull requests to commits."""
+        user = self.create_user()
+        project = self.create_project()
+        release = Release.objects.create(
+            organization_id=project.organization_id, version=uuid4().hex
+        )
+        release.add_project(project)
+        repository = Repository.objects.create(
+            organization_id=project.organization_id, name="test/test"
+        )
+        commit1 = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key="abc",
+            message="waddap",
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            release=release,
+            commit=commit1,
+            order=1,
+        )
+
+        commit2 = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key="def",
+            message="waddap2",
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            release=release,
+            commit=commit2,
+            order=2,
+        )
+
+        PullRequest.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key="pr1",
+            merge_commit_sha=commit1.key,
+        )
+        PullRequest.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key="pr2",
+            merge_commit_sha=commit2.key,
+        )
+        PullRequest.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key="pr3",
+            merge_commit_sha=commit1.key,
+        )
+
+        results = serialize([commit1, commit2], user)
+
+        # In the case of multiple pull requests, one is chosen arbitrarily.
+        assert results[0]["pullRequest"]["id"] == "pr1" or results[0]["pullRequest"]["id"] == "pr3"
+        assert results[1]["pullRequest"]["id"] == "pr2"


### PR DESCRIPTION
I found the [p95 of /releases/](https://sentry.sentry.io/traces/?field=id&field=span.op&field=span.description&field=span.duration&field=transaction&field=timestamp&mode=aggregate&project=1&query=transaction%3A%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Freleases%2F&source=traces&statsPeriod=24h&targetId=8352cb4e96e0defb&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%7D) transaction has an expensive serialize (`on_results`) step. In samples, I see that many PullRequest's are being queried individually, in a loop, from CommitWithReleaseSerializer.

Ref https://github.com/getsentry/sentry/issues/86806

