### PR TITLE
ref(dashboards): Add more explicit typing to some `TimeSeries`

### DIFF
--- a/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
+++ b/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
@@ -1,10 +1,11 @@
 import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 import {scaleTimeSeriesData} from './scaleTimeSeriesData';
 
 describe('scaleTimeSeriesData', () => {
   describe('does not scale unscalable types', () => {
-    const timeSeries = {
+    const timeSeries: TimeSeries = {
       field: 'user',
       data: [
         {
@@ -27,7 +28,7 @@ describe('scaleTimeSeriesData', () => {
   });
 
   it('does not scale duration units from second to gigabyte', () => {
-    const timeSeries = {
+    const timeSeries: TimeSeries = {
       field: 'transaction.duration',
       data: [
         {
@@ -45,7 +46,7 @@ describe('scaleTimeSeriesData', () => {
   });
 
   it('scales duration units from second to millisecond', () => {
-    const timeSeries = {
+    const timeSeries: TimeSeries = {
       field: 'transaction.duration',
       data: [
         {
@@ -75,7 +76,7 @@ describe('scaleTimeSeriesData', () => {
   });
 
   it('scales size units from mebibyte to byte', () => {
-    const timeSeries = {
+    const timeSeries: TimeSeries = {
       field: 'file.size',
       data: [
         {

--- a/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
+++ b/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
@@ -1,5 +1,7 @@
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+
 import {DurationUnit} from '../discover/fields';
 
 import {splitSeriesIntoCompleteAndIncomplete} from './splitSeriesIntoCompleteAndIncomplete';
@@ -14,7 +16,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
   });
 
   it('Does not split a series with all complete data', () => {
-    const serie = {
+    const serie: TimeSeries = {
       field: 'p99(span.duration)',
       data: [
         {
@@ -60,7 +62,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
   });
 
   it('Does not split a series with all incomplete data', () => {
-    const serie = {
+    const serie: TimeSeries = {
       field: 'p99(span.duration)',
       data: [
         {
@@ -114,7 +116,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
   });
 
   it('Splits a series with partial incomplete data', () => {
-    const serie = {
+    const serie: TimeSeries = {
       field: 'p99(span.duration)',
       data: [
         {
@@ -183,7 +185,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
   it('Splits a series with long buckets', () => {
     // The time buckets are an hour long. The ingestion delay is 90s. The last buckets should be marked incomplete.
 
-    const serie = {
+    const serie: TimeSeries = {
       field: 'p99(span.duration)',
       data: [
         {

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
@@ -9,6 +9,8 @@ import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 
+import type {Meta} from '../common/types';
+
 import {BigNumberWidgetVisualization} from './bigNumberWidgetVisualization';
 
 export default storyBook('BigNumberWidgetVisualization', story => {
@@ -219,7 +221,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
   });
 
   story('Thresholds', () => {
-    const meta = {
+    const meta: Meta = {
       type: 'rate',
       unit: RateUnit.PER_SECOND,
     };

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
@@ -1,6 +1,8 @@
 import {DurationUnit} from 'sentry/utils/discover/fields';
 
-export const sampleDurationTimeSeries = {
+import {TimeSeries} from '../../common/types';
+
+export const sampleDurationTimeSeries: TimeSeries = {
   field: 'p99(span.duration)',
   meta: {
     type: 'duration',

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
@@ -1,6 +1,8 @@
 import {RateUnit} from 'sentry/utils/discover/fields';
 
-export const sampleThroughputTimeSeries = {
+import {TimeSeries} from '../../common/types';
+
+export const sampleThroughputTimeSeries: TimeSeries = {
   field: 'eps()',
   meta: {
     type: 'rate',

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -32,7 +32,7 @@ const sampleDurationTimeSeries2 = {
   data: sampleDurationTimeSeries.data.map(datum => {
     return {
       ...datum,
-      value: datum.value * 0.3 + 30 * Math.random(),
+      value: datum.value ? datum.value * 0.3 + 30 * Math.random() : null,
     };
   }),
 };
@@ -257,12 +257,12 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     const millisecondsSeries = sampleDurationTimeSeries;
 
     // Create a very similar series, but with a different unit to demonstrate automatic scaling
-    const secondsSeries = {
+    const secondsSeries: TimeSeries = {
       field: 'p99(span.self_time)',
       data: sampleDurationTimeSeries.data.map(datum => {
         return {
           ...datum,
-          value: (datum.value / 1000) * (1 + Math.random() / 10), // Introduce jitter so the series is visible
+          value: datum.value ? (datum.value / 1000) * (1 + Math.random() / 10) : null, // Introduce jitter so the series is visible
         };
       }),
       meta: {
@@ -375,7 +375,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
   story('Color', () => {
     const theme = useTheme();
 
-    const timeSeries = {
+    const timeSeries: TimeSeries = {
       ...sampleThroughputTimeSeries,
       field: 'error_rate()',
       meta: {


### PR DESCRIPTION
A little cleanup. This makes type checking more pleasant, because if the data becomes invalid at any point, the error will point directly to where the data is created, rather to where it was used. I peeled this off another PR I'm working on.
