### PR TITLE
feat(aci): setup workflow preview abstraction

### DIFF
--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -170,7 +170,9 @@ class DataCondition(DefaultFieldsModel):
         return self.get_condition_result() if result else None
 
     def get_preview_groups(self, group_ids: set[int]) -> set[int]:
-        return set()
+        # TODO(cathy): grab the handler which should implement how to
+        # filter the groups based on the condition
+        return group_ids
 
 
 def is_slow_condition(condition: DataCondition) -> bool:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -169,6 +169,9 @@ class DataCondition(DefaultFieldsModel):
         result = handler.evaluate_value(value, self.comparison)
         return self.get_condition_result() if result else None
 
+    def get_preview_groups(self, group_ids: set[int]) -> set[int]:
+        return set()
+
 
 def is_slow_condition(condition: DataCondition) -> bool:
     return Condition(condition.type) in SLOW_CONDITIONS

--- a/src/sentry/workflow_engine/processors/workflow_preview.py
+++ b/src/sentry/workflow_engine/processors/workflow_preview.py
@@ -1,0 +1,140 @@
+import logging
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.models.group import Group
+from sentry.workflow_engine.models import (
+    DataCondition,
+    DataConditionGroup,
+    Detector,
+    Workflow,
+    WorkflowDataConditionGroup,
+)
+from sentry.workflow_engine.processors.data_condition import split_conditions_by_speed
+from sentry.workflow_engine.processors.data_condition_group import get_data_conditions_for_group
+
+logger = logging.getLogger(__name__)
+
+
+def preview_conditions(
+    logic_type: DataConditionGroup.Type, data_conditions: list[DataCondition], group_ids: set[int]
+) -> tuple[set[int], set[int]]:
+    # groups that would have triggered each condition
+    conditions_to_triggered_groups = {}
+
+    for condition in data_conditions:
+        conditions_to_triggered_groups[condition.id] = condition.get_preview_groups(group_ids)
+
+    groups_to_check = set(group_ids)
+    groups_meeting_conditions: set[int] = set()
+
+    triggered_groups: list[set[int]] = list(conditions_to_triggered_groups.values())
+
+    match logic_type:
+        case DataConditionGroup.Type.ALL:
+            # ALL logic type: intersection of all the groups that meet any condition (= met all conditions)
+            # should only continue checking groups that have already met these conditions
+            groups_meeting_conditions = set.intersection(*triggered_groups)
+            groups_to_check = groups_meeting_conditions
+        case DataConditionGroup.Type.ANY:
+            # ANY logic type: union of all the groups that meet any condition
+            # should only continue checking groups that have not already met these conditions
+            groups_meeting_conditions = set().union(*triggered_groups)
+            groups_to_check -= groups_meeting_conditions
+        case DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
+            groups_meeting_conditions = set().union(*triggered_groups)
+            groups_to_check -= groups_meeting_conditions
+        case DataConditionGroup.Type.NONE:
+            # NONE logic type: all the group ids - intersection of all the groups that meet any condition (= did not meet any condition)
+            # should only continue checking groups that did not meet any condition
+            groups_meeting_conditions = groups_to_check - set().union(*triggered_groups)
+            groups_to_check = groups_meeting_conditions
+
+    return groups_to_check, groups_meeting_conditions
+
+
+def preview_data_condition_group(data_condition_group_id: int, group_ids: set[int]) -> set[int]:
+    try:
+        dcg = DataConditionGroup.objects.get_from_cache(id=data_condition_group_id)
+    except DataConditionGroup.DoesNotExist:
+        logger.exception(
+            "DataConditionGroup does not exist",
+            extra={"id": data_condition_group_id},
+        )
+        return set()
+
+    try:
+        logic_type = DataConditionGroup.Type(dcg.logic_type)
+    except ValueError:
+        logger.exception(
+            "Invalid DataConditionGroup.logic_type found in process_data_condition_group",
+            extra={"logic_type": dcg.logic_type},
+        )
+        return set()
+
+    conditions = get_data_conditions_for_group(data_condition_group_id)
+
+    # check fast conditions first
+    fast_conditions, slow_conditions = split_conditions_by_speed(conditions)
+
+    # TODO: early return if they are invalid conditon pairs? see src/sentry/rules/history/preview.py VALID_CONDITION_PAIRS
+
+    groups_to_check, groups_meeting_fast_conditions = preview_conditions(
+        logic_type, fast_conditions, group_ids
+    )
+
+    if not groups_to_check:
+        return groups_meeting_fast_conditions
+
+    _, groups_meeting_conditions = preview_conditions(logic_type, slow_conditions, groups_to_check)
+
+    return groups_meeting_conditions
+
+
+def preview_workflow(workflow: Workflow) -> set[int]:
+    preview_groups: set[int] = set()
+
+    if not workflow.enabled:
+        return preview_groups
+
+    # Get enabled detectors connected to Workflow
+    detectors = set(
+        Detector.objects.filter(
+            detectorworkflow__workflow_id=workflow.id,
+            enabled=True,
+        ).distinct()
+    )
+
+    # Get groups from the last 14 days with the same group type as the detectors
+    group_types = {detector.group_type.type_id for detector in detectors}
+    projects = {detector.project_id for detector in detectors}
+    group_ids = set(
+        Group.objects.filter(
+            project__in=projects,
+            last_seen__gte=timezone.now() - timedelta(days=14),
+            type__in=group_types,
+        ).values_list("id", flat=True)
+    )
+
+    # Filter groups based on workflow triggers
+    if not workflow.when_condition_group:
+        return preview_groups
+
+    groups_meeting_triggers = preview_data_condition_group(
+        workflow.when_condition_group.id, group_ids
+    )
+
+    # Filter groups based on workflow filters
+    filter_groups = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
+
+    if not filter_groups:
+        return groups_meeting_triggers
+
+    for filter_group in filter_groups:
+        # TODO: should we have a separate list per filter group?
+        preview_groups.update(
+            preview_data_condition_group(filter_group.id, groups_meeting_triggers)
+        )
+
+    return preview_groups

