### PR TITLE
feat(issue-details): Copy as markdown analytics

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -119,6 +119,12 @@ export type IssueEventParameters = {
   };
   'issue_details.copy_event_id_clicked': StreamlineGroupEventParams;
   'issue_details.copy_event_link_clicked': StreamlineGroupEventParams;
+  'issue_details.copy_issue_details_as_markdown': {
+    groupId: string;
+    hasAutofix: boolean;
+    hasSummary: boolean;
+    eventId?: string;
+  };
   'issue_details.copy_issue_markdown_link_clicked': StreamlineGroupParams;
   'issue_details.copy_issue_short_id_clicked': StreamlineGroupParams;
   'issue_details.copy_issue_url_clicked': StreamlineGroupParams;
@@ -519,6 +525,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.header_view_replay_clicked': 'Issue Details: Header View Replay Clicked',
   'issue-details.replay-cta-dismiss': 'Issue Details Replay CTA Dismissed',
   'issue_group_details.anr_root_cause_detected': 'Detected ANR Root Cause',
+  'issue_details.copy_issue_details_as_markdown':
+    'Issue Details: Copy Issue Details as Markdown',
   'issue_details.external_issue_loaded': 'Issue Details: External Issue Loaded',
   'issue_details.external_issue_modal_opened':
     'Issue Details: External Issue Modal Opened',

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -1,5 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
@@ -14,6 +15,7 @@ import type {GroupSummaryData} from 'sentry/components/group/groupSummary';
 import * as groupSummaryHooks from 'sentry/components/group/groupSummary';
 import {EntryType} from 'sentry/types/event';
 import * as copyToClipboardModule from 'sentry/utils/useCopyToClipboard';
+import * as useOrganization from 'sentry/utils/useOrganization';
 import {
   issueAndEventToMarkdown,
   useCopyIssueDetails,
@@ -22,6 +24,7 @@ import {
 jest.mock('sentry/utils/useCopyToClipboard');
 
 describe('useCopyIssueDetails', () => {
+  const organization = OrganizationFixture();
   const group = GroupFixture();
   const event = EventFixture({
     id: '123456',
@@ -219,6 +222,7 @@ describe('useCopyIssueDetails', () => {
 
       jest.spyOn(indicators, 'addSuccessMessage').mockImplementation(() => {});
       jest.spyOn(indicators, 'addErrorMessage').mockImplementation(() => {});
+      jest.spyOn(useOrganization, 'default').mockReturnValue(organization);
     });
 
     it('sets up useCopyToClipboard with the correct parameters', () => {
@@ -229,6 +233,7 @@ describe('useCopyIssueDetails', () => {
         text: expect.any(String),
         successMessage: 'Copied issue to clipboard as Markdown',
         errorMessage: 'Could not copy issue to clipboard',
+        onCopy: expect.any(Function),
       });
     });
 


### PR DESCRIPTION
Log analytics for the markdown copy