### PR TITLE
feat(org member invite): create OrganizationMemberInviteSerializer

### DIFF
--- a/src/sentry/api/serializers/models/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/models/organizationmemberinvite.py
@@ -18,6 +18,7 @@ class OrganizationMemberInviteSerializer(Serializer):
     def get_attrs(
         self,
         item_list: Sequence[OrganizationMemberInvite],
+        user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> MutableMapping[OrganizationMemberInvite, MutableMapping[str, Any]]:
         inviters_set = sorted({omi.inviter_id for omi in item_list if omi.inviter_id})
@@ -51,14 +52,12 @@ class OrganizationMemberInviteSerializer(Serializer):
             "email": obj.email,
             "orgRole": obj.role,
             "expired": obj.token_expired,
-            "flags": {
-                "idp:provisioned": obj.idp_provisioned,
-                "idp:role-restricted": obj.idp_role_restricted,
-                "sso:linked": obj.sso_linked,
-                "sso:invalid": obj.sso_invalid,
-                "member-limit:restricted": obj.member_limit_restricted,
-                "partnership:restricted": obj.partnership_restricted,
-            },
+            "idpProvisioned": obj.idp_provisioned,
+            "idpRoleRestricted": obj.idp_role_restricted,
+            "ssoLinked": obj.sso_linked,
+            "ssoInvalid": obj.sso_invalid,
+            "memberLimitRestricted": obj.member_limit_restricted,
+            "partnershipRestricted": obj.partnership_restricted,
             "teams": obj.organization_member_team_data,
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),

