### PR TITLE
input: remove legacy form input export

### DIFF
--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -88,8 +88,6 @@ const StyledInput = styled(
   forwardRef<HTMLInputElement, InputProps>(
     (
       {
-        // Do not forward `required` to avoid default browser behavior
-        required: _required,
         // Do not forward `size` since it's used for custom styling, not as the
         // native `size` attribute (for that, use `nativeSize` instead)
         size: _size,
@@ -109,37 +107,6 @@ const StyledInput = styled(
 export const Input = styled(
   forwardRef<HTMLInputElement, InputProps>((props: InputProps, ref) => (
     <StyledInput {...props} ref={ref} />
-  ))
-)`
-  ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}
-`;
-
-/**
- * @deprecated Use `Input` instead, this should only be used in the old deprecated forms
- */
-const LegacyFormInput = styled(
-  forwardRef<HTMLInputElement, InputProps>(
-    (
-      {
-        // Do not forward `size` since it's used for custom styling, not as the
-        // native `size` attribute (for that, use `nativeSize` instead)
-        size: _size,
-        // Use `nativeSize` as the native `size` attribute
-        nativeSize,
-        ...props
-      },
-      ref
-    ) => <input {...props} ref={ref} size={nativeSize} />
-  ),
-  {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
-)``;
-
-/**
- * @deprecated Use `Input` instead, this should only be used in the old deprecated forms
- */
-export const DO_NOT_USE_LegacyFormInput = styled(
-  forwardRef<HTMLInputElement, InputProps>((props: InputProps, ref) => (
-    <LegacyFormInput {...props} ref={ref} />
   ))
 )`
   ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}

--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -70,10 +70,7 @@ const inputStyles = (p: InputStylesProps & {theme: Theme}) => css`
 `;
 
 export interface InputProps
-  extends Omit<
-      React.InputHTMLAttributes<HTMLInputElement>,
-      'size' | 'readOnly' | 'required'
-    >,
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>,
     InputStylesProps {}
 
 /**

--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -7,6 +7,48 @@ import styled from '@emotion/styled';
 import {chonkInputStyles} from 'sentry/components/core/input/index.chonk';
 import type {FormSize} from 'sentry/utils/theme';
 
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>,
+    InputStylesProps {}
+
+/**
+ * Basic input component.
+ *
+ * Use the `size` prop ('md', 'sm', 'xs') to control the input's height &
+ * padding. To use the native size attribute (which controls the number of
+ * characters the input should fit), use the `nativeSize` prop instead.
+ *
+ * To add leading/trailing items (e.g. a search icon on the left side), use
+ * InputControl (components/inputControl) instead.
+ */
+const StyledInput = styled(
+  forwardRef<HTMLInputElement, InputProps>(
+    (
+      {
+        // Do not forward `size` since it's used for custom styling, not as the
+        // native `size` attribute (for that, use `nativeSize` instead)
+        size: _size,
+        // Use `nativeSize` as the native `size` attribute
+        nativeSize,
+        ...props
+      },
+      ref
+    ) => <input {...props} ref={ref} size={nativeSize} />
+  ),
+  {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
+)``;
+
+// This is a hack - emotion does not support overriding the shouldForwardProp
+// for styled components, but if we wrap it inside another component, we can
+// prevent it from doing that while still applying the styles.
+export const Input = styled(
+  forwardRef<HTMLInputElement, InputProps>((props: InputProps, ref) => (
+    <StyledInput {...props} ref={ref} />
+  ))
+)`
+  ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}
+`;
+
 export interface InputStylesProps {
   monospace?: boolean;
   nativeSize?: React.InputHTMLAttributes<HTMLInputElement>['size'];
@@ -67,47 +109,4 @@ const inputStyles = (p: InputStylesProps & {theme: Theme}) => css`
     -webkit-appearance: none;
     margin: 0;
   }
-`;
-
-export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>,
-    InputStylesProps {}
-
-/**
- * Basic input component.
- *
- * Use the `size` prop ('md', 'sm', 'xs') to control the input's height &
- * padding. To use the native size attribute (which controls the number of
- * characters the input should fit), use the `nativeSize` prop instead.
- *
- * To add leading/trailing items (e.g. a search icon on the left side), use
- * InputControl (components/inputControl) instead.
- */
-
-const StyledInput = styled(
-  forwardRef<HTMLInputElement, InputProps>(
-    (
-      {
-        // Do not forward `size` since it's used for custom styling, not as the
-        // native `size` attribute (for that, use `nativeSize` instead)
-        size: _size,
-        // Use `nativeSize` as the native `size` attribute
-        nativeSize,
-        ...props
-      },
-      ref
-    ) => <input {...props} ref={ref} size={nativeSize} />
-  ),
-  {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
-)``;
-
-// This is a hack - emotion does not support overriding the shouldForwardProp
-// for styled components, but if we wrap it inside another component, we can
-// prevent it from doing that while still applying the styles.
-export const Input = styled(
-  forwardRef<HTMLInputElement, InputProps>((props: InputProps, ref) => (
-    <StyledInput {...props} ref={ref} />
-  ))
-)`
-  ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}
 `;

--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -70,7 +70,10 @@ const inputStyles = (p: InputStylesProps & {theme: Theme}) => css`
 `;
 
 export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>,
+  extends Omit<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      'size' | 'readOnly' | 'required'
+    >,
     InputStylesProps {}
 
 /**

--- a/static/app/components/customIgnoreDurationModal.tsx
+++ b/static/app/components/customIgnoreDurationModal.tsx
@@ -7,6 +7,7 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import ButtonBar from 'sentry/components/buttonBar';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Input} from 'sentry/components/core/input';
 import {t} from 'sentry/locale';
 import type {IgnoredStatusDetails} from 'sentry/types/group';
 
@@ -71,7 +72,7 @@ export default function CustomIgnoreDurationModal(props: Props) {
         <form className="form-horizontal">
           <div className="control-group">
             <h6 className="nav-header">{t('Date')}</h6>
-            <input
+            <Input
               className="form-control"
               type="date"
               id="snooze-until-date"
@@ -83,7 +84,7 @@ export default function CustomIgnoreDurationModal(props: Props) {
           </div>
           <div className="control-group m-b-1">
             <h6 className="nav-header">{t('Time (UTC)')}</h6>
-            <input
+            <Input
               className="form-control"
               type="time"
               id="snooze-until-time"

--- a/static/app/components/deprecatedforms/inputField.tsx
+++ b/static/app/components/deprecatedforms/inputField.tsx
@@ -1,4 +1,4 @@
-import {DO_NOT_USE_LegacyFormInput} from 'sentry/components/core/input';
+import {Input} from 'sentry/components/core/input';
 import FormField from 'sentry/components/deprecatedforms/formField';
 
 type InputFieldProps = FormField['props'] & {
@@ -24,7 +24,7 @@ abstract class InputField<
 > extends FormField<Props, State> {
   getField() {
     return (
-      <DO_NOT_USE_LegacyFormInput
+      <Input
         id={this.getId()} // TODO(Priscila): check the reason behind this. We are getting warnings if we have 2 or more fields with the same name, for instance in the DATA PRIVACY RULES
         type={this.getType()}
         className="form-control"
@@ -33,7 +33,6 @@ abstract class InputField<
         onChange={this.onChange}
         disabled={this.props.disabled}
         name={this.props.name}
-        required={this.props.required}
         value={this.state.value as string | number} // can't pass in boolean here
         style={this.props.inputStyle}
         onBlur={this.props.onBlur}

--- a/static/app/components/deprecatedforms/inputField.tsx
+++ b/static/app/components/deprecatedforms/inputField.tsx
@@ -32,6 +32,7 @@ abstract class InputField<
         placeholder={this.props.placeholder}
         onChange={this.onChange}
         disabled={this.props.disabled}
+        required={this.props.required}
         name={this.props.name}
         value={this.state.value as string | number} // can't pass in boolean here
         style={this.props.inputStyle}

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -194,7 +194,6 @@ export function AutofixOutputStream({
                 placeholder={
                   responseRequired ? 'Please answer to continue...' : 'Interrupt me...'
                 }
-                required={responseRequired}
               />
               <StyledButton
                 type="submit"

--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -212,6 +212,8 @@ function RangeSlider({
               value={sliderValue}
               onChange={handleCustomInputChange}
               onBlur={handleInput}
+              // Do not forward required to avoid default browser behavior
+              required={undefined}
             />
           )}
         </SliderAndInputWrapper>

--- a/static/app/components/forms/fields/datePickerField.tsx
+++ b/static/app/components/forms/fields/datePickerField.tsx
@@ -14,7 +14,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps, OnEvent} from './inputField';
 
-interface DatePickerFieldProps extends Omit<InputFieldProps, 'field'> {}
+interface DatePickerFieldProps extends Omit<InputFieldProps, 'field' | 'required'> {}
 
 function handleChangeDate(
   onChange: OnEvent,
@@ -55,6 +55,8 @@ export default function DatePickerField(props: DatePickerFieldProps) {
                 size={size}
                 value={dateString}
                 readOnly
+                // Do not forward required to avoid default browser behavior
+                required={undefined}
               />
               <StyledIconCalendar inputSize={size} size={size === 'xs' ? 'xs' : 'sm'} />
             </InputWrapper>

--- a/static/app/components/forms/fields/datePickerField.tsx
+++ b/static/app/components/forms/fields/datePickerField.tsx
@@ -14,7 +14,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps, OnEvent} from './inputField';
 
-interface DatePickerFieldProps extends Omit<InputFieldProps, 'field' | 'required'> {}
+interface DatePickerFieldProps extends Omit<InputFieldProps, 'field'> {}
 
 function handleChangeDate(
   onChange: OnEvent,

--- a/static/app/components/forms/fields/fileField.tsx
+++ b/static/app/components/forms/fields/fileField.tsx
@@ -11,8 +11,7 @@ import {t} from 'sentry/locale';
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps} from './inputField';
 
-export interface FileFieldProps
-  extends Omit<InputFieldProps, 'type' | 'accept' | 'required'> {
+export interface FileFieldProps extends Omit<InputFieldProps, 'type' | 'accept'> {
   accept?: string[];
   // TODO(dcramer): multiple is native to the file input type, but not yet supported
   // multiple?: boolean;

--- a/static/app/components/forms/fields/fileField.tsx
+++ b/static/app/components/forms/fields/fileField.tsx
@@ -11,7 +11,8 @@ import {t} from 'sentry/locale';
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps} from './inputField';
 
-export interface FileFieldProps extends Omit<InputFieldProps, 'type' | 'accept'> {
+export interface FileFieldProps
+  extends Omit<InputFieldProps, 'type' | 'accept' | 'required'> {
   accept?: string[];
   // TODO(dcramer): multiple is native to the file input type, but not yet supported
   // multiple?: boolean;
@@ -82,6 +83,8 @@ export default function FileField({accept, hideControlState, ...props}: FileFiel
               name={name}
               accept={accept?.join(', ')}
               onChange={e => handleFile(model, name, onChange, e)}
+              // Do not forward required to `input` to avoid default browser behavior
+              required={undefined}
             />
             {!hideControlState && (
               <InputGroup.TrailingItems disablePointerEvents>

--- a/static/app/components/forms/fields/inputField.tsx
+++ b/static/app/components/forms/fields/inputField.tsx
@@ -18,7 +18,6 @@ export interface InputFieldProps
       | 'children'
       | 'name'
       | 'defaultValue'
-      | 'required'
     > {
   // TODO(ts) Add base types for this. Each input field
   // has different props, but we could use have a base type that contains

--- a/static/app/components/forms/fields/inputField.tsx
+++ b/static/app/components/forms/fields/inputField.tsx
@@ -18,6 +18,7 @@ export interface InputFieldProps
       | 'children'
       | 'name'
       | 'defaultValue'
+      | 'required'
     > {
   // TODO(ts) Add base types for this. Each input field
   // has different props, but we could use have a base type that contains
@@ -52,6 +53,8 @@ function defaultField({
         onChange={e => onChange(e.target.value, e)}
         name={name}
         {...rest}
+        // Do not forward required to `input` to avoid default browser behavior
+        required={undefined}
       />
       {!hideControlState && (
         <InputGroup.TrailingItems>

--- a/static/app/components/forms/fields/numberField.tsx
+++ b/static/app/components/forms/fields/numberField.tsx
@@ -11,7 +11,7 @@ import {space} from 'sentry/styles/space';
 import type {InputFieldProps, OnEvent} from './inputField';
 import InputField from './inputField';
 
-export interface NumberFieldProps extends Omit<InputFieldProps, 'type'> {
+export interface NumberFieldProps extends Omit<InputFieldProps, 'type' | 'required'> {
   /**
    * Optional units/suffix to render inside the number input
    */
@@ -66,6 +66,8 @@ function createFieldWithSuffix({suffix}: {suffix: React.ReactNode}) {
           onChange={e => onChange(e.target.value, e)}
           name={name}
           {...rest}
+          // Do not forward required to `input` to avoid default browser behavior
+          required={undefined}
         />
         <SuffixWrapper {...{size, monospace, alignRight}}>
           <HiddenValue aria-hidden>{rest.value || rest.placeholder}</HiddenValue>

--- a/static/app/components/forms/fields/numberField.tsx
+++ b/static/app/components/forms/fields/numberField.tsx
@@ -11,7 +11,7 @@ import {space} from 'sentry/styles/space';
 import type {InputFieldProps, OnEvent} from './inputField';
 import InputField from './inputField';
 
-export interface NumberFieldProps extends Omit<InputFieldProps, 'type' | 'required'> {
+export interface NumberFieldProps extends Omit<InputFieldProps, 'type'> {
   /**
    * Optional units/suffix to render inside the number input
    */

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -29,7 +29,7 @@ interface DefaultProps {
   allowEmpty: boolean;
 }
 
-export interface TableFieldProps extends Omit<InputFieldProps, 'type'> {}
+export interface TableFieldProps extends Omit<InputFieldProps, 'type' | 'required'> {}
 
 interface RenderProps extends TableFieldProps, DefaultProps, Omit<TableType, 'type'> {}
 
@@ -151,6 +151,8 @@ export default class TableField extends Component<InputFieldProps> {
                   <Input
                     onChange={v => setValue(rowIndex, fieldKey, v)}
                     value={defined(row[fieldKey]) ? row[fieldKey] : ''}
+                    // Do not forward required to `input` to avoid default browser behavior
+                    required={undefined}
                   />
                 </RowInput>
                 {i === mappedKeys.length - 1 && (

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -29,7 +29,7 @@ interface DefaultProps {
   allowEmpty: boolean;
 }
 
-export interface TableFieldProps extends Omit<InputFieldProps, 'type' | 'required'> {}
+export interface TableFieldProps extends Omit<InputFieldProps, 'type'> {}
 
 interface RenderProps extends TableFieldProps, DefaultProps, Omit<TableType, 'type'> {}
 

--- a/static/app/components/forms/fields/textareaField.tsx
+++ b/static/app/components/forms/fields/textareaField.tsx
@@ -35,8 +35,9 @@ function TextareaField({
         <InputGroup>
           <InputGroup.TextArea
             {...{monospace, rows, autosize, name}}
-            // Do not forward required to `textarea` to avoid default browser behavior
-            {...omit(fieldProps, ['onKeyDown', 'children', 'required'])}
+            {...omit(fieldProps, ['onKeyDown', 'children'])}
+            // Do not forward required to avoid default browser behavior
+            required={undefined}
           />
           {!hideControlState && (
             <InputGroup.TrailingItems>

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -374,6 +374,8 @@ function FormField(props: FormFieldProps) {
                         typeof fieldProps.placeholder === 'function'
                           ? fieldProps.placeholder({...props, model})
                           : fieldProps.placeholder,
+                      // !! Do not forward `required` to avoid default browser behavior !!
+                      required: undefined,
                     })}
                   </Fragment>
                 );

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -374,8 +374,6 @@ function FormField(props: FormFieldProps) {
                         typeof fieldProps.placeholder === 'function'
                           ? fieldProps.placeholder({...props, model})
                           : fieldProps.placeholder,
-                      // !! Do not forward `required` to avoid default browser behavior !!
-                      required: undefined,
                     })}
                   </Fragment>
                 );

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
@@ -87,7 +87,6 @@ export default function ActionTargetSelector(props: Props) {
           type="text"
           autoComplete="off"
           disabled={disabled}
-          required={action.type === 'discord'} // Only required for discord channel ID
           key={action.type}
           value={action.targetIdentifier || ''}
           onChange={handleChangeSpecificTargetIdentifier}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -180,7 +180,6 @@ export function SortBySelectors({
           <ArithmeticInput
             name="arithmetic"
             type="text"
-            required
             placeholder={t('Enter Equation')}
             value={getEquation(customEquation.sortBy)}
             onUpdate={value => {

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -33,7 +33,7 @@ function WidgetBuilderNameAndDescription({
   return (
     <Fragment>
       <SectionHeader title={t('Widget Name & Description')} />
-      <StyledInput
+      <StyledTextField
         name={t('Widget Name')}
         size="md"
         placeholder={t('Name')}
@@ -101,7 +101,7 @@ function WidgetBuilderNameAndDescription({
 
 export default WidgetBuilderNameAndDescription;
 
-const StyledInput = styled(TextField)`
+const StyledTextField = styled(TextField)`
   margin-bottom: ${space(1)};
   padding: 0;
   border: none;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/aggregateParameterField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/aggregateParameterField.tsx
@@ -19,7 +19,6 @@ export function AggregateParameterField({
 }) {
   if (parameter.kind === 'value') {
     const inputProps = {
-      required: parameter.required,
       value:
         currentValue ?? ('defaultValue' in parameter && parameter?.defaultValue) ?? '',
       onUpdate: (value: any) => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -576,7 +576,6 @@ function Visualize({error, setError}: VisualizeProps) {
                               name="arithmetic"
                               key="parameter:text"
                               type="text"
-                              required
                               value={field.field}
                               onUpdate={value => {
                                 dispatch({

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
@@ -105,7 +105,6 @@ function VisualizeGhostField({
               key="parameter:text"
               type="text"
               placeholder={t('Equation')}
-              required
               value={draggingField?.field ?? ''}
               onUpdate={() => {}}
             />

--- a/static/app/views/discover/table/arithmeticInput.spec.tsx
+++ b/static/app/views/discover/table/arithmeticInput.spec.tsx
@@ -34,7 +34,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -60,7 +59,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -94,7 +92,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -152,7 +149,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -174,7 +170,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -198,7 +193,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -220,7 +214,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -239,7 +232,6 @@ describe('ArithmeticInput', function () {
       <ArithmeticInput
         name="refinement"
         type="text"
-        required
         value=""
         onUpdate={() => {}}
         options={[]}

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -666,7 +666,6 @@ class _QueryField extends Component<Props> {
             name="arithmetic"
             key="parameter:text"
             type="text"
-            required
             value={fieldValue.field}
             onUpdate={this.handleEquationChange}
             options={otherColumns}

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -215,7 +215,6 @@ class TransactionThresholdModal extends Component<Props, State> {
           <Input
             type="number"
             name="threshold"
-            required
             pattern="[0-9]*(\.[0-9]*)?"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               this.handleFieldChange('threshold')(event.target.value);

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -80,7 +80,6 @@ function GetStarted({relocationState, onUpdateRelocationState, onComplete}: Step
             onChange={evt => {
               onUpdateRelocationState({orgSlugs: evt.target.value});
             }}
-            required
             minLength={3}
             placeholder="org-slug-1, org-slug-2, ..."
             value={orgSlugs}

--- a/static/gsAdmin/views/debuggingTools.tsx
+++ b/static/gsAdmin/views/debuggingTools.tsx
@@ -62,7 +62,6 @@ function IssueOwnerDebbuging() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -72,7 +71,6 @@ function IssueOwnerDebbuging() {
             name="project-slug"
             onChange={e => setProjectSlug(e.target.value)}
             value={projectSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -83,7 +81,6 @@ function IssueOwnerDebbuging() {
             name="stacktrace-path"
             onChange={e => setStacktracePath(e.target.value)}
             value={stacktracePath}
-            required
             minLength={1}
             placeholder="/src/sentry/integrations/github/webhook.py"
           />
@@ -210,7 +207,6 @@ function IssueEscalatingDebugging() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -220,7 +216,6 @@ function IssueEscalatingDebugging() {
             name="group-id"
             onChange={e => setGroupId(e.target.value)}
             value={groupId}
-            required
             minLength={1}
             placeholder="1"
           />

--- a/static/gsAdmin/views/privateAPIs.tsx
+++ b/static/gsAdmin/views/privateAPIs.tsx
@@ -53,7 +53,6 @@ function ForceAutoAssignment() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -63,7 +62,6 @@ function ForceAutoAssignment() {
             name="group-list"
             onChange={e => setGroupIds(e.target.value)}
             value={groupIds}
-            required
             minLength={1}
             placeholder="1, 2, 3"
           />

--- a/static/gsAdmin/views/relocationCreate.tsx
+++ b/static/gsAdmin/views/relocationCreate.tsx
@@ -152,12 +152,11 @@ function RelocationForm() {
           type="text"
           name="owner"
           aria-label="owner-input"
-          required
           minLength={1}
           placeholder=""
         />
         <InputLabel>List of Organization Slugs</InputLabel>
-        <Input type="text" name="orgs" aria-label="orgs-input" required minLength={1} />
+        <Input type="text" name="orgs" aria-label="orgs-input" minLength={1} />
         <InputLabel>Promo Code (Optional)</InputLabel>
         <Input
           type="text"

--- a/static/gsApp/components/billingDetailsForm.tsx
+++ b/static/gsApp/components/billingDetailsForm.tsx
@@ -346,7 +346,6 @@ function BillingDetailsForm({
                   <Fragment>
                     <Input
                       id="addressLine1"
-                      required
                       name="addressLine1"
                       placeholder={t('Street address')}
                       maxLength={100}


### PR DESCRIPTION
Undoes changes and fixes the root cause of required prop not being forwarded inside form components
