### PR TITLE
fix(mep): Do not allow `!has` in metrics requests

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -4,6 +4,9 @@ from typing import Literal, TypedDict
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import DATASETS
 
+HAS_FILTER_ERROR_MESSAGE = """
+"has" filter is not supported in this search.
+"""
 RATE_LIMIT_ERROR_MESSAGE = """
 Rate limit exceeded. Please try your query with a smaller date range or fewer projects.
 """

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -4,8 +4,8 @@ from typing import Literal, TypedDict
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import DATASETS
 
-HAS_FILTER_ERROR_MESSAGE = """
-"has" filter is not supported in this search.
+NOT_HAS_FILTER_ERROR_MESSAGE = """
+"!has" filter is not supported in this search.
 """
 RATE_LIMIT_ERROR_MESSAGE = """
 Rate limit exceeded. Please try your query with a smaller date range or fewer projects.

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -138,6 +138,7 @@ class DiscoverDatasetConfig(DatasetConfig):
             TRACE_PARENT_SPAN_ALIAS: self._trace_parent_span_converter,
             "performance.issue_ids": self._performance_issue_ids_filter_converter,
             EVENT_TYPE_ALIAS: self._event_type_filter_converter,
+            "transaction": self._transaction_filter_converter,
         }
 
     @property
@@ -1956,5 +1957,22 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ["transaction"],
             ]:
                 return None
+
+        return self.builder.default_filter_converter(search_filter)
+
+    def _transaction_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        if self.builder.dataset == Dataset.Transactions:
+            operator = search_filter.operator
+            value = search_filter.value.value
+
+            if operator in ("=", "!=") and value == "":
+                # !has:transaction
+                if operator == "=":
+                    raise InvalidSearchQuery(
+                        "All events have a transaction so this query wouldn't return anything"
+                    )
+                else:
+                    # All events have a "transaction" since we map null -> unparam so no need to filter
+                    return None
 
         return self.builder.default_filter_converter(search_filter)

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -79,7 +79,7 @@ def query(
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
-                parser_config_overrides={"allow_has_filter": False},
+                parser_config_overrides={"allow_not_has_filter": False},
             ),
         )
         if referrer is None:
@@ -183,7 +183,7 @@ def bulk_timeseries_query(
                         functions_acl=functions_acl,
                         allow_metric_aggregates=allow_metric_aggregates,
                         use_metrics_layer=use_metrics_layer,
-                        parser_config_overrides={"allow_has_filter": False},
+                        parser_config_overrides={"allow_not_has_filter": False},
                     ),
                 )
                 snql_query = metrics_query.get_snql_query()
@@ -293,7 +293,7 @@ def timeseries_query(
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
                     on_demand_metrics_type=on_demand_metrics_type,
                     transform_alias_to_input_format=transform_alias_to_input_format,
-                    parser_config_overrides={"allow_has_filter": False},
+                    parser_config_overrides={"allow_not_has_filter": False},
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
@@ -452,7 +452,7 @@ def top_events_timeseries(
             on_demand_metrics_enabled=on_demand_metrics_enabled,
             on_demand_metrics_type=on_demand_metrics_type,
             transform_alias_to_input_format=transform_alias_to_input_format,
-            parser_config_overrides={"allow_has_filter": False},
+            parser_config_overrides={"allow_not_has_filter": False},
         ),
     )
     if len(top_events["data"]) == limit and include_other:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -79,6 +79,7 @@ def query(
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
+                parser_config_overrides={"allow_has_filter": False},
             ),
         )
         if referrer is None:
@@ -182,6 +183,7 @@ def bulk_timeseries_query(
                         functions_acl=functions_acl,
                         allow_metric_aggregates=allow_metric_aggregates,
                         use_metrics_layer=use_metrics_layer,
+                        parser_config_overrides={"allow_has_filter": False},
                     ),
                 )
                 snql_query = metrics_query.get_snql_query()
