### PR TITLE
chore(onboarding): add dispatch_uids to all onboarding signals to prevent them from being called multiple times

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -136,7 +136,7 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
         )
 
 
-@first_event_received.connect(weak=False)
+@first_event_received.connect(weak=False, dispatch_uid="onboarding.record_first_event")
 def record_first_event(project, event, **kwargs):
     """
     Requires up to 2 database calls, but should only run with the first event in
@@ -229,7 +229,7 @@ def record_first_event(project, event, **kwargs):
             )
 
 
-@first_transaction_received.connect(weak=False)
+@first_transaction_received.connect(weak=False, dispatch_uid="onboarding.record_first_transaction")
 def _record_first_transaction(project, event, **kwargs):
     return record_first_transaction(project, event.datetime, **kwargs)
 
@@ -261,7 +261,7 @@ def record_first_transaction(project, datetime, **kwargs):
     )
 
 
-@first_profile_received.connect(weak=False)
+@first_profile_received.connect(weak=False, dispatch_uid="onboarding.record_first_profile")
 def record_first_profile(project, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_profiles))
 
@@ -274,7 +274,7 @@ def record_first_profile(project, **kwargs):
     )
 
 
-@first_replay_received.connect(weak=False)
+@first_replay_received.connect(weak=False, dispatch_uid="onboarding.record_first_replay")
 def record_first_replay(project, **kwargs):
     logger.info("record_first_replay_start")
     project.update(flags=F("flags").bitor(Project.flags.has_replays))
@@ -299,7 +299,7 @@ def record_first_replay(project, **kwargs):
         logger.info("record_first_replay_analytics_end")
 
 
-@first_flag_received.connect(weak=False)
+@first_flag_received.connect(weak=False, dispatch_uid="onboarding.record_first_flag")
 def record_first_flag(project, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_flags))
 
@@ -311,7 +311,7 @@ def record_first_flag(project, **kwargs):
     )
 
 
-@first_feedback_received.connect(weak=False)
+@first_feedback_received.connect(weak=False, dispatch_uid="onboarding.record_first_feedback")
 def record_first_feedback(project, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_feedbacks))
 
@@ -324,7 +324,9 @@ def record_first_feedback(project, **kwargs):
     )
 
 
-@first_new_feedback_received.connect(weak=False)
+@first_new_feedback_received.connect(
+    weak=False, dispatch_uid="onboarding.record_first_new_feedback"
+)
 def record_first_new_feedback(project, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_new_feedbacks))
 
@@ -337,7 +339,7 @@ def record_first_new_feedback(project, **kwargs):
     )
 
 
-@first_cron_monitor_created.connect(weak=False)
+@first_cron_monitor_created.connect(weak=False, dispatch_uid="onboarding.record_first_cron_monitor")
 def record_first_cron_monitor(project, user, from_upsert, **kwargs):
     updated = project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
 
@@ -351,7 +353,7 @@ def record_first_cron_monitor(project, user, from_upsert, **kwargs):
         )
 
 
-@cron_monitor_created.connect(weak=False)
+@cron_monitor_created.connect(weak=False, dispatch_uid="onboarding.record_cron_monitor_created")
 def record_cron_monitor_created(project, user, from_upsert, **kwargs):
     analytics.record(
         "cron_monitor.created",
@@ -362,7 +364,9 @@ def record_cron_monitor_created(project, user, from_upsert, **kwargs):
     )
 
 
-@first_cron_checkin_received.connect(weak=False)
+@first_cron_checkin_received.connect(
+    weak=False, dispatch_uid="onboarding.record_first_cron_checkin"
+)
 def record_first_cron_checkin(project, monitor_id, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_cron_checkins))
 
@@ -412,7 +416,7 @@ def record_first_insight_span(project, module, **kwargs):
 first_insight_span_received.connect(record_first_insight_span, weak=False)
 
 
-@member_invited.connect(weak=False)
+@member_invited.connect(weak=False, dispatch_uid="onboarding.record_member_invited")
 def record_member_invited(member, user, **kwargs):
     OrganizationOnboardingTask.objects.record(
         organization_id=member.organization_id,
@@ -431,7 +435,7 @@ def record_member_invited(member, user, **kwargs):
     )
 
 
-@member_joined.connect(weak=False)
+@member_joined.connect(weak=False, dispatch_uid="onboarding.record_member_joined")
 def record_member_joined(organization_id: int, organization_member_id: int, **kwargs):
     OrganizationOnboardingTask.objects.create_or_update(
         organization_id=organization_id,
@@ -482,7 +486,9 @@ event_processed.connect(_record_release_received, weak=False)
 transaction_processed.connect(_record_release_received, weak=False)
 
 
-@first_event_with_minified_stack_trace_received.connect(weak=False)
+@first_event_with_minified_stack_trace_received.connect(
+    weak=False, dispatch_uid="onboarding.record_event_with_first_minified_stack_trace_for_project"
+)
 def record_event_with_first_minified_stack_trace_for_project(project, event, **kwargs):
     organization = Organization.objects.get_from_cache(id=project.organization_id)
     owner_id = organization.default_owner_id
@@ -517,7 +523,7 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
             )
 
 
-@event_processed.connect(weak=False)
+@event_processed.connect(weak=False, dispatch_uid="onboarding.record_sourcemaps_received")
 def record_sourcemaps_received(project, event, **kwargs):
     if not has_sourcemap(event):
         return
@@ -549,7 +555,9 @@ def record_sourcemaps_received(project, event, **kwargs):
         )
 
 
-@event_processed.connect(weak=False)
+@event_processed.connect(
+    weak=False, dispatch_uid="onboarding.record_sourcemaps_received_for_project"
+)
 def record_sourcemaps_received_for_project(project, event, **kwargs):
     if not has_sourcemap(event):
         return
@@ -584,7 +592,7 @@ def record_sourcemaps_received_for_project(project, event, **kwargs):
             )
 
 
-@alert_rule_created.connect(weak=False)
+@alert_rule_created.connect(weak=False, dispatch_uid="onboarding.record_alert_rule_created")
 def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
     # The quick start now only has a task for issue alert rules.
     # Please see https://github.com/getsentry/sentry/blob/c06a3aa5fb104406f2a44994d32983e99bc2a479/static/app/components/onboardingWizard/taskConfig.tsx#L351-L352
@@ -602,7 +610,7 @@ def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
     )
 
 
-@integration_added.connect(weak=False)
+@integration_added.connect(weak=False, dispatch_uid="onboarding.record_integration_added")
 def record_integration_added(
     integration_id: int, organization_id: int, user_id: int | None, **kwargs
 ):


### PR DESCRIPTION
- This PR adds dispatch_uid parameters to all onboarding signals, which ensures that each of the signals is only run once per dispatch_uid, and thereby preventing any duplicate inserts that cause transactions to be rolled back. See [django docs](https://docs.djangoproject.com/en/5.1/topics/signals/#preventing-duplicate-signals) for more info on this. 

- Aftermath of https://github.com/getsentry/projects/issues/828