### PR TITLE
fix(auto_source_config): Fix None intermingled with valid frames

### DIFF
--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -19,6 +19,8 @@ def get_frames_to_process(data: NodeData | dict[str, Any], platform: str) -> lis
     for stacktrace in stacktraces:
         frames = stacktrace["frames"] or []
         for frame in frames:
+            if frame is None:
+                continue
 
             if platform_config.creates_in_app_stack_trace_rules():
                 frames_to_process.append(frame)

--- a/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
+++ b/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
@@ -13,6 +13,9 @@ def _stacktrace(frames: list[dict[str, Any]]) -> dict[str, Any]:
     return {"stacktrace": {"frames": frames}}
 
 
+BASIC_FRAME = {"in_app": True, "filename": "foo"}
+
+
 @pytest.mark.parametrize(
     "frames, platform, expected",
     [
@@ -83,7 +86,8 @@ def test_get_frames_to_process(
         (None, []),
         ([None], []),
         ([], []),
-        ([{"in_app": True}], []),
+        ([{"in_app": True}], []),  # Both in_app and filename are required
+        ([BASIC_FRAME, None], [BASIC_FRAME]),  # Handle intermixing of None and dicts
     ],
 )
 def test_with_invalid_frames(frames: list[dict[str, Any]], expected: list[str]) -> None:


### PR DESCRIPTION
Fixes [SENTRY-3NS9](https://sentry.sentry.io/issues/6299550160/)