### PR TITLE
ref(insights): use formatted series name for release grouped session charts

### DIFF
--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -1,5 +1,6 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
+import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useCrashFreeSessions from 'sentry/views/insights/sessions/queries/useCrashFreeSessions';
 
@@ -7,7 +8,10 @@ export default function CrashFreeSessionsChart() {
   const {series, releases, isPending, error} = useCrashFreeSessions();
 
   const aliases = Object.fromEntries(
-    releases?.map(release => [`crash_free_session_rate_${release}`, release]) ?? []
+    releases?.map(release => [
+      `crash_free_session_rate_${release}`,
+      formatSeriesName(release),
+    ]) ?? []
   );
 
   return (

--- a/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useReleaseSessionCounts from 'sentry/views/insights/sessions/queries/useReleaseSessionCounts';
 
@@ -6,7 +7,8 @@ export default function ReleaseSessionCountChart() {
   const {series, releases, isPending, error} = useReleaseSessionCounts();
 
   const aliases = Object.fromEntries(
-    releases?.map(release => [`${release}_total_sessions`, release]) ?? []
+    releases?.map(release => [`${release}_total_sessions`, formatSeriesName(release)]) ??
+      []
   );
 
   return (

--- a/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import useReleaseSessionPercentage from 'sentry/views/insights/sessions/queries/useReleaseSessionPercentage';
 
@@ -6,7 +7,8 @@ export default function ReleaseSessionPercentageChart() {
   const {series, releases, isPending, error} = useReleaseSessionPercentage();
 
   const aliases = Object.fromEntries(
-    releases?.map(release => [`${release}_session_percent`, release]) ?? []
+    releases?.map(release => [`${release}_session_percent`, formatSeriesName(release)]) ??
+      []
   );
 
   return (


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/87317

<img width="400" alt="SCR-20250320-mdhv" src="https://github.com/user-attachments/assets/e03ee246-5ab7-4be6-b43f-1269fbccaaaa" />
