### PR TITLE
feat(releases): Add a line at y=0 for charts w/ release bubbles

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -285,6 +285,20 @@ function ReleaseBubbleSeries({
     name: t('Releases'),
     data,
     color: theme.blue300,
+    markLine: {
+      silent: true,
+      symbol: 'none',
+      label: {
+        show: false,
+      },
+      lineStyle: {
+        color: theme.gray300,
+        opacity: 0.5,
+        type: 'solid',
+        width: 1,
+      },
+      data: [{yAxis: 0}],
+    },
     tooltip: {
       trigger: 'item',
       position: 'bottom',


### PR DESCRIPTION
With release bubbles we moved the x-axis to be below the release bubbles, however this means we don't have an axis line for y=0. This adds a line there when we have release bubbles.


![image](https://github.com/user-attachments/assets/e4db32ff-29b6-464b-ac1c-d41e5c7566fd)
