### PR TITLE
:bug: fix: fix capture message

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -133,7 +133,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             message_identifier = str(ts) if ts is not None else None
             if message_identifier is None:
                 sentry_sdk.capture_message(
-                    "Recieved no thread_ts from Slack",
+                    "Received no thread_ts from Slack",
                     level="info",
                 )
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -131,9 +131,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             )
             ts = response.get("ts")
             message_identifier = str(ts) if ts is not None else None
-            if message_identifier is not None:
+            if message_identifier is None:
                 sentry_sdk.capture_message(
-                    f"Slack message sent with ts: {message_identifier}",
+                    "Recieved no thread_ts from Slack",
                     level="info",
                 )
 


### PR DESCRIPTION
i want to capture when the `message_identifier` is `None` actually