### PR TITLE
chore: Don't mock snuba call in RPC subscription test

### DIFF
--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -282,10 +282,6 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
             time_window=time_window,
         )
         with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
-            resp = Mock()
-            resp.status = 202
-            resp.data = b'\n"0/a92bba96a12e11ef8b0eaeb51d7f1da4'
-
             create_subscription_in_snuba(sub.id)
 
             rpc_request_body = urlopen.call_args[1]["body"]

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -281,15 +281,14 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
             dataset=Dataset.EventsAnalyticsPlatform,
             time_window=time_window,
         )
-        with patch("sentry.utils.snuba_rpc._snuba_pool") as pool:
+        with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
             resp = Mock()
             resp.status = 202
             resp.data = b'\n"0/a92bba96a12e11ef8b0eaeb51d7f1da4'
-            pool.urlopen.return_value = resp
 
             create_subscription_in_snuba(sub.id)
 
-            rpc_request_body = pool.urlopen.call_args[1]["body"]
+            rpc_request_body = urlopen.call_args[1]["body"]
             createSubscriptionRequest = CreateSubscriptionRequest.FromString(rpc_request_body)
 
             assert createSubscriptionRequest.time_window_secs == time_window


### PR DESCRIPTION
We want a full E2E integration test