### PR TITLE
test(ui): Always run jest tests and tsc

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -76,7 +76,7 @@ jobs:
 
   frontend-jest-tests:
     if: needs.files-changed.outputs.testable_rules_changed == 'true' || needs.files-changed.outputs.testable_modified == 'true'
-    needs: [files-changed, typescript]
+    needs: [files-changed]
     name: Jest
     # If you change the runs-on image, you must also change the runner in jest-balance.yml
     # so that the balancer runs in the same environment as the tests.


### PR DESCRIPTION
It is annoying to fix a type error and then follow up with another ci run if there is also a broken test. Run both so you know you need to fix two places.
