### PR TITLE
ref(releases): Change `createReleaseBuckets` to accept an args object

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -366,7 +366,6 @@ export function useReleaseBubbles({
         maxTime,
         finalTime: releasesMaxTime,
         releases,
-        desiredBuckets,
       })) ||
     [];
 

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -361,7 +361,13 @@ export function useReleaseBubbles({
       releases?.length &&
       minTime &&
       maxTime &&
-      createReleaseBuckets(minTime, maxTime, releasesMaxTime, releases)) ||
+      createReleaseBuckets({
+        minTime,
+        maxTime,
+        finalTime: releasesMaxTime,
+        releases,
+        desiredBuckets,
+      })) ||
     [];
 
   if (!releases || !buckets.length) {

--- a/static/app/views/releases/releaseBubbles/utils/createReleaseBuckets.spec.tsx
+++ b/static/app/views/releases/releaseBubbles/utils/createReleaseBuckets.spec.tsx
@@ -11,13 +11,13 @@ describe('createReleaseBuckets', () => {
   ])(
     'creates correct # of buckets for timeSeries with [min, max] of [%d, %d] and %d desired buckets',
     (minTime, maxTime, desiredBuckets, expectedBuckets) => {
-      const buckets = createReleaseBuckets(
+      const buckets = createReleaseBuckets({
         minTime,
         maxTime,
-        Date.now() + 120391, // Shouldn't affect buckets
-        [],
-        desiredBuckets
-      );
+        finalTime: Date.now() + 120391, // Shouldn't affect buckets
+        releases: [],
+        desiredBuckets,
+      });
       expect(buckets).toHaveLength(expectedBuckets);
     }
   );
@@ -27,7 +27,7 @@ describe('createReleaseBuckets', () => {
     const maxTime = Date.now() + 12 * 1000 + 2235;
     const finalTime = maxTime + 9999;
 
-    const buckets = createReleaseBuckets(minTime, maxTime, finalTime, []);
+    const buckets = createReleaseBuckets({minTime, maxTime, finalTime, releases: []});
     expect(buckets).toEqual([
       {start: 1508208080000, end: 1508208081424, releases: []},
       {start: 1508208081424, end: 1508208082848, releases: []},
@@ -102,7 +102,7 @@ describe('createReleaseBuckets', () => {
       },
     ];
 
-    const buckets = createReleaseBuckets(minTime, maxTime, finalTime, releases);
+    const buckets = createReleaseBuckets({minTime, maxTime, finalTime, releases});
 
     expect(buckets).toEqual([
       {

--- a/static/app/views/releases/releaseBubbles/utils/createReleaseBuckets.tsx
+++ b/static/app/views/releases/releaseBubbles/utils/createReleaseBuckets.tsx
@@ -19,13 +19,21 @@ import type {Bucket} from 'sentry/views/releases/releaseBubbles/types';
 //
 // where only the first bucket's starting timestamp is inclusive.
 //
-export function createReleaseBuckets(
-  minTime: number | undefined,
-  maxTime: number | undefined,
-  finalTime: number,
-  releases: ReleaseMetaBasic[],
-  desiredBuckets = 10
-): Bucket[] {
+interface CreateReleaseBucketsParams {
+  finalTime: number;
+  maxTime: number | undefined;
+  minTime: number | undefined;
+  releases: ReleaseMetaBasic[];
+  desiredBuckets?: number;
+}
+
+export function createReleaseBuckets({
+  minTime,
+  maxTime,
+  finalTime,
+  releases,
+  desiredBuckets = 10,
+}: CreateReleaseBucketsParams): Bucket[] {
   const buckets: Bucket[] = [];
 
   if (!minTime || !maxTime) {


### PR DESCRIPTION
...instead of 4-5 positional args
