### PR TITLE
fix(outcomes): Make 'Too Large' outcome future proof

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -16,20 +16,12 @@ describe('getReasonGroupName', function () {
       ['to_large:raw_security', 'internal'],
       [':attachment', 'internal'],
       ['', 'internal'],
+      ['too_large:future_reason', 'too_large_future_reason'],
     ];
 
     testCases.forEach(([input, expected]) => {
       expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
     });
-  });
-
-  it('handles unknown too_large reasons', function () {
-    // Make sure that future too large types are still being displayed correctly
-    // That is, if someone adds a new item type in Relay they do not need to update
-    // the front-end.
-    expect(getReasonGroupName(Outcome.INVALID, 'too_large:future_type')).toBe(
-      'too_large_future_type'
-    );
   });
 
   it('handles other existing reason types', function () {

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -7,37 +7,15 @@ describe('getReasonGroupName', function () {
     expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
   });
 
-  // We apply the following to all the reasons: startCase(reason.replace(/-|_/g, ' '))
-  // Which will convert: 'too_large_attachment' -> 'Too Large Attachment'
-  it('handles all new too_large reasons', function () {
+  it('handles all edge cases for reasons', function () {
     const testCases: Array<[string, string]> = [
       ['too_large:unknown', 'too_large'],
-      ['too_large:event', 'too_large_event'],
-      ['too_large:transaction', 'too_large_transaction'],
-      ['too_large:security', 'too_large_security'],
+      ['too_large', 'too_large'],
       ['too_large:attachment', 'too_large_attachment'],
-      ['too_large:form_data', 'too_large_form_data'],
-      ['too_large:raw_security', 'too_large_raw_security'],
-      ['too_large:nel', 'too_large_nel'],
-      ['too_large:unreal_report', 'too_large_unreal_report'],
-      ['too_large:user_report', 'too_large_user_report'],
-      ['too_large:session', 'too_large_session'],
-      ['too_large:sessions', 'too_large_sessions'],
-      ['too_large:statsd', 'too_large_statsd'],
-      ['too_large:metric_buckets', 'too_large_metric_buckets'],
-      ['too_large:client_report', 'too_large_client_report'],
-      ['too_large:profile', 'too_large_profile'],
-      ['too_large:replay_event', 'too_large_replay_event'],
-      ['too_large:replay_recording', 'too_large_replay_recording'],
-      ['too_large:replay_video', 'too_large_replay_video'],
-      ['too_large:check_in', 'too_large_check_in'],
-      ['too_large:otel_log', 'too_large_otel_log'],
-      ['too_large:log', 'too_large_log'],
-      ['too_large:span', 'too_large_span'],
-      ['too_large:otel_span', 'too_large_otel_span'],
-      ['too_large:otel_traces_data', 'too_large_otel_traces_data'],
-      ['too_large:user_report_v2', 'too_large_user_report_v2'],
-      ['too_large:profile_chunk', 'too_large_profile_chunk'],
+      ['too_large:strange:reason', 'too_large_strange:reason'],
+      ['to_large:raw_security', 'internal'],
+      [':attachment', 'internal'],
+      ['', 'internal'],
     ];
 
     testCases.forEach(([input, expected]) => {

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -4,19 +4,54 @@ import {ClientDiscardReason, getReasonGroupName} from './getReasonGroupName';
 
 describe('getReasonGroupName', function () {
   it('handles legacy too_large reason', function () {
-    expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
+    expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large_other');
+  });
+
+  it('handles all new (visible) discard reasons', function () {
+    const testCases: Array<[string, string]> = [
+      ['too_large:unknown', 'too_large_other'],
+      ['too_large:security', 'too_large_other'],
+      ['too_large:raw_security', 'too_large_other'],
+      ['too_large:statsd', 'too_large_other'],
+      ['too_large:metric_buckets', 'too_large_other'],
+      ['too_large:client_report', 'too_large_other'],
+      ['too_large:check_in', 'too_large_other'],
+      ['too_large:otel_traces_data', 'too_large_other'],
+
+      ['too_large:event', 'too_large_event'],
+      ['too_large:transaction', 'too_large_transaction'],
+      ['too_large:attachment', 'too_large_attachment'],
+      ['too_large:form_data', 'too_large_form_data'],
+      ['too_large:nel', 'too_large_nel'],
+      ['too_large:unreal_report', 'too_large_unreal_report'],
+      ['too_large:user_report', 'too_large_user_report'],
+      ['too_large:user_report_v2', 'too_large_user_report'],
+      ['too_large:session', 'too_large_session'],
+      ['too_large:sessions', 'too_large_session'],
+      ['too_large:profile', 'too_large_profile'],
+      ['too_large:replay_event', 'too_large_replay'],
+      ['too_large:replay_recording', 'too_large_replay'],
+      ['too_large:replay_video', 'too_large_replay'],
+      ['too_large:otel_log', 'too_large_log'],
+      ['too_large:log', 'too_large_log'],
+      ['too_large:span', 'too_large_span'],
+      ['too_large:otel_span', 'too_large_span'],
+      ['too_large:profile_chunk', 'too_large_profile'],
+    ];
+
+    testCases.forEach(([input, expected]) => {
+      expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
+    });
   });
 
   it('handles all edge cases for reasons', function () {
     const testCases: Array<[string, string]> = [
-      ['too_large:unknown', 'too_large'],
-      ['too_large', 'too_large'],
-      ['too_large:attachment', 'too_large_attachment'],
-      ['too_large:strange:reason', 'too_large_strange:reason'],
+      ['too_large:invalid', 'too_large_other'],
+      ['too_large:strange:reason', 'too_large_other'],
       ['to_large:raw_security', 'internal'],
       [':attachment', 'internal'],
       ['', 'internal'],
-      ['too_large:future_reason', 'too_large_future_reason'],
+      ['too_large:future_reason', 'too_large_other'],
     ];
 
     testCases.forEach(([input, expected]) => {

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -1,69 +1,70 @@
-import {Outcome} from 'sentry/types/core';
+// TODO: Update these to work for the new logic
+// import {Outcome} from 'sentry/types/core';
 
-import {ClientDiscardReason, getReasonGroupName} from './getReasonGroupName';
+// import {ClientDiscardReason, getReasonGroupName} from './getReasonGroupName';
 
-describe('getReasonGroupName', function () {
-  it('handles legacy too_large reason', function () {
-    expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
-  });
+// describe('getReasonGroupName', function () {
+//   it('handles legacy too_large reason', function () {
+//     expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
+//   });
 
-  it('handles all new too_large reasons', function () {
-    const testCases: Array<[string, string]> = [
-      ['too_large_unknown', 'too_large'],
-      ['too_large_event', 'too_large_event'],
-      ['too_large_transaction', 'too_large_transaction'],
-      ['too_large_security', 'too_large_security'],
-      ['too_large_attachment', 'too_large_attachment'],
-      ['too_large_form_data', 'too_large_form_data'],
-      ['too_large_raw_security', 'too_large_raw_security'],
-      ['too_large_nel', 'too_large_nel'],
-      ['too_large_unreal_report', 'too_large_unreal_report'],
-      ['too_large_user_report', 'too_large_user_report'],
-      ['too_large_session', 'too_large_session'],
-      ['too_large_sessions', 'too_large_sessions'],
-      ['too_large_statsd', 'too_large_statsd'],
-      ['too_large_metric_buckets', 'too_large_metric_buckets'],
-      ['too_large_client_report', 'too_large_client_report'],
-      ['too_large_profile', 'too_large_profile'],
-      ['too_large_replay_event', 'too_large_replay_event'],
-      ['too_large_replay_recording', 'too_large_replay_recording'],
-      ['too_large_replay_video', 'too_large_replay_video'],
-      ['too_large_check_in', 'too_large_check_in'],
-      ['too_large_otel_log', 'too_large_otel_log'],
-      ['too_large_log', 'too_large_log'],
-      ['too_large_span', 'too_large_span'],
-      ['too_large_otel_span', 'too_large_otel_span'],
-      ['too_large_otel_traces_data', 'too_large_otel_traces_data'],
-      ['too_large_user_report_v2', 'too_large_user_report_v2'],
-      ['too_large_profile_chunk', 'too_large_profile_chunk'],
-    ];
+//   it('handles all new too_large reasons', function () {
+//     const testCases: Array<[string, string]> = [
+//       ['too_large_unknown', 'too_large'],
+//       ['too_large_event', 'too_large_event'],
+//       ['too_large_transaction', 'too_large_transaction'],
+//       ['too_large_security', 'too_large_security'],
+//       ['too_large_attachment', 'too_large_attachment'],
+//       ['too_large_form_data', 'too_large_form_data'],
+//       ['too_large_raw_security', 'too_large_raw_security'],
+//       ['too_large_nel', 'too_large_nel'],
+//       ['too_large_unreal_report', 'too_large_unreal_report'],
+//       ['too_large_user_report', 'too_large_user_report'],
+//       ['too_large_session', 'too_large_session'],
+//       ['too_large_sessions', 'too_large_sessions'],
+//       ['too_large_statsd', 'too_large_statsd'],
+//       ['too_large_metric_buckets', 'too_large_metric_buckets'],
+//       ['too_large_client_report', 'too_large_client_report'],
+//       ['too_large_profile', 'too_large_profile'],
+//       ['too_large_replay_event', 'too_large_replay_event'],
+//       ['too_large_replay_recording', 'too_large_replay_recording'],
+//       ['too_large_replay_video', 'too_large_replay_video'],
+//       ['too_large_check_in', 'too_large_check_in'],
+//       ['too_large_otel_log', 'too_large_otel_log'],
+//       ['too_large_log', 'too_large_log'],
+//       ['too_large_span', 'too_large_span'],
+//       ['too_large_otel_span', 'too_large_otel_span'],
+//       ['too_large_otel_traces_data', 'too_large_otel_traces_data'],
+//       ['too_large_user_report_v2', 'too_large_user_report_v2'],
+//       ['too_large_profile_chunk', 'too_large_profile_chunk'],
+//     ];
 
-    testCases.forEach(([input, expected]) => {
-      expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
-    });
-  });
+//     testCases.forEach(([input, expected]) => {
+//       expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
+//     });
+//   });
 
-  it('handles unknown too_large reasons', function () {
-    expect(getReasonGroupName(Outcome.INVALID, 'too_large_future_type')).toBe('internal');
-  });
+//   it('handles unknown too_large reasons', function () {
+//     expect(getReasonGroupName(Outcome.INVALID, 'too_large_future_type')).toBe('internal');
+//   });
 
-  it('handles other existing reason types', function () {
-    expect(getReasonGroupName(Outcome.INVALID, 'duplicate')).toBe('duplicate');
-    expect(getReasonGroupName(Outcome.INVALID, 'duplicate_item')).toBe('invalid_request');
-    expect(getReasonGroupName(Outcome.INVALID, 'project_id')).toBe('project_missing');
-    expect(getReasonGroupName(Outcome.INVALID, 'invalid_transaction')).toBe(
-      'invalid_data'
-    );
+//   it('handles other existing reason types', function () {
+//     expect(getReasonGroupName(Outcome.INVALID, 'duplicate')).toBe('duplicate');
+//     expect(getReasonGroupName(Outcome.INVALID, 'duplicate_item')).toBe('invalid_request');
+//     expect(getReasonGroupName(Outcome.INVALID, 'project_id')).toBe('project_missing');
+//     expect(getReasonGroupName(Outcome.INVALID, 'invalid_transaction')).toBe(
+//       'invalid_data'
+//     );
 
-    expect(getReasonGroupName(Outcome.RATE_LIMITED, 'key_quota')).toBe('DSN limit');
-    expect(getReasonGroupName(Outcome.RATE_LIMITED, 'org_quota')).toBe('global limit');
+//     expect(getReasonGroupName(Outcome.RATE_LIMITED, 'key_quota')).toBe('DSN limit');
+//     expect(getReasonGroupName(Outcome.RATE_LIMITED, 'org_quota')).toBe('global limit');
 
-    expect(getReasonGroupName(Outcome.FILTERED, 'browser-extensions')).toBe(
-      'Browser Extensions'
-    );
+//     expect(getReasonGroupName(Outcome.FILTERED, 'browser-extensions')).toBe(
+//       'Browser Extensions'
+//     );
 
-    expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'queue_overflow')).toBe(
-      ClientDiscardReason.QUEUE_OVERFLOW
-    );
-  });
-});
+//     expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'queue_overflow')).toBe(
+//       ClientDiscardReason.QUEUE_OVERFLOW
+//     );
+//   });
+// });

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -1,70 +1,76 @@
-// TODO: Update these to work for the new logic
-// import {Outcome} from 'sentry/types/core';
+import {Outcome} from 'sentry/types/core';
 
-// import {ClientDiscardReason, getReasonGroupName} from './getReasonGroupName';
+import {ClientDiscardReason, getReasonGroupName} from './getReasonGroupName';
 
-// describe('getReasonGroupName', function () {
-//   it('handles legacy too_large reason', function () {
-//     expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
-//   });
+describe('getReasonGroupName', function () {
+  it('handles legacy too_large reason', function () {
+    expect(getReasonGroupName(Outcome.INVALID, 'too_large')).toBe('too_large');
+  });
 
-//   it('handles all new too_large reasons', function () {
-//     const testCases: Array<[string, string]> = [
-//       ['too_large_unknown', 'too_large'],
-//       ['too_large_event', 'too_large_event'],
-//       ['too_large_transaction', 'too_large_transaction'],
-//       ['too_large_security', 'too_large_security'],
-//       ['too_large_attachment', 'too_large_attachment'],
-//       ['too_large_form_data', 'too_large_form_data'],
-//       ['too_large_raw_security', 'too_large_raw_security'],
-//       ['too_large_nel', 'too_large_nel'],
-//       ['too_large_unreal_report', 'too_large_unreal_report'],
-//       ['too_large_user_report', 'too_large_user_report'],
-//       ['too_large_session', 'too_large_session'],
-//       ['too_large_sessions', 'too_large_sessions'],
-//       ['too_large_statsd', 'too_large_statsd'],
-//       ['too_large_metric_buckets', 'too_large_metric_buckets'],
-//       ['too_large_client_report', 'too_large_client_report'],
-//       ['too_large_profile', 'too_large_profile'],
-//       ['too_large_replay_event', 'too_large_replay_event'],
-//       ['too_large_replay_recording', 'too_large_replay_recording'],
-//       ['too_large_replay_video', 'too_large_replay_video'],
-//       ['too_large_check_in', 'too_large_check_in'],
-//       ['too_large_otel_log', 'too_large_otel_log'],
-//       ['too_large_log', 'too_large_log'],
-//       ['too_large_span', 'too_large_span'],
-//       ['too_large_otel_span', 'too_large_otel_span'],
-//       ['too_large_otel_traces_data', 'too_large_otel_traces_data'],
-//       ['too_large_user_report_v2', 'too_large_user_report_v2'],
-//       ['too_large_profile_chunk', 'too_large_profile_chunk'],
-//     ];
+  // We apply the following to all the reasons: startCase(reason.replace(/-|_/g, ' '))
+  // Which will convert: 'too_large:_attachment' -> 'Too Large: Attachment'
+  it('handles all new too_large reasons', function () {
+    const testCases: Array<[string, string]> = [
+      ['too_large:unknown', 'too_large'],
+      ['too_large:event', 'too_large:_event'],
+      ['too_large:transaction', 'too_large:_transaction'],
+      ['too_large:security', 'too_large:_security'],
+      ['too_large:attachment', 'too_large:_attachment'],
+      ['too_large:form_data', 'too_large:_form_data'],
+      ['too_large:raw_security', 'too_large:_raw_security'],
+      ['too_large:nel', 'too_large:_nel'],
+      ['too_large:unreal_report', 'too_large:_unreal_report'],
+      ['too_large:user_report', 'too_large:_user_report'],
+      ['too_large:session', 'too_large:_session'],
+      ['too_large:sessions', 'too_large:_sessions'],
+      ['too_large:statsd', 'too_large:_statsd'],
+      ['too_large:metric_buckets', 'too_large:_metric_buckets'],
+      ['too_large:client_report', 'too_large:_client_report'],
+      ['too_large:profile', 'too_large:_profile'],
+      ['too_large:replay_event', 'too_large:_replay_event'],
+      ['too_large:replay_recording', 'too_large:_replay_recording'],
+      ['too_large:replay_video', 'too_large:_replay_video'],
+      ['too_large:check_in', 'too_large:_check_in'],
+      ['too_large:otel_log', 'too_large:_otel_log'],
+      ['too_large:log', 'too_large:_log'],
+      ['too_large:span', 'too_large:_span'],
+      ['too_large:otel_span', 'too_large:_otel_span'],
+      ['too_large:otel_traces_data', 'too_large:_otel_traces_data'],
+      ['too_large:user_report_v2', 'too_large:_user_report_v2'],
+      ['too_large:profile_chunk', 'too_large:_profile_chunk'],
+    ];
 
-//     testCases.forEach(([input, expected]) => {
-//       expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
-//     });
-//   });
+    testCases.forEach(([input, expected]) => {
+      expect(getReasonGroupName(Outcome.INVALID, input)).toBe(expected);
+    });
+  });
 
-//   it('handles unknown too_large reasons', function () {
-//     expect(getReasonGroupName(Outcome.INVALID, 'too_large_future_type')).toBe('internal');
-//   });
+  it('handles unknown too_large reasons', function () {
+    // Make sure that future too large types are still being displayed correctly
+    // That is, if someone adds a new item type in Relay they do not need to update
+    // the front-end.
+    expect(getReasonGroupName(Outcome.INVALID, 'too_large:future_type')).toBe(
+      'too_large:_future_type'
+    );
+  });
 
-//   it('handles other existing reason types', function () {
-//     expect(getReasonGroupName(Outcome.INVALID, 'duplicate')).toBe('duplicate');
-//     expect(getReasonGroupName(Outcome.INVALID, 'duplicate_item')).toBe('invalid_request');
-//     expect(getReasonGroupName(Outcome.INVALID, 'project_id')).toBe('project_missing');
-//     expect(getReasonGroupName(Outcome.INVALID, 'invalid_transaction')).toBe(
-//       'invalid_data'
-//     );
+  it('handles other existing reason types', function () {
+    expect(getReasonGroupName(Outcome.INVALID, 'duplicate')).toBe('duplicate');
+    expect(getReasonGroupName(Outcome.INVALID, 'duplicate_item')).toBe('invalid_request');
+    expect(getReasonGroupName(Outcome.INVALID, 'project_id')).toBe('project_missing');
+    expect(getReasonGroupName(Outcome.INVALID, 'invalid_transaction')).toBe(
+      'invalid_data'
+    );
 
-//     expect(getReasonGroupName(Outcome.RATE_LIMITED, 'key_quota')).toBe('DSN limit');
-//     expect(getReasonGroupName(Outcome.RATE_LIMITED, 'org_quota')).toBe('global limit');
+    expect(getReasonGroupName(Outcome.RATE_LIMITED, 'key_quota')).toBe('DSN limit');
+    expect(getReasonGroupName(Outcome.RATE_LIMITED, 'org_quota')).toBe('global limit');
 
-//     expect(getReasonGroupName(Outcome.FILTERED, 'browser-extensions')).toBe(
-//       'Browser Extensions'
-//     );
+    expect(getReasonGroupName(Outcome.FILTERED, 'browser-extensions')).toBe(
+      'Browser Extensions'
+    );
 
-//     expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'queue_overflow')).toBe(
-//       ClientDiscardReason.QUEUE_OVERFLOW
-//     );
-//   });
-// });
+    expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'queue_overflow')).toBe(
+      ClientDiscardReason.QUEUE_OVERFLOW
+    );
+  });
+});

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -8,36 +8,36 @@ describe('getReasonGroupName', function () {
   });
 
   // We apply the following to all the reasons: startCase(reason.replace(/-|_/g, ' '))
-  // Which will convert: 'too_large:_attachment' -> 'Too Large: Attachment'
+  // Which will convert: 'too_large_attachment' -> 'Too Large Attachment'
   it('handles all new too_large reasons', function () {
     const testCases: Array<[string, string]> = [
-      ['too_large:unknown', 'too_large'],
-      ['too_large:event', 'too_large:_event'],
-      ['too_large:transaction', 'too_large:_transaction'],
-      ['too_large:security', 'too_large:_security'],
-      ['too_large:attachment', 'too_large:_attachment'],
-      ['too_large:form_data', 'too_large:_form_data'],
-      ['too_large:raw_security', 'too_large:_raw_security'],
-      ['too_large:nel', 'too_large:_nel'],
-      ['too_large:unreal_report', 'too_large:_unreal_report'],
-      ['too_large:user_report', 'too_large:_user_report'],
-      ['too_large:session', 'too_large:_session'],
-      ['too_large:sessions', 'too_large:_sessions'],
-      ['too_large:statsd', 'too_large:_statsd'],
-      ['too_large:metric_buckets', 'too_large:_metric_buckets'],
-      ['too_large:client_report', 'too_large:_client_report'],
-      ['too_large:profile', 'too_large:_profile'],
-      ['too_large:replay_event', 'too_large:_replay_event'],
-      ['too_large:replay_recording', 'too_large:_replay_recording'],
-      ['too_large:replay_video', 'too_large:_replay_video'],
-      ['too_large:check_in', 'too_large:_check_in'],
-      ['too_large:otel_log', 'too_large:_otel_log'],
-      ['too_large:log', 'too_large:_log'],
-      ['too_large:span', 'too_large:_span'],
-      ['too_large:otel_span', 'too_large:_otel_span'],
-      ['too_large:otel_traces_data', 'too_large:_otel_traces_data'],
-      ['too_large:user_report_v2', 'too_large:_user_report_v2'],
-      ['too_large:profile_chunk', 'too_large:_profile_chunk'],
+      // ['too_large:unknown', 'too_large'],
+      ['too_large:event', 'too_large_event'],
+      ['too_large:transaction', 'too_large_transaction'],
+      ['too_large:security', 'too_large_security'],
+      ['too_large:attachment', 'too_large_attachment'],
+      ['too_large:form_data', 'too_large_form_data'],
+      ['too_large:raw_security', 'too_large_raw_security'],
+      ['too_large:nel', 'too_large_nel'],
+      ['too_large:unreal_report', 'too_large_unreal_report'],
+      ['too_large:user_report', 'too_large_user_report'],
+      ['too_large:session', 'too_large_session'],
+      ['too_large:sessions', 'too_large_sessions'],
+      ['too_large:statsd', 'too_large_statsd'],
+      ['too_large:metric_buckets', 'too_large_metric_buckets'],
+      ['too_large:client_report', 'too_large_client_report'],
+      ['too_large:profile', 'too_large_profile'],
+      ['too_large:replay_event', 'too_large_replay_event'],
+      ['too_large:replay_recording', 'too_large_replay_recording'],
+      ['too_large:replay_video', 'too_large_replay_video'],
+      ['too_large:check_in', 'too_large_check_in'],
+      ['too_large:otel_log', 'too_large_otel_log'],
+      ['too_large:log', 'too_large_log'],
+      ['too_large:span', 'too_large_span'],
+      ['too_large:otel_span', 'too_large_otel_span'],
+      ['too_large:otel_traces_data', 'too_large_otel_traces_data'],
+      ['too_large:user_report_v2', 'too_large_user_report_v2'],
+      ['too_large:profile_chunk', 'too_large_profile_chunk'],
     ];
 
     testCases.forEach(([input, expected]) => {
@@ -50,7 +50,7 @@ describe('getReasonGroupName', function () {
     // That is, if someone adds a new item type in Relay they do not need to update
     // the front-end.
     expect(getReasonGroupName(Outcome.INVALID, 'too_large:future_type')).toBe(
-      'too_large:_future_type'
+      'too_large_future_type'
     );
   });
 

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -11,7 +11,7 @@ describe('getReasonGroupName', function () {
   // Which will convert: 'too_large_attachment' -> 'Too Large Attachment'
   it('handles all new too_large reasons', function () {
     const testCases: Array<[string, string]> = [
-      // ['too_large:unknown', 'too_large'],
+      ['too_large:unknown', 'too_large'],
       ['too_large:event', 'too_large_event'],
       ['too_large:transaction', 'too_large_transaction'],
       ['too_large:security', 'too_large_security'],

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -106,25 +106,33 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
   sampling: [DiscardReason.TRANSACTION_SAMPLED],
 };
 
-function getInvalidReasonGroupName(reason: string): string {
-  // The reason for 'too large' are of the from 'too_large:reason'
-  // We want to convert this to 'too_large_reason' as we later apply
-  // the following logic to the reason: startCase(reason.replace(/-|_/g, ' '))
-  // That is, we want to 'too_large: attachment' to be displayed as
-  // 'Too Large Attachment' in the UI. The one exception to that
-  // is 'too_large:unknown' which should just be 'Too Large'
-  if (reason.startsWith('too_large:')) {
-    if (reason === 'too_large:unknown') {
-      return DiscardReason.TOO_LARGE;
-    }
-    return reason.replace('too_large:', 'too_large_');
-  }
+function lookupInvalidReasonGroup(reason: DiscardReason): string {
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
     if (reasons.includes(reason as DiscardReason)) {
       return group;
     }
   }
   return 'internal';
+}
+
+function getInvalidReasonGroupName(reason: string): string {
+  // Reasons can be of the form 'baseReason:subReason' for the `baseReason` we expect it
+  // to be part of `DiscardReason` while the `subReason` can be freeform.
+  //
+  // If the `baseReason` and `subReason` are valid we want to return `baseReason_subReason`
+  // else we just want to return the reasonGroup for the `baseReason`
+
+  const [baseReason, ...rest] = reason.split(':');
+  const subReason = rest.join(':');
+  const group_name = lookupInvalidReasonGroup(baseReason as DiscardReason);
+
+  if (group_name === 'internal' || subReason === 'unknown' || subReason.length === 0) {
+    // Ensures we return `internal` rather than `internal: foo`
+    // Ensures we return `too_large` rather than too_large_unknown`
+    // Ensures we don't return `too_large_` if there is no subReason
+    return group_name;
+  }
+  return [baseReason, subReason].join('_');
 }
 
 function getRateLimitedReasonGroupName(reason: RateLimitedReason | string): string {

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -154,7 +154,7 @@ function getInvalidReasonGroupName(reason: string): string {
     }
   }
   // 2. If there is no direct match check if there is a match for the baseReason
-  const [baseReason, ..._] = reason.split(':');
+  const baseReason = reason.split(':')[0];
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
     if (reasons.includes(baseReason as DiscardReason)) {
       return group;

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -25,33 +25,6 @@ enum DiscardReason {
   PAYLOAD = 'payload',
   INVALID_COMPRESSION = 'invalid_compression',
   TOO_LARGE = 'too_large', // Left for backwards compatibility
-  TOO_LARGE_UNKNOWN = 'too_large_unknown',
-  TOO_LARGE_EVENT = 'too_large_event',
-  TOO_LARGE_TRANSACTION = 'too_large_transaction',
-  TOO_LARGE_SECURITY = 'too_large_security',
-  TOO_LARGE_ATTACHMENT = 'too_large_attachment',
-  TOO_LARGE_FORM_DATA = 'too_large_form_data',
-  TOO_LARGE_RAW_SECURITY = 'too_large_raw_security',
-  TOO_LARGE_NEL = 'too_large_nel',
-  TOO_LARGE_UNREAL_REPORT = 'too_large_unreal_report',
-  TOO_LARGE_USER_REPORT = 'too_large_user_report',
-  TOO_LARGE_SESSION = 'too_large_session',
-  TOO_LARGE_SESSIONS = 'too_large_sessions',
-  TOO_LARGE_STATSD = 'too_large_statsd',
-  TOO_LARGE_METRIC_BUCKETS = 'too_large_metric_buckets',
-  TOO_LARGE_CLIENT_REPORT = 'too_large_client_report',
-  TOO_LARGE_PROFILE = 'too_large_profile',
-  TOO_LARGE_REPLAY_EVENT = 'too_large_replay_event',
-  TOO_LARGE_REPLAY_RECORDING = 'too_large_replay_recording',
-  TOO_LARGE_REPLAY_VIDEO = 'too_large_replay_video',
-  TOO_LARGE_CHECK_IN = 'too_large_check_in',
-  TOO_LARGE_OTEL_LOG = 'too_large_otel_log',
-  TOO_LARGE_LOG = 'too_large_log',
-  TOO_LARGE_SPAN = 'too_large_span',
-  TOO_LARGE_OTEL_SPAN = 'too_large_otel_span',
-  TOO_LARGE_OTEL_TRACES_DATA = 'too_large_otel_traces_data',
-  TOO_LARGE_USER_REPORT_V2 = 'too_large_user_report_v2',
-  TOO_LARGE_PROFILE_CHUNK = 'too_large_profile_chunk',
   MISSING_MINIDUMP_UPLOAD = 'missing_minidump_upload',
   INVALID_MINIDUMP = 'invalid_minidump',
   SECURITY_REPORT = 'security_report',
@@ -120,34 +93,7 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
   payload: [DiscardReason.PAYLOAD, DiscardReason.INVALID_COMPRESSION],
   too_large: [
     DiscardReason.TOO_LARGE, // Left for backwards compatibility
-    DiscardReason.TOO_LARGE_UNKNOWN,
   ],
-  too_large_event: [DiscardReason.TOO_LARGE_EVENT],
-  too_large_transaction: [DiscardReason.TOO_LARGE_TRANSACTION],
-  too_large_security: [DiscardReason.TOO_LARGE_SECURITY],
-  too_large_attachment: [DiscardReason.TOO_LARGE_ATTACHMENT],
-  too_large_form_data: [DiscardReason.TOO_LARGE_FORM_DATA],
-  too_large_raw_security: [DiscardReason.TOO_LARGE_RAW_SECURITY],
-  too_large_nel: [DiscardReason.TOO_LARGE_NEL],
-  too_large_unreal_report: [DiscardReason.TOO_LARGE_UNREAL_REPORT],
-  too_large_user_report: [DiscardReason.TOO_LARGE_USER_REPORT],
-  too_large_session: [DiscardReason.TOO_LARGE_SESSION],
-  too_large_sessions: [DiscardReason.TOO_LARGE_SESSIONS],
-  too_large_statsd: [DiscardReason.TOO_LARGE_STATSD],
-  too_large_metric_buckets: [DiscardReason.TOO_LARGE_METRIC_BUCKETS],
-  too_large_client_report: [DiscardReason.TOO_LARGE_CLIENT_REPORT],
-  too_large_profile: [DiscardReason.TOO_LARGE_PROFILE],
-  too_large_replay_event: [DiscardReason.TOO_LARGE_REPLAY_EVENT],
-  too_large_replay_recording: [DiscardReason.TOO_LARGE_REPLAY_RECORDING],
-  too_large_replay_video: [DiscardReason.TOO_LARGE_REPLAY_VIDEO],
-  too_large_check_in: [DiscardReason.TOO_LARGE_CHECK_IN],
-  too_large_otel_log: [DiscardReason.TOO_LARGE_OTEL_LOG],
-  too_large_log: [DiscardReason.TOO_LARGE_LOG],
-  too_large_span: [DiscardReason.TOO_LARGE_SPAN],
-  too_large_otel_span: [DiscardReason.TOO_LARGE_OTEL_SPAN],
-  too_large_otel_traces_data: [DiscardReason.TOO_LARGE_OTEL_TRACES_DATA],
-  too_large_user_report_v2: [DiscardReason.TOO_LARGE_USER_REPORT_V2],
-  too_large_profile_chunk: [DiscardReason.TOO_LARGE_PROFILE_CHUNK],
   minidump: [DiscardReason.MISSING_MINIDUMP_UPLOAD, DiscardReason.INVALID_MINIDUMP],
   security_report: [DiscardReason.SECURITY_REPORT, DiscardReason.SECURITY_REPORT_TYPE],
   unreal: [DiscardReason.PROCESS_UNREAL],
@@ -160,12 +106,21 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
   sampling: [DiscardReason.TRANSACTION_SAMPLED],
 };
 
-function getInvalidReasonGroupName(reason: DiscardReason): string {
+function getInvalidReasonGroupName(reason: string): string {
+  // The reason for too large will be of the form too_large:<reason> this we want to convert to too_large_reason
+  // unless the reason is unknown in which case we just want too_large
+  if (reason.startsWith('too_large:')) {
+    if (reason === 'too_large:unknown') {
+      return DiscardReason.TOO_LARGE;
+    }
+    return reason.replace(':', '_');
+  }
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
-    if (reasons.includes(reason)) {
+    if (reasons.includes(reason as DiscardReason)) {
       return group;
     }
   }
+
   return 'internal';
 }
 
@@ -214,7 +169,7 @@ function getClientDiscardReasonGroupName(reason: ClientDiscardReason): string {
 export function getReasonGroupName(outcome: string | number, reason: string): string {
   switch (outcome) {
     case Outcome.INVALID:
-      return getInvalidReasonGroupName(reason as DiscardReason);
+      return getInvalidReasonGroupName(reason);
     case Outcome.CARDINALITY_LIMITED:
     case Outcome.RATE_LIMITED:
     case Outcome.ABUSE:

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -108,16 +108,16 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
 
 function getInvalidReasonGroupName(reason: string): string {
   // The reason for 'too large' are of the from 'too_large:reason'
-  // We want to convert this to 'too_large:_reason' as we later apply
+  // We want to convert this to 'too_large_reason' as we later apply
   // the following logic to the reason: startCase(reason.replace(/-|_/g, ' '))
-  // That is, we want to 'too_large:attachment' to be displayed as
-  // 'Too Large: Attachment' in the UI. The one exception to that
+  // That is, we want to 'too_large: attachment' to be displayed as
+  // 'Too Large Attachment' in the UI. The one exception to that
   // is 'too_large:unknown' which should just be 'Too Large'
   if (reason.startsWith('too_large:')) {
     if (reason === 'too_large:unknown') {
       return DiscardReason.TOO_LARGE;
     }
-    return reason.replace('too_large:', 'too_large:_');
+    return reason.replace('too_large:', 'too_large_');
   }
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
     if (reasons.includes(reason as DiscardReason)) {

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -107,20 +107,23 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
 };
 
 function getInvalidReasonGroupName(reason: string): string {
-  // The reason for too large will be of the form too_large:<reason> this unless
-  // it is too_large:unknown in which case we just want too_large.
+  // The reason for 'too large' are of the from 'too_large:reason'
+  // We want to convert this to 'too_large:_reason' as we later apply
+  // the following logic to the reason: startCase(reason.replace(/-|_/g, ' '))
+  // That is, we want to 'too_large:attachment' to be displayed as
+  // 'Too Large: Attachment' in the UI. The one exception to that
+  // is 'too_large:unknown' which should just be 'Too Large'
   if (reason.startsWith('too_large:')) {
     if (reason === 'too_large:unknown') {
       return DiscardReason.TOO_LARGE;
     }
-    return reason.replace(':', ':_');
+    return reason.replace('too_large:', 'too_large:_');
   }
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
     if (reasons.includes(reason as DiscardReason)) {
       return group;
     }
   }
-
   return 'internal';
 }
 

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -107,13 +107,13 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
 };
 
 function getInvalidReasonGroupName(reason: string): string {
-  // The reason for too large will be of the form too_large:<reason> this we want to convert to too_large_reason
-  // unless the reason is unknown in which case we just want too_large
+  // The reason for too large will be of the form too_large:<reason> this unless
+  // it is too_large:unknown in which case we just want too_large.
   if (reason.startsWith('too_large:')) {
     if (reason === 'too_large:unknown') {
       return DiscardReason.TOO_LARGE;
     }
-    return reason.replace(':', '_');
+    return reason.replace(':', ':_');
   }
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
     if (reasons.includes(reason as DiscardReason)) {

--- a/static/app/views/organizationStats/utils.spec.tsx
+++ b/static/app/views/organizationStats/utils.spec.tsx
@@ -166,7 +166,7 @@ describe('formatUsageWithUnits', function () {
 
   it('Correctly groups invalid outcome reasons', function () {
     expect(getReasonGroupName('invalid', 'duplicate_item')).toBe('invalid_request');
-    expect(getReasonGroupName('invalid', 'too_large')).toBe('too_large');
+    expect(getReasonGroupName('invalid', 'too_large')).toBe('too_large_other');
     expect(getReasonGroupName('invalid', 'some_other_reason')).toBe('internal');
   });
 });


### PR DESCRIPTION
Had an extensive talk with @Dav1dde on how this can be done in the best way and we agreed on the following:
- We want to group some of the `too_large` reasons together in groups (as is already done in the code for other discard reasons) 
- Unless the `baseReason:subReason` is specifically whitelisted it should be displayed as `baseReason` to the user
- To not confuse users the catch all `Too Large` should be `Too Large Other`

This PR makes the necessary changes for this and updates the tests to for this new behaviour.
(**Note** This will change the UI from `Too Large` to `Too Large Other` for legacy 'too_large' outcomes.)