### PR TITLE
ref: remove unused _metric_tags

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -377,10 +377,6 @@ class Endpoint(APIView):
 
         sentry_sdk.set_tag("http.referer", request.META.get("HTTP_REFERER", ""))
 
-        # Tags that will ultimately flow into the metrics backend at the end of
-        # the request (happens via middleware/stats.py).
-        request._metric_tags = {}
-
         start_time = time.time()
 
         origin = request.META.get("HTTP_ORIGIN", "null")


### PR DESCRIPTION
I forgot this in 68398f58cdfc1872ee715b1818052587bf99b146

<!-- Describe your PR here. -->