### PR TITLE
fix(sentry apps): stop capturing sentry errors

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -61,6 +61,7 @@ class SentryAppWebhookHaltReason(StrEnum):
 
     GOT_CLIENT_ERROR = "got_client_error"
     INTEGRATOR_ERROR = "integrator_error"
+    MISSING_INSTALLATION = "missing_installation"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -27,6 +27,7 @@ from sentry.sentry_apps.metrics import (
     SentryAppInteractionEvent,
     SentryAppInteractionType,
     SentryAppWebhookFailureReason,
+    SentryAppWebhookHaltReason,
 )
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
@@ -184,6 +185,7 @@ def send_alert_webhook(
         if not installations:
             # when someone deletes an installation we don't clean up the rule actions
             # so we can have missing installations here
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.MISSING_INSTALLATION)
             return
         (install,) = installations
 

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -70,8 +70,8 @@ CONTROL_TASK_OPTIONS = {
 
 retry_decorator = retry(
     on=(RequestException, ApiHostError, ApiTimeoutError),
-    ignore=(ClientError,),
-    ignore_and_capture=(SentryAppSentryError, AssertionError, ValueError),
+    ignore=(ClientError, SentryAppSentryError, AssertionError, ValueError),
+    ignore_and_capture=(),
 )
 
 # We call some models by a different name, publicly, than their class name.
@@ -182,7 +182,9 @@ def send_alert_webhook(
             )
         )
         if not installations:
-            raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_INSTALLATION)
+            # when someone deletes an installation we don't clean up the rule actions
+            # so we can have missing installations here
+            return
         (install,) = installations
 
         nodedata = nodestore.backend.get(
@@ -517,7 +519,7 @@ def send_resource_change_webhook(
 def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
     for f in futures:
         if not f.kwargs.get("sentry_app"):
-            logger.error(
+            logger.info(
                 "notify_sentry_app.future_missing_sentry_app",
                 extra={"event": event.as_dict(), "future": f, "event_id": event.event_id},
             )

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -197,18 +197,15 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
             notify_sentry_app(group_event, [rule_future])
 
         assert not safe_urlopen.called
-        assert_failure_metric(
-            mock_record=mock_record,
-            error_msg=SentryAppSentryError(
-                message=SentryAppWebhookFailureReason.MISSING_INSTALLATION
-            ),
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.MISSING_INSTALLATION
         )
         # PREPARE_WEBHOOK (failure)
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=1
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
         )
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)


### PR DESCRIPTION
We've captured enough data to debug so to have pipelines not stop, stop capturing errors