### PR TITLE
fix(ACI): Avoid RPC call from action.target for workflow name generation

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -191,7 +191,9 @@ class EmailActionHandler(ActionHandler):
             ):
                 return set()
 
-            return {target.user_id}
+            if target.user_id:
+                return {target.user_id}
+            return set()
 
         elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
             assert isinstance(target, Team)

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -44,6 +44,7 @@ from sentry.incidents.typings.metric_detector import (
 )
 from sentry.integrations.metric_alerts import get_metric_count_from_incident
 from sentry.integrations.types import ExternalProviders
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.team import Team
@@ -184,13 +185,13 @@ class EmailActionHandler(ActionHandler):
             return set()
 
         if action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
-            assert isinstance(target, RpcUser)
+            assert isinstance(target, OrganizationMember)
             if RuleSnooze.objects.is_snoozed_for_user(
-                user_id=target.id, alert_rule=incident.alert_rule
+                user_id=target.user_id, alert_rule=incident.alert_rule
             ):
                 return set()
 
-            return {target.id}
+            return {target.user_id}
 
         elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
             assert isinstance(target, Team)

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -29,7 +29,7 @@ def human_desc(
     if action_type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action_target:
             if target_type == AlertRuleTriggerAction.TargetType.USER.value:
-                return "Send a notification to " + target.email
+                return "Send a notification to " + target.get_email()
             elif target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
                 return "Send an email to members of #" + target.slug
     elif action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -39,7 +39,6 @@ from sentry.notifications.models.notificationaction import (
 from sentry.seer.anomaly_detection.delete_rule import delete_rule_in_seer
 from sentry.snuba.models import QuerySubscription
 from sentry.types.actor import Actor
-from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
@@ -468,7 +467,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         db_table = "sentry_alertruletriggeraction"
 
     @property
-    def target(self) -> RpcUser | Team | str | None:
+    def target(self) -> OrganizationMember | Team | str | None:
         if self.target_identifier is None:
             return None
 

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -473,19 +473,9 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
 
         if self.target_type == self.TargetType.USER.value:
             try:
-                trigger = AlertRuleTrigger.objects.get(id=self.alert_rule_trigger_id)
-            except AlertRuleTrigger.DoesNotExist:
-                return None
-
-            try:
-                alert_rule = AlertRule.objects_with_snapshots.get(id=trigger.alert_rule_id)
-            except AlertRule.DoesNotExist:
-                return None
-
-            try:
                 return OrganizationMember.objects.get(
                     user_id=int(self.target_identifier),
-                    organization=alert_rule.organization,
+                    organization=self.alert_rule_trigger.alert_rule.organization.id,
                 )
             except OrganizationMember.DoesNotExist:
                 pass

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -473,9 +473,19 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
 
         if self.target_type == self.TargetType.USER.value:
             try:
+                trigger = AlertRuleTrigger.objects.get(id=self.alert_rule_trigger_id)
+            except AlertRuleTrigger.DoesNotExist:
+                return None
+
+            try:
+                alert_rule = AlertRule.objects.get(id=trigger.alert_rule_id)
+            except AlertRule.DoesNotExist:
+                return None
+
+            try:
                 return OrganizationMember.objects.get(
                     user_id=int(self.target_identifier),
-                    organization=self.alert_rule_trigger.alert_rule.organization,
+                    organization=alert_rule.organization,
                 )
             except OrganizationMember.DoesNotExist:
                 pass

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -478,7 +478,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
                 return None
 
             try:
-                alert_rule = AlertRule.objects.get(id=trigger.alert_rule_id)
+                alert_rule = AlertRule.objects_with_snapshots.get(id=trigger.alert_rule_id)
             except AlertRule.DoesNotExist:
                 return None
 

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -475,7 +475,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
             try:
                 return OrganizationMember.objects.get(
                     user_id=int(self.target_identifier),
-                    organization=self.alert_rule_trigger.alert_rule.organization.id,
+                    organization=self.alert_rule_trigger.alert_rule.organization_id,
                 )
             except OrganizationMember.DoesNotExist:
                 pass

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -13,12 +13,7 @@ from sentry.workflow_engine.handlers.action.notification.issue_alert import (
 from sentry.workflow_engine.handlers.action.notification.metric_alert import (
     metric_alert_handler_registry,
 )
-from sentry.workflow_engine.models import (
-    Action,
-    DataConditionGroup,
-    DataConditionGroupAction,
-    Detector,
-)
+from sentry.workflow_engine.models import Action, DataConditionGroupAction, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowJob
 
@@ -212,20 +207,12 @@ class MetricAlertRegistryInvoker(LegacyRegistryInvoker):
         if target_identifier is None:
             return None
 
-        try:
-            dcga = DataConditionGroupAction.objects.get(action=action)
-        except DataConditionGroupAction.DoesNotExist:
-            return None
-        try:
-            dcg = DataConditionGroup.objects.get(id=dcga.condition_group_id)
-        except DataConditionGroup.DoesNotExist:
-            return None
-
         target_type = action.config.get("target_type")
         if target_type == ActionTarget.USER.value:
+            dcga = DataConditionGroupAction.objects.get(action=action)
             return OrganizationMember.objects.get(
                 user_id=int(target_identifier),
-                organization=dcg.organization,
+                organization=dcga.condition_group.organization,
             )
         elif target_type == ActionTarget.TEAM.value:
             try:

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -23,6 +23,7 @@ def get_action_description(action: AlertRuleTriggerAction) -> str:
 
     if action.type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
+            missing_user_text = "Email [missing user]"
             try:
                 org_member = OrganizationMember.objects.get(
                     user_id=action.target_identifier,
@@ -32,15 +33,24 @@ def get_action_description(action: AlertRuleTriggerAction) -> str:
                 logger.info(
                     "Organization member not found", extra={"user_id": action.target_identifier}
                 )
-                return "Email missing user"
-            return "Email " + org_member.user_email
+                return missing_user_text
+
+            if org_member.user_email:
+                return "Email " + org_member.user_email
+
+            return missing_user_text
+
         elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
-            try:
-                team = Team.objects.get(id=int(action.target_identifier))
-            except Team.DoesNotExist:
-                logger.info("Team not found", extra={"team_id": action.target_identifier})
-                return "Email missing team"
-            return "Email #" + team.slug
+            missing_team_text = "Email [missing team]"
+            if action.target_identifier:
+                try:
+                    team = Team.objects.get(id=int(action.target_identifier))
+                except Team.DoesNotExist:
+                    logger.info("Team not found", extra={"team_id": action.target_identifier})
+                    return missing_team_text
+                if team:
+                    return "Email #" + team.slug
+            return missing_team_text
 
     elif action.type == AlertRuleTriggerAction.Type.SENTRY_APP.value:
         return f"Notify {action.target_display}"

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -17,7 +17,6 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.alert_rule import TemporaryAlertRuleTriggerActionRegistry
-from sentry.users.services.user.service import user_service
 
 
 class IncidentGetForSubscriptionTest(TestCase):
@@ -196,16 +195,23 @@ class AlertRuleFetchForOrganizationTest(TestCase):
 
 
 class AlertRuleTriggerActionTargetTest(TestCase):
+    def setUp(self):
+        self.metric_alert = self.create_alert_rule()
+        self.alert_rule_trigger = self.create_alert_rule_trigger(alert_rule=self.metric_alert)
+
     def test_user(self):
-        trigger = AlertRuleTriggerAction(
-            target_type=AlertRuleTriggerAction.TargetType.USER.value,
+        trigger = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
             target_identifier=str(self.user.id),
         )
-        assert trigger.target == user_service.get_user(user_id=self.user.id)
+        assert trigger.target.user_id == self.user.id
 
     def test_invalid_user(self):
-        trigger = AlertRuleTriggerAction(
-            target_type=AlertRuleTriggerAction.TargetType.USER.value, target_identifier="10000000"
+        trigger = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="10000000",
         )
         assert trigger.target is None
 

--- a/tests/sentry/incidents/serializers/test_workflow_engine_action.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_action.py
@@ -30,6 +30,10 @@ class TestActionSerializer(TestCase):
             action_id=self.action.id,
             alert_rule_trigger_action_id=self.trigger_action.id,
         )
+        self.data_condition_group = self.create_data_condition_group(organization=self.organization)
+        self.create_data_condition_group_action(
+            action=self.action, condition_group=self.data_condition_group
+        )
 
     def test_simple(self) -> None:
         serialized_action = serialize(self.action, self.user, WorkflowEngineActionSerializer())

--- a/tests/sentry/workflow_engine/migration_helpers/test_utils.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_utils.py
@@ -27,7 +27,7 @@ class WorkflowNameTest(APITestCase):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.alert_rule_trigger_critical,
             target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier=str(self.user.id),
+            target_identifier=str(self.rpc_user.id),
         )
         self.slack_integration = install_slack(self.organization)
         self.opsgenie_integration = self.create_provider_integration(
@@ -81,7 +81,7 @@ class WorkflowNameTest(APITestCase):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.alert_rule_trigger_warning,
             target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier=str(self.user.id),
+            target_identifier=str(self.rpc_user.id),
         )
         migrate_alert_rule(self.metric_alert, self.rpc_user)
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
@@ -100,6 +100,9 @@ class WorkflowNameTest(APITestCase):
         user2 = self.create_user(email="meow@woof.com")
         user3 = self.create_user(email="bark@meow.com")
         user4 = self.create_user(email="idk@lol.com")
+        self.create_member(user=user2, organization=self.organization, role="admin", teams=[])
+        self.create_member(user=user3, organization=self.organization, role="admin", teams=[])
+        self.create_member(user=user4, organization=self.organization, role="admin", teams=[])
 
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.alert_rule_trigger_critical,

--- a/tests/sentry/workflow_engine/migration_helpers/test_utils.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_utils.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -73,52 +71,6 @@ class WorkflowNameTest(APITestCase):
 
         assert self.rpc_user
         assert workflow.name == f"Email {self.rpc_user.email}"
-
-    @mock.patch("sentry.workflow_engine.migration_helpers.utils.logger")
-    def test_missing_user(self, mock_logger):
-        user2 = self.create_user(email="meow@woof.com")
-        rpc_user2 = user_service.get_user(user_id=user2.id)
-        fake_user_id = 55
-
-        metric_alert = self.create_alert_rule()
-        alert_rule_trigger_critical = self.create_alert_rule_trigger(
-            alert_rule=metric_alert, label="critical"
-        )
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=alert_rule_trigger_critical,
-            target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier=str(fake_user_id),
-        )
-        migrate_alert_rule(metric_alert, rpc_user2)
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=metric_alert)
-        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
-        assert workflow.name == "Email [missing user]"
-        mock_logger.info.assert_called_with(
-            "Organization member not found",
-            extra={"user_id": str(fake_user_id)},
-        )
-
-    @mock.patch("sentry.workflow_engine.migration_helpers.utils.logger")
-    def test_missing_team(self, mock_logger):
-        fake_team_id = 55
-
-        metric_alert = self.create_alert_rule()
-        alert_rule_trigger_critical = self.create_alert_rule_trigger(
-            alert_rule=metric_alert, label="critical"
-        )
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=alert_rule_trigger_critical,
-            target_type=AlertRuleTriggerAction.TargetType.TEAM,
-            target_identifier=str(fake_team_id),
-        )
-        migrate_alert_rule(metric_alert, self.rpc_user)
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=metric_alert)
-        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
-        assert workflow.name == "Email [missing team]"
-        mock_logger.info.assert_called_with(
-            "Team not found",
-            extra={"team_id": str(fake_team_id)},
-        )
 
     def test_warning_and_critical(self):
         """


### PR DESCRIPTION
During generation of the workflow name we access `action.target` which makes an RPC call [here](https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/models/alert_rule.py#L476-L476) to fetch the user. This was causing an error since it's done inside a transaction, so this PR rewrites it to get the `OrganizationMember` and then grab the email using `get_email()`.

Fixes https://sentry.sentry.io/issues/6427930562