### PR TITLE
feat(issue-views): Change add view button to just + icon near starred views header'

### DIFF
--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -75,7 +75,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
       onClick={handleOnAddView}
       disabled={isLoading}
       title={!isLoading && t('Add View')}
-      aria-label={t('Add View Button')}
+      aria-label={t('Add View')}
       tooltipProps={{
         delay: 500,
       }}

--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -1,13 +1,11 @@
-import {Fragment, useState} from 'react';
-import {css} from '@emotion/react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
-import {motion} from 'framer-motion';
 
 import {Button} from 'sentry/components/core/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {useNavContext} from 'sentry/components/nav/context';
 import useDefaultProject from 'sentry/components/nav/issueViews/useDefaultProject';
-import {NavLayout} from 'sentry/components/nav/types';
+import type {NavLayout} from 'sentry/components/nav/types';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -70,64 +68,35 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
   };
 
   return (
-    <motion.div>
-      <AddViewButton
-        borderless
-        size="zero"
-        layout={layout}
-        onClick={handleOnAddView}
-        disabled={isLoading}
-      >
-        {isLoading ? (
-          <LoadingIndicator mini />
+    <AddViewButton
+      borderless
+      size="zero"
+      layout={layout}
+      onClick={handleOnAddView}
+      disabled={isLoading}
+      title={!isLoading && t('Add View')}
+      aria-label={t('Add View Button')}
+      tooltipProps={{
+        delay: 500,
+      }}
+      icon={
+        isLoading ? (
+          <StyledLoadingIndicator mini size={14} />
         ) : (
-          <Fragment>
-            <StyledIconAdd size="xs" />
-            {t('Add View')}
-          </Fragment>
-        )}
-      </AddViewButton>
-    </motion.div>
+          <IconAdd size="sm" color="subText" />
+        )
+      }
+    />
   );
 }
 
-const AddViewButton = styled(Button)<{layout: NavLayout}>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${space(0.5)};
-
-  width: 100%;
-  position: relative;
-  height: 34px;
-  color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  line-height: 177.75%;
-  border-radius: ${p => p.theme.borderRadius};
-
-  &:hover {
-    color: inherit;
-  }
-
-  [data-isl] {
-    transform: translate(0, 0);
-    top: 1px;
-    bottom: 1px;
-    right: 0;
-    left: 0;
-    width: initial;
-    height: initial;
-  }
-
-  ${p =>
-    p.layout === NavLayout.MOBILE &&
-    css`
-      padding: 0 ${space(1.5)} 0 48px;
-      border-radius: 0;
-    `}
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  width: 14px;
+  height: 14px !important;
+  margin: 0 !important;
 `;
 
-const StyledIconAdd = styled(IconAdd)`
-  margin-right: 4px;
+const AddViewButton = styled(Button)<{layout: NavLayout}>`
+  padding: ${space(0.5)};
+  margin-right: -${space(0.5)};
 `;

--- a/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/components/nav/issueViews/issueViewAddViewButton.tsx
@@ -98,5 +98,5 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
 
 const AddViewButton = styled(Button)<{layout: NavLayout}>`
   padding: ${space(0.5)};
-  margin-right: -${space(0.5)};
+  /* margin-right: -${space(0.5)}; */
 `;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -150,6 +150,10 @@ export function IssueViewNavItemContent({
       }}
       dragListener={false}
       dragControls={controls}