@@ -291,6 +293,7 @@ def timeseries_query(
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
                     on_demand_metrics_type=on_demand_metrics_type,
                     transform_alias_to_input_format=transform_alias_to_input_format,
+                    parser_config_overrides={"allow_has_filter": False},
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
@@ -449,6 +452,7 @@ def top_events_timeseries(
             on_demand_metrics_enabled=on_demand_metrics_enabled,
             on_demand_metrics_type=on_demand_metrics_type,
             transform_alias_to_input_format=transform_alias_to_input_format,
+            parser_config_overrides={"allow_has_filter": False},
         ),
     )
     if len(top_events["data"]) == limit and include_other:

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1036,6 +1036,90 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         # First bucket, where the transaction should be
         assert response.data["data"][0][1][0]["count"] == 1
 
+    def test_metrics_enhanced_with_has_filter_falls_back_to_indexed_data(self):
+        transaction_data = load_data("transaction")
+        self.store_event(
+            {
+                **transaction_data,
+                "tags": {"existingTag": "true"},
+                "start_timestamp": before_now(days=1, minutes=1).isoformat(),
+                "timestamp": before_now(days=1).isoformat(),
+                "measurements": {"time_to_initial_display": {"value": 222}},
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_transaction_metric(
+                111,
+                metric="measurements.time_to_initial_display",
+                timestamp=timestamp,
+                tags={"existingTag": "true"},
+            )
+        query = {
+            "field": ["avg(measurements.time_to_initial_display)"],
+            "query": "has:existingTag !has:nonExistingTag",
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "dataset": "metricsEnhanced",
+            "yAxis": ["avg(measurements.time_to_initial_display)"],
+        }
+        response = self.do_request(query, **self.additional_params)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+
+        # The request fell back to indexed data because the tag doesn't exist in the metrics indexer
+        assert response.data["meta"]["isMetricsData"] is False
+
+        # First bucket, where the transaction should be
+        assert response.data["data"][0][1][0]["count"] == 222
+
+    def test_top_events_with_metrics_enhanced_with_has_filter_falls_back_to_indexed_data(self):
+        transaction_data = load_data("transaction")
+        self.store_event(
+            {
+                **transaction_data,
+                "tags": {"existingTag": "true"},
+                "start_timestamp": before_now(days=1, minutes=1).isoformat(),
+                "timestamp": before_now(days=1).isoformat(),
+                "measurements": {"time_to_initial_display": {"value": 222}},
+                "transaction": "foo_transaction",
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_transaction_metric(
+                111,
+                metric="measurements.time_to_initial_display",
+                timestamp=timestamp,
+                tags={"existingTag": "true"},
+            )
+        query = {
+            "field": ["avg(measurements.time_to_initial_display)", "transaction"],
+            "query": "has:existingTag !has:nonExistingTag",
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "dataset": "metricsEnhanced",
+            "yAxis": ["avg(measurements.time_to_initial_display)"],
+            "topEvents": 1,
+        }
+        response = self.do_request(query, **self.additional_params)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["foo_transaction"]["data"]) == 2
+
+        data_series = response.data["foo_transaction"]
+
+        # The request fell back to indexed data because the tag doesn't exist in the metrics indexer
+        assert data_series["meta"]["isMetricsData"] is False
+
+        # First bucket, where the transaction should be
+        assert data_series["data"][0][1][0]["count"] == 222
+
 
 class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandWidgets(
     MetricsEnhancedPerformanceTestCase


### PR DESCRIPTION
We do not support `!has` well with metrics data, so we're going to bypass it completely for any requests on metrics. The queries should still pass if called with `dataset: metricsEnhanced` because we would just fall back to the indexed data.

The only special case I needed to make was for `team_key_transaction`. We use this on the performance page and instead of falling back to indexed data, I figured this is a key we control so we should be able to make the request. Let me know if you think this would result in unintended behaviour, but I didn't think it would because of the way it's used.