### PR TITLE
feat(taskworker): Only create client stub after shuffle

### DIFF
--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -96,26 +96,26 @@ class TaskworkerClient:
 
         # TODO(taskworker) Need to support xds bootstrap file
         grpc_config = options.get("taskworker.grpc_service_config")
-        grpc_options = []
+        self._grpc_options = []
         if grpc_config:
-            grpc_options = [("grpc.service_config", grpc_config)]
+            self._grpc_options = [("grpc.service_config", grpc_config)]
 
-        stubs: list[ConsumerServiceStub] = []
-
-        for host in hosts:
-            logger.info("Connecting to %s with options %s", host, grpc_options)
-            channel = grpc.insecure_channel(host, options=grpc_options)
-            if settings.TASKWORKER_SHARED_SECRET:
-                channel = grpc.intercept_channel(
-                    channel, RequestSignatureInterceptor(settings.TASKWORKER_SHARED_SECRET)
-                )
-            stubs.append(ConsumerServiceStub(channel))
-
-        self._stubs = stubs
-        self._cur_stubs = random.randint(0, len(stubs) - 1)
+        self._cur_stub_idx = random.randint(0, len(hosts) - 1)
+        self._stubs: dict[int, ConsumerServiceStub] = {
+            self._cur_stub_idx: self._connect_to_host(hosts[self._cur_stub_idx])
+        }
         self._max_tasks_before_rebalance = max_tasks_before_rebalance
         self._num_tasks_before_rebalance = max_tasks_before_rebalance
         self._task_id_to_stub_idx: dict[str, int] = {}
+
+    def _connect_to_host(self, host: str) -> ConsumerServiceStub:
+        logger.info("Connecting to %s with options %s", host, self._grpc_options)
+        channel = grpc.insecure_channel(host, options=self._grpc_options)
+        if settings.TASKWORKER_SHARED_SECRET:
+            channel = grpc.intercept_channel(
+                channel, RequestSignatureInterceptor(settings.TASKWORKER_SHARED_SECRET)
+            )
+        return ConsumerServiceStub(channel)
 
     def _get_all_hosts(self, pattern: str, num_brokers: int) -> list[str]:
         """
@@ -130,10 +130,15 @@ class TaskworkerClient:
 
     def _get_cur_stub(self) -> tuple[int, ConsumerServiceStub]:
         if self._num_tasks_before_rebalance == 0:
-            self._cur_stubs = random.randint(0, len(self._stubs) - 1)
+            new_stub_idx = random.randint(0, len(self._stubs) - 1)
+            if new_stub_idx != self._cur_stub_idx:
+                self._cur_stub_idx = new_stub_idx
+                self._stubs[self._cur_stub_idx] = self._stubs.get(
+                    self._cur_stub_idx, self._connect_to_host(self._hosts[self._cur_stub_idx])
+                )
             self._num_tasks_before_rebalance = self._max_tasks_before_rebalance
+
         self._num_tasks_before_rebalance -= 1
-        return self._cur_stubs, self._stubs[self._cur_stubs]
 
     def get_task(self, namespace: str | None = None) -> TaskActivation | None:
         """

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -380,3 +380,6 @@ def test_client_loadbalance():
             assert task is not None and task.id == "3"
 
             assert client._task_id_to_stub_idx == {"0": 0, "1": 1, "2": 2, "3": 3}
+
+
+# TODO(taskworker): Test popping the task from dict

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -380,6 +380,3 @@ def test_client_loadbalance():
             assert task is not None and task.id == "3"
 
             assert client._task_id_to_stub_idx == {"0": 0, "1": 1, "2": 2, "3": 3}
-
-
-# TODO(taskworker): Test popping the task from dict


### PR DESCRIPTION
This PR is responsible for changing when we initialize GRPC client stubs in taskworker when load balancing. Instead of establishing a connection to all taskbrokers during initialization, the taskworker first tries to connect to one random taskbroker. Once  `_num_tasks_before_rebalance` is depleted to `0`, do another dice roll and create a new client stub. This ensures that not all taskbrokers need to be healthy before taskworker can start processing tasks. Stubs are not thrown away after shuffle as they can be reused in a later shuffle. 