### PR TITLE
ref(aci): convert WorkflowJob TypedDict to dataclass

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -37,7 +37,7 @@ from sentry.utils.safe import get_path, safe_execute
 from sentry.utils.sdk import bind_organization_context, set_current_event_project
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import build_sdk_crash_detection_configs
 from sentry.utils.services import build_instance_from_options_of_type
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 
 if TYPE_CHECKING:
     from sentry.eventstore.models import Event, GroupEvent
@@ -945,15 +945,20 @@ def process_workflow_engine(job: PostProcessJob) -> None:
 
     from sentry.workflow_engine.processors.workflow import process_workflows
 
-    # PostProcessJob event is optional, WorkflowJob event is required
+    # PostProcessJob event is optional, WorkflowEventData event is required
     if "event" not in job:
-        logger.error("Missing event to create WorkflowJob", extra={"job": job})
+        logger.error("Missing event to create WorkflowEventData", extra={"job": job})
         return
 
     try:
-        workflow_job = WorkflowJob(**job)
+        workflow_job = WorkflowEventData(
+            event=job["event"],
+            group_state=job.get("group_state"),
+            has_reappeared=job.get("has_reappeared"),
+            has_escalated=job.get("has_escalated"),
+        )
     except Exception:
-        logger.exception("Could not create WorkflowJob", extra={"job": job})
+        logger.exception("Could not create WorkflowEventData", extra={"job": job})
         return
 
     with sentry_sdk.start_span(op="tasks.post_process_group.workflow_engine.process_workflow"):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -951,7 +951,7 @@ def process_workflow_engine(job: PostProcessJob) -> None:
         return
 
     try:
-        workflow_job = WorkflowJob({**job})  # type: ignore[typeddict-item]
+        workflow_job = WorkflowJob(**job)
     except Exception:
         logger.exception("Could not create WorkflowJob", extra={"job": job})
         return

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -111,7 +111,7 @@ class BaseIssueAlertHandler(ABC):
         :param job: WorkflowJob
         :return: Rule instance
         """
-        workflow = job.get("workflow")
+        workflow = job.workflow
         environment_id = None
         if workflow and workflow.environment:
             environment_id = workflow.environment.id
@@ -147,7 +147,7 @@ class BaseIssueAlertHandler(ABC):
         with sentry_sdk.start_span(
             op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.activate_downstream_actions"
         ):
-            grouped_futures = activate_downstream_actions(rule, job["event"], notification_uuid)
+            grouped_futures = activate_downstream_actions(rule, job.event, notification_uuid)
             return grouped_futures.values()
 
     @staticmethod
@@ -165,7 +165,7 @@ class BaseIssueAlertHandler(ABC):
             op="workflow_engine.handlers.action.notification.issue_alert.execute_futures"
         ):
             for callback, futures in futures:
-                safe_execute(callback, job["event"], futures)
+                safe_execute(callback, job.event, futures)
 
     @classmethod
     def invoke_legacy_registry(

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -17,7 +17,7 @@ from sentry.types.rules import RuleFuture
 from sentry.utils.registry import Registry
 from sentry.utils.safe import safe_execute
 from sentry.workflow_engine.models import Action, Detector
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import (
     ACTION_FIELD_MAPPINGS,
     ActionFieldMapping,
@@ -102,13 +102,13 @@ class BaseIssueAlertHandler(ABC):
         cls,
         action: Action,
         detector: Detector,
-        job: WorkflowJob,
+        job: WorkflowEventData,
     ) -> Rule:
         """
         Creates a Rule instance from the Action model.
         :param action: Action
         :param detector: Detector
