### PR TITLE
ref: make flatten(...) only operate on recursive lists

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -298,7 +298,7 @@ def translate_escape_sequences(string: str) -> str:
 type _RecursiveList[T] = list[T] | list[_RecursiveList[T]]
 
 
-def flatten[T](children: T | _RecursiveList[T]) -> list[T]:
+def flatten[T](children: _RecursiveList[T]) -> list[T]:
     def _flatten(seq: _RecursiveList[T]) -> Generator[T]:
         # there is a list from search_term and one from free_text, so flatten them.
         # Flatten each group in the list, since nodes can return multiple items
@@ -307,9 +307,6 @@ def flatten[T](children: T | _RecursiveList[T]) -> list[T]:
                 yield from _flatten(item)
             else:
                 yield item
-
-    if not isinstance(children, list):
-        return [children]
 
     return [_f for _f in _flatten(children) if _f]
 
@@ -726,8 +723,15 @@ class SearchVisitor(NodeVisitor):
     def is_boolean_key(self, key):
         return key in self.config.boolean_keys
 
-    def visit_search(self, node, children):
-        return remove_optional_nodes(flatten(children[1]))
+    def visit_search(
+        self,
+        node: Node,
+        children: tuple[str, Node | _RecursiveList[QueryToken]],
+    ) -> list[QueryToken]:
+        if isinstance(children[1], Node):  # empty search
+            return []
+        else:
+            return remove_optional_nodes(flatten(children[1]))
 
     def visit_term(self, node, children):
         return remove_optional_nodes(flatten(children[0]))
@@ -1190,8 +1194,19 @@ class SearchVisitor(NodeVisitor):
     def visit_raw_aggregate_param(self, node, children):
         return node.text
 
-    def visit_quoted_aggregate_param(self, node, children):
-        value = "".join(node.text for node in flatten(children[1]))
+    def visit_quoted_aggregate_param(
+        self,
+        node: Node,
+        children: tuple[
+            Node,  # "
+            Node | _RecursiveList[Node],  # content
+            Node,  # "
+        ],
+    ) -> str:
+        if isinstance(children[1], Node):  # empty string
+            value = ""
+        else:
+            value = "".join(node.text for node in flatten(children[1]))
 
         return f'"{value}"'
 
@@ -1231,8 +1246,19 @@ class SearchVisitor(NodeVisitor):
 
         return node.text.replace('\\"', '"')
 
-    def visit_quoted_value(self, node, children):
-        value = "".join(node.text for node in flatten(children[1]))
+    def visit_quoted_value(
+        self,
+        node: Node,
+        children: tuple[
+            Node,  # "
+            Node | _RecursiveList[Node],  # content
+            Node,  # "
+        ],
+    ) -> str:
+        if isinstance(children[1], Node):  # empty string
+            value = ""
+        else:
+            value = "".join(node.text for node in flatten(children[1]))
         value = value.replace('\\"', '"')
 
         return value

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -241,11 +241,6 @@ def test_flatten(value: _RecursiveList[int], expected: list[int]) -> None:
     assert flatten(value) == expected
 
 
-def test_flatten_with_primitive() -> None:
-    # flatten sometimes gets called with just bare `Node` so this tests that
-    assert flatten(1) == [1]
-
-
 class ParseSearchQueryBackendTest(SimpleTestCase):
     """
     These test cases cannot be represented by the test data used to drive the
@@ -387,6 +382,13 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
                 operator="<",
                 value=SearchValue(3 * 1000**5),
             ),
+        ]
+
+    def test_aggregate_empty_quoted_arg(self):
+        assert parse_search_query('p50(""):5') == [
+            AggregateFilter(
+                key=AggregateKey(name='p50("")'), operator="=", value=SearchValue(raw_value=5.0)
+            )
         ]
 
     @patch("sentry.search.events.builder.base.BaseQueryBuilder.get_field_type")


### PR DESCRIPTION
otherwise `T` gets greedily inferred to the wrong value -- this also makes the implementation more robust against mismatches

<!-- Describe your PR here. -->