### PR TITLE
fix(autofix): Trace context fixes

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -27,6 +27,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.models.organization import Organization
+from sentry.seer.autofix_tools import get_error_event_details, get_profile_details
 from sentry.seer.fetch_issues.fetch_issues_given_patches import get_issues_related_to_file_patches
 from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
@@ -169,6 +170,8 @@ seer_method_registry: dict[str, Callable[..., dict[str, Any]]] = {
     "get_organization_slug": get_organization_slug,
     "get_organization_autofix_consent": get_organization_autofix_consent,
     "get_issues_related_to_file_patches": get_issues_related_to_file_patches,
+    "get_error_event_details": get_error_event_details,
+    "get_profile_details": get_profile_details,
 }
 
 

--- a/src/sentry/seer/autofix_tools.py
+++ b/src/sentry/seer/autofix_tools.py
@@ -1,0 +1,36 @@
+import orjson
+
+from sentry import eventstore
+from sentry.api.serializers import EventSerializer, serialize
+from sentry.profiles.utils import get_from_profiling_service
+from sentry.seer.autofix import _convert_profile_to_execution_tree
+
+
+def get_profile_details(organization_id: str, project_id: int, profile_id: str):
+    response = get_from_profiling_service(
+        "GET",
+        f"/organizations/{organization_id}/projects/{project_id}/profiles/{profile_id}",
+        params={"format": "sample"},
+    )
+
+    if response.status == 200:
+        profile = orjson.loads(response.data)
+        execution_tree = _convert_profile_to_execution_tree(profile)
+        output = (
+            None
+            if not execution_tree
+            else {
+                "profile_matches_issue": True,
+                "execution_tree": execution_tree,
+            }
+        )
+        return output
+
+
+def get_error_event_details(project_id: int, event_id: str):
+    event = eventstore.backend.get_event_by_id(project_id, event_id)
+    if not event:
+        return None
+
+    serialized_event = serialize(objects=event, user=None, serializer=EventSerializer())
+    return serialized_event

