### PR TITLE
fix: Update EAP search config to override default

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -32,7 +32,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.api import event_search
-from sentry.api.event_search import SearchConfig
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
@@ -164,7 +163,10 @@ class SearchResolver:
         try:
             parsed_terms = event_search.parse_search_query(
                 querystring,
-                config=SearchConfig(wildcard_free_text=True),
+                config=event_search.SearchConfig.create_from(
+                    event_search.default_config,
+                    wildcard_free_text=True,
+                ),
                 params=self.params.filter_params,
                 get_field_type=self.get_field_type,
                 get_function_result_type=self.get_field_type,

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -28,6 +28,7 @@ from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 
 
 class SearchResolverQueryTest(TestCase):
@@ -127,6 +128,18 @@ class SearchResolverQueryTest(TestCase):
             )
         )
         assert having is None
+
+    def test_timestamp_relative_filter(self):
+        with freeze_time("2018-12-11 10:20:00"):
+            where, having, _ = self.resolver.resolve_query("timestamp:-24h")
+            assert where == TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="sentry.timestamp", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                    value=AttributeValue(val_str="2018-12-10 10:20:00+00:00"),
+                )
+            )
+            assert having is None
 
     def test_query_with_and(self):
         where, having, _ = self.resolver.resolve_query("span.description:foo span.op:bar")


### PR DESCRIPTION
When config isn't passed, it falls back to default config, so always start from there and then override.

Fixes issues with relative timestamp filters like:
`timestamp:-24h`