### PR TITLE
fix(aci): only parse buffer data to fetch event_ids for groups we should fire

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -311,7 +311,7 @@ def parse_dcg_group_event_data(
 
         group_id = int(data[1])
         if group_id not in groups_to_dcg_ids:
-            # the group did not trigger any workflows
+            # the group did not trigger any data condition groups
             continue
 
         event_data = json.loads(instance_data)

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -487,13 +487,29 @@ def process_delayed_workflows(
     _, workflows_to_envs = fetch_workflows_envs(list(dcg_to_workflow.values()))
     data_condition_groups = fetch_data_condition_groups(list(dcg_to_groups.keys()))
 
+    logger.info(
+        "delayed_workflow.workflows",
+        extra={"data": workflow_event_dcg_data, "workflows": set(dcg_to_workflow.values())},
+    )
+
     # Get unique query groups to query Snuba
     condition_groups = get_condition_query_groups(
         data_condition_groups, dcg_to_groups, dcg_to_workflow, workflows_to_envs
     )
+
+    if not condition_groups:
+        return
+
+    repr_condition_groups = {
+        repr(condition_group): group_ids for condition_group, group_ids in condition_groups.items()
+    }
     logger.info(
         "delayed_workflow.condition_query_groups",
-        extra={"condition_groups": condition_groups, "project_id": project_id},
+        extra={
+            "condition_groups": repr_condition_groups,
+            "num_condition_groups": len(condition_groups),
+            "project_id": project_id,
+        },
     )
     condition_group_results = get_condition_group_results(condition_groups)
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -308,8 +308,13 @@ def parse_dcg_group_event_data(
 
     for workflow_group_dcg, instance_data in workflow_event_dcg_data.items():
         data = workflow_group_dcg.split(":")
-        event_data = json.loads(instance_data)
 
+        group_id = int(data[1])
+        if group_id not in groups_to_dcg_ids:
+            # the group did not trigger any workflows
+            continue
+
+        event_data = json.loads(instance_data)
         event_id = event_data.get("event_id")
         if event_id:
             event_ids.add(event_id)
@@ -318,7 +323,6 @@ def parse_dcg_group_event_data(
         if occurrence_id:
             occurrence_ids.add(occurrence_id)
 
-        group_id = int(data[1])
         dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
 
         for dcg_id in dcg_ids:

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -722,6 +722,26 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert event_ids == {self.event1.event_id, self.event2.event_id}
         assert occurrence_ids == set()
 
+    def test_parse_dcg_group_event_data__triggered_groups_only(self):
+        # buffer data represents all the data from the buffer
+        # groups_to_dcgs represents that groups that triggered DCGs --> fire actions
+        # the groups in the buffer may not be fired.
+
+        del self.groups_to_dcgs[self.group1.id]
+
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
+            buffer_data, self.groups_to_dcgs
+        )
+
+        del self.dcg_group_to_event_data[(self.workflow1_dcgs[0].id, self.group1.id)]
+        del self.dcg_group_to_event_data[(self.workflow1_dcgs[1].id, self.group1.id)]
+
+        assert dcg_group_to_event_data == self.dcg_group_to_event_data
+        assert event_ids == {self.event2.event_id}
+        assert occurrence_ids == set()
+
     def test_bulk_fetch_events(self):
         event_ids = [self.event1.event_id, self.event2.event_id]
         events = bulk_fetch_events(event_ids, self.project.id)


### PR DESCRIPTION
Delayed workflow fix:
- `parse_dcg_group_event_data` parses the original buffer data to fetch `event_ids` for the groups we should fire workflows for. This is currently being done by iterating through the original buffer data and then indexing into the dictionary of groups to triggered DCGs.
- There can be a mismatch where a group from the buffer data does not trigger any DCGs, so indexing into the dictionary will cause an index error (SENTRY-3QE8), instead we should skipping these groups.

Logging:
- `condition_groups` is being logged as an empty dict and I cannot tell if it's because there are no condition groups (which shouldn't be the case) or if GCP is having a hard time storing the dictionary of unique condition queries to group_ids we need to fetch data for...
- Update the logging to explicitly log the `repr` of `UniqueConditionQuery`
- Also add an early return so it won't log if there are no unique queries.