### PR TITLE
feat(ACI): Generate Workflow names based on actions

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -19,6 +19,7 @@ from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.users.services.user import RpcUser
+from sentry.workflow_engine.migration_helpers.utils import get_workflow_name
 from sentry.workflow_engine.models import (
     Action,
     ActionAlertRuleTriggerAction,
@@ -528,14 +529,6 @@ def migrate_alert_rule(
         alert_rule_workflow,
         detector_workflow,
     )
-
-
-def get_workflow_name(alert_rule: AlertRule) -> str:
-    # max length of name is 256 characters
-    # get triggers -> get actions
-    # this is a placeholder replicating the existing behavior; changes to the workflow
-    # name will come in a subsequent PR
-    return alert_rule.name
 
 
 def dual_write_alert_rule(alert_rule: AlertRule, user: RpcUser | None = None) -> None:

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -6,17 +6,18 @@ from sentry.users.services.user import RpcUser
 
 MAX_ACTIONS = 3
 
+ACTION_TYPE_TO_STRING = {
+    AlertRuleTriggerAction.Type.PAGERDUTY.value: "PagerDuty",
+    AlertRuleTriggerAction.Type.SLACK.value: "Slack",
+    AlertRuleTriggerAction.Type.MSTEAMS.value: "Microsoft Teams",
+    AlertRuleTriggerAction.Type.OPSGENIE.value: "Opsgenie",
+}
+
 
 def get_action_description(action: AlertRuleTriggerAction) -> str:
     """
     Returns a human readable action description
     """
-    ACTION_TYPE_TO_STRING = {
-        AlertRuleTriggerAction.Type.PAGERDUTY.value: "PagerDuty",
-        AlertRuleTriggerAction.Type.SLACK.value: "Slack",
-        AlertRuleTriggerAction.Type.MSTEAMS.value: "Microsoft Teams",
-        AlertRuleTriggerAction.Type.OPSGENIE.value: "Opsgenie",
-    }
 
     if action.type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action.target:

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -1,4 +1,8 @@
+from typing import cast
+
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.models.team import Team
+from sentry.users.services.user import RpcUser
 
 MAX_CHARS = 248  # (256 minus space for '...(+3_)')
 
@@ -17,15 +21,18 @@ def get_action_description(action: AlertRuleTriggerAction) -> str:
     if action.type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action.target:
             if action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
-                return "Email " + action.target.email
+                action_target_user = cast(RpcUser, action.target)
+                return "Email " + action_target_user.email
             elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
-                return "Email #" + action.target.slug
+                action_target_team = cast(Team, action.target)
+                return "Email #" + action_target_team.slug
     elif action.type == AlertRuleTriggerAction.Type.OPSGENIE.value:
         return f"Opsgenie to {action.target_display}"
     elif action.type == AlertRuleTriggerAction.Type.DISCORD.value:
         return f"Discord to {action.target_display}"
     else:
         return action_type_to_string[action.type]
+    return ""
 
 
 def get_workflow_name(alert_rule: AlertRule) -> str:

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -1,6 +1,6 @@
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 
-MAX_CHARS = 249  # (256 minus space for '...(+3)')
+MAX_CHARS = 248  # (256 minus space for '...(+3_)')
 
 
 def get_action_description(action: AlertRuleTriggerAction) -> str:
@@ -33,7 +33,6 @@ def get_workflow_name(alert_rule: AlertRule) -> str:
     Generate a workflow name like 'Slack @michelle.fu, Email michelle.fu@sentry.io...(+3)' if there is only a critical trigger
     or with priority label: 'Critical - Slack @michelle.fu, Warning email michelle.fu@sentry.io...(+3)''
     """
-    # we have to read from the old tables because at this point we may not have written to the new ones
     name = ""
     triggers = AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id).order_by("label")
     include_label = False if triggers.count() == 1 else True

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -1,0 +1,63 @@
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+
+MAX_CHARS = 249  # (256 minus space for '...(+3)')
+
+
+def get_action_description(action: AlertRuleTriggerAction) -> str:
+    """
+    Returns a human readable action description
+    """
+    action_type_to_string = {
+        AlertRuleTriggerAction.Type.PAGERDUTY.value: f"PagerDuty to {action.target_display}",
+        AlertRuleTriggerAction.Type.SLACK.value: f"Slack {action.target_display}",
+        AlertRuleTriggerAction.Type.MSTEAMS.value: f"Microsoft Teams {action.target_display}",
+        AlertRuleTriggerAction.Type.SENTRY_APP.value: f"Notify {action.target_display}",
+    }
+
+    if action.type == AlertRuleTriggerAction.Type.EMAIL.value:
+        if action.target:
+            if action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
+                return "Email " + action.target.email
+            elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
+                return "Email #" + action.target.slug
+    elif action.type == AlertRuleTriggerAction.Type.OPSGENIE.value:
+        return f"Opsgenie to {action.target_display}"
+    elif action.type == AlertRuleTriggerAction.Type.DISCORD.value:
+        return f"Discord to {action.target_display}"
+    else:
+        return action_type_to_string[action.type]
+
+
+def get_workflow_name(alert_rule: AlertRule) -> str:
+    """
+    Generate a workflow name like 'Slack @michelle.fu, Email michelle.fu@sentry.io...(+3)' if there is only a critical trigger
+    or with priority label: 'Critical - Slack @michelle.fu, Warning email michelle.fu@sentry.io...(+3)''
+    """
+    # we have to read from the old tables because at this point we may not have written to the new ones
+    name = ""
+    triggers = AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id).order_by("label")
+    include_label = False if triggers.count() == 1 else True
+
+    actions = AlertRuleTriggerAction.objects.filter(
+        alert_rule_trigger_id__in=[trigger.id for trigger in triggers]
+    )
+    actions_counter = 0
+
+    for trigger in triggers:
+        name += f"{trigger.label.title()} - " if include_label else ""
+        for action in actions.filter(alert_rule_trigger_id=trigger.id):
+            description = get_action_description(action) + ", "
+
+            if len(name) + len(description) <= MAX_CHARS:
+                name += description
+                actions_counter += 1
+            else:
+                remaining_actions = actions.count() - actions_counter
+                name = name[:-2]
+                name += f"...(+{remaining_actions})"
+                break
+
+    if name[-2:] == ", ":
+        name = name[:-2]  # chop off the trailing comma
+
+    return name

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -38,6 +38,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     get_action_filter,
     get_detector_trigger,
     get_resolve_threshold,
+    get_workflow_name,
     migrate_alert_rule,
     migrate_metric_action,
     migrate_metric_data_conditions,
@@ -70,7 +71,7 @@ def assert_alert_rule_migrated(alert_rule, project_id):
     alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=alert_rule)
 
     workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
-    assert workflow.name == alert_rule.name
+    assert workflow.name == get_workflow_name(alert_rule)
     assert workflow.organization_id == alert_rule.organization.id
     detector = Detector.objects.get(id=alert_rule_detector.detector.id)
     assert detector.name == alert_rule.name

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -38,12 +38,12 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     get_action_filter,
     get_detector_trigger,
     get_resolve_threshold,
-    get_workflow_name,
     migrate_alert_rule,
     migrate_metric_action,
     migrate_metric_data_conditions,
     migrate_resolve_threshold_data_conditions,
 )
+from sentry.workflow_engine.migration_helpers.utils import get_workflow_name
 from sentry.workflow_engine.models import (
     Action,
     ActionAlertRuleTriggerAction,

--- a/tests/sentry/workflow_engine/migration_helpers/test_utils.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_utils.py
@@ -1,15 +1,27 @@
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import install_slack
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow
+
+OPSGENIE_METADATA = {
+    "api_key": "1234-ABCD",
+    "base_url": "https://api.opsgenie.com/",
+    "domain_name": "test-app.app.opsgenie.com",
+}
 
 
 class WorkflowNameTest(APITestCase):
     def setUp(self):
         self.rpc_user = user_service.get_user(user_id=self.user.id)
+        self.og_team = self.create_team(organization=self.organization)
+        self.og_team_table = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
         self.metric_alert = self.create_alert_rule(resolve_threshold=2)
         self.alert_rule_trigger_critical = self.create_alert_rule_trigger(
             alert_rule=self.metric_alert, label="critical"
@@ -19,6 +31,36 @@ class WorkflowNameTest(APITestCase):
             target_type=AlertRuleTriggerAction.TargetType.USER,
             target_identifier=str(self.user.id),
         )
+        self.slack_integration = install_slack(self.organization)
+        self.opsgenie_integration = self.create_provider_integration(
+            provider="opsgenie",
+            name="hello-world",
+            external_id="hello-world",
+            metadata=OPSGENIE_METADATA,
+        )
+        self.sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            is_alertable=True,
+            verify_install=False,
+        )
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization, user=self.rpc_user
+        )
+        with assume_test_silo_mode_of(Integration, OrganizationIntegration):
+            self.slack_integration.add_organization(self.organization, self.rpc_user)
+            self.org_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.slack_integration.id
+            )
+            self.org_integration.config = {"team_table": [self.og_team_table]}
+            self.org_integration.save()
+
+            self.opsgenie_integration.add_organization(self.organization, self.rpc_user)
+            self.org_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.opsgenie_integration.id
+            )
+            self.org_integration.config = {"team_table": [self.og_team_table]}
+            self.org_integration.save()
 
     def test_simple(self):
         """
@@ -81,8 +123,46 @@ class WorkflowNameTest(APITestCase):
 
         assert workflow.name == f"Email {self.rpc_user.email}, Email {user2.email}...(+2)"
 
-    def test_every_integration(self):
+    def test_with_integrations(self):
         """
-        Test that we receive the text we expect for actions of every integration type
+        Test that we receive the text we expect for actions of various integration types
         """
-        pass
+        self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="warning"
+        )
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_warning,
+            target_type=AlertRuleTriggerAction.TargetType.TEAM,
+            target_identifier=str(self.og_team.id),
+        )
+        self.create_alert_rule_trigger_action(
+            target_identifier=self.og_team_table["id"],
+            type=AlertRuleTriggerAction.Type.OPSGENIE,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.opsgenie_integration,
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+        )
+
+        self.create_alert_rule_trigger_action(
+            type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
+            sentry_app=self.sentry_app,
+            alert_rule_trigger=self.alert_rule_trigger_warning,
+        )
+        # we create this directly to avoid the api calls to slack for channel verification
+        slack_channel_name = "myChannel"
+        AlertRuleTriggerAction.objects.create(
+            alert_rule_trigger=self.alert_rule_trigger_warning,
+            target_identifier="123",
+            target_display=slack_channel_name,
+            type=AlertRuleTriggerAction.Type.SLACK,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration_id=self.slack_integration.id,
+        )
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+        assert (
+            workflow.name
+            == f"Critical - Email {self.rpc_user.email}, Opsgenie to {self.og_team_table["team"]}, Warning - Email #{self.og_team.slug}, Notify {self.sentry_app.name}, Slack {slack_channel_name}"
+        )