+      // This style is a hack to fix a framer-motion bug that causes views to
+      // jump from the bottom of the nav bar to their correct positions
+      // upon scrolling down on the page and triggering a page navigation.
+      // See: https://github.com/motiondivision/motion/issues/2006
       style={{
         ...(isDragging || scrollPosition === 0
           ? {}

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -130,6 +130,8 @@ export function IssueViewNavItemContent({
 
   const {startInteraction, endInteraction, isInteractingRef} = useNavContext();
 
+  const scrollPosition = window.scrollY || document.documentElement.scrollTop;
+
   return (
     <StyledReorderItem
       as="div"
@@ -149,12 +151,13 @@ export function IssueViewNavItemContent({
       dragListener={false}
       dragControls={controls}
       style={{
-        ...(isDragging
+        ...(isDragging || scrollPosition === 0
           ? {}
           : {
               originY: '0px',
             }),
       }}
+      grabbing={isDragging === view.id}
     >
       <StyledSecondaryNavItem
         to={constructViewLink(baseUrl, view)}
@@ -345,9 +348,9 @@ const hasUnsavedChanges = (
 
 // Reorder.Item does handle lifting an item being dragged above other items out of the box,
 // but we need to ensure the item is relatively positioned and has a background color for it to work
-const StyledReorderItem = styled(Reorder.Item)`
+const StyledReorderItem = styled(Reorder.Item)<{grabbing: boolean}>`
   position: relative;
-  background-color: ${p => p.theme.translucentSurface200};
+  background-color: ${p => (p.grabbing ? p.theme.translucentSurface200 : 'transparent')};
   border-radius: ${p => p.theme.borderRadius};
 `;
 

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -1,11 +1,14 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
-import {AnimatePresence, Reorder} from 'framer-motion';
+import styled from '@emotion/styled';
+import {Reorder} from 'framer-motion';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
 import {IssueViewAddViewButton} from 'sentry/components/nav/issueViews/issueViewAddViewButton';
 import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
+import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -256,17 +259,25 @@ export function IssueViewNavItems({
   );
 
   return (
-    <Reorder.Group
-      as="div"
-      axis="y"
-      values={views}
-      onReorder={newOrder => setViews(newOrder)}
-      initial={false}
-      ref={sectionRef}
+    <SecondaryNav.Section
+      title={
+        <TitleWrapper>
+          {t('Starred Views')}
+          <IssueViewAddViewButton baseUrl={baseUrl} />
+        </TitleWrapper>
+      }
     >
-      {views.map(view => (
-        <AnimatePresence key={view.id} mode="sync">
+      <Reorder.Group
+        as="div"
+        axis="y"
+        values={views}
+        onReorder={newOrder => setViews(newOrder)}
+        initial={false}
+        ref={sectionRef}
+      >
+        {views.map(view => (
           <IssueViewNavItemContent
+            key={view.id}
             view={view}
             sectionRef={sectionRef}
             isActive={view.id === viewId}
@@ -278,10 +289,9 @@ export function IssueViewNavItems({
             isDragging={isDragging}
             setIsDragging={setIsDragging}
           />
-        </AnimatePresence>
-      ))}
-      <IssueViewAddViewButton baseUrl={baseUrl} />
-    </Reorder.Group>
+        ))}
+      </Reorder.Group>
+    </SecondaryNav.Section>
   );
 }
 
@@ -299,3 +309,9 @@ export const constructViewLink = (baseUrl: string, view: IssueView) => {
     },
   });
 };
+
+const TitleWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -61,41 +61,39 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
             </SecondaryNav.Item>
           </SecondaryNav.Section>
           {groupSearchViews && (
-            <SecondaryNav.Section title={t('Starred Views')}>
-              <IssueViewNavItems
-                loadedViews={groupSearchViews.map(
-                  (
-                    {
-                      id,
-                      name,
-                      query: viewQuery,
-                      querySort: viewQuerySort,
-                      environments: viewEnvironments,
-                      projects: viewProjects,
-                      timeFilters: viewTimeFilters,
-                      isAllProjects,
-                    },
-                    index
-                  ): IssueView => {
-                    const tabId = id ?? `default${index.toString()}`;
+            <IssueViewNavItems
+              loadedViews={groupSearchViews.map(
+                (
+                  {
+                    id,
+                    name,
+                    query: viewQuery,
+                    querySort: viewQuerySort,
+                    environments: viewEnvironments,
+                    projects: viewProjects,
+                    timeFilters: viewTimeFilters,
+                    isAllProjects,
+                  },
+                  index
+                ): IssueView => {
+                  const tabId = id ?? `default${index.toString()}`;
 
-                    return {
-                      id: tabId,
-                      key: tabId,
-                      label: name,
-                      query: viewQuery,
-                      querySort: viewQuerySort,
-                      environments: viewEnvironments,
-                      projects: isAllProjects ? [-1] : viewProjects,
-                      timeFilters: viewTimeFilters,
-                      isCommitted: true,
-                    };
-                  }
-                )}
-                sectionRef={sectionRef}
-                baseUrl={baseUrl}
-              />
-            </SecondaryNav.Section>
+                  return {
+                    id: tabId,
+                    key: tabId,
+                    label: name,
+                    query: viewQuery,
+                    querySort: viewQuerySort,
+                    environments: viewEnvironments,
+                    projects: isAllProjects ? [-1] : viewProjects,
+                    timeFilters: viewTimeFilters,
+                    isCommitted: true,
+                  };
+                }
+              )}
+              sectionRef={sectionRef}
+              baseUrl={baseUrl}
+            />
           )}
           <SecondaryNav.Section title={t('Configure')}>
             <SecondaryNav.Item


### PR DESCRIPTION
Moves the Add View Button from below the views to the right of the "Starred Views" header. Adds a tooltip that says "Add View" 

Before: 

![image](https://github.com/user-attachments/assets/0ace702a-1d31-47df-af81-cd27fae3ea10)

After:

![image](https://github.com/user-attachments/assets/52b2ee7f-5b87-4ec4-b445-192911f84ce1)

Includes a couple of annotated drive by changes that aren't super related

