### PR TITLE
feat(billing): Add recurring credit support for UI profiling

### DIFF
--- a/static/gsAdmin/components/addGiftEventsAction.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.tsx
@@ -22,6 +22,7 @@ export const FREE_EVENTS_KEYS = {
   [DataCategory.SPANS]: 'addFreeSpans',
   [DataCategory.SPANS_INDEXED]: 'addFreeSpansIndexed',
   [DataCategory.PROFILE_DURATION]: 'addFreeProfileDuration',
+  [DataCategory.PROFILE_DURATION_UI]: 'addFreeProfileDurationUI',
 };
 
 /**
@@ -38,6 +39,7 @@ const DISPLAY_FREE_EVENTS_MULTIPLE = {
   [DataCategory.SPANS]: 100_000,
   [DataCategory.SPANS_INDEXED]: 100_000,
   [DataCategory.PROFILE_DURATION]: 1, // hours
+  [DataCategory.PROFILE_DURATION_UI]: 1, // hours
 };
 
 type Props = AdminConfirmRenderProps & {
@@ -118,7 +120,10 @@ class AddGiftEventsAction extends Component<Props, State> {
       if (dataCategory === DataCategory.ATTACHMENTS) {
         return 'How many attachments in GB?';
       }
-      if (dataCategory === DataCategory.PROFILE_DURATION) {
+      if (
+        dataCategory === DataCategory.PROFILE_DURATION ||
+        dataCategory === DataCategory.PROFILE_DURATION_UI
+      ) {
         return 'How many profile hours?';
       }
       const categoryName = getPlanCategoryName({
@@ -138,7 +143,10 @@ class AddGiftEventsAction extends Component<Props, State> {
     const total = this.calculatedTotal.toLocaleString();
     function getHelp() {
       let postFix = '';
-      if (dataCategory === DataCategory.PROFILE_DURATION) {
+      if (
+        dataCategory === DataCategory.PROFILE_DURATION ||
+        dataCategory === DataCategory.PROFILE_DURATION_UI
+      ) {
         if (total === '1') {
           postFix = ' hour';
         } else {

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -709,6 +709,7 @@ export enum CreditType {
   SPAN = 'span',
   SPAN_INDEXED = 'spanIndexed',
   PROFILE_DURATION = 'profileDuration',
+  PROFILE_DURATION_UI = 'profileDurationUI',
   ATTACHMENT = 'attachment',
   REPLAY = 'replay',
   MONITOR_SEAT = 'monitorSeat',
@@ -742,6 +743,7 @@ interface RecurringEventCredit extends BaseRecurringCredit {
     | CreditType.TRANSACTION
     | CreditType.SPAN
     | CreditType.PROFILE_DURATION
+    | CreditType.PROFILE_DURATION_UI
     | CreditType.ATTACHMENT
     | CreditType.REPLAY;
 }

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -40,6 +40,7 @@ const CREDIT_TYPE_TO_DATA_CATEGORY = {
   [CreditType.TRANSACTION]: DataCategory.TRANSACTIONS,
   [CreditType.SPAN]: DataCategory.SPANS,
   [CreditType.PROFILE_DURATION]: DataCategory.PROFILE_DURATION,
+  [CreditType.PROFILE_DURATION_UI]: DataCategory.PROFILE_DURATION_UI,
   [CreditType.ATTACHMENT]: DataCategory.ATTACHMENTS,
   [CreditType.REPLAY]: DataCategory.REPLAYS,
   [CreditType.MONITOR_SEAT]: DataCategory.MONITOR_SEATS,

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -22,6 +22,7 @@ export const GIFT_CATEGORIES: string[] = [
   DataCategory.SPANS,
   DataCategory.SPANS_INDEXED,
   DataCategory.PROFILE_DURATION,
+  DataCategory.PROFILE_DURATION_UI,
   DataCategory.UPTIME,
 ];
 

--- a/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
@@ -115,6 +115,43 @@ describe('Recurring Credits', function () {
     expect(screen.getByTestId('amount')).toHaveTextContent('+10/mo');
   });
 
+  it('renders profile duration ui recurring credits', async function () {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/recurring-credits/`,
+      method: 'GET',
+      body: [
+        RecurringCreditFixture({
+          id: 1,
+          periodStart: moment().format(),
+          periodEnd: moment().utc().add(3, 'months').format(),
+          amount: 10,
+          type: CreditType.PROFILE_DURATION_UI,
+          totalAmountRemaining: null,
+        }),
+      ],
+    });
+
+    const planDetails: Plan = {
+      ...subscription.planDetails,
+      categoryDisplayNames: {
+        ...subscription.planDetails.categoryDisplayNames,
+        [DataCategory.PROFILE_DURATION_UI]: {
+          singular: 'profile ui hour',
+          plural: 'profile ui hours',
+        },
+      },
+    };
+
+    render(<RecurringCredits displayType="data" planDetails={planDetails} />, {
+      organization,
+    });
+
+    await screen.findByRole('heading', {name: /recurring credits/i});
+
+    expect(screen.getByText('profile ui hours')).toBeInTheDocument();
+    expect(screen.getByTestId('amount')).toHaveTextContent('+10/mo');
+  });
+
   it('renders attachment recurring credits', async function () {
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/recurring-credits/`,

--- a/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
@@ -136,8 +136,8 @@ describe('Recurring Credits', function () {
       categoryDisplayNames: {
         ...subscription.planDetails.categoryDisplayNames,
         [DataCategory.PROFILE_DURATION_UI]: {
-          singular: 'profile ui hour',
-          plural: 'profile ui hours',
+          singular: 'ui profile hour',
+          plural: 'ui profile hours',
         },
       },
     };
@@ -148,7 +148,7 @@ describe('Recurring Credits', function () {
 
     await screen.findByRole('heading', {name: /recurring credits/i});
 
-    expect(screen.getByText('profile ui hours')).toBeInTheDocument();
+    expect(screen.getByText('ui profile hours')).toBeInTheDocument();
     expect(screen.getByTestId('amount')).toHaveTextContent('+10/mo');
   });
 


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/16962

Adds `PROFILE_DURATION_UI` to the FE CreditType enum and gift category lists