### PR TITLE
feat(events): Add a debug param

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -334,6 +334,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 isMetricsData = meta.pop("isMetricsData", False)
                 isMetricsExtractedData = meta.pop("isMetricsExtractedData", False)
                 discoverSplitDecision = meta.pop("discoverSplitDecision", None)
+                query = meta.pop("query", None)
                 fields, units = self.handle_unit_meta(fields_meta)
                 meta = {
                     "fields": fields,
@@ -348,6 +349,10 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
                 if discoverSplitDecision is not None:
                     meta["discoverSplitDecision"] = discoverSplitDecision
+
+                # Only appears in meta when debug is passed to the endpoint
+                if query:
+                    meta["query"] = query
             else:
                 meta = fields_meta
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -443,6 +443,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         # Only works when dataset == spans
         use_rpc = request.GET.get("useRpc", "0") == "1"
         sentry_sdk.set_tag("performance.use_rpc", use_rpc)
+        debug = request.user.is_superuser and "debug" in request.GET
 
         def _data_fn(
             dataset_query: DatasetQuery,
@@ -459,6 +460,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     offset=offset,
                     limit=limit,
                     referrer=referrer,
+                    debug=debug,
                     config=SearchResolverConfig(
                         auto_fields=True,
                         use_aggregate_conditions=use_aggregate_conditions,
@@ -490,6 +492,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     actor=request.user,
                 ),
                 query_source=query_source,
+                debug=debug,
             )
 
         @sentry_sdk.tracing.trace

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -71,6 +71,8 @@ class EventsMeta(TypedDict):
     isMetricsData: NotRequired[bool]
     isMetricsExtractedData: NotRequired[bool]
     discoverSplitDecision: NotRequired[str]
+    # only returned when debug=True
+    query: NotRequired[dict[str, Any] | str]
 
 
 class EventsResponse(TypedDict):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -184,6 +184,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     """
     High-level API for doing arbitrary user queries against events.
@@ -256,6 +257,8 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -59,6 +59,7 @@ def query(
     dataset: Dataset = Dataset.Events,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -90,6 +91,8 @@ def query(
         builder.add_conditions(conditions)
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
     result["meta"]["tips"] = transform_tips(builder.tips)
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     return result
 
 

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -43,6 +43,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -70,6 +71,8 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -40,6 +40,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     """
     High-level API for doing arbitrary user queries against events.
@@ -100,6 +101,8 @@ def query(
     if conditions is not None:
         builder.add_conditions(conditions)
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -49,6 +49,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     metrics_compatible = not equations
     dataset_reason = discover.DEFAULT_DATASET_REASON
@@ -76,6 +77,7 @@ def query(
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
                 query_source=query_source,
+                debug=debug,
             )
             result["meta"]["datasetReason"] = dataset_reason
 
@@ -114,6 +116,7 @@ def query(
             transform_alias_to_input_format=transform_alias_to_input_format,
             has_metrics=has_metrics,
             query_source=query_source,
+            debug=debug,
         )
         results["meta"]["isMetricsData"] = False
         results["meta"]["isMetricsExtractedData"] = False

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -55,6 +55,7 @@ def query(
     granularity: int | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     with sentry_sdk.start_span(op="mep", name="MetricQueryBuilder"):
         metrics_query = MetricsQueryBuilder(
@@ -91,6 +92,8 @@ def query(
         results = metrics_query.process_results(results)
         results["meta"]["isMetricsData"] = True
         results["meta"]["isMetricsExtractedData"] = metrics_query.use_on_demand
+        if debug:
+            results["meta"]["query"] = str(metrics_query.get_snql_query().query)
         sentry_sdk.set_tag("performance.dataset", "metrics")
         sentry_sdk.set_tag("on_demand.is_extracted", metrics_query.use_on_demand)
         return results

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -49,6 +49,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     return run_table_query(
         query_string=query or "",
@@ -64,4 +65,5 @@ def query(
                 use_aggregate_conditions=use_aggregate_conditions,
             ),
         ),
+        debug=debug,
     )

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -35,6 +35,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -57,6 +58,8 @@ def query(
         ),
     )
     result = builder.process_results(builder.run_query(referrer, query_source=query_source))
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 

--- a/src/sentry/snuba/spans_eap.py
+++ b/src/sentry/snuba/spans_eap.py
@@ -50,6 +50,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     builder = SpansEAPQueryBuilder(
         Dataset.EventsAnalyticsPlatform,
@@ -77,6 +78,8 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     return result
 
 

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -46,6 +46,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ):
     builder = SpansIndexedQueryBuilder(
         Dataset.SpansIndexed,
@@ -73,6 +74,8 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     return result
 
 

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -44,6 +44,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ):
     builder = SpansMetricsQueryBuilder(
         dataset=Dataset.PerformanceMetrics,
@@ -72,6 +73,8 @@ def query(
     result = builder.process_results(
         builder.run_query(referrer=referrer, query_source=query_source)
     )
+    if debug:
+        result["meta"]["query"] = str(builder.get_snql_query().query)
     return result
 
 

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -82,6 +82,7 @@ def run_table_query(
     referrer: str,
     config: SearchResolverConfig,
     search_resolver: SearchResolver | None = None,
+    debug: bool = False,
 ) -> EAPResponse:
     return rpc_dataset_common.run_table_query(
         query_string,
@@ -91,6 +92,7 @@ def run_table_query(
         limit,
         referrer,
         search_resolver or get_resolver(params, config),
+        debug,
     )
 
 

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -42,6 +42,7 @@ def query(
     dataset: Dataset = Dataset.Discover,
     fallback_to_transactions: bool = False,
     query_source: QuerySource | None = None,
+    debug: bool = False,
 ) -> EventsResponse:
     return discover.query(
         selected_columns,
@@ -70,6 +71,7 @@ def query(
         dataset=Dataset.Transactions,
         fallback_to_transactions=fallback_to_transactions,
         query_source=query_source,
+        debug=debug,
     )
 
 

--- a/src/sentry/snuba/types.py
+++ b/src/sentry/snuba/types.py
@@ -37,4 +37,5 @@ class DatasetQuery(Protocol):
         dataset: Dataset = Dataset.Discover,
         fallback_to_transactions: bool = False,
         query_source: QuerySource | None = None,
+        debug: bool = False,
     ) -> EventsResponse: ...


### PR DESCRIPTION
- This adds a debug param to the /events/ endpoint that lets superusers get either the snql or rpc query back for debugging purposes