### PR TITLE
ref(ourlogs): Remove excessive log for meta

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import type EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
@@ -16,8 +14,6 @@ import {
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {AlwaysPresentLogFields} from 'sentry/views/explore/logs/constants';
 import {useOurlogs} from 'sentry/views/insights/common/queries/useDiscover';
-
-const {warn, fmt} = Sentry._experiment_log;
 
 export interface OurLogsTableResult {
   eventView: EventView;
@@ -50,10 +46,6 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
     },
     'api.explore.logs-table'
   );
-
-  if (!meta) {
-    warn(fmt`meta is 'undefined' for useExploreLogsTable`);
-  }
 
   return {data, meta, isError, isPending, pageLinks};
 }


### PR DESCRIPTION
### Summary
Meta is never returned at the moment, this is increasingly showing up as more people use logs internally.
