### PR TITLE
fix(releases): Fix release bubbles hover bug

### DIFF
--- a/static/app/views/releases/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/releases/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -95,4 +95,18 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
 
     trackLegend(params);
   });
+
+  // This fixes a bug where if you hover over a bubble and mouseout via xaxis
+  // (i.e. bottom of chart), the bubble will remain highlighted. This makes it
+  // look buggy and can be misleading especially for bubbles w/ 0 releases.
+  echartsInstance.on('globalout', () => {
+    const series = echartsInstance.getOption().series;
+    const seriesIndex = series.findIndex((s: Series) => s.id === BUBBLE_SERIES_ID);
+    // We could find and include a `dataIndex` to be specific about which
+    // bubble to "downplay", but I think it's ok to downplay everything
+    echartsInstance.dispatchAction({
+      type: 'downplay',
+      seriesIndex,
+    });
+  });
 }


### PR DESCRIPTION
Release bubbles hoverstate would get stuck if you were to exit the chart via x-axis direction (e.g. hover over bubble and move downwards). This PR adds a "globalout" eventlistener, which appears to be when the mouse leaves the chart, to trigger a "unhover" event to all of the bubbles. We could target a specific bubble, but I think its ok to do the entire series.

ref https://github.com/getsentry/sentry/issues/85775