### PR TITLE
chore(traceview): tighten padding and reduce vertical space

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -76,5 +76,4 @@ const TraceTagsContainer = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(1)};
-  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -630,8 +630,7 @@ const IssuesWrapper = styled('div')`
   flex-direction: column;
   gap: ${space(0.75)};
   justify-content: left;
-  margin-bottom: ${space(1.5)};
-  margin-top: ${space(1)};
+  margin: ${space(1)} 0;
 
   ${StyledPanel} {
     margin-bottom: 0;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -119,7 +119,7 @@ function Issue(props: IssueProps) {
       <LoadingIndicator size={24} mini />
     </StyledLoadingIndicatorWrapper>
   ) : fetchedIssue ? (
-    <StyledPanelItem hasNewLayout={hasNewLayout}>
+    <StyledPanelItem>
       <IconWrapper className={iconClassName}>
         <IconBackground className={iconClassName}>
           <TraceIcons.Icon event={props.issue} />
@@ -258,7 +258,7 @@ function LegacyIssue(
       <LoadingIndicator size={24} mini />
     </StyledLoadingIndicatorWrapper>
   ) : props.fetchedIssue ? (
-    <StyledLegacyPanelItem hasNewLayout={hasNewLayout}>
+    <StyledLegacyPanelItem>
       {hasNewLayout ? (
         <NarrowIssueSummaryWrapper>
           <EventOrGroupHeader data={props.fetchedIssue} organization={organization} />
@@ -653,7 +653,7 @@ const StyledLoadingIndicatorWrapper = styled('div')`
   justify-content: center;
   width: 100%;
   padding: ${space(2)} 0;
