### PR TITLE
feat(explore): Add exclude param to get explore saved queries endpoint

### DIFF
--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -129,6 +129,12 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         else:
             order_by = ["lower_name"]
 
+        exclude = request.query_params.get("exclude")
+        if exclude == "shared":
+            queryset = queryset.filter(created_by_id=request.user.id)
+        elif exclude == "owned":
+            queryset = queryset.exclude(created_by_id=request.user.id)
+
         queryset = queryset.order_by(*order_by)
 
         def data_fn(offset, limit):

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -227,6 +227,7 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
             response = self.client.get(self.url, data={"exclude": "shared"})
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
+        assert response.data[0]["name"] == "Test query"
 
     def test_get_shared_queries(self):
         query = {"fields": ["span.op"], "mode": "samples"}
@@ -242,6 +243,7 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
             response = self.client.get(self.url, data={"exclude": "owned"})
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
+        assert response.data[0]["name"] == "Shared query"
 
     def test_post_require_mode(self):
         with self.feature(self.feature_name):

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -222,6 +222,27 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data[0]["expired"]
 
+    def test_get_my_queries(self):
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url, data={"exclude": "shared"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+    def test_get_shared_queries(self):
+        query = {"fields": ["span.op"], "mode": "samples"}
+        model = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id + 1,
+            name="Shared query",
+            query=query,
+        )
+        model.set_projects(self.project_ids)
+
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url, data={"exclude": "owned"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
     def test_post_require_mode(self):
         with self.feature(self.feature_name):
             response = self.client.post(


### PR DESCRIPTION
Adds an `exclude` query parameter to filter queries owned by the user or unowned.
This is to be used in the explore all queries view to render owned and unowned tables