### PR TITLE
chore(fe): Convert `<ExternalIssueForm />` to an FC

### DIFF
--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -18,6 +18,7 @@ import FormModel from 'sentry/components/forms/model';
 import {tct} from 'sentry/locale';
 import type {Choices, SelectValue} from 'sentry/types/core';
 import type {IntegrationIssueConfig, IssueConfigField} from 'sentry/types/integrations';
+import {defined} from 'sentry/utils';
 import type {FormField} from 'sentry/views/alerts/rules/issue/ruleNode';
 
 export type ExternalIssueAction = 'create' | 'link';
@@ -89,8 +90,9 @@ export default class AbstractExternalIssueForm<
   ): {[key: string]: FieldValue | null} => {
     return getDynamicFields({
       action: this.state.action,
-      paramConfig: integrationDetailsParam,
-      stateConfig: this.state.integrationDetails,
+      integrationDetails: defined(integrationDetailsParam)
+        ? integrationDetailsParam
+        : this.state.integrationDetails,
     });
   };
 

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -1,18 +1,43 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {Span} from '@sentry/core';
 import * as Sentry from '@sentry/react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import type DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import type {RequestOptions, ResponseMeta} from 'sentry/api';
 import type {ExternalIssueAction} from 'sentry/components/externalIssues/abstractExternalIssueForm';
-import AbstractExternalIssueForm from 'sentry/components/externalIssues/abstractExternalIssueForm';
-import type {FormProps} from 'sentry/components/forms/form';
+import {ExternalForm} from 'sentry/components/externalIssues/externalForm';
+import {useAsyncOptionsCache} from 'sentry/components/externalIssues/useAsyncOptionsCache';
+import {
+  getConfigName,
+  getDynamicFields,
+  getFieldProps,
+  getOptions,
+  loadAsyncThenFetchAllFields,
+} from 'sentry/components/externalIssues/utils';
+import type {FieldValue} from 'sentry/components/forms/model';
+import FormModel from 'sentry/components/forms/model';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NavTabs from 'sentry/components/navTabs';
 import {t, tct} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import type {Integration, IntegrationExternalIssue} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
