### PR TITLE
ref(dashboards): Split up time series types and tabular types

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -225,10 +225,8 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
           key={i}
           field={field}
           value={value}
-          meta={{
-            type: meta.fields?.[field] ?? null,
-            unit: (meta.units?.[field] as DataUnit) ?? null,
-          }}
+          type={meta.fields?.[field] ?? null}
+          unit={(meta.units?.[field] as DataUnit) ?? null}
           thresholds={widget.thresholds ?? undefined}
           preferredPolarity="-"
         />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
@@ -23,10 +23,8 @@ describe('BigNumberWidgetVisualization', () => {
             <BigNumberWidgetVisualization
               value={Infinity}
               field="count()"
-              meta={{
-                type: 'number',
-                unit: null,
-              }}
+              type="number"
+              unit={null}
             />
           }
         />
@@ -40,10 +38,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={'2024-10-17T16:08:07+00:00'}
           field="max(timestamp)"
-          meta={{
-            type: 'date',
-            unit: null,
-          }}
+          type="date"
+          unit={null}
         />
       );
 
@@ -55,10 +51,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={'/api/0/fetch'}
           field="any(transaction)"
-          meta={{
-            type: 'string',
-            unit: null,
-          }}
+          type="string"
+          unit={null}
         />
       );
 
@@ -70,10 +64,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={17.28}
           field="p95(span.duration)"
-          meta={{
-            type: 'duration',
-            unit: DurationUnit.MILLISECOND,
-          }}
+          type="duration"
+          unit={DurationUnit.MILLISECOND}
         />
       );
 
@@ -85,10 +77,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={178451214}
           field="count()"
-          meta={{
-            type: 'integer',
-            unit: null,
-          }}
+          type="integer"
+          unit={null}
         />
       );
 