-        :param job: WorkflowJob
+        :param job: WorkflowEventData
         :return: Rule instance
         """
         workflow = job.workflow
@@ -136,7 +136,7 @@ class BaseIssueAlertHandler(ABC):
 
     @staticmethod
     def get_rule_futures(
-        job: WorkflowJob,
+        job: WorkflowEventData,
         rule: Rule,
         notification_uuid: str,
     ) -> Collection[tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]]:
@@ -152,7 +152,7 @@ class BaseIssueAlertHandler(ABC):
 
     @staticmethod
     def execute_futures(
-        job: WorkflowJob,
+        job: WorkflowEventData,
         futures: Collection[
             tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
         ],
@@ -170,7 +170,7 @@ class BaseIssueAlertHandler(ABC):
     @classmethod
     def invoke_legacy_registry(
         cls,
-        job: WorkflowJob,
+        job: WorkflowEventData,
         action: Action,
         detector: Detector,
     ) -> None:

--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -14,7 +14,7 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models import Action, Detector
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 
 
 class BaseMetricAlertHandler(ABC):
@@ -43,7 +43,7 @@ class BaseMetricAlertHandler(ABC):
 
     def invoke_legacy_registry(
         cls,
-        job: WorkflowJob,
+        job: WorkflowEventData,
         action: Action,
         detector: Detector,
     ) -> None:

--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -51,7 +51,7 @@ class BaseMetricAlertHandler(ABC):
         with sentry_sdk.start_span(
             op="workflow_engine.handlers.action.notification.metric_alert.invoke_legacy_registry"
         ):
-            event = job["event"]
+            event = job.event
             if not event.occurrence:
                 raise ValueError("Event occurrence is required for alert context")
 

--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -30,7 +30,7 @@ class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         first_seen = event.group.first_seen
         current_time = timezone.now()
         comparison_type = comparison["comparison_type"]

--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -6,11 +6,11 @@ from sentry.rules.age import AgeComparisonType, age_comparison_map
 from sentry.rules.filters.age_comparison import timeranges
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.AGE_COMPARISON)
-class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
+class AgeComparisonConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
 
@@ -29,7 +29,7 @@ class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         first_seen = event.group.first_seen
         current_time = timezone.now()

--- a/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
@@ -2,15 +2,15 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ANOMALY_DETECTION)
-class AnomalyDetectionHandler(DataConditionHandler[WorkflowJob]):
+class AnomalyDetectionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.DETECTOR_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         # this is a placeholder
         return False

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -7,11 +7,11 @@ from sentry.notifications.types import AssigneeTargetType
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ASSIGNED_TO)
-class AssignedToConditionHandler(DataConditionHandler[WorkflowJob]):
+class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
 
@@ -35,7 +35,7 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowJob]):
         return assignee_list
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         target_type = AssigneeTargetType(comparison.get("target_type"))
         assignees = AssignedToConditionHandler.get_assignees(event.group)

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -36,7 +36,7 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         target_type = AssigneeTargetType(comparison.get("target_type"))
         assignees = AssignedToConditionHandler.get_assignees(event.group)
 

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -8,11 +8,11 @@ from sentry.rules.conditions.event_attribute import attribute_registry
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.EVENT_ATTRIBUTE)
-class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
+class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
 
@@ -50,7 +50,7 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
         return attribute_values
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         attribute = comparison.get("attribute", "")
         attribute_values = EventAttributeConditionHandler.get_attribute_values(event, attribute)

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -51,7 +51,7 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         attribute = comparison.get("attribute", "")
         attribute_values = EventAttributeConditionHandler.get_attribute_values(event, attribute)
 

--- a/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
@@ -11,7 +11,7 @@ class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         if event.occurrence is None or event.occurrence.evidence_data is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
@@ -2,15 +2,15 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.EVENT_CREATED_BY_DETECTOR)
-class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowJob]):
+class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         if event.occurrence is None or event.occurrence.evidence_data is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
@@ -2,14 +2,14 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.EVENT_SEEN_COUNT)
-class EventSeenCountConditionHandler(DataConditionHandler[WorkflowJob]):
+class EventSeenCountConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         return event.group.times_seen == comparison

--- a/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
@@ -11,5 +11,5 @@ class EventSeenCountConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         return event.group.times_seen == comparison

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -3,16 +3,16 @@ from typing import Any
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.EXISTING_HIGH_PRIORITY_ISSUE)
-class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob]):
+class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         state = job.group_state
         if state is None or state["is_new"]:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -13,11 +13,9 @@ class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        state = job.get("group_state")
+        state = job.group_state
         if state is None or state["is_new"]:
             return False
 
-        has_reappeared = job.get("has_reappeared", False)
-        has_escalated = job.get("has_escalated", False)
-        is_escalating = has_reappeared or has_escalated
-        return is_escalating and job["event"].group.priority == PriorityLevel.HIGH
+        is_escalating = bool(job.has_reappeared or job.has_escalated)
+        return is_escalating and job.event.group.priority == PriorityLevel.HIGH

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -2,10 +2,10 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
-def is_new_event(job: WorkflowJob) -> bool:
+def is_new_event(job: WorkflowEventData) -> bool:
     state = job.group_state
     if state is None:
         return False
@@ -18,10 +18,10 @@ def is_new_event(job: WorkflowJob) -> bool:
 
 
 @condition_handler_registry.register(Condition.FIRST_SEEN_EVENT)
-class FirstSeenEventConditionHandler(DataConditionHandler[WorkflowJob]):
+class FirstSeenEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         return is_new_event(job)

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -6,11 +6,11 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 def is_new_event(job: WorkflowJob) -> bool:
-    state = job.get("group_state")
+    state = job.group_state
     if state is None:
         return False
 
-    workflow = job.get("workflow")
+    workflow = job.workflow
     if workflow is None or workflow.environment_id is None:
         return state["is_new"]
 

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -3,11 +3,11 @@ from typing import Any
 from sentry.issues.grouptype import GroupCategory
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ISSUE_CATEGORY)
-class IssueCategoryConditionHandler(DataConditionHandler[WorkflowJob]):
+class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
 
     comparison_json_schema = {
@@ -20,7 +20,7 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         group = job.event.group
 
         try:

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -21,7 +21,7 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        group = job["event"].group
+        group = job.event.group
 
         try:
             value: GroupCategory = GroupCategory(int(comparison["value"]))

--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -22,7 +22,7 @@ class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        group: Group = job["event"].group
+        group: Group = job.event.group
         try:
             value = int(comparison["value"])
         except (TypeError, ValueError, KeyError):

--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -3,11 +3,11 @@ from typing import Any
 from sentry.models.group import Group
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ISSUE_OCCURRENCES)
-class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowJob]):
+class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
 
@@ -21,7 +21,7 @@ class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         group: Group = job.event.group
         try:
             value = int(comparison["value"])

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
@@ -2,15 +2,15 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ISSUE_PRIORITY_EQUALS)
-class IssuePriorityCondition(DataConditionHandler[WorkflowJob]):
+class IssuePriorityCondition(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         group = job.event.group
         return group.priority == comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
@@ -12,5 +12,5 @@ class IssuePriorityCondition(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        group = job["event"].group
+        group = job.event.group
         return group.priority == comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
@@ -2,14 +2,14 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.ISSUE_RESOLUTION_CHANGE)
-class IssueResolutionConditionHandler(DataConditionHandler[WorkflowJob]):
+class IssueResolutionConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         group = job.event.group
         return group.status == comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
@@ -11,5 +11,5 @@ class IssueResolutionConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        group = job["event"].group
+        group = job.event.group
         return group.status == comparison

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -13,11 +13,11 @@ from sentry.workflow_engine.handlers.condition.latest_release_handler import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.LATEST_ADOPTED_RELEASE)
-class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
+class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
 
@@ -33,7 +33,7 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         release_age_type = comparison["release_age_type"]
         age_comparison = comparison["age_comparison"]
         environment_name = comparison["environment"]

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -38,7 +38,7 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
         age_comparison = comparison["age_comparison"]
         environment_name = comparison["environment"]
 
-        event = job["event"]
+        event = job.event
 
         if follows_semver_versioning_scheme(event.organization.id, event.project.id):
             order_type = LatestReleaseOrders.SEMVER

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -47,8 +47,8 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
-        workflow = job.get("workflow")
+        event = job.event
+        workflow = job.workflow
         environment = workflow.environment if workflow else None
 
         latest_release = get_latest_release_for_env(environment, event)

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -9,7 +9,7 @@ from sentry.search.utils import get_latest_release
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 def get_latest_release_for_env(
@@ -40,13 +40,13 @@ def get_latest_release_for_env(
 
 
 @condition_handler_registry.register(Condition.LATEST_RELEASE)
-class LatestReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
+class LatestReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         workflow = job.workflow
         environment = workflow.environment if workflow else None

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -24,7 +24,7 @@ class LevelConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         level_name = event.get_tag("level")
         if level_name is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -4,11 +4,11 @@ from sentry.constants import LOG_LEVELS_MAP
 from sentry.rules import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.LEVEL)
-class LevelConditionHandler(DataConditionHandler[WorkflowJob]):
+class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
 
@@ -23,7 +23,7 @@ class LevelConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         level_name = event.get_tag("level")
         if level_name is None:

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -4,16 +4,16 @@ from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.condition.first_seen_event_handler import is_new_event
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.NEW_HIGH_PRIORITY_ISSUE)
-class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob]):
+class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         is_new = is_new_event(job)
         event = job.event
         if not event.project.flags.has_high_priority_alerts:

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -15,7 +15,7 @@ class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowJob]):
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
         is_new = is_new_event(job)
-        event = job["event"]
+        event = job.event
         if not event.project.flags.has_high_priority_alerts:
             return is_new
 

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -2,16 +2,16 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.REAPPEARED_EVENT)
-class ReappearedEventConditionHandler(DataConditionHandler[WorkflowJob]):
+class ReappearedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         has_reappeared = job.has_reappeared
         if has_reappeared is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -12,7 +12,7 @@ class ReappearedEventConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        has_reappeared = job.get("has_reappeared")
+        has_reappeared = job.has_reappeared
         if has_reappeared is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -2,16 +2,16 @@ from typing import Any
 
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.REGRESSION_EVENT)
-class RegressionEventConditionHandler(DataConditionHandler[WorkflowJob]):
+class RegressionEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         state = job.group_state
         if state is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -12,7 +12,7 @@ class RegressionEventConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        state = job.get("group_state")
+        state = job.group_state
         if state is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -50,7 +50,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
-        event = job["event"]
+        event = job.event
         raw_tags = event.tags
         key = comparison["key"]
         match = comparison["match"]

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -4,11 +4,11 @@ from sentry import tagstore
 from sentry.rules import MatchType, match_values
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
 @condition_handler_registry.register(Condition.TAGGED_EVENT)
-class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
+class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
 
@@ -49,7 +49,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
+    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
         raw_tags = event.tags
         key = comparison["key"]

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -13,7 +13,7 @@ from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.workflow_engine.models.json_config import JSONConfigBase
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowJob
+from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models import Detector
@@ -66,7 +66,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, job: WorkflowJob, detector: Detector) -> None:
+    def trigger(self, job: WorkflowEventData, detector: Detector) -> None:
         # get the handler for the action type
         handler = self.get_handler()
         handler.execute(job, self, detector)

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Any
 
 from django.conf import settings
@@ -79,9 +80,9 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True, []
 
-        job["workflow"] = self
+        workflow_job = replace(job, workflow=self)
         (evaluation, _), remaining_conditions = process_data_condition_group(
-            self.when_condition_group.id, job
+            self.when_condition_group.id, workflow_job
         )
         return evaluation, remaining_conditions
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -11,7 +11,7 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 
 from .json_config import JSONConfigBase
 
@@ -68,7 +68,9 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
 
-    def evaluate_trigger_conditions(self, job: WorkflowJob) -> tuple[bool, list[DataCondition]]:
+    def evaluate_trigger_conditions(
+        self, job: WorkflowEventData
+    ) -> tuple[bool, list[DataCondition]]:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
         If there aren't any workflow trigger conditions, the workflow is considered triggered.

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -394,7 +394,7 @@ def fire_actions_for_groups(
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
     for group, group_event in group_to_groupevent.items():
-        job = WorkflowJob({"event": group_event})
+        job = WorkflowJob(event=group_event)
         detector = get_detector_by_event(job)
 
         workflow_triggers: set[DataConditionGroup] = set()

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -48,7 +48,7 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflows_action_filters,
     log_fired_workflows,
 )
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 logger = logging.getLogger("sentry.workflow_engine.processors.delayed_workflow")
 
@@ -394,7 +394,7 @@ def fire_actions_for_groups(
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
     for group, group_event in group_to_groupevent.items():
-        job = WorkflowJob(event=group_event)
+        job = WorkflowEventData(event=group_event)
         detector = get_detector_by_event(job)
 
         workflow_triggers: set[DataConditionGroup] = set()

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -8,12 +8,12 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.types import DetectorGroupKey, WorkflowJob
+from sentry.workflow_engine.types import DetectorGroupKey, WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
 
-def get_detector_by_event(job: WorkflowJob) -> Detector:
+def get_detector_by_event(job: WorkflowEventData) -> Detector:
     evt = job.event
     issue_occurrence = evt.occurrence
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_detector_by_event(job: WorkflowJob) -> Detector:
-    evt = job["event"]
+    evt = job.event
     issue_occurrence = evt.occurrence
 
     if issue_occurrence is None:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -22,7 +22,7 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ def enqueue_workflow(
     )
 
 
-def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> set[Workflow]:
+def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowEventData) -> set[Workflow]:
     triggered_workflows: set[Workflow] = set()
 
     for workflow in workflows:
@@ -80,7 +80,7 @@ def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> se
 
 def evaluate_workflows_action_filters(
     workflows: set[Workflow],
-    job: WorkflowJob,
+    job: WorkflowEventData,
 ) -> BaseQuerySet[Action]:
     filtered_action_groups: set[DataConditionGroup] = set()
 
@@ -116,7 +116,7 @@ def evaluate_workflows_action_filters(
     return filter_recently_fired_workflow_actions(filtered_action_groups, job.event.group)
 
 
-def log_fired_workflows(log_name: str, actions: list[Action], job: WorkflowJob) -> None:
+def log_fired_workflows(log_name: str, actions: list[Action], job: WorkflowEventData) -> None:
     # go from actions to workflows
     action_ids = {action.id for action in actions}
     action_conditions = DataConditionGroup.objects.filter(
@@ -144,7 +144,7 @@ def log_fired_workflows(log_name: str, actions: list[Action], job: WorkflowJob) 
         )
 
 
-def process_workflows(job: WorkflowJob) -> set[Workflow]:
+def process_workflows(job: WorkflowEventData) -> set[Workflow]:
     """
     This method will get the detector based on the event, and then gather the associated workflows.
     Next, it will evaluate the "when" (or trigger) conditions for each workflow, if the conditions are met,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import asdict
 from enum import StrEnum
 
 import sentry_sdk
