### PR TITLE
chore: Rename team in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -647,9 +647,9 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/data_secrecy/                                           @getsentry/core-product-foundations
 ## End of Core Product Foundations
 
-# Taskworkers
-/src/sentry/taskworker/                                       @getsentry/taskworker
-/tests/sentry/taskworker/                                     @getsentry/taskworker
+# Taskbroker workers
+/src/sentry/taskworker/                                       @getsentry/taskbroker
+/tests/sentry/taskworker/                                     @getsentry/taskbroker
 
 # Tempest
 /src/sentry/tempest/                                       @getsentry/gdx


### PR DESCRIPTION
Refs getsentry/security-as-code#1329