### PR TITLE
feat(bitbucket): Commit context

### DIFF
--- a/src/sentry/integrations/bitbucket/blame.py
+++ b/src/sentry/integrations/bitbucket/blame.py
@@ -1,0 +1,273 @@
+import datetime
+import email.utils
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+from typing import Any
+from urllib.parse import urlencode
+
+import unidiff
+
+from sentry.integrations.bitbucket.utils import BitbucketAPIPath
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
+from sentry.integrations.utils.commit_context import is_date_less_than_year
+from sentry.shared_integrations.client.base import BaseApiClient
+from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger("sentry.integrations.bitbucket")
+
+
+def _map_new_line_to_old(patched_file: unidiff.PatchedFile, lineno: int) -> int | None:
+    """
+    Given a unidiff Patch object (for a single file) and a lineno in the 'new' version,
+    determine the corresponding line number in the 'old' version, or return None if
+    the line is newly inserted by this patch.
+    """
+
+    # Sort hunks by the top of their "target" (new) range,
+    # to process them in ascending order.
+    sorted_hunks = sorted(patched_file, key=lambda h: h.target_start)
+
+    # Track the "old" file line index and "new" file line index
+    # where we are as we move down the file. They start at 1 by convention,
+    # but we'll see if your patch library uses 0-based or 1-based.
+    old_cursor = 1
+    new_cursor = 1
+
+    for hunk in sorted_hunks:
+        # If this hunk starts *below* our current new_cursor,
+        # first jump our cursors down to the start of the hunk.
+
+        # Step 1: move old_cursor/new_cursor down to hunk.target_start
+        # by counting them as context lines (1:1).
+        # But if the hunk.target_start is *beyond* our lineno, we can break early:
+        if new_cursor > lineno:
+            # We've already passed the line we care about;
+            # it was unaffected by any hunk. So just compute offset.
+            return lineno + (old_cursor - new_cursor)
+
+        # Move the cursors together in context (lines that are not changed)
+        while new_cursor < hunk.target_start:
+            # If we pass the lineno in that gap:
+            if new_cursor == lineno:
+                # That line is unaffected => same shift
+                return lineno + (old_cursor - new_cursor)
+            old_cursor += 1
+            new_cursor += 1
+
+        # Now new_cursor == hunk.target_start (or we've broken early).
+        # We process lines *within* this hunk:
+
+        for diff_line in hunk:
+            if diff_line.is_added:
+                # There's a new line but no old line
+                if diff_line.target_line_no == lineno:
+                    # Found our line; it's newly added
+                    return None  # blame this patch
+                # Advance new_cursor only
+                new_cursor += 1
+
+            elif diff_line.is_removed:
+                # There's an old line but no new line
+                # Advance old_cursor only
+                old_cursor += 1
+
+            else:
+                # context line => line exists in both old and new
+                # Check if new_cursor is our line
+                if diff_line.target_line_no == lineno:
+                    # Old line no is old_cursor
+                    return old_cursor
+                old_cursor += 1
+                new_cursor += 1
+
+    # If we finish all hunks and still haven't located lineno,
+    # that means the line is below the last hunk. It's unaffected by
+    # any changes in this patch, so we apply the final offset:
+
+    if new_cursor <= lineno:
+        # The line is below the last hunk
+        return lineno + (old_cursor - new_cursor)
+
+    # If somehow new_cursor > lineno, we would have returned earlier,
+    # so typically we don't reach here, but just in case:
+    return lineno + (old_cursor - new_cursor)
+
+
+def _parse_commit(commit: Mapping[str, Any]) -> CommitInfo:
+    id = commit["commit"]["hash"]
+
+    committed_date = commit["commit"].get("date")
+    if isinstance(committed_date, str):
+        committed_date = datetime.datetime.fromisoformat(committed_date)
+
+    message = commit["commit"].get("message")
+    if isinstance(message, str):
+        message = message.strip()
+
+    author = commit["commit"]["author"].get("raw")
+    if isinstance(author, str):
+        author_name, author_email = email.utils.parseaddr(author)
+    else:
+        author_name = None
+        author_email = None
+
+    return CommitInfo(
+        commitId=id,
+        committedDate=committed_date,
+        commitMessage=message,
+        commitAuthorName=author_name,
+        commitAuthorEmail=author_email,
+    )
+
+
+def _blame_file(
+    client: BaseApiClient, file: SourceLineInfo, extra: Mapping[str, Any]
+) -> FileBlameInfo | None:
+    if file.lineno is None:
+        logger.warning(
+            "blame_file.no_lineno",
+            extra={**extra, "file_path": file.path},
+        )
+        return None
+
+    current_lineno = file.lineno
+    logger.info("blame_file.start", extra={**extra, "current_lineno": current_lineno})
+
+    filehistory_params = urlencode(
+        {
+            "fields": ",".join(
+                [
+                    "next",
+                    "values.commit.author.*",
+                    "values.commit.hash",
+                    "values.commit.date",
+                    "values.commit.message",
+                ]
+            ),
+        }
+    )
+    filehistory_url = f"{BitbucketAPIPath.filehistory.format(repo=file.repo.name, sha=file.ref, path=file.path)}?{filehistory_params}"
+
+    while filehistory_url:
+        try:
+            data = client.get(filehistory_url)
+        except ApiError as e:
+            if e.code in (401, 403, 404):
+                logger.warning(
+                    "blame_file.filehistory.api_error",
+                    extra={
+                        **extra,
+                        "code": e.code,
+                        "error_message": e.text,
+                        "repo_name": file.repo.name,
+                        "file_path": file.path,
+                        "branch_name": file.ref,
+                        "file_lineno": file.lineno,
+                    },
+                )
+                return None
+            raise
+
+        for commit in data["values"]:
+            commit_info = _parse_commit(commit)
+
+            if not is_date_less_than_year(commit_info.committedDate):
+                logger.warning(
+                    "blame_file.commit_too_old",
+                    extra={**extra, "commit_id": commit_info.commitId},
+                )
+
+                # We only want to blame commits from the last year
+                return None
+
+            diff_params = urlencode({"path": file.path})
+            diff_url = f"{BitbucketAPIPath.repository_diff.format(repo=file.repo.name, spec=commit_info.commitId)}?{diff_params}"
+
+            try:
+                diff_response = client.get_cached(diff_url, raw_response=True)
+            except ApiError as e:
+                if e.code in (401, 403, 404):
+                    logger.warning(
+                        "blame_file.diff.api_error",
+                        extra={
+                            **extra,
+                            "commit_id": commit_info.commitId,
+                            "code": e.code,
+                            "error_message": e.text,
+                            "repo_name": file.repo.name,
+                            "file_path": file.path,
+                            "branch_name": file.ref,
+                            "file_lineno": file.lineno,
+                        },
+                    )
+                    return None
+                raise
+
+            patch_set = unidiff.PatchSet.from_string(diff_response.text)
+
+            if len(patch_set) == 0:
+                logger.warning(
+                    "fetch_file_blames.no_patched_file",
+                    extra={**extra, "file": file.path},
+                )
+
+                continue
+
+            elif len(patch_set) > 1:
+                raise ValueError(f"Expected 1 patched file, got {len(patch_set)}")
+
+            old_lineno = _map_new_line_to_old(patch_set[0], current_lineno)
+            if old_lineno is None:
+                logger.info(
+                    "blame_file.newly_inserted",
+                    extra={
+                        **extra,
+                        "current_lineno": current_lineno,
+                        "commit_id": commit_info.commitId,
+                    },
+                )
+
+                # The line is newly inserted, so we can blame the commit
+                return FileBlameInfo(
+                    **asdict(file),
+                    commit=commit_info,
+                )
+
+            # Otherwise, we need to blame the old line number
+            logger.info(
+                "blame_file.old_lineno",
+                extra={
+                    **extra,
+                    "current_lineno": current_lineno,
+                    "commit_id": commit_info.commitId,
+                },
+            )
+            current_lineno = old_lineno
+
+        # Get the next page of file history, if any
+        filehistory_url = data.get("next")
+
+    return None
+
+
+def fetch_file_blames(
+    client: BaseApiClient, files: Sequence[SourceLineInfo], extra: Mapping[str, Any]
+) -> list[FileBlameInfo]:
+    blames = []
+
+    for file in files:
+        blame = _blame_file(client, file, extra)
+        if blame:
+            blames.append(blame)
+        else:
+            logger.warning(
+                "fetch_file_blames.no_blame_info",
+                extra={**extra, "file_path": file.path, "file_lineno": file.lineno},
+            )
+
+    return blames

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -19,6 +19,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.atlassian_connect import (
@@ -99,7 +100,7 @@ metadata = IntegrationMetadata(
 scopes = ("issue:write", "pullrequest", "webhook", "repository")
 
 
-class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
+class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec, CommitContextIntegration):
     codeowners_locations = [".bitbucket/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/bitbucket/utils.py
+++ b/src/sentry/integrations/bitbucket/utils.py
@@ -1,0 +1,23 @@
+class BitbucketAPIPath:
+    """
+    All UUID's must be surrounded by curlybraces.
+
+    repo is the fully qualified slug containing 'username/repo_slug'
+
+    repo_slug - repository slug or UUID
+    username - username or UUID
+    """
+
+    issue = "/2.0/repositories/{repo}/issues/{issue_id}"
+    issues = "/2.0/repositories/{repo}/issues"
+    issue_comments = "/2.0/repositories/{repo}/issues/{issue_id}/comments"
+
+    repository = "/2.0/repositories/{repo}"
+    repositories = "/2.0/repositories/{username}"
+    repository_commits = "/2.0/repositories/{repo}/commits/{revision}"
+    repository_diff = "/2.0/repositories/{repo}/diff/{spec}"
+    repository_hook = "/2.0/repositories/{repo}/hooks/{uid}"
+    repository_hooks = "/2.0/repositories/{repo}/hooks"
+
+    source = "/2.0/repositories/{repo}/src/{sha}/{path}"
+    filehistory = "/2.0/repositories/{repo}/filehistory/{sha}/{path}"

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1076,7 +1076,12 @@ def process_commits(job: PostProcessJob) -> None:
 
                     org_integrations = integration_service.get_organization_integrations(
                         organization_id=event.project.organization_id,
-                        providers=["github", "gitlab", "github_enterprise"],
+                        providers=[
+                            "github",
+                            "gitlab",
+                            "github_enterprise",
+                            "bitbucket",
+                        ],
                     )
                     has_integrations = len(org_integrations) > 0
                     # Cache the integrations check for 4 hours

--- a/tests/sentry/integrations/bitbucket/test_client.py
+++ b/tests/sentry/integrations/bitbucket/test_client.py
@@ -1,10 +1,22 @@
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any
+from unittest import mock
+from urllib.parse import urlencode
+
 import jwt
 import pytest
 import responses
 from requests import Request
 
-from sentry.integrations.bitbucket.client import BitbucketApiClient, BitbucketAPIPath
+from sentry.integrations.bitbucket.client import BitbucketApiClient
 from sentry.integrations.bitbucket.integration import BitbucketIntegration
+from sentry.integrations.bitbucket.utils import BitbucketAPIPath
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.integrations.utils.atlassian_connect import get_query_hash
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -154,3 +166,314 @@ class BitbucketApiClientTest(TestCase, BaseTestCase):
             self.config.repository, ref=self.config.default_branch
         )
         assert result == BITBUCKET_CODEOWNERS
+
+
+@control_silo_test
+class BitbucketBlameForFilesTest(BitbucketApiClientTest):
+    def setUp(self):
+        super().setUp()
+
+        """
+        The commit history is as follows, from newest to oldest:
+        ---
+        1. This is
+        2. an updated
+        3. multiline example
+        4. with
+        5. some lines
+        6. in it
+        7.
+        8. (The end)
+        ---
+        1. This is
+        2. an updated
+        3. multiline example
+        4. with
+        5. some lines
+        6. in it
+        7.
+        8. Another chunk
+        9. of text
+        10.
+        11. (The end)
+        ---
+        1. This is
+        2. a multiline
+        3. file with
+        4. some lines
+        5. in it
+        6.
+        7. Another chunk
+        8. of text
+        9. here
+        10.
+        11. (The end)
+        """
+
+        self.third_commit = CommitInfo(
+            commitId="third",
+            commitMessage="third commit message",
+            committedDate=datetime(2025, 1, 3, 0, 0, 0, tzinfo=timezone.utc),
+            commitAuthorEmail="third@user.com",
+            commitAuthorName="Third User",
+        )
+        self.second_commit = CommitInfo(
+            commitId="second",
+            commitMessage="second commit message",
+            committedDate=datetime(2025, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+            commitAuthorEmail="second@user.com",
+            commitAuthorName="Second User",
+        )
+        self.first_commit = CommitInfo(
+            commitId="first",
+            commitMessage="first commit message",
+            committedDate=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            commitAuthorEmail="first@user.com",
+            commitAuthorName="First User",
+        )
+
+        self.file_diffs: list[tuple[CommitInfo, str]] = [
+            (
+                self.third_commit,
+                """diff --git a/example.txt b/example.txt
+index 6ce42d3..02ac986 100644
+--- a/example.txt
++++ b/example.txt
+@@ -5,7 +5,4 @@ with
+ some lines
+ in it
+
+-Another chunk
+-of text
+-
+ (The end)
+""",
+            ),
+            (
+                self.second_commit,
+                """diff --git a/example.txt b/example.txt
+index 2b313e3..6ce42d3 100644
+--- a/example.txt
++++ b/example.txt
+@@ -1,11 +1,11 @@
+ This is
+-a multiline
+-file with
++an updated
++multiline example
++with
+ some lines
+ in it
+
+ Another chunk
+ of text
+-here
+
+ (The end)
+""",
+            ),
+            (
+                self.first_commit,
+                """diff --git a/example.txt b/example.txt
+new file mode 100644
+index 0000000..2b313e3
+--- /dev/null
++++ b/example.txt
+@@ -0,0 +1,11 @@
++This is
++a multiline
++file with
++some lines
++in it
++
++Another chunk
++of text
++here
++
++(The end)
+""",
+            ),
+        ]
+
+        self.file = SourceLineInfo(
+            path="example.txt",
+            lineno=mock.ANY,
+            ref="master",
+            repo=self.repo,
+            code_mapping=mock.ANY,
+        )
+
+    def set_up_success_responses(self):
+        responses.add(
+            method=responses.GET,
+            url=self.make_filehistory_url(file=self.file, page=None),
+            json=self.make_filehistory_response(
+                file=self.file, diffs=[self.file_diffs[0], self.file_diffs[1]], next_page=1
+            ),
+            status=200,
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.make_filehistory_url(file=self.file, page=1),
+            json=self.make_filehistory_response(
+                file=self.file, diffs=[self.file_diffs[2]], next_page=None
+            ),
+            status=200,
+        )
+        for commit, diff in self.file_diffs:
+            responses.add(
+                method=responses.GET,
+                url=self.make_diff_url(file=self.file, hash=commit.commitId),
+                body=diff,
+                content_type="text/plain",
+                status=200,
+            )
+
+    def make_filehistory_url(self, file: SourceLineInfo, page: int | None = None) -> str:
+        params = urlencode(
+            {
+                "fields": ",".join(
+                    [
+                        "next",
+                        "values.commit.author.*",
+                        "values.commit.hash",
+                        "values.commit.date",
+                        "values.commit.message",
+                    ],
+                ),
+                **({"page": page} if page is not None else {}),
+            }
+        )
+        return f"https://api.bitbucket.org/2.0/repositories/{self.repo.config['name']}/filehistory/master/{file.path}?{params}"
+
+    def make_filehistory_response(
+        self,
+        file: SourceLineInfo,
+        diffs: list[tuple[CommitInfo, str]],
+        next_page: int | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "values": [
+                {
+                    "commit": {
+                        "author": {
+                            "raw": f"{commit.commitAuthorName} <{commit.commitAuthorEmail}>"
+                        },
+                        "date": commit.committedDate.isoformat(),
+                        "hash": commit.commitId,
+                        "message": commit.commitMessage,
+                    },
+                }
+                for commit, _diff in diffs
+            ],
+            **(
+                {"next": self.make_filehistory_url(file=file, page=next_page)}
+                if next_page is not None
+                else {}
+            ),
+        }
+
+    def make_diff_url(self, file: SourceLineInfo, hash: str) -> str:
+        params = urlencode({"path": file.path})
+        return f"https://api.bitbucket.org/2.0/repositories/{self.repo.config['name']}/diff/{hash}?{params}"
+
+    @freeze_time("2025-01-01 01:01:01")
+    @responses.activate
+    def test_success_line_not_changed(self):
+        # Line 1 was introduced in the first commit and has not been changed since.
+        file = SourceLineInfo(
+            path="example.txt",
+            lineno=1,
+            ref="master",
+            repo=self.repo,
+            code_mapping=mock.ANY,
+        )
+        blame = FileBlameInfo(
+            **asdict(file),
+            commit=self.first_commit,
+        )
+
+        self.set_up_success_responses()
+        resp = self.bitbucket_client.get_blame_for_files(files=[file], extra={})
+
+        assert resp == [blame]
+
+    @freeze_time("2025-01-01 01:01:01")
+    @responses.activate
+    def test_success_line_changed_multiple_times(self):
+        # Line 8 was introduced in the first commit. Note that the line has been updated in subsequent commits
+        # so the blame should be the first commit.
+        file = SourceLineInfo(
+            path="example.txt",
+            lineno=8,
+            ref="master",
+            repo=self.repo,
+            code_mapping=mock.ANY,
+        )
+        blame = FileBlameInfo(
+            **asdict(file),
+            commit=self.first_commit,
+        )
+
+        self.set_up_success_responses()
+        resp = self.bitbucket_client.get_blame_for_files(files=[file], extra={})
+
+        assert resp == [blame]
+
+    @freeze_time("2025-01-01 01:01:01")
+    @responses.activate
+    def test_success_line_changed_once(self):
+        # Line 2 was changed in the second commit.
+        file = SourceLineInfo(
+            path="example.txt",
+            lineno=2,
+            ref="master",
+            repo=self.repo,
+            code_mapping=mock.ANY,
+        )
+        blame = FileBlameInfo(
+            **asdict(file),
+            commit=self.second_commit,
+        )
+
+        self.set_up_success_responses()
+        resp = self.bitbucket_client.get_blame_for_files(files=[file], extra={})
+
+        assert resp == [blame]
+
+    @mock.patch(
+        "sentry.integrations.bitbucket.blame.logger.warning",
+    )
+    @responses.activate
+    def test_failure_404(self, mock_logger_warning):
+        responses.add(
+            responses.GET,
+            self.make_filehistory_url(file=self.file, page=None),
+            status=404,
+            body="No file found",
+        )
+        resp = self.bitbucket_client.get_blame_for_files(files=[self.file], extra={})
+
+        assert resp == []
+        mock_logger_warning.assert_any_call(
+            "blame_file.filehistory.api_error",
+            extra={
+                "provider": "bitbucket",
+                "org_integration_id": self.bitbucket_client.integration_id,
+                "code": 404,
+                "error_message": "No file found",
+                "repo_name": self.repo.name,
+                "file_path": self.file.path,
+                "branch_name": self.file.ref,
+                "file_lineno": self.file.lineno,
+            },
+        )
+        mock_logger_warning.assert_any_call(
+            "fetch_file_blames.no_blame_info",
+            extra={
+                "provider": "bitbucket",
+                "org_integration_id": self.bitbucket_client.integration_id,
+                "file_path": self.file.path,
+                "file_lineno": self.file.lineno,
+            },
+        )


### PR DESCRIPTION
Commit context (Suspect commit) for Bitbucket.

Unfortunately, the Bitbucket Cloud REST API 2.0 does not support blame, so I had to examine the commit history of the relevant file to find the commit that introduced the line.

The algorithm is as follows:
1. The file history is presented from the newest commits to the oldest.
2. Go through each commit.
3. If that commit introduced the line, return the commit.
4. Otherwise, map the line number to the old line number.
5. Use the old line number to check the next commit.

As we only display suspect commits from the past year, exit early if the commit is older than that.

<details>
<summary>Screenshots</summary>

![Screenshot 2025-03-21 at 02 25 59](https://github.com/user-attachments/assets/de72fb3d-b427-44b3-a0d9-1155a047d208)
![Screenshot 2025-03-21 at 02 25 22](https://github.com/user-attachments/assets/6eb5dfe8-2a82-4ef0-ac96-8c1fd4696a2c)
![Screenshot 2025-03-21 at 02 26 14](https://github.com/user-attachments/assets/f71a09a2-a94a-43f5-9252-6a7576b8cf70)



</details>