@@ -67,7 +68,7 @@ def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> se
             enqueue_workflow(
                 workflow,
                 remaining_conditions,
-                job["event"],
+                job.event,
                 WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
             )
         else:
@@ -91,6 +92,8 @@ def evaluate_workflows_action_filters(
     ).distinct()
 
     for action_condition in action_conditions:
+        # TODO(cathy): attach correct workflow to job
+
         (evaluation, result), remaining_conditions = process_data_condition_group(
             action_condition.id, job
         )
@@ -103,14 +106,14 @@ def evaluate_workflows_action_filters(
                 enqueue_workflow(
                     condition_group.workflow,
                     remaining_conditions,
-                    job["event"],
+                    job.event,
                     WorkflowDataConditionGroupType.ACTION_FILTER,
                 )
         else:
             if evaluation:
                 filtered_action_groups.add(action_condition)
 
-    return filter_recently_fired_workflow_actions(filtered_action_groups, job["event"].group)
+    return filter_recently_fired_workflow_actions(filtered_action_groups, job.event.group)
 
 
 def log_fired_workflows(log_name: str, actions: list[Action], job: WorkflowJob) -> None:
@@ -134,9 +137,9 @@ def log_fired_workflows(log_name: str, actions: list[Action], job: WorkflowJob) 
             extra={
                 "workflow_id": workflow.id,
                 "rule_id": workflow_to_rule.get(workflow.id),
-                "payload": job,
-                "group_id": job["event"].group_id,
-                "event_id": job["event"].event_id,
+                "payload": asdict(job),
+                "group_id": job.event.group_id,
+                "event_id": job.event.event_id,
             },
         )
 
