### PR TITLE
feat(releases): Remove hover effect w/ release bubbles

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -268,13 +268,6 @@ function ReleaseBubbleSeries({
         // TODO: figure out correct opacity calculations
         opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
       },
-      emphasis: {
-        style: {
-          opacity: 1,
-          stroke: 'transparent',
-          fill: theme.blue400,
-        },
-      },
     } satisfies CustomSeriesRenderItemReturn;
   };
 


### PR DESCRIPTION
This hover effect made it confusing for bubbles w/ 0 releases as it looks like there are releases since the hover effect turned a blank bubble into a blue bubble. There already exists 2 other hover effects (highlight area + tooltips), so removing the bubble hover effect will be ok.
