### PR TITLE
ref(laravel-insights): Use GridEditable for paths table

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/pathsTable.tsx
+++ b/static/app/views/insights/pages/backend/laravel/pathsTable.tsx
@@ -1,18 +1,25 @@
-import {Fragment, useMemo} from 'react';
-import {useSearchParams} from 'react-router-dom';
+import {Fragment, memo, useCallback, useMemo, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+  type GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
-import {PanelTable} from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconArrow, IconUser} from 'sentry/icons';
+import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import type {QueryValue} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/backend/laravel/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
@@ -39,34 +46,92 @@ interface RouteControllerMapping {
   'transaction.method': string;
 }
 
+interface TableData {
+  avg: number;
+  controller: string | undefined;
+  errorRate: number;
+  isControllerLoading: boolean;
+  method: string;
+  p95: number;
+  projectId: string;
+  requests: number;
+  transaction: string;
+  users: number;
+}
+
 const errorRateColorThreshold = {
-  danger: 0.1,
+  error: 0.1,
   warning: 0.05,
 } as const;
 
 const getP95Threshold = (avg: number) => {
   return {
-    danger: avg * 3,
+    error: avg * 3,
     warning: avg * 2,
   };
 };
 
 const getCellColor = (value: number, thresholds: Record<string, number>) => {
-  return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0];
+  return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0] as
+    | 'error'
+    | 'warning'
+    | undefined;
 };
 
 const getOrderBy = (field: string, order: 'asc' | 'desc') => {
   return order === 'asc' ? field : `-${field}`;
 };
 
+const EMPTY_ARRAY: never[] = [];
+const PER_PAGE = 10;
+
+const defaultColumnOrder: Array<GridColumnOrder<SortableField>> = [
+  {key: 'http.method', name: t('Method'), width: 90},
+  {key: 'transaction', name: t('Path'), width: COL_WIDTH_UNDEFINED},
+  {key: 'count()', name: t('Requests'), width: 112},
+  {key: 'failure_rate()', name: t('Error Rate'), width: 124},
+  {key: 'avg(transaction.duration)', name: t('AVG'), width: 90},
+  {key: 'p95()', name: t('P95'), width: 90},
+  {key: 'count_unique(user)', name: t('Users'), width: 90},
+];
+
+function isSortField(value: string): value is SortableField {
+  return defaultColumnOrder.some(column => column.key === value);
+}
+
+function decodeSortField(value: QueryValue): SortableField {
+  if (typeof value === 'string' && isSortField(value)) {
+    return value;
+  }
+  return 'count()';
+}
+
+function isSortOrder(value: string): value is 'asc' | 'desc' {
+  return value === 'asc' || value === 'desc';
+}
+
+function decodeSortOrder(value: QueryValue): 'asc' | 'desc' {
+  if (typeof value === 'string' && isSortOrder(value)) {
+    return value;
+  }
+  return 'desc';
+}
+
+function useTableSortParams() {
+  const {field: sortField, order: sortOrder} = useLocationQuery({
+    fields: {
+      field: decodeSortField,
+      order: decodeSortOrder,
+    },
+  });
+  return {sortField, sortOrder};
+}
+
 export function PathsTable({query}: {query?: string}) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
-  const theme = useTheme();
-  const [sortState, setSortState] = useSearchParams({field: 'count()', order: 'desc'});
-
-  const sortField = sortState.get('field') as SortableField;
-  const sortOrder = sortState.get('order') as 'asc' | 'desc';
+  const [columnOrder, setColumnOrder] = useState(defaultColumnOrder);
+  const {sortField, sortOrder} = useTableSortParams();
 
   const transactionsRequest = useApiQuery<DiscoverQueryResponse>(
     [
@@ -88,7 +153,7 @@ export function PathsTable({query}: {query?: string}) {
           query: `(transaction.op:http.server) event.type:transaction ${query}`,
           referrer: 'api.performance.landing-table',
           orderby: getOrderBy(sortField, sortOrder as 'asc' | 'desc'),
-          per_page: 10,
+          per_page: PER_PAGE,
         },
       },
     ],