@@ -154,21 +157,20 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
         detector = get_detector_by_event(job)
     except Detector.DoesNotExist:
         metrics.incr("workflow_engine.process_workflows.error")
-        logger.exception("Detector not found for event", extra={"event_id": job["event"].event_id})
+        logger.exception("Detector not found for event", extra={"event_id": job.event.event_id})
         return set()
 
     try:
-        environment = job["event"].get_environment()
+        environment = job.event.get_environment()
     except Environment.DoesNotExist:
         metrics.incr("workflow_engine.process_workflows.error")
-        logger.exception("Missing environment for event", extra={"event_id": job["event"].event_id})
+        logger.exception("Missing environment for event", extra={"event_id": job.event.event_id})
         return set()
 
     # TODO: remove fetching org, only used for FF check
     organization = detector.project.organization
 
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
-    environment = job["event"].get_environment()
     workflows = set(
         Workflow.objects.filter(
             (Q(environment_id=None) | Q(environment_id=environment.id)),
@@ -185,8 +187,8 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
             "workflow_engine.process_workflows.process_event",
             extra={
                 "payload": job,
-                "group_id": job["event"].group_id,
-                "event_id": job["event"].event_id,
+                "group_id": job.event.group_id,
+                "event_id": job.event.event_id,
                 "event_environment_id": environment.id,
                 "workflows": [workflow.id for workflow in workflows],
             },

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -34,16 +34,10 @@ ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
 
 
 @dataclass(frozen=True)
-class EventJob:
+class WorkflowEventData:
     event: GroupEvent
-
-
-@dataclass(frozen=True)
-class WorkflowJob(EventJob):
     group_state: GroupState | None = None
-    is_reprocessed: bool | None = None
     has_reappeared: bool | None = None
-    has_alert: bool | None = None
     has_escalated: bool | None = None
     workflow: Workflow | None = None
 
@@ -60,7 +54,7 @@ class ActionHandler:
     group: ClassVar[Group]
 
     @staticmethod
-    def execute(job: WorkflowJob, action: Action, detector: Detector) -> None:
+    def execute(job: WorkflowEventData, action: Action, detector: Detector) -> None:
         raise NotImplementedError
 
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
@@ -32,17 +33,19 @@ DataConditionResult = DetectorPriorityLevel | int | float | bool | None
 ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
 
 
-class EventJob(TypedDict):
+@dataclass(frozen=True)
+class EventJob:
     event: GroupEvent
 
 
-class WorkflowJob(EventJob, total=False):
-    group_state: GroupState
-    is_reprocessed: bool
-    has_reappeared: bool
-    has_alert: bool
-    has_escalated: bool
-    workflow: Workflow
+@dataclass(frozen=True)
+class WorkflowJob(EventJob):
+    group_state: GroupState | None = None
+    is_reprocessed: bool | None = None
+    has_reappeared: bool | None = None
+    has_alert: bool | None = None
+    has_escalated: bool | None = None
+    workflow: Workflow | None = None
 
 
 class ActionHandler:

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -168,11 +168,11 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
 
         # Verify activate_downstream_actions called with correct args
         mock_activate_downstream_actions.assert_called_once_with(
-            mock.ANY, self.job["event"], "12345678-1234-5678-1234-567812345678"  # Rule instance
+            mock.ANY, self.job.event, "12345678-1234-5678-1234-567812345678"  # Rule instance
         )
 
         # Verify callback execution
-        mock_safe_execute.assert_called_once_with(mock_callback, self.job["event"], mock_futures)
+        mock_safe_execute.assert_called_once_with(mock_callback, self.job.event, mock_futures)
 
 
 class TestDiscordIssueAlertHandler(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -27,7 +27,7 @@ from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     WebhookIssueAlertHandler,
 )
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import (
     ACTION_FIELD_MAPPINGS,
     EXCLUDED_ACTION_DATA_KEYS,
@@ -72,7 +72,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
 
         class TestHandler(BaseIssueAlertHandler):
             @classmethod
@@ -127,7 +127,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
     def test_create_rule_instance_from_action_no_environment(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
         workflow = self.create_workflow()
-        job = WorkflowJob(event=self.group_event, workflow=workflow)
+        job = WorkflowEventData(event=self.group_event, workflow=workflow)
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector, job)
 
         assert isinstance(rule, Rule)
@@ -189,7 +189,7 @@ class TestDiscordIssueAlertHandler(BaseWorkflowTest):
         # self.project = self.create_project()
         # self.detector = self.create_detector(project=self.project)
         # self.group, self.event, self.group_event = self.create_group_event()
-        # self.job = WorkflowJob(event=self.group_event)
+        # self.job = WorkflowEventData(event=self.group_event)
 
     def test_build_rule_action_blob(self):
         """Test that build_rule_action_blob creates correct Discord action data"""

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.handlers.action.notification.metric_alert import (
     PagerDutyMetricAlertHandler,
 )
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -149,7 +149,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
         self.handler = TestHandler()
 
     def test_missing_occurrence_raises_value_error(self):
@@ -339,7 +339,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowJob(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
         self.handler = PagerDutyMetricAlertHandler()
 
     @mock.patch(

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -153,7 +153,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         self.handler = TestHandler()
 
     def test_missing_occurrence_raises_value_error(self):
-        self.job["event"].occurrence = None
+        self.job.event.occurrence = None
 
         with pytest.raises(ValueError):
             self.handler.invoke_legacy_registry(self.job, self.action, self.detector)

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -12,7 +12,7 @@ from sentry.workflow_engine.handlers.action.notification.handler import (
     NotificationHandlerException,
 )
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -23,7 +23,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def test_execute_without_group_type(self):
         """Test that execute does nothing when detector has no group_type"""
@@ -90,7 +90,7 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.handler.issue_alert_handler_registry.get"
@@ -128,7 +128,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.handler.metric_alert_handler_registry.get"

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -23,7 +23,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     def test_execute_without_group_type(self):
         """Test that execute does nothing when detector has no group_type"""
@@ -90,7 +90,7 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.handler.issue_alert_handler_registry.get"
@@ -128,7 +128,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.handler.metric_alert_handler_registry.get"

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -7,7 +7,7 @@ from sentry.rules.age import AgeComparisonType
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -17,11 +17,11 @@ class TestAgeComparisonCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.payload = {
             "id": AgeComparisonFilter.id,
             "comparison_type": AgeComparisonType.OLDER,

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -17,19 +17,11 @@ class TestAgeComparisonCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.payload = {
             "id": AgeComparisonFilter.id,
             "comparison_type": AgeComparisonType.OLDER,

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -4,7 +4,7 @@ from jsonschema import ValidationError
 from sentry.models.groupassignee import GroupAssignee
 from sentry.rules.filters.assigned_to import AssignedToFilter
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -18,7 +18,7 @@ class TestAssignedToCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -18,11 +18,7 @@ class TestAssignedToCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -10,7 +10,7 @@ from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     translate_to_data_condition as dual_write_condition,
 )
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -25,10 +25,10 @@ class ConditionTestCase(BaseWorkflowTest):
         data_condition.save()
         return data_condition
 
-    def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+    def assert_passes(self, data_condition: DataCondition, job: WorkflowEventData) -> None:
         assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
 
-    def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+    def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowEventData) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
     def assert_slow_condition_passes(self, data_condition: DataCondition, value: list[int]) -> None:

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -90,17 +90,15 @@ class TestEventAttributeCondition(ConditionTestCase):
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    {
-                        "id": 1,
-                        "is_regression": False,
-                        "is_new": False,
-                        "is_new_group_environment": False,
-                    }
-                ),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": False,
+                    "is_new": False,
+                    "is_new_group_environment": False,
+                }
+            ),
         )
 
     def error_setup(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -9,7 +9,7 @@ from sentry.rules.filters.event_attribute import EventAttributeFilter
 from sentry.rules.match import MatchType
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -89,7 +89,7 @@ class TestEventAttributeCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 from jsonschema import ValidationError
 
@@ -16,19 +18,17 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    {
-                        "id": 1,
-                        "is_regression": True,
-                        "is_new": False,
-                        "is_new_group_environment": False,
-                    }
-                ),
-                "has_reappeared": True,
-                "has_escalated": True,
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": True,
+                    "is_new": False,
+                    "is_new_group_environment": False,
+                }
+            ),
+            has_reappeared=True,
+            has_escalated=True,
         )
         self.dc = self.create_data_condition(
             type=self.condition,
@@ -68,20 +68,18 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_group_state_is_new(self):
-        self.job["group_state"]["is_new"] = True
+        assert self.job.group_state
+        self.job.group_state["is_new"] = True
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_is_escalating(self):
-        self.job["has_reappeared"] = False
-        self.job["has_escalated"] = True
+        self.job = replace(self.job, has_reappeared=False, has_escalated=True)
         self.assert_passes(self.dc, self.job)
 
-        self.job["has_reappeared"] = True
-        self.job["has_escalated"] = False
+        self.job = replace(self.job, has_reappeared=True, has_escalated=False)
         self.assert_passes(self.dc, self.job)
 
-        self.job["has_reappeared"] = False
-        self.job["has_escalated"] = False
+        self.job = replace(self.job, has_reappeared=False, has_escalated=False)
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_priority(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -7,7 +7,7 @@ from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -17,7 +17,7 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -7,7 +7,7 @@ from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow import Workflow
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -17,7 +17,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 from jsonschema import ValidationError
 
@@ -16,18 +18,16 @@ class TestFirstSeenEventCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    {
-                        "id": 1,
-                        "is_regression": True,
-                        "is_new": True,
-                        "is_new_group_environment": True,
-                    }
-                ),
-                "workflow": Workflow(environment_id=None),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": True,
+                    "is_new": True,
+                    "is_new_group_environment": True,
+                }
+            ),
+            workflow=Workflow(environment_id=None),
         )
         self.dc = self.create_data_condition(
             type=self.condition,
@@ -65,22 +65,24 @@ class TestFirstSeenEventCondition(ConditionTestCase):
     def test(self):
         self.assert_passes(self.dc, self.job)
 
-        self.job["group_state"]["is_new"] = False
+        assert self.job.group_state
+        self.job.group_state["is_new"] = False
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_with_environment(self):
-        self.job["workflow"] = Workflow(environment_id=1)
+        self.job = replace(self.job, workflow=Workflow(environment_id=1))
+        assert self.job.group_state
 
         self.assert_passes(self.dc, self.job)
 
-        self.job["group_state"]["is_new"] = False
-        self.job["group_state"]["is_new_group_environment"] = True
+        self.job.group_state["is_new"] = False
+        self.job.group_state["is_new_group_environment"] = True
         self.assert_passes(self.dc, self.job)
 
-        self.job["group_state"]["is_new"] = True
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new"] = True
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.job["group_state"]["is_new"] = False
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new"] = False
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -6,7 +6,7 @@ from jsonschema import ValidationError
 from sentry.issues.grouptype import GroupCategory
 from sentry.rules.filters.issue_category import IssueCategoryFilter
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -19,7 +19,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -81,11 +81,11 @@ class TestIssueCategoryCondition(ConditionTestCase):
         group_event = self.event.for_group(self.group)
 
         self.dc.update(comparison={"value": GroupCategory.ERROR.value})
-        self.assert_passes(self.dc, WorkflowJob(event=self.event))
-        self.assert_passes(self.dc, WorkflowJob(event=group_event))
+        self.assert_passes(self.dc, WorkflowEventData(event=self.event))
+        self.assert_passes(self.dc, WorkflowEventData(event=group_event))
 
     @patch("sentry.issues.grouptype.GroupTypeRegistry.get_by_type_id")
     def test_invalid_issue_category(self, mock_get_by_type_id):
         mock_get_by_type_id.side_effect = ValueError("Invalid group type")
 
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.event))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=self.event))

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -19,11 +19,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -85,11 +81,11 @@ class TestIssueCategoryCondition(ConditionTestCase):
         group_event = self.event.for_group(self.group)
 
         self.dc.update(comparison={"value": GroupCategory.ERROR.value})
