### PR TITLE
feat(explore): Adds a saved queries table view

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -232,6 +232,18 @@ function Sidebar() {
     </Feature>
   );
 
+  const savedQueries = hasOrganization && (
+    <Feature features="performance-saved-queries" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="saved-queries">{t('All Queries')}</GuideAnchor>}
+        to={`/organizations/${organization?.slug}/explore/saved-queries/`}
+        id="performance-saved-queries"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
   const hasPerfLandingRemovalFlag = organization?.features.includes(
     'insights-performance-landing-removal'
   );
@@ -426,6 +438,7 @@ function Sidebar() {
       {profiling}
       {replays}
       {discover}
+      {savedQueries}
     </SidebarAccordion>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2016,6 +2016,10 @@ function buildRoutes() {
         {releasesChildRoutes}
       </Route>
       <Route path="logs/" component={make(() => import('sentry/views/explore/logs'))} />
+      <Route
+        path="saved-queries/"
+        component={make(() => import('sentry/views/explore/savedQueries'))}
+      />
     </Route>
   );
 

--- a/static/app/views/explore/hooks/useDeleteQuery.tsx
+++ b/static/app/views/explore/hooks/useDeleteQuery.tsx
@@ -1,0 +1,20 @@
+import {useCallback} from 'react';
+
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useDeleteQuery() {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const deleteQuery = useCallback(
+    (id: number) => {
+      api.requestPromise(`/organizations/${organization.slug}/explore/saved/${id}/`, {
+        method: 'DELETE',
+      });
+    },
+    [api, organization.slug]
+  );
+
+  return {deleteQuery};
+}

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -1,8 +1,8 @@
 import type {Actor} from 'sentry/types/core';
-import {useQuery} from 'sentry/utils/queryClient';
-import useApi from 'sentry/utils/useApi';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
+// Comes from ExploreSavedQueryModelSerializer
 export type SavedQuery = {
   createdBy: Actor;
   dateAdded: string;
@@ -35,20 +35,16 @@ type Props = {
 };
 
 export function useGetSavedQueries({sortBy, exclude, perPage = 5}: Props) {
-  const api = useApi();
   const organization = useOrganization();
-  const {data, isLoading} = useQuery({
-    queryKey: ['saved-queries', organization.slug, sortBy, exclude, perPage],
-    queryFn: () =>
-      api.requestPromise(`/organizations/${organization.slug}/explore/saved/`, {
-        method: 'GET',
-        data: {
-          sortBy,
-          exclude,
-          per_page: perPage,
-        },
-      }),
-  });
+  const {data, isLoading} = useApiQuery<SavedQuery[]>(
+    [
+      `/organizations/${organization.slug}/explore/saved/`,
+      {query: {sortBy, exclude, per_page: perPage}},
+    ],
+    {
+      staleTime: 0,
+    }
+  );
 
   return {data, isLoading};
 }

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -1,0 +1,54 @@
+import type {Actor} from 'sentry/types/core';
+import {useQuery} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export type SavedQuery = {
+  createdBy: Actor;
+  dateAdded: string;
+  dateUpdated: string;
+  end: string;
+  environment: string[];
+  fields: string[];
+  id: number;
+  interval: string;
+  lastVisited: string;
+  mode: string;
+  name: string;
+  orderby: string;
+  projects: number[];
+  query: string;
+  queryDataset: string;
+  range: string;
+  start: string;
+  // Can probably have stricter type here
+  visualize: Array<{
+    chartType: number;
+    yAxes: string[];
+  }>;
+};
+
+type Props = {
+  sortBy: string;
+  exclude?: 'owned' | 'shared';
+  perPage?: number;
+};
+
+export function useGetSavedQueries({sortBy, exclude, perPage = 5}: Props) {
+  const api = useApi();
+  const organization = useOrganization();
+  const {data, isLoading} = useQuery({
+    queryKey: ['saved-queries', organization.slug, sortBy, exclude, perPage],
+    queryFn: () =>
+      api.requestPromise(`/organizations/${organization.slug}/explore/saved/`, {
+        method: 'GET',
+        data: {
+          sortBy,
+          exclude,
+          per_page: perPage,
+        },
+      }),
+  });
+
+  return {data, isLoading};
+}

--- a/static/app/views/explore/navigation.tsx
+++ b/static/app/views/explore/navigation.tsx
@@ -75,6 +75,11 @@ export default function ExploreNavigation({children}: Props) {
             >
               {t('Releases')}
             </SecondaryNav.Item>
+            <Feature features="performance-saved-queries">
+              <SecondaryNav.Item to={`${baseUrl}/saved-queries/`}>
+                {t('All Queries')}
+              </SecondaryNav.Item>
+            </Feature>
           </SecondaryNav.Section>
         </SecondaryNav.Body>
       </SecondaryNav>

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -1,0 +1,43 @@
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {SavedQueriesLandingContent} from 'sentry/views/explore/savedQueries/savedQueriesLandingContent';
+
+export default function SavedQueriesView() {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={t('All Queries')} orgSlug={organization?.slug}>
+      <Layout.Page>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Explore'),
+                  to: `/organizations/${organization.slug}/traces/`,
+                },
+                {
+                  label: t('All Queries'),
+                  to: `/organizations/${organization.slug}/explore/saved-queries/`,
+                },
+              ]}
+            />
+            <Layout.Title>
+              {t('All Queries')}
+              <FeatureBadge type="alpha" />
+            </Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <SavedQueriesLandingContent />
+          </Layout.Main>
+        </Layout.Body>
+      </Layout.Page>
+    </SentryDocumentTitle>
+  );
+}

