### PR TITLE
ref(aci): pass workflow_env in WorkflowJob instead of workflow

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -111,10 +111,7 @@ class BaseIssueAlertHandler(ABC):
         :param job: WorkflowJob
         :return: Rule instance
         """
-        workflow = job.get("workflow")
-        environment_id = None
-        if workflow and workflow.environment:
-            environment_id = workflow.environment.id
+        environment = job.get("workflow_env")
 
         # TODO(iamrajjoshi): Remove the project null check once https://github.com/getsentry/sentry/pull/85240/files is merged
         if detector.project is None:
@@ -123,7 +120,7 @@ class BaseIssueAlertHandler(ABC):
         rule = Rule(
             id=action.id,
             project=detector.project,
-            environment_id=environment_id,
+            environment_id=environment.id if environment else None,
             label=detector.name,
             data={
                 "actions": [cls.build_rule_action_blob(action, detector.project.organization.id)]

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -10,8 +10,8 @@ def is_new_event(job: WorkflowJob) -> bool:
     if state is None:
         return False
 
-    workflow = job.get("workflow")
-    if workflow is None or workflow.environment_id is None:
+    workflow_env = job.get("workflow_env")
+    if workflow_env is None:
         return state["is_new"]
 
     return state["is_new_group_environment"]

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -48,8 +48,7 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
         event = job["event"]
-        workflow = job.get("workflow")
-        environment = workflow.environment if workflow else None
+        environment = job.get("workflow_env")
 
         latest_release = get_latest_release_for_env(environment, event)
         if not latest_release:

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -79,7 +79,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True, []
 
-        job["workflow"] = self
+        job["workflow_env"] = self.environment
         (evaluation, _), remaining_conditions = process_data_condition_group(
             self.when_condition_group.id, job
         )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -438,6 +438,7 @@ def fire_actions_for_groups(
             "organizations:workflow-engine-trigger-actions",
             organization,
         ):
+            # TODO: attach correct env to job. consider refactoring
             for action in filtered_actions:
                 action.trigger(job, detector)
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -227,6 +227,7 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
             "organizations:workflow-engine-trigger-actions",
             organization,
         ):
+            # TODO: attach correct env to job. consider refactoring
             for action in actions:
                 action.trigger(job, detector)
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -9,8 +9,9 @@ if TYPE_CHECKING:
     from sentry.deletions.base import ModelRelation
     from sentry.eventstore.models import GroupEvent
     from sentry.eventstream.base import GroupState
+    from sentry.models.environment import Environment
     from sentry.snuba.models import SnubaQueryEventType
-    from sentry.workflow_engine.models import Action, Detector, Workflow
+    from sentry.workflow_engine.models import Action, Detector
     from sentry.workflow_engine.models.data_condition import Condition
 
 T = TypeVar("T")
@@ -42,7 +43,7 @@ class WorkflowJob(EventJob, total=False):
     has_reappeared: bool
     has_alert: bool
     has_escalated: bool
-    workflow: Workflow
+    workflow_env: Environment | None
 
 
 class ActionHandler:

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -72,7 +72,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowJob(event=self.group_event, workflow_env=self.workflow.environment)
 
         class TestHandler(BaseIssueAlertHandler):
             @classmethod
@@ -127,7 +127,8 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
     def test_create_rule_instance_from_action_no_environment(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
         workflow = self.create_workflow()
-        job = WorkflowJob(event=self.group_event, workflow=workflow)
+
+        job = WorkflowJob(event=self.group_event, workflow_env=workflow.environment)
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector, job)
 
         assert isinstance(rule, Rule)

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -4,7 +4,6 @@ from jsonschema import ValidationError
 from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -26,7 +25,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
                         "is_new_group_environment": True,
                     }
                 ),
-                "workflow": Workflow(environment_id=None),
+                "workflow_env": None,
             }
         )
         self.dc = self.create_data_condition(
@@ -69,7 +68,8 @@ class TestFirstSeenEventCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_with_environment(self):
-        self.job["workflow"] = Workflow(environment_id=1)
+
+        self.job["workflow_env"] = self.environment
 
         self.assert_passes(self.dc, self.job)
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -9,7 +9,6 @@ from sentry.rules.filters.latest_release import LatestReleaseFilter, get_project
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -147,7 +146,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         self.job = WorkflowJob(
             {
                 "event": self.group_event,
-                "workflow": Workflow(environment_id=self.environment.id),
+                "workflow_env": self.environment,
             }
         )
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -5,7 +5,6 @@ from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssueCondition
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -27,7 +26,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
                         "is_new_group_environment": True,
                     }
                 ),
-                "workflow": Workflow(environment_id=1),
+                "workflow_env": self.environment,
             }
         )
         self.dc = self.create_data_condition(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -748,11 +748,11 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
         assert mock_trigger.call_count == 2
         assert mock_trigger.call_args_list[0][0] == (
-            {"event": self.event1.for_group(self.group1)},
+            {"event": self.event1.for_group(self.group1), "workflow_env": self.environment},
             self.detector,
         )
         assert mock_trigger.call_args_list[1][0] == (
-            {"event": self.event2.for_group(self.group2)},
+            {"event": self.event2.for_group(self.group2), "workflow_env": None},
             self.detector,
         )
 


### PR DESCRIPTION
Condition handlers and action handlers only use the `environment_id` from `Workflow`, if they use it at all. We don't need to be passing the entire `Workflow` object around.

Also updates `evaluate_workflows_action_filters` to correctly set the `workflow_env` for each workflow being evaluated. We need to do this because we evaluate workflows in bulk for a single event, and each condition group should evaluate with its corresponding workflow environment.

TODO: set correct workflow env to each action that is triggered