-        self.assert_passes(self.dc, WorkflowJob({"event": self.event}))
-        self.assert_passes(self.dc, WorkflowJob({"event": group_event}))
+        self.assert_passes(self.dc, WorkflowJob(event=self.event))
+        self.assert_passes(self.dc, WorkflowJob(event=group_event))
 
     @patch("sentry.issues.grouptype.GroupTypeRegistry.get_by_type_id")
     def test_invalid_issue_category(self, mock_get_by_type_id):
         mock_get_by_type_id.side_effect = ValueError("Invalid group type")
 
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": self.event}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.event))

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -3,7 +3,7 @@ from jsonschema import ValidationError
 
 from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -17,7 +17,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.group.times_seen_pending = 0
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -17,11 +17,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.group.times_seen_pending = 0
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
@@ -5,7 +5,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_metric_data_conditions,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -14,7 +14,7 @@ class TestIssuePriorityCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.metric_alert = self.create_alert_rule()
         self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
             alert_rule=self.metric_alert, label="warning"

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
@@ -14,7 +14,7 @@ class TestIssuePriorityCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
         self.metric_alert = self.create_alert_rule()
         self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
             alert_rule=self.metric_alert, label="warning"

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
@@ -8,11 +8,7 @@ class TestIssueResolutionChangeCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=1,

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
@@ -1,5 +1,5 @@
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -8,7 +8,7 @@ class TestIssueResolutionChangeCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=1,

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -62,11 +62,7 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
             adopted=self.now,
         )
 
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -111,25 +107,25 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": self.group_event}))
+        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_2}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_3}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
 
         # Check that the group cache invalidation works by adding an older release to the first group
         self.create_group_release(group=self.group, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": self.group_event}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.group_event))
 
         # Check that the project cache invalidation works by adding a newer release to the project
         group_4, group_event_4 = self.create_new_group_event("group4")
         self.create_group_release(group=group_4, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": group_event_4}))
+        self.assert_passes(self.dc, WorkflowJob(event=group_event_4))
 
         self.create_release(
             project=self.event.group.project,
@@ -138,20 +134,20 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
             environments=[self.prod_env],
             adopted=self.now - timedelta(days=2),
         )
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_4}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_4))
 
     def test_date(self):
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": self.group_event}))
+        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_2}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_3}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
 
     def test_oldest_older(self):
         self.dc.update(
@@ -163,18 +159,18 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": self.group_event}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
 
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": group_event_2}))
+        self.assert_passes(self.dc, WorkflowJob(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
 
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_3}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
 
     def test_newest_newer(self):
         self.dc.update(
@@ -186,18 +182,18 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": self.group_event}))
+        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
 
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_passes(self.dc, WorkflowJob({"event": group_event_2}))
+        self.assert_passes(self.dc, WorkflowJob(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
 
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_3}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
 
     def test_newest_older(self):
         self.dc.update(
@@ -209,16 +205,16 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.event.group, release=self.newest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": self.event}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_2}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob({"event": group_event_3}))
+        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
 
     def test_caching(self):
         cache_key = get_first_last_release_for_group_cache_key(

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -14,7 +14,7 @@ from sentry.rules.filters.latest_adopted_release_filter import (
 from sentry.search.utils import LatestReleaseOrders
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -62,7 +62,7 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
             adopted=self.now,
         )
 
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -107,25 +107,25 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
+        self.assert_passes(self.dc, WorkflowEventData(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3))
 
         # Check that the group cache invalidation works by adding an older release to the first group
         self.create_group_release(group=self.group, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.group_event))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=self.group_event))
 
         # Check that the project cache invalidation works by adding a newer release to the project
         group_4, group_event_4 = self.create_new_group_event("group4")
         self.create_group_release(group=group_4, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=group_event_4))
+        self.assert_passes(self.dc, WorkflowEventData(event=group_event_4))
 
         self.create_release(
             project=self.event.group.project,
@@ -134,20 +134,20 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
             environments=[self.prod_env],
             adopted=self.now - timedelta(days=2),
         )
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_4))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_4))
 
     def test_date(self):
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
+        self.assert_passes(self.dc, WorkflowEventData(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3))
 
     def test_oldest_older(self):
         self.dc.update(
@@ -159,18 +159,18 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.group_event))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
 
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=group_event_2))
+        self.assert_passes(self.dc, WorkflowEventData(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
 
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3))
 
     def test_newest_newer(self):
         self.dc.update(
@@ -182,18 +182,18 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.group, release=self.newest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=self.group_event))
+        self.assert_passes(self.dc, WorkflowEventData(event=self.group_event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
 
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_passes(self.dc, WorkflowJob(event=group_event_2))
+        self.assert_passes(self.dc, WorkflowEventData(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
 
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3))
 
     def test_newest_older(self):
         self.dc.update(
@@ -205,16 +205,16 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         )
 
         self.create_group_release(group=self.event.group, release=self.newest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=self.event))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=self.event))
 
         group_2, group_event_2 = self.create_new_group_event("group2")
         self.create_group_release(group=group_2, release=self.newest_release)
         self.create_group_release(group=group_2, release=self.oldest_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_2))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_2))
 
         group_3, group_event_3 = self.create_new_group_event("group3")
         self.create_group_release(group=group_3, release=self.middle_release)
