### PR TITLE
feat(new-trace): Disabling collapse state persistence for trace drawer sections

### DIFF
--- a/static/app/components/events/contexts/contextDataSection.tsx
+++ b/static/app/components/events/contexts/contextDataSection.tsx
@@ -13,6 +13,7 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 
 interface ContextDataSectionProps {
   event: Event;
+  disableCollapsePersistence?: boolean;
   group?: Group;
   project?: Project;
 }
@@ -21,6 +22,7 @@ export default function ContextDataSection({
   event,
   group,
   project,
+  disableCollapsePersistence,
 }: ContextDataSectionProps) {
   const cards = getOrderedContextItems(event).map(
     ({alias, type, value: contextValue}) => (
@@ -52,6 +54,7 @@ export default function ContextDataSection({
         }
       )}
       isHelpHoverable
+      disableCollapsePersistence={disableCollapsePersistence}
     >
       <ErrorBoundary mini message={t('There was a problem loading event context.')}>
         <KeyValueData.Container>{cards}</KeyValueData.Container>

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -8,6 +8,7 @@ import useProjects from 'sentry/utils/useProjects';
 
 type Props = {
   event: Event;
+  disableCollapsePersistence?: boolean;
   group?: Group;
 };
 
@@ -70,7 +71,7 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   return items;
 }
 
-export function EventContexts({event, group}: Props) {
+export function EventContexts({event, group, disableCollapsePersistence}: Props) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
   const {contexts, sdk} = event;
@@ -87,5 +88,12 @@ export function EventContexts({event, group}: Props) {
     }
   }, [usingOtel, sdk]);
 
-  return <ContextDataSection event={event} group={group} project={project} />;
+  return (
+    <ContextDataSection
+      event={event}
+      group={group}
+      project={project}
+      disableCollapsePersistence={disableCollapsePersistence}
+    />
+  );
 }

--- a/static/app/components/events/eventAttachments.tsx
+++ b/static/app/components/events/eventAttachments.tsx
@@ -32,6 +32,7 @@ type EventAttachmentsProps = {
    */
   group: Group | undefined;
   project: Project;
+  disableCollapsePersistence?: boolean;
 };
 
 type AttachmentPreviewOpenMap = Record<string, boolean>;
@@ -60,7 +61,12 @@ function ViewAllGroupAttachmentsButton() {
   );
 }
 
