### PR TITLE
ref(symbolication): Improve Electron minidump detection

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -323,7 +323,10 @@ def process_minidump(symbolicator: Symbolicator, data: Any) -> Any:
 
     # We do module rewriting only for Electron minidumps.
     # See the documentation of `ELECTRON_FIRST_MODULE_REWRITE_RULES`.
-    if get_path(data, "sdk", "name") == "sentry.javascript.electron":
+    #
+    # Electron minidumps can be detected via the "prod" key in the
+    # "crashpad" context.
+    if get_path(data, "contexts", "crashpad", "prod") == "Electron":
         rewrite_first_module = ELECTRON_FIRST_MODULE_REWRITE_RULES
     else:
         rewrite_first_module = []


### PR DESCRIPTION
Previously we tried to detect Electron minidumps by checking the SDK name, but in practice Electron minidumps reach us that don't have an SDK name set (likely because they are sent into Relay's minidump endpoint).

However, we can instead use the `"crashpad"` context, which is populated during initial minidump processing in Relay, and check that the `"prod"` key is set to `"Electron"`. This value is populated by Crashpad client- side and doesn't depend on how the minidump winds up at Sentry.