### PR TITLE
chore(anomaly detection): Downgrade logger.error to logger.info

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -92,7 +92,7 @@ def get_anomaly_data_from_seer(
         return None
 
     if response.status > 400:
-        logger.error(
+        logger.info(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "response_data": response.data,
@@ -129,7 +129,7 @@ def get_anomaly_data_from_seer(
         return None
 
     if not results.get("success"):
-        logger.error(
+        logger.info(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "error_message": results.get("message", ""),

--- a/tests/sentry/api/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/api/endpoints/test_organization_events_anomalies.py
@@ -265,7 +265,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             )
 
         assert mock_seer_request.call_count == 1
-        mock_logger.error.assert_called_with(
+        mock_logger.info.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "response_data": "Bad stuff",
@@ -301,7 +301,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             )
 
         assert mock_seer_request.call_count == 1
-        mock_logger.error.assert_called_with(
+        mock_logger.info.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "response_data": "I have revolted against my human overlords",

--- a/tests/sentry/api/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/api/endpoints/test_organization_events_anomalies.py
@@ -265,7 +265,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             )
 
         assert mock_seer_request.call_count == 1
-        mock_logger.info.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "response_data": "Bad stuff",
@@ -301,7 +301,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             )
 
         assert mock_seer_request.call_count == 1
-        mock_logger.info.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "response_data": "I have revolted against my human overlords",

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -973,7 +973,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             last_update=processor.last_update.timestamp(),
             aggregation_value=10,
         )
-        mock_logger.error.assert_called_with(
+        mock_logger.info.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
                 "subscription_id": self.sub.id,


### PR DESCRIPTION
Downgrading this `logger.error` to a `logger.info` as they're all caused by Seer not having enough data points. Closes https://sentry.sentry.io/issues/5859668374