### PR TITLE
feat(nav): Add analytics for secondary items

### DIFF
--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -196,7 +196,7 @@ describe('Nav', function () {
       const issues = screen.getByRole('link', {name: 'Issues'});
       await userEvent.click(issues);
       expect(trackAnalytics).toHaveBeenCalledWith(
-        'growth.clicked_sidebar',
+        'navigation.primary_item_clicked',
         expect.objectContaining({
           item: 'issues',
         })

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -207,6 +207,7 @@ export function IssueViewNavItemContent({
             });
           }
         }}
+        analyticsItemName="issues_view_starred"
       >
         <IssueViewNavEditableTitle
           label={view.label}

--- a/static/app/components/nav/primary/components.tsx
+++ b/static/app/components/nav/primary/components.tsx
@@ -1,4 +1,4 @@
-import {type MouseEventHandler, useCallback} from 'react';
+import type {MouseEventHandler} from 'react';
 import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,6 +12,7 @@ import {isLinkActive, makeLinkPropsFromTo} from 'sentry/components/nav/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -43,6 +44,13 @@ interface SidebarButtonProps {
   onClick?: MouseEventHandler<HTMLElement>;
 }
 
+function recordPrimaryItemClick(analyticsKey: string, organization: Organization) {
+  trackAnalytics('navigation.primary_item_clicked', {
+    item: analyticsKey,
+    organization,
+  });
+}
+
 export function SidebarItem({
   children,
   ...props
@@ -63,10 +71,6 @@ export function SidebarMenu({
   forceLabel,
 }: SidebarItemDropdownProps) {
   const organization = useOrganization();
-  const recordAnalytics = useCallback(
-    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
-    [organization, analyticsKey]
-  );
   const {layout} = useNavContext();
 
   const showLabel = forceLabel || layout === NavLayout.MOBILE;
@@ -82,7 +86,7 @@ export function SidebarMenu({
               {...props}
               aria-label={showLabel ? undefined : label}
               onClick={event => {
-                recordAnalytics();
+                recordPrimaryItemClick(analyticsKey, organization);
                 props.onClick?.(event);
               }}
               isMobile={layout === NavLayout.MOBILE}
@@ -115,17 +119,12 @@ export function SidebarLink({
   const {layout} = useNavContext();
   const showLabel = forceLabel || layout === NavLayout.MOBILE;
 
-  const recordAnalytics = useCallback(
-    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
-    [organization, analyticsKey]
-  );
-
   return (
     <SidebarItem>
       <Tooltip title={label} disabled={showLabel} position="right" skipWrapper>
         <NavLink
           {...linkProps}
-          onClick={recordAnalytics}
+          onClick={() => recordPrimaryItemClick(analyticsKey, organization)}
           aria-selected={isActive}
           aria-current={isActive ? 'page' : undefined}
           aria-label={showLabel ? undefined : label}
@@ -157,7 +156,7 @@ export function SidebarButton({
       isMobile={layout === NavLayout.MOBILE}
       aria-label={showLabel ? undefined : label}
       onClick={(e: React.MouseEvent<HTMLElement>) => {
-        trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization});
+        recordPrimaryItemClick(analyticsKey, organization);
         buttonProps.onClick?.(e);
         onClick?.(e);
       }}

--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -75,7 +75,7 @@ export function PrimaryNavigationItems() {
           <SidebarLink
             to={`/${prefix}/dashboards/`}
             activeTo={`/${prefix}/dashboard`}
-            analyticsKey="customizable-dashboards"
+            analyticsKey="dashboards"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
           >
             <IconDashboard />
@@ -86,7 +86,7 @@ export function PrimaryNavigationItems() {
           <SidebarLink
             to={`/${prefix}/insights/frontend/`}
             activeTo={`/${prefix}/insights`}
-            analyticsKey="insights-domains"
+            analyticsKey="insights"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
           >
             <IconGraph type="area" />

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -13,7 +13,9 @@ import {isLinkActive} from 'sentry/components/nav/utils';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type SecondaryNavProps = {
   children: ReactNode;
@@ -27,6 +29,7 @@ interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
    * Will display the link as active under the given path.
    */
   activeTo?: To;
+  analyticsItemName?: string;
   /**
    * When passed, will not show the link as active for descendant paths.
    * Same as the RR6 `NavLink` `end` prop.
@@ -103,6 +106,7 @@ SecondaryNav.Section = function SecondaryNavSection({
 };
 
 SecondaryNav.Item = function SecondaryNavItem({
+  analyticsItemName,
   children,
   to,
   activeTo = to,
@@ -112,6 +116,7 @@ SecondaryNav.Item = function SecondaryNavItem({
   trailingItems,
   ...linkProps
 }: SecondaryNavItemProps) {
+  const organization = useOrganization();
   const location = useLocation();
   const isActive = incomingIsActive ?? isLinkActive(activeTo, location.pathname, {end});
 
@@ -124,6 +129,14 @@ SecondaryNav.Item = function SecondaryNavItem({
       aria-current={isActive ? 'page' : undefined}
       aria-selected={isActive}
       layout={layout}
+      onClick={() => {
+        if (analyticsItemName) {
+          trackAnalytics('navigation.secondary_item_clicked', {
+            item: analyticsItemName,
+            organization,
+          });
+        }
+      }}
     >
       {leadingItems}
       <InteractionStateLayer data-isl hasSelectedBackground={isActive} />

--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -1,6 +1,12 @@
+type NavigationItemClicked = {
+  item: string;
+};
+
 export type NavigationEventParameters = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
+  'navigation.primary_item_clicked': NavigationItemClicked;
+  'navigation.secondary_item_clicked': NavigationItemClicked;
 };
 
 export type NavigationEventKey = keyof NavigationEventParameters;
@@ -10,4 +16,6 @@ export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | nu
     'Navigation: Help Menu Opt In To Stacked Navigation Clicked',
   'navigation.help_menu_opt_out_stacked_navigation_clicked':
     'Navigation: Help Menu Opt Out Of Stacked Navigation Clicked',
+  'navigation.primary_item_clicked': 'Navigation: Primary Item Clicked',
+  'navigation.secondary_item_clicked': 'Navigation: Secondary Item Clicked',
 };

--- a/static/app/views/dashboards/navigation.tsx
+++ b/static/app/views/dashboards/navigation.tsx
@@ -39,7 +39,7 @@ function DashboardsSecondaryNav({children}: DashboardsNavigationProps) {
         </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
-            <SecondaryNav.Item to={`${baseUrl}/`} end>
+            <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="dashboards_all">
               {t('All')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
@@ -48,6 +48,7 @@ function DashboardsSecondaryNav({children}: DashboardsNavigationProps) {
               <SecondaryNav.Item
                 key={dashboard.id}
                 to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                analyticsItemName="dashboard_starred_item"
               >
                 {dashboard.title}
               </SecondaryNav.Item>

--- a/static/app/views/explore/navigation.tsx
+++ b/static/app/views/explore/navigation.tsx
@@ -32,20 +32,31 @@ export default function ExploreNavigation({children}: Props) {
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <Feature features="performance-trace-explorer">
-              <SecondaryNav.Item to={`${baseUrl}/traces/`}>
+              <SecondaryNav.Item
+                to={`${baseUrl}/traces/`}
+                analyticsItemName="explore_traces"
+              >
                 {t('Traces')}
               </SecondaryNav.Item>
             </Feature>
             <Feature features="ourlogs-enabled">
-              <SecondaryNav.Item to={`${baseUrl}/logs/`}>{t('Logs')}</SecondaryNav.Item>
+              <SecondaryNav.Item to={`${baseUrl}/logs/`} analyticsItemName="explore_logs">
+                {t('Logs')}
+              </SecondaryNav.Item>
             </Feature>
             <Feature features="profiling">
-              <SecondaryNav.Item to={`${baseUrl}/profiling/`}>
+              <SecondaryNav.Item
+                to={`${baseUrl}/profiling/`}
+                analyticsItemName="explore_profiles"
+              >
                 {t('Profiles')}
               </SecondaryNav.Item>
             </Feature>
             <Feature features="session-replay-ui">
-              <SecondaryNav.Item to={`${baseUrl}/replays/`}>
+              <SecondaryNav.Item
+                to={`${baseUrl}/replays/`}
+                analyticsItemName="explore_replays"
+              >
                 {t('Replays')}
               </SecondaryNav.Item>
             </Feature>
@@ -53,11 +64,15 @@ export default function ExploreNavigation({children}: Props) {
               <SecondaryNav.Item
                 to={`${baseUrl}/discover/homepage/`}
                 activeTo={`${baseUrl}/discover/`}
+                analyticsItemName="explore_discover"
               >
                 {t('Discover')}
               </SecondaryNav.Item>
             </Feature>
-            <SecondaryNav.Item to={`${baseUrl}/releases/`}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/releases/`}
+              analyticsItemName="explore_releases"
+            >
               {t('Releases')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -85,7 +85,10 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
         </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
-            <SecondaryNav.Item to={`${baseUrl}/${FRONTEND_LANDING_SUB_PATH}/`}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/${FRONTEND_LANDING_SUB_PATH}/`}
+              analyticsItemName="insights_frontend"
+            >
               {FRONTEND_SIDEBAR_LABEL}
             </SecondaryNav.Item>
             <SecondaryNav.Item
@@ -98,14 +101,19 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
                 (!isStarredProjectSelected || !isLaravelInsightsEnabled)
               }
               to={`${baseUrl}/${BACKEND_LANDING_SUB_PATH}/`}
+              analyticsItemName="insights_backend"
             >
               {BACKEND_SIDEBAR_LABEL}
             </SecondaryNav.Item>
-            <SecondaryNav.Item to={`${baseUrl}/${MOBILE_LANDING_SUB_PATH}/`}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/${MOBILE_LANDING_SUB_PATH}/`}
+              analyticsItemName="insights_mobile"
+            >
               {MOBILE_SIDEBAR_LABEL}
             </SecondaryNav.Item>
             <SecondaryNav.Item
               to={`${baseUrl}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS[ModuleName.AI]}/`}
+              analyticsItemName="insights_ai"
             >
               {AI_SIDEBAR_LABEL}
             </SecondaryNav.Item>
@@ -136,11 +144,16 @@ function InsightsSecondaryNav({children}: InsightsNavigationProps) {
                     projectPlatforms={project.platform ? [project.platform] : ['default']}
                   />
                 }
+                analyticsItemName="insights_project_starred"
               >
                 {project.slug}
               </SecondaryNav.Item>
             ))}
-            <SecondaryNav.Item to={`${baseUrl}/projects/`} end>
+            <SecondaryNav.Item
+              to={`${baseUrl}/projects/`}
+              end
+              analyticsItemName="insights_projects_all"
+            >
               {t('All Projects')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -50,10 +50,13 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
         <SecondaryNav.Header>{t('Issues')}</SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
-            <SecondaryNav.Item to={`${baseUrl}/`} end>
+            <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="issues_feed">
               {t('Feed')}
             </SecondaryNav.Item>
-            <SecondaryNav.Item to={`${baseUrl}/feedback/`}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/feedback/`}
+              analyticsItemName="issues_feedback"
+            >
               {t('Feedback')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
@@ -98,6 +101,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
             <SecondaryNav.Item
               to={`${baseUrl}/alerts/rules/`}
               activeTo={`${baseUrl}/alerts/`}
+              analyticsItemName="issues_alerts"
             >
               {t('Alerts')}
             </SecondaryNav.Item>

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -48,6 +48,7 @@ function SettingsNavItem({badge, label, id, to, index, ...props}: Props) {
       to={to}
       end={index}
       trailingItems={badge ? <SettingsNavBadge badge={badge} /> : null}
+      analyticsItemName={id ? `settings_${id}` : undefined}
       {...props}
     >
       <LabelHook id={id}>{label}</LabelHook>


### PR DESCRIPTION
- Adds `navigation.secondary_item_clicked` analytic event for secondary nav items
- Renames primary analytic event from `growth.sidebar_clicked` to `navigation.primary_item_clicked`