### PR TITLE
feat(laravel-insights): Disable for other platforms

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/features.tsx
+++ b/static/app/views/insights/pages/backend/laravel/features.tsx
@@ -14,8 +14,16 @@ export function hasLaravelInsightsFeature(organization: Organization) {
 
 export function useIsLaravelInsightsAvailable() {
   const organization = useOrganization();
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
 
-  return hasLaravelInsightsFeature(organization);
+  const selectedProjects = getSelectedProjectList(selection.projects, projects);
+
+  const isOnlyLaravelSelected = selectedProjects.every(
+    project => project.platform === 'php-laravel'
+  );
+
+  return hasLaravelInsightsFeature(organization) && isOnlyLaravelSelected;
 }
 
 // It started out as a dictionary of project IDs, but as we now want a global toggle we use a special key
@@ -24,20 +32,11 @@ const ALL_PROJECTS_KEY = 'all';
 
 export function useIsLaravelInsightsEnabled() {
   const organization = useOrganization();
-  const {projects} = useProjects();
-  const {selection} = usePageFilters();
   const user = useUser();
-
-  const selectedProjects = getSelectedProjectList(selection.projects, projects);
-
-  // The new experience is enabled by default for Laravel projects
-  const defaultValue = Boolean(
-    selectedProjects.every(project => project.platform === 'php-laravel')
-  );
 
   const isEnabled = Boolean(
     hasLaravelInsightsFeature(organization) &&
-      (user.options.prefersSpecializedProjectOverview[ALL_PROJECTS_KEY] ?? defaultValue)
+      (user.options.prefersSpecializedProjectOverview[ALL_PROJECTS_KEY] ?? true)
   );
 
   const {mutate: mutateUserOptions} = useMutateUserOptions();

--- a/static/app/views/insights/pages/backend/laravel/features.tsx
+++ b/static/app/views/insights/pages/backend/laravel/features.tsx
@@ -33,9 +33,10 @@ const ALL_PROJECTS_KEY = 'all';
 export function useIsLaravelInsightsEnabled() {
   const organization = useOrganization();
   const user = useUser();
+  const isAvailable = useIsLaravelInsightsAvailable();
 
   const isEnabled = Boolean(
-    hasLaravelInsightsFeature(organization) &&
+    isAvailable &&
       (user.options.prefersSpecializedProjectOverview[ALL_PROJECTS_KEY] ?? true)
   );
 


### PR DESCRIPTION
Make the toggle for the new overview only available for if laravel project(s) are selected