--- a/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
@@ -1,0 +1,14 @@
+import {t} from 'sentry/locale';
+
+import {SavedQueriesTable} from './savedQueriesTable';
+
+export function SavedQueriesLandingContent() {
+  return (
+    <div>
+      <h4>{t('Owned by Me')}</h4>
+      <SavedQueriesTable mode="owned" />
+      <h4>{t('Shared with Me')}</h4>
+      <SavedQueriesTable mode="shared" perPage={8} />
+    </div>
+  );
+}

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -51,7 +51,7 @@ describe('SavedQueriesTable', () => {
         `/organizations/${organization.slug}/explore/saved/`,
         expect.objectContaining({
           method: 'GET',
-          data: expect.objectContaining({sortBy: 'mostPopular', exclude: 'owned'}),
+          data: expect.objectContaining({sortBy: 'mostPopular', exclude: 'shared'}),
         })
       )
     );
@@ -66,7 +66,7 @@ describe('SavedQueriesTable', () => {
           method: 'GET',
           data: expect.objectContaining({
             sortBy: 'mostPopular',
-            exclude: 'shared',
+            exclude: 'owned',
           }),
         })
       )

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -1,0 +1,90 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SavedQueriesTable} from 'sentry/views/explore/savedQueries/savedQueriesTable';
+
+describe('SavedQueriesTable', () => {
+  const {organization} = initializeOrg();
+  let getQueriesMock: jest.Mock;
+  let deleteQueryMock: jest.Mock;
+
+  beforeEach(() => {
+    getQueriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [
+        {
+          id: 1,
+          name: 'Query Name',
+          visualize: [],
+          projects: [1],
+          createdBy: {
+            name: 'Test User',
+          },
+        },
+      ],
+    });
+    deleteQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/1/`,
+      method: 'DELETE',
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('should render', async () => {
+    render(<SavedQueriesTable mode="owned" />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+    expect(screen.getByText('Query')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Access')).toBeInTheDocument();
+    expect(screen.getByText('Last Viewed')).toBeInTheDocument();
+    await screen.findByText('Query Name');
+  });
+
+  it('should request for owned queries', async () => {
+    render(<SavedQueriesTable mode="owned" />);
+    await waitFor(() =>
+      expect(getQueriesMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/explore/saved/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: expect.objectContaining({sortBy: 'mostPopular', exclude: 'owned'}),
+        })
+      )
+    );
+  });
+
+  it('should request for shared queries', async () => {
+    render(<SavedQueriesTable mode="shared" />);
+    await waitFor(() =>
+      expect(getQueriesMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/explore/saved/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: expect.objectContaining({
+            sortBy: 'mostPopular',
+            exclude: 'shared',
+          }),
+        })
+      )
+    );
+  });
+
+  it('deletes a query', async () => {
+    render(<SavedQueriesTable mode="owned" />);
+    await screen.findByText('Query Name');
+    await userEvent.click(screen.getByLabelText('Query actions'));
+    await userEvent.click(screen.getByText('Delete'));
+    await waitFor(() =>
+      expect(deleteQueryMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/explore/saved/1/`,
+        expect.objectContaining({
+          method: 'DELETE',
+        })
+      )
+    );
+  });
+});

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -51,7 +51,7 @@ describe('SavedQueriesTable', () => {
         `/organizations/${organization.slug}/explore/saved/`,
         expect.objectContaining({
           method: 'GET',
-          data: expect.objectContaining({sortBy: 'mostPopular', exclude: 'shared'}),
+          query: expect.objectContaining({sortBy: 'mostPopular', exclude: 'shared'}),
         })
       )
     );
