### PR TITLE
ref(issues): Correct header sizing when replay button present

### DIFF
--- a/static/app/views/issueDetails/streamline/header/replayBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/replayBadge.tsx
@@ -30,7 +30,6 @@ export function ReplayBadge({group, project}: {group: Group; project: Project}) 
       <ReplayButton
         type="button"
         priority="link"
-        size="zero"
         icon={<IconPlay size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,


### PR DESCRIPTION
The replay button had extra padding because of size=zero. Without
specifying the size you won't have this problem