### PR TITLE
fix(relocation) Handle miscased emails better

### DIFF
--- a/src/sentry/users/models/email.py
+++ b/src/sentry/users/models/email.py
@@ -38,10 +38,14 @@ class Email(Model):
 
         # `Sentry.Email` models don't have any explicit dependencies on `Sentry.User`, so we need to
         # find them manually via `UserEmail`.
-        emails = UserEmail.objects.filter(
-            user_id__in=pk_map.get_pks(get_model_name(User))
-        ).values_list("email", flat=True)
+        emails = (
+            UserEmail.objects.filter(user_id__in=pk_map.get_pks(get_model_name(User)))
+            .annotate(email_lower=models.Func(models.F("email"), function="LOWER"))
+            .values_list("email_lower", flat=True)
+        )
 
+        # Use case-insensitive matching as useremail and email are case-insensitive
+        # This doesn't handle upper case Email records, with lowercase Useremail records.
         return q & models.Q(email__in=emails)
 
     def write_relocation_import(


### PR DESCRIPTION
We have a relocation stuck because casing of email addresseses differs between `sentry_email` and `sentry_useremail`. This delta can occur if a useremail is first created with one casing, and then updated to another casing. Because `sentry_email` records are only updated on create/delete email values can diverge.
