### PR TITLE
chore(flags): add flag and tag drawer files to replay codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -333,6 +333,8 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/flags/                                          @getsentry/replay-backend
 /tests/sentry/flags/                                        @getsentry/replay-backend
 /static/app/components/events/featureFlags/                 @getsentry/replay-frontend
+/static/app/views/issueDetails/groupFeatureFlags/           @getsentry/replay-frontend
+/static/app/views/issueDetails/groupTags/                   @getsentry/replay-frontend
 ## End of Flags
 
 


### PR DESCRIPTION
Replays is updating the tags drawer into a combined tags + feature flags drawer. Ref https://github.com/getsentry/sentry/pull/87105