### PR TITLE
feat(schema-hints): Drawer part of content on large screens

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -30,6 +30,8 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
+export const SCHEMA_HINTS_DRAWER_WIDTH = '35vw';
+
 interface SchemaHintsListProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
@@ -40,6 +42,12 @@ interface SchemaHintsListProps {
 const seeFullListTag: Tag = {
   key: 'seeFullList',
   name: t('See full list'),
+  kind: undefined,
+};
+
+const hideListTag: Tag = {
+  key: 'hideList',
+  name: t('Hide list'),
   kind: undefined,
 };
 
@@ -58,7 +66,7 @@ function SchemaHintsList({
   const setExploreQuery = useSetExploreQuery();
   const location = useLocation();
 
-  const {openDrawer, isDrawerOpen} = useDrawer();
+  const {openDrawer, isDrawerOpen, closeDrawer} = useDrawer();
 
   const functionTags = useMemo(() => {
     return getFunctionTags(supportedAggregates);
@@ -136,7 +144,10 @@ function SchemaHintsList({
         lastVisibleIndex = items.length;
       }
 
-      setVisibleHints([...filterTagsSorted.slice(0, lastVisibleIndex), seeFullListTag]);
+      setVisibleHints([
+        ...filterTagsSorted.slice(0, lastVisibleIndex),
+        isDrawerOpen ? hideListTag : seeFullListTag,
+      ]);
 
       // Remove the temporary div
       document.body.removeChild(measureDiv);
@@ -151,7 +162,7 @@ function SchemaHintsList({
     }
 
     return () => resizeObserver.disconnect();
-  }, [filterTagsSorted]);
+  }, [filterTagsSorted, isDrawerOpen]);
 
   const onHintClick = useCallback(
     (hint: Tag) => {
@@ -165,7 +176,13 @@ function SchemaHintsList({
             ),
             {
               ariaLabel: t('Schema Hints Drawer'),
-              drawerWidth: '35vw',
+              drawerWidth: SCHEMA_HINTS_DRAWER_WIDTH,
+              transitionProps: {
+                key: 'schema-hints-drawer',
+                type: 'tween',
+                duration: 0.7,
+                ease: 'easeOut',
+              },
               shouldCloseOnLocationChange: newLocation => {
                 return (
                   location.pathname !== newLocation.pathname ||
@@ -182,6 +199,13 @@ function SchemaHintsList({
         return;
       }
 
+      if (hint.key === hideListTag.key) {
+        if (isDrawerOpen) {
+          closeDrawer();
+        }
+        return;
+      }
+
       const newSearchQuery = new MutableSearch(exploreQuery);
       const isBoolean =
         getFieldDefinition(hint.key, 'span', hint.kind)?.valueType ===
@@ -192,11 +216,20 @@ function SchemaHintsList({
       );
       setExploreQuery(newSearchQuery.formatString());
     },
-    [exploreQuery, setExploreQuery, isDrawerOpen, openDrawer, filterTagsSorted, location]
+    [
+      exploreQuery,
+      setExploreQuery,
+      isDrawerOpen,
+      openDrawer,
+      filterTagsSorted,
+      location.pathname,
+      location.query,
+      closeDrawer,
+    ]
   );
 
   const getHintText = (hint: Tag) => {
-    if (hint.key === seeFullListTag.key) {
+    if (hint.key === seeFullListTag.key || hint.key === hideListTag.key) {
       return hint.name;
     }
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -1,10 +1,12 @@
 import {useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import Feature from 'sentry/components/acl/feature';
 import {getDiffInMinutes} from 'sentry/components/charts/utils';
 import {Button} from 'sentry/components/core/button';
+import useDrawer from 'sentry/components/globalDrawer';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -26,10 +28,13 @@ import {
   type AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
 } from 'sentry/utils/fields';
+import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ExploreCharts} from 'sentry/views/explore/charts';
-import SchemaHintsList from 'sentry/views/explore/components/schemaHintsList';
+import SchemaHintsList, {
+  SCHEMA_HINTS_DRAWER_WIDTH,
+} from 'sentry/views/explore/components/schemaHintsList';
 import {
   PageParamsProvider,
   useExploreDataset,
@@ -85,6 +90,14 @@ export function SpansTabContentImpl({
 
   const query = useExploreQuery();
   const setQuery = useSetExploreQuery();
+
+  const {isDrawerOpen: isSchemaHintsDrawerOpen} = useDrawer();
+  const theme = useTheme();
+  const isLargeScreen = useMedia(`(min-width: ${theme.breakpoints.xlarge})`);
+  const isSchemaHintsDrawerOpenOnLargeScreen =
+    isSchemaHintsDrawerOpen &&
+    isLargeScreen &&
+    organization.features.includes('traces-schema-hints');
 
   const toolbarExtras = [
     ...(organization?.features?.includes('visibility-explore-dataset')
@@ -172,6 +185,9 @@ export function SpansTabContentImpl({
     <Body
       withToolbar={expanded}
       withHints={organization.features.includes('traces-schema-hints')}
+      thirdColumnWidth={
+        isSchemaHintsDrawerOpenOnLargeScreen ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'
+      }
     >
       <TopSection>
         <StyledPageFilterBar condensed>
@@ -222,7 +238,7 @@ export function SpansTabContentImpl({
         )}
       </TopSection>
       <Feature features="organizations:traces-schema-hints">
-        <HintsSection>
+        <HintsSection withSchemaHintsDrawer={isSchemaHintsDrawerOpenOnLargeScreen}>
           <SchemaHintsList
             supportedAggregates={
               mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
@@ -341,13 +357,17 @@ function checkIsAllowedSelection(
   return selectedMinutes <= maxPickableMinutes;
 }
 
-const Body = styled(Layout.Body)<{withHints: boolean; withToolbar: boolean}>`
+const Body = styled(Layout.Body)<{
+  thirdColumnWidth: string;
+  withHints: boolean;
+  withToolbar: boolean;
+}>`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     display: grid;
     ${p =>
       p.withToolbar
-        ? `grid-template-columns: 300px minmax(100px, auto);`
-        : `grid-template-columns: 0px minmax(100px, auto);`}
+        ? `grid-template-columns: 300px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`
+        : `grid-template-columns: 0px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`}
     grid-template-rows: auto ${p => (p.withHints ? 'auto 1fr' : '1fr')};
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};
@@ -373,7 +393,7 @@ const SideSection = styled('aside')<{withToolbar: boolean}>`
   }
 `;
 
-const HintsSection = styled('div')`
+const HintsSection = styled('div')<{withSchemaHintsDrawer: boolean}>`
   display: grid;
   /* This is to ensure the hints section spans all the columns */
   grid-column: 1/-1;
@@ -382,7 +402,8 @@ const HintsSection = styled('div')`
   height: fit-content;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr ${p =>
+        p.withSchemaHintsDrawer ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'};
     margin-bottom: 0;
     margin-top: 0;
   }


### PR DESCRIPTION
[Last PR](https://github.com/getsentry/sentry/pull/87284) messed up the traces UI because I didn't add the "third column" conditionally  😬 

Just like last time it makes room for the drawer on `xlarge` screens but this time only when the feature flag is on 🤩   


