### PR TITLE
fix(analytics): Record the tour exit stage on esc-key press

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -67,6 +67,7 @@ export function TourContextProvider<T extends TourEnumType>({
   omitBlur,
   orderedStepIds,
 }: TourContextProviderProps<T>) {
+  const organization = useOrganization();
   const {mutate} = useMutateAssistant();
   const tourContextValue = useTourReducer<T>({
     isAvailable,
@@ -91,13 +92,18 @@ export function TourContextProvider<T extends TourEnumType>({
           if (tourKey) {
             mutate({guide: tourKey, status: 'dismissed'});
           }
+          trackAnalytics('tour-guide.close', {
+            organization,
+            id: `${currentStepId}`,
+            mechanism: 'esc_key',
+          });
           dispatch({type: 'END_TOUR'});
         },
       },
       {match: ['left', 'h'], callback: () => dispatch({type: 'PREVIOUS_STEP'})},
       {match: ['right', 'l'], callback: () => dispatch({type: 'NEXT_STEP'})},
     ];
-  }, [dispatch, mutate, tourKey, isTourActive]);
+  }, [dispatch, mutate, tourKey, isTourActive, organization, currentStepId]);
 
   useHotkeys(tourHotkeys);
 
@@ -320,7 +326,11 @@ export function TourGuide({
                           {isDismissVisible && (
                             <TourCloseButton
                               onClick={e => {
-                                trackAnalytics('tour-guide.close', {organization, id});
+                                trackAnalytics('tour-guide.close', {
+                                  organization,
+                                  id,
+                                  mechanism: 'close_button',
+                                });
                                 handleDismiss(e);
                               }}
                               icon={<IconClose style={{color: darkTheme.textColor}} />}

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -92,11 +92,7 @@ export function TourContextProvider<T extends TourEnumType>({
           if (tourKey) {
             mutate({guide: tourKey, status: 'dismissed'});
           }
-          trackAnalytics('tour-guide.close', {
-            organization,
-            id: `${currentStepId}`,
-            mechanism: 'esc_key',
-          });
+          trackAnalytics('tour-guide.dismiss', {organization, id: `${currentStepId}`});
           dispatch({type: 'END_TOUR'});
         },
       },
@@ -326,11 +322,7 @@ export function TourGuide({
                           {isDismissVisible && (
                             <TourCloseButton
                               onClick={e => {
-                                trackAnalytics('tour-guide.close', {
-                                  organization,
-                                  id,
-                                  mechanism: 'close_button',
-                                });
+                                trackAnalytics('tour-guide.dismiss', {organization, id});
                                 handleDismiss(e);
                               }}
                               icon={<IconClose style={{color: darkTheme.textColor}} />}

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -372,7 +372,7 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
-  'tour-guide.close': {id?: string};
+  'tour-guide.close': {id?: string; mechanism?: 'close_button' | 'esc_key'};
   'tour-guide.open': {id?: string};
   'whats_new.link_clicked': Pick<Broadcast, 'title'> &
     Partial<Pick<Broadcast, 'category'>>;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -372,7 +372,7 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
-  'tour-guide.close': {id?: string; mechanism?: 'close_button' | 'esc_key'};
+  'tour-guide.dismiss': {id?: string};
   'tour-guide.open': {id?: string};
   'whats_new.link_clicked': Pick<Broadcast, 'title'> &
     Partial<Pick<Broadcast, 'category'>>;
@@ -530,6 +530,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.comment_deleted': 'Issue Details: Comment Deleted',
   'issue_details.comment_updated': 'Issue Details: Comment Updated',
   'tour-guide.open': 'Tour Guide: Opened',
-  'tour-guide.close': 'Tour Guide: Closed',
+  'tour-guide.dismiss': 'Tour Guide: Dismissed',
   'whats_new.link_clicked': "What's New: Link Clicked",
 };


### PR DESCRIPTION
Improve analytics by recording the dismiss event for escape key press. Also labelling it dismiss, since close implies its recorded on unmount, which is not true.