### PR TITLE
fix(issue-details): Show opt-out button for enforce flag

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -62,21 +62,6 @@ describe('NewIssueExperienceButton', function () {
     unmountOptionFalse();
   });
 
-  it('does not appear when an organization has the enforce flag', function () {
-    render(
-      <div data-test-id="test-id">
-        <NewIssueExperienceButton />
-      </div>,
-      {
-        organization: {
-          ...organization,
-          features: [...organization.features, 'issue-details-streamline-enforce'],
-        },
-      }
-    );
-    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
-  });
-
   it('appears when organization has flag', function () {
     render(
       <div data-test-id="test-id">

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -57,9 +57,6 @@ export function NewIssueExperienceButton() {
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
-  const hasEnforceStreamlinedUIFlag = organization.features.includes(
-    'issue-details-streamline-enforce'
-  );
   const hasNewUIOnly = Boolean(organization.streamlineOnly);
 
   const openForm = useFeedbackForm();
@@ -168,11 +165,7 @@ export function NewIssueExperienceButton() {
       //  - The org does not have the opt-in flag
       //  - The org has the enforce flag
       //  - The org has the new UI only option
-      hidden:
-        !hasStreamlinedUI ||
-        !hasStreamlinedUIFlag ||
-        hasEnforceStreamlinedUIFlag ||
-        hasNewUIOnly,
+      hidden: !hasStreamlinedUI || !hasStreamlinedUIFlag || hasNewUIOnly,
       onAction: handleToggle,
     },
     {

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -163,7 +163,6 @@ export function NewIssueExperienceButton() {
       // Do not show the toggle out of the new UI if any of these are true:
       //  - The user is on the old UI
       //  - The org does not have the opt-in flag
-      //  - The org has the enforce flag
       //  - The org has the new UI only option
       hidden: !hasStreamlinedUI || !hasStreamlinedUIFlag || hasNewUIOnly,
       onAction: handleToggle,


### PR DESCRIPTION
this pr updates the new experience button to still allow opting out under the "enforce" flag. we are using that flag to opt people into the experience, but we still want to give them a way to opt out if they want.