### PR TITLE
ref(issues): Correct header sizing with "badges"

### DIFF
--- a/static/app/views/issueDetails/streamline/header/attachmentsBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/attachmentsBadge.tsx
@@ -40,7 +40,6 @@ export function AttachmentsBadge({group}: {group: Group}) {
       <AttachmentButton
         type="button"
         priority="link"
-        size="zero"
         icon={<IconAttachment size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.ATTACHMENTS]}`,

--- a/static/app/views/issueDetails/streamline/header/replayBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/replayBadge.tsx
@@ -30,7 +30,6 @@ export function ReplayBadge({group, project}: {group: Group; project: Project}) 
       <ReplayButton
         type="button"
         priority="link"
-        size="zero"
         icon={<IconPlay size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,

--- a/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
@@ -26,7 +26,6 @@ export function UserFeedbackBadge({group, project}: {group: Group; project: Proj
       <UserFeedbackButton
         type="button"
         priority="link"
-        size="zero"
         icon={<IconMegaphone size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.USER_FEEDBACK]}`,


### PR DESCRIPTION
These include replayBadge, attachmentsBadge, and userFeedbackBadge

The replay button had extra padding because of size=zero. Without
specifying the size you won't have this problem