### PR TITLE
chore(issue-details): Add property to streamline opt out

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -180,6 +180,7 @@ export type IssueEventParameters = {
   'issue_details.sourcemap_wizard_dismiss': SourceMapWizardParam;
   'issue_details.sourcemap_wizard_learn_more': SourceMapWizardParam;
   'issue_details.streamline_ui_toggle': {
+    enforced_streamline_ui: boolean;
     isEnabled: boolean;
   };
   'issue_details.tour.reminder': {method: 'dismissed' | 'timeout'};

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -14,6 +14,7 @@ import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
@@ -58,6 +59,8 @@ export function NewIssueExperienceButton() {
   const hasStreamlinedUI = useHasStreamlinedUI();
   const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
   const hasNewUIOnly = Boolean(organization.streamlineOnly);
+  const user = useUser();
+  const userStreamlinePreference = user?.options?.prefersIssueDetailsStreamlinedUI;
 
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
@@ -67,8 +70,11 @@ export function NewIssueExperienceButton() {
     trackAnalytics('issue_details.streamline_ui_toggle', {
       isEnabled: !hasStreamlinedUI,
       organization,
+      enforced_streamline_ui:
+        organization.features.includes('issue-details-streamline-enforced') &&
+        userStreamlinePreference === null,
     });
-  }, [mutateUserOptions, organization, hasStreamlinedUI]);
+  }, [mutateUserOptions, organization, hasStreamlinedUI, userStreamlinePreference]);
 
   // The promotional modal should only appear if:
   //  - The tour is available to this user


### PR DESCRIPTION
adds a property to allow us to easily track if an opt out is coming from someone with the enforced streamline experience 