--- a/tests/sentry/seer/test_autofix.py
+++ b/tests/sentry/seer/test_autofix.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import orjson
@@ -155,7 +155,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         root_tx_span_id = "aaaaaaaaaaaaaaaa"
         root_tx_event_data = {
             "event_id": "root-tx-id",
-            "datetime": "2023-01-01T10:00:00Z",
+            "start_timestamp": 1672567200.0,
             "spans": [{"span_id": "child1-span-id"}, {"span_id": "child2-span-id"}],
             "contexts": {
                 "trace": {"trace_id": trace_id, "span_id": root_tx_span_id, "op": "http.server"}
@@ -169,7 +169,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child1_span_id = "child1-span-id"
         child1_tx_event_data = {
             "event_id": "child1-tx-id",
-            "datetime": "2023-01-01T10:00:10Z",
+            "start_timestamp": 1672567210.0,
             "spans": [{"span_id": "grandchild1-span-id"}],
             "contexts": {
                 "trace": {
@@ -188,7 +188,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child2_span_id = "child2-span-id"
         child2_error_event_data = {
             "event_id": "child2-error-id",
-            "datetime": "2023-01-01T10:00:20Z",
+            "start_timestamp": 1672567220.0,
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -205,7 +205,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         grandchild1_span_id = "grandchild1-span-id"
         grandchild1_error_event_data = {
             "event_id": "grandchild1-error-id",
-            "datetime": "2023-01-01T10:00:15Z",
+            "start_timestamp": 1672567215.0,
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -222,7 +222,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         another_root_span_id = "bbbbbbbbbbbbbbbb"
         another_root_tx_event_data = {
             "event_id": "another-root-id",
-            "datetime": "2023-01-01T09:59:00Z",
+            "start_timestamp": 1672567140.0,
             "spans": [],
             "contexts": {
                 "trace": {"trace_id": trace_id, "span_id": another_root_span_id, "op": "browser"}
@@ -241,9 +241,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             mock_event = Mock()
             # Set attributes directly instead of using data property
             mock_event.event_id = event_data["event_id"]
-            mock_event.datetime = datetime.fromisoformat(
-                event_data["datetime"].replace("Z", "+00:00")
-            )
+            mock_event.start_timestamp = event_data["start_timestamp"]
             mock_event.data = event_data
             mock_event.title = event_data["title"]
             mock_event.platform = event_data["platform"]
@@ -256,9 +254,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             mock_event = Mock()
             # Set attributes directly instead of using data property
             mock_event.event_id = event_data["event_id"]
-            mock_event.datetime = datetime.fromisoformat(
-                event_data["datetime"].replace("Z", "+00:00")
-            )
+            mock_event.start_timestamp = event_data["start_timestamp"]
             mock_event.data = event_data
             mock_event.title = event_data["title"]
             mock_event.platform = event_data["platform"]
@@ -267,6 +263,24 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             mock_event.message = event_data.get("message", event_data["title"])
             mock_event.transaction = event_data.get("transaction", None)
             error_events.append(mock_event)
+
+        # Sort root events by start_timestamp
+        root_events = [
+            event
+            for event in tx_events + error_events
+            if event.event_id in ["root-tx-id", "another-root-id"]
+        ]
+        root_events.sort(key=lambda x: x.start_timestamp)
+
+        # Function to recursively sort children by start_timestamp
+        def sort_tree(node):
+            if node["children"]:
+                # Sort children by start_timestamp
+                node["children"].sort(key=lambda x: x["start_timestamp"])
+                # Recursively sort each child's children
+                for child in node["children"]:
+                    sort_tree(child)
+            return node
 
         # Update to patch both Transactions and Events dataset calls
         with patch("sentry.eventstore.backend.get_events") as mock_get_events:
@@ -293,7 +307,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         first_root = trace_tree["events"][0]
         assert first_root["event_id"] == "another-root-id"
         assert first_root["title"] == "browser - Earlier Transaction"
-        assert first_root["datetime"].isoformat() == "2023-01-01T09:59:00+00:00"
+        assert first_root["datetime"] == 1672567140.0
         assert first_root["is_transaction"] is True
         assert first_root["is_error"] is False
         assert len(first_root["children"]) == 0
@@ -302,7 +316,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         second_root = trace_tree["events"][1]
         assert second_root["event_id"] == "root-tx-id"
         assert second_root["title"] == "http.server - Root Transaction"
-        assert second_root["datetime"].isoformat() == "2023-01-01T10:00:00+00:00"
+        assert second_root["datetime"] == 1672567200.0
         assert second_root["is_transaction"] is True
         assert second_root["is_error"] is False
 
@@ -313,7 +327,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child1 = second_root["children"][0]
         assert child1["event_id"] == "child1-tx-id"
         assert child1["title"] == "db - Database Query"
-        assert child1["datetime"].isoformat() == "2023-01-01T10:00:10+00:00"
+        assert child1["datetime"] == 1672567210.0
         assert child1["is_transaction"] is True
         assert child1["is_error"] is False
 
@@ -322,7 +336,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         grandchild1 = child1["children"][0]
         assert grandchild1["event_id"] == "grandchild1-error-id"
         assert grandchild1["title"] == "Database Error"
-        assert grandchild1["datetime"].isoformat() == "2023-01-01T10:00:15+00:00"
+        assert grandchild1["datetime"] == 1672567215.0
         assert grandchild1["is_transaction"] is False
         assert grandchild1["is_error"] is True
         assert len(grandchild1["children"]) == 0
@@ -331,7 +345,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child2 = second_root["children"][1]
         assert child2["event_id"] == "child2-error-id"
         assert child2["title"] == "Division by zero"
-        assert child2["datetime"].isoformat() == "2023-01-01T10:00:20+00:00"
+        assert child2["datetime"] == 1672567220.0
         assert child2["is_transaction"] is False
         assert child2["is_error"] is True
         assert len(child2["children"]) == 0
@@ -388,10 +402,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Create proper child event object
         child_event = Mock()
         child_event.event_id = "child-id"
-        child_event.datetime = datetime.fromisoformat("2023-01-01T10:00:10+00:00")
+        child_event.start_timestamp = 1672567210.0
         child_event.data = {
             "event_id": "child-id",
-            "datetime": "2023-01-01T10:00:10Z",
+            "start_timestamp": 1672567210.0,
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -413,10 +427,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Create proper parent event object
         parent_event = Mock()
         parent_event.event_id = "parent-id"
-        parent_event.datetime = datetime.fromisoformat("2023-01-01T10:00:00+00:00")
+        parent_event.start_timestamp = 1672567200.0
         parent_event.data = {
             "event_id": "parent-id",
-            "datetime": "2023-01-01T10:00:00Z",
+            "start_timestamp": 1672567200.0,
             "spans": [],
             "contexts": {
                 "trace": {"trace_id": trace_id, "span_id": parent_span_id, "op": "http.server"}
@@ -487,7 +501,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         error1_span_id = "error1-span-id"
         error1 = Mock()
         error1.event_id = "error1-id"
-        error1.datetime = datetime.fromisoformat("2023-01-01T10:00:00+00:00")
+        error1.start_timestamp = 1672567200.0
         error1.data = {
             "contexts": {
                 "trace": {
@@ -508,7 +522,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         error2_span_id = "error2-span-id"
         error2 = Mock()
         error2.event_id = "error2-id"
-        error2.datetime = datetime.fromisoformat("2023-01-01T10:00:10+00:00")
+        error2.start_timestamp = 1672567210.0
         error2.data = {
             "contexts": {
                 "trace": {
@@ -529,7 +543,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # This error is a child of error2
         error3 = Mock()
         error3.event_id = "error3-id"
-        error3.datetime = datetime.fromisoformat("2023-01-01T10:00:20+00:00")
+        error3.start_timestamp = 1672567220.0
         error3.data = {
             "contexts": {
                 "trace": {
@@ -550,7 +564,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Another "orphaned" error with a parent_span_id that doesn't point to anything
         error4 = Mock()
         error4.event_id = "error4-id"
-        error4.datetime = datetime.fromisoformat("2023-01-01T10:00:30+00:00")
+        error4.start_timestamp = 1672567230.0
         error4.data = {
             "contexts": {
                 "trace": {
@@ -631,7 +645,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         root_tx = Mock()
         root_tx.event_id = "root-tx-id"
-        root_tx.datetime = datetime.fromisoformat("2023-01-01T10:00:00+00:00")
+        root_tx.start_timestamp = 1672567200.0
         root_tx.data = {
             "spans": [{"span_id": tx_span_1}, {"span_id": tx_span_2}],
             "contexts": {
@@ -649,7 +663,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Rule 1: Child whose parent_span_id matches another event's span_id
         rule1_child = Mock()
         rule1_child.event_id = "rule1-child-id"
-        rule1_child.datetime = datetime.fromisoformat("2023-01-01T10:00:10+00:00")
+        rule1_child.start_timestamp = 1672567210.0
         rule1_child.data = {
             "contexts": {
                 "trace": {
@@ -670,7 +684,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Rule 2: Child whose parent_span_id matches a span in a transaction
         rule2_child = Mock()
         rule2_child.event_id = "rule2-child-id"
-        rule2_child.datetime = datetime.fromisoformat("2023-01-01T10:00:20+00:00")
+        rule2_child.start_timestamp = 1672567220.0
         rule2_child.data = {
             "contexts": {
                 "trace": {
@@ -691,7 +705,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         # Rule 3: Child whose span_id matches a span in a transaction
         rule3_child = Mock()
         rule3_child.event_id = "rule3-child-id"
-        rule3_child.datetime = datetime.fromisoformat("2023-01-01T10:00:30+00:00")
+        rule3_child.start_timestamp = 1672567230.0
         rule3_child.data = {
             "contexts": {
                 "trace": {
@@ -760,14 +774,22 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.get_from_profiling_service")
     def test_get_profile_from_trace_tree(self, mock_get_from_profiling_service):
         """
-        Test the _get_profile_from_trace_tree method which finds a profile for a transaction
-        that is a parent of an error event in a trace tree.
+        Test the _get_profile_from_trace_tree method which finds a transaction
+        that contains the event's span_id or has a matching span_id.
         """
+        # Setup mock event with span_id
         event = Mock()
         event.event_id = "error-event-id"
         event.trace_id = "1234567890abcdef1234567890abcdef"
+        event.data = {
+            "contexts": {
+                "trace": {
+                    "span_id": "event-span-id",
+                }
+            }
+        }
 
-        # Create a mock trace tree with a transaction that has a profile_id
+        # Create a mock trace tree with a transaction that includes the event span_id in its span_ids
         profile_id = "profile123456789"
         trace_tree = {
             "trace_id": "1234567890abcdef1234567890abcdef",
@@ -778,6 +800,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
                     "is_transaction": True,
                     "is_error": False,
                     "profile_id": profile_id,
+                    "span_ids": ["some-span", "event-span-id", "another-span"],
                     "children": [
                         {
                             "event_id": "error-event-id",
@@ -831,91 +854,41 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
         )
 
     @patch("sentry.seer.autofix.get_from_profiling_service")
-    def test_get_profile_from_trace_tree_api_error(self, mock_get_from_profiling_service):
+    def test_get_profile_from_trace_tree_matching_span_id(self, mock_get_from_profiling_service):
         """
-        Test the _get_profile_from_trace_tree method when the profiling service API returns an error.
+        Test _get_profile_from_trace_tree with a transaction whose own span_id
+        matches the event's span_id.
         """
+        # Setup mock event with span_id
         event = Mock()
         event.event_id = "error-event-id"
         event.trace_id = "1234567890abcdef1234567890abcdef"
+        event.data = {
+            "contexts": {
+                "trace": {
+                    "span_id": "tx-span-id",
+                }
+            }
+        }
 
-        # Create a mock trace tree with a transaction that has a profile_id
+        # Create a mock trace tree with a transaction whose span_id matches event span_id
         profile_id = "profile123456789"
         trace_tree = {
             "trace_id": "1234567890abcdef1234567890abcdef",
             "events": [
                 {
-                    "event_id": "tx-root-id",
-                    "span_id": "root-span-id",
+                    "event_id": "tx-id",
+                    "span_id": "tx-span-id",  # This matches the event's span_id
                     "is_transaction": True,
                     "is_error": False,
                     "profile_id": profile_id,
                     "children": [
                         {
                             "event_id": "error-event-id",
-                            "span_id": "event-span-id",
+                            "span_id": "error-span-id",
                             "is_transaction": False,
                             "is_error": True,
                             "children": [],
-                        }
-                    ],
-                }
-            ],
-        }
-
-        # Configure the mock response to simulate an API error
-        mock_response = Mock()
-        mock_response.status = 404
-        mock_get_from_profiling_service.return_value = mock_response
-
-        # Call the function directly instead of through an endpoint
-        profile_result = _get_profile_from_trace_tree(trace_tree, event, self.project)
-
-        assert profile_result is None
-
-        mock_get_from_profiling_service.assert_called_once_with(
-            "GET",
-            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
-            params={"format": "sample"},
-        )
-
-    @patch("sentry.seer.autofix.get_from_profiling_service")
-    def test_get_profile_from_trace_tree_multi_level(self, mock_get_from_profiling_service):
-        """
-        Test the _get_profile_from_trace_tree method with a multi-level trace tree
-        where the profile is found in a grandparent transaction.
-        """
-        event = Mock()
-        event.event_id = "error-event-id"
-        event.trace_id = "1234567890abcdef1234567890abcdef"
-
-        # Create a mock trace tree with multiple levels
-        profile_id = "profile123456789"
-        trace_tree = {
-            "trace_id": "1234567890abcdef1234567890abcdef",
-            "events": [
-                {
-                    "event_id": "root-tx-id",
-                    "span_id": "root-span-id",
-                    "is_transaction": True,
-                    "is_error": False,
-                    "profile_id": profile_id,  # Profile is at the root level
-                    "children": [
-                        {
-                            "event_id": "mid-tx-id",
-                            "span_id": "mid-span-id",
-                            "is_transaction": True,
-                            "is_error": False,
-                            # No profile_id at this level
-                            "children": [
-                                {
-                                    "event_id": "error-event-id",
-                                    "span_id": "event-span-id",
-                                    "is_transaction": False,
-                                    "is_error": True,
-                                    "children": [],
-                                }
-                            ],
                         }
                     ],
                 }
@@ -946,7 +919,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
         mock_response.data = orjson.dumps(mock_profile_data)
         mock_get_from_profiling_service.return_value = mock_response
 
-        # Call the function directly instead of through an endpoint
+        # Call the function
         profile_result = _get_profile_from_trace_tree(trace_tree, event, self.project)
 
         assert profile_result is not None
@@ -958,6 +931,147 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
             f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
             params={"format": "sample"},
         )
+
+    @patch("sentry.seer.autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree_api_error(self, mock_get_from_profiling_service):
+        """
+        Test the behavior when the profiling service API returns an error.
+        """
+        # Setup mock event with span_id
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+        event.data = {
+            "contexts": {
+                "trace": {
+                    "span_id": "event-span-id",
+                }
+            }
+        }
+
+        # Create a mock trace tree with a transaction that includes the event span_id
+        profile_id = "profile123456789"
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "tx-root-id",
+                    "span_id": "root-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": profile_id,
+                    "span_ids": ["event-span-id"],
+                    "children": [
+                        {
+                            "event_id": "error-event-id",
+                            "span_id": "event-span-id",
+                            "is_transaction": False,
+                            "is_error": True,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Configure the mock response to simulate an API error
+        mock_response = Mock()
+        mock_response.status = 404
+        mock_get_from_profiling_service.return_value = mock_response
+
+        # Call the function directly instead of through an endpoint
+        profile_result = _get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is None
+
+        mock_get_from_profiling_service.assert_called_once_with(
+            "GET",
+            f"/organizations/{self.project.organization_id}/projects/{self.project.id}/profiles/{profile_id}",
+            params={"format": "sample"},
+        )
+
+    @patch("sentry.seer.autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree_no_matching_transaction(
+        self, mock_get_from_profiling_service
+    ):
+        """
+        Test that the function returns None when no matching transaction is found.
+        """
+        # Setup mock event with span_id
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+        event.data = {
+            "contexts": {
+                "trace": {
+                    "span_id": "event-span-id",
+                }
+            }
+        }
+
+        # Create a mock trace tree with a transaction that DOESN'T include the event span_id
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "tx-root-id",
+                    "span_id": "root-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": "profile123456789",
+                    "span_ids": ["different-span-id"],  # Doesn't include event's span_id
+                    "children": [
+                        {
+                            "event_id": "error-event-id",
+                            "span_id": "event-span-id",
+                            "is_transaction": False,
+                            "is_error": True,
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Call the function
+        profile_result = _get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is None
+        # API should not be called if no matching transaction is found
+        mock_get_from_profiling_service.assert_not_called()
+
+    @patch("sentry.seer.autofix.get_from_profiling_service")
+    def test_get_profile_from_trace_tree_no_span_id(self, mock_get_from_profiling_service):
+        """
+        Test the behavior when the event doesn't have a span_id.
+        """
+        # Setup mock event WITHOUT span_id
+        event = Mock()
+        event.event_id = "error-event-id"
+        event.trace_id = "1234567890abcdef1234567890abcdef"
+        event.data = {"contexts": {"trace": {}}}  # No span_id
+
+        # Create a mock trace tree
+        trace_tree = {
+            "trace_id": "1234567890abcdef1234567890abcdef",
+            "events": [
+                {
+                    "event_id": "tx-id",
+                    "span_id": "tx-span-id",
+                    "is_transaction": True,
+                    "is_error": False,
+                    "profile_id": "profile123456789",
+                    "children": [],
+                }
+            ],
+        }
+
+        # Call the function
+        profile_result = _get_profile_from_trace_tree(trace_tree, event, self.project)
+
+        assert profile_result is None
+        # API should not be called if event has no span_id
+        mock_get_from_profiling_service.assert_not_called()
 
 
 @requires_snuba


### PR DESCRIPTION
- sort trace tree by start_timestamps instead of datetime
- attempt fix at profile-selection logic
- implement RPC tools for Seer to use later