### PR TITLE
issues: fix border radius in chonk

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -274,6 +274,15 @@ const DropdownButton = styled(Button)`
   height: unset;
   border-radius: 20px;
   box-shadow: none;
+
+  ${p =>
+    // Chonk tags have a smaller border radius, so we need make sure it matches.
+    p.theme.isChonk &&
+    `
+      > span > div {
+        border-radius: 20px;
+      }
+    `}
 `;
 
 const StyledTag = styled(Tag)`

--- a/static/app/components/core/badge/tag.chonk.tsx
+++ b/static/app/components/core/badge/tag.chonk.tsx
@@ -30,10 +30,10 @@ export const TagPill = chonkStyled('div')<{
 }>`
   ${p => ({...makeTagPillTheme(p.type, p.theme)})};
 
+  height: 20px;
   font-size: ${p => p.theme.fontSizeSmall};
   display: inline-flex;
   align-items: center;
-  height: 20px;
   border-radius: ${p => p.theme.radius.mini};
   padding: 0 ${space(1)};
   max-width: 166px;

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {assignToActor, clearAssignment} from 'sentry/actionCreators/group';
@@ -79,6 +80,8 @@ export function AssigneeSelector({
   owners,
   additionalMenuFooterItems,
 }: AssigneeSelectorProps) {
+  const theme = useTheme();
+
   return (
     <AssigneeSelectorDropdown
       group={group}
@@ -93,7 +96,7 @@ export function AssigneeSelector({
         <StyledDropdownButton
           {...props}
           aria-label={t('Modify issue assignee')}
-          borderless
+          borderless={!theme.isChonk}
           size="zero"
         >
           <AssigneeBadge
@@ -121,4 +124,13 @@ const StyledDropdownButton = styled(Button)`
   height: unset;
   border-radius: 20px;
   box-shadow: none;
+
+  ${p =>
+    // Chonk tags have a smaller border radius, so we need make sure it matches.
+    p.theme.isChonk &&
+    `
+      > span > div {
+        border-radius: 20px;
+      }
+    `}
 `;


### PR DESCRIPTION
The two are no longer identical, so we need to account for that, else the badge overflows. The correct solution here would be to do something like Button as AssigneeBadge, but we dont have an API for that right now, and we are not yet sure if we want to go down that path.

Chonk is properly radiused
![CleanShot 2025-03-21 at 16 09 12@2x](https://github.com/user-attachments/assets/35f75c20-b5dc-4c12-b1a1-3ec5cff43b52)

Current UI is unchanged
![CleanShot 2025-03-21 at 16 09 05@2x](https://github.com/user-attachments/assets/c5528211-f8bc-4937-ad78-b01171f1aea7)