-  height: 84px;
+  min-height: 78px;
 
   /* Add a border between two rows of loading issue states */
   & + & {
@@ -716,29 +716,18 @@ const ChartWrapper = styled('div')`
   }
 `;
 
-const StyledLegacyPanelItem = styled(PanelItem)<{hasNewLayout: boolean}>`
+const StyledLegacyPanelItem = styled(PanelItem)`
   justify-content: space-between;
   align-items: center;
-  padding-top: ${p => (p.hasNewLayout ? '0px' : space(1))};
-  padding-bottom: ${p => (p.hasNewLayout ? '0px' : space(1))};
-  ${p =>
-    p.hasNewLayout
-      ? css`
-          padding: ${space(1)} 0;
-          min-height: 66px;
-          line-height: 1.1;
-        `
-      : css`
-          height: 84px;
-        `}
+  padding: ${space(1)} 0;
 `;
 
 const StyledPanelItem = styled(StyledLegacyPanelItem)`
   justify-content: left;
-  align-items: center;
-  gap: ${space(1.5)};
+  align-items: flex-start;
+  gap: ${space(1)};
   height: fit-content;
-  padding: ${space(1)} ${space(2)};
+  padding: ${space(1)} ${space(2)} ${space(1.5)} ${space(1)};
 `;
 
 const StyledIssueStreamHeaderLabel = styled(IssueStreamHeaderLabel)`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -653,7 +653,7 @@ const StyledLoadingIndicatorWrapper = styled('div')`
   justify-content: center;
   width: 100%;
   padding: ${space(2)} 0;
-  min-height: 78px;
+  min-height: 76px;
 
   /* Add a border between two rows of loading issue states */
   & + & {
@@ -720,6 +720,7 @@ const StyledLegacyPanelItem = styled(PanelItem)`
   justify-content: space-between;
   align-items: center;
   padding: ${space(1)} 0;
+  line-height: 1.1;
 `;
 
 const StyledPanelItem = styled(StyledLegacyPanelItem)`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -91,10 +91,9 @@ import {
 const BodyContainer = styled('div')<{hasNewTraceUi?: boolean}>`
   display: flex;
   flex-direction: column;
-  gap: ${p => (p.hasNewTraceUi ? 0 : space(2))};
-  padding: ${p => (p.hasNewTraceUi ? `${space(0.5)} ${space(2)}` : space(1))};
   height: calc(100% - 52px);
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   ${DataSection} {
     padding: 0;
@@ -104,7 +103,7 @@ const BodyContainer = styled('div')<{hasNewTraceUi?: boolean}>`
 const DetailContainer = styled('div')`
   height: 100%;
   overflow: hidden;
-  padding-bottom: ${space(1)};
+  margin: ${space(1)} ${space(2)};
 `;
 
 const FlexBox = styled('div')`
@@ -262,9 +261,7 @@ const HeaderContainer = styled(FlexBox)`
   align-items: baseline;
   justify-content: space-between;
   gap: ${space(3)};
-  padding: ${space(0.25)} 0 ${space(0.5)} 0;
-  margin: 0 ${space(2)} ${space(1)} ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
+  margin-bottom: ${space(1)};
 `;
 
 const DURATION_COMPARISON_STATUS_COLORS: {
@@ -587,7 +584,7 @@ const StyledPanelHeader = styled(PanelHeader)`
 
 const SectionDivider = styled('hr')`
   border-color: ${p => p.theme.translucentBorder};
-  margin: ${space(3)} 0 ${space(1.5)} 0;
+  margin: ${space(1)} 0;
 `;
 
 const VerticalLine = styled('div')`
@@ -897,7 +894,7 @@ function PanelPositionDropDown({organization}: {organization: Organization}) {
         traceAnalytics.trackLayoutChange('drawer left', organization);
         traceDispatch({type: 'set layout', payload: 'drawer left'});
       },
-      leadingItems: <IconPanel direction="left" size="xs" />,
+      leadingItems: <IconPanel direction="left" />,
       label: t('Left'),
       disabled: traceState.preferences.layout === 'drawer left',
     });
@@ -910,7 +907,7 @@ function PanelPositionDropDown({organization}: {organization: Organization}) {
         traceAnalytics.trackLayoutChange('drawer right', organization);
         traceDispatch({type: 'set layout', payload: 'drawer right'});
       },
-      leadingItems: <IconPanel direction="right" size="xs" />,
+      leadingItems: <IconPanel direction="right" />,
       label: t('Right'),
       disabled: traceState.preferences.layout === 'drawer right',
     });
@@ -923,7 +920,7 @@ function PanelPositionDropDown({organization}: {organization: Organization}) {
         traceAnalytics.trackLayoutChange('drawer bottom', organization);
         traceDispatch({type: 'set layout', payload: 'drawer bottom'});
       },
-      leadingItems: <IconPanel direction="down" size="xs" />,
+      leadingItems: <IconPanel direction="down" />,
       label: t('Bottom'),
       disabled: traceState.preferences.layout === 'drawer bottom',
     });
@@ -940,7 +937,7 @@ function PanelPositionDropDown({organization}: {organization: Organization}) {
             {...triggerProps}
             size="xs"
             aria-label={t('Panel position')}
-            icon={<IconPanel direction="right" size="xs" />}
+            icon={<IconPanel direction="right" />}
           />
         </Tooltip>
       )}
@@ -1021,7 +1018,7 @@ function NodeActions(props: {
           }}
           size="xs"
           aria-label={t('Show in view')}
-          icon={<IconFocus size="xs" />}
+          icon={<IconFocus />}
         />
       </Tooltip>
       {isTransactionNode(props.node) ? (
@@ -1031,7 +1028,7 @@ function NodeActions(props: {
             href={`/api/0/projects/${props.organization.slug}/${props.node.value.project_slug}/events/${props.node.value.event_id}/json/`}
             size="xs"
             aria-label={t('JSON')}
-            icon={<IconJson size="xs" />}
+            icon={<IconJson />}
           />
         </Tooltip>
       ) : null}
@@ -1042,7 +1039,7 @@ function NodeActions(props: {
             to={continuousProfileTarget}
             size="xs"
             aria-label={t('Profile')}
-            icon={<IconProfiling size="xs" />}
+            icon={<IconProfiling />}
           />
         </Tooltip>
       ) : transactionProfileTarget ? (
@@ -1052,7 +1049,7 @@ function NodeActions(props: {
             to={transactionProfileTarget}
             size="xs"
             aria-label={t('Profile')}
-            icon={<IconProfiling size="xs" />}
+            icon={<IconProfiling />}
           />
         </Tooltip>
       ) : null}


### PR DESCRIPTION
This PR primarily tightens the padding and margins everywhere so there isn't as much vertical space.

**Before:**
![Screenshot 2025-03-20 at 11 55 55 AM](https://github.com/user-attachments/assets/7ab3c917-0a14-4801-8d97-32cb1b09ce53)
![Screenshot 2025-03-20 at 9 39 46 AM](https://github.com/user-attachments/assets/92ee417a-1735-40ee-bba8-62b4c2c08c7b)
<img width="573" alt="Screenshot 2025-03-20 at 12 34 49 PM" src="https://github.com/user-attachments/assets/83890759-9484-4edb-b3d5-0be21e72ff8b" />

**After:**
![Screenshot 2025-03-20 at 11 55 48 AM](https://github.com/user-attachments/assets/357bb86c-139c-4399-8ef5-b7902d6ef957)
![Screenshot 2025-03-20 at 9 42 15 AM](https://github.com/user-attachments/assets/1b0fb0f5-246f-4d62-84fe-a5ed0b34810d)
<img width="524" alt="Screenshot 2025-03-20 at 12 34 21 PM" src="https://github.com/user-attachments/assets/b96f1d0f-032f-4117-a733-4f40926676b7" />
