### PR TITLE
fix(auto_source_config): Use `get_or_create` properly

### DIFF
--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -205,13 +205,15 @@ def create_repos_and_code_mappings(
                 _, created = RepositoryProjectPathConfig.objects.get_or_create(
                     project=project,
                     stack_root=code_mapping.stacktrace_root,
-                    repository=repository,
-                    organization_integration_id=organization_integration.id,
-                    integration_id=organization_integration.integration_id,
-                    organization_id=organization_integration.organization_id,
-                    source_root=code_mapping.source_path,
-                    default_branch=code_mapping.repo.branch,
-                    automatically_generated=True,
+                    defaults={
+                        "repository": repository,
+                        "organization_integration_id": organization_integration.id,
+                        "integration_id": organization_integration.integration_id,
+                        "organization_id": organization_integration.organization_id,
+                        "source_root": code_mapping.source_path,
+                        "default_branch": code_mapping.repo.branch,
+                        "automatically_generated": True,
+                    },
                 )
             if created or dry_run:
                 metrics.incr(


### PR DESCRIPTION
This fixes a bunch of integrity errors introduced in #87437.

From the [docs](https://docs.djangoproject.com/en/5.1/ref/models/querysets/#get-or-create):

> Any keyword arguments passed to get_or_create() — except an optional one called defaults — will be used in a get() call. If an object is found, get_or_create() returns a tuple of that object and False.