--- a/src/sentry/workflow_engine/processors/workflow_preview.py
+++ b/src/sentry/workflow_engine/processors/workflow_preview.py
@@ -1,29 +1,34 @@
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.models.environment import Environment
 from sentry.models.group import Group
-from sentry.workflow_engine.models import (
-    DataCondition,
-    DataConditionGroup,
-    Detector,
-    Workflow,
-    WorkflowDataConditionGroup,
-)
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector
 from sentry.workflow_engine.processors.data_condition import split_conditions_by_speed
-from sentry.workflow_engine.processors.data_condition_group import get_data_conditions_for_group
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class EvaluationGroup:
+    logic_type: DataConditionGroup.Type
+    conditions: list[DataCondition]
+
+
 def preview_conditions(
-    logic_type: DataConditionGroup.Type, data_conditions: list[DataCondition], group_ids: set[int]
+    logic_type: DataConditionGroup.Type, conditions: list[DataCondition], group_ids: set[int]
 ) -> tuple[set[int], set[int]]:
+    if not conditions:
+        # no conditions, all groups are valid
+        return set(), group_ids
+
     # groups that would have triggered each condition
     conditions_to_triggered_groups = {}
 
-    for condition in data_conditions:
+    for condition in conditions:
         conditions_to_triggered_groups[condition.id] = condition.get_preview_groups(group_ids)
 
     groups_to_check = set(group_ids)
