### PR TITLE
fix(aci): ignore conflicts when bulk creating action group statuses

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -78,6 +78,7 @@ def filter_recently_fired_workflow_actions(
             for action in actions_without_statuses
         ],
         batch_size=1000,
+        ignore_conflicts=True,
     )
 
     actions_without_statuses_ids = {action.id for action in actions_without_statuses}


### PR DESCRIPTION
Resolves https://sentry.sentry.io/issues/6421507139/

`RuleProcessor` uses `ignore_conflicts=True`

https://github.com/getsentry/sentry/blob/b56df0101ce7e53912c2f77da73be6b247b199ba/src/sentry/rules/processing/processor.py#L115-L123