### PR TITLE
chore(anomaly detection): Add logs for subscription processor

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -423,6 +423,14 @@ class SubscriptionProcessor:
             has_anomaly_detection
             and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
         ):
+            logger.info(
+                "Raw subscription update",
+                extra={
+                    "result": subscription_update,
+                    "aggregation_value": aggregation_value,
+                    "rule_id": self.alert_rule.id,
+                },
+            )
             with metrics.timer(
                 "incidents.subscription_processor.process_update.get_anomaly_data_from_seer"
             ):


### PR DESCRIPTION
Still trying to figure out why Seer is getting null values sometimes so I'm putting these logs back to continue investigating.