@@ -64,7 +64,7 @@ describe('SavedQueriesTable', () => {
         `/organizations/${organization.slug}/explore/saved/`,
         expect.objectContaining({
           method: 'GET',
-          data: expect.objectContaining({
+          query: expect.objectContaining({
             sortBy: 'mostPopular',
             exclude: 'owned',
           }),

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -1,0 +1,239 @@
+import styled from '@emotion/styled';
+
+import Avatar from 'sentry/components/core/avatar';
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
+import {Button} from 'sentry/components/core/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+  type GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {IconEllipsis} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import type {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+import {useDeleteQuery} from '../hooks/useDeleteQuery';
+import {type SavedQuery, useGetSavedQueries} from '../hooks/useGetSavedQueries';
+
+const NO_VALUE = ' \u2014 ';
+
+const ORDER: Array<GridColumnOrder<keyof SavedQuery | 'options' | 'access'>> = [
+  {key: 'name', width: COL_WIDTH_UNDEFINED, name: t('Name')},
+  {key: 'projects', width: COL_WIDTH_UNDEFINED, name: t('Projects')},
+  {key: 'query', width: COL_WIDTH_UNDEFINED, name: t('Query')},
+  {key: 'createdBy', width: COL_WIDTH_UNDEFINED, name: t('Owner')},
+  {key: 'access', width: COL_WIDTH_UNDEFINED, name: t('Access')},
+  {key: 'lastVisited', width: COL_WIDTH_UNDEFINED, name: t('Last Viewed')},
+  {key: 'options', width: COL_WIDTH_UNDEFINED, name: ''},
+];
+
+type Column = GridColumnHeader<keyof SavedQuery | 'options' | 'access'>;
+
+type Props = {
+  mode: 'owned' | 'shared';
+  perPage?: number;
+};
+
+export function SavedQueriesTable({mode, perPage}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const {data, isLoading} = useGetSavedQueries({
+    sortBy: 'mostPopular',
+    exclude: mode,
+    perPage,
+  });
+  const {deleteQuery} = useDeleteQuery();
+  const renderBodyCell = (col: Column, row: SavedQuery) => {
+    if (col.key === 'name') {
+      return (
+        <NoOverflow>
+          <Link
+            to={getExploreUrl({
+              organization,
+              ...row,
+              title: row.name,
+              mode: row.mode as Mode,
+              selection: {
+                datetime: {end: row.end, period: row.range, start: row.start, utc: null},
+                environments: row.environment,
+                projects: row.projects,
+              },
+            })}
+          >
+            {row.name}
+          </Link>
+        </NoOverflow>
+      );
+    }
+    if (col.key === 'options') {
+      return (
+        <Center>
+          <DropdownMenu
+            items={[
+              // TODO
+              {
+                key: 'rename',
+                label: t('Rename'),
+              },
+              {
+                key: 'share',
+                label: t('Share'),
+              },
+              {
+                key: 'duplicate',
+                label: t('Duplicate'),
+              },
+              {
+                key: 'delete',
+                label: t('Delete'),
+                onAction: () => deleteQuery(row.id),
+                priority: 'danger',
+              },
+            ]}
+            trigger={triggerProps => (
+              <DropdownTriggerWrapper>
+                <Button
+                  {...triggerProps}
+                  aria-label={t('Query actions')}
+                  size="xs"
+                  borderless
+                  onClick={e => {
+                    e.stopPropagation();
+                    e.preventDefault();
+
+                    triggerProps.onClick?.(e);
+                  }}
+                  icon={<IconEllipsis direction="down" size="sm" />}
+                  data-test-id="menu-trigger"
+                />
+              </DropdownTriggerWrapper>
+            )}
+          />
+        </Center>
+      );
+    }
+    if (col.key === 'query') {
+      return (
+        <FormattedQueryWrapper>
+          <FormattedQuery query={row.query} />
+        </FormattedQueryWrapper>
+      );
+    }
+    if (col.key === 'createdBy') {
+      return (
+        <Center>
+          <Avatar user={row.createdBy} tooltip={row.createdBy.name} hasTooltip />
+        </Center>
+      );
+    }
+    if (col.key === 'projects') {
+      const rowProjects = row.projects
+        .map(p => projects.find(project => Number(project.id) === p))
+        .filter(p => p !== undefined)
+        .slice(0, 3);
+
+      return (
+        <Center>
+          <StackedProjectBadges>
+            {rowProjects.map(project => (
+              <ProjectAvatar
+                key={project.slug}
+                project={project}
+                tooltip={project.name}
+                hasTooltip
+              />
+            ))}
+          </StackedProjectBadges>
+        </Center>
+      );
+    }
+    if (col.key === 'lastVisited') {
+      return (
+        <Center>
+          {row.lastVisited ? new Date(row.lastVisited).toDateString() : NO_VALUE}
+        </Center>
+      );
+    }
+    // TODO
+    if (col.key === 'access') {
+      return <Center>{NO_VALUE}</Center>;
+    }
+    // We don't actually use this column, but we return null here to prevent typescript from complaining
+    if (col.key === 'visualize') {
+      return null;
+    }
+    return <div>{row[col.key]}</div>;
+  };
+
+  const renderHeadCell = (col: Column) => {
+    if (col.key === 'projects' || col.key === 'createdBy') {
+      return <Center>{col.name}</Center>;
+    }
+    return <div>{col.name}</div>;
+  };
+
+  return (
+    <GridEditable
+      isLoading={isLoading}
+      data={data}
+      grid={{renderBodyCell, renderHeadCell}}
+      columnOrder={ORDER}
+      columnSortBy={[]}
+    />
+  );
+}
+
+const Center = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+const StackedProjectBadges = styled('div')`
+  display: flex;
+  align-items: center;
+  & * {
+    margin-left: 0;
+    margin-right: 0;
+    cursor: pointer !important;
+  }
+
+  & *:hover {
+    z-index: unset;
+  }
+
+  & > :not(:first-child) {
+    margin-left: -${space(0.5)};
+  }
+`;
+
+const DropdownTriggerWrapper = styled('div')`
+  width: 20px;
+`;
+
+const FormattedQueryWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  > div {
+    flex-wrap: nowrap;
+  }
+`;
+
+const NoOverflow = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -46,7 +46,7 @@ export function SavedQueriesTable({mode, perPage}: Props) {
   const {projects} = useProjects();
   const {data, isLoading} = useGetSavedQueries({
     sortBy: 'mostPopular',
-    exclude: mode,
+    exclude: mode === 'owned' ? 'shared' : 'owned', // Inverse because this is an exclusion
     perPage,
   });
   const {deleteQuery} = useDeleteQuery();

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -182,7 +182,7 @@ export function SavedQueriesTable({mode, perPage}: Props) {
   return (
     <GridEditable
       isLoading={isLoading}
-      data={data}
+      data={data ?? []}
       grid={{renderBodyCell, renderHeadCell}}
       columnOrder={ORDER}
       columnSortBy={[]}

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -25,6 +25,8 @@ export function getExploreUrl({
   groupBy,
   sort,
   field,
+  id,
+  title,
 }: {
   interval: string;
   organization: Organization;
@@ -32,9 +34,11 @@ export function getExploreUrl({
   visualize: Array<Omit<Visualize, 'label'>>;
   field?: string[];
   groupBy?: string[];
+  id?: number;
   mode?: Mode;
   query?: string;
   sort?: string;
+  title?: string;
 }) {
   const {start, end, period: statsPeriod, utc} = selection.datetime;
   const {environments, projects} = selection;
@@ -53,6 +57,8 @@ export function getExploreUrl({
     sort,
     field,
     utc,
+    id,
+    title,
   };
 
   return (


### PR DESCRIPTION
Adds an `All Queries` page containing a table view of owned and shared saved explore queries. Guarded behind the `performance-saved-queries` feature flag, and accessible from the sidenav under `Explore`.

Many features on this page are still in progress.


![image](https://github.com/user-attachments/assets/dfa5b050-31ed-42d5-b916-76bf13c4c7ef)
