### PR TITLE
fix(metric-issues): Enable stats for metric issues

### DIFF
--- a/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
@@ -48,7 +48,7 @@ const metricIssueConfig: IssueCategoryConfigMapping = {
     similarIssues: {enabled: false},
     usesIssuePlatform: true,
     useOpenPeriodChecks: true,
-    stats: {enabled: false},
+    stats: {enabled: true},
     tags: {enabled: false},
     issueSummary: {enabled: false},
   },


### PR DESCRIPTION
This should display the graph of occurrences in the stream for parity. We'll need to change the contents of the graph in the near future to show open periods/metric data.