### PR TITLE
Update Flutter manual setup verify code snippet

### DIFF
--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -102,7 +102,7 @@ const configureAdditionalInfo = tct(
 const getVerifySnippet = () => `
 child: ElevatedButton(
   onPressed: () {
-    throw Exception('This is test exception');
+    throw StateError('This is test exception');
   },
   child: const Text('Verify Sentry Setup'),
 )


### PR DESCRIPTION
Update the doc code snippet to throw `StateError` instead of a generic `Exception`, this leads to better results in issue titles when users try out the Flutter SDK