### PR TITLE
feat: enable sentry consumers to use max dlq size parameter

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -461,6 +461,7 @@ def get_stream_processor(
     stale_threshold_sec: int | None = None,
     enforce_schema: bool = False,
     group_instance_id: str | None = None,
+    max_dlq_buffer_length: int | None = None,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
 
@@ -594,7 +595,7 @@ def get_stream_processor(
         dlq_policy = DlqPolicy(
             dlq_producer,
             None,
-            None,
+            max_dlq_buffer_length,
         )
 
     else:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -532,6 +532,11 @@ def cron(**options: Any) -> None:
         "offsets mean data-loss.\n\n"
     ),
 )
+@click.option(
+    "--max-dlq-buffer-length",
+    type=int,
+    help="The maximum number of messages to buffer in the dlq before dropping messages. Defaults to unbounded.",
+)
 @configuration
 def basic_consumer(
     consumer_name: str, consumer_args: tuple[str, ...], topic: str | None, **options: Any


### PR DESCRIPTION
this allows you to pass in max dlq buffer size to consumers. this is configured in the ops repo