### PR TITLE
ref(releases): Rename `createReleaseBubbleHighlighter` to `connectReleaseBubbleChartRef`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -106,13 +106,12 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const latestTimeStamp = allBoundaries.at(-1);
 
   const {
-    createReleaseBubbleHighlighter,
+    connectReleaseBubbleChartRef,
     releaseBubbleEventHandlers,
     releaseBubbleSeries,
     releaseBubbleXAxis,
     releaseBubbleGrid,
   } = useReleaseBubbles({
-    chartRef,
     chartRenderer: ({start: trimStart, end: trimEnd}) => {
       return (
         <TimeSeriesWidgetVisualization
@@ -167,14 +166,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       registerWithWidgetSyncContext(echartsInstance);
 
       if (hasReleaseBubblesSeries) {
-        createReleaseBubbleHighlighter(echartsInstance);
+        connectReleaseBubbleChartRef(e);
       }
     },
-    [
-      hasReleaseBubblesSeries,
-      createReleaseBubbleHighlighter,
-      registerWithWidgetSyncContext,
-    ]
+    [hasReleaseBubblesSeries, connectReleaseBubbleChartRef, registerWithWidgetSyncContext]
   );
 
   const chartZoomProps = useChartZoom({

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -1,4 +1,4 @@
-import type {ReactElement} from 'react';
+import {type ReactElement, useCallback, useRef} from 'react';
 import {type Theme, useTheme} from '@emotion/react';
 import type {
   CustomSeriesOption,
@@ -322,7 +322,6 @@ ${t('Click to expand')}
 }
 
 interface UseReleaseBubblesParams {
-  chartRef: React.RefObject<ReactEchartsRef | null>;
   bubblePadding?: number;
   bubbleSize?: number;
   chartRenderer?: (rendererProps: {
@@ -335,7 +334,6 @@ interface UseReleaseBubblesParams {
   releases?: ReleaseMetaBasic[];
 }
 export function useReleaseBubbles({
-  chartRef,
   chartRenderer,
   releases,
   minTime,
@@ -355,7 +353,16 @@ export function useReleaseBubbles({
   const releasesMaxTime = defined(selection.datetime.end)
     ? new Date(selection.datetime.end).getTime()
     : Date.now();
+  const chartRef = useRef<ReactEchartsRef | null>(null);
   const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
+  const handleChartRef = useCallback((e: ReactEchartsRef | null) => {
+    chartRef.current = e;
+
+    if (e?.getEchartsInstance) {
+      createReleaseBubbleHighlighter(e.getEchartsInstance());
+    }
+  }, []);
+
   const buckets =
     (hasReleaseBubbles &&
       releases?.length &&
@@ -366,7 +373,7 @@ export function useReleaseBubbles({
 
   if (!releases || !buckets.length) {
     return {
-      createReleaseBubbleHighlighter: () => {},
+      connectReleaseBubbleChartRef: () => {},
       releaseBubbleEventHandlers: {},
       ReleaseBubbleSeries: null,
       releaseBubbleXAxis: {},
@@ -377,7 +384,7 @@ export function useReleaseBubbles({
   const totalBubblePaddingY = bubblePadding * 2;
 
   return {
-    createReleaseBubbleHighlighter,
+    connectReleaseBubbleChartRef: handleChartRef,
 
     /**
      * An object map of ECharts event handlers. These should be spread onto a Chart component


### PR DESCRIPTION
Renamed this to be a bit more generic as we want to be able to reference the charts ref inside of the hook. We still use the echarts instance to attach listeners as well, but we hide that now w/ the name.
