### PR TITLE
fix(celery) Remove pickle param usage in update_code_owners_schema

### DIFF
--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -90,21 +90,17 @@ class ExternalActor(ReplicatedRegionModel):
         )
 
 
-def process_resource_change(instance, **kwargs):
-    from sentry.models.organization import Organization
+def process_resource_change(instance: ExternalActor, **kwargs):
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema
 
     def _spawn_task():
-        try:
-            update_code_owners_schema.apply_async(
-                kwargs={
-                    "organization": instance.organization,
-                    "integration": instance.integration_id,
-                }
-            )
-        except (Organization.DoesNotExist, Project.DoesNotExist):
-            pass
+        update_code_owners_schema.apply_async(
+            kwargs={
+                "organization": instance.organization_id,
+                "integration": instance.integration_id,
+            }
+        )
 
     transaction.on_commit(_spawn_task, router.db_for_write(Project))
 

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -44,9 +44,8 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
         )
 
 
-def process_resource_change(instance, **kwargs):
+def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
     from sentry.models.group import Group
-    from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema
     from sentry.utils.cache import cache
@@ -58,11 +57,11 @@ def process_resource_change(instance, **kwargs):
         try:
             update_code_owners_schema.apply_async(
                 kwargs={
-                    "organization": instance.project.organization,
-                    "projects": [instance.project],
+                    "organization": instance.project.organization_id,
+                    "projects": [instance.project_id],
                 }
             )
-        except (Project.DoesNotExist, Organization.DoesNotExist):
+        except Project.DoesNotExist:
             pass
 
     def _clear_commit_context_cache():

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -40,8 +40,7 @@ class ProjectTeam(Model):
     __repr__ = sane_repr("project_id", "team_id")
 
 
-def process_resource_change(instance, **kwargs):
-    from sentry.models.organization import Organization
+def process_resource_change(instance: ProjectTeam, **kwargs):
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema
 
@@ -49,11 +48,11 @@ def process_resource_change(instance, **kwargs):
         try:
             update_code_owners_schema.apply_async(
                 kwargs={
-                    "organization": instance.project.organization,
-                    "projects": [instance.project],
+                    "organization": instance.project.organization_id,
+                    "projects": [instance.project_id],
                 }
             )
-        except (Project.DoesNotExist, Organization.DoesNotExist):
+        except Project.DoesNotExist:
             pass
 
     transaction.on_commit(_spawn_task, router.db_for_write(ProjectTeam))

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -79,11 +79,10 @@ class TeamManager(BaseManager["Team"]):
     def post_save(self, *, instance: Team, created: bool, **kwargs: object) -> None:
         self.process_resource_change(instance, **kwargs)
 
-    def post_delete(self, instance, **kwargs):
+    def post_delete(self, instance: Team, **kwargs):
         self.process_resource_change(instance, **kwargs)
 
-    def process_resource_change(self, instance, **kwargs):
-        from sentry.models.organization import Organization
+    def process_resource_change(self, instance: Team, **kwargs):
         from sentry.models.project import Project
         from sentry.tasks.codeowners import update_code_owners_schema
 
@@ -91,11 +90,11 @@ class TeamManager(BaseManager["Team"]):
             try:
                 update_code_owners_schema.apply_async(
                     kwargs={
-                        "organization": instance.organization,
-                        "projects": list(instance.get_projects()),
+                        "organization": instance.organization_id,
+                        "projects": [project.id for project in instance.get_projects()],
                     }
                 )
-            except (Organization.DoesNotExist, Project.DoesNotExist):
+            except Project.DoesNotExist:
                 pass
 
         transaction.on_commit(_spawn_task, router.db_for_write(Team))

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -53,7 +53,9 @@ class CodeOwnersTest(TestCase):
         with self.tasks() and self.feature({"organizations:integrations-codeowners": True}):
             # new external team mapping
             self.external_team = self.create_external_team(integration=self.integration)
-            update_code_owners_schema(organization=self.organization, integration=self.integration)
+            update_code_owners_schema(
+                organization=self.organization.id, integration=self.integration.id
+            )
 
         code_owners = ProjectCodeOwners.objects.get(id=self.code_owners.id)
 
@@ -72,7 +74,9 @@ class CodeOwnersTest(TestCase):
         with self.tasks() and self.feature({"organizations:integrations-codeowners": True}):
             # delete external team mapping
             ExternalActor.objects.get(id=self.external_team.id).delete()
-            update_code_owners_schema(organization=self.organization, integration=self.integration)
+            update_code_owners_schema(
+                organization=self.organization.id, integration=self.integration.id
+            )
 
         code_owners = ProjectCodeOwners.objects.get(id=self.code_owners.id)
 

--- a/tests/sentry/tasks/test_update_code_owners_schema.py
+++ b/tests/sentry/tasks/test_update_code_owners_schema.py
@@ -25,25 +25,25 @@ class UpdateCodeOwnersSchemaTest(TestCase):
 
     def test_no_op(self):
         with self.feature("organizations:integrations-codeowners"):
-            update_code_owners_schema(self.organization)
+            update_code_owners_schema(self.organization.id)
         self.mock_update.assert_not_called()
 
     def test_with_project(self):
         with self.feature("organizations:integrations-codeowners"):
-            update_code_owners_schema(self.organization, projects=[self.project])
+            update_code_owners_schema(self.organization.id, projects=[self.project.id])
         self.mock_update.assert_called_with(organization=self.organization)
 
     def test_with_project_id(self):
         with self.feature("organizations:integrations-codeowners"):
-            update_code_owners_schema(self.organization, projects=[self.project.id])
+            update_code_owners_schema(self.organization.id, projects=[self.project.id])
         self.mock_update.assert_called_with(organization=self.organization)
 
     def test_with_integration(self):
         with self.feature("organizations:integrations-codeowners"):
-            update_code_owners_schema(self.organization, integration=self.integration)
+            update_code_owners_schema(self.organization.id, integration=self.integration.id)
         self.mock_update.assert_called_with(organization=self.organization)
 
     def test_with_integration_id(self):
         with self.feature("organizations:integrations-codeowners"):
-            update_code_owners_schema(self.organization, integration=self.integration.id)
+            update_code_owners_schema(self.organization.id, integration=self.integration.id)
         self.mock_update.assert_called_with(organization=self.organization)


### PR DESCRIPTION
Remove callsites that provide parameters requiring pickle for the update_code_owners_schema task. We need to remove all usage of pickle in task parameters in preparation for the taskbroker transition.

Refs #81913