### PR TITLE
chore(aci): update filters for environments on workflows

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -281,7 +281,9 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         assert triggered_workflows == {self.workflow}
 
     def test_workflow_trigger__no_conditions(self):
+        assert self.workflow.when_condition_group
         self.workflow.when_condition_group.conditions.all().delete()
+
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
         assert triggered_workflows == {self.workflow}
 

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -187,6 +187,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         project: Project | None = None,
         event: Event | None = None,
         occurrence: IssueOccurrence | None = None,
+        environment: str | None = None,
         fingerprint="test_fingerprint",
         group_type_id: int | None = None,
     ) -> tuple[Group, Event, GroupEvent]:
@@ -195,6 +196,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             project.id,
             datetime.now(),
             fingerprint,
+            environment,
         )
 
         if group_type_id:


### PR DESCRIPTION
1. We don't evaluate rules when the event environment does not exist when we try to fetch it. We early return
https://github.com/getsentry/sentry/blob/4631b634bd6469eeece28289f383c72d98dd07cb/src/sentry/rules/processing/processor.py#L315-L318
https://github.com/getsentry/sentry/blob/c8f1a90fdbc8fa113a07effd650379069444a824/src/sentry/eventstore/models.py#L176-L185
We should replicate this behavior in workflow engine, at least for the shadow rollout period when we are checking that the systems evaluate the same.
2. Update filtering for environments in Workflows to use `environment_id=environment.id`, not `environment_id=environment`. We always grab workflows with `environment_id=None` because those evaluate on all events, similar to Rules
https://github.com/getsentry/sentry/blob/c8f1a90fdbc8fa113a07effd650379069444a824/src/sentry/rules/processing/processor.py#L320-L321

Unrelated, but I also updated some logging:
1. Log `EventState.__dict__` because it's a regular class, I can't see the values if we just log the object
2. Add logs to see which workflows are evaluating on which events