### PR TITLE
fix(issues): Change span evidence copy "View full trace"

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -67,11 +67,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -142,11 +141,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -217,11 +215,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -302,11 +299,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Starting Span'})).toBeInTheDocument();
       expect(
@@ -446,11 +442,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -600,11 +595,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow DB Query'})).toBeInTheDocument();
       expect(
@@ -654,11 +648,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(
@@ -719,11 +712,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(
@@ -820,11 +812,10 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29`
       );
-      expect(
-        screen.getByRole('button', {
-          name: /view full event/i,
-        })
-      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/');
+      expect(screen.getByRole('button', {name: 'View Full Trace'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project:a1/'
+      );
 
       expect(
         screen.getByRole('cell', {name: 'Large HTTP Payload Span'})

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -12,6 +12,7 @@ import {getKeyValueListData as getRegressionIssueKeyValueList} from 'sentry/comp
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {Entry, EntryRequest, Event, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -485,14 +486,16 @@ const makeTransactionNameRow = (
 
   const actionButton = projectSlug ? (
     <LinkButton size="xs" to={eventDetailsLocation}>
-      {t('View Full Event')}
+      {t('View Full Trace')}
     </LinkButton>
   ) : undefined;
 
   return makeRow(
     t('Transaction'),
     <pre>
-      <Link to={transactionSummaryLocation}>{event.title}</Link>
+      <Tooltip title={t('View Transaction Summary')} skipWrapper>
+        <Link to={transactionSummaryLocation}>{event.title}</Link>
+      </Tooltip>
     </pre>,
     actionButton
   );


### PR DESCRIPTION
Change the copy in the button. Add a tooltip.

before - "view full event"
![image](https://github.com/user-attachments/assets/3df4bc2f-1aaf-431c-8f28-eccc57baa740)


after - view full trace and tooltip
![image](https://github.com/user-attachments/assets/bdbd9464-dc59-4590-ab84-e7e800ab5cff)
