### PR TITLE
fix(dashboards-eap): Remove spans specific intervals

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -119,14 +119,7 @@ export class GranularityLadder {
   }
 }
 
-export type Fidelity =
-  | 'high'
-  | 'medium'
-  | 'low'
-  | 'metrics'
-  | 'issues'
-  | 'spans'
-  | 'spans-low';
+export type Fidelity = 'high' | 'medium' | 'low' | 'metrics' | 'issues' | 'spans-low';
 
 export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'medium') {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
@@ -137,7 +130,6 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     low: lowFidelityLadder,
     metrics: metricsFidelityLadder,
     issues: issuesFidelityLadder,
-    spans: spansFidelityLadder,
     'spans-low': spansLowFidelityLadder,
   }[fidelity].getInterval(diffInMinutes);
 }
@@ -186,18 +178,6 @@ const issuesFidelityLadder = new GranularityLadder([
   [TWENTY_FOUR_HOURS, '20m'],
   [SIX_HOURS, '5m'],
   [ONE_HOUR, '1m'],
-  [0, '1m'],
-]);
-
-const spansFidelityLadder = new GranularityLadder([
-  [SIXTY_DAYS, '1d'],
-  [THIRTY_DAYS, '12h'],
-  [TWO_WEEKS, '4h'],
-  [ONE_WEEK, '2h'],
-  [FORTY_EIGHT_HOURS, '30m'],
-  [TWENTY_FOUR_HOURS, '15m'],
-  [SIX_HOURS, '15m'],
-  [ONE_HOUR, '5m'],
   [0, '1m'],
 ]);
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -119,7 +119,14 @@ export class GranularityLadder {
   }
 }
 
-export type Fidelity = 'high' | 'medium' | 'low' | 'metrics' | 'issues' | 'spans-low';
+export type Fidelity =
+  | 'high'
+  | 'medium'
+  | 'low'
+  | 'metrics'
+  | 'issues'
+  | 'spans'
+  | 'spans-low';
 
 export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'medium') {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
@@ -130,6 +137,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     low: lowFidelityLadder,
     metrics: metricsFidelityLadder,
     issues: issuesFidelityLadder,
+    spans: spansFidelityLadder,
     'spans-low': spansLowFidelityLadder,
   }[fidelity].getInterval(diffInMinutes);
 }
@@ -178,6 +186,18 @@ const issuesFidelityLadder = new GranularityLadder([
   [TWENTY_FOUR_HOURS, '20m'],
   [SIX_HOURS, '5m'],
   [ONE_HOUR, '1m'],
+  [0, '1m'],
+]);
+
+const spansFidelityLadder = new GranularityLadder([
+  [SIXTY_DAYS, '1d'],
+  [THIRTY_DAYS, '12h'],
+  [TWO_WEEKS, '4h'],
+  [ONE_WEEK, '2h'],
+  [FORTY_EIGHT_HOURS, '30m'],
+  [TWENTY_FOUR_HOURS, '15m'],
+  [SIX_HOURS, '15m'],
+  [ONE_HOUR, '5m'],
   [0, '1m'],
 ]);
 

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -2,7 +2,6 @@ import pickBy from 'lodash/pickBy';
 
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
-import {getInterval} from 'sentry/components/charts/utils';
 import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {
@@ -282,7 +281,6 @@ function getSeriesRequest(
   );
 
   requestData.useRpc = true;
-  requestData.interval = getInterval(pageFilters.datetime, 'spans');
 
   // Filtering out all spans with op like 'ui.interaction*' which aren't
   // embedded under transactions. The trace view does not support rendering


### PR DESCRIPTION
Since we've capped the spans requests at 30d of data and added support for more intervals, we can remove the span specific intervals because they should be compatible now.

Avoiding unique intervals means we don't run into issues with the synced cursors across charts either and makes them easier to compare across transactions and spans.