### PR TITLE
feat(ui): Display labels in cron and uptime create forms

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -156,7 +156,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             name="projectSlug"
             label={t('Project')}
             placeholder={t('Choose Project')}
-            hideLabel
             projects={projects}
             valueIsSlug
             inline={false}
@@ -169,7 +168,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             label={t('Environment')}
             placeholder={t('Select an environment')}
             noOptionsMessage={() => t('Start typing to create an environment')}
-            hideLabel
             onCreateOption={(env: any) => {
               setNewEnvironment(env);
               formModel.setValue('environment', env);
@@ -317,7 +315,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
           <TextField
             name="name"
             label={t('Uptime rule name')}
-            hideLabel
             placeholder={t('Uptime rule name')}
             inline={false}
             flexibleControlStateSize
@@ -327,7 +324,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
           <SentryMemberTeamSelectorField
             name="owner"
             label={t('Owner')}
-            hideLabel
             menuPlacement="auto"
             inline={false}
             flexibleControlStateSize

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -260,7 +260,6 @@ function MonitorForm({
           <TextField
             name="name"
             label={t('Name')}
-            hideLabel
             placeholder={t('My Cron Job')}
             required
             stacked
@@ -270,7 +269,6 @@ function MonitorForm({
             <TextField
               name="slug"
               label={t('Slug')}
-              hideLabel
               help={tct(
                 'The [strong:monitor-slug] is used to uniquely identify your monitor within your organization. Changing this slug will require updates to any instrumented check-in calls.',
                 {strong: <strong />}
@@ -285,7 +283,6 @@ function MonitorForm({
           <SentryProjectSelectorField
             name="project"
             label={t('Project')}
-            hideLabel
             groupProjects={project =>
               platformsWithGuides.includes(project.platform) ? 'suggested' : 'other'
             }


### PR DESCRIPTION
For things like Project, Environment, Name do not hide the label to help
indicate that it's required