--- a/tests/sentry/workflow_engine/migration_helpers/test_utils.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_utils.py
@@ -1,0 +1,88 @@
+from unittest import mock
+
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.testutils.cases import APITestCase
+from sentry.users.services.user.service import user_service
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow
+
+
+class WorkflowNameTest(APITestCase):
+    def setUp(self):
+        self.rpc_user = user_service.get_user(user_id=self.user.id)
+        self.metric_alert = self.create_alert_rule(resolve_threshold=2)
+        self.alert_rule_trigger_critical = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="critical"
+        )
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(self.user.id),
+        )
+
+    def test_simple(self):
+        """
+        Test that the action text is what we expect when we migrate an alert rule with only a critical trigger
+        """
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+
+        assert workflow.name == f"Email {self.rpc_user.email}"
+
+    def test_warning_and_critical(self):
+        """
+        Test that the action text is what we expect when we have both a critical and warning trigger
+        """
+        self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="warning"
+        )
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_warning,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(self.user.id),
+        )
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+
+        assert (
+            workflow.name
+            == f"Critical - Email {self.rpc_user.email}, Warning - Email {self.rpc_user.email}"
+        )
+
+    @mock.patch("sentry.workflow_engine.migration_helpers.utils.MAX_CHARS", 50)
+    def test_many_actions(self):
+        """
+        Test that if we have so many actions we exceed the char limit we format the name as expected
+        """
+        user2 = self.create_user(email="meow@woof.com")
+        user3 = self.create_user(email="bark@meow.com")
+        user4 = self.create_user(email="idk@lol.com")
+
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(user2.id),
+        )
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(user3.id),
+        )
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(user4.id),
+        )
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+
+        assert workflow.name == f"Email {self.rpc_user.email}, Email {user2.email}...(+2)"
+
+    def test_every_integration(self):
+        """
+        Test that we receive the text we expect for actions of every integration type
+        """
+        pass

