### PR TITLE
fix(spans-eap): time series not working with all formulas

### DIFF
--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import Expression, TimeSeriesRequest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
 
 from sentry.exceptions import InvalidSearchQuery
 
@@ -59,8 +60,13 @@ def transform_column_to_expression(column: Column) -> Expression:
             label=column.label,
         )
 
+    if column.aggregation.aggregate == Function.FUNCTION_UNSPECIFIED:
+        return Expression(
+            conditional_aggregation=column.conditional_aggregation,
+            label=column.label,
+        )
+
     return Expression(
         aggregation=column.aggregation,
-        conditional_aggregation=column.conditional_aggregation,
         label=column.label,
     )

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1344,6 +1344,56 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[2][1][0]["count"] == 0.25
         assert response.data["meta"]["dataset"] == self.dataset
 
+    def test_trace_status_rate(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "unauthenticated"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "unknown"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=3),
+                "interval": "1m",
+                "yAxis": "trace_status_rate(ok)",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 3
+
+        assert data[0][1][0]["count"] == 0.0
+        assert data[1][1][0]["count"] == 0.5
+        assert data[2][1][0]["count"] == 0.75
+        assert response.data["meta"]["dataset"] == self.dataset
+
     def test_count_op(self):
         self.store_spans(
             [


### PR DESCRIPTION
`trace_status_rate` was failing with an internal server error on the time series request because when we convert Column.BinaryFormula -> Expression.BinaryFormula. The `right` was being set to `conditional_aggregate {}` instead of `aggregation { .... }`

Turns out even if `column.conditional_aggregation` is not defined, but `column.aggregation` is, we can't pass in both `conditional_aggregation` and `aggregation` into `Expression`. It seems like `Expression` prioritizes `conditional_aggregation`.

In this PR we only pass in either `conditional_aggregation` or `aggregation` depending on if the `aggregation` is defined or not.