### PR TITLE
fix(nav): Better styles for starting a trial

### DIFF
--- a/static/app/components/nav/primary/primaryButtonOverlay.tsx
+++ b/static/app/components/nav/primary/primaryButtonOverlay.tsx
@@ -51,7 +51,7 @@ export function PrimaryButtonOverlay({
 const ScrollableOverlay = styled(Overlay)<{
   isMobile: boolean;
 }>`
-  min-height: 300px;
+  min-height: 150px;
   max-height: ${p => (p.isMobile ? '80vh' : '60vh')};
   overflow-y: auto;
   width: ${p => (p.isMobile ? `calc(100vw - ${space(4)})` : '400px')};

--- a/static/gsApp/components/tryBusinessSidebarItem.tsx
+++ b/static/gsApp/components/tryBusinessSidebarItem.tsx
@@ -1,4 +1,5 @@
 import {Component} from 'react';
+import styled from '@emotion/styled';
 
 import {prefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {
@@ -28,11 +29,13 @@ type Props = Parameters<Hooks['sidebar:bottom-items']>[0] & {
 const TRY_BUSINESS_SEEN_KEY = `sidebar-new-seen:try-business-v1`;
 
 function TryBusinessNavigationItem({
+  organization,
   subscription,
   onClick,
 }: {
   label: string;
   onClick: () => void;
+  organization: Organization;
   subscription: Subscription;
 }) {
   const [tryBusinessSeen, setTryBusinessSeen] = useLocalStorageState(
@@ -44,17 +47,19 @@ function TryBusinessNavigationItem({
   const showIsNew = isNew && !tryBusinessSeen;
 
   return (
-    <SidebarButton
-      label={t('Try Business')}
-      onClick={() => {
-        setTryBusinessSeen(true);
-        onClick();
-      }}
-      analyticsKey="try-business"
-    >
-      <IconBusiness size="md" />
-      {showIsNew && <SidebarItemUnreadIndicator />}
-    </SidebarButton>
+    <StackedNavTrialStartedSidebarItem {...{organization, subscription}}>
+      <SidebarButton
+        label={t('Try Business')}
+        onClick={() => {
+          setTryBusinessSeen(true);
+          onClick();
+        }}
+        analyticsKey="try-business"
+      >
+        <IconBusiness size="md" />
+        {showIsNew && <SidebarItemUnreadIndicator />}
+      </SidebarButton>
+    </StackedNavTrialStartedSidebarItem>
   );
 }
 
@@ -118,30 +123,39 @@ class TryBusinessSidebarItem extends Component<Props> {
       return null;
     }
 
+    if (prefersStackedNav()) {
+      return (
+        <TryBusinessNavigationItem
+          organization={organization}
+          subscription={subscription}
+          label={this.labelText}
+          onClick={this.openModal}
+        />
+      );
+    }
+
     return (
       <TrialStartedSidebarItem {...{organization, subscription}}>
-        {prefersStackedNav() ? (
-          <TryBusinessNavigationItem
-            subscription={subscription}
-            label={this.labelText}
-            onClick={this.openModal}
-          />
-        ) : (
-          <SidebarItem
-            {...sidebarItemProps}
-            id="try-business"
-            icon={<IconBusiness size="md" />}
-            label={this.labelText}
-            onClick={this.openModal}
-            key="gs-try-business"
-            data-test-id="try-business-sidebar"
-            isNewSeenKeySuffix="-v1"
-            isNew={!subscription.isTrial && subscription.canTrial}
-          />
-        )}
+        <SidebarItem
+          {...sidebarItemProps}
+          id="try-business"
+          icon={<IconBusiness size="md" />}
+          label={this.labelText}
+          onClick={this.openModal}
+          key="gs-try-business"
+          data-test-id="try-business-sidebar"
+          isNewSeenKeySuffix="-v1"
+          isNew={!subscription.isTrial && subscription.canTrial}
+        />
       </TrialStartedSidebarItem>
     );
   }
 }
+
+const StackedNavTrialStartedSidebarItem = styled(TrialStartedSidebarItem)`
+  margin: 0;
+  padding: 0;
+  border-radius: ${p => p.theme.borderRadius};
+`;
 
 export default withSubscription(TryBusinessSidebarItem, {noLoader: true});


### PR DESCRIPTION
When starting a trial, we show an animation which was a bit broken in the new nav before these changes.

Now it looks like this:

https://github.com/user-attachments/assets/39f7bd25-ac1f-46d6-8933-ae91495c806e


![CleanShot 2025-03-19 at 09 47 09](https://github.com/user-attachments/assets/b9945166-7384-4036-a027-86a19a8d1dd8)
