### PR TITLE
♻️ ref: refactor `build_incident_attachment` to use `MetricIssue` dataclass

### DIFF
--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -22,22 +22,16 @@ class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
         chart_url: str | None = None,
     ) -> None:
         self.alert_context = alert_context
-        self.open_period_identifier = metric_issue_context.open_period_identifier
-        self.snuba_query = metric_issue_context.snuba_query
+        self.metric_issue_context = metric_issue_context
         self.organization = organization
         self.date_started = date_started
-        self.metric_value = metric_issue_context.metric_value
-        self.new_status = metric_issue_context.new_status
         self.chart_url = chart_url
 
     def build(self, notification_uuid: str | None = None) -> dict[str, object]:
         data = incident_attachment_info(
-            alert_context=self.alert_context,
-            open_period_identifier=self.open_period_identifier,
             organization=self.organization,
-            snuba_query=self.snuba_query,
-            metric_value=self.metric_value,
-            new_status=self.new_status,
+            alert_context=self.alert_context,
+            metric_issue_context=self.metric_issue_context,
             notification_uuid=notification_uuid,
             referrer="metric_alert_discord",
         )

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -19,7 +19,7 @@ from sentry.incidents.models.incident import (
     IncidentStatus,
     IncidentTrigger,
 )
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.incidents.utils.format_duration import format_duration_idiomatic
 from sentry.models.organization import Organization
 from sentry.snuba.metrics import format_mri_field, format_mri_field_value, is_mri_field
