### PR TITLE
ref: add tests for invalid datetime range

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -508,6 +508,12 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
                 SearchFilter(key=SearchKey(name="random"), operator="=", value=SearchValue("-2w"))
             ]
 
+    def test_invalid_rel_time_filter(self):
+        with pytest.raises(InvalidSearchQuery) as excinfo:
+            parse_search_query(f'time:+{"1" * 9999}d')
+        (msg,) = excinfo.value.args
+        assert msg.endswith(" is not a valid datetime query")
+
     def test_aggregate_rel_time_filter(self):
         now = timezone.now()
         with freeze_time(now):
@@ -528,6 +534,12 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             assert parse_search_query("random():-2w") == [
                 SearchFilter(key=SearchKey(name="random()"), operator="=", value=SearchValue("-2w"))
             ]
+
+    def test_invalid_aggregate_rel_time_filter(self):
+        with pytest.raises(InvalidSearchQuery) as excinfo:
+            parse_search_query(f'last_seen():+{"1" * 9999}d')
+        (msg,) = excinfo.value.args
+        assert msg.endswith(" is not a valid datetime query")
 
     def test_invalid_date_filter(self):
         with pytest.raises(InvalidSearchQuery) as excinfo:


### PR DESCRIPTION
I initially thought these were unreachable and had factored out the `try:` / `except:` here -- but found an edge case so this adds test coverage for it

<!-- Describe your PR here. -->