### PR TITLE
feat(checkout): New PAYG step

### DIFF
--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -85,7 +85,7 @@ type GetsentryEventParameters = {
   'checkout.ondemand_budget.turned_off': Record<PropertyKey, unknown>;
   'checkout.ondemand_budget.update': OnDemandBudgetUpdate;
   'checkout.ondemand_changed': {cents: number} & Checkout;
-  'checkout.payg_changed': {cents: number} & Checkout;
+  'checkout.payg_changed': {cents: number; method?: 'button' | 'textbox'} & Checkout;
   'checkout.transactions_upgrade': {
     previous_transactions: number;
     transactions: number;

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-disabled-tests */
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
@@ -9,7 +10,8 @@ import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout';
 
-describe('SetPayAsYouGo', function () {
+// NOTE(isabella): This a temporary skip while we haven't added the step to the checkout flow
+describe.skip('SetPayAsYouGo', function () {
   const api = new MockApiClient();
   const organization = OrganizationFixture({
     features: ['ondemand-budgets', 'am3-billing'],

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.spec.tsx
@@ -1,0 +1,285 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import AMCheckout from 'getsentry/views/amCheckout';
+
+describe('SetPayAsYouGo', function () {
+  const api = new MockApiClient();
+  const organization = OrganizationFixture({
+    features: ['ondemand-budgets', 'am3-billing'],
+  });
+  const params = {};
+
+  const stepBody =
+    /Pay-as-you-go applies across all Sentry products, on a first-come, first-served basis./;
+
+  async function openPanel(planChoice: 'Business' | 'Team' = 'Business') {
+    expect(await screen.findByTestId('header-choose-your-plan')).toBeInTheDocument();
+    const selectedRadio = screen.getByRole('radio', {name: planChoice});
+    await userEvent.click(selectedRadio);
+    expect(selectedRadio).toBeChecked();
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+  }
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/promotions/trigger-check/`,
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/plan-migrations/?applied=0`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('renders with business plan and default PAYG budget by default for new customers', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel();
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '300'
+    );
+    expect(screen.getByText(/Suggested Amount/)).toBeInTheDocument();
+  });
+
+  it('renders with team plan and default PAYG budget by default for new customers', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel('Team');
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '100'
+    );
+    expect(screen.getByText(/Suggested Amount/)).toBeInTheDocument();
+  });
+
+  it('renders with existing PAYG budget', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      planTier: PlanTier.AM3,
+      onDemandMaxSpend: 30_00,
+      onDemandBudgets: {
+        budgetMode: OnDemandBudgetMode.SHARED,
+        sharedMaxBudget: 30_00,
+        enabled: true,
+        onDemandSpendUsed: 0,
+      },
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel();
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue('30');
+    expect(screen.queryByText(/Suggested Amount/)).not.toBeInTheDocument();
+  });
+
+  it('can complete step', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel();
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+
+    // continue to close
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+    expect(screen.queryByText(stepBody)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {name: 'Pay-as-you-go budget'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders with closest plan and default PAYG budget by default for customers migrating from partner billing', async function () {
+    organization.features.push('partner-billing-migration');
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am2_sponsored_team_auf',
+      planTier: PlanTier.AM2,
+      partner: {
+        isActive: true,
+        externalId: 'yuh',
+        partnership: {
+          id: 'FOO',
+          displayName: 'FOO',
+          supportNote: '',
+        },
+        name: '',
+      },
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel('Team');
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '100'
+    );
+    expect(screen.getByText(/Suggested Amount/)).toBeInTheDocument();
+  });
+
+  it('renders warnings when setting PAYG budget to 0', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel();
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Setting this to \$0 may result in you losing the ability to fully monitor your applications within Sentry/
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Products locked/)).not.toBeInTheDocument();
+
+    // set to 0
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'}));
+    expect(
+      await screen.findByRole('textbox', {name: 'Pay-as-you-go budget'})
+    ).toHaveValue('0');
+    expect(
+      screen.getByText(
+        /Setting this to \$0 may result in you losing the ability to fully monitor your applications within Sentry/
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Products locked/)).toBeInTheDocument();
+  });
+
+  it('can increment and decrement PAYG budget with buttons', async function () {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: PlanTier.AM3,
+    });
+    act(() => SubscriptionStore.set(organization.slug, sub));
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        organization={organization}
+        checkoutTier={PlanTier.AM3}
+        onToggleLegacy={jest.fn()}
+      />
+    );
+    await openPanel('Team');
+
+    expect(screen.getByText(stepBody)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '100'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Increase'}));
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '125'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue(
+      '100'
+    );
+
+    // should not go below 0
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue('0');
+    await userEvent.click(screen.getByRole('button', {name: 'Decrease'}));
+    expect(screen.getByRole('textbox', {name: 'Pay-as-you-go budget'})).toHaveValue('0');
+  });
+});

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -1,0 +1,406 @@
+import {useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Alert} from 'sentry/components/core/alert';
+import {Tag} from 'sentry/components/core/badge/tag';
+import {Button} from 'sentry/components/core/button';
+import {Input} from 'sentry/components/core/input';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelFooter from 'sentry/components/panels/panelFooter';
+import {IconAdd, IconInfo, IconLock, IconSentry, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+import {OnDemandBudgetMode, type OnDemandBudgets} from 'getsentry/types';
+import {
+  hasPartnerMigrationFeature,
+  isBizPlanFamily,
+  isDeveloperPlan,
+} from 'getsentry/utils/billing';
+import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
+import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
+import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
+import type {StepProps} from 'getsentry/views/amCheckout/types';
+import {getTotalBudget} from 'getsentry/views/onDemandBudgets/utils';
+
+const PAYG_BUSINESS_DEFAULT = 300_00;
+const PAYG_TEAM_DEFAULT = 100_00;
+const INCREMENT_STEP = 25_00;
+
+function SetPayAsYouGo({
+  isActive,
+  organization,
+  subscription,
+  activePlan,
+  stepNumber,
+  isCompleted,
+  formData,
+  onEdit,
+  onUpdate,
+  onCompleteStep,
+}: StepProps) {
+  const [currentBudget, setCurrentBudget] = useState<number>(
+    formData.onDemandBudget ? getTotalBudget(formData.onDemandBudget) : 0
+  );
+
+  const checkoutCategories = useMemo(() => {
+    return activePlan.checkoutCategories;
+  }, [activePlan]);
+
+  const paygOnlyCategories = useMemo(() => {
+    return activePlan.categories.filter(
+      category => !checkoutCategories.includes(category)
+    );
+  }, [activePlan, checkoutCategories]);
+
+  const suggestedBudgetForPlan = useMemo(() => {
+    return isBizPlanFamily(activePlan) ? PAYG_BUSINESS_DEFAULT : PAYG_TEAM_DEFAULT;
+  }, [activePlan]);
+
+  const isNewPayingCustomer =
+    isDeveloperPlan(subscription.planDetails) || hasPartnerMigrationFeature(organization);
+
+  useEffect(() => {
+    if (isNewPayingCustomer) {
+      setCurrentBudget(suggestedBudgetForPlan);
+    }
+  }, [isNewPayingCustomer, suggestedBudgetForPlan]);
+
+  const handleBudgetChange = (value: OnDemandBudgets) => {
+    // NOTE: `value` is always a SharedOnDemandBudget here because we don't support per-category budgets
+    // on AM3 but we use getTotalBudget anyway to be type safe
+    const totalBudget = getTotalBudget(value);
+    onUpdate({
+      ...formData,
+      onDemandBudget: value,
+      onDemandMaxSpend: totalBudget,
+    });
+
+    if (organization) {
+      trackGetsentryAnalytics('checkout.payg_changed', {
+        organization,
+        subscription,
+        plan: formData.plan,
+        cents: totalBudget || 0,
+      });
+    }
+    setCurrentBudget(totalBudget);
+  };
+
+  const coerceValue = (value: number): string => {
+    return (value / 100).toString();
+  };
+
+  const parseInputValue = (e: React.ChangeEvent<HTMLInputElement>): number => {
+    let value = parseInt(e.target.value, 10) || 0;
+    value = Math.max(value, 0);
+    const cents = value * 100;
+    return cents;
+  };
+
+  const incrementBudget = (step: number) => {
+    handleBudgetChange({
+      budgetMode: OnDemandBudgetMode.SHARED,
+      sharedMaxBudget: Math.max(0, currentBudget + step),
+    });
+  };
+
+  const renderProductAccessInfo = () => {
+    if (paygOnlyCategories.length === 0) {
+      return null;
+    }
+
+    const coveredProductsTitle =
+      currentBudget === 0 ? t('No additional coverage') : t('Covers additional usage');
+    const coveredProductsSubtitle =
+      currentBudget === 0
+        ? t('Risk of data loss during an overage')
+        : t('Prevents dropped data');
+    const paygProductsTitle =
+      currentBudget === 0 ? t('No product access') : t('Requires pay-as-you-go budget');
+    const paygProductsSubtitle =
+      currentBudget === 0
+        ? t('Requires pay-as-you-go budget')
+        : t('Unlocks product access');
+
+    return (
+      <TwoColumnContainer gap={space(2)} alignItems="stretch" columnWidth="1fr">
+        <Box>
+          <Title>{coveredProductsTitle}</Title>
+          <CategoryInfoDescription>{coveredProductsSubtitle}</CategoryInfoDescription>
+          <CategoryInfoList>
+            {checkoutCategories.map(category => (
+              <li key={category}>
+                <IconSubtract size="xs" />
+                <span>{getPlanCategoryName({plan: activePlan, category})}</span>
+              </li>
+            ))}
+          </CategoryInfoList>
+        </Box>
+        <Box>
+          <TwoColumnContainer alignItems="start" justifyContent="space-between">
+            <div>
+              <Title>{paygProductsTitle}</Title>
+              <CategoryInfoDescription>{paygProductsSubtitle}</CategoryInfoDescription>
+              <CategoryInfoList>
+                {paygOnlyCategories.map(category => (
+                  <li key={category}>
+                    {currentBudget === 0 ? (
+                      <IconLock size="xs" locked />
+                    ) : (
+                      <IconSubtract size="xs" />
+                    )}
+                    <span>{getPlanCategoryName({plan: activePlan, category})}</span>
+                  </li>
+                ))}
+              </CategoryInfoList>
+            </div>
+            {currentBudget === 0 && (
+              <Box padding={`${space(1)} ${space(1)} ${space(0.5)}`}>
+                <IconLock locked />
+              </Box>
+            )}
+          </TwoColumnContainer>
+        </Box>
+      </TwoColumnContainer>
+    );
+  };
+
+  const renderBody = () => {
+    return (
+      <StyledPanelBody data-test-id="body-set-payg" withPadding>
+        <TwoColumnContainer>
+          <Column>
+            <Title>{t('Pay-as-you-go Budget')}</Title>
+            <Description>
+              {t(
+                "Pay-as-you-go applies across all Sentry products, on a first-come, first-served basis. You're charged only for what you use, capped at your defined monthly limit."
+              )}
+            </Description>
+            <Description>
+              {t(
+                'Once this limit is reached, data collection will automatically stop until the next usage cycle begins.'
+              )}
+            </Description>
+            <Description>
+              {t(
+                'Charges are applied at the end of your usage cycle, and budget can be adjusted at anytime.'
+              )}
+            </Description>
+          </Column>
+          <Column>
+            <PayAsYouGoInputContainer>
+              <Button
+                icon={<IconSubtract />}
+                aria-label={t('Decrease')}
+                onClick={() => incrementBudget(-INCREMENT_STEP)}
+              />
+              <Currency>
+                <PayAsYouGoInput
+                  aria-label="Pay-as-you-go budget"
+                  name="payAsYouGoBudget"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={7}
+                  placeholder="e.g. 50"
+                  value={coerceValue(currentBudget)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    handleBudgetChange({
+                      budgetMode: OnDemandBudgetMode.SHARED,
+                      sharedMaxBudget: parseInputValue(e),
+                    });
+                  }}
+                />
+              </Currency>
+              <Button
+                icon={<IconAdd />}
+                aria-label={t('Increase')}
+                onClick={() => incrementBudget(INCREMENT_STEP)}
+              />
+            </PayAsYouGoInputContainer>
+            <AnimatePresence>
+              {(currentBudget === suggestedBudgetForPlan || currentBudget === 0) && (
+                <motion.div
+                  initial={{opacity: 0}}
+                  animate={{opacity: 1}}
+                  exit={{opacity: 0}}
+                  transition={{
+                    type: 'spring',
+                    duration: 0.4,
+                    bounce: 0.1,
+                  }}
+                >
+                  <SuggestedAmountTag
+                    icon={
+                      currentBudget === suggestedBudgetForPlan ? (
+                        <IconSentry />
+                      ) : (
+                        <IconLock locked />
+                      )
+                    }
+                  >
+                    {currentBudget === suggestedBudgetForPlan
+                      ? t('Suggested Amount')
+                      : t('Products locked')}
+                  </SuggestedAmountTag>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Column>
+        </TwoColumnContainer>
+        <AnimatePresence>
+          {currentBudget === 0 && (
+            <motion.div
+              initial={{height: 0, opacity: 0}}
+              animate={{height: 'auto', opacity: 1}}
+              exit={{height: 0, opacity: 0}}
+              transition={{
+                type: 'spring',
+                duration: 0.4,
+                bounce: 0.1,
+              }}
+            >
+              <Alert type="info" icon={<IconInfo />} showIcon>
+                {t(
+                  'Setting this to $0 may result in you losing the ability to fully monitor your applications within Sentry.'
+                )}
+              </Alert>
+            </motion.div>
+          )}
+        </AnimatePresence>
+        {renderProductAccessInfo()}
+      </StyledPanelBody>
+    );
+  };
+
+  const renderFooter = () => {
+    return (
+      <StepFooter data-test-id={'footer-set-payg'}>
+        <Button priority="primary" onClick={() => onCompleteStep(stepNumber)}>
+          {t('Continue')}
+        </Button>
+      </StepFooter>
+    );
+  };
+
+  return (
+    <Panel>
+      <StepHeader
+        canSkip
+        title={t('Set Your Pay-as-you-go Budget')}
+        isActive={isActive}
+        stepNumber={stepNumber}
+        isCompleted={isCompleted}
+        onEdit={onEdit}
+      />
+      {isActive && renderBody()}
+      {isActive && renderFooter()}
+    </Panel>
+  );
+}
+
+export default SetPayAsYouGo;
+
+const StepFooter = styled(PanelFooter)`
+  padding: ${space(2)};
+  display: grid;
+  align-items: center;
+  justify-content: end;
+`;
+
+const Description = styled(TextBlock)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray300};
+  margin: 0;
+`;
+
+const Currency = styled('div')`
+  &::before {
+    position: absolute;
+    padding: 9px ${space(1.5)};
+    content: '$';
+    color: ${p => p.theme.subText};
+    font-size: ${p => p.theme.fontSizeMedium};
+  }
+`;
+
+const PayAsYouGoInput = styled(Input)`
+  color: ${p => p.theme.textColor};
+  max-width: 120px;
+  height: 36px;
+  text-align: right;
+  font-weight: bold;
+`;
+
+const PayAsYouGoInputContainer = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: ${space(1)};
+  align-items: start;
+`;
+
+const StyledPanelBody = styled(PanelBody)`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const TwoColumnContainer = styled('div')<{
+  alignItems?: string;
+  columnWidth?: string;
+  gap?: string;
+  justifyContent?: string;
+}>`
+  display: grid;
+  grid-template-columns: repeat(2, ${p => p.columnWidth || 'auto'});
+  gap: ${p => p.gap || space(4)};
+  align-items: ${p => p.alignItems || 'start'};
+  justify-content: ${p => p.justifyContent || 'normal'};
+`;
+
+const CategoryInfoDescription = styled(Description)`
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Title = styled('label')`
+  font-weight: 600;
+  font-size: ${p => p.theme.fontSizeLarge};
+  margin: 0;
+`;
+
+const Column = styled('div')`
+  display: grid;
+  grid-template-columns: auto;
+  gap: ${space(1)};
+`;
+
+const SuggestedAmountTag = styled(Tag)`
+  max-width: fit-content;
+  justify-self: center;
+  display: flex;
+  align-items: center;
+`;
+
+const Box = styled('div')<{padding?: string}>`
+  border: 1px solid ${p => p.theme.border};
+  padding: ${p => p.padding || space(2)};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const CategoryInfoList = styled('ul')`
+  margin: ${space(1)} 0;
+  padding: 0;
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+
+  li {
+    list-style-type: none;
+    display: flex;
+    align-items: center;
+    gap: ${space(1)};
+  }
+`;

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -223,7 +223,8 @@ function SetPayAsYouGo({
               />
             </PayAsYouGoInputContainer>
             <AnimatePresence>
-              {(currentBudget === suggestedBudgetForPlan || currentBudget === 0) && (
+              {(currentBudget === suggestedBudgetForPlan ||
+                (currentBudget === 0 && paygOnlyCategories.length > 0)) && (
                 <motion.div
                   initial={{opacity: 0}}
                   animate={{opacity: 1}}
@@ -312,12 +313,6 @@ const StepFooter = styled(PanelFooter)`
   justify-content: end;
 `;
 
-const Description = styled(TextBlock)`
-  font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
-  margin: 0;
-`;
-
 const Currency = styled('div')`
   &::before {
     position: absolute;
@@ -362,8 +357,16 @@ const TwoColumnContainer = styled('div')<{
   justify-content: ${p => p.justifyContent || 'normal'};
 `;
 
-const CategoryInfoDescription = styled(Description)`
-  font-size: ${p => p.theme.fontSizeSmall};
+const Column = styled('div')`
+  display: grid;
+  grid-template-columns: auto;
+  gap: ${space(1)};
+`;
+
+const Box = styled('div')<{padding?: string}>`
+  border: 1px solid ${p => p.theme.border};
+  padding: ${p => p.padding || space(2)};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const Title = styled('label')`
@@ -372,10 +375,10 @@ const Title = styled('label')`
   margin: 0;
 `;
 
-const Column = styled('div')`
-  display: grid;
-  grid-template-columns: auto;
-  gap: ${space(1)};
+const Description = styled(TextBlock)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray300};
+  margin: 0;
 `;
 
 const SuggestedAmountTag = styled(Tag)`
@@ -386,10 +389,8 @@ const SuggestedAmountTag = styled(Tag)`
   line-height: normal;
 `;
 
-const Box = styled('div')<{padding?: string}>`
-  border: 1px solid ${p => p.theme.border};
-  padding: ${p => p.padding || space(2)};
-  border-radius: ${p => p.theme.borderRadius};
+const CategoryInfoDescription = styled(Description)`
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const CategoryInfoList = styled('ul')`

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -69,7 +69,7 @@ function SetPayAsYouGo({
     }
   }, [isNewPayingCustomer, suggestedBudgetForPlan]);
 
-  const handleBudgetChange = (value: OnDemandBudgets) => {
+  const handleBudgetChange = (value: OnDemandBudgets, fromButton = false) => {
     // NOTE: `value` is always a SharedOnDemandBudget here because we don't support per-category budgets
     // on AM3 but we use getTotalBudget anyway to be type safe
     const totalBudget = getTotalBudget(value);
@@ -85,6 +85,7 @@ function SetPayAsYouGo({
         subscription,
         plan: formData.plan,
         cents: totalBudget || 0,
+        method: fromButton ? 'button' : 'textbox',
       });
     }
     setCurrentBudget(totalBudget);
@@ -102,10 +103,13 @@ function SetPayAsYouGo({
   };
 
   const incrementBudget = (step: number) => {
-    handleBudgetChange({
-      budgetMode: OnDemandBudgetMode.SHARED,
-      sharedMaxBudget: Math.max(0, currentBudget + step),
-    });
+    handleBudgetChange(
+      {
+        budgetMode: OnDemandBudgetMode.SHARED,
+        sharedMaxBudget: Math.max(0, currentBudget + step),
+      },
+      true
+    );
   };
 
   const renderProductAccessInfo = () => {

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -383,6 +383,7 @@ const SuggestedAmountTag = styled(Tag)`
   justify-self: center;
   display: flex;
   align-items: center;
+  line-height: normal;
 `;
 
 const Box = styled('div')<{padding?: string}>`


### PR DESCRIPTION
this PR adds the new PAYG step. This step will not be live in checkout on merge, until we're ready to launch the new experience. 

Follow up PRs will add the new reserved volumes step, then update the checkout overview component and introduce the two new steps.

Figma: https://www.figma.com/design/o5VEiQ84cLCZEDUcP1lIHV/Checkout-Prototype?node-id=653-8250&t=sjKItWmz1zAoRWTC-0

https://github.com/user-attachments/assets/34efa3bf-880f-4eb3-b592-743e187c59a8

What this step will look like pre-profiling launch:
![image](https://github.com/user-attachments/assets/042c0ac5-7156-4689-b19a-d42deb29ea06)
![image](https://github.com/user-attachments/assets/8b40c7d2-2503-4a9e-947f-f9b2e212c77a)


