### PR TITLE
fix(ui): Move collapsible props to Header instead of entire panel

### DIFF
--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -63,16 +63,15 @@ function FormPanel({
   const handleCollapseToggle = useCallback(() => setCollapse(current => !current), []);
 
   return (
-    <Panel
-      id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}
-      onClick={collapsible ? handleCollapseToggle : undefined}
-      style={collapsible ? {cursor: 'pointer'} : undefined}
-      role={collapsible ? 'button' : undefined}
-      aria-label={collapsible ? t('Expand Options') : t('Panel')}
-      aria-expanded={!collapsed}
-    >
+    <Panel id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}>
       {title && (
-        <PanelHeader>
+        <PanelHeader
+          onClick={collapsible ? handleCollapseToggle : undefined}
+          style={collapsible ? {cursor: 'pointer'} : undefined}
+          role={collapsible ? 'button' : undefined}
+          aria-label={collapsible ? t('Expand Options') : t('Panel')}
+          aria-expanded={!collapsed}
+        >
           {title}
           {collapsible && (
             <Collapse


### PR DESCRIPTION
Fixes a bug where clicking anywhere on the panel would cause the collapse event to fire, including when sliders and child elements were clicked. Moving this to just the header component achieves the original expected behaviour