-        self.assert_does_not_pass(self.dc, WorkflowJob(event=group_event_3))
+        self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3))
 
     def test_caching(self):
         cache_key = get_first_last_release_for_group_cache_key(

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -24,11 +24,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=True,
@@ -145,10 +141,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         )
 
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "workflow": Workflow(environment_id=self.environment.id),
-            }
+            event=self.group_event, workflow=Workflow(environment_id=self.environment.id)
         )
 
         self.event.data["tags"] = (("release", new_release.version),)

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -10,7 +10,7 @@ from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow import Workflow
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
@@ -24,7 +24,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=True,
@@ -140,7 +140,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
             date_added=datetime(2020, 9, 3, 3, 8, 24, 880386, tzinfo=UTC),
         )
 
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event, workflow=Workflow(environment_id=self.environment.id)
         )
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -5,7 +5,7 @@ from sentry.rules.conditions.level import LevelCondition
 from sentry.rules.filters.level import LevelFilter
 from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -19,7 +19,7 @@ class TestLevelCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -19,12 +19,7 @@ class TestLevelCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "has_reappeared": True,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -17,18 +17,16 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    {
-                        "id": 1,
-                        "is_regression": True,
-                        "is_new": True,
-                        "is_new_group_environment": True,
-                    }
-                ),
-                "workflow": Workflow(environment_id=1),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": True,
+                    "is_new": True,
+                    "is_new_group_environment": True,
+                }
+            ),
+            workflow=Workflow(environment_id=1),
         )
         self.dc = self.create_data_condition(
             type=self.condition,
@@ -67,13 +65,15 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
         self.project.flags.has_high_priority_alerts = True
         self.project.save()
 
+        assert self.job.group_state
+
         # This will only pass for new issues
         self.group_event.group.update(priority=PriorityLevel.HIGH)
-        self.job["group_state"]["is_new_group_environment"] = True
+        self.job.group_state["is_new_group_environment"] = True
         self.assert_passes(self.dc, self.job)
 
         # These will never pass
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)
 
         self.group_event.group.update(priority=PriorityLevel.MEDIUM)