--- a/tests/sentry/workflow_engine/migration_helpers/test_utils.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_utils.py
@@ -70,6 +70,7 @@ class WorkflowNameTest(APITestCase):
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
         workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
 
+        assert self.rpc_user
         assert workflow.name == f"Email {self.rpc_user.email}"
 
     def test_warning_and_critical(self):
@@ -88,6 +89,7 @@ class WorkflowNameTest(APITestCase):
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
         workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
 
+        assert self.rpc_user
         assert (
             workflow.name
             == f"Critical - Email {self.rpc_user.email}, Warning - Email {self.rpc_user.email}"
@@ -121,6 +123,7 @@ class WorkflowNameTest(APITestCase):
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
         workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
 
+        assert self.rpc_user
         assert workflow.name == f"Email {self.rpc_user.email}, Email {user2.email}...(+2)"
 
     def test_with_integrations(self):
@@ -162,6 +165,8 @@ class WorkflowNameTest(APITestCase):
         migrate_alert_rule(self.metric_alert, self.rpc_user)
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
         workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+
+        assert self.rpc_user
         assert (
             workflow.name
             == f"Critical - Email {self.rpc_user.email}, Opsgenie to {self.og_team_table["team"]}, Warning - Email #{self.og_team.slug}, Notify {self.sentry_app.name}, Slack {slack_channel_name}"


### PR DESCRIPTION
We want to name workflows something meaningful and descriptive that isn't the same thing as the detector name. This PR builds the workflow name based on the action text so the name will be like "Email colleen@sentry.io". 