### PR TITLE
input: required was a lie

### DIFF
--- a/static/app/components/customIgnoreDurationModal.tsx
+++ b/static/app/components/customIgnoreDurationModal.tsx
@@ -7,6 +7,7 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import ButtonBar from 'sentry/components/buttonBar';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Input} from 'sentry/components/core/input';
 import {t} from 'sentry/locale';
 import type {IgnoredStatusDetails} from 'sentry/types/group';
 
@@ -71,7 +72,7 @@ export default function CustomIgnoreDurationModal(props: Props) {
         <form className="form-horizontal">
           <div className="control-group">
             <h6 className="nav-header">{t('Date')}</h6>
-            <input
+            <Input
               className="form-control"
               type="date"
               id="snooze-until-date"
@@ -83,7 +84,7 @@ export default function CustomIgnoreDurationModal(props: Props) {
           </div>
           <div className="control-group m-b-1">
             <h6 className="nav-header">{t('Time (UTC)')}</h6>
-            <input
+            <Input
               className="form-control"
               type="time"
               id="snooze-until-time"

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -194,7 +194,6 @@ export function AutofixOutputStream({
                 placeholder={
                   responseRequired ? 'Please answer to continue...' : 'Interrupt me...'
                 }
-                required={responseRequired}
               />
               <StyledButton
                 type="submit"

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
@@ -87,7 +87,6 @@ export default function ActionTargetSelector(props: Props) {
           type="text"
           autoComplete="off"
           disabled={disabled}
-          required={action.type === 'discord'} // Only required for discord channel ID
           key={action.type}
           value={action.targetIdentifier || ''}
           onChange={handleChangeSpecificTargetIdentifier}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -180,7 +180,6 @@ export function SortBySelectors({
           <ArithmeticInput
             name="arithmetic"
             type="text"
-            required
             placeholder={t('Enter Equation')}
             value={getEquation(customEquation.sortBy)}
             onUpdate={value => {

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -33,7 +33,7 @@ function WidgetBuilderNameAndDescription({
   return (
     <Fragment>
       <SectionHeader title={t('Widget Name & Description')} />
-      <StyledInput
+      <StyledTextField
         name={t('Widget Name')}
         size="md"
         placeholder={t('Name')}
@@ -101,7 +101,7 @@ function WidgetBuilderNameAndDescription({
 
 export default WidgetBuilderNameAndDescription;
 
-const StyledInput = styled(TextField)`
+const StyledTextField = styled(TextField)`
   margin-bottom: ${space(1)};
   padding: 0;
   border: none;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
@@ -105,7 +105,6 @@ function VisualizeGhostField({
               key="parameter:text"
               type="text"
               placeholder={t('Equation')}
-              required
               value={draggingField?.field ?? ''}
               onUpdate={() => {}}
             />

--- a/static/app/views/discover/table/arithmeticInput.spec.tsx
+++ b/static/app/views/discover/table/arithmeticInput.spec.tsx
@@ -34,7 +34,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -60,7 +59,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -94,7 +92,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -152,7 +149,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -174,7 +170,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -198,7 +193,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -220,7 +214,6 @@ describe('ArithmeticInput', function () {
         name="refinement"
         key="parameter:text"
         type="text"
-        required
         value=""
         onUpdate={jest.fn()}
         options={columns}
@@ -239,7 +232,6 @@ describe('ArithmeticInput', function () {
       <ArithmeticInput
         name="refinement"
         type="text"
-        required
         value=""
         onUpdate={() => {}}
         options={[]}

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -666,7 +666,6 @@ class _QueryField extends Component<Props> {
             name="arithmetic"
             key="parameter:text"
             type="text"
-            required
             value={fieldValue.field}
             onUpdate={this.handleEquationChange}
             options={otherColumns}

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -215,7 +215,6 @@ class TransactionThresholdModal extends Component<Props, State> {
           <Input
             type="number"
             name="threshold"
-            required
             pattern="[0-9]*(\.[0-9]*)?"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               this.handleFieldChange('threshold')(event.target.value);

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -80,7 +80,6 @@ function GetStarted({relocationState, onUpdateRelocationState, onComplete}: Step
             onChange={evt => {
               onUpdateRelocationState({orgSlugs: evt.target.value});
             }}
-            required
             minLength={3}
             placeholder="org-slug-1, org-slug-2, ..."
             value={orgSlugs}

--- a/static/gsAdmin/views/debuggingTools.tsx
+++ b/static/gsAdmin/views/debuggingTools.tsx
@@ -62,7 +62,6 @@ function IssueOwnerDebbuging() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -72,7 +71,6 @@ function IssueOwnerDebbuging() {
             name="project-slug"
             onChange={e => setProjectSlug(e.target.value)}
             value={projectSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -83,7 +81,6 @@ function IssueOwnerDebbuging() {
             name="stacktrace-path"
             onChange={e => setStacktracePath(e.target.value)}
             value={stacktracePath}
-            required
             minLength={1}
             placeholder="/src/sentry/integrations/github/webhook.py"
           />
@@ -210,7 +207,6 @@ function IssueEscalatingDebugging() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -220,7 +216,6 @@ function IssueEscalatingDebugging() {
             name="group-id"
             onChange={e => setGroupId(e.target.value)}
             value={groupId}
-            required
             minLength={1}
             placeholder="1"
           />

--- a/static/gsAdmin/views/privateAPIs.tsx
+++ b/static/gsAdmin/views/privateAPIs.tsx
@@ -53,7 +53,6 @@ function ForceAutoAssignment() {
             name="organizaton-slug"
             onChange={e => setOrganizationSlug(e.target.value)}
             value={organizationSlug}
-            required
             minLength={1}
             placeholder="sentry"
           />
@@ -63,7 +62,6 @@ function ForceAutoAssignment() {
             name="group-list"
             onChange={e => setGroupIds(e.target.value)}
             value={groupIds}
-            required
             minLength={1}
             placeholder="1, 2, 3"
           />

--- a/static/gsApp/components/billingDetailsForm.tsx
+++ b/static/gsApp/components/billingDetailsForm.tsx
@@ -346,7 +346,6 @@ function BillingDetailsForm({
                   <Fragment>
                     <Input
                       id="addressLine1"
-                      required
                       name="addressLine1"
                       placeholder={t('Street address')}
                       maxLength={100}


### PR DESCRIPTION
Unfortunately, the Input component has lied to us, and was [never](https://github.com/getsentry/sentry/blob/a3096e5c1dafb4a2afec2fbe62a5dfae7a1881df/static/app/components/core/input/index.tsx#L91) actually forwarding the required prop to the native input component... 

Fixing this unfortunately creates a breaking change in the functionality of some forms, some of which are untested. however given that this prop had never worked, I have taken the liberty to remove it, and the authors of the code that relied on it can add it back.