### PR TITLE
feat(issues): Add overlays to each trace row

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -1,17 +1,13 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import type {LocationDescriptor} from 'history';
 
 import ButtonBar from 'sentry/components/buttonBar';
 import {LinkButton} from 'sentry/components/core/button';
-import Link from 'sentry/components/links/link';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
@@ -19,6 +15,7 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 import {TraceIssueEvent} from 'sentry/views/issueDetails/traceTimeline/traceIssue';
 import {useTraceTimelineEvents} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
 import {IssuesTraceWaterfall} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfall';
+import {getTraceLinkForIssue} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfallOverlay';
 import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useIssuesTraceTree';
 import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
 import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
@@ -59,15 +56,9 @@ interface EventTraceViewInnerProps {
   event: Event;
   organization: Organization;
   traceId: string;
-  traceTarget: LocationDescriptor;
 }
 
-function EventTraceViewInner({
-  event,
-  organization,
-  traceId,
-  traceTarget,
-}: EventTraceViewInnerProps) {
+function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
   const timestamp = new Date(event.dateReceived).getTime() / 1e3;
 
   const trace = useTrace({
@@ -115,32 +106,9 @@ function EventTraceViewInner({
           replay={null}
           event={event}
         />
-        <IssuesTraceOverlayContainer
-          to={getHrefFromTraceTarget(traceTarget)}
-          onClick={() => {
-            trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
-              organization,
-            });
-          }}
-        />
       </IssuesTraceContainer>
     </TraceStateProvider>
   );
-}
-
-function getHrefFromTraceTarget(traceTarget: LocationDescriptor) {
-  if (typeof traceTarget === 'string') {
-    return traceTarget;
-  }
-
-  const searchParams = new URLSearchParams();
-  for (const key in traceTarget.query) {
-    if (defined(traceTarget.query[key])) {
-      searchParams.append(key, traceTarget.query[key]);
-    }
-  }
-
-  return `${traceTarget.pathname}?${searchParams.toString()}`;
 }
 
 function OneOtherIssueEvent({event}: {event: Event}) {
@@ -161,12 +129,6 @@ function OneOtherIssueEvent({event}: {event: Event}) {
 
 const IssuesTraceContainer = styled('div')`
   position: relative;
-`;
-
-const IssuesTraceOverlayContainer = styled(Link)`
-  position: absolute;
-  inset: 0;
-  z-index: 10;
 `;
 
 interface EventTraceViewProps {
@@ -216,7 +178,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
           <SwitchToNonEAPTraceButton location={location} organization={organization} />
           <LinkButton
             size="xs"
-            to={getHrefFromTraceTarget(traceTarget)}
+            to={getTraceLinkForIssue(traceTarget)}
             analyticsEventName="Issue Details: View Full Trace Action Button Clicked"
             analyticsEventKey="issue_details.view_full_trace_action_button_clicked"
           >
@@ -231,7 +193,6 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
           event={event}
           organization={organization}
           traceId={traceId}
-          traceTarget={traceTarget}
         />
       )}
     </InterimSection>

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import {
   Fragment,
   useCallback,
@@ -16,6 +15,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {IssueTraceWaterfallOverlay} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfallOverlay';
 import {
   isSpanNode,
   isTraceErrorNode,
@@ -58,6 +58,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
   const organization = useOrganization();
   const traceState = useTraceState();
   const traceDispatch = useTraceStateDispatch();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const [forceRender, rerender] = useReducer(x => (x + 1) % Number.MAX_SAFE_INTEGER, 0);
 
@@ -318,21 +319,32 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
             : 8
         }
       >
-        <IssuesPointerDisabled>
-          <Trace
-            metaQueryResults={props.meta}
-            trace={props.tree}
-            rerender={rerender}
-            trace_id={props.traceSlug}
-            onRowClick={onRowClick}
-            onTraceSearch={noopTraceSearch}
-            previouslyFocusedNodeRef={previouslyFocusedNodeRef}
-            manager={viewManager}
-            scheduler={traceScheduler}
-            forceRerender={forceRender}
-            isLoading={props.tree.type === 'loading' || onLoadScrollStatus === 'pending'}
+        <IssuesTraceContainer ref={containerRef}>
+          <IssuesPointerDisabled>
+            <Trace
+              metaQueryResults={props.meta}
+              trace={props.tree}
+              rerender={rerender}
+              trace_id={props.traceSlug}
+              onRowClick={onRowClick}
+              onTraceSearch={noopTraceSearch}
+              previouslyFocusedNodeRef={previouslyFocusedNodeRef}
+              manager={viewManager}
+              scheduler={traceScheduler}
+              forceRerender={forceRender}
+              isLoading={
+                props.tree.type === 'loading' || onLoadScrollStatus === 'pending'
+              }
+            />
+          </IssuesPointerDisabled>
+          <IssueTraceWaterfallOverlay
+            containerRef={containerRef}
+            event={props.event}
+            groupId={props.event.groupID}
+            tree={props.tree}
+            viewManager={viewManager}
           />
-        </IssuesPointerDisabled>
+        </IssuesTraceContainer>
 
         {props.tree.type === 'loading' || onLoadScrollStatus === 'pending' ? (
           <TraceWaterfallState.Loading />
@@ -369,4 +381,10 @@ const IssuesTraceGrid = styled(TraceGrid)<{
   height: ${p =>
     Math.min(Math.max(p.rowCount, MIN_ROW_COUNT), MAX_ROW_COUNT) * ROW_HEIGHT +
     HEADER_HEIGHT}px;
+`;
+
+const IssuesTraceContainer = styled('div')`
+  position: relative;
+  height: 100%;
+  width: 100%;
 `;

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
 import type {LocationDescriptor} from 'history';
@@ -115,39 +115,34 @@ export function IssueTraceWaterfallOverlay({
     };
   }, [viewManager, containerRef, tree]);
 
+  const handleLinkClick = useCallback(() => {
+    trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
+      organization,
+    });
+  }, [organization]);
+
   const baseLink = getTraceLinkForIssue(traceTarget);
 
   return (
-    <OverlayWrapper to={baseLink}>
-      {rowPositions?.length ? (
-        rowPositions.map(pos => (
-          <IssuesTraceOverlayContainer
-            key={pos.pathToNode[0]!}
-            to={getTraceLinkForIssue(traceTarget, pos.pathToNode)}
-            onClick={() => {
-              trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
-                organization,
-              });
-            }}
-            style={{
-              top: `${pos.top}px`,
-              left: `${pos.left}px`,
-              width: '100%',
-              height: `${pos.height}px`,
-            }}
-          />
-        ))
-      ) : (
+    <OverlayWrapper>
+      <FallbackOverlayContainer
+        to={baseLink}
+        onClick={handleLinkClick}
+        style={{inset: 0}}
+      />
+      {rowPositions?.map(pos => (
         <IssuesTraceOverlayContainer
-          to={baseLink}
-          onClick={() => {
-            trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
-              organization,
-            });
+          key={pos.pathToNode[0]!}
+          to={getTraceLinkForIssue(traceTarget, pos.pathToNode)}
+          onClick={handleLinkClick}
+          style={{
+            top: `${pos.top}px`,
+            left: `${pos.left}px`,
+            width: '100%',
+            height: `${pos.height}px`,
           }}
-          style={{inset: 0}}
         />
-      )}
+      ))}
     </OverlayWrapper>
   );
 }
@@ -175,11 +170,17 @@ export function getTraceLinkForIssue(
   return `${traceTarget.pathname}?${qs.stringify(searchParams)}`;
 }
 
-const OverlayWrapper = styled(Link)`
+const OverlayWrapper = styled('div')`
   position: absolute;
   inset: 0;
   z-index: 10;
   overflow: hidden;
+`;
+
+const FallbackOverlayContainer = styled(Link)`
+  position: absolute;
+  display: block;
+  pointer-events: auto;
 `;
 
 const IssuesTraceOverlayContainer = styled(Link)`

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -1,0 +1,196 @@
+import {useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import Color from 'color';
+import type {LocationDescriptor} from 'history';
+import * as qs from 'query-string';
+
+import Link from 'sentry/components/links/link';
+import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
+import type {Event} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {isCollapsedNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import type {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/issuesTraceTree';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+import type {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
+
+interface RowPosition {
+  height: number;
+  left: number;
+  pathToNode: ReturnType<typeof TraceTree.PathToNode>;
+  top: number;
+  width: number;
+}
+
+interface TraceOverlayProps {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  event: Event;
+  groupId: string | undefined;
+  tree: IssuesTraceTree;
+  viewManager: VirtualizedViewManager;
+}
+
+/**
+ * Renders a overlay over each row in the trace waterfall that blocks interaction with the row.
+ * Instead, the overlay will link to the full trace view for the row.
+ */
+export function IssueTraceWaterfallOverlay({
+  containerRef,
+  event,
+  groupId,
+  tree,
+  viewManager,
+}: TraceOverlayProps) {
+  const organization = useOrganization();
+  const [rowPositions, setRowPositions] = useState<RowPosition[] | null>(null);
+  const location = useLocation();
+
+  const traceTarget = useMemo(
+    () =>
+      generateTraceTarget(
+        event,
+        organization,
+        {
+          ...location,
+          query: {
+            ...location.query,
+            ...(groupId ? {groupId} : {}),
+          },
+        },
+        TraceViewSources.ISSUE_DETAILS
+      ),
+    [event, organization, location, groupId]
+  );
+
+  useEffect(() => {
+    const measurePositions = () => {
+      const container = containerRef.current;
+
+      if (!container) {
+        return;
+      }
+
+      const rows = document.querySelectorAll('.TraceRow:not(.Hidden)');
+      const newPositions: RowPosition[] = [];
+      const containerRect = container.getBoundingClientRect();
+
+      // Rows should match the number of rows in the tree
+      if (rows.length === 0 || rows.length !== tree.list.length) {
+        setRowPositions(null);
+        return;
+      }
+
+      rows.forEach((row, index) => {
+        const node = tree.list[index];
+        if (!node || isCollapsedNode(node)) {
+          return;
+        }
+
+        const pathToNode = TraceTree.PathToNode(node);
+
+        if (!pathToNode) {
+          return;
+        }
+
+        const rect = row.getBoundingClientRect();
+        newPositions.push({
+          top: rect.top - containerRect.top,
+          left: rect.left - containerRect.left,
+          width: rect.width,
+          height: rect.height,
+          pathToNode,
+        });
+      });
+
+      setRowPositions(newPositions);
+    };
+
+    viewManager.row_measurer.on('row measure end', measurePositions);
+    return () => {
+      viewManager.row_measurer.off('row measure end', measurePositions);
+    };
+  }, [viewManager, containerRef, tree]);
+
+  const baseLink = getTraceLinkForIssue(traceTarget);
+
+  return (
+    <OverlayWrapper to={baseLink}>
+      {rowPositions?.length ? (
+        rowPositions.map(pos => (
+          <IssuesTraceOverlayContainer
+            key={pos.pathToNode[0]!}
+            to={getTraceLinkForIssue(traceTarget, pos.pathToNode)}
+            onClick={() => {
+              trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
+                organization,
+              });
+            }}
+            style={{
+              top: `${pos.top}px`,
+              left: `${pos.left}px`,
+              width: '100%',
+              height: `${pos.height}px`,
+            }}
+          />
+        ))
+      ) : (
+        <IssuesTraceOverlayContainer
+          to={baseLink}
+          onClick={() => {
+            trackAnalytics('issue_details.view_full_trace_waterfall_clicked', {
+              organization,
+            });
+          }}
+          style={{inset: 0}}
+        />
+      )}
+    </OverlayWrapper>
+  );
+}
+
+export function getTraceLinkForIssue(
+  traceTarget: LocationDescriptor,
+  pathToNode?: ReturnType<typeof TraceTree.PathToNode>
+) {
+  if (typeof traceTarget === 'string') {
+    return traceTarget;
+  }
+
+  const searchParams = new URLSearchParams();
+  for (const key in traceTarget.query) {
+    if (key === 'node' && pathToNode) {
+      continue;
+    }
+    if (defined(traceTarget.query[key])) {
+      searchParams.append(key, traceTarget.query[key]);
+    }
+  }
+
+  let pathSearchParams = '';
+  if (pathToNode) {
+    pathSearchParams = `&${qs.stringify({node: pathToNode})}`;
+  }
+
+  return `${traceTarget.pathname}?${searchParams.toString()}${pathSearchParams}`;
+}
+
+const OverlayWrapper = styled(Link)`
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  overflow: hidden;
+`;
+
+const IssuesTraceOverlayContainer = styled(Link)`
+  position: absolute;
+  display: block;
+  pointer-events: auto;
+
+  &:hover {
+    background: ${p => Color(p.theme.backgroundSecondary).alpha(0.3).toString()};
+  }
+`;

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -160,22 +160,19 @@ export function getTraceLinkForIssue(
     return traceTarget;
   }
 
-  const searchParams = new URLSearchParams();
+  const searchParams: Record<string, string | string[]> = {};
   for (const key in traceTarget.query) {
-    if (key === 'node' && pathToNode) {
-      continue;
-    }
     if (defined(traceTarget.query[key])) {
-      searchParams.append(key, traceTarget.query[key]);
+      searchParams[key] = traceTarget.query[key];
     }
   }
 
-  let pathSearchParams = '';
   if (pathToNode) {
-    pathSearchParams = `&${qs.stringify({node: pathToNode})}`;
+    // Override the node query param from traceTarget.query
+    searchParams.node = pathToNode;
   }
 
-  return `${traceTarget.pathname}?${searchParams.toString()}${pathSearchParams}`;
+  return `${traceTarget.pathname}?${qs.stringify(searchParams)}`;
 }
 
 const OverlayWrapper = styled(Link)`
@@ -191,6 +188,6 @@ const IssuesTraceOverlayContainer = styled(Link)`
   pointer-events: auto;
 
   &:hover {
-    background: ${p => Color(p.theme.backgroundSecondary).alpha(0.3).toString()};
+    background: ${p => Color(p.theme.gray300).alpha(0.1).toString()};
   }
 `;


### PR DESCRIPTION
Currently, we have one big overlay that hijacks any interaction and links you to the trace view. Now each row will have its own overlay and link you to that specific span.

video of the new hover behavior

https://github.com/user-attachments/assets/6df4395f-0b50-4bbf-b391-50503286cd08