-function EventAttachmentsContent({event, project, group}: EventAttachmentsProps) {
+function EventAttachmentsContent({
+  event,
+  project,
+  group,
+  disableCollapsePersistence,
+}: EventAttachmentsProps) {
   const organization = useOrganization();
   const {
     data: attachments = [],
@@ -113,6 +119,7 @@ function EventAttachmentsContent({event, project, group}: EventAttachmentsProps)
       actions={
         hasStreamlinedUI && project && group ? <ViewAllGroupAttachmentsButton /> : null
       }
+      disableCollapsePersistence={disableCollapsePersistence}
     >
       {crashFileStripped && (
         <EventAttachmentsCrashReportsNotice

--- a/static/app/components/events/eventEvidence.tsx
+++ b/static/app/components/events/eventEvidence.tsx
@@ -11,13 +11,23 @@ import {
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
-type EvidenceProps = {event: Event; project: Project; group?: Group};
+type EvidenceProps = {
+  event: Event;
+  project: Project;
+  disableCollapsePersistence?: boolean;
+  group?: Group;
+};
 
 /**
  * This component is rendered whenever an `event.occurrence.evidenceDisplay` is
  * present and the issue type config is set up to use evidenceDisplay.
  */
-export function EventEvidence({event, group, project}: EvidenceProps) {
+export function EventEvidence({
+  event,
+  group,
+  project,
+  disableCollapsePersistence,
+}: EvidenceProps) {
   if (!event.occurrence) {
     return null;
   }
@@ -40,6 +50,7 @@ export function EventEvidence({event, group, project}: EvidenceProps) {
       type={SectionKey.EVIDENCE}
       title={config.title}
       help={config.helpText}
+      disableCollapsePersistence={disableCollapsePersistence}
     >
       <KeyValueList
         data={evidenceDisplay.map(item => ({

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -27,10 +27,14 @@ type Props = {
    * Additional buttons to render in the header of the section
    */
   additionalActions?: React.ReactNode;
+  disableCollapsePersistence?: boolean;
 };
 
 export const EventTagsDataSection = forwardRef<HTMLElement, Props>(
-  function EventTagsDataSection({event, projectSlug, additionalActions}: Props, ref) {
+  function EventTagsDataSection(
+    {event, projectSlug, additionalActions, disableCollapsePersistence}: Props,
+    ref
+  ) {
     const sentryTags = getSentryDefaultTags();
 
     const [tagFilter, setTagFilter] = useState<TagFilter>(TagFilter.ALL);
@@ -73,6 +77,7 @@ export const EventTagsDataSection = forwardRef<HTMLElement, Props>(
 
     return (
       <StyledEventDataSection
+        disableCollapsePersistence={disableCollapsePersistence}
         title={
           <GuideAnchor target="tags" position="top">
             {t('Tags')}

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -21,9 +21,10 @@ import {ViewHierarchy} from './viewHierarchy';
 type Props = {
   event: Event;
   project: Project;
+  disableCollapsePersistence?: boolean;
 };
 
-function EventViewHierarchyContent({event, project}: Props) {
+function EventViewHierarchyContent({event, project, disableCollapsePersistence}: Props) {
   const organization = useOrganization();
 
   const {data: attachments} = useFetchEventAttachments(
@@ -86,7 +87,11 @@ function EventViewHierarchyContent({event, project}: Props) {
   }
 
   return (
-    <InterimSection title={t('View Hierarchy')} type={SectionKey.VIEW_HIERARCHY}>
+    <InterimSection
+      title={t('View Hierarchy')}
+      type={SectionKey.VIEW_HIERARCHY}
+      disableCollapsePersistence={disableCollapsePersistence}
+    >
       <ErrorBoundary mini>
         <ViewHierarchy viewHierarchy={hierarchy} project={project} />
       </ErrorBoundary>

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -36,6 +36,7 @@ type Props = {
   };
   event: Event;
   organization: Organization;
+  disableCollapsePersistence?: boolean;
   hideTitle?: boolean;
 };
 
@@ -88,7 +89,13 @@ export function applyBreadcrumbSearch<T extends BreadcrumbListType>(
   );
 }
 
-function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Props) {
+function BreadcrumbsContainer({
+  data,
+  event,
+  organization,
+  hideTitle = false,
+  disableCollapsePersistence,
+}: Props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterSelections, setFilterSelections] = useState<Array<SelectOption<string>>>(
     []
@@ -323,6 +330,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
       type={SectionKey.BREADCRUMBS}
       title={hideTitle ? '' : t('Breadcrumbs')}
       actions={actions}
+      disableCollapsePersistence={disableCollapsePersistence}
     >
       <ErrorBoundary>
         <Breadcrumbs

--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -18,11 +18,17 @@ type Props = {
   event: Event;
   orgId: Organization['id'];
   projectSlug: Project['slug'];
+  disableCollapsePersistence?: boolean;
 };
 
 const LazyReplayer = lazy(() => import('./rrwebReplayer'));
 
-function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
+function EventRRWebIntegrationContent({
+  orgId,
+  projectSlug,
+  event,
+  disableCollapsePersistence,
+}: Props) {
   const {
     data: attachmentList,
     isPending,
@@ -63,7 +69,11 @@ function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
     `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
 
   return (
-    <StyledReplayEventDataSection type={SectionKey.RRWEB} title={t('Replay')}>
+    <StyledReplayEventDataSection
+      type={SectionKey.RRWEB}
+      title={t('Replay')}
+      disableCollapsePersistence={disableCollapsePersistence}
+    >
       <LazyLoad
         LazyComponent={LazyReplayer}
         urls={attachmentList.map(createAttachmentUrl)}

--- a/static/app/views/issueDetails/streamline/foldSection.stories.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.stories.tsx
@@ -60,7 +60,7 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
     );
   });
 
-  story('Disabling persistence of collapse state', () => {
+  story('Disabling persistence of collapsed state', () => {
     return (
       <Fragment>
         <FoldSection

--- a/static/app/views/issueDetails/streamline/foldSection.stories.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.stories.tsx
@@ -60,6 +60,25 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
     );
   });
 
+  story('Disabling persistence of collapse state', () => {
+    return (
+      <Fragment>
+        <FoldSection
+          title="Disable Persistence Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          disableCollapsePersistence
+        >
+          <Lorem />
+        </FoldSection>
+        <CodeSnippet language="jsx">
+          {`<FoldSection title="Disable Persistence Section" sectionKey={SectionKey.MY_SECTION} disableCollapsePersistence>
+  <p>Lorem ipsum...</p>
+</FoldSection>`}
+        </CodeSnippet>
+      </Fragment>
+    );
+  });
+
   story('Custom headers/titles for the section', () => {
     return (
       <Fragment>

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -61,6 +61,22 @@ export interface FoldSectionProps {
   style?: CSSProperties;
 }
 
+function useOptionalLocalStorageState(
+  key: SectionKey,
+  initialState: boolean,
+  disablePersistence: boolean
+): [boolean, (value: boolean) => void] {
+  const [localState, setLocalState] = useState(initialState);
+  const [persistedState, setPersistedState] = useSyncedLocalStorageState(
+    getFoldSectionKey(key),
+    initialState
+  );
+
+  return disablePersistence
+    ? [localState, setLocalState]
+    : [persistedState, setPersistedState];
+}
+
 export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function FoldSection(
   {
     children,
@@ -77,19 +93,10 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
   const organization = useOrganization();
   const {sectionData, navScrollMargin, dispatch} = useIssueDetails();
 
-  const [localState, setLocalState] = useState(initialCollapse);
-  const [persistedState, setPersistedState] = useSyncedLocalStorageState(
-    getFoldSectionKey(sectionKey),
-    initialCollapse
-  );
-
-  const isCollapsed = disableCollapsePersistence ? localState : persistedState;
-  const setIsCollapsed = useCallback(
-    (value: boolean) => {
-      setLocalState(value);
-      setPersistedState(value);
-    },
-    [setLocalState, setPersistedState]
+  const [isCollapsed, setIsCollapsed] = useOptionalLocalStorageState(
+    sectionKey,
+    initialCollapse,
+    disableCollapsePersistence
   );
 
   const hasAttemptedScroll = useRef(false);

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -47,6 +47,10 @@ export interface FoldSectionProps {
   actions?: React.ReactNode;
   className?: string;
   /**
+   * Disable persisting collapse state to localStorage
+   */
+  disableCollapsePersistence?: boolean;
+  /**
    * Should this section be initially open, gets overridden by user preferences
    */
   initialCollapse?: boolean;
@@ -66,15 +70,28 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
     className,
     initialCollapse = false,
     preventCollapse = false,
+    disableCollapsePersistence = false,
   },
   forwardedRef
 ) {
   const organization = useOrganization();
   const {sectionData, navScrollMargin, dispatch} = useIssueDetails();
-  const [isCollapsed, setIsCollapsed] = useSyncedLocalStorageState(
+
+  const [localState, setLocalState] = useState(initialCollapse);
+  const [persistedState, setPersistedState] = useSyncedLocalStorageState(
     getFoldSectionKey(sectionKey),
     initialCollapse
   );
+
+  const isCollapsed = disableCollapsePersistence ? localState : persistedState;
+  const setIsCollapsed = useCallback(
+    (value: boolean) => {
+      setLocalState(value);
+      setPersistedState(value);
+    },
+    [setLocalState, setPersistedState]
+  );
+
   const hasAttemptedScroll = useRef(false);
 
   // If the section is prevented from collapsing, we need to update the local storage state and open

--- a/static/app/views/issueDetails/streamline/interimSection.tsx
+++ b/static/app/views/issueDetails/streamline/interimSection.tsx
@@ -18,9 +18,22 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
  */
 export const InterimSection = forwardRef<
   HTMLElement,
-  EventDataSectionProps & Pick<FoldSectionProps, 'initialCollapse' | 'preventCollapse'>
+  EventDataSectionProps &
+    Pick<
+      FoldSectionProps,
+      'initialCollapse' | 'preventCollapse' | 'disableCollapsePersistence'
+    >
 >(function InterimSection(
-  {children, title, type, actions = null, initialCollapse, preventCollapse, ...props},
+  {
+    children,
+    title,
+    type,
+    actions = null,
+    initialCollapse,
+    preventCollapse,
+    disableCollapsePersistence,
+    ...props
+  },
   ref
 ) {
   const hasStreamlinedUI = useHasStreamlinedUI();
@@ -33,6 +46,7 @@ export const InterimSection = forwardRef<
       ref={ref}
       initialCollapse={initialCollapse}
       preventCollapse={preventCollapse}
+      disableCollapsePersistence={disableCollapsePersistence}
     >
       {children}
     </FoldSection>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -163,7 +163,11 @@ function SpanSections({
         onParentClick={onParentClick}
       />
       {hasSpanSpecificData ? (
-        <InterimSection title={t('Span Specific')} type="span_specifc" initialCollapse>
+        <InterimSection
+          title={t('Span Specific')}
+          type="span_specifc"
+          disableCollapsePersistence
+        >
           <TraceDrawerComponents.SectionCardGroup>
             {hasSpanKeys(node) ? <SpanKeys node={node} /> : null}
             {hasSpanHTTPInfo(node.value) ? <SpanHTTPInfo span={node.value} /> : null}
@@ -231,7 +235,11 @@ function ProfileDetails({
   }
 
   return (
-    <InterimSection title={t('Profile')} type="span_profile_details" initialCollapse>
+    <InterimSection
+      title={t('Profile')}
+      type="span_profile_details"
+      disableCollapsePersistence
+    >
       <EmbededContentWrapper>
         <SpanProfileDetails span={span} event={event} />
       </EmbededContentWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -246,7 +246,11 @@ export function GeneralInfo(props: GeneralnfoProps) {
   items = [...items, ...ancestryAndGroupingItems];
 
   return (
-    <InterimSection title={t('General')} initialCollapse type="trace_transaction_general">
+    <InterimSection
+      title={t('General')}
+      disableCollapsePersistence
+      type="trace_transaction_general"
+    >
       <ContentWrapper>
         {items.map(item => (
           <Content key={item.key} item={item} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1253,7 +1253,13 @@ function EventTags({projectSlug, event}: {event: Event; projectSlug: string}) {
     return <LegacyEventTags event={event} projectSlug={projectSlug} />;
   }
 
-  return <EventTagsDataSection event={event} projectSlug={projectSlug} />;
+  return (
+    <EventTagsDataSection
+      event={event}
+      projectSlug={projectSlug}
+      disableCollapsePersistence
+    />
+  );
 }
 
 function LegacyEventTags({projectSlug, event}: {event: Event; projectSlug: string}) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -244,9 +244,11 @@ export function TransactionNodeDetails({
           event={event}
         />
 
-        <EventContexts event={event} />
+        <EventContexts event={event} disableCollapsePersistence />
 
-        {project ? <EventEvidence event={event} project={project} /> : null}
+        {project ? (
+          <EventEvidence event={event} project={project} disableCollapsePersistence />
+        ) : null}
 
         {replay ? null : <ReplayPreview event={event} organization={organization} />}
 
@@ -256,13 +258,20 @@ export function TransactionNodeDetails({
           <EventAttachments event={event} project={project} group={undefined} />
         ) : null}
 
-        {project ? <EventViewHierarchy event={event} project={project} /> : null}
+        {project ? (
+          <EventViewHierarchy
+            event={event}
+            project={project}
+            disableCollapsePersistence
+          />
+        ) : null}
 
         {event.projectSlug ? (
           <EventRRWebIntegration
             event={event}
             orgId={organization.slug}
             projectSlug={event.projectSlug}
+            disableCollapsePersistence
           />
         ) : null}
       </TraceDrawerComponents.BodyContainer>
@@ -302,7 +311,7 @@ function TransactionSpecificSections(props: TransactionSpecificSectionsProps) {
       <InterimSection
         title={t('Transaction Specific')}
         type="transaction_specifc"
-        initialCollapse
+        disableCollapsePersistence
       >
         <TraceDrawerComponents.SectionCardGroup>
           {hasSDKContext(event) || cacheMetrics.length > 0 ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -114,7 +114,7 @@ function GeneralInfo(props: GeneralInfoProps) {
   return (
     <InterimSection
       title={t('General')}
-      disableCollapsePersistence
+      disableCollapsePersistence={false}
       type="trace_transaction_general"
     >
       <ContentWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -114,7 +114,7 @@ function GeneralInfo(props: GeneralInfoProps) {
   return (
     <InterimSection
       title={t('General')}
-      disableCollapsePersistence={false}
+      disableCollapsePersistence
       type="trace_transaction_general"
     >
       <ContentWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -112,7 +112,11 @@ function GeneralInfo(props: GeneralInfoProps) {
   }
 
   return (
-    <InterimSection title={t('General')} initialCollapse type="trace_transaction_general">
+    <InterimSection
+      title={t('General')}
+      disableCollapsePersistence
+      type="trace_transaction_general"
+    >
       <ContentWrapper>
         {items.map(item => (
           <Content key={item.key} item={item} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
@@ -77,7 +77,7 @@ function ReplayPreview({
     <InterimSection
       title={t('Session Replay')}
       type="trace_session_replay"
-      initialCollapse
+      disableCollapsePersistence
     >
       <ReplaySection event={event} organization={organization} />
     </InterimSection>


### PR DESCRIPTION
We want the trace drawer sections to be initially expanded and don't want collapsed state to persist. 

<img width="1239" alt="Screenshot 2025-03-19 at 9 51 51 PM" src="https://github.com/user-attachments/assets/0651f82e-7d13-4a3a-a4c5-388a39b8d3db" />



Added a `disableCollapsePersistence` prop to the `FoldSection` component and used it in the trace drawer.

Added section to component stories.