--- a/src/sentry/api/serializers/models/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/models/organizationmemberinvite.py
@@ -1,0 +1,68 @@
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.api.serializers import Serializer, register
+from sentry.models.organizationmemberinvite import (
+    OrganizationMemberInvite,
+    OrganizationMemberInviteResponse,
+)
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+from sentry.users.services.user.service import user_service
+
+
+@register(OrganizationMemberInvite)
+class OrganizationMemberInviteSerializer(Serializer):
+    def get_attrs(
+        self,
+        item_list: Sequence[OrganizationMemberInvite],
+        **kwargs: Any,
+    ) -> MutableMapping[OrganizationMemberInvite, MutableMapping[str, Any]]:
+        inviters_set = sorted({omi.inviter_id for omi in item_list if omi.inviter_id})
+        inviters_by_id: Mapping[int, RpcUser] = {
+            u.id: u for u in user_service.get_many_by_id(ids=inviters_set)
+        }
+        attrs: MutableMapping[OrganizationMemberInvite, MutableMapping[str, Any]] = {}
+        for item in item_list:
+            if item.inviter_id is not None:
+                inviter = inviters_by_id.get(item.inviter_id, None)
+            else:
+                inviter = None
+            attrs[item] = {"inviter": inviter}
+        return attrs
+
+    def serialize(
+        self,
+        obj: OrganizationMemberInvite,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> OrganizationMemberInviteResponse:
+        inviter_name = None
+        if obj.inviter_id:
+            inviter = attrs["inviter"]
+            if inviter:
+                inviter_name = inviter.get_display_name()
+
+        data: OrganizationMemberInviteResponse = {
+            "id": str(obj.id),
+            "email": obj.email,
+            "orgRole": obj.role,
+            "expired": obj.token_expired,
+            "flags": {
+                "idp:provisioned": obj.idp_provisioned,
+                "idp:role-restricted": obj.idp_role_restricted,
+                "sso:linked": obj.sso_linked,
+                "sso:invalid": obj.sso_invalid,
+                "member-limit:restricted": obj.member_limit_restricted,
+                "partnership:restricted": obj.partnership_restricted,
+            },
+            "teams": obj.organization_member_team_data,
+            "dateCreated": obj.date_added,
+            "inviteStatus": obj.get_invite_status_name(),
+            "inviterName": inviter_name,
+        }
+
+        return data

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from sentry.api.serializers.models.organization_member.response import _OrganizationMemberFlags
+# from sentry.api.serializers.models.organization_member.response import _OrganizationMemberFlags
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -50,6 +50,21 @@ def default_expiration():
 
 def generate_token():
     return secrets.token_hex(nbytes=32)
+
+
+# Causes a circular import error when importing
+# from sentry.api.serializers.models.organization_member.response
+_OrganizationMemberFlags = TypedDict(
+    "_OrganizationMemberFlags",
+    {
+        "idp:provisioned": bool,
+        "idp:role-restricted": bool,
+        "sso:linked": bool,
+        "sso:invalid": bool,
+        "member-limit:restricted": bool,
+        "partnership:restricted": bool,
+    },
+)
 
 
 class OrganizationMemberInviteResponse(TypedDict):

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -66,7 +66,7 @@ class OrganizationMemberInviteResponse(TypedDict):
     dateCreated: datetime
     inviteStatus: str
     inviterName: str | None
-    teams: list[str]
+    teams: list[dict]
 
 
 @region_silo_model

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -1,12 +1,14 @@
 import secrets
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import TypedDict
 
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.api.serializers.models.organization_member.response import _OrganizationMemberFlags
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -48,6 +50,17 @@ def default_expiration():
 
 def generate_token():
     return secrets.token_hex(nbytes=32)
+
+
+class OrganizationMemberInviteResponse(TypedDict):
+    id: str
+    email: str
+    orgRole: str
+    expired: bool
+    flags: _OrganizationMemberFlags
+    dateCreated: datetime
+    inviteStatus: str
+    inviterName: str | None
 
 
 @region_silo_model
@@ -125,6 +138,12 @@ class OrganizationMemberInvite(DefaultFieldsModel):
     @property
     def requested_to_be_invited(self):
         return self.invite_status == InviteStatus.REQUESTED_TO_BE_INVITED.value
+
+    @property
+    def token_expired(self):
+        if self.token_expires_at > timezone.now():
+            return False
+        return True
 
     def write_relocation_import(
         self, scope: ImportScope, flags: ImportFlags

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -96,6 +96,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationslugreservation import OrganizationSlugReservation
 from sentry.models.orgauthtoken import OrgAuthToken
@@ -420,6 +421,21 @@ class Factories:
             for team in teams:
                 Factories.create_team_membership(team=team, member=om, role=teamRole)
         return om
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_member_invite(
+        organization: Organization | None = None,
+        email: str | None = None,
+        **kwargs,
+    ) -> OrganizationMemberInvite:
+        if organization is None:
+            organization = Factories.create_organization()
+        if email is None:
+            email = f"{petname.generate().title()}@email.com"
+        return OrganizationMemberInvite.objects.create(
+            organization=organization, email=email, **kwargs
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -164,6 +164,9 @@ class Fixtures:
     def create_member(self, *args, **kwargs):
         return Factories.create_member(*args, **kwargs)
 
+    def create_member_invite(self, *args, **kwargs):
+        return Factories.create_member_invite(*args, **kwargs)
+
     def create_api_key(self, *args, **kwargs):
         return Factories.create_api_key(*args, **kwargs)
 

--- a/tests/sentry/api/serializers/test_organization_member_invite.py
+++ b/tests/sentry/api/serializers/test_organization_member_invite.py
@@ -1,4 +1,7 @@
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organizationmemberinvite import (
+    OrganizationMemberInviteSerializer,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -8,8 +11,10 @@ class OrganizationMemberInviteSerializerTest(TestCase):
         self.email = "user@email.com"
 
     def test_simple(self):
-        member_invite = self.create_member_invite(organization=self.org, email=self.email)
-        result = serialize(member_invite, None)
+        member_invite = self.create_member_invite(
+            organization=self.org, email=self.email, organization_member_team_data=[]
+        )
+        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
 
         assert result == {
             "id": str(member_invite.id),
@@ -22,7 +27,7 @@ class OrganizationMemberInviteSerializerTest(TestCase):
             "ssoInvalid": member_invite.sso_invalid,
             "memberLimitRestricted": member_invite.member_limit_restricted,
             "partnershipRestricted": member_invite.partnership_restricted,
-            "teams": {},
+            "teams": [],
             "dateCreated": member_invite.date_added,
             "inviteStatus": member_invite.get_invite_status_name(),
             "inviterName": None,
@@ -32,11 +37,13 @@ class OrganizationMemberInviteSerializerTest(TestCase):
         team = self.create_team(organization=self.org)
 
         member_invite = self.create_member_invite(
-            organization=self.org, email=self.email, organization_member_team_data=[str(team.id)]
+            organization=self.org,
+            email=self.email,
+            organization_member_team_data=[{"id": team.id, "slug": team.slug}],
         )
         result = serialize(member_invite, None)
 
-        assert result["teams"] == [str(team.id)]
+        assert result["teams"] == [{"id": team.id, "slug": team.slug}]
 
     def test_inviter(self):
         user = self.create_user()

--- a/tests/sentry/api/serializers/test_organization_member_invite.py
+++ b/tests/sentry/api/serializers/test_organization_member_invite.py
@@ -1,7 +1,4 @@
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.organizationmemberinvite import (
-    OrganizationMemberInviteSerializer,
-)
 from sentry.testutils.cases import TestCase
 
 
@@ -12,21 +9,19 @@ class OrganizationMemberInviteSerializerTest(TestCase):
 
     def test_simple(self):
         member_invite = self.create_member_invite(organization=self.org, email=self.email)
-        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+        result = serialize(member_invite, None)
 
         assert result == {
             "id": str(member_invite.id),
             "email": self.email,
             "orgRole": member_invite.role,
             "expired": False,
-            "flags": {
-                "idp:provisioned": member_invite.idp_provisioned,
-                "idp:role-restricted": member_invite.idp_role_restricted,
-                "sso:linked": member_invite.sso_linked,
-                "sso:invalid": member_invite.sso_invalid,
-                "member-limit:restricted": member_invite.member_limit_restricted,
-                "partnership:restricted": member_invite.partnership_restricted,
-            },
+            "idpProvisioned": member_invite.idp_provisioned,
+            "idpRoleRestricted": member_invite.idp_role_restricted,
+            "ssoLinked": member_invite.sso_linked,
+            "ssoInvalid": member_invite.sso_invalid,
+            "memberLimitRestricted": member_invite.member_limit_restricted,
+            "partnershipRestricted": member_invite.partnership_restricted,
             "teams": {},
             "dateCreated": member_invite.date_added,
             "inviteStatus": member_invite.get_invite_status_name(),
@@ -37,17 +32,17 @@ class OrganizationMemberInviteSerializerTest(TestCase):
         team = self.create_team(organization=self.org)
 
         member_invite = self.create_member_invite(
-            organization=self.org, email=self.email, organization_member_team_data=[team.slug]
+            organization=self.org, email=self.email, organization_member_team_data=[str(team.id)]
         )
-        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+        result = serialize(member_invite, None)
 
-        assert result["teams"] == [team.slug]
+        assert result["teams"] == [str(team.id)]
 
     def test_inviter(self):
         user = self.create_user()
         member_invite = self.create_member_invite(
             organization=self.org, email=self.email, inviter_id=user.id
         )
-        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+        result = serialize(member_invite, None)
 
         assert result["inviterName"] == user.get_display_name()

--- a/tests/sentry/api/serializers/test_organization_member_invite.py
+++ b/tests/sentry/api/serializers/test_organization_member_invite.py
@@ -1,0 +1,53 @@
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organizationmemberinvite import (
+    OrganizationMemberInviteSerializer,
+)
+from sentry.testutils.cases import TestCase
+
+
+class OrganizationMemberInviteSerializerTest(TestCase):
+    def setUp(self):
+        self.org = self.create_organization()
+        self.email = "user@email.com"
+
+    def test_simple(self):
+        member_invite = self.create_member_invite(organization=self.org, email=self.email)
+        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+
+        assert result == {
+            "id": str(member_invite.id),
+            "email": self.email,
+            "orgRole": member_invite.role,
+            "expired": False,
+            "flags": {
+                "idp:provisioned": member_invite.idp_provisioned,
+                "idp:role-restricted": member_invite.idp_role_restricted,
+                "sso:linked": member_invite.sso_linked,
+                "sso:invalid": member_invite.sso_invalid,
+                "member-limit:restricted": member_invite.member_limit_restricted,
+                "partnership:restricted": member_invite.partnership_restricted,
+            },
+            "teams": {},
+            "dateCreated": member_invite.date_added,
+            "inviteStatus": member_invite.get_invite_status_name(),
+            "inviterName": None,
+        }
+
+    def test_teams(self):
+        team = self.create_team(organization=self.org)
+
+        member_invite = self.create_member_invite(
+            organization=self.org, email=self.email, organization_member_team_data=[team.slug]
+        )
+        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+
+        assert result["teams"] == [team.slug]
+
+    def test_inviter(self):
+        user = self.create_user()
+        member_invite = self.create_member_invite(
+            organization=self.org, email=self.email, inviter_id=user.id
+        )
+        result = serialize(member_invite, None, OrganizationMemberInviteSerializer())
+
+        assert result["inviterName"] == user.get_display_name()


### PR DESCRIPTION
Build out the `OrganizationMemberInviteSerializer`, to be used by the new member invite endpoints.