### PR TITLE
dev(webpack): Exclude `gsAdmin` entry from being included in HTML entry

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -774,7 +774,7 @@ if (IS_UI_DEV_ONLY || SENTRY_EXPERIMENTAL_SPA) {
       favicon: path.resolve(sentryDjangoAppPath, 'images', 'favicon-dev.png'),
       template: path.resolve(staticPrefix, 'index.ejs'),
       mobile: true,
-      excludeChunks: ['pipeline'],
+      excludeChunks: ['pipeline', 'gsAdmin'],
       title: 'Sentry',
       window: {
         __SENTRY_DEV_UI: true,


### PR DESCRIPTION
This excludes `gsAdmin` entry from being included in our `index.html` entry. This caused flashes (and crashes) of 404 errors in our dev environments and vercel.
