### PR TITLE
feat(onboarding): assign dispatch uid to project_created signal

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -56,7 +56,7 @@ START_DATE_TRACKING_FIRST_EVENT_WITH_MINIFIED_STACK_TRACE_PER_PROJ = datetime(
 START_DATE_TRACKING_FIRST_SOURCEMAP_PER_PROJ = datetime(2023, 11, 16, tzinfo=timezone.utc)
 
 
-@project_created.connect(weak=False)
+@project_created.connect(weak=False, dispatch_uid="record_new_project")
 def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
 
     scope = sentry_sdk.get_current_scope()


### PR DESCRIPTION
- Contributes to https://github.com/getsentry/projects/issues/828
- Per [django documentation](https://docs.djangoproject.com/en/5.1/topics/signals/#preventing-duplicate-signals), there is no prevention of duplicate signals, and developer should attach a dispatch_uid to the signal connect call in order to prevent the signal from being called multiple times. Since we have an IntegrítyError in an atomic database transaction that fails, this could be the root cause - when the signal gets processed multiple times within the same transaction, there will be an integrity error, and the insert will fail, causing everything to be rolled back. 