### PR TITLE
fix(dashboards): Improve handling for `TimeSeries` with unknown data types

### DIFF
--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,6 +1,18 @@
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
+// NOTE: This is a subset! Some types like `"string"`, `"date"`, and
+// `"percent_change"` are not supported yet. Once we support them, we can remove
+// this constant and any code that checks it.
+export const PLOTTABLE_TIME_SERIES_VALUE_TYPES = [
+  'number',
+  'integer',
+  'duration',
+  'percentage',
+  'size',
+  'rate',
+] as const;
+
 export const MIN_WIDTH = 110;
 export const MIN_HEIGHT = 96;
 

--- a/static/app/views/dashboards/widgets/common/typePredicates.tsx
+++ b/static/app/views/dashboards/widgets/common/typePredicates.tsx
@@ -1,4 +1,9 @@
+import {defined} from 'sentry/utils';
 import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+
+import type {PlottableTimeSeriesValueType} from '../timeSeriesWidget/plottables/plottable';
+
+import {PLOTTABLE_TIME_SERIES_VALUE_TYPES} from './settings';
 
 export function isADurationUnit(unit?: string): unit is DurationUnit {
   return Object.values(DurationUnit).includes(unit as unknown as DurationUnit);
@@ -13,4 +18,16 @@ export function isAUnitConvertibleFieldType(
   fieldType?: string
 ): fieldType is 'duration' | 'size' | 'rate' {
   return ['duration', 'size', 'rate'].includes(fieldType as unknown as string);
+}
+
+export function isAPlottableTimeSeriesValueType(
+  timeSeriesValueType?: string | undefined | null
+): timeSeriesValueType is PlottableTimeSeriesValueType {
+  if (!defined(timeSeriesValueType)) {
+    return false;
+  }
+
+  return (PLOTTABLE_TIME_SERIES_VALUE_TYPES as unknown as string[]).includes(
+    timeSeriesValueType
+  );
 }

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -7,6 +7,7 @@ export type TimeSeriesValueType =
   | 'number'
   | 'integer'
   | 'date'
+  | 'boolean'
   | 'duration'
   | 'percentage'
   | 'percent_change'

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -3,9 +3,23 @@ import type {DataUnit} from 'sentry/utils/discover/fields';
 
 import type {ThresholdsConfig} from '../../widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
+export type TimeSeriesValueType =
+  | 'number'
+  | 'integer'
+  | 'date'
+  | 'duration'
+  | 'percentage'
+  | 'percent_change'
+  | 'string'
+  | 'size'
+  | 'rate'
+  | null;
+
+export type TimeSeriesValueUnit = DataUnit | null;
+
 export type Meta = {
-  type: string | null; // TODO: This can probably be `AggregationOutputType`
-  unit: DataUnit | null;
+  type: TimeSeriesValueType;
+  unit: TimeSeriesValueUnit;
   isOther?: boolean;
 };
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -1,10 +1,14 @@
 import type {SeriesOption} from 'echarts';
 
-import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
+import type {DataUnit} from 'sentry/utils/discover/fields';
 import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 
-import type {TimeSeries} from '../../common/types';
+import {isAPlottableTimeSeriesValueType} from '../../common/typePredicates';
+import type {TimeSeries, TimeSeriesValueUnit} from '../../common/types';
 import {formatSeriesName} from '../formatters/formatSeriesName';
+import {FALLBACK_TYPE} from '../settings';
+
+import type {PlottableTimeSeriesValueType} from './plottable';
 
 export type ContinuousTimeSeriesConfig = {
   /**
@@ -29,7 +33,7 @@ export type ContinuousTimeSeriesPlottingOptions = {
   /**
    * Final plottable unit. This might be different from the original unit of the data, because we scale all time series to a single common unit.
    */
-  unit: DataUnit;
+  unit: TimeSeriesValueUnit;
   /**
    * If the chart has multiple Y axes (e.g., plotting durations and rates on the same chart), whether this value should be plotted on the left or right axis.
    */
@@ -65,12 +69,13 @@ export abstract class ContinuousTimeSeries<
     return !this.config?.color;
   }
 
-  get dataType(): AggregationOutputType {
-    // TODO: Remove the `as` cast. `TimeSeries` meta should use `AggregationOutputType` instead of `string`
-    return this.timeSeries.meta.type as AggregationOutputType;
+  get dataType(): PlottableTimeSeriesValueType {
+    return isAPlottableTimeSeriesValueType(this.timeSeries.meta.type)
+      ? this.timeSeries.meta.type
+      : FALLBACK_TYPE;
   }
 
-  get dataUnit(): DataUnit {
+  get dataUnit(): TimeSeriesValueUnit {
     return this.timeSeries.meta.unit;
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -1,6 +1,5 @@
 import type {SeriesOption} from 'echarts';
 
-import type {DataUnit} from 'sentry/utils/discover/fields';
 import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 
 import {isAPlottableTimeSeriesValueType} from '../../common/typePredicates';
@@ -103,7 +102,7 @@ export abstract class ContinuousTimeSeries<
     };
   }
 
-  scaleToUnit(destinationUnit: DataUnit): TimeSeries {
+  scaleToUnit(destinationUnit: TimeSeriesValueUnit): TimeSeries {
     return scaleTimeSeriesData(this.timeSeries, destinationUnit);
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -15,7 +15,13 @@ export interface Plottable {
    * date boundaries provided
    */
   constrain(boundaryStart: Date | null, boundaryEnd: Date | null): Plottable;
+  /**
+   * Type of the underlying data
+   */
   dataType: PlottableTimeSeriesValueType;
+  /**
+   * Unit of the underlying data
+   */
   dataUnit: TimeSeriesValueUnit;
   /**
    * Start timestamp of the plottable, if applicable

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -1,6 +1,10 @@
 import type {SeriesOption} from 'echarts';
 
-import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
+import type {PLOTTABLE_TIME_SERIES_VALUE_TYPES} from '../../common/settings';
+import type {TimeSeriesValueUnit} from '../../common/types';
+
+export type PlottableTimeSeriesValueType =
+  (typeof PLOTTABLE_TIME_SERIES_VALUE_TYPES)[number];
 
 /**
  * A `Plottable` is any object that can be converted to an ECharts `Series` and therefore plotted on an ECharts chart. This could be a data series, releases, samples, and other kinds of markers. `TimeSeriesWidgetVisualization` uses `Plottable` objects under the hood, to convert data coming into the component via props into ECharts series.
@@ -11,14 +15,8 @@ export interface Plottable {
    * date boundaries provided
    */
   constrain(boundaryStart: Date | null, boundaryEnd: Date | null): Plottable;
-  /**
-   * If the plottable is based on data, the type. Otherwise, null
-   */
-  dataType: AggregationOutputType | null;
-  /**
-   * If the plottable is based on data, the unit. Otherwise, null
-   */
-  dataUnit: DataUnit;
+  dataType: PlottableTimeSeriesValueType;
+  dataUnit: TimeSeriesValueUnit;
   /**
    * Start timestamp of the plottable, if applicable
    */

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
@@ -7,7 +7,7 @@ import {
 } from 'sentry/utils/discover/fields';
 
 export const Y_AXIS_INTEGER_TOLERANCE = 0.000001;
-export const FALLBACK_TYPE = 'number';
+export const FALLBACK_TYPE = 'number' as const;
 export const FALLBACK_UNIT_FOR_FIELD_TYPE = {
   number: null,
   integer: null,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -262,10 +262,12 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               plottables={[
                 new Line({
                   ...sampleThroughputTimeSeries,
+                  field: 'equation|spm() + 1',
                   meta: NULL_META,
                 }),
                 new Line({
                   ...sampleDurationTimeSeries,
+                  field: 'custom_aggregate()',
                   meta: NULL_META,
                 }),
               ]}
@@ -277,6 +279,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               plottables={[
                 new Line({
                   ...sampleThroughputTimeSeries,
+                  field: 'equation|spm() + 1',
                   meta: {
                     type: 'number',
                     unit: null,
@@ -284,6 +287,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                 }),
                 new Line({
                   ...sampleDurationTimeSeries,
+                  field: 'custom_aggregate()',
                   meta: NULL_META,
                 }),
               ]}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -14,7 +14,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {shiftTimeSeriesToNow} from 'sentry/utils/timeSeries/shiftTimeSeriesToNow';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 
-import type {LegendSelection, Release, TimeSeries} from '../common/types';
+import type {LegendSelection, Meta, Release, TimeSeries} from '../common/types';
 
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
 import {sampleThroughputTimeSeries} from './fixtures/sampleThroughputTimeSeries';
@@ -248,6 +248,47 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               ]}
             />
           </MediumWidget>
+        </SideBySide>
+
+        <p>
+          In rare cases, none of the data will have a known type. In these cases we drop
+          down to a generic "number" axis. This also accounts for combinations of unknown
+          types and the generic "number" type.
+        </p>
+
+        <SideBySide>
+          <SmallWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Line({
+                  ...sampleThroughputTimeSeries,
+                  meta: NULL_META,
+                }),
+                new Line({
+                  ...sampleDurationTimeSeries,
+                  meta: NULL_META,
+                }),
+              ]}
+            />
+          </SmallWidget>
+
+          <SmallWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Line({
+                  ...sampleThroughputTimeSeries,
+                  meta: {
+                    type: 'number',
+                    unit: null,
+                  },
+                }),
+                new Line({
+                  ...sampleDurationTimeSeries,
+                  meta: NULL_META,
+                }),
+              ]}
+            />
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );
@@ -592,3 +633,8 @@ function toTimeSeriesSelection(
 function hasTimestamp(release: Partial<Release>): release is Release {
   return Boolean(release?.timestamp);
 }
+
+const NULL_META: Meta = {
+  type: null,
+  unit: null,
+};

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -187,17 +187,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const fieldTypeCounts = mapValues(plottablesByType, plottables => plottables.length);
 
   // Sort the field types by how many plottables use each one
-  const axisTypes = (
-    Object.keys(fieldTypeCounts).filter(key => {
-      // JavaScript objects cannot have `undefined` or `null` as keys. lodash
-      // `groupBy` casts those cases to strings. This is _very_ rare, since it
-      // indicates a backend failure to provide the correct data type, but it
-      // happens sometimes. Filter those out. It would be cleaner to use a type
-      // predicate here, but consistently enforcing plottable values is a lot of
-      // work
-      return !['undefined', 'null'].includes(key);
-    }) as AggregationOutputType[]
-  )
+  const axisTypes = Object.keys(fieldTypeCounts)
     .toSorted(
       // `dataTypes` is extracted from `dataTypeCounts`, so the counts are guaranteed to exist
       (a, b) => fieldTypeCounts[b]! - fieldTypeCounts[a]!

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -195,7 +195,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     .filter(axisType => !!axisType); // `TimeSeries` allows for a `null` data type , though it's not likely
 
   // Assign most popular field type to left axis
-  const leftYAxisType = axisTypes.at(0) ?? FALLBACK_TYPE;
+  const leftYAxisType = axisTypes.at(0)!;
 
   // Assign the rest of the field types to right
   const rightYAxisTypes = axisTypes.slice(1);
@@ -375,7 +375,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     if (plottable.dataType === leftYAxisType) {
       // This plottable matches the left axis
       yAxisPosition = 'left';
-    } else if (rightYAxisTypes.includes(plottable.dataType ?? FALLBACK_TYPE)) {
+    } else if (rightYAxisTypes.includes(plottable.dataType)) {
       // This plottable matches the right axis
       yAxisPosition = 'right';
     } else {
@@ -393,8 +393,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           rightAxisType: rightYAxisType,
         });
       });
