### PR TITLE
:sparkles: feat(aci): add config and data schemas for messaging actions

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2198,15 +2198,25 @@ class Factories:
     def create_action(
         config: dict[str, Any] | None = None,
         type: Action.Type | None = None,
+        data: dict[str, Any] | None = None,
         **kwargs,
     ) -> Action:
         if config is None:
             config = {}
+            if type == Action.Type.SLACK:
+                config = {
+                    "target_identifier": "1",
+                    "target_display": "Sentry User",
+                    "target_type": ActionTarget.SPECIFIC,
+                }
+
+        if data is None:
+            data = {}
 
         if type is None:
             type = Action.Type.SLACK
 
-        return Action.objects.create(type=type, config=config, **kwargs)
+        return Action.objects.create(type=type, config=config, data=data, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2201,14 +2201,19 @@ class Factories:
         data: dict[str, Any] | None = None,
         **kwargs,
     ) -> Action:
+        if config is None and type is None and data is None:
+            # Default to a slack action with nice defaults so someone can just do
+            # self.create_action() and have a sane default
+            config = {
+                "target_identifier": "1",
+                "target_display": "Sentry User",
+                "target_type": ActionTarget.SPECIFIC,
+            }
+
+            data = {"notes": "bufos are great", "tags": "bufo-bot"}
+
         if config is None:
             config = {}
-            if type == Action.Type.SLACK:
-                config = {
-                    "target_identifier": "1",
-                    "target_display": "Sentry User",
-                    "target_type": ActionTarget.SPECIFIC,
-                }
 
         if data is None:
             data = {}

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -677,7 +677,7 @@ class ExhaustiveFixtures(Fixtures):
             organization=org,
         )
 
-        send_notification_action = self.create_action(type=Action.Type.SLACK)
+        send_notification_action = self.create_action()
         self.create_data_condition_group_action(
             action=send_notification_action,
             condition_group=notification_condition_group,

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -677,7 +677,7 @@ class ExhaustiveFixtures(Fixtures):
             organization=org,
         )
 
