### PR TITLE
:wrench: chore(aci): add action group to action handler abc

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -91,72 +91,72 @@ class NotificationActionHandler(ActionHandler, ABC):
 
 @action_handler_registry.register(Action.Type.DISCORD)
 class DiscordActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = NotificationActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.SLACK)
 class SlackActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.MSTEAMS)
 class MsteamsActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.PAGERDUTY)
 class PagerdutyActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = NotificationActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.OPSGENIE)
 class OpsgenieActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.EMAIL)
 class EmailActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.SENTRY_APP)
 class SentryAppActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.PLUGIN)
 class PluginActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.NOTIFICATION
+    group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.GITHUB)
 class GithubActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.TICKET_CREATION
+    group = ActionHandler.Group.TICKET_CREATION
 
 
 @action_handler_registry.register(Action.Type.GITHUB_ENTERPRISE)
 class GithubEnterpriseActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.TICKET_CREATION
+    group = ActionHandler.Group.TICKET_CREATION
 
 
 @action_handler_registry.register(Action.Type.JIRA)
 class JiraActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.TICKET_CREATION
+    group = ActionHandler.Group.TICKET_CREATION
 
 
 @action_handler_registry.register(Action.Type.JIRA_SERVER)
 class JiraServerActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.TICKET_CREATION
+    group = ActionHandler.Group.TICKET_CREATION
 
 
 @action_handler_registry.register(Action.Type.AZURE_DEVOPS)
 class AzureDevopsActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.TICKET_CREATION
+    group = ActionHandler.Group.TICKET_CREATION
 
 
 @action_handler_registry.register(Action.Type.WEBHOOK)
 class WebhookActionHandler(NotificationActionHandler):
-    group = NotificationActionHandler.ActionGroup.OTHER
+    group = ActionHandler.Group.OTHER
 
 
 @group_type_notification_registry.register(ErrorGroupType.slug)

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -1,7 +1,5 @@
 import logging
 from abc import ABC, abstractmethod
-from enum import StrEnum
-from typing import ClassVar
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import MetricIssuePOC
@@ -64,13 +62,6 @@ class NotificationActionHandler(ActionHandler):
     }
 
     data_schema = {}
-
-    class ActionGroup(StrEnum):
-        NOTIFICATION = "notification"
-        TICKET_CREATION = "ticket_creation"
-        OTHER = "other"
-
-    action_group = ClassVar[ActionGroup]
 
     @staticmethod
     def execute(

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -49,12 +49,12 @@ class ActionHandler:
     config_schema: ClassVar[dict[str, Any]]
     data_schema: ClassVar[dict[str, Any]]
 
-    class ActionGroup(StrEnum):
+    class Group(StrEnum):
         NOTIFICATION = "notification"
         TICKET_CREATION = "ticket_creation"
         OTHER = "other"
 
-    group: ClassVar[ActionGroup]
+    group: ClassVar[Group]
 
     @staticmethod
     def execute(job: WorkflowJob, action: Action, detector: Detector) -> None:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -54,7 +54,7 @@ class ActionHandler:
         TICKET_CREATION = "ticket_creation"
         OTHER = "other"
 
-    action_group: ClassVar[ActionGroup]
+    group: ClassVar[ActionGroup]
 
     @staticmethod
     def execute(job: WorkflowJob, action: Action, detector: Detector) -> None:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -49,6 +49,13 @@ class ActionHandler:
     config_schema: ClassVar[dict[str, Any]]
     data_schema: ClassVar[dict[str, Any]]
 
+    class ActionGroup(StrEnum):
+        NOTIFICATION = "notification"
+        TICKET_CREATION = "ticket_creation"
+        OTHER = "other"
+
+    action_group: ClassVar[ActionGroup]
+
     @staticmethod
     def execute(job: WorkflowJob, action: Action, detector: Detector) -> None:
         raise NotImplementedError


### PR DESCRIPTION
so that the ui can group different action types together, we introduce a `action_group` class variable on the `NotificationActionHandler` which will let us group different types of notification actions togather.

defined the groups based on
<img width="382" alt="image" src="https://github.com/user-attachments/assets/103da3ab-3102-4150-bea4-ae54abe22027" />
