### PR TITLE
ref(shared-views): Delete all usages of groupsearchview.position

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -59,7 +59,6 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
         default_view, created = GroupSearchView.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,
-            position=0,
             values={
                 "name": "Default Search",
                 "query": result["query"],

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -263,7 +263,6 @@ def _update_existing_view(
         gsv.name = view["name"]
         gsv.query = view["query"]
         gsv.query_sort = view["querySort"]
-        gsv.position = position
         gsv.is_all_projects = view.get("isAllProjects", False)
 
         if "projects" in view:
@@ -300,7 +299,6 @@ def _create_view(
         name=view["name"],
         query=view["query"],
         query_sort=view["querySort"],
-        position=position,
         is_all_projects=view.get("isAllProjects", False),
         environments=view.get("environments", []),
         time_filters=view.get("timeFilters", {"period": "14d"}),

--- a/src/sentry/models/groupsearchview.py
+++ b/src/sentry/models/groupsearchview.py
@@ -85,7 +85,3 @@ class GroupSearchView(DefaultFieldsModelExisting):
                 deferrable=models.Deferrable.DEFERRED,
             )
         ]
-
-    @property
-    def is_default(self):
-        return self.position == 0

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -628,7 +628,6 @@ class ExhaustiveFixtures(Fixtures):
             organization=org,
             query=f"some query for {slug}",
             query_sort="date",
-            position=0,
         )
         GroupSearchViewProject.objects.create(
             group_search_view=group_search_view,

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -44,7 +44,6 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             user_id=self.member.id,
             query=query,
             query_sort=sort,
-            position=0,
         )
         assert GroupSearchViewStarred.objects.filter(
             organization=self.organization,

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -16,7 +16,6 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
             name="Custom View",
             query="is:unresolved",
             query_sort="date",
-            position=0,
         )
 
         self.ScheduledDeletion.schedule(instance=member, days=0)
@@ -41,7 +40,6 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
             name="Custom View",
             query="is:unresolved",
             query_sort="date",
-            position=0,
         )
 
         custom_view_two = GroupSearchView.objects.create(
@@ -50,7 +48,6 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
             name="Custom View",
             query="is:unresolved",
             query_sort="date",
-            position=0,
         )
 
         self.ScheduledDeletion.schedule(instance=member_one, days=0)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2377,7 +2377,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         default_view = GroupSearchView.objects.create(
             organization=self.organization,
             user_id=self.user.id,
-            position=0,
             name="Default View",
             query="ZeroDivisionError",
             query_sort="date",
@@ -2422,7 +2421,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         GroupSearchView.objects.create(
             organization=self.organization,
             user_id=self.user.id,
-            position=0,
             name="Default View",
             query="TypeError",
             query_sort="date",
@@ -2431,7 +2429,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         view = GroupSearchView.objects.create(
             organization=self.organization,
             user_id=self.user.id,
-            position=1,
             name="Custom View",
             query="ZeroDivisionError",
             query_sort="date",

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -43,7 +43,6 @@ class BaseGSVTestCase(APITestCase):
             user_id=user_1.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -59,7 +58,6 @@ class BaseGSVTestCase(APITestCase):
             user_id=user_1.id,
             query="is:ignored",
             query_sort="freq",
-            position=2,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -74,7 +72,6 @@ class BaseGSVTestCase(APITestCase):
             user_id=user_1.id,
             query="is:resolved",
             query_sort="new",
-            position=1,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -89,7 +86,6 @@ class BaseGSVTestCase(APITestCase):
             user_id=self.user_2.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -104,7 +100,6 @@ class BaseGSVTestCase(APITestCase):
             user_id=self.user_2.id,
             query="is:resolved",
             query_sort="new",
-            position=1,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -500,7 +495,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             user_id=user_1.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             time_filters={"period": "14d"},
             environments=[],
         )
@@ -518,7 +512,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             user_id=user_1.id,
             query="is:resolved",
             query_sort="new",
-            position=1,
             time_filters={"period": "7d"},
             environments=["staging", "production"],
         )
@@ -536,7 +529,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             user_id=user_1.id,
             query="is:ignored",
             query_sort="freq",
-            position=2,
             time_filters={"period": "30d"},
             environments=["development"],
         )
@@ -709,7 +701,6 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
             user_id=self.user.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             time_filters={"period": "14d"},
             environments=["production"],
         )
@@ -777,7 +768,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             user_id=user_1.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             is_all_projects=False,
             time_filters={"period": "14d"},
             environments=[],
@@ -796,7 +786,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             user_id=user_1.id,
             query="is:resolved",
             query_sort="new",
-            position=1,
             is_all_projects=False,
             time_filters={"period": "7d"},
             environments=["staging", "production"],
@@ -815,7 +804,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             user_id=user_1.id,
             query="is:ignored",
             query_sort="freq",
-            position=2,
             is_all_projects=True,
             time_filters={"period": "30d"},
             environments=["development"],
@@ -834,7 +822,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             user_id=self.user_2.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             is_all_projects=False,
             time_filters={"period": "14d"},
             environments=[],
@@ -853,7 +840,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             user_id=self.user_4.id,
             query="is:unresolved",
             query_sort="date",
-            position=0,
             is_all_projects=False,
             time_filters={"period": "14d"},
             environments=[],

--- a/tests/sentry/models/test_groupsearchview.py
+++ b/tests/sentry/models/test_groupsearchview.py
@@ -13,7 +13,6 @@ class GroupSearchViewTestCase(TestCase):
             organization=org,
             query="some query",
             query_sort="date",
-            position=0,
         )
 
         GroupSearchView.objects.create(
@@ -22,9 +21,6 @@ class GroupSearchViewTestCase(TestCase):
             organization=org,
             query="some query #2",
             query_sort="date",
-            position=1,
         )
 
         assert GroupSearchView.objects.filter(user_id=user.id).count() == 2
-        assert GroupSearchView.objects.filter(user_id=user.id, position=0).count() == 1
-        assert GroupSearchView.objects.filter(user_id=user.id, position=1).count() == 1


### PR DESCRIPTION
This PR Deletes all usages of groupsearchview.position, except for any usages in migration tests.

I global searches for `GroupSearchView.` and `position` in all .py files and hand checked to make sure we were not using it anywhere.