### PR TITLE
♻️ ref(messaging): refactor messaging spec to use data classes

### DIFF
--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -65,12 +65,9 @@ def send_incident_alert_notification(
 
     message = DiscordMetricAlertMessageBuilder(
         alert_context=alert_context,
-        open_period_identifier=metric_issue_context.open_period_identifier,
-        snuba_query=metric_issue_context.snuba_query,
+        metric_issue_context=metric_issue_context,
         organization=organization,
         date_started=open_period_context.date_started,
-        new_status=metric_issue_context.new_status,
-        metric_value=metric_issue_context.metric_value,
         chart_url=chart_url,
     ).build(notification_uuid=notification_uuid)
 

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -3,21 +3,13 @@ from __future__ import annotations
 import sentry_sdk
 
 from sentry import features
-from sentry.api.serializers import serialize
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.endpoints.serializers.alert_rule import (
-    AlertRuleSerializer,
-    AlertRuleSerializerResponse,
-)
-from sentry.incidents.endpoints.serializers.incident import (
-    DetailedIncidentSerializer,
-    DetailedIncidentSerializerResponse,
-)
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
+    NotificationContext,
     OpenPeriodContext,
 )
 from sentry.integrations.discord.client import DiscordClient
@@ -30,62 +22,55 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
-from sentry.integrations.metric_alerts import get_metric_count_from_incident
+from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import logger
 
 
 def send_incident_alert_notification(
-    action: AlertRuleTriggerAction,
-    incident: Incident,
-    metric_value: int | float | None,
-    new_status: IncidentStatus,
+    organization: Organization,
+    alert_context: AlertContext,
+    notification_context: NotificationContext,
+    metric_issue_context: MetricIssueContext,
+    open_period_context: OpenPeriodContext,
+    alert_rule_serialized_response: AlertRuleSerializerResponse,
+    incident_serialized_response: DetailedIncidentSerializerResponse,
     notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None
-    if features.has("organizations:metric-alert-chartcuterie", incident.organization):
+    if features.has("organizations:metric-alert-chartcuterie", organization):
         try:
-            alert_rule_serialized_response: AlertRuleSerializerResponse = serialize(
-                incident.alert_rule, None, AlertRuleSerializer()
-            )
-            incident_serialized_response: DetailedIncidentSerializerResponse = serialize(
-                incident, None, DetailedIncidentSerializer()
-            )
             chart_url = build_metric_alert_chart(
-                organization=incident.organization,
+                organization=organization,
                 alert_rule_serialized_response=alert_rule_serialized_response,
-                snuba_query=incident.alert_rule.snuba_query,
-                alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-                open_period_context=OpenPeriodContext.from_incident(incident),
+                snuba_query=metric_issue_context.snuba_query,
+                alert_context=alert_context,
+                open_period_context=open_period_context,
                 selected_incident_serialized=incident_serialized_response,
-                subscription=incident.subscription,
+                subscription=metric_issue_context.subscription,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)
 
-    channel = action.target_identifier
+    channel = notification_context.target_identifier
 
     if not channel:
         # We can't send a message if we don't know the channel
         logger.warning(
             "discord.metric_alert.no_channel",
-            extra={"incident_id": incident.id},
+            extra={"incident_id": metric_issue_context.id},
         )
         return False
 
-    if metric_value is None:
-        metric_value = get_metric_count_from_incident(incident)
-
     message = DiscordMetricAlertMessageBuilder(
-        alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-        metric_issue_context=MetricIssueContext.from_legacy_models(
-            incident=incident,
-            new_status=new_status,
-            metric_value=metric_value,
-        ),
-        organization=incident.organization,
-        date_started=incident.date_started,
+        alert_context=alert_context,
+        open_period_identifier=metric_issue_context.open_period_identifier,
+        snuba_query=metric_issue_context.snuba_query,
+        organization=organization,
+        date_started=open_period_context.date_started,
+        new_status=metric_issue_context.new_status,
+        metric_value=metric_issue_context.metric_value,
         chart_url=chart_url,
     ).build(notification_uuid=notification_uuid)
 
@@ -103,7 +88,7 @@ def send_incident_alert_notification(
         except Exception as error:
             lifecycle.add_extras(
                 {
-                    "incident_id": incident.id,
+                    "incident_id": metric_issue_context.id,
                     "channel_id": channel,
                 }
             )

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -1,12 +1,18 @@
 from sentry import analytics
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+    OpenPeriodContext,
+)
 from sentry.integrations.base import IntegrationProvider
 from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
-from sentry.models.project import Project
+from sentry.models.organization import Organization
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -38,11 +44,13 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
 
     def send_incident_alert_notification(
         self,
-        action: AlertRuleTriggerAction,
-        incident: Incident,
-        project: Project,
-        metric_value: int | float | None,
-        new_status: IncidentStatus,
+        organization: Organization,
+        alert_context: AlertContext,
+        notification_context: NotificationContext,
+        metric_issue_context: MetricIssueContext,
+        open_period_context: OpenPeriodContext,
+        alert_rule_serialized_response: AlertRuleSerializerResponse,
+        incident_serialized_response: DetailedIncidentSerializerResponse,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.discord.actions.metric_alert import (
@@ -50,10 +58,13 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
         )
 
         return send_incident_alert_notification(
-            action=action,
-            incident=incident,
-            new_status=new_status,
-            metric_value=metric_value,
+            organization=organization,
+            alert_context=alert_context,
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            incident_serialized_response=incident_serialized_response,
             notification_uuid=notification_uuid,
         )
 

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -1,12 +1,18 @@
 from sentry import analytics
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+    OpenPeriodContext,
+)
 from sentry.integrations.base import IntegrationProvider
 from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
-from sentry.models.project import Project
+from sentry.models.organization import Organization
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -40,20 +46,25 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
 
     def send_incident_alert_notification(
         self,
-        action: AlertRuleTriggerAction,
-        incident: Incident,
-        project: Project,
-        metric_value: int | float | None,
-        new_status: IncidentStatus,
+        organization: Organization,
+        alert_context: AlertContext,
+        notification_context: NotificationContext,
+        metric_issue_context: MetricIssueContext,
+        open_period_context: OpenPeriodContext,
+        alert_rule_serialized_response: AlertRuleSerializerResponse,
+        incident_serialized_response: DetailedIncidentSerializerResponse,
         notification_uuid: str | None = None,
     ) -> bool:
         from sentry.integrations.msteams.utils import send_incident_alert_notification
 
         return send_incident_alert_notification(
-            action=action,
-            incident=incident,
-            metric_value=metric_value,
-            new_status=new_status,
+            organization=organization,
+            alert_context=alert_context,
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            incident_serialized_response=incident_serialized_response,
             notification_uuid=notification_uuid,
         )
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import enum
 import logging
 
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
-from sentry.integrations.metric_alerts import get_metric_count_from_incident
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+    OpenPeriodContext,
+)
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
@@ -101,32 +105,33 @@ def get_channel_id(organization: Organization, integration_id: int, name: str) -
 
 
 def send_incident_alert_notification(
-    action: AlertRuleTriggerAction,
-    incident: Incident,
-    metric_value: float | int | None,
-    new_status: IncidentStatus,
+    organization: Organization,
+    alert_context: AlertContext,
+    notification_context: NotificationContext,
+    metric_issue_context: MetricIssueContext,
+    open_period_context: OpenPeriodContext,
+    alert_rule_serialized_response: AlertRuleSerializerResponse,
+    incident_serialized_response: DetailedIncidentSerializerResponse,
     notification_uuid: str | None = None,
 ) -> bool:
     from .card_builder.incident_attachment import build_incident_attachment
 
