### PR TITLE
fix(aci): set workflow in job when evaluating action filters

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -117,6 +117,54 @@ class TestProcessWorkflows(BaseWorkflowTest):
             },
         )
 
+    @patch("sentry.workflow_engine.processors.workflow.filter_recently_fired_workflow_actions")
+    def test_populate_workflow_for_filters(self, mock_filter):
+        # this should not pass because the environment is not None
+        self.error_workflow.update(environment=self.group_event.get_environment())
+        error_workflow_filters = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        )
+        self.create_data_condition(
+            condition_group=error_workflow_filters,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+        self.create_workflow_data_condition_group(
+            workflow=self.error_workflow, condition_group=error_workflow_filters
+        )
+
+        workflow_triggers = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        )
+        workflow_filters = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        )
+        # this should pass because the environment is None
+        self.create_data_condition(
+            condition_group=workflow_filters,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+        workflow = self.create_workflow(
+            name="testy",
+            when_condition_group=workflow_triggers,
+        )
+        self.create_detector_workflow(
+            detector=self.error_detector,
+            workflow=workflow,
+        )
+        self.create_workflow_data_condition_group(
+            workflow=workflow, condition_group=workflow_filters
+        )
+
+        self.job["group_state"]["is_new"] = True
+
+        process_workflows(self.job)
+
+        mock_filter.assert_called_with({workflow_filters}, self.group)
+
     def test_same_environment_only(self):
         # only processes workflows with the same env or no env specified
         self.error_workflow.update(environment=None)


### PR DESCRIPTION
I wrote a test and found that
1. In `workflow.evaluate_trigger_conditions(job)` we attach the `workflow` to the `job`
2. If we have a set of workflows we're evaluating, the last `workflow` we evaluate remains attached to the `job`
3. Next in `evaluate_workflows_action_filters` we end up passing that last workflow to every single filter/IF data condition group we evaluate, even if the filter/IF DCG is not actually attached to that last workflow

We should be correctly setting the workflow for each data condition group we evaluate.

(Wrote a test with a condition that should not be an allowable filter condition for demonstration purposes only)