### PR TITLE
fix(releases): Redirect to normalized path when project query param does not exist

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -319,9 +319,10 @@ function ReleasesDetailContainer(props: ReleasesDetailContainerProps) {
         }))}
         router={router}
         nextPath={{
-          pathname: `/organizations/${organization.slug}/releases/${encodeURIComponent(
-            release!
-          )}/`,
+          pathname: makeReleasesPathname({
+            path: `/${encodeURIComponent(release!)}/`,
+            organization,
+          }),
         }}
         noProjectRedirectPath={makeReleasesPathname({
           organization,


### PR DESCRIPTION
If you go to the release details page, remove the `?project=id` param and reload the page, you will get redirected to a route with `/organizations/:orgSlug/` prepended. This is solved by normalizing `nextPath`.

This was also a path that needed to be converted to use the new route structure, so two birds one stone.