-        send_notification_action = self.create_action(type=Action.Type.SLACK, data="")
+        send_notification_action = self.create_action(type=Action.Type.SLACK)
         self.create_data_condition_group_action(
             action=send_notification_action,
             condition_group=notification_condition_group,

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -25,6 +25,53 @@ class NotificationHandlerException(Exception):
     pass
 
 
+MESSAGING_ACTION_CONFIG_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The configuration schema for a Messaging Action",
+    "type": "object",
+    "properties": {
+        "target_identifier": {"type": ["string"]},
+        "target_display": {"type": ["string"]},
+        "target_type": {
+            "type": ["integer"],
+            "enum": [*ActionTarget],
+        },
+    },
+    "required": ["target_identifier", "target_display", "target_type"],
+    "additionalProperties": False,
+}
+
+# Main difference between the discord and slack action config schemas is that
+# the target_display is null
+DISCORD_ACTION_CONFIG_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The configuration schema for a Discord Action",
+    "type": "object",
+    "properties": {
+        "target_identifier": {"type": "string"},
+        "target_display": {
+            "type": ["null"],
+        },
+        "target_type": {
+            "type": ["integer"],
+            "enum": [*ActionTarget],
+        },
+    },
+    "required": ["target_identifier", "target_type"],
+    "additionalProperties": False,
+}
+
+TAGS_SCHEMA = {
+    "type": "string",
+    "description": "Tags to add to the message",
+}
+
+NOTES_SCHEMA = {
+    "type": "string",
+    "description": "Notes to add to the message",
+}
+
+
 class LegacyRegistryInvoker(ABC):
     """
     Abstract base class that defines the interface for notification handlers.
@@ -93,33 +140,14 @@ class NotificationActionHandler(ActionHandler, ABC):
 class DiscordActionHandler(NotificationActionHandler):
     group = NotificationActionHandler.Group.NOTIFICATION
 
-    config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for a Discord Action",
-        "type": "object",
-        "properties": {
-            "target_identifier": {"type": "string"},
-            "target_display": {
-                "type": ["null"],
-            },
-            "target_type": {
-                "type": ["integer"],
-                "enum": [*ActionTarget],
-            },
-        },
-        "required": ["target_identifier", "target_type"],
-        "additionalProperties": False,
-    }
+    config_schema = DISCORD_ACTION_CONFIG_SCHEMA
 
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "description": "Schema for Discord action data blob",
         "properties": {
-            "tags": {
-                "type": "string",
-                "description": "Tags to add to the Discord message",
-            },
+            "tags": TAGS_SCHEMA,
         },
         "additionalProperties": False,
     }
@@ -127,35 +155,15 @@ class DiscordActionHandler(NotificationActionHandler):
 
 @action_handler_registry.register(Action.Type.SLACK)
 class SlackActionHandler(NotificationActionHandler):
-    config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for a Slack Action",
-        "type": "object",
-        "properties": {
-            "target_identifier": {"type": ["string"]},
-            "target_display": {"type": ["string"]},
-            "target_type": {
-                "type": ["integer"],
-                "enum": [*ActionTarget],
-            },
-        },
-        "required": ["target_identifier", "target_display", "target_type"],
-        "additionalProperties": False,
-    }
+    config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
 
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "description": "Schema for Slack action data blob",
         "properties": {
-            "tags": {
-                "type": "string",
-                "description": "Tags to add to the Slack message",
-            },
-            "notes": {
-                "type": "string",
-                "description": "Notes to add to the Slack message",
-            },
+            "tags": TAGS_SCHEMA,
+            "notes": NOTES_SCHEMA,
         },
         "additionalProperties": False,
     }
@@ -165,21 +173,7 @@ class SlackActionHandler(NotificationActionHandler):
 
 @action_handler_registry.register(Action.Type.MSTEAMS)
 class MsteamsActionHandler(NotificationActionHandler):
-    config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for a MSTeams Action",
-        "type": "object",
-        "properties": {
-            "target_identifier": {"type": ["string"]},
-            "target_display": {"type": ["string"]},
-            "target_type": {
-                "type": ["integer"],
-                "enum": [*ActionTarget],
-            },
-        },
-        "required": ["target_identifier", "target_display", "target_type"],
-        "additionalProperties": False,
-    }
+    config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
 
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -93,14 +93,104 @@ class NotificationActionHandler(ActionHandler, ABC):
 class DiscordActionHandler(NotificationActionHandler):
     group = NotificationActionHandler.Group.NOTIFICATION
 
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Discord Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {"type": "string"},
+            "target_display": {
+                "type": ["null"],
+            },
+            "target_type": {
+                "type": ["integer"],
+                "enum": [*ActionTarget],
+            },
+        },
+    }
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for Discord action data blob",
+        "properties": {
+            "tags": {
+                "type": "string",
+                "description": "Tags to add to the Discord message",
+            },
+        },
+        "additionalProperties": False,
+    }
+
 
 @action_handler_registry.register(Action.Type.SLACK)
 class SlackActionHandler(NotificationActionHandler):
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Slack Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {
+                "type": ["string"],
+            },
+            "target_display": {
+                "type": ["string"],
+            },
+            "target_type": {
+                "type": ["integer"],
+                "enum": [*ActionTarget],
+            },
+        },
+    }
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for Slack action data blob",
+        "properties": {
+            "tags": {
+                "type": "string",
+                "description": "Tags to add to the Slack message",
+            },
+            "notes": {
+                "type": "string",
+                "description": "Notes to add to the Slack message",
+            },
+        },
+        "additionalProperties": False,
+    }
+
     group = ActionHandler.Group.NOTIFICATION
 
 
 @action_handler_registry.register(Action.Type.MSTEAMS)
 class MsteamsActionHandler(NotificationActionHandler):
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a MSTeams Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {
+                "type": ["string"],
+            },
+            "target_display": {
+                "type": ["string"],
+            },
+            "target_type": {
+                "type": ["integer"],
+                "enum": [*ActionTarget],
+            },
+        },
+    }
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for MSTeams action data blob",
+        "properties": {},
+        "additionalProperties": False,
+    }
+
     group = ActionHandler.Group.NOTIFICATION
 
 

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -107,6 +107,8 @@ class DiscordActionHandler(NotificationActionHandler):
                 "enum": [*ActionTarget],
             },
         },
+        "required": ["target_identifier", "target_type"],
+        "additionalProperties": False,
     }
 
     data_schema = {
@@ -130,17 +132,15 @@ class SlackActionHandler(NotificationActionHandler):
         "description": "The configuration schema for a Slack Action",
         "type": "object",
         "properties": {
-            "target_identifier": {
-                "type": ["string"],
-            },
-            "target_display": {
-                "type": ["string"],
-            },
+            "target_identifier": {"type": ["string"]},
+            "target_display": {"type": ["string"]},
             "target_type": {
                 "type": ["integer"],
                 "enum": [*ActionTarget],
             },
         },
+        "required": ["target_identifier", "target_display", "target_type"],
+        "additionalProperties": False,
     }
 
     data_schema = {
@@ -170,17 +170,15 @@ class MsteamsActionHandler(NotificationActionHandler):
         "description": "The configuration schema for a MSTeams Action",
         "type": "object",
         "properties": {
-            "target_identifier": {
-                "type": ["string"],
-            },
-            "target_display": {
-                "type": ["string"],
-            },
+            "target_identifier": {"type": ["string"]},
+            "target_display": {"type": ["string"]},
             "target_type": {
                 "type": ["integer"],
                 "enum": [*ActionTarget],
             },
         },
+        "required": ["target_identifier", "target_display", "target_type"],
+        "additionalProperties": False,
     }
 
     data_schema = {

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -328,10 +328,6 @@ class MSTeamsActionTranslator(BaseActionTranslator):
     def target_type(self) -> ActionTarget:
         return ActionTarget.SPECIFIC
 
-    @property
-    def blob_type(self) -> type[DataBlob]:
-        return OnCallDataBlob
-
 
 @issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.PAGERDUTY]["id"])
 class PagerDutyActionTranslator(BaseActionTranslator):

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -16,7 +16,6 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.rules import RuleFuture
-from sentry.workflow_engine.models import Action
 
 
 class TestInit(RuleTestCase):
@@ -64,9 +63,7 @@ class TestInit(RuleTestCase):
             notification_uuid=self.notification_uuid,
         )
 
-        self.action = self.create_action(
-            type=Action.Type.SLACK, config={"target_identifier": "C0123456789"}
-        )
+        self.action = self.create_action()
 
     def test_when_rule_fire_history_is_passed_in(self) -> None:
         instance = SlackNotifyServiceAction(

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -16,6 +16,7 @@ from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.models.activity import Activity
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -23,6 +24,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
 
 
 class TestGetNotificationMessageToSend(TestCase):
@@ -102,7 +104,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
                 metadata={"access_token": "xoxb-access-token"},
             )
 
-        self.action = self.create_action(config={"target_identifier": self.channel_id})
+        self.action = self.create_action()
 
         self.parent_notification_action = NotificationMessage.objects.create(
             message_identifier=self.message_identifier,
@@ -504,7 +506,14 @@ class TestSlackServiceMethods(TestCase):
             rule_fire_history=self.slack_rule_fire_history,
         )
 
-        self.action = self.create_action(config={"target_identifier": self.channel_id})
+        self.action = self.create_action(
+            type=Action.Type.SLACK,
+            config={
+                "target_identifier": self.channel_id,
+                "target_type": ActionTarget.SPECIFIC,
+                "target_display": "#test-notifications",
+            },
+        )
 
         self.parent_notification_action = NotificationActionNotificationMessage(
             id=123,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -295,7 +295,7 @@ class TestActionSerializer(TestCase):
 
         action2 = self.create_action(
             type=Action.Type.SLACK,
-            data={"foo": "bar"},
+            data={"tags": "bar"},
             integration_id=self.integration.id,
             config={
                 "target_type": ActionTarget.USER,
@@ -309,7 +309,7 @@ class TestActionSerializer(TestCase):
         assert result2 == {
             "id": str(action2.id),
             "type": "slack",
-            "data": '{"foo":"bar"}',
+            "data": '{"tags":"bar"}',
             "integration_id": self.integration.id,
             "config": '{"target_type":1,"target_display":"freddy frog","target_identifier":"123-id"}',
         }

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -5,6 +5,7 @@ import pytest
 
 from sentry.constants import ObjectStatus
 from sentry.models.rule import Rule, RuleSource
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
     EMAIL_ACTION_DATA_BLOBS,
@@ -68,7 +69,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            config={"target_identifier": "channel456"},
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
@@ -118,11 +119,6 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         }
         assert rule.status == ObjectStatus.ACTIVE
         assert rule.source == RuleSource.ISSUE
-
-    def test_create_rule_instance_from_action_missing_action_properties_raises_value_error(self):
-        action = self.create_action(type=Action.Type.DISCORD)
-        with pytest.raises(ValueError):
-            self.handler.create_rule_instance_from_action(action, self.detector, self.job)
 
     def test_create_rule_instance_from_action_no_environment(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
@@ -183,7 +179,7 @@ class TestDiscordIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            config={"target_identifier": "channel456"},
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
         # self.project = self.create_project()
@@ -226,6 +222,7 @@ class TestMSTeamsIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": "channel789",
                 "target_display": "General Channel",
+                "target_type": ActionTarget.SPECIFIC,
             },
         )
 
@@ -253,6 +250,7 @@ class TestSlackIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": "channel789",
                 "target_display": "#general",
+                "target_type": ActionTarget.SPECIFIC,
             },
         )
 

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -18,6 +18,7 @@ from sentry.issues.grouptype import MetricIssuePOC
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import GroupStatus
 from sentry.models.organization import Organization
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.action.notification.metric_alert import (
@@ -133,7 +134,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         self.action = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            config={"target_identifier": "channel456"},
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
         self.snuba_query = self.create_snuba_query()

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -9,6 +9,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.rules.conditions.event_frequency import ComparisonType
 from sentry.rules.processing.buffer_processing import process_in_batches
 from sentry.rules.processing.delayed_processing import fetch_project
@@ -668,7 +669,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         action1 = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            config={"target_identifier": "channel456"},
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
         self.create_data_condition_group_action(
@@ -682,6 +683,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             config={
                 "target_identifier": "channel789",
                 "target_display": "#general",
+                "target_type": ActionTarget.SPECIFIC,
             },
         )
         self.create_data_condition_group_action(

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -166,11 +166,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
     ) -> tuple[DataConditionGroup, Action]:
         action_group = self.create_data_condition_group(logic_type="any-short")
 
-        action = self.create_action(
-            type=Action.Type.SLACK,
-            data={"notes": "bufos are great", "tags": "bufo-bot"},
-            **kwargs,
-        )
+        action = self.create_action()
 
         self.create_data_condition_group_action(
             condition_group=action_group,

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -168,7 +168,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
         action = self.create_action(
             type=Action.Type.SLACK,
-            data={"message": "test"},
+            data={"notes": "bufos are great", "tags": "bufo-bot"},
             **kwargs,
         )
 


### PR DESCRIPTION
adding `config` and `data` schemas for messaging actions.

this caught a mistake i made where i attached a on-call dataclass to the msteams translator