@@ -120,7 +185,7 @@ export function PathsTable({query}: {query?: string}) {
             transactionPaths.map(transactions => `"${transactions}"`).join(',') || '""'
           }]`,
           sort: '-transaction',
-          per_page: 25,
+          per_page: PER_PAGE,
         },
       },
     ],
@@ -131,7 +196,7 @@ export function PathsTable({query}: {query?: string}) {
     }
   );
 
-  const tableData = useMemo(() => {
+  const tableData = useMemo<TableData[]>(() => {
     if (!transactionsRequest.data?.data) {
       return [];
     }
@@ -152,174 +217,186 @@ export function PathsTable({query}: {query?: string}) {
       p95: transaction['p95()'],
       errorRate: transaction['failure_rate()'],
       users: transaction['count_unique(user)'],
+      isControllerLoading: routeControllersRequest.isLoading,
       controller: controllerMap.get(transaction.transaction),
       projectId: transaction['project.id'],
     }));
-  }, [transactionsRequest.data, routeControllersRequest.data]);
+  }, [
+    transactionsRequest.data,
+    routeControllersRequest.data,
+    routeControllersRequest.isLoading,
+  ]);
 
-  function handleSort(field: SortableField) {
-    setSortState(params => {
-      const prevField = params.get('field') as SortableField;
-      const prevOrder = params.get('order') as 'asc' | 'desc';
-      params.set('field', field);
-      params.set(
-        'order',
-        prevField === field ? (prevOrder === 'asc' ? 'desc' : 'asc') : 'desc'
-      );
-      return params;
-    });
-  }
+  const handleResizeColumn = useCallback(
+    (columnIndex: number, nextColumn: GridColumnHeader<SortableField>) => {
+      setColumnOrder(prev => {
+        const newColumnOrder = [...prev];
+        newColumnOrder[columnIndex] = {
+          ...newColumnOrder[columnIndex]!,
+          width: nextColumn.width,
+        };
+        return newColumnOrder;
+      });
+    },
+    []
+  );
 
-  function SortableHeaderCell({
-    children,
-    field,
-    ...props
-  }: {
-    children: React.ReactNode;
-    field: SortableField;
-  } & React.HTMLAttributes<HTMLDivElement>) {
-    return (
-      <HeaderCell data-clickable onClick={() => handleSort(field)} {...props}>
-        {sortField === field ? (
-          <IconArrow direction={sortOrder === 'asc' ? 'up' : 'down'} />
-        ) : null}
-        {children}
-      </HeaderCell>
-    );
-  }
+  const renderHeadCell = useCallback((column: GridColumnHeader<SortableField>) => {
+    return <HeadCell column={column} />;
+  }, []);
 
-  // TODO(aknaus): Use GridEditable for better sorting UX
+  const renderBodyCell = useCallback(
+    (column: GridColumnOrder<SortableField>, dataRow: TableData) => {
+      return <BodyCell column={column} dataRow={dataRow} />;
+    },
+    []
+  );
+
   return (
-    <StyledPanelTable
-      headers={[
-        <SortableHeaderCell key="method" field="http.method">
-          {t('Method')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="path" field="transaction">
-          {t('Path')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="requests" field="count()">
-          {t('Requests')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="errorRate" field="failure_rate()">
-          {t('Error Rate')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="avg" field="avg(transaction.duration)">
-          {t('AVG')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="p95" field="p95()">
-          {t('P95')}
-        </SortableHeaderCell>,
-        <SortableHeaderCell key="users" field="count_unique(user)">
-          {t('Users')}
-        </SortableHeaderCell>,
-      ]}
+    <GridEditable
       isLoading={transactionsRequest.isLoading}
-      isEmpty={!tableData || tableData.length === 0}
-    >
-      {tableData?.map(transaction => {
-        const p95Color = getCellColor(transaction.p95, getP95Threshold(transaction.avg));
-        const errorRateColor = getCellColor(
-          transaction.errorRate,
-          errorRateColorThreshold
-        );
+      error={transactionsRequest.error}
+      data={tableData}
+      columnOrder={columnOrder}
+      columnSortBy={EMPTY_ARRAY}
+      stickyHeader
+      grid={{
+        renderBodyCell,
+        renderHeadCell,
+        onResizeColumn: handleResizeColumn,
+      }}
+    />
+  );
+}
 
-        return (
-          <Fragment key={transaction.method + transaction.transaction}>
-            <Cell>{transaction.method}</Cell>
-            <PathCell>
+const HeadCell = memo(function HeadCell({
+  column,
+}: {
+  column: GridColumnHeader<SortableField>;
+}) {
+  const location = useLocation();
+  const {sortField, sortOrder} = useTableSortParams();
+  return (
+    <SortLink
+      align={column.key === 'count_unique(user)' ? 'right' : 'left'}
+      direction={sortField === column.key ? sortOrder : undefined}
+      canSort
+      generateSortLink={() => ({
+        ...location,
+        query: {
+          ...location.query,
+          field: column.key,
+          order:
+            sortField === column.key ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'desc',
+        },
+      })}
+      title={
+        <Fragment>
+          {column.key === 'transaction' && <CellExpander />}
+          {column.name}
+        </Fragment>
+      }
+    />
+  );
+});
+
+const BodyCell = memo(function BodyCell({
+  column,
+  dataRow,
+}: {
+  column: GridColumnHeader<SortableField>;
+  dataRow: TableData;
+}) {
+  const theme = useTheme();
+  const organization = useOrganization();
+  const p95Color = getCellColor(dataRow.p95, getP95Threshold(dataRow.avg));
+  const errorRateColor = getCellColor(dataRow.errorRate, errorRateColorThreshold);
+
+  switch (column.key) {
+    case 'http.method':
+      return dataRow.method;
+    case 'transaction':
+      return (
+        <PathCell>
+          <Tooltip
+            title={dataRow.transaction}
+            position="top"
+            maxWidth={400}
+            showOnlyOnOverflow
+            skipWrapper
+          >
+            <Link
+              css={css`
+                ${theme.overflowEllipsis};
+                min-width: 0px;
+              `}
+              to={transactionSummaryRouteWithQuery({
+                organization,
+                transaction: dataRow.transaction,
+                view: 'backend',
+                projectID: dataRow.projectId,
+                query: {},
+              })}
+            >
+              {dataRow.transaction}
+            </Link>
+          </Tooltip>
+          {dataRow.isControllerLoading ? (
+            <Placeholder height={theme.fontSizeSmall} width="200px" />
+          ) : (
+            dataRow.controller && (
               <Tooltip
-                title={transaction.transaction}
+                title={dataRow.controller}
                 position="top"
                 maxWidth={400}
                 showOnlyOnOverflow
                 skipWrapper
               >
-                <Link
-                  css={css`
-                    ${theme.overflowEllipsis};
-                    min-width: 0px;
-                  `}
-                  to={transactionSummaryRouteWithQuery({
-                    organization,
-                    transaction: transaction.transaction,
-                    view: 'backend',
-                    projectID: transaction.projectId,
-                    query: {},
-                  })}
-                >
-                  {transaction.transaction}
-                </Link>
+                <ControllerText>{dataRow.controller}</ControllerText>
               </Tooltip>
-              {routeControllersRequest.isLoading ? (
-                <Placeholder height={theme.fontSizeSmall} width="200px" />
-              ) : (
-                transaction.controller && (
-                  <Tooltip
-                    title={transaction.controller}
-                    position="top"
-                    maxWidth={400}
-                    showOnlyOnOverflow
-                    skipWrapper
-                  >
-                    <ControllerText>{transaction.controller}</ControllerText>
-                  </Tooltip>
-                )
-              )}
-            </PathCell>
-            <Cell>{formatAbbreviatedNumber(transaction.requests)}</Cell>
-            <Cell data-color={errorRateColor}>
-              {(transaction.errorRate * 100).toFixed(2)}%
-            </Cell>
-            <Cell>{getDuration(transaction.avg / 1000, 2, true, true)}</Cell>
-            <Cell data-color={p95Color}>
-              {getDuration(transaction.p95 / 1000, 2, true, true)}
-            </Cell>
-            <Cell data-align="right">
-              {formatAbbreviatedNumber(transaction.users)}
-              <IconUser size="xs" />
-            </Cell>
-          </Fragment>
-        );
-      })}
-    </StyledPanelTable>
-  );
-}
+            )
+          )}
+        </PathCell>
+      );
+    case 'count()':
+      return formatAbbreviatedNumber(dataRow.requests);
+    case 'failure_rate()':
+      return (
+        <div style={{color: errorRateColor && theme[errorRateColor]}}>
+          {(dataRow.errorRate * 100).toFixed(2)}%
+        </div>
+      );
+    case 'avg(transaction.duration)':
+      return getDuration(dataRow.avg / 1000, 2, true, true);
+    case 'p95()':
+      return (
+        <div style={{color: p95Color && theme[p95Color]}}>
+          {getDuration(dataRow.p95 / 1000, 2, true, true)}
+        </div>
+      );
+    case 'count_unique(user)':
+      return (
+        <div
+          style={{
+            minWidth: '0',
+            display: 'flex',
+            alignItems: 'center',
+            gap: space(0.5),
+            justifyContent: 'flex-end',
+          }}
+        >
+          {formatAbbreviatedNumber(dataRow.users)}
+          <IconUser size="xs" />
+        </div>
+      );
+    default:
+      return null;
+  }
+});
 
-const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: max-content minmax(200px, 1fr) repeat(5, max-content);
-`;
-
-const Cell = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
+const PathCell = styled('div')`
   overflow: hidden;
   white-space: nowrap;
-  padding: ${space(1)} ${space(2)};
-
-  &[data-color='danger'] {
-    color: ${p => p.theme.red400};
-  }
-  &[data-color='warning'] {
-    color: ${p => p.theme.yellow400};
-  }
-  &[data-align='right'] {
-    text-align: right;
-    justify-content: flex-end;
-  }
-`;
-
-const HeaderCell = styled(Cell)`
-  padding: 0;
-
-  &[data-clickable] {
-    cursor: pointer;
-    user-select: none;
-  }
-`;
-
-const PathCell = styled(Cell)`
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
@@ -327,10 +404,17 @@ const PathCell = styled(Cell)`
   min-width: 0px;
 `;
 
+/**
+ * Used to force the cell to expand take as much width as possible in the table layout
+ * otherwise grid editable will let the last column grow
+ */
+const CellExpander = styled('div')`
+  width: 100vw;
+`;
+
 const ControllerText = styled('div')`
   ${p => p.theme.overflowEllipsis};
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 1;
   min-width: 0px;
 `;


### PR DESCRIPTION
Use `GridEditable` instead of `PanelTable`.
Preserve column sizes while sorting loading states.
Allow users to adjust column sizes.

- closes https://github.com/getsentry/projects/issues/827
- closes https://github.com/getsentry/sentry/issues/87281
