### PR TITLE
fix(insights): Backfill value type for message latency chart

### DIFF
--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {useProcessQueuesTimeSeriesQuery} from 'sentry/views/insights/queues/queries/useProcessQueuesTimeSeriesQuery';
@@ -22,16 +24,18 @@ export function LatencyChart({error, destination, referrer}: Props) {
     referrer,
   });
 
-  const latencySeries = {
-    ...data['avg(messaging.message.receive.latency)'],
-  };
+  const messageReceiveLatencySeries = cloneDeep(
+    data['avg(messaging.message.receive.latency)']
+  );
 
   if (
     !isPending &&
     !error &&
-    defined(latencySeries.data) &&
-    defined(latencySeries.meta) &&
-    !defined(latencySeries.meta?.fields['avg(messaging.message.receive.latency)'])
+    defined(messageReceiveLatencySeries.data) &&
+    defined(messageReceiveLatencySeries.meta) &&
+    !defined(
+      messageReceiveLatencySeries.meta?.fields['avg(messaging.message.receive.latency)']
+    )
   ) {
     // This is a tricky data issue. If Snuba doesn't find any data for a field,
     // it doesn't return a unit. If Discover can't guess the type based on the
@@ -40,17 +44,16 @@ export function LatencyChart({error, destination, referrer}: Props) {
     // axis, which looks weird. This is a rare case, and I'm hoping that in the
     // future, backend will be able to determine types most of the time. For
     // now, backfill the type, since we know it.
-    latencySeries.meta.fields['avg(messaging.message.receive.latency)'] = 'duration';
-    latencySeries.meta.units['avg(messaging.message.receive.latency)'] = 'millisecond';
+    messageReceiveLatencySeries.meta.fields['avg(messaging.message.receive.latency)'] =
+      'duration';
+    messageReceiveLatencySeries.meta.units['avg(messaging.message.receive.latency)'] =
+      'millisecond';
   }
 
   return (
     <InsightsAreaChartWidget
       title={t('Average Duration')}
-      series={[
-        data['avg(messaging.message.receive.latency)'],
-        data['avg(span.duration)'],
-      ]}
+      series={[messageReceiveLatencySeries, data['avg(span.duration)']]}
       aliases={FIELD_ALIASES}
       error={error ?? latencyError}
       isLoading={isPending}


### PR DESCRIPTION
See code comment for details.

**Before:**
<img width="467" alt="Screenshot 2025-03-19 at 5 43 50 PM" src="https://github.com/user-attachments/assets/df0f03d6-a278-4a87-8e36-158c7804f3bc" />

Gross! We can't figure out the value type for one of the series, so we create an extra axis for it. That data actually is always "duration", so it should use the existing "duration" axis.

**After:**
<img width="478" alt="Screenshot 2025-03-19 at 5 44 11 PM" src="https://github.com/user-attachments/assets/d4924c9f-605a-4510-96ce-0b1acda191f1" />

Much better.
