### PR TITLE
feat(billing): Update the provisioning form for Profile Duration UI

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -118,6 +118,7 @@ describe('provisionSubscriptionAction', function () {
     expect(getSpinbutton('Reserved Performance Units')).toBeInTheDocument();
     expect(getSpinbutton('Reserved Attachments (in GB)')).toBeInTheDocument();
     expect(getSpinbutton('Reserved Profile Duration (in hours)')).toBeInTheDocument();
+    expect(getSpinbutton('Reserved Profile Duration UI (in hours)')).toBeInTheDocument();
 
     expect(getSpinbutton('Price for Errors')).toBeInTheDocument();
     expect(getSpinbutton('Price for Performance Units')).toBeInTheDocument();
@@ -141,9 +142,11 @@ describe('provisionSubscriptionAction', function () {
     expect(screen.getByLabelText('Soft Cap Type Performance Units')).toBeDisabled();
     expect(screen.getByLabelText('Soft Cap Type Spans')).toBeDisabled();
     expect(screen.getByLabelText('Soft Cap Type Profile Duration')).toBeDisabled();
+    expect(screen.getByLabelText('Soft Cap Type Profile Duration UI')).toBeDisabled();
     expect(screen.getByLabelText('Price for Performance Units')).toBeDisabled();
     expect(screen.getByLabelText('Price for Spans')).toBeDisabled();
     expect(screen.getByLabelText('Price for Profile Duration')).toBeDisabled();
+    expect(screen.getByLabelText('Price for Profile Duration UI')).toBeDisabled();
 
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Plan'}),
@@ -159,6 +162,7 @@ describe('provisionSubscriptionAction', function () {
     expect(screen.getByLabelText('Price for Spans')).toBeDisabled();
     // TODO: change to enabled when profile duration is enabled
     expect(screen.getByLabelText('Price for Profile Duration')).toBeDisabled();
+    expect(screen.getByLabelText('Price for Profile Duration UI')).toBeDisabled();
 
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Plan'}),
@@ -174,6 +178,7 @@ describe('provisionSubscriptionAction', function () {
     expect(screen.getByLabelText('Price for Spans')).toBeEnabled();
     // TODO: change to enabled when profile duration is enabled
     expect(screen.getByLabelText('Price for Profile Duration')).toBeDisabled();
+    expect(screen.getByLabelText('Price for Profile Duration UI')).toBeDisabled();
   });
 
   it('select coterm disables effectiveAt and atPeriodEnd', async function () {
@@ -731,6 +736,7 @@ describe('provisionSubscriptionAction', function () {
             uptime: false,
             attachments: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
         },
       })
@@ -838,6 +844,7 @@ describe('provisionSubscriptionAction', function () {
           softCapTypeReplays: null,
           softCapTypeTransactions: null,
           softCapTypeProfileDuration: null,
+          softCapTypeProfileDurationUI: null,
           trueForward: {
             attachments: false,
             errors: false,
@@ -846,6 +853,7 @@ describe('provisionSubscriptionAction', function () {
             replays: false,
             transactions: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
           type: 'invoiced',
         },
@@ -971,6 +979,7 @@ describe('provisionSubscriptionAction', function () {
           softCapTypeReplays: null,
           softCapTypeTransactions: null,
           softCapTypeProfileDuration: null,
+          softCapTypeProfileDurationUI: null,
           trueForward: {
             attachments: false,
             errors: false,
@@ -979,6 +988,7 @@ describe('provisionSubscriptionAction', function () {
             replays: false,
             transactions: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
           type: 'invoiced',
         },
@@ -1103,6 +1113,7 @@ describe('provisionSubscriptionAction', function () {
             uptime: true,
             attachments: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
         },
       })
@@ -1226,6 +1237,7 @@ describe('provisionSubscriptionAction', function () {
             uptime: true,
             attachments: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
         },
       })
@@ -1349,6 +1361,7 @@ describe('provisionSubscriptionAction', function () {
             uptime: false,
             attachments: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
         },
       })
@@ -1453,10 +1466,12 @@ describe('provisionSubscriptionAction', function () {
           softCapTypeUptime: null,
           softCapTypeAttachments: null,
           softCapTypeProfileDuration: null,
+          softCapTypeProfileDurationUI: null,
           trueForward: {
             errors: false,
             transactions: false,
             profile_duration: false,
+            profile_duration_ui: false,
             replays: false,
             monitor_seats: false,
             uptime: false,
@@ -1665,6 +1680,7 @@ describe('provisionSubscriptionAction', function () {
             uptime: false,
             attachments: false,
             profile_duration: false,
+            profile_duration_ui: false,
           },
         },
       })

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -178,6 +178,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
           reservedSpansIndexed: subscription.categories.spansIndexed?.reserved,
           reservedAttachments: subscription.categories.attachments?.reserved,
           reservedProfileDuration: subscription.categories.profileDuration?.reserved,
+          reservedProfileDurationUI: subscription.categories.profileDurationUI?.reserved,
           softCapTypeErrors: subscription.categories.errors?.softCapType,
           softCapTypeTransactions: subscription.categories.transactions?.softCapType,
           softCapTypeReplays: subscription.categories.replays?.softCapType,
@@ -188,6 +189,8 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
           softCapTypeAttachments: subscription.categories.attachments?.softCapType,
           softCapTypeProfileDuration:
             subscription.categories.profileDuration?.softCapType,
+          softCapTypeProfileDurationUI:
+            subscription.categories.profileDurationUI?.softCapType,
           customPriceErrors: toAnnualDollars(
             subscription.categories.errors?.customPrice,
             subscription.billingInterval
@@ -222,6 +225,10 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
           ),
           customPriceProfileDuration: toAnnualDollars(
             subscription.categories.profileDuration?.customPrice,
+            subscription.billingInterval
+          ),
+          customPriceProfileDurationUI: toAnnualDollars(
+            subscription.categories.profileDurationUI?.customPrice,
             subscription.billingInterval
           ),
           customPricePcss: toAnnualDollars(
@@ -274,6 +281,11 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
           ),
           onDemandCpeProfileDuration: toAnnualDollars(
             subscription.categories.profileDuration?.onDemandCpe,
+            null,
+            CPE_DECIMAL_PRECISION
+          ),
+          onDemandCpeProfileDurationUI: toAnnualDollars(
+            subscription.categories.profileDurationUI?.onDemandCpe,
             null,
             CPE_DECIMAL_PRECISION
           ),
@@ -368,6 +380,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       delete postData.customPriceSpans;
       delete postData.customPriceSpansIndexed;
       delete postData.customPriceProfileDuration;
+      delete postData.customPriceProfileDurationUI;
     }
 
     // only set reserved & custom price for spans OR transactions
@@ -389,6 +402,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       delete postData.onDemandCpeUptime;
       delete postData.onDemandCpeSpans;
       delete postData.onDemandCpeProfileDuration;
+      delete postData.onDemandCpeProfileDurationUI;
 
       // clear corresponding state
       this.setState(state => ({
@@ -409,6 +423,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       postData.softCapTypeUptime = null;
       postData.softCapTypeSpans = null;
       postData.softCapTypeProfileDuration = null;
+      postData.softCapTypeProfileDurationUI = null;
       this.setState(state => ({
         ...state,
         data: {
@@ -421,6 +436,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
           softCapTypeUptime: null,
           softCapTypeSpans: null,
           softCapTypeProfileDuration: null,
+          softCapTypeProfileDurationUI: null,
         },
       }));
     } else {
@@ -432,6 +448,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       delete postData.onDemandCpeUptime;
       delete postData.onDemandCpeSpans;
       delete postData.onDemandCpeProfileDuration;
+      delete postData.onDemandCpeProfileDurationUI;
     }
 
     if (this.isEnablingSoftCap()) {
@@ -444,6 +461,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       delete postData.onDemandCpeUptime;
       delete postData.onDemandCpeSpans;
       delete postData.onDemandCpeProfileDuration;
+      delete postData.onDemandCpeProfileDurationUI;
     }
 
     if (!isNaN(postData.onDemandCpeErrors)) {
@@ -500,6 +518,12 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
         CPE_DECIMAL_PRECISION
       );
     }
+    if (!isNaN(postData.onDemandCpeProfileDurationUI)) {
+      postData.onDemandCpeProfileDuration = toCents(
+        postData.onDemandCpeProfileDuration,
+        CPE_DECIMAL_PRECISION
+      );
+    }
 
     if (!isNaN(postData.reservedCpeSpans)) {
       postData.reservedCpeSpans = toCpeCents(postData.reservedCpeSpans);
@@ -547,6 +571,9 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
     if (!isNaN(postData.customPriceProfileDuration)) {
       postData.customPriceProfileDuration *= 100; // Price should be in cents
     }
+    if (!isNaN(postData.customPriceProfileDurationUI)) {
+      postData.customPriceProfileDurationUI *= 100; // Price should be in cents
+    }
 
     if (!isNaN(postData.customPrice)) {
       postData.customPrice *= 100; // Price should be in cents
@@ -565,6 +592,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
             postData.customPriceAttachments +
             postData.customPricePcss +
             (postData.customPriceProfileDuration ?? 0) +
+            (postData.customPriceProfileDurationUI ?? 0) +
             (isAm3DsPlan(postData.plan) ? (postData.customPriceSpansIndexed ?? 0) : 0)
       ) {
         onSubmitError({
@@ -597,7 +625,10 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
       if (!postData.softCapTypeProfileDuration) {
         postData.softCapTypeProfileDuration = null;
       }
-      // If a data category has a set soft cap type, trueForwad will also need to be set to true for that category
+      if (!postData.softCapTypeProfileDurationUI) {
+        postData.softCapTypeProfileDuration = null;
+      }
+      // If a data category has a set soft cap type, trueForward will also need to be set to true for that category
       // until the true forward fields are fully deprecated and soft cap types are used in their place.
       postData.trueForward = {
         errors: postData.softCapTypeErrors ? true : false,
@@ -606,6 +637,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
         monitor_seats: postData.softCapTypeMonitorSeats ? true : false,
         uptime: postData.softCapTypeUptime ? true : false,
         profile_duration: postData.softCapTypeProfileDuration ? true : false,
+        profile_duration_ui: postData.softCapTypeProfileDurationUI ? true : false,
       };
 
       if (isAm3Plan(postData.plan)) {
@@ -1254,6 +1286,37 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                     }))
                   }
                 />
+                <NumberField
+                  label="Reserved Profile Duration UI (in hours)"
+                  name="reservedProfileDurationUI"
+                  required={isAmEnt}
+                  disabled={!isAmEnt || true} // TODO: remove this when profile duration is enabled
+                  value={this.state.data.reservedProfileDurationUI}
+                  onChange={v =>
+                    this.setState(state => ({
+                      ...state,
+                      data: {...state.data, reservedProfileDurationUI: v},
+                    }))
+                  }
+                />
+                <SelectField
+                  label="Soft Cap Type Profile Duration UI"
+                  name="softCapTypeProfileDurationUI"
+                  clearable
+                  required={false}
+                  choices={[
+                    ['ON_DEMAND', 'On Demand'],
+                    ['TRUE_FORWARD', 'True Forward'],
+                  ]}
+                  disabled={this.isEnablingOnDemandMaxSpend() || !isAmEnt || true} // TODO: remove this when profile duration is enabled
+                  value={this.state.data.softCapTypeProfileDurationUI}
+                  onChange={v =>
+                    this.setState(state => ({
+                      ...state,
+                      data: {...state.data, softCapTypeProfileDurationUI: v},
+                    }))
+                  }
+                />
               </div>
               <div>
                 <SectionHeader>Reserved Volume Prices</SectionHeader>
@@ -1410,6 +1473,22 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                       data: {
                         ...state.data,
                         customPriceProfileDuration: v,
+                      },
+                    }))
+                  }
+                />
+                <StyledDollarsField
+                  label="Price for Profile Duration UI"
+                  name="customPriceProfileDurationUI"
+                  disabled={!hasCustomSkuPrices || true} // TODO: remove this when profile duration is enabled
+                  required={hasCustomSkuPrices}
+                  value={data.customPriceProfileDurationUI}
+                  onChange={v =>
+                    this.setState(state => ({
+                      ...state,
+                      data: {
+                        ...state.data,
+                        customPriceProfileDurationUI: v,
                       },
                     }))
                   }
@@ -1652,6 +1731,39 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                             data: {
                               ...state.data,
                               onDemandCpeProfileDuration:
+                                currentValue.toFixed(CPE_DECIMAL_PRECISION),
+                            },
+                          }));
+                        }
+                      }}
+                    />
+                    <StyledDollarsAndCentsField
+                      label="On-Demand Cost-Per-Profile Duration UI"
+                      name="onDemandCpeProfileDurationUI"
+                      disabled={!this.isEnablingOnDemandMaxSpend() || true} // TODO: remove this when profile duration is enabled
+                      value={data.onDemandCpeProfileDurationUI}
+                      step={0.00000001}
+                      min={0.00000001}
+                      max={1}
+                      onChange={v =>
+                        this.setState(state => ({
+                          ...state,
+                          data: {
+                            ...state.data,
+                            onDemandCpeProfileDurationUI: v,
+                          },
+                        }))
+                      }
+                      onBlur={() => {
+                        const currentValue = parseFloat(
+                          this.state.data.onDemandCpeProfileDurationUI
+                        );
+                        if (!isNaN(currentValue)) {
+                          this.setState(state => ({
+                            ...state,
+                            data: {
+                              ...state.data,
+                              onDemandCpeProfileDurationUI:
                                 currentValue.toFixed(CPE_DECIMAL_PRECISION),
                             },
                           }));


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/16918

Adds Profile Duration UI fields to the form in a disabled state.

### Left Column
<img width="578" alt="Screenshot 2025-03-20 at 2 13 30 PM" src="https://github.com/user-attachments/assets/ae251dd8-e64e-4fea-ae56-0d291e7bbc06" />

### Right Column
<img width="572" alt="Screenshot 2025-03-20 at 2 11 32 PM" src="https://github.com/user-attachments/assets/74e3474f-7cc2-41bd-9efc-ffbb38c5df40" />

