### PR TITLE
ref(chart): Loosen type for `BaseChart.additionalSeries`

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -137,7 +137,7 @@ export interface BaseChartProps {
    * Additional Chart Series
    * This is to pass series to BaseChart bypassing the wrappers like LineChart, AreaChart etc.
    */
-  additionalSeries?: LineSeriesOption[];
+  additionalSeries?: SeriesOption[];
   /**
    * If true, ignores height value and auto-scales chart to fit container height.
    */


### PR DESCRIPTION
This can accept any ECharts series type, not just lines. Needed for https://github.com/getsentry/sentry/issues/86946 where it'll be passed a `CustomSeries`
