### PR TITLE
:recycle: ref(slack): pull thread util methods into a separate class

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -18,10 +18,7 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionType,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.repository import (
-    get_default_issue_alert_repository,
-    get_default_notification_action_repository,
-)
+from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.base import NotificationMessageValidationError
 from sentry.integrations.repository.issue_alert import NewIssueAlertNotificationMessage
 from sentry.integrations.repository.notification_action import (
@@ -41,6 +38,7 @@ from sentry.integrations.slack.metrics import (
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.channel import SlackChannelIdData, get_channel_id
+from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
 from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.options.organization_option import OrganizationOption
@@ -182,25 +180,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             pass
 
     @classmethod
-    def _save_notification_action_message(
-        cls,
-        data: NewNotificationActionNotificationMessage,
-    ) -> None:
-        """Save a notification action message to the repository."""
-        try:
-            action_repository = get_default_notification_action_repository()
-            action_repository.create_notification_message(data=data)
-        except NotificationMessageValidationError as err:
-            extra = data.__dict__ if data else None
-            _default_logger.info(
-                "Validation error for new notification action message", exc_info=err, extra=extra
-            )
-        except Exception:
-            # if there's an error trying to save a notification message, don't let that error block this flow
-            # we already log at the repository layer, no need to log again here
-            pass
-
-    @classmethod
     def _get_issue_alert_thread_ts(
         cls,
         organization: Organization,
@@ -251,48 +230,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         )
         # To reply to a thread, use the specific key in the payload as referenced by the docs
         # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
-        return parent_notification_message.message_identifier
-
-    @classmethod
-    def _get_notification_action_thread_ts(
-        cls,
-        organization: Organization,
-        lifecycle: EventLifecycle,
-        action: Action,
-        event: GroupEvent,
-        open_period_start: datetime | None,
-        new_notification_message_object: NewNotificationActionNotificationMessage,
-    ) -> str | None:
-        """Find the thread in which to post a notification action notification as a reply.
-
-        Return None to post the notification as a top-level message.
-        """
-        if not (
-            OrganizationOption.objects.get_value(
-                organization=organization,
-                key="sentry:issue_alerts_thread_flag",
-                default=ISSUE_ALERTS_THREAD_DEFAULT,
-            )
-        ):
-            return None
-
-        try:
-            action_repository = get_default_notification_action_repository()
-            parent_notification_message = action_repository.get_parent_notification_message(
-                action=action,
-                group=event.group,
-                open_period_start=open_period_start,
-            )
-        except Exception as e:
-            lifecycle.record_halt(e)
-            return None
-
-        if parent_notification_message is None:
-            return None
-
-        new_notification_message_object.parent_notification_message_id = (
-            parent_notification_message.id
-        )
         return parent_notification_message.message_identifier
 
     def _send_notification(
@@ -460,13 +397,14 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         with MessagingInteractionEvent(
             MessagingInteractionType.GET_PARENT_NOTIFICATION, SlackMessagingSpec()
         ).capture() as lifecycle:
-            thread_ts = SlackNotifyServiceAction._get_notification_action_thread_ts(
+            thread_ts = NotificationActionThreadUtils._get_notification_action_thread_ts(
                 lifecycle=lifecycle,
                 event=event,
                 new_notification_message_object=new_notification_message_object,
                 organization=self.project.organization,
                 action=action,
                 open_period_start=open_period_start,
+                thread_option_default=ISSUE_ALERTS_THREAD_DEFAULT,
             )
 
         self._send_notification(
@@ -477,7 +415,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             channel=channel,
             notification_uuid=notification_uuid,
             notification_message_object=new_notification_message_object,
-            save_notification_method=SlackNotifyServiceAction._save_notification_action_message,
+            save_notification_method=NotificationActionThreadUtils._save_notification_action_message,
             thread_ts=thread_ts,
         )
         self.record_notification_sent(event, channel, rule, notification_uuid)

--- a/src/sentry/integrations/slack/utils/threads.py
+++ b/src/sentry/integrations/slack/utils/threads.py
@@ -1,0 +1,91 @@
+import logging
+from datetime import datetime
+
+from sentry.integrations.repository import get_default_notification_action_repository
+from sentry.integrations.repository.notification_action import (
+    NewNotificationActionNotificationMessage,
+    NotificationActionNotificationMessageRepository,
+    NotificationMessageValidationError,
+)
+from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.models.group import GroupEvent
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.organization import Organization
+from sentry.workflow_engine.models.action import Action
+
+_default_logger = logging.getLogger(__name__)
+
+
+class NotificationActionThreadUtils:
+    """
+    Stateless utility class for handling notification action threads.
+    This class will will be used for the issue and metric alert handlers.
+
+    Eventually with Notification Platform, we should delete this class
+    """
+
+    @classmethod
+    def _save_notification_action_message(
+        cls,
+        data: NewNotificationActionNotificationMessage,
+    ) -> None:
+        """Save a notification action message to the repository."""
+        try:
+            action_repository: NotificationActionNotificationMessageRepository = (
+                get_default_notification_action_repository()
+            )
+            action_repository.create_notification_message(data=data)
+        except NotificationMessageValidationError as err:
+            extra = data.__dict__ if data else None
+            _default_logger.info(
+                "Validation error for new notification action message", exc_info=err, extra=extra
+            )
+        except Exception:
+            # if there's an error trying to save a notification message, don't let that error block this flow
+            # we already log at the repository layer, no need to log again here
+            pass
+
+    @classmethod
+    def _get_notification_action_thread_ts(
+        cls,
+        organization: Organization,
+        lifecycle: EventLifecycle,
+        action: Action,
+        event: GroupEvent,
+        open_period_start: datetime | None,
+        new_notification_message_object: NewNotificationActionNotificationMessage,
+        thread_option_default: bool,
+    ) -> str | None:
+        """Find the thread in which to post a notification action notification as a reply.
+
+        Return None to post the notification as a top-level message.
+        """
+        if not (
+            OrganizationOption.objects.get_value(
+                organization=organization,
+                key="sentry:issue_alerts_thread_flag",
+                default=thread_option_default,
+            )
+        ):
+            return None
+
+        try:
+            action_repository: NotificationActionNotificationMessageRepository = (
+                get_default_notification_action_repository()
+            )
+            parent_notification_message = action_repository.get_parent_notification_message(
+                action=action,
+                group=event.group,
+                open_period_start=open_period_start,
+            )
+        except Exception as e:
+            lifecycle.record_halt(e)
+            return None
+
+        if parent_notification_message is None:
+            return None
+
+        new_notification_message_object.parent_notification_message_id = (
+            parent_notification_message.id
+        )
+        return parent_notification_message.message_identifier

--- a/src/sentry/integrations/slack/utils/threads.py
+++ b/src/sentry/integrations/slack/utils/threads.py
@@ -1,14 +1,14 @@
 import logging
 from datetime import datetime
 
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.repository import get_default_notification_action_repository
+from sentry.integrations.repository.base import NotificationMessageValidationError
 from sentry.integrations.repository.notification_action import (
     NewNotificationActionNotificationMessage,
     NotificationActionNotificationMessageRepository,
-    NotificationMessageValidationError,
 )
 from sentry.integrations.utils.metrics import EventLifecycle
-from sentry.models.group import GroupEvent
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.workflow_engine.models.action import Action


### PR DESCRIPTION
i will end up reusing these methods between issue and metric alerts, so pulling it out of the action handler into a generic util class we can reuse.

id imagine we probably delete this after notification platform. didn't make it super generic yet because of the rule of 3.