### PR TITLE
chore(onboarding): Reorder product selector items and update links

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -389,7 +389,7 @@ export function ProductSelection({
           description={t(
             'Automatic performance issue detection across services and context on who is impacted, outliers, regressions, and the root cause of your slowdown.'
           )}
-          docLink="https://docs.sentry.io/platforms/javascript/guides/react/tracing/"
+          docLink="https://docs.sentry.io/concepts/key-terms/tracing/"
           onClick={() => handleClickProduct(ProductSolution.PERFORMANCE_MONITORING)}
           disabled={disabledProducts[ProductSolution.PERFORMANCE_MONITORING]}
           checked={urlProducts.includes(ProductSolution.PERFORMANCE_MONITORING)}
@@ -404,7 +404,7 @@ export function ProductSelection({
               strong: <strong />,
             }
           )}
-          docLink="https://docs.sentry.io/platforms/python/profiling/"
+          docLink="https://docs.sentry.io/product/explore/profiling/"
           onClick={() => handleClickProduct(ProductSolution.PROFILING)}
           disabled={disabledProducts[ProductSolution.PROFILING]}
           checked={urlProducts.includes(ProductSolution.PROFILING)}
@@ -416,7 +416,7 @@ export function ProductSelection({
           description={t(
             'Video-like reproductions of user sessions with debugging context to help you confirm issue impact and troubleshoot faster.'
           )}
-          docLink="https://docs.sentry.io/platforms/javascript/guides/react/session-replay/"
+          docLink="https://docs.sentry.io/product/explore/session-replay/"
           onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
           disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
           checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -395,18 +395,6 @@ export function ProductSelection({
           checked={urlProducts.includes(ProductSolution.PERFORMANCE_MONITORING)}
         />
       )}
-      {products.includes(ProductSolution.SESSION_REPLAY) && (
-        <Product
-          label={t('Session Replay')}
-          description={t(
-            'Video-like reproductions of user sessions with debugging context to help you confirm issue impact and troubleshoot faster.'
-          )}
-          docLink="https://docs.sentry.io/platforms/javascript/guides/react/session-replay/"
-          onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
-          disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
-          checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}
-        />
-      )}
       {products.includes(ProductSolution.PROFILING) && (
         <Product
           label={t('Profiling')}
@@ -420,6 +408,18 @@ export function ProductSelection({
           onClick={() => handleClickProduct(ProductSolution.PROFILING)}
           disabled={disabledProducts[ProductSolution.PROFILING]}
           checked={urlProducts.includes(ProductSolution.PROFILING)}
+        />
+      )}
+      {products.includes(ProductSolution.SESSION_REPLAY) && (
+        <Product
+          label={t('Session Replay')}
+          description={t(
+            'Video-like reproductions of user sessions with debugging context to help you confirm issue impact and troubleshoot faster.'
+          )}
+          docLink="https://docs.sentry.io/platforms/javascript/guides/react/session-replay/"
+          onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
+          disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
+          checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}
         />
       )}
     </Products>


### PR DESCRIPTION
<!-- Describe your PR here. -->

- updates order of products in the product selector to: Tracing - Profiling - Session Replay
  - came up in [this PR](https://github.com/getsentry/sentry/pull/87304)
  - relevant for Mobile platforms that have all three now, first of which is [Android](https://github.com/getsentry/sentry/pull/87408)
- changes the links in the product buttons from specific SDK pages to generic product pages
  - came up in [this PR](https://github.com/getsentry/sentry/pull/87304#discussion_r2002096452)
  - TBD: Tracing links to Key Terms page because there isn't a dedicated single product page

![Screenshot 2025-03-18 at 19 03 11](https://github.com/user-attachments/assets/a6eb56b8-6ad6-4427-b4c9-32163f8e31c1)