@@ -167,24 +167,21 @@ def build_title_link(
 
 
 def incident_attachment_info(
-    alert_context: AlertContext,
-    open_period_identifier: int,
     organization: Organization,
-    snuba_query: SnubaQuery,
-    new_status: IncidentStatus,
-    metric_value: float | None = None,
+    alert_context: AlertContext,
+    metric_issue_context: MetricIssueContext,
     referrer: str = "metric_alert",
     notification_uuid: str | None = None,
 ) -> AttachmentInfo:
-    status = get_status_text(new_status)
+    status = get_status_text(metric_issue_context.new_status)
 
     text = ""
-    if metric_value is not None:
+    if metric_issue_context.metric_value is not None:
         text = get_incident_status_text(
-            snuba_query,
+            metric_issue_context.snuba_query,
             alert_context.threshold_type,
             alert_context.comparison_delta,
-            str(metric_value),
+            str(metric_issue_context.metric_value),
         )
 
     if features.has("organizations:anomaly-detection-alerts", organization) and features.has(
@@ -195,7 +192,7 @@ def incident_attachment_info(
     title = get_title(status, alert_context.name)
 
     title_link_params: TitleLinkParams = {
-        "alert": str(open_period_identifier),
+        "alert": str(metric_issue_context.open_period_identifier),
         "referrer": referrer,
         "detection_type": alert_context.detection_type.value,
     }

--- a/src/sentry/integrations/msteams/card_builder/incident_attachment.py
+++ b/src/sentry/integrations/msteams/card_builder/incident_attachment.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from sentry.incidents.models.incident import IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.msteams.card_builder.block import (
     AdaptiveCard,
@@ -13,27 +12,20 @@ from sentry.integrations.msteams.card_builder.block import (
     TextWeight,
 )
 from sentry.models.organization import Organization
-from sentry.snuba.models import SnubaQuery
 
 
 def build_incident_attachment(
     alert_context: AlertContext,
-    open_period_identifier: int,
-    snuba_query: SnubaQuery,
+    metric_issue_context: MetricIssueContext,
     organization: Organization,
     date_started: datetime,
-    new_status: IncidentStatus,
-    metric_value: float | None = None,
     notification_uuid: str | None = None,
 ) -> AdaptiveCard:
 
     data = incident_attachment_info(
         alert_context=alert_context,
-        open_period_identifier=open_period_identifier,
+        metric_issue_context=metric_issue_context,
         organization=organization,
-        snuba_query=snuba_query,
-        metric_value=metric_value,
-        new_status=new_status,
         notification_uuid=notification_uuid,
         referrer="metric_alert_msteams",
     )

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.metric_alerts import get_metric_count_from_incident
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -117,12 +117,11 @@ def send_incident_alert_notification(
 
     attachment = build_incident_attachment(
         alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-        open_period_identifier=incident.identifier,
-        snuba_query=incident.alert_rule.snuba_query,
+        metric_issue_context=MetricIssueContext.from_legacy_models(
+            incident, new_status, metric_value
+        ),
         organization=incident.organization,
         date_started=incident.date_started,
-        new_status=new_status,
-        metric_value=metric_value,
         notification_uuid=notification_uuid,
     )
     success = integration_service.send_msteams_incident_alert_notification(

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -21,7 +21,6 @@ from sentry.models.organization import Organization
 from sentry.shared_integrations.client.proxy import infer_org_integration
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import control_silo_function
-from sentry.snuba.models import SnubaQuery
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
@@ -95,45 +94,39 @@ def get_service(
 
 def build_incident_attachment(
     alert_context: AlertContext,
-    open_period_identifier: int,
+    metric_issue_context: MetricIssueContext,
     organization: Organization,
-    snuba_query: SnubaQuery,
     integration_key,
-    new_status: IncidentStatus,
-    metric_value: float | None = None,
     notification_uuid: str | None = None,
 ) -> dict[str, Any]:
 
     data = incident_attachment_info(
-        alert_context=alert_context,
-        open_period_identifier=open_period_identifier,
         organization=organization,
-        snuba_query=snuba_query,
-        metric_value=metric_value,
-        new_status=new_status,
+        alert_context=alert_context,
+        metric_issue_context=metric_issue_context,
         notification_uuid=notification_uuid,
         referrer="metric_alert_pagerduty",
     )
     severity = "info"
-    if new_status == IncidentStatus.CRITICAL:
+    if metric_issue_context.new_status == IncidentStatus.CRITICAL:
         severity = "critical"
-    elif new_status == IncidentStatus.WARNING:
+    elif metric_issue_context.new_status == IncidentStatus.WARNING:
         severity = "warning"
-    elif new_status == IncidentStatus.CLOSED:
+    elif metric_issue_context.new_status == IncidentStatus.CLOSED:
         severity = "info"
 
     event_action = "resolve"
-    if new_status in [IncidentStatus.WARNING, IncidentStatus.CRITICAL]:
+    if metric_issue_context.new_status in [IncidentStatus.WARNING, IncidentStatus.CRITICAL]:
         event_action = "trigger"
 
     return {
         "routing_key": integration_key,
         "event_action": event_action,
-        "dedup_key": f"incident_{organization.id}_{open_period_identifier}",
+        "dedup_key": f"incident_{organization.id}_{metric_issue_context.open_period_identifier}",
         "payload": {
             "summary": alert_context.name,
             "severity": severity,
-            "source": str(open_period_identifier),
+            "source": str(metric_issue_context.open_period_identifier),
             "custom_details": {"details": data["text"]},
         },
         "links": [{"href": data["title_link"], "text": data["title"]}],
@@ -224,12 +217,9 @@ def send_incident_alert_notification(
 
     attachment = build_incident_attachment(
         alert_context=alert_context,
-        open_period_identifier=metric_issue_context.open_period_identifier,
+        metric_issue_context=metric_issue_context,
         organization=organization,
-        snuba_query=metric_issue_context.snuba_query,
         integration_key=client.integration_key,
-        new_status=metric_issue_context.new_status,
-        metric_value=metric_issue_context.metric_value,
         notification_uuid=notification_uuid,
     )
     attachment = attach_custom_severity(

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -40,11 +40,8 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
         """
         super().__init__()
         self.alert_context = alert_context
-        self.open_period_identifier = metric_issue_context.open_period_identifier
+        self.metric_issue_context = metric_issue_context
         self.organization = organization
-        self.snuba_query = metric_issue_context.snuba_query
-        self.metric_value = metric_issue_context.metric_value
-        self.new_status = metric_issue_context.new_status
         self.date_started = date_started
         self.chart_url = chart_url
         self.notification_uuid = notification_uuid
@@ -52,11 +49,8 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
     def build(self) -> SlackBody:
         data = incident_attachment_info(
             alert_context=self.alert_context,
-            open_period_identifier=self.open_period_identifier,
+            metric_issue_context=self.metric_issue_context,
             organization=self.organization,
-            snuba_query=self.snuba_query,
-            new_status=self.new_status,
-            metric_value=self.metric_value,
             notification_uuid=self.notification_uuid,
             referrer="metric_alert_slack",
         )

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -11,7 +11,7 @@ from sentry.eventstore.models import GroupEvent
 from sentry.incidents.endpoints.serializers.incident import IncidentSerializer
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.metric_alerts import (
     get_metric_count_from_incident,
     incident_attachment_info,
@@ -47,12 +47,11 @@ def build_incident_attachment(
         metric_value = get_metric_count_from_incident(incident)
 
     data = incident_attachment_info(
-        AlertContext.from_alert_rule_incident(incident.alert_rule),
-        open_period_identifier=incident.identifier,
         organization=incident.organization,
-        snuba_query=incident.alert_rule.snuba_query,
-        new_status=new_status,
-        metric_value=metric_value,
+        alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+        metric_issue_context=MetricIssueContext.from_legacy_models(
+            incident, new_status, metric_value
+        ),
         notification_uuid=notification_uuid,
         referrer="metric_alert_sentry_app",
     )

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -14,7 +14,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.messaging.spec import MessagingActionHandler
 from sentry.integrations.msteams.card_builder.block import (
     Block,
@@ -100,12 +100,11 @@ class MsTeamsActionHandlerTest(FireTest):
 
         assert data["attachments"][0]["content"] == build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
-            snuba_query=incident.alert_rule.snuba_query,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
             date_started=incident.date_started,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
 
         assert_slo_metric(mock_record)
@@ -130,12 +129,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         data = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(alert_rule),
-            open_period_identifier=incident.identifier,
-            snuba_query=alert_rule.snuba_query,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
             date_started=incident.date_started,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
         body: list[Block] = data["body"]
         column_set_block = cast(ColumnSetBlock, body[0])
@@ -181,12 +179,11 @@ class MsTeamsActionHandlerTest(FireTest):
         metric_value = 1000
         data = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(alert_rule),
-            open_period_identifier=incident.identifier,
-            snuba_query=alert_rule.snuba_query,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
             date_started=incident.date_started,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
         body: list[Block] = data["body"]
         column_set_block = cast(ColumnSetBlock, body[0])

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -13,7 +13,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.seer.anomaly_detection.types import StoreDataResponse
@@ -94,11 +94,10 @@ class OpsgenieActionHandlerTest(FireTest):
         metric_value = 1000
         data = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -152,12 +151,11 @@ class OpsgenieActionHandlerTest(FireTest):
         )
         metric_value = 1000
         data = build_incident_attachment(
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -202,12 +200,11 @@ class OpsgenieActionHandlerTest(FireTest):
                 status=202,
             )
             expected_payload = build_incident_attachment(
+                metric_issue_context=MetricIssueContext.from_legacy_models(
+                    incident, new_status, metric_value=1000
+                ),
                 alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-                open_period_identifier=incident.identifier,
                 organization=incident.organization,
-                snuba_query=incident.alert_rule.snuba_query,
-                new_status=new_status,
-                metric_value=1000,
             )
             expected_payload = attach_custom_priority(expected_payload, self.action, new_status)
 

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -16,7 +16,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
-from sentry.incidents.typings.metric_detector import AlertContext
+from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
@@ -81,13 +81,12 @@ class PagerDutyActionHandlerTest(FireTest):
         metric_value = 1000
         notification_uuid = str(uuid.uuid4())
         data = build_incident_attachment(
-            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             integration_key=self.integration_key,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
             notification_uuid=notification_uuid,
         )
 
@@ -139,12 +138,11 @@ class PagerDutyActionHandlerTest(FireTest):
         notification_uuid = str(uuid.uuid4())
         data = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
             integration_key=self.integration_key,
-            new_status=IncidentStatus(incident.status),
-            metric_value=metric_value,
             notification_uuid=notification_uuid,
         )
 
@@ -192,12 +190,11 @@ class PagerDutyActionHandlerTest(FireTest):
 
         expected_payload = build_incident_attachment(
             alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
-            open_period_identifier=incident.identifier,
+            metric_issue_context=MetricIssueContext.from_legacy_models(
+                incident, IncidentStatus(incident.status), metric_value
+            ),
             organization=incident.organization,
-            snuba_query=incident.alert_rule.snuba_query,
             integration_key=self.integration_key,
-            new_status=new_status,
-            metric_value=metric_value,
         )
         expected_payload = attach_custom_severity(
             expected_payload, self.action.sentry_app_config, new_status


### PR DESCRIPTION
since we have introduced, `MetricIssue` dataclass, lets use that so we don't have to pass tons of parameters around which can be prone to mistakes