### PR TITLE
ref: CommitContextClient methods accept repository instance

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -227,11 +227,11 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
         """
         return self.get_cached(f"/repos/{repo}/commits/{sha}")
 
-    def get_merge_commit_sha_from_commit(self, repo: str, sha: str) -> str | None:
+    def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         """
         Get the merge commit sha from a commit sha.
         """
-        response = self.get_pullrequest_from_commit(repo, sha)
+        response = self.get_pullrequest_from_commit(repo.name, sha)
         if not response or (isinstance(response, list) and len(response) != 1):
             # the response should return a single merged PR, return if multiple
             return None

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -309,7 +309,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """
         return self.get_cached(GitLabApiClientPath.commit.format(project=project_id, sha=sha))
 
-    def get_merge_commit_sha_from_commit(self, repo: str, sha: str) -> str | None:
+    def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         raise IntegrationFeatureNotImplementedError
 
     def compare_commits(self, project_id, start_sha, end_sha):

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -216,7 +216,7 @@ class CommitContextIntegration(ABC):
             try:
                 client = self.get_client()
                 merge_commit_sha = client.get_merge_commit_sha_from_commit(
-                    repo=repo.name, sha=commit.key
+                    repo=repo, sha=commit.key
                 )
             except Exception as e:
                 sentry_sdk.capture_exception(e)
@@ -413,5 +413,5 @@ class CommitContextClient(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_merge_commit_sha_from_commit(self, repo: str, sha: str) -> str | None:
+    def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         raise NotImplementedError

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -364,9 +364,7 @@ class GitHubApiClientTest(TestCase):
             json=pull_requests,
         )
 
-        sha = self.github_client.get_merge_commit_sha_from_commit(
-            repo=self.repo.name, sha=commit_sha
-        )
+        sha = self.github_client.get_merge_commit_sha_from_commit(repo=self.repo, sha=commit_sha)
         assert sha == merge_commit_sha
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
@@ -381,9 +379,7 @@ class GitHubApiClientTest(TestCase):
             json=pull_requests,
         )
 
-        sha = self.github_client.get_merge_commit_sha_from_commit(
-            repo=self.repo.name, sha=commit_sha
-        )
+        sha = self.github_client.get_merge_commit_sha_from_commit(repo=self.repo, sha=commit_sha)
         assert sha is None
 
     @responses.activate


### PR DESCRIPTION
The issue is that `repo.name` works well for GitHub (it’s in the format `getsentry/sentry`, which can be used in the API URL path), whereas `repo.name` in GitLab is `name_with_namespace` (formatted as `Get Sentry / Sentry`), which is not suitable for use in the URL path.

GitLab, in particular, offers an option to use the internal `project_id` in URL paths.
https://docs.gitlab.com/api/commits/#list-merge-requests-associated-with-a-commit

I propose a change to make the `get_merge_commit_sha_from_commit` accept a more generic instance of `Repository`, leaving the implementation details to the integration.