### PR TITLE
ref(insights): Session Health tab should be labelled new

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -22,7 +22,6 @@ import {
 import {useIsLaravelInsightsEnabled} from 'sentry/views/insights/pages/backend/laravel/features';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
-  isModuleConsideredBeta,
   isModuleConsideredNew,
   isModuleEnabled,
   isModuleVisible,
@@ -145,15 +144,10 @@ function TabLabel({moduleName}: TabLabelProps) {
   const organization = useOrganization();
   const showBusinessIcon = !isModuleEnabled(moduleName, organization);
 
-  if (
-    showBusinessIcon ||
-    isModuleConsideredBeta(moduleName) ||
-    isModuleConsideredNew(moduleName)
-  ) {
+  if (showBusinessIcon || isModuleConsideredNew(moduleName)) {
     return (
       <TabContainer>
         {moduleTitles[moduleName]}
-        {isModuleConsideredBeta(moduleName) && <Badge type="beta">{t('Beta')}</Badge>}
         {isModuleConsideredNew(moduleName) && <Badge type="new">{t('New')}</Badge>}
         {showBusinessIcon && <IconBusiness />}
       </TabContainer>

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -4,7 +4,6 @@ import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {
   MODULE_FEATURE_MAP,
   MODULE_FEATURE_VISIBLE_MAP,
-  MODULES_CONSIDERED_BETA,
   MODULES_CONSIDERED_NEW,
 } from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
@@ -14,9 +13,6 @@ export const isModuleEnabled = (module: ModuleName, organization: Organization) 
 
 export const isModuleVisible = (module: ModuleName, organization: Organization) =>
   MODULE_FEATURE_VISIBLE_MAP[module].every(f => organization.features.includes(f));
-
-export const isModuleConsideredBeta = (module: ModuleName) =>
-  MODULES_CONSIDERED_BETA.has(module);
 
 export const isModuleConsideredNew = (module: ModuleName) =>
   MODULES_CONSIDERED_NEW.has(module);

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -238,9 +238,9 @@ export const MODULE_FEATURE_VISIBLE_MAP: Record<ModuleName, string[]> = {
 /**
  * Modules that are considered "new", e.g. used to show a badge on the tab.
  */
-export const MODULES_CONSIDERED_BETA: Set<ModuleName> = new Set([ModuleName.SESSIONS]);
 export const MODULES_CONSIDERED_NEW: Set<ModuleName> = new Set([
   ModuleName.MOBILE_VITALS,
+  ModuleName.SESSIONS,
 ]);
 
 export const INGESTION_DELAY = 90;


### PR DESCRIPTION
Back basics with 'new' instead of 'beta'

The data is not beta or anything, it's just a new tab to visualize things. I think new fits better.

![SCR-20250318-nhxn](https://github.com/user-attachments/assets/f3749856-c5c3-46ba-999a-63968e260899)
