### PR TITLE
feat(ourlogs): Add autocomplete to logs ui

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -152,7 +152,7 @@ export function SpanSearchQueryBuilder({
   );
 }
 
-interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
+export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
   getFilterTokenWarning?: (key: string) => React.ReactNode;

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -208,6 +208,8 @@ export function recentSearchTypeToLabel(type: SavedSearchType | undefined) {
       return 'sessions';
     case SavedSearchType.SPAN:
       return 'spans';
+    case SavedSearchType.LOG:
+      return 'logs';
     default:
       return 'none';
   }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -59,6 +59,7 @@ export enum SavedSearchType {
   SPAN = 5,
   ERROR = 6,
   TRANSACTION = 7,
+  LOG = 8,
 }
 
 export enum IssueCategory {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1849,6 +1849,8 @@ const SPAN_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   ...SPAN_HTTP_FIELD_DEFINITIONS,
 };
 
+const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {};
+
 export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.AGE,
   FieldKey.ASSIGNED_OR_SUGGESTED,
@@ -2459,7 +2461,7 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
 
 export const getFieldDefinition = (
   key: string,
-  type: 'event' | 'replay' | 'replay_click' | 'feedback' | 'span' = 'event',
+  type: 'event' | 'replay' | 'replay_click' | 'feedback' | 'span' | 'log' = 'event',
   kind?: FieldKind
 ): FieldDefinition | null => {
   switch (type) {
@@ -2512,6 +2514,21 @@ export const getFieldDefinition = (
       }
 
       return null;
+
+    case 'log':
+      if (key in LOG_FIELD_DEFINITIONS) {
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        return LOG_FIELD_DEFINITIONS[key];
+      }
+
+      if (kind === FieldKind.TAG) {
+        return {
+          kind: FieldKind.FIELD,
+          valueType: FieldValueType.STRING,
+        };
+      }
+      return null;
+
     case 'event':
     default:
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -20,9 +20,6 @@ interface TraceItemSearchQueryBuilderProps {
   numberAttributes: TagCollection;
   searchSource: string;
   stringAttributes: TagCollection;
-  /**
-   * Optional props
-   */
   datetime?: PageFilters['datetime'];
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onBlur?: (query: string, state: CallbackSearchState) => void;

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -1,0 +1,193 @@
+import {useCallback, useMemo} from 'react';
+
+import {getHasTag} from 'sentry/components/events/searchBar';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
+import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
+import {SavedSearchType, type Tag, type TagCollection} from 'sentry/types/group';
+import type {AggregationKey} from 'sentry/utils/fields';
+import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
+import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
+
+import {useTraceItemAttributeValues} from '../hooks/useTraceItemAttributeValues';
+import {TraceItemDataset} from '../types';
+
+interface TraceItemSearchQueryBuilderProps {
+  /**
+   * Required props
+   */
+  initialQuery: string;
+  itemType: TraceItemDataset.LOGS; // This should include TraceItemDataset.SPANS etc.
+  numberAttributes: TagCollection;
+  searchSource: string;
+  stringAttributes: TagCollection;
+  /**
+   * Optional props
+   */
+  datetime?: PageFilters['datetime'];
+  getFilterTokenWarning?: (key: string) => React.ReactNode;
+  onBlur?: (query: string, state: CallbackSearchState) => void;
+  onSearch?: (query: string, state: CallbackSearchState) => void;
+  placeholder?: string;
+  portalTarget?: HTMLElement | null;
+  projects?: PageFilters['projects'];
+  supportedAggregates?: AggregationKey[];
+}
+
+export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
+  if (!supportedAggregates?.length) {
+    return {};
+  }
+
+  return supportedAggregates.reduce((acc, item) => {
+    acc[item] = {
+      key: item,
+      name: item,
+      kind: FieldKind.FUNCTION,
+    };
+    return acc;
+  }, {} as TagCollection);
+};
+
+function getTraceItemFieldDefinitionFunction(tags: TagCollection) {
+  return (key: string) => {
+    return getFieldDefinition(key, 'span', tags[key]?.kind);
+  };
+}
+
+/**
+ * This component should replace EAPSpansSearchQueryBuilder in the future,
+ * once spans support has been added to the trace-items attribute endpoints.
+ */
+export function TraceItemSearchQueryBuilder({
+  initialQuery,
+  numberAttributes,
+  searchSource,
+  stringAttributes,
+  itemType,
+  datetime: _datetime,
+  getFilterTokenWarning,
+  onBlur,
+  onSearch,
+  placeholder,
+  portalTarget,
+  projects: _projects,
+  supportedAggregates = [],
+}: TraceItemSearchQueryBuilderProps) {
+  const placeholderText = placeholder ?? itemTypeToDefaultPlaceholder(itemType);
+  const functionTags = useFunctionTags(itemType, supportedAggregates);
+  const filterTags = useFilterTags(numberAttributes, stringAttributes, functionTags);
+  const filterKeySections = useFilterKeySections(itemType, stringAttributes);
+
+  const {getTraceItemAttributeValues} = useTraceItemAttributeValues({
+    traceItemType: itemType,
+    attributeKey: '', // Empty as we're only using the callback function
+    enabled: true,
+    type: 'string', // Only string attributes are supported for now
+  });
+
+  const getTraceItemTagValues = useCallback(
+    (tag: Tag, queryString: string) => {
+      if (tag.kind === 'function' || numberAttributes.hasOwnProperty(tag.key)) {
+        // We can't really auto suggest values for aggregate functions or numbers
+        return Promise.resolve([]);
+      }
+
+      // Use the trace item attributes endpoint
+      return getTraceItemAttributeValues(tag, queryString);
+    },
+    [getTraceItemAttributeValues, numberAttributes]
+  );
+
+  return (
+    <SearchQueryBuilder
+      placeholder={placeholderText}
+      filterKeys={filterTags}
+      initialQuery={initialQuery}
+      fieldDefinitionGetter={getTraceItemFieldDefinitionFunction(filterTags)}
+      onSearch={onSearch}
+      onBlur={onBlur}
+      getFilterTokenWarning={getFilterTokenWarning}
+      searchSource={searchSource}
+      filterKeySections={filterKeySections}
+      getTagValues={getTraceItemTagValues}
+      disallowUnsupportedFilters
+      recentSearches={itemTypeToRecentSearches(itemType)}
+      showUnsubmittedIndicator
+      portalTarget={portalTarget}
+    />
+  );
+}
+
+function useFunctionTags(
+  itemType: TraceItemDataset,
+  supportedAggregates?: AggregationKey[]
+) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return getFunctionTags(supportedAggregates);
+  }
+  return {};
+}
+
+function useFilterTags(
+  numberAttributes: TagCollection,
+  stringAttributes: TagCollection,
+  functionTags: TagCollection
+) {
+  return useMemo(() => {
+    const tags: TagCollection = {
+      ...functionTags,
+      ...numberAttributes,
+      ...stringAttributes,
+    };
+    tags.has = getHasTag({...stringAttributes});
+    return tags;
+  }, [numberAttributes, stringAttributes, functionTags]);
+}
+
+function useFilterKeySections(
+  itemType: TraceItemDataset,
+  stringAttributes: TagCollection
+) {
+  return useMemo(() => {
+    const predefined = new Set(
+      itemTypeToFilterKeySections(itemType).flatMap(section => section.children)
+    );
+    return [
+      ...itemTypeToFilterKeySections(itemType).map(section => {
+        return {
+          ...section,
+          children: section.children.filter(key => stringAttributes.hasOwnProperty(key)),
+        };
+      }),
+      {
+        value: 'custom_fields',
+        label: 'Custom Tags',
+        children: Object.keys(stringAttributes).filter(key => !predefined.has(key)),
+      },
+    ];
+  }, [stringAttributes, itemType]);
+}
+
+function itemTypeToRecentSearches(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return SavedSearchType.SPAN;
+  }
+  return SavedSearchType.LOG;
+}
+
+function itemTypeToFilterKeySections(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return SPANS_FILTER_KEY_SECTIONS;
+  }
+  return LOGS_FILTER_KEY_SECTIONS;
+}
+
+function itemTypeToDefaultPlaceholder(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return t('Search for spans, users, tags, and more');
+  }
+  return t('Search for logs, users, tags, and more');
+}

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -24,7 +24,6 @@ interface TraceItemSearchQueryBuilderProps {
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onBlur?: (query: string, state: CallbackSearchState) => void;
   onSearch?: (query: string, state: CallbackSearchState) => void;
-  placeholder?: string;
   portalTarget?: HTMLElement | null;
   projects?: PageFilters['projects'];
   supportedAggregates?: AggregationKey[];
@@ -65,12 +64,11 @@ export function TraceItemSearchQueryBuilder({
   getFilterTokenWarning,
   onBlur,
   onSearch,
-  placeholder,
   portalTarget,
   projects: _projects,
   supportedAggregates = [],
 }: TraceItemSearchQueryBuilderProps) {
-  const placeholderText = placeholder ?? itemTypeToDefaultPlaceholder(itemType);
+  const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
   const filterTags = useFilterTags(numberAttributes, stringAttributes, functionTags);
   const filterKeySections = useFilterKeySections(itemType, stringAttributes);

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -15,9 +15,6 @@ import {useTraceItemAttributeValues} from '../hooks/useTraceItemAttributeValues'
 import {TraceItemDataset} from '../types';
 
 interface TraceItemSearchQueryBuilderProps {
-  /**
-   * Required props
-   */
   initialQuery: string;
   itemType: TraceItemDataset.LOGS; // This should include TraceItemDataset.SPANS etc.
   numberAttributes: TagCollection;

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -1,10 +1,9 @@
 import {useCallback, useMemo} from 'react';
 
 import {getHasTag} from 'sentry/components/events/searchBar';
+import type {EAPSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
 import {SavedSearchType, type Tag, type TagCollection} from 'sentry/types/group';
 import type {AggregationKey} from 'sentry/utils/fields';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
@@ -14,20 +13,11 @@ import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {useTraceItemAttributeValues} from '../hooks/useTraceItemAttributeValues';
 import {TraceItemDataset} from '../types';
 
-interface TraceItemSearchQueryBuilderProps {
-  initialQuery: string;
+export type TraceItemSearchQueryBuilderProps = {
   itemType: TraceItemDataset.LOGS; // This should include TraceItemDataset.SPANS etc.
   numberAttributes: TagCollection;
-  searchSource: string;
   stringAttributes: TagCollection;
-  datetime?: PageFilters['datetime'];
-  getFilterTokenWarning?: (key: string) => React.ReactNode;
-  onBlur?: (query: string, state: CallbackSearchState) => void;
-  onSearch?: (query: string, state: CallbackSearchState) => void;
-  portalTarget?: HTMLElement | null;
-  projects?: PageFilters['projects'];
-  supportedAggregates?: AggregationKey[];
-}
+} & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
 export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
   if (!supportedAggregates?.length) {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -175,7 +175,8 @@ function itemTypeToRecentSearches(itemType: TraceItemDataset) {
   if (itemType === TraceItemDataset.SPANS) {
     return SavedSearchType.SPAN;
   }
-  return SavedSearchType.LOG;
+  // TODO: Add logs recent searches
+  return SavedSearchType.SPAN;
 }
 
 function itemTypeToFilterKeySections(itemType: TraceItemDataset) {

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,3 +1,5 @@
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
 import {SpanIndexedField} from '../insights/types';
 
 export const SENTRY_SPAN_STRING_TAGS: string[] = [
@@ -42,3 +44,18 @@ export const SENTRY_SPAN_NUMBER_TAGS: string[] = [
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.SPAN_SELF_TIME,
 ];
+
+export const SENTRY_LOG_STRING_TAGS: string[] = [
+  OurLogKnownFieldKey.TRACE_ID,
+  OurLogKnownFieldKey.ID,
+  OurLogKnownFieldKey.BODY,
+  OurLogKnownFieldKey.SEVERITY_TEXT,
+  OurLogKnownFieldKey.ORGANIZATION_ID,
+  OurLogKnownFieldKey.PROJECT_ID,
+  OurLogKnownFieldKey.SENTRY_PROJECT_ID,
+  OurLogKnownFieldKey.SPAN_ID,
+  OurLogKnownFieldKey.TIMESTAMP,
+  OurLogKnownFieldKey.ITEM_TYPE,
+];
+
+export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NUMBER];

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -1,0 +1,143 @@
+import type React from 'react';
+import {createContext, useContext, useMemo} from 'react';
+
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
+import {useSpanFieldCustomTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
+
+import {
+  SENTRY_LOG_NUMBER_TAGS,
+  SENTRY_LOG_STRING_TAGS,
+  SENTRY_SPAN_NUMBER_TAGS,
+  SENTRY_SPAN_STRING_TAGS,
+} from '../constants';
+import {useTraceItemAttributeKeys} from '../hooks/useTraceItemAttributeKeys';
+import {TraceItemDataset} from '../types';
+
+type TypedTraceItemAttributes = {number: TagCollection; string: TagCollection};
+
+type TypedTraceItemAttributesStatus = {
+  numberAttributesLoading: boolean;
+  stringAttributesLoading: boolean;
+};
+
+type TypedTraceItemAttributesResult = TypedTraceItemAttributes &
+  TypedTraceItemAttributesStatus;
+
+export const TraceItemAttributeContext = createContext<
+  TypedTraceItemAttributesResult | undefined
+>(undefined);
+
+interface TraceItemAttributeProviderProps {
+  children: React.ReactNode;
+  enabled: boolean;
+  traceItemType: TraceItemDataset;
+}
+
+export function TraceItemAttributeProvider({
+  children,
+  traceItemType,
+  enabled,
+}: TraceItemAttributeProviderProps) {
+  const {data: indexedTags} = useSpanFieldCustomTags({
+    enabled: traceItemType === TraceItemDataset.SPANS && enabled,
+  });
+
+  const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
+    useTraceItemAttributeKeys({
+      enabled,
+      type: 'number',
+      traceItemType,
+    });
+
+  const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
+    useTraceItemAttributeKeys({
+      enabled,
+      type: 'string',
+      traceItemType,
+    });
+
+  const allNumberAttributes = useMemo(() => {
+    const measurements = getDefaultNumberAttributes(traceItemType).map(measurement => [
+      measurement,
+      {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
+    ]);
+
+    return {...numberAttributes, ...Object.fromEntries(measurements)};
+  }, [numberAttributes, traceItemType]);
+
+  const allStringAttributes = useMemo(() => {
+    const tags = getDefaultStringAttributes(traceItemType).map(tag => [
+      tag,
+      {key: tag, name: tag, kind: FieldKind.TAG},
+    ]);
+
+    if (traceItemType === TraceItemDataset.SPANS) {
+      return {...indexedTags, ...stringAttributes, ...Object.fromEntries(tags)};
+    }
+
+    return {...stringAttributes, ...Object.fromEntries(tags)};
+  }, [traceItemType, indexedTags, stringAttributes]);
+
+  const attributesResult = useMemo(() => {
+    return {
+      number: allNumberAttributes,
+      string: allStringAttributes,
+      numberAttributesLoading,
+      stringAttributesLoading,
+    };
+  }, [
+    allNumberAttributes,
+    allStringAttributes,
+    numberAttributesLoading,
+    stringAttributesLoading,
+  ]);
+
+  return (
+    <TraceItemAttributeContext.Provider value={attributesResult}>
+      {children}
+    </TraceItemAttributeContext.Provider>
+  );
+}
+
+export function useTraceItemAttributes(type?: 'number' | 'string') {
+  const typedAttributesResult = useContext(TraceItemAttributeContext);
+
+  if (typedAttributesResult === undefined) {
+    throw new Error(
+      'useTraceItemAttributes must be used within a TraceItemAttributeProvider'
+    );
+  }
+
+  if (type === 'number') {
+    return {
+      attributes: typedAttributesResult.number,
+      isLoading: typedAttributesResult.numberAttributesLoading,
+    };
+  }
+  return {
+    attributes: typedAttributesResult.string,
+    isLoading: typedAttributesResult.stringAttributesLoading,
+  };
+}
+
+export function useTraceItemAttribute(key: string) {
+  const {attributes: numberAttributes} = useTraceItemAttributes('number');
+  const {attributes: stringAttributes} = useTraceItemAttributes('string');
+
+  return stringAttributes[key] ?? numberAttributes[key] ?? null;
+}
+
+function getDefaultStringAttributes(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return SENTRY_SPAN_STRING_TAGS;
+  }
+  return SENTRY_LOG_STRING_TAGS;
+}
+
+function getDefaultNumberAttributes(itemType: TraceItemDataset) {
+  if (itemType === TraceItemDataset.SPANS) {
+    return SENTRY_SPAN_NUMBER_TAGS;
+  }
+  return SENTRY_LOG_NUMBER_TAGS;
+}

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -1,0 +1,260 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import type {Organization} from 'sentry/types/organization';
+import {FieldKind} from 'sentry/utils/fields';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+const mockedUsedLocation = jest.mocked(useLocation);
+
+function createWrapper(organization: Organization) {
+  return function ({children}: {children?: React.ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useTraceItemAttributeKeys', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const mockAttributeKeys = [
+    {
+      key: 'test.attribute1',
+      name: 'Test Attribute 1',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'test.attribute2',
+      name: 'Test Attribute 2',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'test.attribute3',
+      name: 'Test Attribute 3',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'sentry.attribute',
+      name: 'Sentry Attribute',
+      kind: FieldKind.TAG,
+    },
+  ];
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+    mockedUsedLocation.mockReturnValue(LocationFixture());
+
+    // Setup the PageFilters store with default values
+    const {organization: _initOrg} = initializeOrg();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [1],
+        environments: [],
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+      },
+      new Set()
+    );
+  });
+
+  it('fetches attribute keys correctly for string type', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: mockAttributeKeys,
+      match: [
+        (_url: string, options: {query?: Record<string, any>}) => {
+          const query = options?.query || {};
+          return (
+            query.item_type === TraceItemDataset.LOGS && query.attribute_type === 'string'
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeKeys({
+          traceItemType: TraceItemDataset.LOGS,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockResponse).toHaveBeenCalled();
+
+    // Verify expected attributes (excluding sentry. prefixed ones)
+    const expectedAttributes = {
+      'test.attribute1': {
+        key: 'test.attribute1',
+        name: 'Test Attribute 1',
+        kind: FieldKind.TAG,
+      },
+      'test.attribute2': {
+        key: 'test.attribute2',
+        name: 'Test Attribute 2',
+        kind: FieldKind.TAG,
+      },
+      'test.attribute3': {
+        key: 'test.attribute3',
+        name: 'Test Attribute 3',
+        kind: FieldKind.TAG,
+      },
+    };
+
+    expect(result.current.attributes).toEqual(expectedAttributes);
+  });
+
+  it('fetches attribute keys correctly for number type', async () => {
+    const numberAttributeKeys = [
+      {
+        key: 'measurement.duration',
+        name: 'Duration',
+        kind: FieldKind.MEASUREMENT,
+      },
+      {
+        key: 'measurement.size',
+        name: 'Size',
+        kind: FieldKind.MEASUREMENT,
+      },
+    ];
+
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: numberAttributeKeys,
+      match: [
+        (_url: string, options: {query?: Record<string, any>}) => {
+          const query = options?.query || {};
+          return (
+            query.item_type === TraceItemDataset.LOGS && query.attribute_type === 'number'
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeKeys({
+          traceItemType: TraceItemDataset.LOGS,
+          type: 'number',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockResponse).toHaveBeenCalled();
+
+    const expectedAttributes = {
+      'measurement.duration': {
+        key: 'measurement.duration',
+        name: 'Duration',
+        kind: FieldKind.MEASUREMENT,
+      },
+      'measurement.size': {
+        key: 'measurement.size',
+        name: 'Size',
+        kind: FieldKind.MEASUREMENT,
+      },
+    };
+
+    expect(result.current.attributes).toEqual(expectedAttributes);
+  });
+  it('test escape characters on the query', async () => {
+    const attributesWithInvalidChars = [
+      {
+        key: 'valid.attribute',
+        name: 'Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'invalid-attribute',
+        name: 'Invalid Attribute',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'another_valid.attribute',
+        name: 'Another Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+    ];
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: attributesWithInvalidChars,
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeKeys({
+          traceItemType: TraceItemDataset.LOGS,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Should only contain valid attributes
+    const expectedAttributes = {
+      'valid.attribute': {
+        key: 'valid.attribute',
+        name: 'Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+      'another_valid.attribute': {
+        key: 'another_valid.attribute',
+        name: 'Another Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+    };
+
+    expect(result.current.attributes).toEqual(expectedAttributes);
+  });
+
+  it('test enabled option', () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: mockAttributeKeys,
+    });
+
+    renderHook(
+      () =>
+        useTraceItemAttributeKeys({
+          traceItemType: TraceItemDataset.LOGS,
+          type: 'string',
+          enabled: false,
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    expect(mockResponse).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -236,25 +236,4 @@ describe('useTraceItemAttributeKeys', () => {
 
     expect(result.current.attributes).toEqual(expectedAttributes);
   });
-
-  it('test enabled option', () => {
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/trace-items/attributes/`,
-      body: mockAttributeKeys,
-    });
-
-    renderHook(
-      () =>
-        useTraceItemAttributeKeys({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'string',
-          enabled: false,
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
-    );
-
-    expect(mockResponse).not.toHaveBeenCalled();
-  });
 });

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -54,13 +54,7 @@ export function useTraceItemAttributeKeys({
     const allAttributes: TagCollection = {};
 
     for (const attribute of result.data ?? []) {
-      // For now, skip all the sentry. prefixed attributes as they
-      // should be covered by the static attributes that will be
-      // merged with these results.
-      if (
-        attribute.key.startsWith('sentry.') ||
-        attribute.key.startsWith('tags[sentry.')
-      ) {
+      if (isKnownAttribute(attribute)) {
         continue;
       }
 
@@ -89,4 +83,20 @@ export function useTraceItemAttributeKeys({
     attributes: result.isLoading ? previousAttributes : attributes,
     isLoading: result.isLoading,
   };
+}
+
+function isKnownAttribute(attribute: Tag) {
+  // For now, skip all the sentry. prefixed attributes as they
+  // should be covered by the static attributes that will be
+  // merged with these results.
+
+  // For logs we include sentry.message.* since it contains params etc.
+  if (
+    attribute.key.startsWith('sentry.message.') ||
+    attribute.key.startsWith('tags[sentry.message.')
+  ) {
+    return false;
+  }
+
+  return attribute.key.startsWith('sentry.') || attribute.key.startsWith('tags[sentry.');
 }

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -1,0 +1,92 @@
+import {useMemo} from 'react';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {Tag, TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import usePrevious from 'sentry/utils/usePrevious';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
+
+export interface UseTraceItemAttributeBaseProps {
+  /**
+   * The trace item type supported by the endpoint, currently only supports LOGS.
+   */
+  traceItemType: TraceItemDataset;
+  /**
+   * The attribute type supported by the endpoint, currently only supports string and number.
+   */
+  type: 'number' | 'string';
+}
+
+interface UseTraceItemAttributeKeysProps extends UseTraceItemAttributeBaseProps {
+  enabled?: boolean;
+}
+
+export function useTraceItemAttributeKeys({
+  enabled,
+  type,
+  traceItemType,
+}: UseTraceItemAttributeKeysProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const path = `/organizations/${organization.slug}/trace-items/attributes/`;
+  const endpointOptions = {
+    query: {
+      project: selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(selection.datetime),
+      item_type: traceItemType,
+      attribute_type: type,
+    },
+  };
+
+  const result = useApiQuery<Tag[]>([path, endpointOptions], {
+    enabled,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  const attributes: TagCollection = useMemo(() => {
+    const allAttributes: TagCollection = {};
+
+    for (const attribute of result.data ?? []) {
+      // For now, skip all the sentry. prefixed attributes as they
+      // should be covered by the static attributes that will be
+      // merged with these results.
+      if (
+        attribute.key.startsWith('sentry.') ||
+        attribute.key.startsWith('tags[sentry.')
+      ) {
+        continue;
+      }
+
+      // EAP spans contain tags with illegal characters
+      // SnQL forbids `-` but is allowed in RPC. So add it back later
+      if (
+        !/^[a-zA-Z0-9_.:]+$/.test(attribute.key) &&
+        !/^tags\[[a-zA-Z0-9_.:]+,number\]$/.test(attribute.key)
+      ) {
+        continue;
+      }
+
+      allAttributes[attribute.key] = {
+        key: attribute.key,
+        name: attribute.name,
+        kind: type === 'number' ? FieldKind.MEASUREMENT : FieldKind.TAG,
+      };
+    }
+
+    return allAttributes;
+  }, [result.data, type]);
+
+  const previousAttributes = usePrevious(attributes, result.isLoading);
+
+  return {
+    attributes: result.isLoading ? previousAttributes : attributes,
+    isLoading: result.isLoading,
+  };
+}

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.spec.tsx
@@ -1,0 +1,301 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import type {Organization} from 'sentry/types/organization';
+import {FieldKind} from 'sentry/utils/fields';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useTraceItemAttributeValues} from 'sentry/views/explore/hooks/useTraceItemAttributeValues';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+const mockedUsedLocation = jest.mocked(useLocation);
+
+function createWrapper(organization: Organization) {
+  return function ({children}: {children?: React.ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useTraceItemAttributeValues', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const attributeKey = 'test.attribute';
+  const mockAttributeValues = [
+    {
+      key: attributeKey,
+      value: 'value1',
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    },
+    {
+      key: attributeKey,
+      value: 'value2',
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    },
+    {
+      key: attributeKey,
+      value: 'value3',
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    },
+  ];
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+
+    mockedUsedLocation.mockReturnValue(LocationFixture());
+
+    const {organization: _initOrg} = initializeOrg();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [1],
+        environments: [],
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+      },
+      new Set()
+    );
+  });
+
+  it('fetches attribute values correctly', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockAttributeValues,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.item_type === TraceItemDataset.LOGS &&
+            query.attribute_type === 'string' &&
+            !query.query
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeValues({
+          traceItemType: TraceItemDataset.LOGS,
+          attributeKey,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockResponse).toHaveBeenCalled();
+    expect(result.current.data).toEqual(['value1', 'value2', 'value3']);
+  });
+
+  it('applies search filters', async () => {
+    const searchTerm = 'value';
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockAttributeValues,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.item_type === TraceItemDataset.LOGS &&
+            query.attribute_type === 'string' &&
+            query.query === searchTerm
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeValues({
+          traceItemType: TraceItemDataset.LOGS,
+          attributeKey,
+          search: searchTerm,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockResponse).toHaveBeenCalled();
+  });
+
+  it('applies project filters', async () => {
+    const projectIds = [1, 2, 3];
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockAttributeValues,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.item_type === TraceItemDataset.LOGS &&
+            query.attribute_type === 'string' &&
+            JSON.stringify(query.project) === JSON.stringify(projectIds.map(String))
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeValues({
+          traceItemType: TraceItemDataset.LOGS,
+          attributeKey,
+          projectIds,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockResponse).toHaveBeenCalled();
+  });
+
+  it('getTraceItemAttributeValues works correctly for string type', async () => {
+    const mockSearchResponse = [
+      {
+        key: attributeKey,
+        value: 'search-result',
+        first_seen: null,
+        last_seen: null,
+        times_seen: null,
+      },
+    ];
+
+    // Initial fetch
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockAttributeValues,
+    });
+
+    // Mock getTraceItemAttributeValues call
+    const searchQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockSearchResponse,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return query.query === 'search-query';
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeValues({
+          traceItemType: TraceItemDataset.LOGS,
+          attributeKey,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const tag = {
+      key: attributeKey,
+      name: attributeKey,
+      kind: FieldKind.TAG,
+    };
+
+    expect(searchQueryMock).not.toHaveBeenCalled();
+
+    const searchResults = await result.current.getTraceItemAttributeValues(
+      tag,
+      'search-query'
+    );
+
+    expect(searchQueryMock).toHaveBeenCalled();
+    expect(searchResults).toEqual(['search-result']);
+  });
+
+  it('getTraceItemAttributeValues returns empty array for number type', async () => {
+    const mockSearchResponse = [
+      {
+        key: attributeKey,
+        value: 'search-result',
+        first_seen: null,
+        last_seen: null,
+        times_seen: null,
+      },
+    ];
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockAttributeValues,
+    });
+
+    // Mock for the getTraceItemAttributeValues call
+    const searchQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: mockSearchResponse,
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return query.query === 'search-query';
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeValues({
+          traceItemType: TraceItemDataset.LOGS,
+          attributeKey,
+          type: 'number',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const tag = {
+      key: attributeKey,
+      name: attributeKey,
+      kind: FieldKind.TAG,
+    };
+
+    expect(searchQueryMock).not.toHaveBeenCalled();
+
+    const searchResults = await result.current.getTraceItemAttributeValues(
+      tag,
+      'search-query'
+    );
+
+    expect(searchQueryMock).not.toHaveBeenCalled();
+    expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for numbers
+  });
+});

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
@@ -33,21 +33,9 @@ interface UseTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseProp
    * The attribute key for which to fetch values
    */
   attributeKey: string;
-  /**
-   * Optional datetime filter
-   */
   datetime?: PageFilters['datetime'];
-  /**
-   * Whether the query should be enabled
-   */
   enabled?: boolean;
-  /**
-   * Optional project IDs to filter by
-   */
   projectIds?: PageFilters['projects'];
-  /**
-   * Optional search string to filter values
-   */
   search?: string;
 }
 

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
@@ -4,6 +4,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import type {PageFilters} from 'sentry/types/core';
 import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {FieldKind} from 'sentry/utils/fields';
 import {
   type ApiQueryKey,
   useApiQuery,

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
@@ -1,0 +1,172 @@
+import {useCallback} from 'react';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {PageFilters} from 'sentry/types/core';
+import type {Tag} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
+import {
+  getRetryDelay,
+  shouldRetryHandler,
+} from 'sentry/views/insights/common/utils/retryHandlers';
+
+export interface TraceItemAttributeValue {
+  first_seen: null;
+  key: string;
+  last_seen: null;
+  times_seen: null;
+  value: string;
+}
+
+interface UseTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseProps {
+  /**
+   * The attribute key for which to fetch values
+   */
+  attributeKey: string;
+  /**
+   * Optional datetime filter
+   */
+  datetime?: PageFilters['datetime'];
+  /**
+   * Whether the query should be enabled
+   */
+  enabled?: boolean;
+  /**
+   * Optional project IDs to filter by
+   */
+  projectIds?: PageFilters['projects'];
+  /**
+   * Optional search string to filter values
+   */
+  search?: string;
+}
+
+type OrganizationTraceItemAttributeValuesResponse = TraceItemAttributeValue[];
+
+function traceItemAttributeValuesQueryKey({
+  orgSlug,
+  attributeKey,
+  search,
+  projectIds,
+  datetime,
+  traceItemType,
+  type = 'string',
+}: {
+  attributeKey: string;
+  orgSlug: string;
+  traceItemType: TraceItemDataset;
+  datetime?: PageFilters['datetime'];
+  projectIds?: number[];
+  search?: string;
+  type?: 'string' | 'number';
+}): ApiQueryKey {
+  const query: Record<string, string | string[] | number[]> = {
+    item_type: traceItemType,
+    attribute_type: type,
+  };
+
+  if (search) {
+    query.query = search;
+  }
+
+  if (projectIds?.length) {
+    query.project = projectIds.map(String);
+  }
+
+  if (datetime) {
+    Object.entries(normalizeDateTimeParams(datetime)).forEach(([key, value]) => {
+      if (value !== undefined) {
+        query[key] = value as string | string[];
+      }
+    });
+  }
+
+  return [
+    `/organizations/${orgSlug}/trace-items/attributes/${attributeKey}/values/`,
+    {query},
+  ];
+}
+
+/**
+ * Hook to fetch trace item attribute values for the Explore interface.
+ * This is designed to be used with the organization_trace_item_attributes endpoint.
+ */
+export function useTraceItemAttributeValues({
+  traceItemType,
+  attributeKey,
+  search = '',
+  projectIds,
+  datetime,
+  type = 'string',
+  enabled = true,
+}: UseTraceItemAttributeValuesProps) {
+  const api = useApi();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const queryOptions: UseApiQueryOptions<OrganizationTraceItemAttributeValuesResponse> = {
+    staleTime: 60000, // 1 minute
+    retry: shouldRetryHandler,
+    retryDelay: getRetryDelay,
+    enabled: enabled && !!attributeKey,
+  };
+
+  const queryKey = traceItemAttributeValuesQueryKey({
+    orgSlug: organization.slug,
+    attributeKey,
+    search,
+    projectIds: projectIds ?? selection.projects,
+    datetime: datetime ?? selection.datetime,
+    traceItemType,
+    type,
+  });
+
+  const queryResult = useApiQuery<OrganizationTraceItemAttributeValuesResponse>(
+    queryKey,
+    queryOptions
+  );
+
+  // Reformat the data to match the expected format for the SearchQueryBuilder
+  const formattedData = queryResult.data
+    ?.filter(item => defined(item.value))
+    .map(item => item.value);
+
+  // Create a function that can be used as getTagValues
+  const getTraceItemAttributeValues = useCallback(
+    async (tag: Tag, queryString: string): Promise<string[]> => {
+      if (tag.kind === 'function' || type === 'number') {
+        // We can't really auto suggest values for aggregate functions or numbers
+        return Promise.resolve([]);
+      }
+
+      try {
+        const result = await api.requestPromise(queryKey[0], {
+          method: 'GET',
+          query: {...queryKey[1]?.query, query: queryString},
+        });
+
+        return result
+          .filter((item: TraceItemAttributeValue) => defined(item.value))
+          .map((item: TraceItemAttributeValue) => item.value);
+      } catch (e) {
+        throw new Error(`Unable to fetch trace item attribute values: ${e}`);
+      }
+    },
+    [api, type, queryKey]
+  );
+
+  return {
+    ...queryResult,
+    data: formattedData,
+    getTraceItemAttributeValues,
+  };
+}

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
@@ -143,7 +143,7 @@ export function useTraceItemAttributeValues({
   // Create a function that can be used as getTagValues
   const getTraceItemAttributeValues = useCallback(
     async (tag: Tag, queryString: string): Promise<string[]> => {
-      if (tag.kind === 'function' || type === 'number') {
+      if (tag.kind === FieldKind.FUNCTION || type === 'number') {
         // We can't really auto suggest values for aggregate functions or numbers
         return Promise.resolve([]);
       }

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -1,4 +1,9 @@
+import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
+import {
+  SENTRY_LOG_NUMBER_TAGS,
+  SENTRY_LOG_STRING_TAGS,
+} from 'sentry/views/explore/constants';
 import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 export const LogAttributesHumanLabel: Record<OurLogFieldKey, string> = {
@@ -25,3 +30,11 @@ export const HiddenLogDetailFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.ITEM_TYPE,
 ];
+
+const LOGS_FILTERS: FilterKeySection = {
+  value: 'logs_filters',
+  label: 'Logs',
+  children: [...SENTRY_LOG_STRING_TAGS, ...SENTRY_LOG_NUMBER_TAGS],
+};
+
+export const LOGS_FILTER_KEY_SECTIONS: FilterKeySection[] = [LOGS_FILTERS];

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -33,7 +33,7 @@ export const HiddenLogDetailFields: OurLogFieldKey[] = [
 
 const LOGS_FILTERS: FilterKeySection = {
   value: 'logs_filters',
-  label: 'Logs',
+  label: t('Logs'),
   children: [...SENTRY_LOG_STRING_TAGS, ...SENTRY_LOG_NUMBER_TAGS],
 };
 

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -6,7 +6,9 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
 export default function LogsPage() {
@@ -28,13 +30,15 @@ export default function LogsPage() {
               </Layout.Title>
             </Layout.HeaderContent>
           </Layout.Header>
-          <LogsPageParamsProvider>
-            <LogsTabContent
-              defaultPeriod={defaultPeriod}
-              maxPickableDays={maxPickableDays}
-              relativeOptions={relativeOptions}
-            />
-          </LogsPageParamsProvider>
+          <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+            <LogsPageParamsProvider>
+              <LogsTabContent
+                defaultPeriod={defaultPeriod}
+                maxPickableDays={maxPickableDays}
+                relativeOptions={relativeOptions}
+              />
+            </LogsPageParamsProvider>
+          </TraceItemAttributeProvider>
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -76,7 +76,6 @@ export function LogsTabContent({
             />
           </PageFilterBar>
           <TraceItemSearchQueryBuilder
-            placeholder={t('Search for logs')}
             initialQuery={logsSearch.formatString()}
             searchSource="ourlogs"
             onSearch={setLogsQuery}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -8,20 +8,21 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {TagCollection} from 'sentry/types/group';
+import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {
   useLogsFields,
   useLogsSearch,
   useSetLogsFields,
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
 
 export type LogsTabProps = {
@@ -40,6 +41,10 @@ export function LogsTabContent({
   const fields = useLogsFields();
   const setFields = useSetLogsFields();
   const tableData = useExploreLogsTable({});
+
+  const {attributes: stringTags} = useTraceItemAttributes('string');
+  const {attributes: numberTags} = useTraceItemAttributes('number');
+
   const openColumnEditor = useCallback(() => {
     openModal(
       modalProps => (
@@ -47,13 +52,13 @@ export function LogsTabContent({
           {...modalProps}
           columns={fields}
           onColumnsChange={setFields}
-          stringTags={[] as unknown as TagCollection}
-          numberTags={[] as unknown as TagCollection}
+          stringTags={stringTags}
+          numberTags={numberTags}
         />
       ),
       {closeEvents: 'escape-key'}
     );
-  }, [fields, setFields]);
+  }, [fields, setFields, stringTags, numberTags]);
   return (
     <Layout.Body>
       <Layout.Main fullWidth>
@@ -70,13 +75,14 @@ export function LogsTabContent({
               })}
             />
           </PageFilterBar>
-          <SearchQueryBuilder
+          <TraceItemSearchQueryBuilder
             placeholder={t('Search for logs')}
-            filterKeys={{}}
-            getTagValues={() => new Promise<string[]>(() => [])}
             initialQuery={logsSearch.formatString()}
             searchSource="ourlogs"
             onSearch={setLogsQuery}
+            numberAttributes={numberTags}
+            stringAttributes={stringTags}
+            itemType={TraceItemDataset.LOGS}
           />
 
           <Button onClick={openColumnEditor} icon={<IconTable />}>

--- a/static/app/views/explore/types.tsx
+++ b/static/app/views/explore/types.tsx
@@ -1,0 +1,4 @@
+export enum TraceItemDataset {
+  LOGS = 'logs',
+  SPANS = 'spans',
+}


### PR DESCRIPTION
### Summary
This uses the newly added trace-items endpoints (which themselves use the updated eap_items rpc calls) to give autocomplete for log attributes in our search and column editor.

#### Screenshots
|![Screenshot 2025-03-19 at 10 41 36 AM](https://github.com/user-attachments/assets/6b7185ef-a74f-4530-becc-2df0ffab3a88)|
|-|


#### Other
- Adds recent search support, although that requires #87382 so I may shortcut it to use `SPANS` to land this PR.

#### Trace Item Components

We add some re-usable hooks for trace items here, that should be used for any items living in the generic table (eap-items) moving forward (eg. spans, logs, *error markers).
- `TraceItemSearchQueryBuilder` - This component should replace EAPSpansSearchQueryBuilder in the future
- `useTraceItemAttributeKeys` - Can be used to get any attribute key for a trace item type. (eg. autocomplete, and column editor lists)
- `useTraceItemAttributeValues` - Can be used to get any attribute value for a trace item type. (eg. autocomplete values)