### PR TITLE
fix: Dedupe keys in tags list

### DIFF
--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -53,6 +53,7 @@ export function ColumnEditorModal({
             value: column,
             textValue: column,
             trailingItems: <TypeBadge kind={classifyTagKey(column)} />,
+            key: `${column}-${classifyTagKey(column)}`,
           };
         }),
       ...Object.values(stringTags).map(tag => {
@@ -61,6 +62,7 @@ export function ColumnEditorModal({
           value: tag.key,
           textValue: tag.name,
           trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+          key: `${tag.key}-${FieldKind.TAG}`,
         };
       }),
       ...Object.values(numberTags).map(tag => {
@@ -69,6 +71,7 @@ export function ColumnEditorModal({
           value: tag.key,
           textValue: tag.name,
           trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+          key: `${tag.key}-${FieldKind.MEASUREMENT}`,
         };
       }),
     ];


### PR DESCRIPTION
We were getting back string and numeric tags with the same tag key value,
keys are inferred using the value if not explicitly provided. When the same
value appears in string and numeric tags, it causes rendering issues. Updated
the key to take in field type to make the render keys unique.

Before
![Screenshot 2025-03-18 at 12 46 01 PM](https://github.com/user-attachments/assets/e43ff7ba-3a57-48f0-ae0f-e11b052e5fc7)

After
![Screenshot 2025-03-18 at 12 48 06 PM](https://github.com/user-attachments/assets/4e16234d-17a8-4d71-82c9-a28037d97158)
