### PR TITLE
fix(nav): Remove tooltip when menus are opened

### DIFF
--- a/static/app/components/nav/primary/components.tsx
+++ b/static/app/components/nav/primary/components.tsx
@@ -84,12 +84,12 @@ export function SidebarMenu({
   const showLabel = forceLabel || layout === NavLayout.MOBILE;
 
   return (
-    <SidebarItem label={label} showLabel={showLabel}>
-      <DropdownMenu
-        position={layout === NavLayout.MOBILE ? 'bottom' : 'right-end'}
-        shouldApplyMinWidth={false}
-        trigger={(props, isOpen) => {
-          return (
+    <DropdownMenu
+      position={layout === NavLayout.MOBILE ? 'bottom' : 'right-end'}
+      shouldApplyMinWidth={false}
+      trigger={(props, isOpen) => {
+        return (
+          <SidebarItem label={label} showLabel={showLabel}>
             <NavButton
               {...props}
               aria-label={showLabel ? undefined : label}
@@ -103,11 +103,11 @@ export function SidebarMenu({
               {children}
               {showLabel ? label : null}
             </NavButton>
-          );
-        }}
-        items={items}
-      />
-    </SidebarItem>
+          </SidebarItem>
+        );
+      }}
+      items={items}
+    />
   );
 }
 

--- a/static/app/components/nav/primary/onboarding.tsx
+++ b/static/app/components/nav/primary/onboarding.tsx
@@ -105,12 +105,12 @@ function OnboardingItem({
             <SidebarItemUnreadIndicator data-test-id="pending-seen-indicator" />
           )}
         </NavButton>
-        {isOpen && (
-          <PrimaryButtonOverlay overlayProps={overlayProps}>
-            <OnboardingSidebarContent onClose={() => SidebarPanelStore.hidePanel()} />
-          </PrimaryButtonOverlay>
-        )}
       </SidebarItem>
+      {isOpen && (
+        <PrimaryButtonOverlay overlayProps={overlayProps}>
+          <OnboardingSidebarContent onClose={() => SidebarPanelStore.hidePanel()} />
+        </PrimaryButtonOverlay>
+      )}
     </GuideAnchor>
   );
 }


### PR DESCRIPTION
Prevents the current issue where tooltips stay open when interacting with the menu, by just wrapping the button itself:

![CleanShot 2025-03-19 at 11 28 22](https://github.com/user-attachments/assets/47dd07e2-665b-454a-b3ab-2fdb31f47ab1)
