### PR TITLE
feat(billing): Add support for PROFILE_DURATION_UI

### DIFF
--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -18,7 +18,8 @@ type LimitName =
   | 'reservedMonitorSeats'
   | 'reservedUptime'
   | 'reservedSpans'
-  | 'reservedProfileDuration';
+  | 'reservedProfileDuration'
+  | 'reservedProfileDurationUI';
 
 type Props = {
   onLimitChange: (limit: LimitName, value: number) => void;
@@ -29,6 +30,7 @@ type Props = {
   reservedErrors: null | number;
   reservedMonitorSeats: null | number;
   reservedProfileDuration: null | number;
+  reservedProfileDurationUI: null | number;
   reservedReplays: null | number;
   reservedSpans: null | number;
   reservedTransactions: null | number;
@@ -44,6 +46,7 @@ const configurableCategories: DataCategory[] = [
   DataCategory.UPTIME,
   DataCategory.SPANS,
   DataCategory.PROFILE_DURATION,
+  DataCategory.PROFILE_DURATION_UI,
 ];
 
 function PlanList({
@@ -56,6 +59,7 @@ function PlanList({
   reservedMonitorSeats,
   reservedUptime,
   reservedProfileDuration,
+  reservedProfileDurationUI,
   reservedSpans,
   onPlanChange,
   onLimitChange,
@@ -154,6 +158,9 @@ function PlanList({
                     break;
                   case DataCategory.PROFILE_DURATION:
                     fieldValue = reservedProfileDuration;
+                    break;
+                  case DataCategory.PROFILE_DURATION_UI:
+                    fieldValue = reservedProfileDurationUI;
                     break;
                   case DataCategory.UPTIME:
                     fieldValue = reservedUptime;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -33,6 +33,7 @@ export const MAX_ADMIN_CATEGORY_GIFTS = {
   [DataCategory.UPTIME]: 10_000,
   [DataCategory.SPANS]: 1_000_000_000,
   [DataCategory.PROFILE_DURATION]: 10_000, // TODO(continuous profiling): confirm max amount
+  [DataCategory.PROFILE_DURATION_UI]: 10_000, // TODO(continuous profiling): confirm max amount
 };
 
 // While we no longer offer or support unlimited ondemand we still
@@ -56,4 +57,6 @@ export const PRODUCT_TRIAL_CATEGORIES: DataCategory[] = [
   DataCategory.REPLAYS,
   DataCategory.SPANS,
   DataCategory.TRANSACTIONS,
+  DataCategory.PROFILE_DURATION,
+  DataCategory.PROFILE_DURATION_UI,
 ];

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -189,6 +189,7 @@ export function calculateCategoryPrepaidUsage(
         prepaidTotal = prepaid * GIGABYTE;
         break;
       case DataCategory.PROFILE_DURATION:
+      case DataCategory.PROFILE_DURATION_UI:
         prepaidTotal = prepaid * MILLISECONDS_IN_HOUR;
         break;
       default:


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/16662

Adds the new `PROFILE_DURATION_UI` data category to the lists associated with user and admin experiences, including product trials