### PR TITLE
fix(issue-details): Remove timestamp from participants list

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -17,10 +17,15 @@ import useOverlay from 'sentry/utils/useOverlay';
 
 interface DropdownListProps {
   users: User[];
+  hideTimestamp?: boolean;
   teams?: Team[];
 }
 
-export default function ParticipantList({users, teams}: DropdownListProps) {
+export default function ParticipantList({
+  users,
+  teams,
+  hideTimestamp,
+}: DropdownListProps) {
   const {overlayProps, isOpen, triggerProps} = useOverlay({
     position: 'bottom-start',
     shouldCloseOnBlur: true,
@@ -41,8 +46,12 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
           renderTooltip={user => (
             <Fragment>
               {userDisplayName(user)}
-              <br />
-              <LastSeen date={(user as AvatarUser).lastSeen} />
+              {!hideTimestamp && (
+                <Fragment>
+                  <br />
+                  <LastSeen date={(user as AvatarUser).lastSeen} />
+                </Fragment>
+              )}
             </Fragment>
           )}
         />
@@ -76,7 +85,7 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
                     {user.email === user.name ? null : (
                       <SmallText>{user.email}</SmallText>
                     )}
-                    <LastSeen date={(user as AvatarUser).lastSeen} />
+                    {!hideTimestamp && <LastSeen date={(user as AvatarUser).lastSeen} />}
                   </NameWrapper>
                 </UserRow>
               ))}

--- a/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
@@ -23,7 +23,11 @@ export default function PeopleSection({
       <SidebarSectionTitle>{t('People')}</SidebarSectionTitle>
       {hasParticipants && (
         <Flex gap={space(0.5)} align="center">
-          <ParticipantList users={userParticipants} teams={teamParticipants} />
+          <ParticipantList
+            users={userParticipants}
+            teams={teamParticipants}
+            hideTimestamp
+          />
           {t('participating')}
         </Flex>
       )}


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/81584, this pr removes the timestamp from the participants list/tooltip. right now it just defaults to showing the current time for all participants. keeps the last seen timestamp which is working correctly. 