### PR TITLE
fix(celery) Remove more tasks from the pickle list

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -14,9 +14,6 @@ LEGACY_PICKLE_TASKS = frozenset(
     [
         # basic tasks that must be passed models still
         "sentry.tasks.process_buffer.process_incr",
-        "sentry.tasks.unmerge",
-        # basic tasks that can already deal with primary keys passed
-        "sentry.tasks.update_code_owners_schema",
     ]
 )
 


### PR DESCRIPTION
update_code_owners_schema was recently changed, and unmerge() has already been updated to not use any parameters that require pickle.

Refs #81913