### PR TITLE
fix(context): Render more known context fields appropriately

### DIFF
--- a/static/app/components/events/contexts/knownContext/app.tsx
+++ b/static/app/components/events/contexts/knownContext/app.tsx
@@ -7,6 +7,7 @@ import type {Event} from 'sentry/types/event';
 import type {KeyValueListData} from 'sentry/types/group';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 
+// https://github.com/getsentry/relay/blob/25.3.0/relay-event-schema/src/protocol/contexts/app.rs
 enum AppContextKeys {
   ID = 'app_id',
   START_TIME = 'app_start_time',
@@ -17,8 +18,11 @@ enum AppContextKeys {
   VERSION = 'app_version',
   BUILD = 'app_build',
   IN_FOREGROUND = 'in_foreground',
-  MEMORY = 'app_memory',
+  APP_MEMORY = 'app_memory',
   VIEW_NAMES = 'view_names',
+  // XXX: From https://github.com/getsentry/sentry/issues/87238, not in the schema yet.
+  FREE_MEMORY = 'free_memory',
+  ARCHITECTURE = 'app_arch',
 }
 
 export interface AppContext {
@@ -33,8 +37,10 @@ export interface AppContext {
   [AppContextKeys.TYPE]?: string;
   [AppContextKeys.DEVICE_HASH]?: string;
   [AppContextKeys.IN_FOREGROUND]?: boolean;
-  [AppContextKeys.MEMORY]?: number;
+  [AppContextKeys.APP_MEMORY]?: number;
   [AppContextKeys.VIEW_NAMES]?: string[];
+  [AppContextKeys.FREE_MEMORY]?: number;
+  [AppContextKeys.ARCHITECTURE]?: string;
 }
 
 // https://github.com/getsentry/relay/blob/24.10.0/relay-event-schema/src/protocol/contexts/app.rs#L37
@@ -113,7 +119,7 @@ export function getAppContextData({
           subject: t('In Foreground'),
           value: data.in_foreground,
         };
-      case AppContextKeys.MEMORY:
+      case AppContextKeys.APP_MEMORY:
         return {
           key: ctxKey,
           subject: t('Memory Usage'),
@@ -124,6 +130,18 @@ export function getAppContextData({
           key: ctxKey,
           subject: t('View Names'),
           value: data.view_names,
+        };
+      case AppContextKeys.FREE_MEMORY:
+        return {
+          key: ctxKey,
+          subject: t('Free Memory'),
+          value: data.free_memory ? formatMemory(data.free_memory) : undefined,
+        };
+      case AppContextKeys.ARCHITECTURE:
+        return {
+          key: ctxKey,
+          subject: t('Architecture'),
+          value: data.app_arch,
         };
       default:
         return {

--- a/static/app/components/events/contexts/knownContext/device.tsx
+++ b/static/app/components/events/contexts/knownContext/device.tsx
@@ -264,6 +264,15 @@ export function getDeviceContextData({
           ) : undefined,
         };
       }
+      case DeviceContextKey.EXTERNAL_TOTAL_STORAGE: {
+        return {
+          key: ctxKey,
+          subject: t('External Total Storage'),
+          value: data.external_total_storage ? (
+            <FileSize bytes={data.external_total_storage} />
+          ) : undefined,
+        };
+      }
       case DeviceContextKey.SIMULATOR:
         return {
           key: ctxKey,
@@ -284,6 +293,12 @@ export function getDeviceContextData({
           key: ctxKey,
           subject: t('Device Type'),
           value: data.device_type,
+        };
+      case DeviceContextKey.DEVICE_UNIQUE_IDENTIFIER:
+        return {
+          key: ctxKey,
+          subject: t('Device UID'),
+          value: data.device_unique_identifier,
         };
       case DeviceContextKey.BRAND:
         return {
@@ -363,7 +378,49 @@ export function getDeviceContextData({
           subject: t('Screen Width Pixels'),
           value: data.screen_width_pixels,
         };
-
+      case DeviceContextKey.PROCESSOR_COUNT:
+        return {
+          key: ctxKey,
+          subject: t('Processor Count'),
+          value: data.processor_count,
+        };
+      case DeviceContextKey.PROCESSOR_FREQUENCY:
+        return {
+          key: ctxKey,
+          // https://github.com/getsentry/relay/blob/25.3.0/relay-event-schema/src/protocol/contexts/device.rs#L137
+          subject: t('Processor Frequency (MHz)'),
+          value: data.processor_frequency,
+        };
+      case DeviceContextKey.SUPPORTS_ACCELEROMETER:
+        return {
+          key: ctxKey,
+          subject: t('Supports Accelerometer'),
+          value: data.supports_accelerometer,
+        };
+      case DeviceContextKey.SUPPORTS_AUDIO:
+        return {
+          key: ctxKey,
+          subject: t('Supports Audio'),
+          value: data.supports_audio,
+        };
+      case DeviceContextKey.SUPPORTS_GYROSCOPE:
+        return {
+          key: ctxKey,
+          subject: t('Supports Gyroscope'),
+          value: data.supports_gyroscope,
+        };
+      case DeviceContextKey.SUPPORTS_LOCATION_SERVICE:
+        return {
+          key: ctxKey,
+          subject: t('Supports Location Service'),
+          value: data.supports_location_service,
+        };
+      case DeviceContextKey.SUPPORTS_VIBRATION:
+        return {
+          key: ctxKey,
+          subject: t('Supports Vibration'),
+          value: data.supports_vibration,
+        };
       default:
         return {
           key: ctxKey,


### PR DESCRIPTION
Adds a few context to `app` from https://github.com/getsentry/sentry/issues/87238.
While working on it I noticed a few missing from `device` as well, so updated those.

Resolves https://github.com/getsentry/sentry/issues/87238

<img width="537" alt="image" src="https://github.com/user-attachments/assets/c2bc72d4-4505-4cf5-81e5-0be3c74c0178" />
<img width="551" alt="image" src="https://github.com/user-attachments/assets/756e2f86-5429-4ac7-a429-e3940af78d57" />
