### PR TITLE
chore(feature): Rename connected to linked traces

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -414,7 +414,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable feature to load new trace view ui improvements
     manager.add("organizations:trace-view-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to show link to previous/next traces
-    manager.add("organizations:trace-view-connected-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:trace-view-linked-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to load new tracing onboarding ui
     manager.add("organizations:tracing-onboarding-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to search by key value pairs from trace view, in explore.


### PR DESCRIPTION
follow-up for this PR: https://github.com/getsentry/sentry/pull/87483

"linked traces" is a better naming for this feature flag as everything else around this topic is named like this. "connected traces" would add another naming and could be confusing.
