### PR TITLE
fix(ui): Prevent palette hotkeys when any modal is open

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -69,7 +69,6 @@ function App({children, params}: Props) {
     return [
       {
         match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
-        includeInputs: true,
         callback: () => openCommandPalette(),
       },
     ];

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -12,6 +12,7 @@ import {initApiClientErrorHandling} from 'sentry/api';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {GlobalDrawer} from 'sentry/components/globalDrawer';
 import GlobalModal from 'sentry/components/globalModal';
+import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import Hook from 'sentry/components/hook';
 import Indicators from 'sentry/components/indicators';
 import {DEPLOY_PREVIEW_CONFIG, EXPERIMENTAL_SPA} from 'sentry/constants';
@@ -57,18 +58,24 @@ function App({children, params}: Props) {
   const api = useApi();
   const user = useUser();
   const config = useLegacyStore(ConfigStore);
+  const {visible: isModalOpen} = useGlobalModal();
   const preloadData = shouldPreloadData(config);
 
   // Command palette global-shortcut
   const commandPaletteHotkeys = useMemo(() => {
-    return {
-      match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
-      includeInputs: true,
-      callback: () => openCommandPalette(),
-    };
-  }, []);
+    if (isModalOpen) {
+      return [];
+    }
+    return [
+      {
+        match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
+        includeInputs: true,
+        callback: () => openCommandPalette(),
+      },
+    ];
+  }, [isModalOpen]);
 
-  useHotkeys([commandPaletteHotkeys]);
+  useHotkeys(commandPaletteHotkeys);
 
   /**
    * Loads the users organization list into the OrganizationsStore


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/87340

The command palette is itself a modal which means it'd override whatever modal was currently in view, which isn't the best experience, the ticket was specifically talking about issue linking but I think it makes sense to be universal. 

There was also a very good point about `ctrl+k` on mac being a shortcut to delete text, so I removed `includeInputs` but i'm open to other solutions.