@@ -37,48 +42,27 @@ def preview_conditions(
             # should only continue checking groups that have already met these conditions
             groups_meeting_conditions = set.intersection(*triggered_groups)
             groups_to_check = groups_meeting_conditions
-        case DataConditionGroup.Type.ANY:
-            # ANY logic type: union of all the groups that meet any condition
-            # should only continue checking groups that have not already met these conditions
-            groups_meeting_conditions = set().union(*triggered_groups)
-            groups_to_check -= groups_meeting_conditions
-        case DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-            groups_meeting_conditions = set().union(*triggered_groups)
-            groups_to_check -= groups_meeting_conditions
         case DataConditionGroup.Type.NONE:
             # NONE logic type: all the group ids - intersection of all the groups that meet any condition (= did not meet any condition)
             # should only continue checking groups that did not meet any condition
             groups_meeting_conditions = groups_to_check - set().union(*triggered_groups)
             groups_to_check = groups_meeting_conditions
+        case _:  # any or any_short_circuit
+            # ANY logic type: union of all the groups that meet any condition
+            # should only continue checking groups that have not already met these conditions
+            groups_meeting_conditions = set().union(*triggered_groups)
+            groups_to_check -= groups_meeting_conditions
 
     return groups_to_check, groups_meeting_conditions
 
 
-def preview_data_condition_group(data_condition_group_id: int, group_ids: set[int]) -> set[int]:
-    try:
-        dcg = DataConditionGroup.objects.get_from_cache(id=data_condition_group_id)
-    except DataConditionGroup.DoesNotExist:
-        logger.exception(
-            "DataConditionGroup does not exist",
-            extra={"id": data_condition_group_id},
-        )
-        return set()
-
-    try:
-        logic_type = DataConditionGroup.Type(dcg.logic_type)
-    except ValueError:
-        logger.exception(
-            "Invalid DataConditionGroup.logic_type found in process_data_condition_group",
-            extra={"logic_type": dcg.logic_type},
-        )
-        return set()
-
-    conditions = get_data_conditions_for_group(data_condition_group_id)
-
+def preview_condition_group(
+    logic_type: DataConditionGroup.Type, conditions: list[DataCondition], group_ids: set[int]
+) -> set[int]:
     # check fast conditions first
     fast_conditions, slow_conditions = split_conditions_by_speed(conditions)
 
-    # TODO: early return if they are invalid conditon pairs? see src/sentry/rules/history/preview.py VALID_CONDITION_PAIRS
+    # TODO(cathy): early return if they are invalid condition pairs? see src/sentry/rules/history/preview.py VALID_CONDITION_PAIRS
 
     groups_to_check, groups_meeting_fast_conditions = preview_conditions(
         logic_type, fast_conditions, group_ids
@@ -92,19 +76,15 @@ def preview_data_condition_group(data_condition_group_id: int, group_ids: set[in
     return groups_meeting_conditions
 
 
-def preview_workflow(workflow: Workflow) -> set[int]:
+# NOTE: assumes an enabled workflow
+def preview_workflow(
+    detectors: list[Detector],
+    environment: Environment | None,
+    trigger_condition_group: EvaluationGroup,
+    filter_condition_groups: list[EvaluationGroup],
+) -> set[int]:
+    # TODO(cathy): account for environment (is it even possible without querying Snuba)?
     preview_groups: set[int] = set()
-
-    if not workflow.enabled:
-        return preview_groups
-
-    # Get enabled detectors connected to Workflow
-    detectors = set(
-        Detector.objects.filter(
-            detectorworkflow__workflow_id=workflow.id,
-            enabled=True,
-        ).distinct()
-    )
 
     # Get groups from the last 14 days with the same group type as the detectors
     group_types = {detector.group_type.type_id for detector in detectors}
@@ -117,24 +97,18 @@ def preview_workflow(workflow: Workflow) -> set[int]:
         ).values_list("id", flat=True)
     )
 
-    # Filter groups based on workflow triggers
-    if not workflow.when_condition_group:
+    if not group_ids:
         return preview_groups
 
-    groups_meeting_triggers = preview_data_condition_group(
-        workflow.when_condition_group.id, group_ids
+    groups_meeting_triggers = preview_condition_group(
+        trigger_condition_group.logic_type, trigger_condition_group.conditions, group_ids
     )
 
-    # Filter groups based on workflow filters
-    filter_groups = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
-
-    if not filter_groups:
-        return groups_meeting_triggers
-
-    for filter_group in filter_groups:
-        # TODO: should we have a separate list per filter group?
+    for filter_group in filter_condition_groups:
         preview_groups.update(
-            preview_data_condition_group(filter_group.id, groups_meeting_triggers)
+            preview_condition_group(
+                filter_group.logic_type, filter_group.conditions, groups_meeting_triggers
+            )
         )
 
     return preview_groups

--- a/tests/sentry/workflow_engine/processors/test_workflow_preview.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_preview.py
@@ -126,7 +126,7 @@ class TestPreviewDataConditionGroup(TestCase):
 
     @patch("sentry.workflow_engine.processors.workflow_preview.preview_conditions")
     def test_groups_to_check(self, mock_preview_conditions):
-        mock_preview_conditions.return_value = [(self.group_ids, self.group_ids), (set(), set())]
+        mock_preview_conditions.side_effect = [(self.group_ids, self.group_ids), (set(), set())]
 
         preview_groups = preview_condition_group(
             logic_type=DataConditionGroup.Type.ALL,

--- a/tests/sentry/workflow_engine/processors/test_workflow_preview.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_preview.py
@@ -1,0 +1,213 @@
+from unittest.mock import patch
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.workflow_preview import (
+    EvaluationGroup,
+    preview_condition_group,
+    preview_conditions,
+    preview_workflow,
+)
+
+
+class TestPreviewConditions(TestCase):
+    def setUp(self):
+        self.condition = self.create_data_condition(
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+        self.condition_2 = self.create_data_condition(
+            type=Condition.REGRESSION_EVENT,
+            comparison=True,
+            condition_result=False,
+        )
+        self.conditions = [
+            self.condition,
+            self.condition_2,
+        ]
+        self.group_2 = self.create_group()
+        self.group_ids = {self.group.id, self.group_2.id}
+
+    def test_no_conditions(self):
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.ALL, conditions=[], group_ids=self.group_ids
+        )
+        assert groups_to_check == set()
+        assert groups_meeting_conditions == self.group_ids
+
+    def test_all_type__meets_all(self):
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.ALL,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == self.group_ids
+        assert groups_meeting_conditions == self.group_ids
+
+    @patch("sentry.workflow_engine.models.data_condition.DataCondition.get_preview_groups")
+    def test_all_type__does_not_meet_all(self, mock_get_preview_groups):
+        mock_get_preview_groups.side_effect = [self.group_ids, set()]
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.ALL,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == set()
+        assert groups_meeting_conditions == set()
+
+    @patch("sentry.workflow_engine.models.data_condition.DataCondition.get_preview_groups")
+    def test_any_type__meets_any(self, mock_get_preview_groups):
+        mock_get_preview_groups.side_effect = [{self.group.id}, set()]
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.ANY,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == {self.group_2.id}
+        assert groups_meeting_conditions == {self.group.id}
+
+    @patch("sentry.workflow_engine.models.data_condition.DataCondition.get_preview_groups")
+    def test_any_type__does_not_meet_any(self, mock_get_preview_groups):
+        mock_get_preview_groups.return_value = set()
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.ANY,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == self.group_ids
+        assert groups_meeting_conditions == set()
+
+    @patch("sentry.workflow_engine.models.data_condition.DataCondition.get_preview_groups")
+    def test_none_type__meets_none(self, mock_get_preview_groups):
+        mock_get_preview_groups.return_value = set()
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.NONE,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == self.group_ids
+        assert groups_meeting_conditions == self.group_ids
+
+    @patch("sentry.workflow_engine.models.data_condition.DataCondition.get_preview_groups")
+    def test_none_type__does_not_meet_none(self, mock_get_preview_groups):
+        mock_get_preview_groups.side_effect = [self.group_ids, set()]
+        groups_to_check, groups_meeting_conditions = preview_conditions(
+            logic_type=DataConditionGroup.Type.NONE,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert groups_to_check == set()
+        assert groups_meeting_conditions == set()
+
+
+class TestPreviewDataConditionGroup(TestCase):
+    def setUp(self):
+        self.fast_condition = self.create_data_condition(
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+        self.slow_condition = self.create_data_condition(
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+        self.conditions = [
+            self.fast_condition,
+            self.slow_condition,
+        ]
+        self.group_ids = {self.group.id}
+
+    @patch("sentry.workflow_engine.processors.workflow_preview.preview_conditions")
+    def test_groups_to_check(self, mock_preview_conditions):
+        mock_preview_conditions.return_value = [(self.group_ids, self.group_ids), (set(), set())]
+
+        preview_groups = preview_condition_group(
+            logic_type=DataConditionGroup.Type.ALL,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert preview_groups == set()
+
+        assert mock_preview_conditions.call_count == 2
+
+    @patch("sentry.workflow_engine.processors.workflow_preview.preview_conditions")
+    def test_no_groups_to_check(self, mock_preview_conditions):
+        mock_preview_conditions.return_value = (set(), self.group_ids)
+
+        preview_groups = preview_condition_group(
+            logic_type=DataConditionGroup.Type.ALL,
+            conditions=self.conditions,
+            group_ids=self.group_ids,
+        )
+        assert preview_groups == self.group_ids
+
+        assert mock_preview_conditions.call_count == 1
+
+
+class TestPreviewWorkflow(TestCase):
+    def setUp(self):
+        self.detector = self.create_detector(
+            name="test_detector",
+            type=ErrorGroupType.slug,
+            project=self.project,
+        )
+        self.fast_condition = self.create_data_condition(
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+        self.slow_condition = self.create_data_condition(
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+        self.conditions = [
+            self.fast_condition,
+            self.slow_condition,
+        ]
+        self.condition_group = EvaluationGroup(
+            logic_type=DataConditionGroup.Type.ANY, conditions=self.conditions
+        )
+        self.group = self.create_group(project=self.project)
+
+    def test_no_groups(self):
+        self.group.delete()
+        preview_groups = preview_workflow(
+            detectors=[self.detector],
+            environment=None,
+            trigger_condition_group=self.condition_group,
+            filter_condition_groups=[self.condition_group],
+        )
+        assert preview_groups == set()
+
+    @patch("sentry.workflow_engine.processors.workflow_preview.preview_conditions")
+    def test_meets_triggers_only(self, mock_preview_conditions):
+        mock_preview_conditions.side_effect = [(set(), {self.group.id}), (set(), set())]
+        preview_groups = preview_workflow(
+            detectors=[self.detector],
+            environment=None,
+            trigger_condition_group=self.condition_group,
+            filter_condition_groups=[self.condition_group],
+        )
+        assert preview_groups == set()
+
+    @patch("sentry.workflow_engine.processors.workflow_preview.preview_conditions")
+    def test_meets_triggers_and_filters(self, mock_preview_conditions):
+        mock_preview_conditions.side_effect = [(set(), {self.group.id}), (set(), {self.group.id})]
+        preview_groups = preview_workflow(
+            detectors=[self.detector],
+            environment=None,
+            trigger_condition_group=self.condition_group,
+            filter_condition_groups=[self.condition_group],
+        )
+        assert preview_groups == {self.group.id}


### PR DESCRIPTION
Get `group_ids` from the past 14 days that would have been triggered by a `Workflow`, which is represented by its trigger condition group + triggers and a list of filter condition groups + their filters. We also manually pass in the detectors that we want to think of as "attached" to the workflow.

We need to pass in all these arguments because we want the workflow preview to update when the user updates the form, so the `Workflow` may not be saved in the db yet.

`preview_workflow` logic

1. Find Groups from the last 14 days with types corresponding to the detectors
2. Filter groups based on workflow triggers (see A)
3. Filter groups based on each workflow filter groups (see A; the word filter is overused, sorry 😞)
4. Return group ids that meet both the triggers and any of the filter groups

A. How to find groups that would have fired a data condition group:
1. Split fast and slow conditions
2. Check fast conditions for a list of groups (see B)
4. Check slow conditions with groups that did not meet the fast conditions according to the data condition group `logic_type` (see B + "continue checking")

B. How to find groups that met a list of conditions
1. Call `get_preview_groups` for each condition with the group_ids, each condition will have this implemented their own way. This will return the group_ids that meet the condition
2. For `logic_type=DataConditionGroup.Type.ALL`: groups that met all conditions, continue checking groups that met all conditions
3. For `logic_type=DataConditionGroup.Type.ANY` / `logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT`: groups that met any condition, continue checking groups that did not
4. For `logic_type=DataConditionGroup.Type.NONE`: groups that met no conditions, continue checking groups that met no conditions
5. If evaluating a list of fast conditions, the list of "continue checking" groups = groups we will evaluate slow conditions on