### PR TITLE
ref(tsc): Convert Discover homepage to FC + useApiQuery

### DIFF
--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -277,11 +277,11 @@ describe('Discover > Homepage', () => {
       {router: initialData.router, organization: initialData.organization}
     );
 
-    expect(mockHomepage).toHaveBeenCalled();
-    expect(screen.getByRole('button', {name: /set as default/i})).toBeDisabled();
     await waitFor(() => {
-      expect(measurementsMetaMock).toHaveBeenCalled();
+      expect(screen.getByRole('button', {name: /set as default/i})).toBeDisabled();
     });
+
+    expect(measurementsMetaMock).toHaveBeenCalled();
   });
 
   it('follows absolute date selection', async () => {

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -282,9 +282,9 @@ export function getSavedQueryDataset(
   return SavedQueryDatasets.DISCOVER;
 }
 
-export function getSavedQueryWithDataset(
-  savedQuery?: SavedQuery | NewQuery
-): SavedQuery | NewQuery | undefined {
+export function getSavedQueryWithDataset<T extends SavedQuery | NewQuery>(
+  savedQuery?: T
+): T | undefined {
   if (!savedQuery) {
     return undefined;
   }


### PR DESCRIPTION
Ref https://github.com/getsentry/frontend-tsc/issues/2

Mostly straightforward conversion, just a couple things to double check:

- `componentDidUpdate` was converted to a useEffect which seems to apply any default query that may have been fetched
- When a feature flag is on, `getSavedQueryWithDataset()` gets called to append a dataset property. This originally was set to the state, but I decided to keep the cache clean and annotate it afterward.