@@ -86,20 +86,22 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
         self.project.flags.has_high_priority_alerts = False
         self.project.save()
 
+        assert self.job.group_state
+
         self.group_event.group.update(priority=PriorityLevel.HIGH)
-        self.job["group_state"]["is_new_group_environment"] = True
+        self.job.group_state["is_new_group_environment"] = True
         self.assert_passes(self.dc, self.job)
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)
 
         self.group_event.group.update(priority=PriorityLevel.MEDIUM)
-        self.job["group_state"]["is_new_group_environment"] = True
+        self.job.group_state["is_new_group_environment"] = True
         self.assert_passes(self.dc, self.job)
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)
 
         self.group_event.group.update(priority=PriorityLevel.LOW)
-        self.job["group_state"]["is_new_group_environment"] = True
+        self.job.group_state["is_new_group_environment"] = True
         self.assert_passes(self.dc, self.job)
-        self.job["group_state"]["is_new_group_environment"] = False
+        self.job.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -6,7 +6,7 @@ from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssue
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow import Workflow
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -16,7 +16,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 from jsonschema import ValidationError
 
@@ -39,12 +41,7 @@ class TestReappearedEventCondition(ConditionTestCase):
             dc.save()
 
     def test(self):
-        job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "has_reappeared": True,
-            }
-        )
+        job = WorkflowJob(event=self.group_event, has_reappeared=True)
         dc = self.create_data_condition(
             type=self.condition,
             comparison=True,
@@ -53,5 +50,5 @@ class TestReappearedEventCondition(ConditionTestCase):
 
         self.assert_passes(dc, job)
 
-        job["has_reappeared"] = False
+        job = replace(job, has_reappeared=False)
         self.assert_does_not_pass(dc, job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -5,7 +5,7 @@ from jsonschema import ValidationError
 
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -41,7 +41,7 @@ class TestReappearedEventCondition(ConditionTestCase):
             dc.save()
 
     def test(self):
-        job = WorkflowJob(event=self.group_event, has_reappeared=True)
+        job = WorkflowEventData(event=self.group_event, has_reappeared=True)
         dc = self.create_data_condition(
             type=self.condition,
             comparison=True,

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -41,17 +41,15 @@ class TestRegressionEventCondition(ConditionTestCase):
 
     def test(self):
         job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    {
-                        "id": 1,
-                        "is_regression": True,
-                        "is_new": False,
-                        "is_new_group_environment": False,
-                    }
-                ),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": True,
+                    "is_new": False,
+                    "is_new_group_environment": False,
+                }
+            ),
         )
         dc = self.create_data_condition(
             type=self.condition,
@@ -61,5 +59,6 @@ class TestRegressionEventCondition(ConditionTestCase):
 
         self.assert_passes(dc, job)
 
-        job["group_state"]["is_regression"] = False
+        assert job.group_state
+        job.group_state["is_regression"] = False
         self.assert_does_not_pass(dc, job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -4,7 +4,7 @@ from jsonschema import ValidationError
 from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.regression_event import RegressionEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -40,7 +40,7 @@ class TestRegressionEventCondition(ConditionTestCase):
             dc.save()
 
     def test(self):
-        job = WorkflowJob(
+        job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -33,11 +33,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.event = self.get_event()
         self.group = self.create_group(project=self.project)
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-            }
-        )
+        self.job = WorkflowJob(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -5,7 +5,7 @@ from sentry.rules.conditions.tagged_event import TaggedEventCondition
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -33,7 +33,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.event = self.get_event()
         self.group = self.create_group(project=self.project)
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 
 from sentry.workflow_engine.models import Workflow
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -14,7 +14,7 @@ class WorkflowTest(BaseWorkflowTest):
         )
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.job)

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -14,7 +14,7 @@ class WorkflowTest(BaseWorkflowTest):
         )
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.job)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -25,7 +25,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     def test(self):
         # test default frequency when no workflow.config set

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -25,7 +25,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def test(self):
         # test default frequency when no workflow.config set

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -53,7 +53,7 @@ from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     WorkflowDataConditionGroupType,
 )
