### PR TITLE
style: darken EmptyStateWarning icon

### DIFF
--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -21,7 +21,7 @@ function EmptyStateWarning({small = false, withIcon = true, children, className}
     </EmptyMessage>
   ) : (
     <EmptyStreamWrapper data-test-id="empty-state" className={className}>
-      {withIcon && <IconSearch legacySize="54px" />}
+      {withIcon && <IconSearch color="gray300" legacySize="54px" />}
       {children}
     </EmptyStreamWrapper>
   );
@@ -41,7 +41,7 @@ export const EmptyStreamWrapper = styled('div')`
   }
 
   > svg {
-    fill: ${p => p.theme.gray200};
+    fill: ${p => p.theme.gray300};
     margin-bottom: ${space(2)};
   }
 `;


### PR DESCRIPTION
Make the icon in EmptyStateWarning consistent between small and !small variants, set to gray300

Small:
![Screenshot 2025-03-19 at 10 20 55 AM](https://github.com/user-attachments/assets/8b03ca67-4c20-4014-9cd7-5532ffb0d1c2)

Not small:
![image](https://github.com/user-attachments/assets/cc396c48-877e-433d-ae35-11d984251453)

Before (not small was gray200):
![Screenshot 2025-03-19 at 10 25 36 AM](https://github.com/user-attachments/assets/eeaae39f-d8ad-4d7a-90c5-8beb873502a2)

