### PR TITLE
chore(aci): more logs for process workflows

### DIFF
--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -405,7 +405,7 @@ class RuleProcessor:
                 "post_process.process_rules.triggered_rule",
                 extra={
                     "rule_id": rule.id,
-                    "payload": state,
+                    "payload": state.__dict__,
                     "group_id": self.group.id,
                     "event_id": self.event.event_id,
                 },


### PR DESCRIPTION
1. Log `EventState.__dict__` because it's a regular class, I can't see the values if we just log the object
2. Add logs to see which workflows are evaluating on which events
