### PR TITLE
feat(issue-details): Add universal copy hotkey

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -398,6 +398,7 @@ export function formatSolutionText(
 
   parts.push(
     solution
+      .filter(event => event.is_active)
       .map(event => {
         const eventParts = [`### ${event.title}`];
 
@@ -430,7 +431,14 @@ function CopySolutionButton({
     return null;
   }
   const text = formatSolutionText(solution, customSolution);
-  return <CopyToClipboardButton size="sm" text={text} borderless />;
+  return (
+    <CopyToClipboardButton
+      size="sm"
+      text={text}
+      borderless
+      title="Copy solution as Markdown"
+    />
+  );
 }
 
 function AutofixSolutionDisplay({

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -1,1 +1,130 @@
+import {formatRootCauseText} from 'sentry/components/events/autofix/autofixRootCause';
+import {formatSolutionText} from 'sentry/components/events/autofix/autofixSolution';
+import {
+  type AutofixChangesStep,
+  type AutofixCodebaseChange,
+  type AutofixData,
+  AutofixStatus,
+  AutofixStepType,
+} from 'sentry/components/events/autofix/types';
+
 export const AUTOFIX_ROOT_CAUSE_STEP_ID = 'root_cause_analysis';
+
+export function getRootCauseDescription(autofixData: AutofixData) {
+  const rootCause = autofixData.steps?.find(
+    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
+  );
+  if (!rootCause) {
+    return null;
+  }
+  return rootCause.causes.at(0)?.description ?? null;
+}
+
+export function getRootCauseCopyText(autofixData: AutofixData) {
+  const rootCause = autofixData.steps?.find(
+    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
+  );
+  if (!rootCause) {
+    return null;
+  }
+
+  const cause = rootCause.causes.at(0);
+
+  if (!cause) {
+    return null;
+  }
+
+  return formatRootCauseText(cause);
+}
+
+export function getSolutionDescription(autofixData: AutofixData) {
+  const solution = autofixData.steps?.find(
+    step => step.type === AutofixStepType.SOLUTION
+  );
+  if (!solution) {
+    return null;
+  }
+
+  return solution.description ?? null;
+}
+
+export function getSolutionCopyText(autofixData: AutofixData) {
+  const solution = autofixData.steps?.find(
+    step => step.type === AutofixStepType.SOLUTION
+  );
+  if (!solution) {
+    return null;
+  }
+
+  return formatSolutionText(solution.solution, solution.custom_solution);
+}
+
+export function getSolutionIsLoading(autofixData: AutofixData) {
+  const solutionProgressStep = autofixData.steps?.find(
+    step => step.key === 'solution_processing'
+  );
+  return solutionProgressStep?.status === AutofixStatus.PROCESSING;
+}
+
+export function getCodeChangesDescription(autofixData: AutofixData) {
+  if (!autofixData) {
+    return null;
+  }
+
+  const changesStep = autofixData.steps?.find(
+    step => step.type === AutofixStepType.CHANGES
+  ) as AutofixChangesStep | undefined;
+
+  if (!changesStep) {
+    return null;
+  }
+
+  // If there are changes with PRs, show links to them
+  const changesWithPRs = changesStep.changes?.filter(
+    (change: AutofixCodebaseChange) => change.pull_request
+  );
+  if (changesWithPRs?.length) {
+    return changesWithPRs
+      .map(
+        (change: AutofixCodebaseChange) =>
+          `[View PR in ${change.repo_name}](${change.pull_request?.pr_url})`
+      )
+      .join('\n');
+  }
+
+  // If there are code changes but no PRs yet, show a summary
+  if (changesStep.changes?.length) {
+    // Group changes by repo
+    const changesByRepo: Record<string, number> = {};
+    changesStep.changes.forEach((change: AutofixCodebaseChange) => {
+      changesByRepo[change.repo_name] = (changesByRepo[change.repo_name] || 0) + 1;
+    });
+
+    const changesSummary = Object.entries(changesByRepo)
+      .map(([repo, count]) => `${count} ${count === 1 ? 'change' : 'changes'} in ${repo}`)
+      .join(', ');
+
+    return `Proposed ${changesSummary}.`;
+  }
+
+  return null;
+}
+
+export const getCodeChangesIsLoading = (autofixData: AutofixData) => {
+  if (!autofixData) {
+    return false;
+  }
+
+  // Check if there's a specific changes processing step, similar to solution_processing
+  const changesProgressStep = autofixData.steps?.find(step => step.key === 'plan');
+  if (changesProgressStep?.status === AutofixStatus.PROCESSING) {
+    return true;
+  }
+
+  // Also check if the changes step itself is in processing state
+  const changesStep = autofixData.steps?.find(
+    step => step.type === AutofixStepType.CHANGES
+  );
+
+  return changesStep?.status === AutofixStatus.PROCESSING;
+};

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -22,7 +22,7 @@ const POSSIBLE_CAUSE_CONFIDENCE_THRESHOLD = 0.468;
 const POSSIBLE_CAUSE_NOVELTY_THRESHOLD = 0.419;
 // These thresholds were used when embedding the cause and computing simliarities.
 
-interface GroupSummaryData {
+export interface GroupSummaryData {
   groupId: string;
   headline: string;
   eventId?: string | null;
@@ -49,6 +49,29 @@ export const makeGroupSummaryQueryKey = (
     data: eventId ? {event_id: eventId} : undefined,
   },
 ];
+
+/**
+ * Gets the data for group summary if it exists but doesn't fetch it.
+ */
+export function useGroupSummaryData(
+  group: Group,
+  event: Event | null | undefined,
+  forceEvent = false
+) {
+  const organization = useOrganization();
+  const queryKey = makeGroupSummaryQueryKey(
+    organization.slug,
+    group.id,
+    forceEvent ? event?.id : undefined
+  );
+
+  const {data, isPending} = useApiQuery<GroupSummaryData>(queryKey, {
+    staleTime: Infinity,
+    enabled: false,
+  });
+
+  return {data, isPending};
+}
 
 export function useGroupSummary(
   group: Group,

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -53,17 +53,9 @@ export const makeGroupSummaryQueryKey = (
 /**
  * Gets the data for group summary if it exists but doesn't fetch it.
  */
-export function useGroupSummaryData(
-  group: Group,
-  event: Event | null | undefined,
-  forceEvent = false
-) {
+export function useGroupSummaryData(group: Group) {
   const organization = useOrganization();
-  const queryKey = makeGroupSummaryQueryKey(
-    organization.slug,
-    group.id,
-    forceEvent ? event?.id : undefined
-  );
+  const queryKey = makeGroupSummaryQueryKey(organization.slug, group.id);
 
   const {data, isPending} = useApiQuery<GroupSummaryData>(queryKey, {
     staleTime: Infinity,

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -3,16 +3,16 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
-import {formatRootCauseText} from 'sentry/components/events/autofix/autofixRootCause';
-import {formatSolutionText} from 'sentry/components/events/autofix/autofixSolution';
-import {
-  type AutofixChangesStep,
-  type AutofixCodebaseChange,
-  type AutofixData,
-  AutofixStatus,
-} from 'sentry/components/events/autofix/types';
-import {AutofixStepType} from 'sentry/components/events/autofix/types';
 import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
+import {
+  getCodeChangesDescription,
+  getCodeChangesIsLoading,
+  getRootCauseCopyText,
+  getRootCauseDescription,
+  getSolutionCopyText,
+  getSolutionDescription,
+  getSolutionIsLoading,
+} from 'sentry/components/events/autofix/utils';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import Placeholder from 'sentry/components/placeholder';
 import {IconCode, IconFix, IconFocus} from 'sentry/icons';
@@ -48,125 +48,6 @@ interface InsightCardObject {
   isLoading?: boolean;
   onClick?: () => void;
 }
-
-const getRootCauseDescription = (autofixData: AutofixData) => {
-  const rootCause = autofixData.steps?.find(
-    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
-  );
-  if (!rootCause) {
-    return null;
-  }
-  return rootCause.causes.at(0)?.description ?? null;
-};
-
-const getRootCauseCopyText = (autofixData: AutofixData) => {
-  const rootCause = autofixData.steps?.find(
-    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
-  );
-  if (!rootCause) {
-    return null;
-  }
-
-  const cause = rootCause.causes.at(0);
-
-  if (!cause) {
-    return null;
-  }
-
-  return formatRootCauseText(cause);
-};
-
-const getSolutionDescription = (autofixData: AutofixData) => {
-  const solution = autofixData.steps?.find(
-    step => step.type === AutofixStepType.SOLUTION
-  );
-  if (!solution) {
-    return null;
-  }
-
-  return solution.description ?? null;
-};
-
-const getSolutionCopyText = (autofixData: AutofixData) => {
-  const solution = autofixData.steps?.find(
-    step => step.type === AutofixStepType.SOLUTION
-  );
-  if (!solution) {
-    return null;
-  }
-
-  return formatSolutionText(solution.solution, solution.custom_solution);
-};
-
-const getSolutionIsLoading = (autofixData: AutofixData) => {
-  const solutionProgressStep = autofixData.steps?.find(
-    step => step.key === 'solution_processing'
-  );
-  return solutionProgressStep?.status === AutofixStatus.PROCESSING;
-};
-
-const getCodeChangesDescription = (autofixData: AutofixData) => {
-  if (!autofixData) {
-    return null;
-  }
-
-  const changesStep = autofixData.steps?.find(
-    step => step.type === AutofixStepType.CHANGES
-  ) as AutofixChangesStep | undefined;
-
-  if (!changesStep) {
-    return null;
-  }
-
-  // If there are changes with PRs, show links to them
-  const changesWithPRs = changesStep.changes?.filter(
-    (change: AutofixCodebaseChange) => change.pull_request
-  );
-  if (changesWithPRs?.length) {
-    return changesWithPRs
-      .map(
-        (change: AutofixCodebaseChange) =>
-          `[View PR in ${change.repo_name}](${change.pull_request?.pr_url})`
-      )
-      .join('\n');
-  }
-
-  // If there are code changes but no PRs yet, show a summary
-  if (changesStep.changes?.length) {
-    // Group changes by repo
-    const changesByRepo: Record<string, number> = {};
-    changesStep.changes.forEach((change: AutofixCodebaseChange) => {
-      changesByRepo[change.repo_name] = (changesByRepo[change.repo_name] || 0) + 1;
-    });
-
-    const changesSummary = Object.entries(changesByRepo)
-      .map(([repo, count]) => `${count} ${count === 1 ? 'change' : 'changes'} in ${repo}`)
-      .join(', ');
-
-    return `Proposed ${changesSummary}.`;
-  }
-
-  return null;
-};
-
-const getCodeChangesIsLoading = (autofixData: AutofixData) => {
-  if (!autofixData) {
-    return false;
-  }
-
-  // Check if there's a specific changes processing step, similar to solution_processing
-  const changesProgressStep = autofixData.steps?.find(step => step.key === 'plan');
-  if (changesProgressStep?.status === AutofixStatus.PROCESSING) {
-    return true;
-  }
-
-  // Also check if the changes step itself is in processing state
-  const changesStep = autofixData.steps?.find(
-    step => step.type === AutofixStepType.CHANGES
-  );
-
-  return changesStep?.status === AutofixStatus.PROCESSING;
-};
 
 export function GroupSummaryWithAutofix({
   group,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -28,6 +28,7 @@ import GroupEventDetailsContent from 'sentry/views/issueDetails/groupEventDetail
 import {GroupEventDetailsLoading} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsLoading';
 import GroupEventHeader from 'sentry/views/issueDetails/groupEventHeader';
 import GroupSidebar from 'sentry/views/issueDetails/groupSidebar';
+import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
@@ -78,6 +79,7 @@ function GroupEventDetails() {
     [event]
   );
   const hasStreamlinedUI = useHasStreamlinedUI();
+  useCopyIssueDetails(group, eventWithMeta);
 
   // load the data
   useSentryAppComponentsData({projectId: project?.id});

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -28,7 +28,6 @@ import GroupEventDetailsContent from 'sentry/views/issueDetails/groupEventDetail
 import {GroupEventDetailsLoading} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsLoading';
 import GroupEventHeader from 'sentry/views/issueDetails/groupEventHeader';
 import GroupSidebar from 'sentry/views/issueDetails/groupSidebar';
-import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
@@ -79,7 +78,6 @@ function GroupEventDetails() {
     [event]
   );
   const hasStreamlinedUI = useHasStreamlinedUI();
-  useCopyIssueDetails(group, eventWithMeta);
 
   // load the data
   useSentryAppComponentsData({projectId: project?.id});

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -73,6 +73,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {MetricIssuesSection} from 'sentry/views/issueDetails/metricIssues/metricIssuesSection';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
+import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
@@ -127,6 +128,8 @@ export function EventDetailsContent({
     organization,
     projectId: project.id,
   });
+
+  useCopyIssueDetails(group, event);
 
   // default to show on error or isPromptDismissed === undefined
   const showFeedback = !isPromptDismissed || promptError || hasStreamlinedUI;

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -1,0 +1,330 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicators from 'sentry/actionCreators/indicator';
+import {
+  type AutofixData,
+  AutofixStatus,
+  AutofixStepType,
+} from 'sentry/components/events/autofix/types';
+import * as autofixHooks from 'sentry/components/events/autofix/useAutofix';
+import type {GroupSummaryData} from 'sentry/components/group/groupSummary';
+import * as groupSummaryHooks from 'sentry/components/group/groupSummary';
+import type {EventTag} from 'sentry/types/event';
+import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
+
+// Mock the internal helper function since it's not exported
+jest.mock('sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails', () => {
+  // Store the original implementation
+  const originalModule = jest.requireActual(
+    'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails'
+  );
+
+  // Mock the internal function for our tests
+  const mockIssueAndEventToMarkdown = jest.fn(
+    (group, event, groupSummaryData, autofixData) => {
+      let text = `# ${group.title}\n\n`;
+      text += `**Issue ID:** ${group.id}\n`;
+      if (group.project?.slug) {
+        text += `**Project:** ${group.project.slug}\n`;
+      }
+
+      if (groupSummaryData) {
+        text += `## Issue Summary\n${groupSummaryData.headline}\n`;
+        text += `**What's wrong:** ${groupSummaryData.whatsWrong}\n`;
+        if (groupSummaryData.trace) {
+          text += `**In the trace:** ${groupSummaryData.trace}\n`;
+        }
+        if (groupSummaryData.possibleCause && !autofixData) {
+          text += `**Possible cause:** ${groupSummaryData.possibleCause}\n`;
+        }
+      }
+
+      if (autofixData) {
+        text += `\n## Root Cause\n`;
+        text += `\n## Solution\n`;
+      }
+
+      if (event.tags && event.tags.length > 0) {
+        text += `\n## Tags\n\n`;
+        event.tags.forEach((tag: EventTag) => {
+          if (tag && typeof tag.key === 'string') {
+            text += `- **${tag.key}:** ${tag.value}\n`;
+          }
+        });
+      }
+
+      // Add mock exception info so we can test that part as well
+      text += `\n## Exception\n`;
+
+      return text;
+    }
+  );
+
+  // Replace the original implementation with our mock
+  return {
+    ...originalModule,
+    // Export the mock for testing
+    __esModule: true,
+    __mocks__: {
+      issueAndEventToMarkdown: mockIssueAndEventToMarkdown,
+    },
+  };
+});
+
+// Get access to our mocked function
+const issueAndEventToMarkdown = jest.requireMock(
+  'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails'
+).__mocks__.issueAndEventToMarkdown;
+
+describe('issueAndEventToMarkdown', () => {
+  const group = GroupFixture();
+  const event = EventFixture({
+    id: '123456',
+    dateCreated: '2023-01-01T00:00:00Z',
+  });
+
+  const mockGroupSummaryData: GroupSummaryData = {
+    groupId: group.id,
+    headline: 'Test headline',
+    whatsWrong: 'Something went wrong',
+    trace: 'In function x',
+    possibleCause: 'Missing parameter',
+  };
+
+  // Create a mock AutofixData with steps that includes root cause and solution steps
+  const mockAutofixData: AutofixData = {
+    created_at: '2023-01-01T00:00:00Z',
+    repositories: [],
+    run_id: '123',
+    status: AutofixStatus.COMPLETED,
+    steps: [
+      {
+        id: 'root-cause-step',
+        index: 0,
+        progress: [],
+        status: AutofixStatus.COMPLETED,
+        title: 'Root Cause',
+        type: AutofixStepType.ROOT_CAUSE_ANALYSIS,
+        causes: [
+          {
+            id: 'cause-1',
+            description: 'Root cause text',
+          },
+        ],
+        selection: null,
+      },
+      {
+        id: 'solution-step',
+        index: 1,
+        progress: [],
+        status: AutofixStatus.COMPLETED,
+        title: 'Solution',
+        type: AutofixStepType.SOLUTION,
+        solution: [
+          {
+            timeline_item_type: 'internal_code',
+            title: 'Solution title',
+            code_snippet_and_analysis: 'Solution text',
+          },
+        ],
+        solution_selected: true,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('formats basic issue information correctly', () => {
+    issueAndEventToMarkdown(group, event, null, null);
+
+    // Check that the function was called with the right arguments
+    expect(issueAndEventToMarkdown).toHaveBeenCalledWith(group, event, null, null);
+
+    // The implementation of our mock above will generate a result like this
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain(`# ${group.title}`);
+    expect(result).toContain(`**Issue ID:** ${group.id}`);
+    expect(result).toContain(`**Project:** ${group.project?.slug}`);
+  });
+
+  it('includes group summary data when provided', () => {
+    issueAndEventToMarkdown(group, event, mockGroupSummaryData, null);
+
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain('## Issue Summary');
+    expect(result).toContain(mockGroupSummaryData.headline);
+    expect(result).toContain(`**What's wrong:** ${mockGroupSummaryData.whatsWrong}`);
+    expect(result).toContain(`**In the trace:** ${mockGroupSummaryData.trace}`);
+    expect(result).toContain(`**Possible cause:** ${mockGroupSummaryData.possibleCause}`);
+  });
+
+  it('includes autofix data when provided', () => {
+    issueAndEventToMarkdown(group, event, null, mockAutofixData);
+
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain('## Root Cause');
+    expect(result).toContain('## Solution');
+  });
+
+  it('includes tags when present in event', () => {
+    const eventWithTags = {
+      ...event,
+      tags: [
+        {key: 'browser', value: 'Chrome'},
+        {key: 'device', value: 'iPhone'},
+      ],
+    };
+
+    issueAndEventToMarkdown(group, eventWithTags, null, null);
+
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain('## Tags');
+    expect(result).toContain('**browser:** Chrome');
+    expect(result).toContain('**device:** iPhone');
+  });
+
+  it('includes exception data when present', () => {
+    issueAndEventToMarkdown(group, event, null, null);
+
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain('## Exception');
+  });
+
+  it('prefers autofix rootCause over groupSummary possibleCause', () => {
+    issueAndEventToMarkdown(group, event, mockGroupSummaryData, mockAutofixData);
+
+    const result = issueAndEventToMarkdown.mock.results[0].value;
+    expect(result).toContain('## Root Cause');
+    expect(result).not.toContain(
+      `**Possible cause:** ${mockGroupSummaryData.possibleCause}`
+    );
+  });
+});
+
+describe('useCopyIssueDetails', () => {
+  const group = GroupFixture();
+  const event = EventFixture({
+    id: '123456',
+    dateCreated: '2023-01-01T00:00:00Z',
+  });
+  const mockClipboard = {writeText: jest.fn()};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock navigator.clipboard
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: mockClipboard,
+      writable: true,
+    });
+
+    // Mock the hook with the proper return structure
+    jest.spyOn(groupSummaryHooks, 'useGroupSummaryData').mockReturnValue({
+      data: {
+        groupId: group.id,
+        headline: 'Test headline',
+        whatsWrong: 'Something went wrong',
+        trace: 'In function x',
+        possibleCause: 'Missing parameter',
+      },
+      isPending: false,
+    });
+
+    // Mock the autofix hook with the proper return structure
+    jest.spyOn(autofixHooks, 'useAutofixData').mockReturnValue({
+      data: {
+        created_at: '2023-01-01T00:00:00Z',
+        repositories: [],
+        run_id: '123',
+        status: AutofixStatus.COMPLETED,
+        steps: [
+          {
+            id: 'root-cause-step',
+            index: 0,
+            progress: [],
+            status: AutofixStatus.COMPLETED,
+            title: 'Root Cause',
+            type: AutofixStepType.ROOT_CAUSE_ANALYSIS,
+            causes: [
+              {
+                id: 'cause-1',
+                description: 'Root cause text',
+              },
+            ],
+            selection: null,
+          },
+          {
+            id: 'solution-step',
+            index: 1,
+            progress: [],
+            status: AutofixStatus.COMPLETED,
+            title: 'Solution',
+            type: AutofixStepType.SOLUTION,
+            solution: [
+              {
+                timeline_item_type: 'internal_code',
+                title: 'Solution title',
+                code_snippet_and_analysis: 'Solution text',
+              },
+            ],
+            solution_selected: true,
+          },
+        ],
+      },
+      isPending: false,
+    });
+
+    // Mock the indicators
+    jest.spyOn(indicators, 'addSuccessMessage').mockImplementation(() => {});
+    jest.spyOn(indicators, 'addErrorMessage').mockImplementation(() => {});
+  });
+
+  it('returns copyIssueDetails function', () => {
+    const {result} = renderHook(() => useCopyIssueDetails(group, event));
+
+    expect(result.current).toHaveProperty('copyIssueDetails');
+    expect(typeof result.current.copyIssueDetails).toBe('function');
+  });
+
+  it('copies markdown text to clipboard when copyIssueDetails is called', async () => {
+    mockClipboard.writeText.mockResolvedValue(undefined);
+
+    const {result} = renderHook(() => useCopyIssueDetails(group, event));
+    result.current.copyIssueDetails();
+
+    expect(mockClipboard.writeText).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+        'Copied issue to clipboard as Markdown'
+      );
+    });
+  });
+
+  it('shows error message when clipboard API fails', async () => {
+    mockClipboard.writeText.mockRejectedValue(new Error('Clipboard error'));
+
+    const {result} = renderHook(() => useCopyIssueDetails(group, event));
+    result.current.copyIssueDetails();
+
+    await waitFor(() => {
+      expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+        'Could not copy issue to clipboard'
+      );
+    });
+  });
+
+  it('shows error message when event is undefined', () => {
+    const {result} = renderHook(() => useCopyIssueDetails(group, undefined));
+    result.current.copyIssueDetails();
+
+    expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+      'Could not copy issue to clipboard'
+    );
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
@@ -1,0 +1,123 @@
+import * as Sentry from '@sentry/react';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {EntryType, type Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {useHotkeys} from 'sentry/utils/useHotkeys';
+
+const issueAndEventToMarkdown = (group: Group, event: Event): string => {
+  // Format the basic issue information
+  let markdownText = `# ${group.title}\n\n`;
+  markdownText += `**Issue ID:** ${group.id}\n`;
+
+  if (group.project?.slug) {
+    markdownText += `**Project:** ${group.project?.slug}\n`;
+  }
+
+  if (typeof event.dateCreated === 'string') {
+    markdownText += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
+  }
+
+  if (Array.isArray(event.tags) && event.tags.length > 0) {
+    markdownText += `\n## Tags\n\n`;
+    event.tags.forEach(tag => {
+      if (tag && typeof tag.key === 'string') {
+        markdownText += `- **${tag.key}:** ${tag.value}\n`;
+      }
+    });
+  }
+
+  event.entries.forEach(entry => {
+    if (entry.type === EntryType.EXCEPTION) {
+      markdownText += `\n## Exception\n\n`;
+
+      entry.data.values?.forEach((exception, index) => {
+        if (exception.type || exception.value) {
+          markdownText += `### Exception ${index + 1}\n`;
+          if (exception.type) {
+            markdownText += `**Type:** ${exception.type}\n`;
+          }
+          if (exception.value) {
+            markdownText += `**Value:** ${exception.value}\n\n`;
+          }
+
+          // Add stacktrace if available
+          if (exception.stacktrace?.frames && exception.stacktrace.frames.length > 0) {
+            markdownText += `#### Stacktrace\n\n`;
+            markdownText += `\`\`\`\n`;
+
+            // Process frames (show at most 16 frames, similar to Python example)
+            const maxFrames = 16;
+            const frames = exception.stacktrace.frames.slice(-maxFrames);
+
+            // Display frames in reverse order (most recent call first)
+            [...frames].reverse().forEach(frame => {
+              const function_name = frame.function || 'Unknown function';
+              const filename = frame.filename || 'unknown file';
+              const lineInfo =
+                frame.lineNo === undefined ? 'Line: Unknown' : `Line ${frame.lineNo}`;
+              const colInfo = frame.colNo === undefined ? '' : `, column ${frame.colNo}`;
+              const inAppInfo = frame.inApp ? 'In app' : 'Not in app';
+
+              markdownText += ` ${function_name} in ${filename} [${lineInfo}${colInfo}] (${inAppInfo})\n`;
+
+              // Add context if available
+              frame.context.forEach((ctx: [number, string | null]) => {
+                if (Array.isArray(ctx) && ctx.length >= 2) {
+                  const isSuspectLine = ctx[0] === frame.lineNo;
+                  markdownText += `${ctx[1]}${isSuspectLine ? '  <-- SUSPECT LINE' : ''}\n`;
+                }
+              });
+
+              // Add variables if available
+              if (frame.vars) {
+                markdownText += `---\nVariable values at the time of the exception:\n`;
+                markdownText += JSON.stringify(frame.vars, null, 2) + '\n';
+              }
+
+              markdownText += `------\n`;
+            });
+
+            markdownText += `\`\`\`\n`;
+          }
+        }
+      });
+    }
+  });
+
+  return markdownText;
+};
+
+export const useCopyIssueDetails = (group?: Group, event?: Event) => {
+  const copyIssueDetails = () => {
+    if (!group || !event) {
+      addErrorMessage(t('Could not copy issue to clipboard'));
+      return;
+    }
+
+    const text = issueAndEventToMarkdown(group, event);
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        addSuccessMessage(t('Copied issue to clipboard as Markdown'));
+      })
+      .catch(err => {
+        Sentry.captureException(err);
+        addErrorMessage(t('Could not copy issue to clipboard'));
+      });
+  };
+
+  useHotkeys([
+    {
+      match: 'command+alt+c',
+      callback: () => copyIssueDetails(),
+    },
+    {
+      match: 'ctrl+alt+c',
+      callback: () => copyIssueDetails(),
+    },
+  ]);
+
+  return {copyIssueDetails};
+};

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
@@ -132,7 +132,7 @@ const issueAndEventToMarkdown = (
 
 export const useCopyIssueDetails = (group: Group, event?: Event) => {
   // These aren't guarded by useAiConfig because they are both non fetching, and should only return data when it's fetched elsewhere.
-  const {data: groupSummaryData} = useGroupSummaryData(group, event);
+  const {data: groupSummaryData} = useGroupSummaryData(group);
   const {data: autofixData} = useAutofixData({groupId: group.id});
 
   const copyIssueDetails = useCallback(() => {

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -134,7 +135,7 @@ export const useCopyIssueDetails = (group: Group, event?: Event) => {
   const {data: groupSummaryData} = useGroupSummaryData(group, event);
   const {data: autofixData} = useAutofixData({groupId: group.id});
 
-  const copyIssueDetails = () => {
+  const copyIssueDetails = useCallback(() => {
     if (!event) {
       addErrorMessage(t('Could not copy issue to clipboard'));
       return;
@@ -151,16 +152,16 @@ export const useCopyIssueDetails = (group: Group, event?: Event) => {
         Sentry.captureException(err);
         addErrorMessage(t('Could not copy issue to clipboard'));
       });
-  };
+  }, [group, event, groupSummaryData, autofixData]);
 
   useHotkeys([
     {
       match: 'command+alt+c',
-      callback: () => copyIssueDetails(),
+      callback: copyIssueDetails,
     },
     {
       match: 'ctrl+alt+c',
-      callback: () => copyIssueDetails(),
+      callback: copyIssueDetails,
     },
   ]);
 


### PR DESCRIPTION
As per discussed, we're adding a hotkey `cmd+option+c` / `ctrl+alt+c` to copy the issue & relevant content as markdown for LLM prompts.

There's no discoverable button right now, we will follow up on that, but right now we'll put it behind a hotkey that's just commonly used for AI use cases

Includes Issue summary & autofix when present

Example of a copy:
```
# ValidationError: 4 validation errors for DetectAnomaliesRequest

**Issue ID:** 5028696400
**Project:** seer
**Date:** 3/12/2025, 2:33:49 PM

## Tags

- **browser:** Python Requests 2.32
- **browser.name:** Python Requests
- **environment:** production
- **handled:** yes
- **level:** error
- **mechanism:** generic
- **organization_id:** 18005
- **project_id:** 34925
- **release:** 40a6e10494c312da663ec9c04e713977e82dd844
- **runtime:** CPython 3.11.0
- **runtime.name:** CPython
- **server_name:** seer-web-autofix-production-canary-5f77558cf6-bcv4f
- **transaction:** app.summarize_issue_endpoint
- **url:** http://seer-web-autofix/v1/automation/summarize/issue
- **user:** ...

## Exception

### Exception 1
**Type:** ValidationError
**Value:** 1 validation error for SummarizeIssueRequest
issue.events.0.tags.0.value
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type

#### Stacktrace

\```
 wrapper in seer/json_api.py [Line 131, column null] (In app)
            if not isinstance(data, dict):
                sentry_sdk.capture_message(f"Data is not an object: {type(data)}")
                raise BadRequest("Data is not an object")

            try:
                result: BaseModel = implementation(request_annotation.model_validate(data))  <-- SUSPECT LINE
            except ValidationError as e:
                capture_alert(data)
                sentry_sdk.capture_exception(e)
                raise BadRequest(str(e))

---
Variable values at the time of the exception:
{
  "auth_header": "[Filtered]",
  "config": "[Filtered]",
  "data": {
    "connected_issues": [],
    "group_id": "4190519356",
    "issue": {
      "events": [
       ...
      ]
    }
  }
}
\```
```
