### PR TITLE
fix(usage): display cumulative spend on zero event days

### DIFF
--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -361,6 +361,8 @@ export function mapReservedBudgetStatsToChart({
     return chartData;
   }
 
+  let previousReservedForDate = 0;
+  let previousOnDemandForDate = 0;
   Object.entries(statsByDateAndCategory).forEach(([date, statsByCategory]) => {
     let reservedForDate = 0;
     let onDemandForDate = 0;
@@ -408,13 +410,26 @@ export function mapReservedBudgetStatsToChart({
         }
       });
     });
+    // if cumulative and there was no new spend on this date, use the previous date's spend
+    if (
+      reservedForDate === 0 &&
+      isCumulative &&
+      moment(date).isSameOrBefore(moment().toDate())
+    ) {
+      reservedForDate = previousReservedForDate;
+    }
+    if (onDemandForDate === 0 && isCumulative) {
+      onDemandForDate = previousOnDemandForDate;
+    }
     const dateKey = getDateFromMoment(moment(date));
     chartData.reserved!.push({
       value: [dateKey, reservedForDate],
     });
+    previousReservedForDate = reservedForDate;
     chartData.onDemand!.push({
       value: [dateKey, onDemandForDate],
     });
+    previousOnDemandForDate = onDemandForDate;
   });
 
   return chartData;


### PR DESCRIPTION
For reserved budget categories, we always display the usage chart in spend mode. When you switch type to cumulative it'd only show the cumulative spend on days that had spend. This PR fixes that so that on days without spend, we just use the previous day's spend. For periodic usage, behavior remains the same as before (only show spend for that day, in which case days without spend will have 0).

# before 
![image](https://github.com/user-attachments/assets/65bbdad1-c2c9-46c4-9538-954f8a2452c1)

# after
![image](https://github.com/user-attachments/assets/e89494ee-f2fd-4ec8-9087-12c721b849ce)