+import type {
+  Integration,
+  IntegrationExternalIssue,
+  IntegrationIssueConfig,
+  IssueConfigField,
+} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
+import {
+  type ApiQueryKey,
+  setApiQueryData,
+  useApiQuery,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 
 const MESSAGES_BY_ACTION = {
   link: t('Successfully linked issue.'),
@@ -24,145 +49,286 @@ const SUBMIT_LABEL_BY_ACTION = {
   create: t('Create Issue'),
 };
 
-type Props = {
+interface ExternalIssueFormProps extends ModalRenderProps {
   group: Group;
   integration: Integration;
   onChange: (onSuccess?: () => void, onError?: () => void) => void;
-  organization: Organization;
-} & AbstractExternalIssueForm['props'];
+}
 
-type State = AbstractExternalIssueForm['state'];
+function makeIntegrationIssueConfigQueryKey({
+  orgSlug,
+  groupId,
+  integrationId,
+  action,
+}: {
+  groupId: string;
+  integrationId: string;
+  orgSlug: string;
+  action?: ExternalIssueAction;
+}): ApiQueryKey {
+  return [
+    `/organizations/${orgSlug}/issues/${groupId}/integrations/${integrationId}/`,
+    {query: {action}},
+  ];
+}
 
-export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, State> {
-  loadSpan: Span | undefined;
-  submitSpan: Span | undefined;
-  trackedLoadStatus = false;
+export default function ExternalIssueForm({
+  group,
+  integration,
+  onChange,
+  closeModal,
+  Header,
+  Body,
+}: ExternalIssueFormProps) {
+  const api = useApi();
+  const modelRef = useRef(new FormModel());
+  const organization = useOrganization();
+  const endpointString = makeIntegrationIssueConfigQueryKey({
+    orgSlug: organization.slug,
+    groupId: group.id,
+    integrationId: integration.id,
+  })[0];
+  const queryClient = useQueryClient();
+  const title = tct('[integration] Issue', {integration: integration.provider.name});
 
-  constructor(props: any) {
-    super(props);
-    this.loadSpan = this.startSpan('load');
-  }
+  const [hasTrackedLoad, setHasTrackedLoad] = useState(false);
+  const [loadSpan, setLoadSpan] = useState<Span | null>(null);
+  const [submitSpan, setSubmitSpan] = useState<Span | null>(null);
+  const [action, setAction] = useState<ExternalIssueAction>('create');
+  const {cache, updateCache} = useAsyncOptionsCache();
+  const [isDynamicallyRefetching, setIsDynamicallyRefetching] = useState(false);
 
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const query: {action?: ExternalIssueAction} = {};
-    if (this.state?.hasOwnProperty('action')) {
-      query.action = this.state.action;
+  const {
+    data: integrationDetails,
+    error,
+    refetch,
+    isPending,
+    isError,
+  } = useApiQuery<IntegrationIssueConfig>(
+    makeIntegrationIssueConfigQueryKey({
+      orgSlug: organization.slug,
+      groupId: group.id,
+      integrationId: integration.id,
+      action,
+    }),
+    {
+      staleTime: Infinity,
+      retry: false,
     }
-    return [['integrationDetails', this.getEndPointString(), {query}]];
-  }
+  );
 
-  handleClick = (action: ExternalIssueAction) => {
-    this.setState({action}, () => this.reloadData());
-  };
+  const dynamicFieldValues = useMemo(
+    () => getDynamicFields({action, integrationDetails}),
+    [action, integrationDetails]
+  );
 
-  startSpan = (type: 'load' | 'submit') => {
-    const {group, integration} = this.props;
-    const {action} = this.state;
-
-    const span = Sentry.withScope(scope => {
-      scope.setTag('issueAction', action);
-      scope.setTag('groupID', group.id);
-      scope.setTag('projectID', group.project.id);
-      scope.setTag('integrationSlug', integration.provider.slug);
-      scope.setTag('integrationType', 'firstParty');
-
-      return Sentry.startInactiveSpan({
-        name: `externalIssueForm.${type}`,
-        forceTransaction: true,
-      });
-    });
-
-    return span;
-  };
-
-  handlePreSubmit = () => {
-    this.submitSpan = this.startSpan('submit');
-  };
-
-  onSubmitSuccess = (_data: IntegrationExternalIssue): void => {
-    const {onChange, closeModal} = this.props;
-    const {action} = this.state;
-
-    trackAnalytics('issue_details.external_issue_created', {
-      organization: this.props.organization,
-      ...getAnalyticsDataForGroup(this.props.group),
-      external_issue_provider: this.props.integration.provider.key,
-      external_issue_type: 'first_party',
-    });
-
-    onChange(() => addSuccessMessage(MESSAGES_BY_ACTION[action]));
-    closeModal();
-
-    this.submitSpan?.end();
-  };
-
-  handleSubmitError = () => {
-    this.submitSpan?.end();
-  };
-
-  trackLoadStatus = (success: boolean) => {
-    if (this.trackedLoadStatus) {
-      return;
-    }
-
-    this.trackedLoadStatus = true;
-    trackAnalytics('issue_details.external_issue_loaded', {
-      organization: this.props.organization,
-      ...getAnalyticsDataForGroup(this.props.group),
-      external_issue_provider: this.props.integration.provider.key,
-      external_issue_type: 'first_party',
-      success,
-    });
-  };
-
-  onLoadAllEndpointsSuccess = () => {
-    this.loadSpan?.end();
-    this.trackLoadStatus(true);
-  };
-
-  onRequestError = () => {
-    this.loadSpan?.end();
-    this.trackLoadStatus(false);
-  };
-
-  getEndPointString() {
-    const {group, integration, organization} = this.props;
-    return `/organizations/${organization.slug}/issues/${group.id}/integrations/${integration.id}/`;
-  }
-
-  getTitle = () => {
-    const {integration} = this.props;
-    return tct('[integration] Issue', {integration: integration.provider.name});
-  };
-
-  getFormProps = (): FormProps => {
-    const {action} = this.state;
-    return {
-      ...this.getDefaultFormProps(),
-      submitLabel: SUBMIT_LABEL_BY_ACTION[action],
-      apiEndpoint: this.getEndPointString(),
-      apiMethod: action === 'create' ? 'POST' : 'PUT',
-      onPreSubmit: this.handlePreSubmit,
-      onSubmitError: this.handleSubmitError,
-      onSubmitSuccess: this.onSubmitSuccess,
+  /**
+   * XXX: This function seems illegal but it's necessary.
+   * The `dynamicFieldValues` are derived from the intial config fetch, see `getDynamicFields`.
+   * It starts as an object, with keys of certain field names, and empty values.
+   * As the user updates the values, those dynamic fields require a refetch of the config, with what
+   * the user entered as a query param. Since we can't conditionally call hooks, we have to avoid
+   * `useApiQuery`, and instead manually call the api, and update the cache ourselves.
+   */
+  const refetchWithDynamicFields = useCallback(() => {
+    setIsDynamicallyRefetching(true);
+    const requestOptions: RequestOptions = {
+      method: 'GET',
+      query: {action, ...dynamicFieldValues},
+      success: (
+        data: IntegrationIssueConfig,
+        _textStatus: string | undefined,
+        _responseMeta: ResponseMeta | undefined
+      ) => {
+        setApiQueryData(
+          queryClient,
+          makeIntegrationIssueConfigQueryKey({
+            orgSlug: organization.slug,
+            groupId: group.id,
+            integrationId: integration.id,
+            action,
+          }),
+          existingData => (data ? data : existingData)
+        );
+        setIsDynamicallyRefetching(false);
+      },
+      error: (err: any) => {
+        // This behavior comes from the DeprecatedAsyncComponent
+        if (err?.responseText) {
+          Sentry.addBreadcrumb({
+            message: err.responseText,
+            category: 'xhr',
+            level: 'error',
+          });
+        }
+        setIsDynamicallyRefetching(false);
+      },
     };
-  };
+    return api.request(endpointString, requestOptions);
+  }, [
+    action,
+    dynamicFieldValues,
+    queryClient,
+    organization.slug,
+    group.id,
+    integration.id,
+    api,
+    endpointString,
+  ]);
 
-  renderNavTabs = () => {
-    const {action} = this.state;
-    return (
-      <NavTabs underlined>
-        <li className={action === 'create' ? 'active' : ''}>
-          <a onClick={() => this.handleClick('create')}>{t('Create')}</a>
-        </li>
-        <li className={action === 'link' ? 'active' : ''}>
-          <a onClick={() => this.handleClick('link')}>{t('Link')}</a>
-        </li>
-      </NavTabs>
-    );
-  };
+  const startSpan = useCallback(
+    (type: 'load' | 'submit') => {
+      return Sentry.withScope(scope => {
+        scope.setTag('issueAction', action);
+        scope.setTag('groupID', group.id);
+        scope.setTag('projectID', group.project.id);
+        scope.setTag('integrationSlug', integration.provider.slug);
+        scope.setTag('integrationType', 'firstParty');
+        return Sentry.startInactiveSpan({
+          name: `externalIssueForm.${type}`,
+          forceTransaction: true,
+        });
+      });
+    },
+    [action, group.id, group.project.id, integration.provider.slug]
+  );
 
-  renderBody() {
-    return this.renderForm(this.loadAsyncThenFetchAllFields());
+  // Start the span for the load request
+  useEffect(() => {
+    const span = startSpan('load');
+    setLoadSpan(span);
+    return () => {
+      span?.end();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // End the span for the load request
+  useEffect(() => {
+    if (!isPending && !hasTrackedLoad) {
+      loadSpan?.end();
+      trackAnalytics('issue_details.external_issue_loaded', {
+        organization,
+        ...getAnalyticsDataForGroup(group),
+        external_issue_provider: integration.provider.key,
+        external_issue_type: 'first_party',
+        success: !isError,
+      });
+      setHasTrackedLoad(true);
+    }
+  }, [isPending, isError, loadSpan, organization, group, integration, hasTrackedLoad]);
+
+  const handleClick = useCallback(
+    (newAction: ExternalIssueAction) => {
+      setAction(newAction);
+      refetch();
+    },
+    [refetch]
+  );
+
+  const handlePreSubmit = useCallback(() => {
+    setSubmitSpan(startSpan('submit'));
+  }, [startSpan]);
+
+  const handleSubmitError = useCallback(() => {
+    submitSpan?.end();
+  }, [submitSpan]);
+
+  const handleSubmitSuccess = useCallback(
+    (_data: IntegrationExternalIssue) => {
+      trackAnalytics('issue_details.external_issue_created', {
+        organization,
+        ...getAnalyticsDataForGroup(group),
+        external_issue_provider: integration.provider.key,
+        external_issue_type: 'first_party',
+      });
+      onChange(() => addSuccessMessage(MESSAGES_BY_ACTION[action]));
+      closeModal();
+      submitSpan?.end();
+    },
+    [organization, group, integration, submitSpan, action, closeModal, onChange]
+  );
+
+  const onFieldChange = useCallback(
+    (fieldName: string, _value: FieldValue) => {
+      if (dynamicFieldValues.hasOwnProperty(fieldName)) {
+        refetchWithDynamicFields();
+      }
+    },
+    [refetchWithDynamicFields, dynamicFieldValues]
+  );
+
+  const getExternalIssueFieldProps = useCallback(
+    (field: IssueConfigField) => {
+      return getFieldProps({
+        field,
+        loadOptions: (input: string) =>
+          getOptions({
+            field,
+            input,
+            model: modelRef.current,
+            successCallback: updateCache,
+          }),
+      });
+    },
+    [updateCache]
+  );
+
+  const formFields = useMemo(() => {
+    if (!integrationDetails) {
+      return [];
+    }
+    return loadAsyncThenFetchAllFields({
+      configName: getConfigName(action),
+      integrationDetails,
+      fetchedFieldOptionsCache: cache,
+    });
+  }, [integrationDetails, action, cache]);
+
+  if (isPending) {
+    return <LoadingIndicator />;
   }
+
+  if (isError) {
+    const errorDetail = error?.responseJSON?.detail;
+    const errorMessage =
+      typeof errorDetail === 'string'
+        ? errorDetail
+        : t('An error occurred loading the issue form');
+    return <LoadingError message={errorMessage} />;
+  }
+
+  return (
+    <ExternalForm
+      Header={Header}
+      Body={Body}
+      formFields={formFields}
+      isLoading={isPending || isDynamicallyRefetching}
+      formProps={{
+        footerClass: 'modal-footer',
+        onFieldChange,
+        submitDisabled: isPending,
+        model: modelRef.current,
+        submitLabel: SUBMIT_LABEL_BY_ACTION[action],
+        apiEndpoint: endpointString,
+        apiMethod: action === 'create' ? 'POST' : 'PUT',
+        onPreSubmit: handlePreSubmit,
+        onSubmitError: handleSubmitError,
+        onSubmitSuccess: handleSubmitSuccess,
+      }}
+      title={title}
+      navTabs={
+        <NavTabs underlined>
+          <li className={action === 'create' ? 'active' : ''}>
+            <a onClick={() => handleClick('create')}>{t('Create')}</a>
+          </li>
+          <li className={action === 'link' ? 'active' : ''}>
+            <a onClick={() => handleClick('link')}>{t('Link')}</a>
+          </li>
+        </NavTabs>
+      }
+      bodyText={null}
+      getFieldProps={getExternalIssueFieldProps}
+    />
+  );
 }

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {Span} from '@sentry/core';
 import * as Sentry from '@sentry/react';
 
@@ -82,7 +82,7 @@ export default function ExternalIssueForm({
   Body,
 }: ExternalIssueFormProps) {
   const api = useApi({persistInFlight: true});
-  const modelRef = useRef(new FormModel());
+  const [model] = useState(() => new FormModel());
   const organization = useOrganization();
   const endpointString = makeIntegrationIssueConfigQueryKey({
     orgSlug: organization.slug,
@@ -268,12 +268,12 @@ export default function ExternalIssueForm({
             field,
             input,
             dynamicFieldValues,
-            model: modelRef.current,
+            model,
             successCallback: updateCache,
           }),
       });
     },
-    [updateCache, dynamicFieldValues]
+    [updateCache, dynamicFieldValues, model]
   );
 
   const formFields = useMemo(() => {
@@ -320,10 +320,10 @@ export default function ExternalIssueForm({
       isLoading={isPending || isDynamicallyRefetching}
       formProps={{
         initialData,
-        footerClass: 'modal-footer',
         onFieldChange,
+        model,
+        footerClass: 'modal-footer',
         submitDisabled: isPending || hasFormErrors,
-        model: modelRef.current,
         submitLabel: SUBMIT_LABEL_BY_ACTION[action],
         apiEndpoint: endpointString,
         apiMethod: action === 'create' ? 'POST' : 'PUT',

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -81,7 +81,7 @@ export default function ExternalIssueForm({
   Header,
   Body,
 }: ExternalIssueFormProps) {
-  const api = useApi();
+  const api = useApi({persistInFlight: true});
   const modelRef = useRef(new FormModel());
   const organization = useOrganization();
   const endpointString = makeIntegrationIssueConfigQueryKey({

--- a/static/app/components/externalIssues/useAsyncOptionsCache.tsx
+++ b/static/app/components/externalIssues/useAsyncOptionsCache.tsx
@@ -1,0 +1,30 @@
+import {useCallback, useState} from 'react';
+
+import type {Choices, SelectValue} from 'sentry/types/core';
+import type {IssueConfigField} from 'sentry/types/integrations';
+
+/**
+ * Manages state cache of options fetched for async fields.
+ * This is used to avoid fetching the same options multiple times.
+ */
+export function useAsyncOptionsCache() {
+  const [asyncOptions, setAsyncOptions] = useState<Record<string, Choices>>({});
+
+  const updateCache = useCallback(
+    ({
+      field,
+      result,
+    }: {
+      field: IssueConfigField;
+      result: Array<SelectValue<string | number>>;
+    }) => {
+      setAsyncOptions({
+        ...asyncOptions,
+        [field.name]: result.map(obj => [obj.value, obj.label]) as Choices,
+      });
+    },
+    [asyncOptions]
+  );
+
+  return {cache: asyncOptions, updateCache};
+}

--- a/static/app/components/externalIssues/utils.tsx
+++ b/static/app/components/externalIssues/utils.tsx
@@ -84,14 +84,14 @@ export function getOptions({
   field,
   input,
   model,
-  dynamicFieldValues,
   successCallback,
+  dynamicFieldValues = {},
 }: {
-  dynamicFieldValues: Record<string, FieldValue | null>;
   field: IssueConfigField;
   input: string;
   model: FormModel;
-  successCallback: ({
+  dynamicFieldValues?: Record<string, FieldValue | null>;
+  successCallback?: ({
     field,
     result,
   }: {
@@ -111,11 +111,11 @@ export function getOptions({
           reject(err);
         } else {
           result = ensureCurrentOption({field, result, model});
-          successCallback({field, result});
+          successCallback?.({field, result});
           resolve(result);
         }
       },
-      dynamicFieldValues: dynamicFieldValues || {},
+      dynamicFieldValues,
     });
   });
 }
@@ -133,22 +133,18 @@ export function getDefaultOptions({
 
 /**
  * Convert IntegrationIssueConfig to an object that maps field names to the
- * values of fields where `updatesFrom` is true. The paramConfig will be
- * preferred over stateConfig.
+ * values of fields where `updatesFrom` is true.
  * @returns Object of field names to values.
  */
 export function getDynamicFields({
   action,
-  paramConfig,
-  stateConfig,
+  integrationDetails,
 }: {
   action: ExternalIssueAction;
-  paramConfig?: IntegrationIssueConfig;
-  stateConfig?: IntegrationIssueConfig | null;
+  integrationDetails: IntegrationIssueConfig | null;
 }): {
   [key: string]: FieldValue | null;
 } {
-  const integrationDetails = paramConfig || stateConfig;
   const config = integrationDetails?.[getConfigName(action)];
   return Object.fromEntries(
     (config || [])

--- a/static/app/components/externalIssues/utils.tsx
+++ b/static/app/components/externalIssues/utils.tsx
@@ -141,7 +141,7 @@ export function getDynamicFields({
   integrationDetails,
 }: {
   action: ExternalIssueAction;
-  integrationDetails: IntegrationIssueConfig | null;
+  integrationDetails?: IntegrationIssueConfig | null;
 }): {
   [key: string]: FieldValue | null;
 } {

--- a/static/app/components/externalIssues/utils.tsx
+++ b/static/app/components/externalIssues/utils.tsx
@@ -133,7 +133,7 @@ export function getDefaultOptions({
 
 /**
  * Convert IntegrationIssueConfig to an object that maps field names to the
- * values of fields where `updatesFrom` is true.
+ * values of fields where `updatesForm` is true.
  * @returns Object of field names to values.
  */
 export function getDynamicFields({


### PR DESCRIPTION
Using the utils from https://github.com/getsentry/sentry/pull/87021 plus l added `useAsyncOptionsCache` since it'd help manage the caching state for these async fields. Also edited those utilities a bit to avoid passing in dummy data for fields that don't apply.

ref: https://github.com/getsentry/frontend-tsc/issues/2 👍 