### PR TITLE
feat(traec): add errors to trace

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -38,7 +38,7 @@ class SerializedEvent(TypedDict):
 
 
 @region_silo_endpoint
-class OrganizationSpansTraceEndpoint(OrganizationEventsV2EndpointBase):
+class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -31,7 +31,6 @@ class SerializedEvent(TypedDict):
     description: str
     event_id: str
     event_type: str
-    is_transaction: bool
     project_id: int
     project_slug: str
     start_timestamp: datetime
@@ -45,6 +44,7 @@ class SerializedSpan(SerializedEvent):
     end_timestamp: datetime
     op: str
     parent_span_id: str | None
+    is_transaction: bool
 
 
 @region_silo_endpoint
@@ -84,7 +84,6 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
                 project_id=event["project.id"],
                 project_slug=event["project.name"],
                 start_timestamp=event["timestamp"],
-                is_transaction=False,
                 transaction=event["transaction"],
                 description=event["message"],
                 event_type="error",

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -168,10 +168,10 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             else:
                 result.append(span)
             if span["id"] in id_to_error:
-                error = id_to_error[span["id"]]
+                error = id_to_error.pop(span["id"])
                 span["errors"].append(error)
-            else:
-                result.append(error)
+        for error in id_to_error.values():
+            result.append(error)
         return [self.serialize_rpc_event(root) for root in result]
 
     def has_feature(self, organization: Organization, request: Request) -> bool:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -573,12 +573,12 @@ from .endpoints.organization_spans_fields import (
     OrganizationSpansFieldValuesEndpoint,
 )
 from .endpoints.organization_spans_fields_stats import OrganizationSpansFieldsStatsEndpoint
-from .endpoints.organization_spans_trace import OrganizationSpansTraceEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
 from .endpoints.organization_stats_v2 import OrganizationStatsEndpointV2
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
+from .endpoints.organization_trace import OrganizationTraceEndpoint
 from .endpoints.organization_traces import (
     OrganizationTracesEndpoint,
     OrganizationTraceSpansEndpoint,
@@ -1607,8 +1607,8 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/trace/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
-        OrganizationSpansTraceEndpoint.as_view(),
-        name="sentry-api-0-organization-spans-trace",
+        OrganizationTraceEndpoint.as_view(),
+        name="sentry-api-0-organization-trace",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/measurements-meta/$",

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -445,7 +445,12 @@ def run_trace_query(
     columns_by_name = {col.proto_definition.name: col for col in columns}
     for item_group in response.item_groups:
         for span_item in item_group.items:
-            span: dict[str, Any] = {"id": span_item.id, "children": []}
+            span: dict[str, Any] = {
+                "id": span_item.id,
+                "children": [],
+                "errors": [],
+                "event_type": "span",
+            }
             for attribute in span_item.attributes:
                 resolved_column = columns_by_name[attribute.key.name]
                 if resolved_column.proto_definition.type == STRING:

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -8,7 +8,7 @@ from tests.snuba.api.endpoints.test_organization_events_trace import (
 
 
 class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
-    url_name = "sentry-api-0-organization-spans-trace"
+    url_name = "sentry-api-0-organization-trace"
     FEATURES = ["organizations:trace-spans-format"]
 
     def assert_event(self, result, event_data, message):

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from django.urls import reverse
 
+from sentry.utils.samples import load_data
 from tests.snuba.api.endpoints.test_organization_events_trace import (
     OrganizationEventsTraceEndpointBase,
 )
@@ -23,7 +24,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         for child in event["children"]:
             if child["is_transaction"]:
                 children.append(child)
-            else:
+            elif child["event_type"] == "span":
                 children.extend(child["children"])
         return sorted(children, key=lambda event: event["description"])
 
@@ -112,3 +113,33 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         data = response.data
         assert len(data) == 1
         self.assert_trace_data(data[0])
+
+    def test_with_errors_data(self):
+        self.load_trace(is_eap=True)
+        start, _ = self.get_start_end_from_day_ago(1000)
+        error_data = load_data(
+            "javascript",
+            timestamp=start,
+        )
+        error_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": self.trace_id,
+            "span_id": self.root_event.data["contexts"]["trace"]["span_id"],
+        }
+        error_data["tags"] = [["transaction", "/transaction/gen1-0"]]
+        error = self.store_event(error_data, project_id=self.gen1_project.id)
+
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={},
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 1
+        self.assert_trace_data(data[0])
+        error_event = None
+        assert len(data[0]["errors"]) == 1
+        error_event = data[0]["errors"][0]
+        assert error_event is not None
+        assert error_event["event_id"] == error.data["event_id"]
+        assert error_event["project_slug"] == self.gen1_project.slug


### PR DESCRIPTION
- This adds a query to the old discover table for errors data for a
  given trace then zips that back together with spans data that we've
  gotten from EAP
- Longterm errors data will also come from EAP but that's not ready yet