-
-      yAxisPosition = leftYAxisType === FALLBACK_TYPE ? 'left' : 'right';
     }
 
     // TODO: Type checking would be welcome here, but `plottingOptions` is unknown, since it depends on the implementation of the `Plottable` interface

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -211,6 +211,17 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         ? FALLBACK_TYPE
         : undefined;
 
+  if (leftYAxisType === FALLBACK_TYPE && rightYAxisType !== FALLBACK_TYPE) {
+    warn(
+      '`TimeSeriesWidgetVisualization` assigned fallback to left Y axis instead of right Y axis',
+      {
+        labels: props.plottables.map(plottable => plottable.label),
+        leftYAxisType,
+        rightYAxisType,
+      }
+    );
+  }
+
   // Create a map of used units by plottable data type
   const unitsByType = mapValues(plottablesByType, plottables =>
     uniq(plottables.map(plottable => plottable.dataUnit))


### PR DESCRIPTION
Closes JAVASCRIPT-2YG7
Closes JAVASCRIPT-2YHG

`TimeSeriesWidgetVisualization` is failing on the Queues page if the project doesn't have any specific queue data. If it doesn't, one of the time series come back with a `null` type, it has no meta information. In this case, the visualization creates a "duration" axis for the one time series that has data, but doesn't create a fallback axis for the time series with a `null` type. This happens because I aggressively filtered out `null` types, since I didn't realize how often this happens.

Rather than patching over that bug, I've added new, more robust types and behaviour.

- `TimeSeries` is allowed to have a `null` type, and the types are now more specifically set in TypeScript. This is just reality
- `Plottable` is _not_ allowed to have a `null` type. It _must_ provide an actually plottable type! To this end, I added more specific types to explain what is and isn't plottable
- `TimeSeriesWidgetVisualization` only works on plottables with good types, so the code there doesn't have to change, the error handling has been moved into the plottable implementations and enforced with types
