### PR TITLE
ref(debugger-modal): Update active tab logic

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.spec.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.spec.tsx
@@ -1,4 +1,9 @@
-import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 
@@ -47,49 +52,54 @@ const defaultSourceResolutionResults: FrameSourceMapDebuggerData = {
   projectPlatform: undefined,
 };
 
-const renderModal = (props?: Partial<SourceMapsDebuggerModalProps>) => {
+const renderModal = async (props?: Partial<SourceMapsDebuggerModalProps>) => {
   renderGlobalModal();
 
-  act(() => {
-    openModal(
-      modalProps => (
-        <SourceMapsDebuggerModal
-          analyticsParams={defaultAnalyticsParams}
-          sourceResolutionResults={defaultSourceResolutionResults}
-          projectId="1"
-          orgSlug="org-slug"
-          {...props}
-          {...modalProps}
-        />
-      ),
-      {
-        onClose: () => {},
+  render(
+    <button
+      onClick={() =>
+        openModal(modalProps => (
+          <SourceMapsDebuggerModal
+            analyticsParams={defaultAnalyticsParams}
+            sourceResolutionResults={defaultSourceResolutionResults}
+            projectId="1"
+            orgSlug="org-slug"
+            {...props}
+            {...modalProps}
+          />
+        ))
       }
-    );
-  });
+    >
+      Unminify Code
+    </button>
+  );
+
+  await userEvent.click(screen.getByRole('button', {name: /unminify code/i}));
+
+  await screen.findByText(/Make Your Stack Traces Readable/i);
 };
 
 describe('SourceMapsDebuggerModal', () => {
   it(`renders proper message when active tab is 'release', release has some
-  artifact and release name fetching was unsuccessful`, () => {
-    const sourceResolutionResults = {
-      ...defaultSourceResolutionResults,
-      releaseProgressPercent: 100, // so the active tab is 'release'
-      releaseHasSomeArtifact: true,
-      sourceFileReleaseNameFetchingResult: 'unsuccessful' as const,
-    };
+    artifact and release name fetching was unsuccessful`, async function () {
+    await renderModal({
+      sourceResolutionResults: {
+        ...defaultSourceResolutionResults,
+        releaseProgressPercent: 100, // so the active tab is 'release'
+        releaseHasSomeArtifact: true,
+        sourceFileReleaseNameFetchingResult: 'unsuccessful' as const,
+        sdkDebugIdSupport: 'not-supported',
+      },
+    });
 
-    renderModal({sourceResolutionResults});
+    expect(screen.getByText(/This stack frame doesn't have a path/)).toBeInTheDocument();
 
-    expect(
-      screen.getByText(
-        "This stack frame doesn't have a path. Check your SDK configuration to send a stack frame path!"
-      )
-    ).toBeInTheDocument();
+    // Close modal
+    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
   });
 
-  it('does not render "Debug IDs" tab if the SDK does not support it', function () {
-    renderModal({
+  it('does not render "Debug IDs" tab if the SDK does not support it', async function () {
+    await renderModal({
       sourceResolutionResults: {
         ...defaultSourceResolutionResults,
         sdkDebugIdSupport: 'not-supported',
@@ -97,15 +107,25 @@ describe('SourceMapsDebuggerModal', () => {
     });
 
     expect(screen.queryByRole('tab', {name: /debug ids/i})).not.toBeInTheDocument();
+
+    // Close modal
+    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
   });
-  it('renders "Debug IDs" tab if the SDK does support it', function () {
-    renderModal({
+
+  it('if SDK fully supports Debug IDs, renders "Debug IDs" tab as active', async function () {
+    await renderModal({
       sourceResolutionResults: {
         ...defaultSourceResolutionResults,
         sdkDebugIdSupport: 'full',
       },
     });
 
-    expect(screen.getByRole('tab', {name: /debug ids/i})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: /debug ids/i})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    // Close modal
+    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
   });
 });

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -456,6 +456,11 @@ export function SourceMapsDebuggerModal({
   const sourceMapsDocLinks = getSourceMapsDocLinks(platform);
 
   const [activeTab, setActiveTab] = useState<'debug-ids' | 'release' | 'fetching'>(() => {
+    // If the SDK supports Debug IDs, the Debug IDs tab should be shown by default
+    if (sourceResolutionResults.sdkDebugIdSupport === 'full') {
+      return 'debug-ids';
+    }
+
     const possibleTabs = [
       {tab: 'debug-ids', progress: sourceResolutionResults.debugIdProgressPercent},
       {tab: 'release', progress: sourceResolutionResults.releaseProgressPercent},
@@ -500,9 +505,7 @@ export function SourceMapsDebuggerModal({
         </p>
         <Tabs<'debug-ids' | 'release' | 'fetching'>
           value={activeTab}
-          onChange={tab => {
-            setActiveTab(tab);
-          }}
+          onChange={setActiveTab}
         >
           <TabList>
             <TabList.Item


### PR DESCRIPTION
The tab 'Debug IDs' should be active by default if the SDK fully supports 'Debug IDs'.

- closes https://github.com/getsentry/sentry/issues/85616