### PR TITLE
🔧 chore(noa): invoke all ticketing actions via the issue alert handlers

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -56,7 +56,7 @@ def execute_via_group_type_registry(
         )
 
 
-def execute_via_metric_alert_handler(
+def execute_via_issue_alert_handler(
     job: WorkflowEventData, action: Action, detector: Detector
 ) -> None:
     """
@@ -69,7 +69,7 @@ def execute_via_metric_alert_handler(
 class NotificationActionHandler(ActionHandler, ABC):
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for a Notification Action",
+        "description": "The configuration schema for Ticketing Actions",
         "type": "object",
         "properties": {
             "target_identifier": {
@@ -85,7 +85,26 @@ class NotificationActionHandler(ActionHandler, ABC):
         },
     }
 
-    data_schema = {}
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for ticket creation action data blob",
+        "properties": {
+            "dynamic_form_fields": {
+                "type": "array",
+                "description": "Dynamic form fields from customer configuration",
+                "items": {"type": "object"},
+                "default": [],
+            },
+            "additional_fields": {
+                "type": "object",
+                "description": "Additional fields that aren't part of standard fields",
+                "additionalProperties": True,
+                "default": {},
+            },
+        },
+        "additionalProperties": False,
+    }
 
     @staticmethod
     def execute(
@@ -123,7 +142,7 @@ class TicketingActionHandler(ActionHandler, ABC):
         action: Action,
         detector: Detector,
     ) -> None:
-        execute_via_metric_alert_handler(job, action, detector)
+        execute_via_issue_alert_handler(job, action, detector)
 
 
 @action_handler_registry.register(Action.Type.DISCORD)

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -60,7 +60,7 @@ def execute_via_metric_alert_handler(
     job: WorkflowEventData, action: Action, detector: Detector
 ) -> None:
     """
-    This exists so that all ticketing actions can use the same handler as issue alerts since thats the only way we can
+    This exists so that all ticketing actions can use the same handler as issue alerts since that's the only way we can
     ensure that the same thread is used for the notification action.
     """
     IssueAlertRegistryInvoker.handle_workflow_action(job, action, detector)

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -138,7 +138,7 @@ class TicketingActionHandler(ActionHandler, ABC):
 
     @staticmethod
     def execute(
-        job: WorkflowJob,
+        job: WorkflowEventData,
         action: Action,
         detector: Detector,
     ) -> None:

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -69,7 +69,7 @@ def execute_via_issue_alert_handler(
 class NotificationActionHandler(ActionHandler, ABC):
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for Ticketing Actions",
+        "description": "The configuration schema for Notification Actions",
         "type": "object",
         "properties": {
             "target_identifier": {
@@ -85,26 +85,7 @@ class NotificationActionHandler(ActionHandler, ABC):
         },
     }
 
-    data_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "description": "Schema for ticket creation action data blob",
-        "properties": {
-            "dynamic_form_fields": {
-                "type": "array",
-                "description": "Dynamic form fields from customer configuration",
-                "items": {"type": "object"},
-                "default": [],
-            },
-            "additional_fields": {
-                "type": "object",
-                "description": "Additional fields that aren't part of standard fields",
-                "additionalProperties": True,
-                "default": {},
-            },
-        },
-        "additionalProperties": False,
-    }
+    data_schema = {}
 
     @staticmethod
     def execute(
@@ -134,7 +115,26 @@ class TicketingActionHandler(ActionHandler, ABC):
         },
     }
 
-    data_schema = {}
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for ticket creation action data blob",
+        "properties": {
+            "dynamic_form_fields": {
+                "type": "array",
+                "description": "Dynamic form fields from customer configuration",
+                "items": {"type": "object"},
+                "default": [],
+            },
+            "additional_fields": {
+                "type": "object",
+                "description": "Additional fields that aren't part of standard fields",
+                "additionalProperties": True,
+                "default": {},
+            },
+        },
+        "additionalProperties": False,
+    }
 
     @staticmethod
     def execute(

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -32,7 +32,6 @@ from sentry.workflow_engine.typings.notification_action import (
     SentryAppIdentifier,
     SlackDataBlob,
     TicketFieldMappingKeys,
-    TicketingActionDataBlobHelper,
 )
 
 logger = logging.getLogger(__name__)
@@ -272,9 +271,10 @@ class TicketingIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         # Use helper to separate fields
-        dynamic_form_fields, additional_fields = TicketingActionDataBlobHelper.separate_fields(
-            action.data
+        dynamic_form_fields = action.data.get(
+            TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {}
         )
+        additional_fields = action.data.get(TicketFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value, {})
 
         final_blob = {
             TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value: dynamic_form_fields,

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -407,7 +407,7 @@ class TicketingActionDataBlobHelper(ABC):
         Returns tuple of (dynamic_form_fields, additional_fields)
         """
         excluded_keys = excluded_keys or []
-        dynamic_form_fields = data.get(TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
+        dynamic_form_fields = data.get(TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, [])
 
         additional_fields = {
             k: v
@@ -443,13 +443,14 @@ class TicketActionTranslator(BaseActionTranslator, TicketingActionDataBlobHelper
         """
         Override to handle custom fields and additional fields that aren't part of the standard fields.
         """
-        data = super().get_sanitized_data()
-        if self.blob_type:
-            # Use helper to separate fields, excluding required fields
-            _, additional_fields = self.separate_fields(
-                self.action, excluded_keys=self.required_fields
-            )
-            data[TicketFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value] = additional_fields
+        # Use helper to separate fields, excluding required fields
+        dynamic_form_fields, additional_fields = self.separate_fields(
+            self.action, excluded_keys=self.required_fields
+        )
+        data = {
+            TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value: dynamic_form_fields,
+            TicketFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value: additional_fields,
+        }
         return data
 
 

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -35,6 +35,7 @@ from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMappingKeys,
     EmailActionHelper,
     SentryAppIdentifier,
+    TicketingActionDataBlobHelper,
 )
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -367,7 +368,7 @@ class TestTicketingIssueAlertHandlerBase(BaseWorkflowTest):
         action = self.create_action(
             type=action_type,
             integration_id=expected["integration"],
-            data=action_data,
+            data=self._form_ticketing_action_blob(action_data),
         )
         blob = self.handler.build_rule_action_blob(action, self.organization.id)
 
@@ -380,6 +381,12 @@ class TestTicketingIssueAlertHandlerBase(BaseWorkflowTest):
             "integration": expected["integration"],
             **expected,
         }
+
+    def _form_ticketing_action_blob(self, expected):
+        dynamic_form_fields, additional_fields = TicketingActionDataBlobHelper.separate_fields(
+            expected
+        )
+        return {"dynamic_form_fields": dynamic_form_fields, "additional_fields": additional_fields}
 
 
 class TestGithubIssueAlertHandler(TestTicketingIssueAlertHandlerBase):

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -458,7 +458,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
         self.handler = OpsgenieMetricAlertHandler()
 
     @mock.patch(


### PR DESCRIPTION
we need all of ticketing actions to flow to the issue alert handler. 

this pr defines a new `TicketingActionHandler ` ABC to handle invoking the issue alert handlers directly and updates the corresponding implementing classes to use the new ABC.

the changes are covered by  [this](https://github.com/getsentry/sentry/blob/master/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py),  so we should be good