### PR TITLE
ref(issue-views): Enforce page filter existence in PUT Request 

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,4 +1,3 @@
-import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
 from rest_framework import status
@@ -10,7 +9,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewStarredSerializer
@@ -139,36 +137,21 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         ):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = GroupSearchViewValidator(data=request.data)
+        serializer = GroupSearchViewValidator(
+            data=request.data, context={"organization": organization}
+        )
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         validated_data = serializer.validated_data
 
-        for view in validated_data["views"]:
-            try:
-                validate_projects(organization, request.user, view)
-            except ValidationError as e:
-                sentry_sdk.capture_message(e.args[0])
-                return Response(status=status.HTTP_400_BAD_REQUEST, data={"detail": e.args[0]})
-
         try:
             with transaction.atomic(using=router.db_for_write(GroupSearchView)):
                 new_view_state = bulk_update_views(
                     organization, request.user.id, validated_data["views"]
                 )
-        except IntegrityError as e:
-            if (
-                len(e.args) > 0
-                and 'insert or update on table "sentry_groupsearchviewproject" violates foreign key constraint'
-                in e.args[0]
-            ):
-                sentry_sdk.capture_exception(e)
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"detail": "One or more projects do not exist"},
-                )
+        except IntegrityError:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         last_visited_views = GroupSearchViewLastVisited.objects.filter(
@@ -204,21 +187,6 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
             ),
             on_results=lambda results: serialize(results, request.user),
         )
-
-
-def validate_projects(
-    org: Organization, user: User | AnonymousUser, view: GroupSearchViewValidatorResponse
-) -> None:
-    if "projects" in view and view["projects"] is not None:
-        if not features.has("organizations:global-views", org) and (
-            view["projects"] == [-1] or view["projects"] == [] or len(view["projects"]) > 1
-        ):
-            raise ValidationError("You do not have the multi project stream feature enabled")
-        elif view["projects"] == [-1]:
-            view["isAllProjects"] = True
-            view["projects"] = []
-        else:
-            view["isAllProjects"] = False
 
 
 def bulk_update_views(

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -33,6 +33,7 @@ DEFAULT_VIEWS: list[GroupSearchViewValidatorResponse] = [
         "position": 0,
         "isAllProjects": False,
         "environments": [],
+        "projects": [],
         "timeFilters": DEFAULT_TIME_FILTER,
         "dateCreated": None,
         "dateUpdated": None,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -262,7 +262,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
             {
                 "name": "Custom View Four",
                 "query": "is:unresolved",
-                "query_sort": "date",
+                "querySort": "date",
                 "projects": [],
                 "isAllProjects": False,
                 "environments": [],
@@ -429,7 +429,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
             {
                 "name": f"Custom View {i}",
                 "query": "is:unresolved",
-                "query_sort": "date",
+                "querySort": "date",
                 "projects": [],
                 "environments": [],
                 "timeFilters": {"period": "14d"},
@@ -597,7 +597,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             {
                 "name": "New View",
                 "query": "is:unresolved",
-                "query_sort": "date",
+                "querySort": "date",
                 "projects": [],
                 "isAllProjects": False,
                 "environments": [],
@@ -733,7 +733,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
                         "id": issue_view_one.id,
                         "name": issue_view_one.name,
                         "query": issue_view_one.query,
-                        "query_sort": issue_view_one.query_sort,
+                        "querySort": issue_view_one.query_sort,
                         "position": issue_view_one.position,
                         "timeFilters": issue_view_one.time_filters,
                         "environments": issue_view_one.environments,
@@ -1011,7 +1011,7 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
             {
                 "name": "Custom View Two",
                 "query": "is:unresolved",
-                "query_sort": "date",
+                "querySort": "date",
                 "projects": [],
                 "isAllProjects": False,
                 "environments": [],

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
@@ -723,7 +725,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
         )
         issue_view_one.projects.set([project1])
 
-        response = self.client.put(
+        response: Any = self.client.put(
             url,
             data={
                 "views": [


### PR DESCRIPTION
This PR enforces the existence of the `projects`, `environments`, and `timeFilters` parameters in the `PUT` `group-search-views` endpoint. I forgot to do this when we fully EA'd page filters for issue views.

The [frontend hook](https://github.com/getsentry/sentry/blob/fa6e6a6b0fd6b8f93f573fa1df759182d56478d0/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx#L24) that calls this endpoint has already been [enforcing](https://github.com/getsentry/sentry/blob/fa6e6a6b0fd6b8f93f573fa1df759182d56478d0/static/app/views/issueList/types.tsx#L30) that these params must exist, so we don't need to update anything there. 

In follow up PRs, we should modify the frontend to no longer send the `isAllProjects` param, though. This is unecsesary, sicne the backend can just infer this based on if the `projects` param is `[-1]`