### PR TITLE
feat(ourlogs): Add logs as a recent search type

### DIFF
--- a/src/sentry/models/search_common.py
+++ b/src/sentry/models/search_common.py
@@ -10,3 +10,4 @@ class SearchType(IntEnum):
     SPAN = 5
     ERROR = 6
     TRANSACTION = 7
+    LOG = 8

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -118,6 +118,14 @@ class RecentSearchesListTest(APITestCase):
             last_seen=timezone.now(),
             date_added=timezone.now(),
         )
+        logs_recent_search = RecentSearch.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            type=SearchType.LOG.value,
+            query="some test",
+            last_seen=timezone.now(),
+            date_added=timezone.now(),
+        )
         self.check_results(issue_recent_searches, search_type=SearchType.ISSUE)
         self.check_results([event_recent_search], search_type=SearchType.EVENT)
         self.check_results([session_recent_search], search_type=SearchType.SESSION)
@@ -125,6 +133,7 @@ class RecentSearchesListTest(APITestCase):
         self.check_results([span_recent_search], search_type=SearchType.SPAN)
         self.check_results([error_recent_search], search_type=SearchType.ERROR)
         self.check_results([transaction_recent_search], search_type=SearchType.TRANSACTION)
+        self.check_results([logs_recent_search], search_type=SearchType.LOG)
 
     def test_param_validation(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
### Summary
As described, we don't want searches in logs showing up in other recent searches.