-from sentry.workflow_engine.types import DataConditionHandler
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
@@ -748,11 +748,11 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
         assert mock_trigger.call_count == 2
         assert mock_trigger.call_args_list[0][0] == (
-            {"event": self.event1.for_group(self.group1)},
+            WorkflowJob(event=self.event1.for_group(self.group1)),
             self.detector,
         )
         assert mock_trigger.call_args_list[1][0] == (
-            {"event": self.event2.for_group(self.group2)},
+            WorkflowJob(event=self.event2.for_group(self.group2)),
             self.detector,
         )
 

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -53,7 +53,7 @@ from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     WorkflowDataConditionGroupType,
 )
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
@@ -748,11 +748,11 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
         assert mock_trigger.call_count == 2
         assert mock_trigger.call_args_list[0][0] == (
-            WorkflowJob(event=self.event1.for_group(self.group1)),
+            WorkflowEventData(event=self.event1.for_group(self.group1)),
             self.detector,
         )
         assert mock_trigger.call_args_list[1][0] == (
-            WorkflowJob(event=self.event2.for_group(self.group2)),
+            WorkflowEventData(event=self.event2.for_group(self.group2)),
             self.detector,
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -32,7 +32,7 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflows_action_filters,
     process_workflows,
 )
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
@@ -56,7 +56,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 id=1, is_new=False, is_regression=True, is_new_group_environment=False
@@ -113,7 +113,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         other_env = self.create_environment(project=self.project)
 
         self.group, self.event, self.group_event = self.create_group_event(environment=env.name)
-        self.job = WorkflowJob(
+        self.job = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 id=1, is_new=False, is_regression=True, is_new_group_environment=False
@@ -262,7 +262,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=occurrence,
         )
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def test_workflow_trigger(self):
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
@@ -347,7 +347,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=occurrence,
         )
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
         self.create_workflow_action(self.workflow)
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
@@ -474,7 +474,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
-        self.job = WorkflowJob(event=self.group_event)
+        self.job = WorkflowEventData(event=self.group_event)
 
     def test_basic__no_filter(self):
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.job)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -56,12 +57,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         self.group, self.event, self.group_event = self.create_group_event()
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    id=1, is_new=False, is_regression=True, is_new_group_environment=False
-                ),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                id=1, is_new=False, is_regression=True, is_new_group_environment=False
+            ),
         )
 
     def test_skips_disabled_workflows(self):
@@ -103,16 +102,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             extra={
                 "workflow_id": self.error_workflow.id,
                 "rule_id": rule.id,
-                "payload": {
-                    "event": self.group_event,
-                    "group_state": {
-                        "id": 1,
-                        "is_new": False,
-                        "is_regression": True,
-                        "is_new_group_environment": False,
-                    },
-                    "workflow": self.error_workflow,
-                },
+                "payload": asdict(self.job),
                 "group_id": self.group.id,
                 "event_id": self.event.event_id,
             },
@@ -124,12 +114,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         self.group, self.event, self.group_event = self.create_group_event(environment=env.name)
         self.job = WorkflowJob(
-            {
-                "event": self.group_event,
-                "group_state": GroupState(
-                    id=1, is_new=False, is_regression=True, is_new_group_environment=False
-                ),
-            }
+            event=self.group_event,
+            group_state=GroupState(
+                id=1, is_new=False, is_regression=True, is_new_group_environment=False
+            ),
         )
 
         # only processes workflows with the same env or no env specified
@@ -222,7 +210,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.workflow.logger")
     def test_no_metrics_triggered(self, mock_logger, mock_incr):
-        self.job["event"].project_id = 0
+        self.job.event.project_id = 0
 
         process_workflows(self.job)
         mock_incr.assert_called_once_with("workflow_engine.process_workflows.error")
@@ -274,7 +262,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=occurrence,
         )
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     def test_workflow_trigger(self):
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
@@ -359,7 +347,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=occurrence,
         )
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
         self.create_workflow_action(self.workflow)
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
@@ -486,7 +474,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = WorkflowJob(event=self.group_event)
 
     def test_basic__no_filter(self):
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.job)


### PR DESCRIPTION
Convert the `WorkflowJob` `TypedDict` to a frozen dataclass. This makes the data much easier to interact with, and modifying the `workflow` on the dataclass requires an explicit `replace` operation to create a new frozen dataclass with the correct `workflow` attached.

TODO:
- [ ] We only use environment from the workflow, so replace workflow on the dataclass with workflow_environment
- [ ] Attach the workflow_environment correctly when evaluating filters and when triggering actions