-    if metric_value is None:
-        metric_value = get_metric_count_from_incident(incident)
-
-    if action.target_identifier is None:
+    if notification_context.target_identifier is None:
         raise ValueError("Can't send without `target_identifier`")
 
     attachment = build_incident_attachment(
-        alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-        metric_issue_context=MetricIssueContext.from_legacy_models(
-            incident, new_status, metric_value
-        ),
-        organization=incident.organization,
-        date_started=incident.date_started,
+        alert_context=alert_context,
+        open_period_identifier=metric_issue_context.open_period_identifier,
+        snuba_query=metric_issue_context.snuba_query,
+        organization=organization,
+        date_started=open_period_context.date_started,
+        new_status=metric_issue_context.new_status,
+        metric_value=metric_issue_context.metric_value,
         notification_uuid=notification_uuid,
     )
     success = integration_service.send_msteams_incident_alert_notification(
-        integration_id=action.integration_id,
-        channel=action.target_identifier,
+        integration_id=notification_context.integration_id,
+        channel=notification_context.target_identifier,
         attachment=attachment,
     )
     return success

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -121,12 +121,9 @@ def send_incident_alert_notification(
 
     attachment = build_incident_attachment(
         alert_context=alert_context,
-        open_period_identifier=metric_issue_context.open_period_identifier,
-        snuba_query=metric_issue_context.snuba_query,
+        metric_issue_context=metric_issue_context,
         organization=organization,
         date_started=open_period_context.date_started,
-        new_status=metric_issue_context.new_status,
-        metric_value=metric_issue_context.metric_value,
         notification_uuid=notification_uuid,
     )
     success = integration_service.send_msteams_incident_alert_notification(

--- a/src/sentry/integrations/slack/spec.py
+++ b/src/sentry/integrations/slack/spec.py
@@ -1,12 +1,18 @@
 from sentry import analytics
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+    OpenPeriodContext,
+)
 from sentry.integrations.base import IntegrationProvider
 from sentry.integrations.messaging.spec import (
     MessagingIdentityLinkViewSet,
     MessagingIntegrationSpec,
 )
-from sentry.models.project import Project
+from sentry.models.organization import Organization
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.rules.actions import IntegrationEventAction
 
@@ -42,21 +48,26 @@ class SlackMessagingSpec(MessagingIntegrationSpec):
 
     def send_incident_alert_notification(
         self,
-        action: AlertRuleTriggerAction,
-        incident: Incident,
-        project: Project,
-        metric_value: int | float | None,
-        new_status: IncidentStatus,
+        organization: Organization,
+        alert_context: AlertContext,
+        notification_context: NotificationContext,
+        metric_issue_context: MetricIssueContext,
+        open_period_context: OpenPeriodContext,
+        alert_rule_serialized_response: AlertRuleSerializerResponse,
+        incident_serialized_response: DetailedIncidentSerializerResponse,
         notification_uuid: str | None = None,
     ) -> bool:
 
         from sentry.integrations.slack.utils.notifications import send_incident_alert_notification
 
         return send_incident_alert_notification(
-            action=action,
-            incident=incident,
-            new_status=new_status,
-            metric_value=metric_value,
+            organization=organization,
+            alert_context=alert_context,
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            incident_serialized_response=incident_serialized_response,
             notification_uuid=notification_uuid,
         )
 


### PR DESCRIPTION
this refactors the messaging spec and the messaging action handlers such that they accept data classes.

this allows us to invoke the function directly from the NOA

to review, i'd recommend starting from the base messaging spec then working your way down.