@@ -103,10 +93,8 @@ describe('BigNumberWidgetVisualization', () => {
           value={178451214}
           field="count()"
           maximumValue={100000000}
-          meta={{
-            type: 'integer',
-            unit: null,
-          }}
+          type="integer"
+          unit={null}
         />
       );
 
@@ -121,10 +109,8 @@ describe('BigNumberWidgetVisualization', () => {
           value={0.14227123}
           previousPeriodValue={0.1728139}
           field="http_response_code_rate(500)"
-          meta={{
-            type: 'percentage',
-            unit: null,
-          }}
+          type="percentage"
+          unit={null}
         />
       );
 
@@ -139,10 +125,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={14.227123}
           field="eps()"
-          meta={{
-            type: 'rate',
-            unit: RateUnit.PER_SECOND,
-          }}
+          type="rate"
+          unit={RateUnit.PER_SECOND}
           thresholds={{
             max_values: {
               max1: 10,
@@ -164,10 +148,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={135} //  2.25/s
           field="mystery_error_rate()"
-          meta={{
-            type: 'rate',
-            unit: RateUnit.PER_MINUTE,
-          }}
+          type="rate"
+          unit={RateUnit.PER_MINUTE}
           thresholds={{
             max_values: {
               max1: 2,
@@ -186,10 +168,8 @@ describe('BigNumberWidgetVisualization', () => {
         <BigNumberWidgetVisualization
           value={135}
           field="mystery_error_rate()"
-          meta={{
-            type: 'rate',
-            unit: RateUnit.PER_SECOND,
-          }}
+          type="rate"
+          unit={RateUnit.PER_SECOND}
           thresholds={{
             max_values: {
               max1: 200,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
@@ -9,7 +9,7 @@ import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 
-import type {Meta} from '../common/types';
+import type {TimeSeriesMeta} from '../common/types';
 
 import {BigNumberWidgetVisualization} from './bigNumberWidgetVisualization';
 
@@ -221,7 +221,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
   });
 
   story('Thresholds', () => {
-    const meta: Meta = {
+    const meta: TimeSeriesMeta = {
       type: 'rate',
       unit: RateUnit.PER_SECOND,
     };

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
@@ -9,8 +9,6 @@ import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 
-import type {TimeSeriesMeta} from '../common/types';
-
 import {BigNumberWidgetVisualization} from './bigNumberWidgetVisualization';
 
 export default storyBook('BigNumberWidgetVisualization', story => {
@@ -62,10 +60,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               <BigNumberWidgetVisualization
                 value={0.01087819860850493}
                 field="eps()"
-                meta={{
-                  type: 'rate',
-                  unit: RateUnit.PER_SECOND,
-                }}
+                type="rate"
+                unit={RateUnit.PER_SECOND}
                 thresholds={{
                   max_values: {
                     max1: 1,
@@ -81,10 +77,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               <BigNumberWidgetVisualization
                 value={178451214}
                 field="count()"
-                meta={{
-                  type: 'integer',
-                  unit: null,
-                }}
+                type="integer"
+                unit={null}
               />
             </Container>
           </SmallSizingWindow>
@@ -93,10 +87,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               <BigNumberWidgetVisualization
                 value={17.28}
                 field="p95(span.duration)"
-                meta={{
-                  type: 'duration',
-                  unit: DurationUnit.MILLISECOND,
-                }}
+                type="duration"
+                unit={DurationUnit.MILLISECOND}
               />
             </Container>
           </SmallSizingWindow>
@@ -105,10 +97,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               <BigNumberWidgetVisualization
                 value={'2024-10-17T16:08:07+00:00'}
                 field="max(timestamp)"
-                meta={{
-                  type: 'date',
-                  unit: null,
-                }}
+                type="date"
+                unit={null}
               />
             </Container>
           </SmallSizingWindow>
@@ -150,10 +140,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               value={1000000}
               field="count()"
               maximumValue={1000000}
-              meta={{
-                type: 'integer',
-                unit: null,
-              }}
+              type="integer"
+              unit={null}
             />
           </SmallWidget>
         </SideBySide>
@@ -184,10 +172,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               value={17.1087819860850493}
               field="eps()"
               previousPeriodValue={15.0088607819850493}
-              meta={{
-                type: 'rate',
-                unit: RateUnit.PER_SECOND,
-              }}
+              type="rate"
+              unit={RateUnit.PER_SECOND}
             />
           </SmallWidget>
 
@@ -197,10 +183,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               previousPeriodValue={0.1728139}
               field="http_rate(500)"
               preferredPolarity="-"
-              meta={{
-                type: 'percentage',
-                unit: null,
-              }}
+              type="percentage"
+              unit={null}
             />
           </SmallWidget>
           <SmallWidget>
@@ -209,10 +193,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               value={0.14227123}
               previousPeriodValue={0.1728139}
               preferredPolarity="+"
-              meta={{
-                type: 'percentage',
-                unit: null,
-              }}
+              type="percentage"
+              unit={null}
             />
           </SmallWidget>
         </SideBySide>
@@ -221,10 +203,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
   });
 
   story('Thresholds', () => {
-    const meta: TimeSeriesMeta = {
-      type: 'rate',
-      unit: RateUnit.PER_SECOND,
-    };
+    const type = 'rate' as const;
+    const unit = RateUnit.PER_SECOND;
 
     const thresholds = {
       max_values: {
@@ -248,7 +228,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               value={7.1}
               field="eps()"
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="+"
             />
@@ -258,7 +239,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               value={27.781}
               field="eps()"
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="-"
             />
@@ -268,7 +250,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               field="eps()"
               value={78.1}
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="+"
             />
@@ -285,7 +268,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               field="eps()"
               value={7.1}
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="-"
             />
@@ -295,7 +279,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               field="eps()"
               value={27.781}
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="-"
             />
@@ -305,7 +290,8 @@ export default storyBook('BigNumberWidgetVisualization', story => {
             <BigNumberWidgetVisualization
               field="eps()"
               value={78.1}
-              meta={meta}
+              type={type}
+              unit={unit}
               thresholds={thresholds}
               preferredPolarity="-"
             />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -23,13 +23,13 @@ import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface BigNumberWidgetVisualizationProps {
   field: string;
-  unit: TabularValueUnit;
   value: number | string;
   maximumValue?: number;
   preferredPolarity?: Polarity;
   previousPeriodValue?: number | string;
   thresholds?: Thresholds;
   type?: TabularValueType;
+  unit?: TabularValueUnit;
 }
 
 export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualizationProps) {

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -10,9 +10,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodValue} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue';
 import type {
-  Meta,
   TableData,
   Thresholds,
+  TimeSeriesMeta,
 } from 'sentry/views/dashboards/widgets/common/types';
 
 import {NON_FINITE_NUMBER_MESSAGE} from '../common/settings';
@@ -24,7 +24,7 @@ export interface BigNumberWidgetVisualizationProps {
   field: string;
   value: number | string;
   maximumValue?: number;
-  meta?: Meta;
+  meta?: TimeSeriesMeta;
   preferredPolarity?: Polarity;
   previousPeriodValue?: number | string;
   thresholds?: Thresholds;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -11,8 +11,9 @@ import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodValue} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue';
 import type {
   TabularRow,
+  TabularValueType,
+  TabularValueUnit,
   Thresholds,
-  TimeSeriesMeta,
 } from 'sentry/views/dashboards/widgets/common/types';
 
 import {NON_FINITE_NUMBER_MESSAGE} from '../common/settings';
@@ -22,12 +23,13 @@ import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface BigNumberWidgetVisualizationProps {
   field: string;
+  unit: TabularValueUnit;
   value: number | string;
   maximumValue?: number;
-  meta?: TimeSeriesMeta;
   preferredPolarity?: Polarity;
   previousPeriodValue?: number | string;
   thresholds?: Thresholds;
+  type?: TabularValueType;
 }
 
 export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualizationProps) {
@@ -37,7 +39,8 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
     previousPeriodValue,
     maximumValue = Number.MAX_VALUE,
     preferredPolarity,
-    meta,
+    type,
+    unit,
   } = props;
 
   if ((typeof value === 'number' && !Number.isFinite(value)) || Number.isNaN(value)) {
@@ -46,9 +49,6 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
 
   const location = useLocation();
   const organization = useOrganization();
-
-  const unit = meta?.unit;
-  const type = meta?.type;
 
   // Create old-school renderer meta, so we can pass it to field renderers
   const rendererMeta: MetaType = {
@@ -63,9 +63,7 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
     };
   }
 
-  const fieldRenderer = meta
-    ? getFieldRenderer(field, rendererMeta, false)
-    : (renderableValue: any) => renderableValue.toString();
+  const fieldRenderer = getFieldRenderer(field, rendererMeta, false);
 
   const baggage = {
     location,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -10,7 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodValue} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue';
 import type {
-  TableData,
+  TabularRow,
   Thresholds,
   TimeSeriesMeta,
 } from 'sentry/views/dashboards/widgets/common/types';
@@ -140,7 +140,7 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
               previousPeriodValue={previousPeriodValue}
               field={field}
               preferredPolarity={preferredPolarity}
-              renderer={(previousDatum: TableData[number]) =>
+              renderer={(previousDatum: TabularRow) =>
                 fieldRenderer(previousDatum, baggage)
               }
             />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
@@ -13,13 +13,13 @@ import {
   DEEMPHASIS_COLOR_NAME,
   LOADING_PLACEHOLDER,
 } from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
-import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
+import type {TabularRow} from 'sentry/views/dashboards/widgets/common/types';
 
 import {DEFAULT_FIELD} from '../common/settings';
 
 interface DifferenceToPreviousPeriodValueProps {
   previousPeriodValue: number;
-  renderer: (datum: TableData[number]) => React.ReactNode;
+  renderer: (datum: TabularRow) => React.ReactNode;
   value: number;
   field?: string;
   preferredPolarity?: Polarity;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -53,6 +53,7 @@ export type TabularMeta = {
 };
 
 export type TabularRow = Record<string, number | string | undefined>;
+
 export type TabularData = {
   data: TabularRow[];
   meta: TabularMeta;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -18,7 +18,7 @@ export type TimeSeriesValueType =
 
 export type TimeSeriesValueUnit = DataUnit | null;
 
-export type Meta = {
+export type TimeSeriesMeta = {
   type: TimeSeriesValueType;
   unit: TimeSeriesValueUnit;
   isOther?: boolean;
@@ -36,7 +36,7 @@ export type TimeSeriesItem = {
 export type TimeSeries = {
   data: TimeSeriesItem[];
   field: string;
-  meta: Meta;
+  meta: TimeSeriesMeta;
   confidence?: Confidence;
   sampleCount?: AccuracyStats<number>;
   samplingRate?: AccuracyStats<number | null>;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -3,7 +3,7 @@ import type {DataUnit} from 'sentry/utils/discover/fields';
 
 import type {ThresholdsConfig} from '../../widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
-export type TimeSeriesValueType =
+type AttributeValueType =
   | 'number'
   | 'integer'
   | 'date'
@@ -16,16 +16,15 @@ export type TimeSeriesValueType =
   | 'rate'
   | null;
 
-export type TimeSeriesValueUnit = DataUnit | null;
+type AttributeValueUnit = DataUnit | null;
 
+export type TimeSeriesValueType = AttributeValueType;
+export type TimeSeriesValueUnit = AttributeValueUnit;
 export type TimeSeriesMeta = {
   type: TimeSeriesValueType;
   unit: TimeSeriesValueUnit;
   isOther?: boolean;
 };
-
-type TableRow = Record<string, number | string | undefined>;
-export type TableData = TableRow[];
 
 export type TimeSeriesItem = {
   timestamp: string;
@@ -40,6 +39,23 @@ export type TimeSeries = {
   confidence?: Confidence;
   sampleCount?: AccuracyStats<number>;
   samplingRate?: AccuracyStats<number | null>;
+};
+
+export type TabularValueType = AttributeValueType;
+export type TabularValueUnit = AttributeValueUnit;
+export type TabularMeta = {
+  fields: {
+    [key: string]: TabularValueType;
+  };
+  units: {
+    [key: string]: TabularValueUnit;
+  };
+};
+
+export type TabularRow = Record<string, number | string | undefined>;
+export type TabularData = {
+  data: TabularRow[];
+  meta: TabularMeta;
 };
 
 export type ErrorProp = Error | string;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -14,7 +14,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {shiftTimeSeriesToNow} from 'sentry/utils/timeSeries/shiftTimeSeriesToNow';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 
-import type {LegendSelection, Meta, Release, TimeSeries} from '../common/types';
+import type {LegendSelection, Release, TimeSeries, TimeSeriesMeta} from '../common/types';
 
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
 import {sampleThroughputTimeSeries} from './fixtures/sampleThroughputTimeSeries';
@@ -640,7 +640,7 @@ function hasTimestamp(release: Partial<Release>): release is Release {
   return Boolean(release?.timestamp);
 }
 
-const NULL_META: Meta = {
+const NULL_META: TimeSeriesMeta = {
   type: null,
   unit: null,
 };

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
@@ -184,10 +184,8 @@ export function ProjectAnrScoreCard({
           previousPeriodValue={previousValue ?? undefined}
           field="anr_rate()"
           preferredPolarity="-"
-          meta={{
-            type: 'percentage',
-            unit: null,
-          }}
+          type="percentage"
+          unit={null}
         />
       }
     />

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -168,10 +168,8 @@ function ProjectApdexScoreCard(props: Props) {
           value={apdex}
           previousPeriodValue={previousApdex}
           field="apdex()"
-          meta={{
-            type: 'number',
-            unit: null,
-          }}
+          type="number"
+          unit={null}
           preferredPolarity="+"
         />
       }

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -195,10 +195,8 @@ function ProjectStabilityScoreCard(props: Props) {
           value={score / 100}
           previousPeriodValue={previousScore ? previousScore / 100 : undefined}
           field={`${props.field}()`}
-          meta={{
-            type: 'percentage',
-            unit: null,
-          }}
+          type="percentage"
+          unit={null}
           preferredPolarity="+"
         />
       }

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -207,10 +207,8 @@ function ProjectVelocityScoreCard(props: Props) {
           previousPeriodValue={previousReleases?.length}
           field="count()"
           maximumValue={API_LIMIT}
-          meta={{
-            type: 'number',
-            unit: null,
-          }}
+          type="number"
+          unit={null}
           preferredPolarity="+"
         />
       }


### PR DESCRIPTION
Making room for incoming work with tabular data (table widgets, and sample time series). Right now there's just one type called `Meta`, but that type describes _time series meta_ which is different from table meta. This PR splits up the types, and creates explicit new types for tabular data.

This immediately causes something weird: `BigNumberWidgetVisualization` accepts time series meta? That's bizarre. Instead, simplify the component's API to not take meta at all, and instead accept a type and a unit.
