### PR TITLE
feat(spans): Infer exclusive time in the segments consumer

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -207,7 +207,7 @@ def _set_exclusive_time(spans: list[Span]) -> None:
     of all time intervals where no child span was active.
     """
 
-    span_map: dict[str, list[tuple[float, float]]] = {}
+    span_map: dict[str, list[tuple[int, int]]] = {}
     for span in spans:
         if parent_span_id := span.get("parent_span_id"):
             interval = (_us(span["start_timestamp_precise"]), _us(span["end_timestamp_precise"]))

--- a/tests/sentry/spans/consumers/process/__init__.py
+++ b/tests/sentry/spans/consumers/process/__init__.py
@@ -1,11 +1,10 @@
-def build_mock_span(project_id, span_op=None, **kwargs):
+def build_mock_span(project_id, span_op=None, is_segment=False, sentry_tags=None, **kwargs):
     span = {
         "description": "OrganizationNPlusOne",
         "duration_ms": 107,
-        "event_id": "61ccae71d70f45bb9b1f2ccb7f7a49ec",
-        "exclusive_time_ms": 107.359,
-        "is_segment": True,
-        "parent_span_id": "b35b839c02985f33",
+        "is_segment": is_segment,
+        "is_remote": is_segment,
+        "parent_span_id": None,
         "profile_id": "dbae2b82559649a1a34a2878134a007b",
         "project_id": project_id,
         "organization_id": 1,
@@ -13,15 +12,11 @@ def build_mock_span(project_id, span_op=None, **kwargs):
         "retention_days": 90,
         "segment_id": "a49b42af9fb69da0",
         "sentry_tags": {
-            "browser.name": "Google Chrome",
             "environment": "development",
             "op": span_op or "base.dispatch.sleep",
             "release": "backend@24.2.0.dev0+699ce0cd1281cc3c7275d0a474a595375c769ae8",
-            "transaction": "/api/0/organizations/{organization_id_or_slug}/n-plus-one/",
-            "transaction.method": "GET",
-            "transaction.op": "http.server",
-            "user": "id:1",
             "platform": "python",
+            **(sentry_tags or {}),
         },
         "span_id": "a49b42af9fb69da0",
         "start_timestamp_ms": 1707953018865,

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -4,17 +4,13 @@ from unittest import mock
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition
 from arroyo.types import Topic as ArroyoTopic
-from sentry_kafka_schemas.codecs import Codec
-from sentry_kafka_schemas.schema_types.snuba_spans_v1 import SpanEvent
 
-from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.conf.types.kafka_definition import Topic
 from sentry.spans.consumers.process_segments.factory import DetectPerformanceIssuesStrategyFactory
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.utils.kafka_config import get_topic_definition
 from tests.sentry.spans.consumers.process import build_mock_span
-
-SNUBA_SPANS_CODEC: Codec[SpanEvent] = get_topic_codec(Topic.SNUBA_SPANS)
 
 
 def build_mock_message(data, topic=None):
@@ -25,11 +21,7 @@ def build_mock_message(data, topic=None):
     return message
 
 
-@override_options(
-    {
-        "standalone-spans.process-segments-consumer.enable": True,
-    }
-)
+@override_options({"standalone-spans.process-segments-consumer.enable": True})
 @mock.patch(
     "sentry.spans.consumers.process_segments.factory.process_segment", side_effect=lambda x: x
 )
@@ -93,4 +85,6 @@ def test_segment_deserialized_correctly(mock_process_segment):
 
         assert mock_producer.produce.call_count == 2
         assert mock_producer.produce.call_args.args[0] == ArroyoTopic("snuba-spans")
-        SNUBA_SPANS_CODEC.decode(mock_producer.produce.call_args.args[1].value)
+
+        value = mock_producer.produce.call_args.args[1].value
+        assert json.loads(value) == span_data

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -7,7 +7,7 @@ import pytest
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.models.environment import Environment
 from sentry.models.release import Release
-from sentry.spans.consumers.process_segments.message import process_segment
+from sentry.spans.consumers.process_segments.message import _set_exclusive_time, process_segment
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from tests.sentry.spans.consumers.process import build_mock_span
@@ -18,31 +18,37 @@ class TestSpansTask(TestCase):
         self.project = self.create_project()
 
     def generate_basic_spans(self):
-        segment_span = build_mock_span(project_id=self.project.id)
+        segment_span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+            sentry_tags={
+                "browser.name": "Google Chrome",
+                "transaction": "/api/0/organizations/{organization_id_or_slug}/n-plus-one/",
+                "transaction.method": "GET",
+                "transaction.op": "http.server",
+                "user": "id:1",
+            },
+        )
         child_span = build_mock_span(
             project_id=self.project.id,
             description="mock_test",
-            is_segment=False,
             parent_span_id=segment_span["span_id"],
             span_id="940ce942561548b5",
             start_timestamp_ms=1707953018867,
             start_timestamp_precise=1707953018.867,
         )
 
-        del child_span["sentry_tags"]["transaction"]
-        del child_span["sentry_tags"]["transaction.method"]
-        del child_span["sentry_tags"]["transaction.op"]
-        del child_span["sentry_tags"]["user"]
-
         return [child_span, segment_span]
 
     def generate_n_plus_one_spans(self):
-        segment_span = build_mock_span(project_id=self.project.id)
+        segment_span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+        )
         child_span = build_mock_span(
             project_id=self.project.id,
             description="OrganizationNPlusOne.get",
-            is_segment=False,
-            parent_span_id="b35b839c02985f33",
+            parent_span_id=segment_span["span_id"],
             span_id="940ce942561548b5",
             start_timestamp_ms=1707953018867,
             start_timestamp_precise=1707953018.867,
@@ -51,7 +57,6 @@ class TestSpansTask(TestCase):
             project_id=self.project.id,
             span_op="db",
             description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
-            is_segment=False,
             parent_span_id="940ce942561548b5",
             span_id="a974da4671bc3857",
             start_timestamp_ms=1707953018867,
@@ -64,7 +69,6 @@ class TestSpansTask(TestCase):
                 project_id=self.project.id,
                 span_op="db",
                 description=repeating_span_description,
-                is_segment=False,
                 parent_span_id="940ce942561548b5",
                 span_id=uuid.uuid4().hex[:16],
                 start_timestamp_ms=1707953018869,
@@ -202,3 +206,300 @@ class TestSpansTask(TestCase):
             ).hexdigest()
         ]
         assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
+
+
+# Tests ported from Relay
+class TestExclusiveTime(TestCase):
+    def test_childless_spans(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455604.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455603.5,
+                span_id="cccccccccccccccc",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455603.0,
+                end_timestamp_precise=1609455604.877,
+                span_id="dddddddddddddddd",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 1123.0,
+            "bbbbbbbbbbbbbbbb": 3000.0,
+            "cccccccccccccccc": 2500.0,
+            "dddddddddddddddd": 1877.0,
+        }
+
+    def test_nested_spans(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.2,
+                end_timestamp_precise=1609455601.8,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.4,
+                end_timestamp_precise=1609455601.6,
+                span_id="dddddddddddddddd",
+                parent_span_id="cccccccccccccccc",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 400.0,
+            "cccccccccccccccc": 400.0,
+            "dddddddddddddddd": 200.0,
+        }
+
+    def test_overlapping_child_spans(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.2,
+                end_timestamp_precise=1609455601.6,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.4,
+                end_timestamp_precise=1609455601.8,
+                span_id="dddddddddddddddd",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 400.0,
+            "cccccccccccccccc": 400.0,
+            "dddddddddddddddd": 400.0,
+        }
+
+    def test_child_spans_dont_intersect_parent(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455600.4,
+                end_timestamp_precise=1609455600.8,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455602.2,
+                end_timestamp_precise=1609455602.6,
+                span_id="dddddddddddddddd",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 1000.0,
+            "cccccccccccccccc": 400.0,
+            "dddddddddddddddd": 400.0,
+        }
+
+    def test_child_spans_extend_beyond_parent(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455600.8,
+                end_timestamp_precise=1609455601.4,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.6,
+                end_timestamp_precise=1609455602.2,
+                span_id="dddddddddddddddd",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 200.0,
+            "cccccccccccccccc": 600.0,
+            "dddddddddddddddd": 600.0,
+        }
+
+    def test_child_spans_consumes_all_of_parent(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455600.8,
+                end_timestamp_precise=1609455601.6,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.4,
+                end_timestamp_precise=1609455602.2,
+                span_id="dddddddddddddddd",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 0.0,
+            "cccccccccccccccc": 800.0,
+            "dddddddddddddddd": 800.0,
+        }
+
+    def test_only_immediate_child_spans_affect_calculation(self):
+        spans = [
+            build_mock_span(
+                project_id=1,
+                is_segment=True,
+                start_timestamp_precise=1609455600.0,
+                end_timestamp_precise=1609455605.0,
+                span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.0,
+                end_timestamp_precise=1609455602.0,
+                span_id="bbbbbbbbbbbbbbbb",
+                parent_span_id="aaaaaaaaaaaaaaaa",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.6,
+                end_timestamp_precise=1609455602.2,
+                span_id="cccccccccccccccc",
+                parent_span_id="bbbbbbbbbbbbbbbb",
+            ),
+            build_mock_span(
+                project_id=1,
+                start_timestamp_precise=1609455601.4,
+                end_timestamp_precise=1609455601.8,
+                span_id="dddddddddddddddd",
+                parent_span_id="cccccccccccccccc",
+            ),
+        ]
+
+        _set_exclusive_time(spans)
+
+        exclusive_times = {span["span_id"]: span["exclusive_time"] for span in spans}
+        assert exclusive_times == {
+            "aaaaaaaaaaaaaaaa": 4000.0,
+            "bbbbbbbbbbbbbbbb": 600.0,
+            "cccccccccccccccc": 400.0,
+            "dddddddddddddddd": 400.0,
+        }


### PR DESCRIPTION
Ports [`compute_span_exclusive_time`](https://github.com/getsentry/relay/blob/2cd7cb433c46e4298a16614b7cc4cae52a348c64/relay-event-normalization/src/normalize/span/exclusive_time.rs#L93) from Relay along with its tests.

See https://github.com/getsentry/streaming-planning/issues/21