### PR TITLE
feat(shared-views): Add endpoint to star and unstar views

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -185,6 +185,7 @@ from sentry.issues.endpoints import (
     OrganizationGroupIndexStatsEndpoint,
     OrganizationGroupSearchViewDetailsEndpoint,
     OrganizationGroupSearchViewsEndpoint,
+    OrganizationGroupSearchViewStarredEndpoint,
     OrganizationGroupSearchViewVisitEndpoint,
     OrganizationIssuesCountEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
@@ -1789,6 +1790,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/visit/$",
         OrganizationGroupSearchViewVisitEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-visit",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-view/(?P<view_id>[^\/]+)/starred/$",
+        OrganizationGroupSearchViewStarredEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-view-starred",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views-starred-order/$",

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -16,6 +16,7 @@ from .organization_eventid import EventIdLookupEndpoint
 from .organization_group_index import OrganizationGroupIndexEndpoint
 from .organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
 from .organization_group_search_view_details import OrganizationGroupSearchViewDetailsEndpoint
+from .organization_group_search_view_starred import OrganizationGroupSearchViewStarredEndpoint
 from .organization_group_search_view_visit import OrganizationGroupSearchViewVisitEndpoint
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
@@ -53,6 +54,7 @@ __all__ = (
     "OrganizationGroupIndexStatsEndpoint",
     "OrganizationGroupSearchViewsEndpoint",
     "OrganizationGroupSearchViewDetailsEndpoint",
+    "OrganizationGroupSearchViewStarredEndpoint",
     "OrganizationGroupSearchViewVisitEndpoint",
     "OrganizationGroupSearchViewStarredEndpoint",
     "OrganizationIssuesCountEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred.py
@@ -1,0 +1,90 @@
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.organization import Organization
+
+
+class StarViewSerializer(serializers.Serializer):
+    starred = serializers.BooleanField(required=True)
+    position = serializers.IntegerField(required=False)
+
+    def validate(self, data):
+        if not data["starred"] and "position" in data:
+            raise serializers.ValidationError("Position is only allowed when starring a view.")
+        return data
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["member:read", "member:write"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewStarredEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def post(self, request: Request, organization: Organization, view_id: int) -> Response:
+        """
+        Update the starred status of a group search view for the current organization member.
+        """
+        if not features.has("organizations:issue-view-sharing", organization, actor=request.user):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = StarViewSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        is_starred = serializer.validated_data["starred"]
+
+        try:
+            view = GroupSearchView.objects.get(id=view_id, organization=organization)
+        except GroupSearchView.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not (
+            view.user_id == request.user.id
+            or view.visibility == GroupSearchViewVisibility.ORGANIZATION
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if is_starred:
+            try:
+                insert_position = (
+                    serializer.validated_data["position"]
+                    if "position" in serializer.validated_data
+                    else GroupSearchViewStarred.objects.num_starred_views(
+                        organization, request.user.id
+                    )
+                )
+
+                GroupSearchViewStarred.objects.insert_starred_view(
+                    organization, request.user.id, view, insert_position
+                )
+
+                return Response(status=status.HTTP_200_OK)
+            except ValueError:
+                pass  # View is already starred, so no need to update anything
+        else:
+            try:
+                GroupSearchViewStarred.objects.delete_starred_view(
+                    organization, request.user.id, view
+                )
+
+                return Response(status=status.HTTP_200_OK)
+            except ValueError:
+                pass  # View is already not starred, so no need to update anything
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred.py
@@ -61,30 +61,20 @@ class OrganizationGroupSearchViewStarredEndpoint(OrganizationEndpoint):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         if is_starred:
-            try:
-                insert_position = (
-                    serializer.validated_data["position"]
-                    if "position" in serializer.validated_data
-                    else GroupSearchViewStarred.objects.num_starred_views(
-                        organization, request.user.id
-                    )
-                )
+            insert_position = (
+                serializer.validated_data["position"]
+                if "position" in serializer.validated_data
+                else GroupSearchViewStarred.objects.num_starred_views(organization, request.user.id)
+            )
 
-                GroupSearchViewStarred.objects.insert_starred_view(
-                    organization, request.user.id, view, insert_position
-                )
-
+            if GroupSearchViewStarred.objects.insert_starred_view(
+                organization, request.user.id, view, insert_position
+            ):
                 return Response(status=status.HTTP_200_OK)
-            except ValueError:
-                pass  # View is already starred, so no need to update anything
         else:
-            try:
-                GroupSearchViewStarred.objects.delete_starred_view(
-                    organization, request.user.id, view
-                )
-
+            if GroupSearchViewStarred.objects.delete_starred_view(
+                organization, request.user.id, view
+            ):
                 return Response(status=status.HTTP_200_OK)
-            except ValueError:
-                pass  # View is already not starred, so no need to update anything
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
@@ -1,0 +1,263 @@
+from django.urls import reverse
+
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+class OrganizationGroupSearchViewStarredEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-starred"
+    method = "post"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+
+    def get_url(self, view_id):
+        return reverse(
+            self.endpoint,
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "view_id": view_id,
+            },
+        )
+
+    def create_view(self, user_id=None, visibility=None, starred=False):
+        if user_id is None:
+            user_id = self.user.id
+
+        if visibility is None:
+            visibility = GroupSearchViewVisibility.OWNER
+
+        view = GroupSearchView.objects.create(
+            name="Test View",
+            organization=self.org,
+            user_id=user_id,
+            query="is:unresolved",
+            query_sort="date",
+            visibility=visibility,
+        )
+        if starred:
+            GroupSearchViewStarred.objects.insert_starred_view(
+                organization=self.org,
+                user_id=user_id,
+                view=view,
+            )
+        return view
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_view_not_found(self):
+        response = self.client.post(self.get_url(737373), data={"starred": True})
+
+        assert response.status_code == 404
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_view_not_accessible(self):
+        other_user = self.create_user()
+        view = self.create_view(user_id=other_user.id)
+
+        response = self.client.post(self.get_url(view.id), data={"starred": True})
+
+        assert response.status_code == 404
+        assert not GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view,
+        ).exists()
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_organization_view_accessible(self):
+        other_user = self.create_user()
+        view = self.create_view(
+            user_id=other_user.id, visibility=GroupSearchViewVisibility.ORGANIZATION
+        )
+
+        response = self.client.post(self.get_url(view.id), data={"starred": True})
+
+        assert response.status_code == 200
+        assert GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view,
+        ).exists()
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_invalid_request_data(self):
+        view = self.create_view()
+
+        # Missing starred field
+        response = self.client.post(self.get_url(view.id), data={})
+        assert response.status_code == 400
+
+        # Invalid position when unstarring
+        response = self.client.post(self.get_url(view.id), data={"starred": False, "position": 0})
+        assert response.status_code == 400
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_star_view_with_position(self):
+        view1 = self.create_view(starred=True)
+        view2 = self.create_view(starred=True)
+        view_to_be_starred = self.create_view()
+
+        response = self.client.post(
+            self.get_url(view_to_be_starred.id), data={"starred": True, "position": 1}
+        )
+
+        assert response.status_code == 200
+
+        starred_view = GroupSearchViewStarred.objects.get(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view_to_be_starred,
+        )
+        assert starred_view.position == 1
+
+        assert GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view1,
+            position=0,
+        ).exists()
+        assert GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view2,
+            position=2,
+        ).exists()
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_star_view_without_position(self):
+        view = self.create_view()
+
+        response = self.client.post(self.get_url(view.id), data={"starred": True})
+
+        assert response.status_code == 200
+
+        starred_view = GroupSearchViewStarred.objects.get(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view,
+        )
+
+        assert starred_view.position == 0
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_unstar_view(self):
+        starred_view = self.create_view(starred=True)
+        view_to_be_unstarred = self.create_view(starred=True)
+
+        response = self.client.post(self.get_url(view_to_be_unstarred.id), data={"starred": False})
+
+        assert response.status_code == 200
+        assert not GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view_to_be_unstarred,
+        ).exists()
+        assert GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=starred_view,
+        ).exists()
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_star_already_starred_view(self):
+        view = self.create_view(starred=True)
+
+        response = self.client.post(self.get_url(view.id), data={"starred": True})
+
+        assert response.status_code == 204
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_unstar_not_starred_view(self):
+        view = self.create_view()
+
+        response = self.client.post(self.get_url(view.id), data={"starred": False})
+
+        assert response.status_code == 204
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_multiple_starred_views_order(self):
+        view1 = self.create_view()
+        view2 = self.create_view()
+        view3 = self.create_view()
+
+        # Star view1 at position 0
+        self.client.post(self.get_url(view1.id), data={"starred": True, "position": 0})
+
+        # Star view2 at position 0, which should push view1 to position 1
+        self.client.post(self.get_url(view2.id), data={"starred": True, "position": 0})
+
+        # Star view3 at position 1, which should push view1 to position 2
+        self.client.post(self.get_url(view3.id), data={"starred": True, "position": 1})
+
+        # Check the final positions
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization=self.org,
+                user_id=self.user.id,
+                group_search_view=view1,
+            ).position
+            == 2
+        )
+
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization=self.org,
+                user_id=self.user.id,
+                group_search_view=view2,
+            ).position
+            == 0
+        )
+
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization=self.org,
+                user_id=self.user.id,
+                group_search_view=view3,
+            ).position
+            == 1
+        )
+
+    @with_feature("organizations:issue-view-sharing")
+    def test_unstar_adjust_positions(self):
+        view1 = self.create_view(starred=True)
+        view2 = self.create_view(starred=True)
+        view3 = self.create_view(starred=True)
+
+        # Unstar the middle view (view2)
+        self.client.post(self.get_url(view2.id), data={"starred": False})
+
+        # Check that view3's position got adjusted to 1
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization=self.org,
+                user_id=self.user.id,
+                group_search_view=view3,
+            ).position
+            == 1
+        )
+
+        # Check that view1 remains at position 0
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization=self.org,
+                user_id=self.user.id,
+                group_search_view=view1,
+            ).position
+            == 0
+        )
+
+    def test_error_when_feature_flag_disabled(self):
+        view = self.create_view()
+
+        response = self.client.post(self.get_url(view.id), data={"starred": True})
+
+        assert response.status_code == 404
+        assert not GroupSearchViewStarred.objects.filter(
+            organization=self.org,
+            user_id=self.user.id,
+            group_search_view=view,
+        ).exists()


### PR DESCRIPTION
This PR adds the `POST` `/group-search-views/:viewId/starred` endpoint, which exposes the ability to star and unstar a view. 

At a high level the logic is as follows: 

1. Validate that the view exists and that the user has access to the view (either they own it, or its an org shared view) 
2. if the `starred` query param is `true`:
		a. Do nothing if the view was already starred. 
		b. If position is provided, insert at that position and increment any new views 
		c. if position is not provided, star the view and insert at the end of the list.
3. If the `starred` query param is `false`, do nothing if its already unstarred, otherwise unstar the view. 