### PR TITLE
fix(eap): relax pass condition of logs autocomplete tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -72,7 +72,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
         assert response.status_code == 200, response.content
 
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 6
+        assert len(keys) >= 6
         assert "test.attribute1" in keys
         assert "test.attribute2" in keys
         assert "test.attribute3" in keys
@@ -108,7 +108,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
-        assert len(keys) == 3
+        assert len(keys) >= 3
         assert "test.attribute1" in keys
         assert "test.attribute2" in keys
         assert "sentry.severity_text" in keys


### PR DESCRIPTION
These tests are getting all the attributes of logs. If for some reason there are more attributes that are stored, these tests fail. The tests already assert that all of the expected attributes are returned, this just allows for extras