### PR TITLE
chore(tour): Increase entrypoint modal size

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -84,7 +84,6 @@ export function NewIssueExperienceButton() {
       openModal(
         props => (
           <IssueDetailsTourModal
-            {...props}
             handleDismissTour={() => {
               mutateAssistant({guide: ISSUE_DETAILS_TOUR_GUIDE_KEY, status: 'dismissed'});
               tourDispatch({type: 'SET_COMPLETION', isCompleted: true});

--- a/static/app/views/issueDetails/issueDetailsTourModal.tsx
+++ b/static/app/views/issueDetails/issueDetailsTourModal.tsx
@@ -3,13 +3,12 @@ import styled from '@emotion/styled';
 
 import issueDetailsPreviewImage from 'sentry-images/spot/issue-details-preview.svg';
 
-import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {TextTourAction, TourAction} from 'sentry/components/tours/components';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {darkTheme} from 'sentry/utils/theme';
 
-interface IssueDetailsTourModalProps extends ModalRenderProps {
+interface IssueDetailsTourModalProps {
   handleDismissTour: () => void;
   handleStartTour: () => void;
 }

--- a/static/app/views/issueDetails/issueDetailsTourModal.tsx
+++ b/static/app/views/issueDetails/issueDetailsTourModal.tsx
@@ -39,7 +39,7 @@ export function IssueDetailsTourModal({
 
 const ImageContainer = styled('div')`
   width: 100%;
-  height: 226px;
+  height: 282.5px;
   background-image: url(${issueDetailsPreviewImage});
   background-size: cover;
   background-position: center;
@@ -79,5 +79,5 @@ const Footer = styled('div')`
 `;
 
 export const IssueDetailsTourModalCss = css`
-  width: 436px;
+  width: 545px;
 `;


### PR DESCRIPTION
increased the width and image height by 25%. I think the current image resolution is alright, but I could also request a higher res asset. Also removed some unused props

<img width="867" alt="image" src="https://github.com/user-attachments/assets/331d468a-e56c-4e6d-b0d9-d6c39d8d3443" />
