### PR TITLE
ref: remove try around parse_numeric_value

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -923,10 +923,7 @@ class SearchVisitor(NodeVisitor):
         operator = handle_negation(negation, "IN")
 
         if self.is_numeric_key(search_key.name):
-            try:
-                search_value = SearchValue([parse_numeric_value(*val) for val in search_value])
-            except InvalidQuery as exc:
-                raise InvalidSearchQuery(str(exc))
+            search_value = SearchValue([parse_numeric_value(*val) for val in search_value])
             return SearchFilter(search_key, operator, search_value)
 
         search_value = SearchValue(["".join(value) for value in search_value])
@@ -957,25 +954,26 @@ class SearchVisitor(NodeVisitor):
         (negation, search_key, _, operator, search_value) = children
         operator = handle_negation(negation, operator)
 
-        try:
-            # Even if the search value matches duration format, only act as
-            # duration for certain columns
-            result_type = self.get_function_result_type(search_key.name)
+        # Even if the search value matches duration format, only act as
+        # duration for certain columns
+        result_type = self.get_function_result_type(search_key.name)
 
-            if result_type == "duration" or result_type in DURATION_UNITS:
+        if result_type == "duration" or result_type in DURATION_UNITS:
+            try:
                 aggregate_value = parse_duration(*search_value)
-            else:
-                # Duration overlaps with numeric values with `m` (million vs
-                # minutes). So we fall through to numeric if it's not a
-                # duration key
-                #
-                # TODO(epurkhiser): Should we validate that the field is
-                # numeric and do some other fallback if it's not?
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(str(exc))
+        else:
+            # Duration overlaps with numeric values with `m` (million vs
+            # minutes). So we fall through to numeric if it's not a
+            # duration key
+            #
+            # TODO(epurkhiser): Should we validate that the field is
+            # numeric and do some other fallback if it's not?
+            try:
                 aggregate_value = parse_numeric_value(*search_value)
-        except ValueError:
-            raise InvalidSearchQuery(f"Invalid aggregate query condition: {search_key}")
-        except InvalidQuery as exc:
-            raise InvalidSearchQuery(str(exc))
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(str(exc))
 
         return AggregateFilter(search_key, operator, SearchValue(aggregate_value))
 
@@ -1005,11 +1003,7 @@ class SearchVisitor(NodeVisitor):
         (negation, search_key, _, operator, search_value) = children
         operator = handle_negation(negation, operator)
 
-        try:
-            aggregate_value = parse_numeric_value(*search_value)
-        except InvalidQuery as exc:
-            raise InvalidSearchQuery(str(exc))
-
+        aggregate_value = parse_numeric_value(*search_value)
         return AggregateFilter(search_key, operator, SearchValue(aggregate_value))
 
     def visit_aggregate_date_filter(self, node, children):


### PR DESCRIPTION
the parser input enforces valid values to these calls

there are other calls to this that are not changed due to "fallback" of duration / bool values

<!-- Describe your PR here. -->