### PR TITLE
fix(ts): Correct broken typeing in projectDetail/utils

### DIFF
--- a/static/app/views/projectDetail/utils.spec.tsx
+++ b/static/app/views/projectDetail/utils.spec.tsx
@@ -86,7 +86,7 @@ describe('ProjectDetail Utils', function () {
     });
 
     it('returns correct query text for other platforms', () => {
-      expect(getANRIssueQueryText('windows')).toBe('mechanism:[ANR,AppExitInfo]');
+      expect(getANRIssueQueryText('other')).toBe('mechanism:[ANR,AppExitInfo]');
       expect(getANRIssueQueryText()).toBe('mechanism:[ANR,AppExitInfo]');
     });
   });


### PR DESCRIPTION
This regressed because we were missing the tsc CI check in sentry since
removing the tsc checking in getsentry.