### PR TITLE
fix(nav): Better onboarding item styles

### DIFF
--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -32,7 +32,7 @@ function SidebarBody({children}: {children: React.ReactNode}) {
 function SidebarFooter({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
   return (
-    <SidebarFooterWrapper>
+    <SidebarFooterWrapper isMobile={layout === NavLayout.MOBILE}>
       <SidebarItemList
         isMobile={layout === NavLayout.MOBILE}
         compact={layout === NavLayout.SIDEBAR}
@@ -149,10 +149,11 @@ const SidebarItemList = styled('ul')<{isMobile: boolean; compact?: boolean}>`
     `}
 `;
 
-const SidebarFooterWrapper = styled('div')`
+const SidebarFooterWrapper = styled('div')<{isMobile: boolean}>`
   position: relative;
   display: flex;
   flex-direction: row;
   align-items: stretch;
   margin-top: auto;
+  margin-bottom: ${p => (p.isMobile ? space(1) : 0)};
 `;

--- a/static/app/components/nav/primary/onboarding.tsx
+++ b/static/app/components/nav/primary/onboarding.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo} from 'react';
 import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -46,7 +47,8 @@ function OnboardingItem({
 }) {
   const theme = useTheme();
   const {layout} = useNavContext();
-  const showLabel = layout === NavLayout.MOBILE;
+  const isMobile = layout === NavLayout.MOBILE;
+  const showLabel = isMobile;
   const demoMode = isDemoModeActive();
   const label = demoMode ? t('Guided Tours') : t('Onboarding');
   const pendingCompletionSeen = doneTasks.length !== completeTasks.length;
@@ -76,30 +78,37 @@ function OnboardingItem({
       <SidebarItem label={label} showLabel={showLabel}>
         <NavButton
           {...overlayTriggerProps}
-          isMobile={layout === NavLayout.MOBILE}
+          isMobile={isMobile}
           aria-label={showLabel ? undefined : label}
           onMouseEnter={() => {
             refetch();
           }}
         >
           <InteractionStateLayer />
-          <ProgressRing
-            animate
-            textCss={() => css`
-              font-size: ${showLabel ? theme.fontSizeSmall : theme.fontSizeMedium};
-              font-weight: ${theme.fontWeightBold};
-              color: ${theme.purple400};
-            `}
-            text={
-              doneTasks.length === allTasks.length ? <IconCheckmark /> : doneTasks.length
-            }
-            value={(doneTasks.length / allTasks.length) * 100}
-            backgroundColor="rgba(255, 255, 255, 0.15)"
-            progressEndcaps="round"
-            progressColor={theme.purple400}
-            size={showLabel ? 28 : 32}
-            barWidth={4}
-          />
+          <ProgressRingWrapper isMobile={isMobile}>
+            <OnboardingProgressRing
+              isMobile={isMobile}
+              animate
+              textCss={() => css`
+                font-size: ${isMobile ? theme.fontSizeExtraSmall : theme.fontSizeSmall};
+                font-weight: ${theme.fontWeightBold};
+                color: ${theme.purple400};
+              `}
+              text={
+                doneTasks.length === allTasks.length ? (
+                  <IconCheckmark />
+                ) : (
+                  doneTasks.length
+                )
+              }
+              value={(doneTasks.length / allTasks.length) * 100}
+              backgroundColor={theme.gray200}
+              progressEndcaps="round"
+              progressColor={theme.purple400}
+              size={isMobile ? 22 : 26}
+              barWidth={4}
+            />
+          </ProgressRingWrapper>
           {showLabel ? label : null}
           {pendingCompletionSeen && (
             <SidebarItemUnreadIndicator data-test-id="pending-seen-indicator" />
@@ -205,3 +214,19 @@ export function PrimaryNavigationOnboarding() {
     />
   );
 }
+
+// This wrapper matches the size of other nav button icons. This is ncessary
+// because the progress ring is larger than the icons, but we want this
+// to be sized similarly to other nav buttons.
+const ProgressRingWrapper = styled('div')<{isMobile: boolean}>`
+  height: ${p => (p.isMobile ? '14px' : '16px')};
+  width: ${p => (p.isMobile ? '14px' : '16px')};
+  position: relative;
+`;
+
+const OnboardingProgressRing = styled(ProgressRing)<{isMobile: boolean}>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;


### PR DESCRIPTION
The onboarding progress ring wasn't showing up correctly on light mode or on mobile, this fixes both issues.

![CleanShot 2025-03-19 at 11 12 20](https://github.com/user-attachments/assets/5763bce7-8c69-4c40-91de-97a0f870102e)

![CleanShot 2025-03-19 at 11 12 28](https://github.com/user-attachments/assets/3b2a56ab-f6a1-4372-b68d-0c0674507d67)
