### PR TITLE
ref(tsc): Remove `contextType` from `<ReleaseOverview>`

### DIFF
--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -663,5 +663,4 @@ const ReleaseBoundsDescription = styled('span')<{primary: boolean}>`
   color: ${p => (p.primary ? p.theme.activeText : p.theme.subText)};
 `;
 
-ReleaseOverview.contextType = ReleaseContext;
 export default ReleaseOverview;


### PR DESCRIPTION
Forgot to remove this when it was converted to a FC.
