### PR TITLE
ref(grouping): Convert `Enhancements.dumps` into a cached property

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -109,7 +109,7 @@ class GroupingConfigLoader:
         try:
             enhancements = Enhancements.from_config_string(
                 project_enhancements, bases=[enhancements_base] if enhancements_base else []
-            ).dumps()
+            ).base64_string
         except InvalidEnhancerConfig:
             enhancements = get_default_enhancements()
         cache.set(cache_key, enhancements)
@@ -174,7 +174,7 @@ def get_default_enhancements(config_id: str | None = None) -> str:
     base: str | None = DEFAULT_GROUPING_ENHANCEMENTS_BASE
     if config_id is not None:
         base = CONFIGURATIONS[config_id].enhancements_base
-    return Enhancements.from_config_string("", bases=[base] if base else []).dumps()
+    return Enhancements.from_config_string("", bases=[base] if base else []).base64_string
 
 
 def get_projects_default_fingerprinting_bases(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -6,6 +6,7 @@ import os
 import zlib
 from collections import Counter
 from collections.abc import Sequence
+from functools import cached_property
 from typing import Any, Literal, NotRequired, TypedDict
 
 import msgpack
@@ -316,6 +317,11 @@ class Enhancements:
         encoded = msgpack.dumps(self._to_config_structure())
         compressed = zstandard.compress(encoded)
         return base64.urlsafe_b64encode(compressed).decode("ascii").strip("=")
+
+    @cached_property
+    def base64_string(self) -> str:
+        """A base64 string representation of the enhancements object"""
+        return self.dumps()
 
     @classmethod
     def _from_config_structure(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -313,15 +313,12 @@ class Enhancements:
             [rule._to_config_structure(self.version) for rule in self.rules],
         ]
 
-    def dumps(self) -> str:
-        encoded = msgpack.dumps(self._to_config_structure())
-        compressed = zstandard.compress(encoded)
-        return base64.urlsafe_b64encode(compressed).decode("ascii").strip("=")
-
     @cached_property
     def base64_string(self) -> str:
         """A base64 string representation of the enhancements object"""
-        return self.dumps()
+        encoded = msgpack.dumps(self._to_config_structure())
+        compressed = zstandard.compress(encoded)
+        return base64.urlsafe_b64encode(compressed).decode("ascii").strip("=")
 
     @classmethod
     def _from_config_structure(

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -988,7 +988,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             function:in_app_function +app
             function:not_in_app_function -app
             """
-        ).dumps()
+        ).base64_string
 
         grouping_config = {"id": DEFAULT_GROUPING_CONFIG, "enhancements": enhancements_str}
 
@@ -2226,7 +2226,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             function:foo2 category=bar
             category:bar -app
             """
-        ).dumps()
+        ).base64_string
 
         grouping_config = {"id": DEFAULT_GROUPING_CONFIG, "enhancements": enhancements_str}
 
@@ -2301,7 +2301,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             function:foo category=foo_like
             category:foo_like -group
             """
-        ).dumps()
+        ).base64_string
 
         grouping_config: GroupingConfig = {
             "id": DEFAULT_GROUPING_CONFIG,

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -376,7 +376,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
             """,
         )
         grouping_config: GroupingConfig = {
-            "enhancements": enhancement.dumps(),
+            "enhancements": enhancement.base64_string,
             "id": DEFAULT_GROUPING_CONFIG,
         }
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -91,7 +91,7 @@ class GroupingInput:
         grouping_config["enhancements"] = Enhancements.from_config_string(
             self.data.get("_grouping", {}).get("enhancements", ""),
             bases=Enhancements.loads(grouping_config["enhancements"]).bases,
-        ).dumps()
+        ).base64_string
         fingerprinting_config = FingerprintingRules.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},
             bases=CONFIGURATIONS[config_name].fingerprinting_bases,

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -61,8 +61,8 @@ error.value:"*something*"                       max-frames=12
 
     insta_snapshot(dump_obj(enhancement))
 
-    dumped = enhancement.dumps()
-    assert Enhancements.loads(dumped).dumps() == dumped
+    dumped = enhancement.base64_string
+    assert Enhancements.loads(dumped).base64_string == dumped
     assert Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
     assert isinstance(dumped, str)
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -639,7 +639,7 @@ def test_apply_new_stack_trace_rules(
             "enhancements": Enhancements.from_config_string(
                 "function:c -group",
                 bases=[],
-            ).dumps(),
+            ).base64_string,
         },
     ):
         # Reprocess


### PR DESCRIPTION
When we cache a project's stacktrace rules, and when we store them on the event, we do so in the form of a base64 string, which we produce using the `Enhancements.dumps` method. But since enhancements are never modified, there's no reason for us to calculate that string more than once. 

This therefore converts the `dumps` method into a cached property, and - since it is no longer _doing_ a thing but instead _being_ a thing - renames it from the verb phrase `dumps` to the noun `base64_string`.