### PR TITLE
feat(schema-hints): Make slideout part of the content on large screen sizes

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -30,6 +30,8 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
+export const SCHEMA_HINTS_DRAWER_WIDTH = '35vw';
+
 interface SchemaHintsListProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
@@ -165,7 +167,7 @@ function SchemaHintsList({
             ),
             {
               ariaLabel: t('Schema Hints Drawer'),
-              drawerWidth: '35vw',
+              drawerWidth: SCHEMA_HINTS_DRAWER_WIDTH,
               shouldCloseOnLocationChange: newLocation => {
                 return (
                   location.pathname !== newLocation.pathname ||

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -1,10 +1,12 @@
 import {useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import Feature from 'sentry/components/acl/feature';
 import {getDiffInMinutes} from 'sentry/components/charts/utils';
 import {Button} from 'sentry/components/core/button';
+import useDrawer from 'sentry/components/globalDrawer';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -26,10 +28,13 @@ import {
   type AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
 } from 'sentry/utils/fields';
+import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ExploreCharts} from 'sentry/views/explore/charts';
-import SchemaHintsList from 'sentry/views/explore/components/schemaHintsList';
+import SchemaHintsList, {
+  SCHEMA_HINTS_DRAWER_WIDTH,
+} from 'sentry/views/explore/components/schemaHintsList';
 import {
   PageParamsProvider,
   useExploreDataset,
@@ -84,6 +89,14 @@ export function SpansTabContentImpl({
 
   const query = useExploreQuery();
   const setQuery = useSetExploreQuery();
+
+  const {isDrawerOpen: isSchemaHintsDrawerOpen} = useDrawer();
+  const theme = useTheme();
+  const isLargeScreen = useMedia(`(min-width: ${theme.breakpoints.xlarge})`);
+  const isSchemaHintsDrawerOpenOnLargeScreen =
+    isSchemaHintsDrawerOpen &&
+    isLargeScreen &&
+    organization.features.includes('traces-schema-hints');
 
   const toolbarExtras = [
     ...(organization?.features?.includes('visibility-explore-dataset')
@@ -169,6 +182,7 @@ export function SpansTabContentImpl({
     <Body
       withToolbar={expanded}
       withHints={organization.features.includes('traces-schema-hints')}
+      withSchemaHintsDrawer={isSchemaHintsDrawerOpenOnLargeScreen}
     >
       <TopSection>
         <StyledPageFilterBar condensed>
@@ -219,7 +233,7 @@ export function SpansTabContentImpl({
         )}
       </TopSection>
       <Feature features="organizations:traces-schema-hints">
-        <HintsSection>
+        <HintsSection withSchemaHintsDrawer={isSchemaHintsDrawerOpenOnLargeScreen}>
           <SchemaHintsList
             supportedAggregates={
               mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
@@ -338,13 +352,17 @@ function checkIsAllowedSelection(
   return selectedMinutes <= maxPickableMinutes;
 }
 
-const Body = styled(Layout.Body)<{withHints: boolean; withToolbar: boolean}>`
+const Body = styled(Layout.Body)<{
+  withHints: boolean;
+  withSchemaHintsDrawer: boolean;
+  withToolbar: boolean;
+}>`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     display: grid;
     ${p =>
       p.withToolbar
-        ? `grid-template-columns: 300px minmax(100px, auto);`
-        : `grid-template-columns: 0px minmax(100px, auto);`}
+        ? `grid-template-columns: 300px minmax(100px, auto) ${p.withSchemaHintsDrawer ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'};`
+        : `grid-template-columns: 0px minmax(100px, auto) ${p.withSchemaHintsDrawer ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'};`}
     grid-template-rows: auto ${p => (p.withHints ? 'auto 1fr' : '1fr')};
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};
@@ -370,7 +388,7 @@ const SideSection = styled('aside')<{withToolbar: boolean}>`
   }
 `;
 
-const HintsSection = styled('div')`
+const HintsSection = styled('div')<{withSchemaHintsDrawer: boolean}>`
   display: grid;
   /* This is to ensure the hints section spans all the columns */
   grid-column: 1/-1;
@@ -379,7 +397,8 @@ const HintsSection = styled('div')`
   height: fit-content;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr ${p =>
+        p.withSchemaHintsDrawer ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'};
     margin-bottom: 0;
     margin-top: 0;
   }


### PR DESCRIPTION
The designs I discussed with Dora had a feature where the drawer was "part of" the page on large screens. I chose to make this possible on `xlarge` screen size because anything smaller looked too crowded and squished. I've just added a conditional column to the body that shows when the drawer is open.

Here's what it looks like:


https://github.com/user-attachments/assets/f42b0bbc-0550-4a1c-a8a8-6b91a111dc99
