### PR TITLE
feat(explore): Adds save query UI to explore

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -4,6 +4,7 @@ import type {ModalTypes} from 'sentry/components/globalModal';
 import type {CreateNewIntegrationModalOptions} from 'sentry/components/modals/createNewIntegrationModal';
 import type {CreateReleaseIntegrationModalOptions} from 'sentry/components/modals/createReleaseIntegrationModal';
 import type {DashboardWidgetQuerySelectorModalOptions} from 'sentry/components/modals/dashboardWidgetQuerySelectorModal';
+import type {SaveQueryModalProps} from 'sentry/components/modals/explore/saveQueryModal';
 import type {ImportDashboardFromFileModalProps} from 'sentry/components/modals/importDashboardFromFileModal';
 import type {InsightChartModalOptions} from 'sentry/components/modals/insightChartModal';
 import type {InviteRow} from 'sentry/components/modals/inviteMembersModal/types';
@@ -394,6 +395,13 @@ export async function openAddTempestCredentialsModal(options: {
   project: Project;
 }) {
   const mod = await import('sentry/components/modals/addTempestCredentialsModal');
+  const {default: Modal} = mod;
+
+  openModal(deps => <Modal {...deps} {...options} />);
+}
+
+export async function openSaveQueryModal(options: SaveQueryModalProps) {
+  const mod = await import('sentry/components/modals/explore/saveQueryModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);

--- a/static/app/components/modals/explore/saveQueryModal.spec.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.spec.tsx
@@ -1,0 +1,78 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import SaveQueryModal from 'sentry/components/modals/explore/saveQueryModal';
+
+const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
+
+describe('SaveQueryModal', function () {
+  let initialData!: ReturnType<typeof initializeOrg>;
+
+  beforeEach(() => {
+    initialData = initializeOrg();
+  });
+
+  it('should render', function () {
+    const saveQuery = jest.fn();
+    render(
+      <SaveQueryModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => {}}
+        organization={initialData.organization}
+        query={'span.op:pageload'}
+        visualizes={[
+          {
+            chartType: 1,
+            yAxes: ['avg(span.duration)'],
+            label: 'A',
+          },
+        ]}
+        groupBys={['span.op']}
+        saveQuery={saveQuery}
+      />
+    );
+
+    expect(screen.getByText('Create a New Query')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Filter')).toBeInTheDocument();
+    expect(screen.getByText('pageload')).toBeInTheDocument();
+    expect(screen.getByText('Visualize')).toBeInTheDocument();
+    expect(screen.getByText('avg(span.duration)')).toBeInTheDocument();
+    expect(screen.getByText('Group By')).toBeInTheDocument();
+    expect(screen.getAllByText('span.op')).toHaveLength(2);
+  });
+
+  it('should call saveQuery', async function () {
+    const saveQuery = jest.fn();
+    render(
+      <SaveQueryModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => {}}
+        organization={initialData.organization}
+        query={'span.op:pageload'}
+        visualizes={[
+          {
+            chartType: 1,
+            yAxes: ['avg(span.duration)'],
+            label: 'A',
+          },
+        ]}
+        groupBys={[]}
+        saveQuery={saveQuery}
+      />
+    );
+
+    await userEvent.type(screen.getByTitle('Enter a name for your saved query'), 'test');
+
+    await userEvent.click(screen.getByLabelText('Create a New Query'));
+
+    await waitFor(() => expect(saveQuery).toHaveBeenCalled());
+  });
+});

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -172,19 +172,18 @@ const ExploreParamSection = styled('span')`
   display: flex;
   flex-direction: row;
   gap: ${space(0.5)};
-  align-items: center;
+  overflow: hidden;
 `;
 
 const ExploreParamTitle = styled('span')`
   font-size: ${p => p.theme.form.sm.fontSize};
   color: ${p => p.theme.gray300};
+  white-space: nowrap;
+  padding-top: 3px;
 `;
 
 const ExploreVisualizes = styled('span')`
   font-size: ${p => p.theme.form.sm.fontSize};
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
   background: ${p => p.theme.background};
   padding: ${space(0.25)} ${space(0.5)};
   border: 1px solid ${p => p.theme.innerBorder};
@@ -192,6 +191,7 @@ const ExploreVisualizes = styled('span')`
   height: 24px;
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const ExploreGroupBys = ExploreVisualizes;

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -98,7 +98,11 @@ function SaveQueryModal({
           <ExploreParamsContainer>
             <ExploreParamSection>
               <ExploreParamTitle>{t('Visualize')}</ExploreParamTitle>
-              <ExploreVisualizes>{yAxes.join(', ')}</ExploreVisualizes>
+              <ExploreParamSection>
+                {yAxes.map(yAxis => (
+                  <ExploreVisualizes key={yAxis}>{yAxis}</ExploreVisualizes>
+                ))}
+              </ExploreParamSection>
             </ExploreParamSection>
             {query && (
               <ExploreParamSection>
@@ -111,7 +115,11 @@ function SaveQueryModal({
             {groupBys && groupBys.length > 0 && (
               <ExploreParamSection>
                 <ExploreParamTitle>{t('Group By')}</ExploreParamTitle>
-                <ExploreGroupBys>{groupBys.join(', ')}</ExploreGroupBys>
+                <ExploreParamSection>
+                  {groupBys.map(groupBy => (
+                    <ExploreGroupBys key={groupBy}>{groupBy}</ExploreGroupBys>
+                  ))}
+                </ExploreParamSection>
               </ExploreParamSection>
             )}
             <ExploreParamSection>...</ExploreParamSection>
@@ -173,6 +181,7 @@ const ExploreParamSection = styled('span')`
   flex-direction: row;
   gap: ${space(0.5)};
   overflow: hidden;
+  flex-wrap: wrap;
 `;
 
 const ExploreParamTitle = styled('span')`
@@ -189,8 +198,8 @@ const ExploreVisualizes = styled('span')`
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   height: 24px;
-  white-space: nowrap;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
 `;
 

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -1,0 +1,201 @@
+import {Fragment, useCallback, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import ButtonBar from 'sentry/components/buttonBar';
+import {Button} from 'sentry/components/core/button';
+import {Input} from 'sentry/components/core/input';
+import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization, SavedQuery} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
+import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+
+export type SaveQueryModalProps = {
+  organization: Organization;
+  query: string;
+  saveQuery: (name: string) => Promise<SavedQuery>;
+  visualizes: Visualize[];
+  groupBys?: string[]; // This needs to be passed in because saveQuery relies on being within the Explore PageParamsContext to fetch params
+};
+
+type Props = ModalRenderProps & SaveQueryModalProps;
+
+function SaveQueryModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  groupBys,
+  query,
+  visualizes,
+  saveQuery,
+}: Props) {
+  const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
+
+  const organization = useOrganization();
+
+  const [name, setName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const setExplorePageParams = useSetExplorePageParams();
+
+  const updatePageIdAndTitle = useCallback(
+    (id: string, title: string) => {
+      setExplorePageParams({id, title});
+    },
+    [setExplorePageParams]
+  );
+
+  const onSave = useCallback(async () => {
+    try {
+      setIsSaving(true);
+      addLoadingMessage(t('Saving query...'));
+      const {id} = await saveQuery(name);
+      updatePageIdAndTitle(id, name);
+      addSuccessMessage(t('Query saved successfully'));
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'saved_query',
+        ui_source: 'toolbar',
+        organization,
+      });
+      closeModal();
+    } catch (error) {
+      addErrorMessage(t('Failed to save query'));
+      Sentry.captureException(error);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [saveQuery, name, updatePageIdAndTitle, closeModal, organization]);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('New Query')}</h4>
+      </Header>
+      <Body>
+        <Wrapper>
+          <SectionHeader>{t('Name')}</SectionHeader>
+          <Input
+            placeholder={t('Enter a name for your saved query')}
+            onChange={e => setName(e.target.value)}
+            value={name}
+            title={t('Enter a name for your saved query')}
+          />
+        </Wrapper>
+        <Wrapper>
+          <SectionHeader>{t('Query')}</SectionHeader>
+          <ExploreParamsContainer>
+            <ExploreParamSection>
+              <ExploreParamTitle>{t('Visualize')}</ExploreParamTitle>
+              <ExploreVisualizes>{yAxes.join(', ')}</ExploreVisualizes>
+            </ExploreParamSection>
+            {query && (
+              <ExploreParamSection>
+                <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
+                <FormattedQueryWrapper>
+                  <FormattedQuery query={query} />
+                </FormattedQueryWrapper>
+              </ExploreParamSection>
+            )}
+            {groupBys && groupBys.length > 0 && (
+              <ExploreParamSection>
+                <ExploreParamTitle>{t('Group By')}</ExploreParamTitle>
+                <ExploreGroupBys>{groupBys.join(', ')}</ExploreGroupBys>
+              </ExploreParamSection>
+            )}
+            <ExploreParamSection>...</ExploreParamSection>
+          </ExploreParamsContainer>
+        </Wrapper>
+      </Body>
+
+      <Footer>
+        <StyledButtonBar gap={1.5}>
+          <Button onClick={closeModal} disabled={isSaving}>
+            {t('Cancel')}
+          </Button>
+          <Button onClick={onSave} disabled={!name || isSaving} priority="primary">
+            {t('Create a New Query')}
+          </Button>
+        </StyledButtonBar>
+      </Footer>
+    </Fragment>
+  );
+}
+
+export default SaveQueryModal;
+
+const Wrapper = styled('div')`
+  margin-bottom: ${space(2)};
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  @media (max-width: ${props => props.theme.breakpoints.small}) {
+    grid-template-rows: repeat(2, 1fr);
+    gap: ${space(1.5)};
+    width: 100%;
+
+    > button {
+      width: 100%;
+    }
+  }
+`;
+
+export const modalCss = css`
+  max-width: 700px;
+  margin: 70px auto;
+`;
+
+const SectionHeader = styled('h6')`
+  font-size: ${p => p.theme.form.md.fontSize};
+  margin-bottom: ${space(0.5)};
+`;
+
+const ExploreParamsContainer = styled('span')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(1)};
+  flex-wrap: wrap;
+`;
+
+const ExploreParamSection = styled('span')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+  align-items: center;
+`;
+
+const ExploreParamTitle = styled('span')`
+  font-size: ${p => p.theme.form.sm.fontSize};
+  color: ${p => p.theme.gray300};
+`;
+
+const ExploreVisualizes = styled('span')`
+  font-size: ${p => p.theme.form.sm.fontSize};
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  background: ${p => p.theme.background};
+  padding: ${space(0.25)} ${space(0.5)};
+  border: 1px solid ${p => p.theme.innerBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  height: 24px;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const ExploreGroupBys = ExploreVisualizes;
+
+const FormattedQueryWrapper = styled('span')`
+  display: inline-block;
+`;

--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -130,7 +130,7 @@ export type TracingEventParameters = {
   };
   'trace_explorer.remove_span_condition': Record<string, unknown>;
   'trace_explorer.save_as': {
-    save_type: 'alert' | 'dashboard';
+    save_type: 'alert' | 'dashboard' | 'saved_query' | 'update_query';
     ui_source: 'toolbar' | 'chart' | 'compare chart';
   };
   'trace_explorer.search_failure': {

--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -1,0 +1,20 @@
+import type {Crumb} from 'sentry/components/breadcrumbs';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+function ExploreBreadcrumb() {
+  const organization = useOrganization();
+  const crumbs: Crumb[] = [];
+  crumbs.push({
+    to: `/organizations/${organization.slug}/traces/`,
+    label: t('Traces'),
+  });
+  crumbs.push({
+    label: t('Saved Query'),
+  });
+
+  return <Breadcrumbs crumbs={crumbs} />;
+}
+
+export default ExploreBreadcrumb;

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -14,6 +14,8 @@ import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
+import {getTitleFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/title';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
@@ -35,14 +37,19 @@ export function ExploreContent() {
     });
   }, [location, navigate]);
 
+  const hasSavedQueries = organization.features.includes('performance-saved-queries');
+
+  const title = getTitleFromLocation(location);
+
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
       <PageFiltersContainer maxPickableDays={maxPickableDays}>
         <Layout.Page>
           <Layout.Header unified={prefersStackedNav}>
             <Layout.HeaderContent unified={prefersStackedNav}>
+              {hasSavedQueries && title ? <ExploreBreadcrumb /> : null}
               <Layout.Title>
-                {t('Traces')}
+                {hasSavedQueries && title ? title : t('Traces')}
                 <PageHeadingQuestionTooltip
                   docsUrl="https://github.com/getsentry/sentry/discussions/81239"
                   title={t(

--- a/static/app/views/explore/contexts/pageParamsContext/id.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/id.tsx
@@ -1,0 +1,20 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function defaultId(): string | undefined {
+  return undefined;
+}
+
+export function getIdFromLocation(location: Location) {
+  return decodeScalar(location.query.id);
+}
+
+export function updateLocationWithId(location: Location, id: string | null | undefined) {
+  if (defined(id)) {
+    location.query.id = id;
+  } else if (id === null) {
+    delete location.query.id;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/id.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/id.tsx
@@ -3,7 +3,7 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 
-export function defaultId(): string | undefined {
+export function defaultId(): undefined {
   return undefined;
 }
 

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -7,10 +7,12 @@ import {
   useSetExploreDataset,
   useSetExploreFields,
   useSetExploreGroupBys,
+  useSetExploreId,
   useSetExploreMode,
   useSetExplorePageParams,
   useSetExploreQuery,
   useSetExploreSortBys,
+  useSetExploreTitle,
   useSetExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -26,6 +28,8 @@ describe('PageParamsProvider', function () {
   let setQuery: ReturnType<typeof useSetExploreQuery>;
   let setSortBys: ReturnType<typeof useSetExploreSortBys>;
   let setVisualizes: ReturnType<typeof useSetExploreVisualizes>;
+  let setId: ReturnType<typeof useSetExploreId>;
+  let setTitle: ReturnType<typeof useSetExploreTitle>;
 
   function Component() {
     pageParams = useExplorePageParams();
@@ -37,6 +41,8 @@ describe('PageParamsProvider', function () {
     setQuery = useSetExploreQuery();
     setSortBys = useSetExploreSortBys();
     setVisualizes = useSetExploreVisualizes();
+    setId = useSetExploreId();
+    setTitle = useSetExploreTitle();
     return <br />;
   }
 
@@ -489,5 +495,17 @@ describe('PageParamsProvider', function () {
         },
       ],
     });
+  });
+
+  it('correctly updates id', function () {
+    renderTestComponent();
+    act(() => setId('123'));
+    expect(pageParams).toEqual(expect.objectContaining({id: '123'}));
+  });
+
+  it('correctly updates title', function () {
+    renderTestComponent();
+    act(() => setTitle('My Query'));
+    expect(pageParams).toEqual(expect.objectContaining({title: 'My Query'}));
   });
 });

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -8,6 +8,11 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {
+  defaultId,
+  getIdFromLocation,
+  updateLocationWithId,
+} from 'sentry/views/explore/contexts/pageParamsContext/id';
 
 import {
   defaultDataset,
@@ -43,6 +48,7 @@ interface ReadablePageParams {
   query: string;
   sortBys: Sort[];
   visualizes: Visualize[];
+  id?: string;
   title?: string;
 }
 
@@ -50,6 +56,7 @@ interface WritablePageParams {
   dataset?: DiscoverDatasets | null;
   fields?: string[] | null;
   groupBys?: string[] | null;
+  id?: string | null;
   mode?: Mode | null;
   query?: string | null;
   sortBys?: Sort[] | null;
@@ -75,6 +82,7 @@ function defaultPageParams(): ReadablePageParams {
   const query = defaultQuery();
   const visualizes = defaultVisualizes();
   const title = defaultTitle();
+  const id = defaultId();
   const sortBys = defaultSortBys(
     mode,
     fields,
@@ -89,6 +97,7 @@ function defaultPageParams(): ReadablePageParams {
     query,
     sortBys,
     title,
+    id,
     visualizes,
   };
 }
@@ -112,6 +121,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
     const visualizes = getVisualizesFromLocation(location, organization);
     const sortBys = getSortBysFromLocation(location, mode, fields, groupBys, visualizes);
     const title = getTitleFromLocation(location);
+    const id = getIdFromLocation(location);
 
     return {
       dataset,
@@ -121,6 +131,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
       query,
       sortBys,
       title,
+      id,
       visualizes,
     };
   }, [location, organization]);
@@ -177,6 +188,11 @@ export function useExploreTitle(): string | undefined {
   return pageParams.title;
 }
 
+export function useExploreId(): string | undefined {
+  const pageParams = useExplorePageParams();
+  return pageParams.id;
+}
+
 export function useExploreVisualizes(): Visualize[] {
   const pageParams = useExplorePageParams();
   return pageParams.visualizes;
@@ -195,6 +211,7 @@ export function newExploreTarget(
   updateLocationWithSortBys(target, pageParams.sortBys);
   updateLocationWithVisualizes(target, pageParams.visualizes);
   updateLocationWithTitle(target, pageParams.title);
+  updateLocationWithId(target, pageParams.id);
   return target;
 }
 
@@ -303,5 +320,25 @@ export function useSetExploreVisualizes() {
       setPageParams(writablePageParams);
     },
     [pageParams, setPageParams]
+  );
+}
+
+export function useSetExploreTitle() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (title: string) => {
+      setPageParams({title});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreId() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (id: string) => {
+      setPageParams({id});
+    },
+    [setPageParams]
   );
 }

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -1,0 +1,114 @@
+import {useCallback} from 'react';
+
+import {encodeSort} from 'sentry/utils/discover/eventView';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
+import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+
+const TRACE_EXPLORER_DATASET = 'ourlogs';
+
+export function useSaveQuery() {
+  const {groupBys, sortBys, visualizes, fields, query, mode, id, title} =
+    useExplorePageParams();
+  const {selection} = usePageFilters();
+  const {datetime, projects, environments} = selection;
+  const {start, end, period} = datetime;
+  const [interval] = useChartInterval();
+
+  const api = useApi();
+  const organization = useOrganization();
+
+  const visualize = visualizes.map(({chartType, yAxes}) => ({
+    chartType,
+    yAxes,
+  }));
+
+  const saveQuery = useCallback(
+    async (newTitle: string) => {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/`,
+        {
+          method: 'POST',
+          data: {
+            name: newTitle,
+            dataset: TRACE_EXPLORER_DATASET, // Only supported for trace explorer for now
+            groupby: groupBys,
+            orderby: sortBys[0] ? encodeSort(sortBys[0]) : undefined,
+            visualize,
+            fields,
+            query: query ?? '',
+            mode,
+            start,
+            end,
+            range: period,
+            interval,
+            projects,
+            environment: environments,
+          },
+        }
+      );
+      return response;
+    },
+    [
+      api,
+      organization.slug,
+      groupBys,
+      sortBys,
+      visualize,
+      fields,
+      query,
+      mode,
+      start,
+      end,
+      period,
+      interval,
+      projects,
+      environments,
+    ]
+  );
+
+  const updateQuery = useCallback(async () => {
+    const response = await api.requestPromise(
+      `/organizations/${organization.slug}/explore/saved/${id}/`,
+      {
+        method: 'PUT',
+        data: {
+          name: title,
+          dataset: TRACE_EXPLORER_DATASET,
+          groupby: groupBys,
+          orderby: sortBys[0] ? encodeSort(sortBys[0]) : undefined,
+          visualize,
+          fields,
+          query: query ?? '',
+          mode,
+          start,
+          end,
+          range: period,
+          interval,
+          projects,
+        },
+      }
+    );
+    return response;
+  }, [
+    api,
+    organization.slug,
+    id,
+    title,
+    groupBys,
+    sortBys,
+    visualize,
+    fields,
+    query,
+    mode,
+    start,
+    end,
+    period,
+    interval,
+    projects,
+  ]);
+
+  return {saveQuery, updateQuery};
+}

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -1,10 +1,19 @@
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {openSaveQueryModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import ButtonBar from 'sentry/components/buttonBar';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
@@ -16,19 +25,23 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {
   useExploreFields,
   useExploreGroupBys,
+  useExploreId,
   useExploreMode,
   useExploreQuery,
   useExploreSortBys,
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useAddToDashboard} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {ToolbarSection} from 'sentry/views/explore/toolbar/styles';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ToolbarSaveAs() {
   const {addToDashboard} = useAddToDashboard();
+  const {updateQuery, saveQuery} = useSaveQuery();
   const location = useLocation();
   const organization = useOrganization();
 
@@ -41,6 +54,7 @@ export function ToolbarSaveAs() {
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();
   const mode = useExploreMode();
+  const id = useExploreId();
   const visualizeYAxes = visualizes.flatMap(v => v.yAxes);
 
   const [interval] = useChartInterval();
@@ -138,6 +152,54 @@ export function ToolbarSaveAs() {
         return addToDashboard(0);
       },
     });
+  }
+
+  if (organization.features.includes('performance-saved-queries')) {
+    items.push({
+      key: 'save-query',
+      label: (
+        <span>
+          {t('A New Query')}
+          <FeatureBadge type="alpha" />
+        </span>
+      ),
+      onAction: () => {
+        openSaveQueryModal({
+          organization,
+          query,
+          groupBys: mode === Mode.AGGREGATE ? groupBys : [],
+          visualizes,
+          saveQuery,
+        });
+      },
+    });
+
+    if (defined(id)) {
+      items.push({
+        key: 'update-query',
+        label: (
+          <span>
+            {t('Existing Query')}
+            <FeatureBadge type="alpha" />
+          </span>
+        ),
+        onAction: async () => {
+          try {
+            addLoadingMessage(t('Updating query...'));
+            await updateQuery();
+            addSuccessMessage(t('Query updated successfully'));
+            trackAnalytics('trace_explorer.save_as', {
+              save_type: 'update_query',
+              ui_source: 'toolbar',
+              organization,
+            });
+          } catch (error) {
+            addErrorMessage(t('Failed to update query'));
+            Sentry.captureException(error);
+          }
+        },
+      });
+    }
   }
 
   if (items.length === 0) {

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -87,6 +87,53 @@ export function ToolbarSaveAs() {
 
   const items: MenuItemProps[] = [];
 
+  if (organization.features.includes('performance-saved-queries')) {
+    if (defined(id)) {
+      items.push({
+        key: 'update-query',
+        label: (
+          <span>
+            {t('Existing Query')}
+            <FeatureBadge type="alpha" />
+          </span>
+        ),
+        onAction: async () => {
+          try {
+            addLoadingMessage(t('Updating query...'));
+            await updateQuery();
+            addSuccessMessage(t('Query updated successfully'));
+            trackAnalytics('trace_explorer.save_as', {
+              save_type: 'update_query',
+              ui_source: 'toolbar',
+              organization,
+            });
+          } catch (error) {
+            addErrorMessage(t('Failed to update query'));
+            Sentry.captureException(error);
+          }
+        },
+      });
+    }
+    items.push({
+      key: 'save-query',
+      label: (
+        <span>
+          {t('A New Query')}
+          <FeatureBadge type="alpha" />
+        </span>
+      ),
+      onAction: () => {
+        openSaveQueryModal({
+          organization,
+          query,
+          groupBys: mode === Mode.AGGREGATE ? groupBys : [],
+          visualizes,
+          saveQuery,
+        });
+      },
+    });
+  }
+
   if (organization.features.includes('alerts-eap')) {
     items.push({
       key: 'create-alert',
@@ -152,54 +199,6 @@ export function ToolbarSaveAs() {
         return addToDashboard(0);
       },
     });
-  }
-
-  if (organization.features.includes('performance-saved-queries')) {
-    items.push({
-      key: 'save-query',
-      label: (
-        <span>
-          {t('A New Query')}
-          <FeatureBadge type="alpha" />
-        </span>
-      ),
-      onAction: () => {
-        openSaveQueryModal({
-          organization,
-          query,
-          groupBys: mode === Mode.AGGREGATE ? groupBys : [],
-          visualizes,
-          saveQuery,
-        });
-      },
-    });
-
-    if (defined(id)) {
-      items.push({
-        key: 'update-query',
-        label: (
-          <span>
-            {t('Existing Query')}
-            <FeatureBadge type="alpha" />
-          </span>
-        ),
-        onAction: async () => {
-          try {
-            addLoadingMessage(t('Updating query...'));
-            await updateQuery();
-            addSuccessMessage(t('Query updated successfully'));
-            trackAnalytics('trace_explorer.save_as', {
-              save_type: 'update_query',
-              ui_source: 'toolbar',
-              organization,
-            });
-          } catch (error) {
-            addErrorMessage(t('Failed to update query'));
-            Sentry.captureException(error);
-          }
-        },
-      });
-    }
   }
 
   if (items.length === 0) {


### PR DESCRIPTION
Updates the Trace Explorer UI to allow saving/updating queries. New save buttons are added as new options under the `Save as...` button.

Feature is gated behind the `performance-saved-queries` flag
![image](https://github.com/user-attachments/assets/70ec62a2-c61e-44f8-9c00-fedb217d2bce)
![image](https://github.com/user-attachments/assets/c2afc972-9b12-40a3-8107-d32c6aeee194)
