### PR TITLE
feat(issue-platform): Support passing fingerprints with multiple hashes when sending status updates

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -150,6 +150,8 @@ def bulk_get_groups_from_fingerprints(
 
     Note that fingerprints for issue platform are expected to be
     processed via `process_occurrence_data` prior to calling this function.
+
+    If we map to multiple groups, we'll use the group that matches the first fingerprint.
     """
     fingerprints_by_project: dict[int, list[str]] = defaultdict(list)
     for project_id, hashes in project_fingerprint_pairs:
@@ -172,7 +174,8 @@ def bulk_get_groups_from_fingerprints(
     result = {}
     for project_id, fingerprint in project_fingerprint_pairs:
         for hash in fingerprint:
-            # See if we managed to load any of the hashes from the fingerprint, prioritising early ones first
+            # See if we managed to load any of the hashes from the fingerprint. We prioritise the first hash we find
+            # for each fingerprint.
             if (project_id, hash) in group_hash_result:
                 result[(project_id, tuple(fingerprint))] = group_hash_result[(project_id, hash)]
                 break

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -137,7 +137,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
         )
 
 
-def get_groups_from_fingerprint(project_id: int, fingerprint: Sequence[str]) -> Group | None:
+def get_group_from_fingerprint(project_id: int, fingerprint: Sequence[str]) -> Group | None:
     results = bulk_get_groups_from_fingerprints([(project_id, fingerprint)])
     return results.get((project_id, tuple(fingerprint)))
 
@@ -228,7 +228,7 @@ def process_status_change_message(
 
     with metrics.timer("occurrence_consumer._process_message.status_change.get_group"):
         fingerprint = status_change_data["fingerprint"]
-        group = get_groups_from_fingerprint(project.id, fingerprint)
+        group = get_group_from_fingerprint(project.id, fingerprint)
         if not group:
             logger.info(
                 "status_change.dropped_group_not_found",

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -495,8 +495,8 @@ class RegressionDetector(ABC):
                 [(project_id, fingerprint) for project_id, fingerprint in pairs]
             )
 
-            for (project_id, fingerprint), bundle in pairs.items():
-                issue_group = issue_groups.get((project_id, tuple(fingerprint)))
+            for key, bundle in pairs.items():
+                issue_group = issue_groups.get(key)
                 if issue_group is None:
                     sentry_sdk.capture_message("Missing issue group for regression issue")
                     continue
@@ -561,8 +561,8 @@ class RegressionDetector(ABC):
                 [(project_id, p_fingerprint) for (project_id, p_fingerprint), _, _ in triples]
             )
 
-            for (project_id, p_fingerprint), regression_group, regression in triples:
-                issue_group = issue_groups.get((project_id, tuple(p_fingerprint)))
+            for key, regression_group, regression in triples:
+                issue_group = issue_groups.get(key)
                 if issue_group is None:
                     sentry_sdk.capture_message("Missing issue group for regression issue")
                     continue
@@ -635,9 +635,9 @@ def generate_fingerprint(regression_type: RegressionType, name: str | int) -> st
         raise ValueError(f"Unsupported RegressionType: {regression_type}")
 
 
-def generate_issue_group_key(project_id: int, fingerprint: str) -> tuple[int, list[str]]:
+def generate_issue_group_key(project_id: int, fingerprint: str) -> tuple[int, tuple[str, ...]]:
     data = {
         "fingerprint": [fingerprint],
     }
     process_occurrence_data(data)
-    return project_id, data["fingerprint"]
+    return project_id, tuple(data["fingerprint"])

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -360,7 +360,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
             status_change=bad_status_change_resolve,
         )
         group.refresh_from_db()
-        mock_metrics_incr.assert_any_call("occurrence_ingest.grouphash.not_found")
+        mock_metrics_incr.assert_any_call("occurrence_ingest.grouphash.not_found", amount=1)
         assert group.status == initial_status
         assert group.substatus == initial_substatus
 


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/87311

We now allow status updates with multiple hashes to be sent to the issue platform. We have a shared function here with statistical detectors, which I've also updated to pass work with full fingerprints. There should be no change to how the detector works.

<!-- Describe your PR here. -->