### PR TITLE
feat(releases): Add link to old release details from drawer

### DIFF
--- a/static/app/utils/analytics/releasesAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/releasesAnalyticsEvents.tsx
@@ -3,6 +3,7 @@ import type {ReleaseComparisonChartType} from 'sentry/types/release';
 export type ReleasesEventParameters = {
   'releases.bubbles_legend': {selected: boolean};
   'releases.change_chart_type': {chartType: ReleaseComparisonChartType};
+  'releases.drawer_view_full_details': {project_id: string};
   'releases.quickstart_copied': {project_id: string};
   'releases.quickstart_create_integration.success': {
     integration_uuid: string;
@@ -15,12 +16,13 @@ export type ReleasesEventParameters = {
 export type ReleasesEventKey = keyof ReleasesEventParameters;
 
 export const releasesEventMap: Record<ReleasesEventKey, string | null> = {
+  'releases.bubbles_legend': 'Releases: Toggle Legend for Bubble',
+  'releases.change_chart_type': 'Releases: Change Chart Type',
+  'releases.drawer_view_full_details': 'Releases: Drawer View Full Details',
   'releases.quickstart_viewed': 'Releases: Quickstart Viewed',
   'releases.quickstart_copied': 'Releases: Quickstart Copied',
   'releases.quickstart_create_integration.success':
     'Releases: Quickstart Created Integration',
   'releases.quickstart_create_integration_modal.close':
     'Releases: Quickstart Create Integration Modal Exit',
-  'releases.change_chart_type': 'Releases: Change Chart Type',
-  'releases.bubbles_legend': 'Releases: Toggle Legend for Bubble',
 };

--- a/static/app/views/releases/drawer/releasesDrawer.tsx
+++ b/static/app/views/releases/drawer/releasesDrawer.tsx
@@ -20,6 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {ReleasesDrawerDetails} from 'sentry/views/releases/drawer/releasesDrawerDetails';
 import {ReleasesDrawerList} from 'sentry/views/releases/drawer/releasesDrawerList';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import {useReleaseDetails} from 'sentry/views/releases/utils/useReleaseDetails';
 
 type Without<T, U> = {[P in Exclude<keyof T, keyof U>]?: never};
@@ -102,9 +103,15 @@ export function ReleasesDrawer({
 
           {releaseOrSelected && (
             <Button
-              to={normalizeUrl(
-                `/organizations/${organization.slug}/releases/${releaseOrSelected}/`
-              )}
+              to={normalizeUrl({
+                pathname: makeReleasesPathname({
+                  path: `/${encodeURIComponent(releaseOrSelected)}/`,
+                  organization,
+                }),
+                query: {
+                  project: selectedRelease?.projectId,
+                },
+              })}
               size="xs"
               onClick={() => {
                 closeDrawer();


### PR DESCRIPTION
This adds a link to the old release details page from inside the releases drawer. It also forces the drawer closed when clicked (though this should be handled in the future via URL routing). Additionally fixes a rendering delay in the drawer header where the title of the details does not get updated until release details are fetched even though release is known (due to rendering of the platform icon).

![image](https://github.com/user-attachments/assets/cd72356a-1169-4be4-9b07-2852313bb47c)
