### PR TITLE
feat(timeseries): Add spans support to timeseries endpoint

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -675,6 +675,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         data: Any,
         column: str,
         null_zero: bool = False,
+        convert_to_milliseconds: bool = False,
     ):
         serialized_values = []
         for timestamp, group in itertools.groupby(data, key=lambda r: r["time"]):
@@ -682,7 +683,12 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 row_value = row.get(column, None)
                 if row_value == 0 and null_zero:
                     row_value = None
-                serialized_values.append({"timestamp": timestamp, "value": row_value})
+                serialized_values.append(
+                    {
+                        "timestamp": timestamp * (1000 if convert_to_milliseconds else 1),
+                        "value": row_value,
+                    }
+                )
         return serialized_values
 
 

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -1,9 +1,9 @@
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import sentry_sdk
-from rest_framework.exceptions import ParseError, ValidationError
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -16,6 +16,7 @@ from sentry.api.endpoints.organization_events_stats import (
     METRICS_ENHANCED_REFERRERS,
     SENTRY_BACKEND_REFERRERS,
 )
+from sentry.api.utils import handle_query_errors
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
 from sentry.search.eap.types import SearchResolverConfig
@@ -28,7 +29,6 @@ from sentry.snuba import (
     metrics_performance,
     ourlogs,
     spans_eap,
-    spans_indexed,
     spans_metrics,
     spans_rpc,
     transactions,
@@ -44,7 +44,6 @@ TOP_EVENTS_DATASETS = {
     functions,
     metrics_performance,
     metrics_enhanced_performance,
-    spans_indexed,
     spans_metrics,
     spans_eap,
     errors,
@@ -61,6 +60,12 @@ class StatsMeta(TypedDict):
 class Row(TypedDict):
     timestamp: float
     value: float
+    comparisonValue: NotRequired[float]
+
+
+class Confidence(TypedDict):
+    timestamp: float
+    value: Literal["low", "high"] | None
 
 
 class SeriesMeta(TypedDict):
@@ -71,11 +76,18 @@ class SeriesMeta(TypedDict):
     interval: float
 
 
+class AccuracyData(TypedDict):
+    sampleCount: list[Row]
+    sampleRate: list[Row]
+    confidence: list[Confidence]
+
+
 class TimeSeries(TypedDict):
     values: list[Row]
     axis: str
     groupBy: NotRequired[list[str]]
     meta: SeriesMeta
+    accuracy: NotRequired[AccuracyData]
 
 
 class StatsResponse(TypedDict):
@@ -157,7 +169,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     raise ParseError(detail=f"{dataset} doesn't support topEvents yet")
 
             metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
-            use_rpc = dataset in {spans_indexed, ourlogs, uptime_checks}
+            use_rpc = dataset in {spans_eap, ourlogs, uptime_checks}
 
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
             try:
@@ -171,11 +183,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
             except NoProjects:
                 return Response([], status=200)
 
-        try:
-            self.validate_comparison_delta(comparison_delta, snuba_params, organization)
-            rollup = self.get_rollup(request, snuba_params, top_events, use_rpc)
-            axes = request.GET.getlist("yAxis", ["count()"])
+        self.validate_comparison_delta(comparison_delta, snuba_params, organization)
+        rollup = self.get_rollup(request, snuba_params, top_events, use_rpc)
+        axes = request.GET.getlist("yAxis", ["count()"])
 
+        with handle_query_errors():
             events_stats = self.get_event_stats(
                 request,
                 organization,
@@ -191,8 +203,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 self.serialize_stats_data(events_stats, axes, snuba_params, rollup, dataset),
                 status=200,
             )
-        except ValidationError:
-            return Response({"detail": "Comparison period is outside retention window"}, status=400)
 
     def get_event_stats(
         self,
@@ -231,7 +241,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         )
 
         if top_events > 0:
-            if dataset == spans_indexed:
+            if dataset == spans_eap:
                 return spans_rpc.run_top_events_timeseries_query(
                     params=snuba_params,
                     query_string=query,
@@ -269,7 +279,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 ),
             )
 
-        if dataset == spans_indexed:
+        if dataset == spans_eap:
             return spans_rpc.run_timeseries_query(
                 params=snuba_params,
                 query_string=query,
@@ -326,46 +336,53 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         serialized_result = []
         if isinstance(result, SnubaTSResult):
             for axis in axes:
-                unit, field_type = self.get_unit_and_type(axis, result.data["meta"]["fields"][axis])
-                serialized_result.extend(
-                    [
-                        TimeSeries(
-                            values=[
-                                Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
-                                for row in result.data["data"]
-                            ],
-                            axis=axis,
-                            meta=SeriesMeta(
-                                valueUnit=unit,
-                                valueType=field_type,
-                                interval=rollup * 1000,
-                            ),
-                        )
-                    ]
-                )
+                serialized_result.append(self.serialize_timeseries(result, axis, rollup))
         else:
             for key, value in result.items():
                 for axis in axes:
-                    unit, field_type = self.get_unit_and_type(
-                        axis, value.data["meta"]["fields"][axis]
-                    )
-                    serialized_result.extend(
-                        [
-                            TimeSeries(
-                                values=[
-                                    Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
-                                    for row in value.data["data"]
-                                ],
-                                axis=axis,
-                                groupBy=value.data.get("groupby", {}),
-                                meta=SeriesMeta(
-                                    order=value.data["order"],
-                                    isOther=value.data.get("is_other", False),
-                                    valueUnit=unit,
-                                    valueType=field_type,
-                                    interval=rollup * 1000,
-                                ),
-                            )
-                        ]
-                    )
+                    serialized_result.append(self.serialize_timeseries(value, axis, rollup))
         return serialized_result
+
+    def serialize_timeseries(self, result: SnubaTSResult, axis: str, rollup: int) -> TimeSeries:
+        unit, field_type = self.get_unit_and_type(axis, result.data["meta"]["fields"][axis])
+        series_meta = SeriesMeta(
+            valueType=field_type,
+            interval=rollup * 1000,
+        )
+        if unit is not None:
+            series_meta["valueUnit"] = unit
+        if "is_other" in result.data:
+            series_meta["isOther"] = result.data["is_other"]
+        if "order" in result.data:
+            series_meta["order"] = result.data["order"]
+
+        timeseries = TimeSeries(
+            values=[],
+            axis=axis,
+            meta=series_meta,
+        )
+
+        for row in result.data["data"]:
+            value_row = Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
+            if "comparisonCount" in row:
+                value_row["comparisonValue"] = row["comparisonCount"]
+            timeseries["values"].append(value_row)
+
+        if "groupby" in result.data:
+            timeseries["groupBy"] = result.data["groupby"]
+
+        if "processed_timeseries" in result.data:
+            processed_timeseries = result.data["processed_timeseries"]
+            timeseries["accuracy"] = AccuracyData(
+                sampleCount=self.serialize_accuracy_data(
+                    processed_timeseries.sample_count, axis, convert_to_milliseconds=True
+                ),
+                sampleRate=self.serialize_accuracy_data(
+                    processed_timeseries.sampling_rate, axis, convert_to_milliseconds=True
+                ),
+                confidence=self.serialize_accuracy_data(
+                    processed_timeseries.confidence, axis, convert_to_milliseconds=True
+                ),
+            )
+
+        return timeseries

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -578,7 +578,7 @@ def top_events_timeseries(
         # Using the top events add the order to the results
         for index, item in enumerate(top_events["data"]):
             result_key = create_result_key(item, translated_groupby, issues)
-            results[result_key] = {"order": index, "data": []}
+            results[result_key] = {"order": index, "data": [], "is_other": False}
         for row in result["data"]:
             result_key = create_result_key(row, translated_groupby, issues)
             if result_key in results:
@@ -607,7 +607,7 @@ def top_events_timeseries(
                         if zerofill_results
                         else item["data"]
                     ),
-                    "groupby": item.get("groupby", []),
+                    "groupby": item.get("groupby", None),
                     "meta": result["meta"],
                     "order": item["order"],
                 },

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -610,6 +610,7 @@ def top_events_timeseries(
                     "groupby": item.get("groupby", None),
                     "meta": result["meta"],
                     "order": item["order"],
+                    "is_other": item["is_other"],
                 },
                 snuba_params.start_date,
                 snuba_params.end_date,

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -26,10 +26,9 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         self.login_as(user=self.user)
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
         self.two_days_ago = self.day_ago - timedelta(days=1)
-        self.DEFAULT_METRIC_TIMESTAMP = self.day_ago
 
         self.url = reverse(
-            "sentry-api-0-organization-events-stats",
+            self.endpoint,
             kwargs={"organization_id_or_slug": self.project.organization.slug},
         )
 
@@ -669,8 +668,9 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert response.status_code == 200, response.content
 
 
-class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsStatsSpansMetricsEndpointTest):
+class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetricsEndpointTest):
     is_eap = True
+    is_rpc = True
 
     def test_count_extrapolation(self):
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -709,11 +709,6 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsStatsSpansMetricsE
         rows = data[0:6]
         for test in zip(event_counts, rows):
             assert test[1][1][0]["count"] == test[0] * 10
-
-
-class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpointTest):
-    is_eap = True
-    is_rpc = True
 
     def test_extrapolation_count(self):
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -1135,7 +1130,6 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         )
         assert response.status_code == 400, response.content
 
-    @pytest.mark.xfail(reason="division by 0 error in snuba")
     def test_handle_nans_from_snuba_top_n(self):
         super().test_handle_nans_from_snuba_top_n()
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -119,7 +119,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "valueUnit": None,
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -160,7 +159,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "valueUnit": None,
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -183,7 +181,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             },
         ]
         assert timeseries["meta"] == {
-            "valueUnit": None,
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -216,7 +213,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["meta"] == {
             "order": 0,
             "isOther": False,
-            "valueUnit": None,
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -268,7 +264,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert timeseries["meta"] == {
             "order": 1,
             "isOther": False,
-            "valueUnit": None,
             "valueType": "integer",
             "interval": 3_600_000,
         }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -1,0 +1,1523 @@
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+
+from sentry.testutils.helpers.datetime import before_now
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+def _timeseries(start, interval, expected, expected_comparison=None):
+    if expected_comparison is not None:
+        assert len(expected_comparison) == len(expected)
+        return [
+            {
+                "timestamp": start.timestamp() * 1000 + interval * index,
+                "value": value,
+                "comparisonValue": expected_comparison[index],
+            }
+            for index, value in enumerate(expected)
+        ]
+    return [
+        {
+            "timestamp": start.timestamp() * 1000 + interval * index,
+            "value": value,
+        }
+        for index, value in enumerate(expected)
+    ]
+
+
+class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpointTestBase):
+    endpoint = "sentry-api-0-organization-events-timeseries"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.start = self.day_ago = before_now(days=1).replace(
+            hour=10, minute=0, second=0, microsecond=0
+        )
+        self.end = self.start + timedelta(hours=6)
+        self.two_days_ago = self.day_ago - timedelta(days=1)
+
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.project.organization.slug},
+        )
+
+    def _do_request(self, data, url=None, features=None):
+        if features is None:
+            features = {"organizations:discover-basic": True, "organizations:global-views": True}
+        features.update(self.features)
+        with self.feature(features):
+            return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    def test_count(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {"description": "foo", "sentry_tags": {"status": "success"}},
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+    def test_handle_nans_from_snuba(self):
+        self.store_spans(
+            [self.create_span({"description": "foo"}, start_ts=self.start)],
+            is_eap=True,
+        )
+
+        response = self._do_request(
+            data={
+                "yAxis": "avg(measurements.lcp)",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+    def test_handle_nans_from_snuba_top_n(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "measurements": {"lcp": {"value": 1}},
+                    },
+                    start_ts=self.start,
+                ),
+                self.create_span({"description": "foo"}, start_ts=self.start),
+                self.create_span({"description": "foo"}, start_ts=self.two_days_ago),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "measurements": {"lcp": {"value": 2}},
+                    },
+                    start_ts=self.start,
+                ),
+                self.create_span({"description": "bar"}, start_ts=self.start),
+                self.create_span({"description": "bar"}, start_ts=self.two_days_ago),
+            ],
+            is_eap=True,
+        )
+        seven_days_ago = self.two_days_ago - timedelta(days=5)
+
+        response = self._do_request(
+            data={
+                "field": ["span.description", "p50(measurements.lcp)", "avg(measurements.lcp)"],
+                "yAxis": ["p50(measurements.lcp)", "avg(measurements.lcp)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 1,
+                "per_page": 50,
+                "interval": "1d",
+                "start": seven_days_ago,
+                "end": self.end,
+                "orderby": "-avg(measurements.lcp)",
+            },
+        )
+        interval = 24 * 60 * 60 * 1000
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": seven_days_ago.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 4
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 7
+        assert timeseries["axis"] == "p50(measurements.lcp)"
+        assert timeseries["values"] == _timeseries(seven_days_ago, interval, [0, 0, 0, 0, 0, 0, 2])
+        assert timeseries["groupBy"] == [{"span.description": "bar"}]
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": interval,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 7
+        assert timeseries["axis"] == "avg(measurements.lcp)"
+        assert timeseries["values"] == _timeseries(seven_days_ago, interval, [0, 0, 0, 0, 0, 0, 2])
+        assert timeseries["groupBy"] == [{"span.description": "bar"}]
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": interval,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 7
+        assert timeseries["axis"] == "p50(measurements.lcp)"
+        assert timeseries["values"] == _timeseries(seven_days_ago, interval, [0, 0, 0, 0, 0, 0, 1])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": interval,
+            "isOther": True,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][3]
+        assert len(timeseries["values"]) == 7
+        assert timeseries["axis"] == "avg(measurements.lcp)"
+        assert timeseries["values"] == _timeseries(seven_days_ago, interval, [0, 0, 0, 0, 0, 0, 1])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": interval,
+            "isOther": True,
+            "order": 1,
+        }
+
+    def test_count_unique(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                            "tags": {"foo": f"foo-{minute}"},
+                        },
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count_unique(foo)",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count_unique(foo)"
+        assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+    def test_p95(self):
+        event_durations = [6, 0, 6, 3, 0, 3]
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    duration=duration,
+                    start_ts=self.start + timedelta(hours=hour, minutes=1),
+                )
+                for hour, duration in enumerate(event_durations)
+            ],
+            is_eap=True,
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "p95()",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "p95()"
+        assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_durations)
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": 3_600_000,
+        }
+
+    def test_multiaxis(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                        },
+                        duration=count,
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()", "p95()"],
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 2
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "p95()"
+        assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": 3_600_000,
+        }
+
+    def test_top_events(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo", "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "bar", "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "baz", "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "qux", "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                ),
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 3
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "foo"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "bar"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 2, 0, 0, 0, 0])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": True,
+            "order": 2,
+        }
+
+    def test_top_events_empty_other(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": transaction, "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                )
+                for transaction in ["foo", "bar"]
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 2
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "foo"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "bar"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+    def test_top_events_multi_y_axis(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": transaction, "status": "success"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                )
+                for transaction in ["foo", "bar", "baz"]
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": ["count()", "p50(span.duration)"],
+                "field": ["transaction", "count()", "p50(span.duration)"],
+                "orderby": ["transaction"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 6
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "bar"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "p50(span.duration)"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 2000, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "bar"}]
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "baz"}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][3]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "p50(span.duration)"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 2000, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"transaction": "baz"}]
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][4]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": True,
+            "order": 2,
+        }
+
+        timeseries = response.data["timeseries"][5]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "p50(span.duration)"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 2000, 0, 0, 0, 0])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueUnit": "millisecond",
+            "valueType": "duration",
+            "interval": 60_000,
+            "isOther": True,
+            "order": 2,
+        }
+
+    def test_top_events_with_project(self):
+        projects = [self.create_project(), self.create_project()]
+        spans = [
+            self.create_span(
+                {"sentry_tags": {"status": "success"}},
+                start_ts=self.start + timedelta(minutes=1),
+                project=project,
+                duration=2000 - index,
+            )
+            for index, project in enumerate(projects)
+        ]
+        spans.append(
+            self.create_span(
+                {"segment_name": "baz", "sentry_tags": {"status": "success"}},
+                start_ts=self.start + timedelta(minutes=1),
+                duration=1,
+            )
+        )
+        self.store_spans(spans, is_eap=True)
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 3
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"project": projects[0].slug}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [{"project": projects[1].slug}]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": True,
+            "order": 2,
+        }
+
+    def test_top_events_with_project_and_project_id(self):
+        projects = [self.create_project(), self.create_project()]
+        spans = [
+            self.create_span(
+                {"sentry_tags": {"status": "success"}},
+                start_ts=self.start + timedelta(minutes=1),
+                project=project,
+                duration=2000 - index,
+            )
+            for index, project in enumerate(projects)
+        ]
+        spans.append(
+            self.create_span(
+                {"segment_name": "baz", "sentry_tags": {"status": "success"}},
+                start_ts=self.start + timedelta(minutes=1),
+            )
+        )
+        self.store_spans(spans, is_eap=True)
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "project.id", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 3
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [
+            {"project": projects[0].slug},
+            {"project.id": str(projects[0].id)},
+        ]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeseries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] == [
+            {"project": projects[1].slug},
+            {"project.id": str(projects[1].id)},
+        ]
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeseries"][2]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0, 1, 0, 0, 0, 0])
+        assert timeseries["groupBy"] is None
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+            "isOther": True,
+            "order": 2,
+        }
+
+    def test_top_events_with_no_data(self):
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "project.id", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+    def test_count_extrapolation(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                            "measurements": {"client_sample_rate": {"value": 0.1}},
+                        },
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(
+            self.start, 3_600_000, [val * 10 for val in event_counts]
+        )
+        assert timeseries["accuracy"] == {
+            "sampleCount": _timeseries(self.start, 3_600_000, event_counts),
+            "sampleRate": _timeseries(
+                self.start, 3_600_000, [pytest.approx(0.1) if val else 0 for val in event_counts]
+            ),
+            "confidence": _timeseries(
+                self.start, 3_600_000, ["low" if val else None for val in event_counts]
+            ),
+        }
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+    def test_confidence_is_set(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                            "measurements": {"client_sample_rate": {"value": 0.1}},
+                        },
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        y_axes = [
+            "count()",
+            "count(span.duration)",
+            "sum(span.duration)",
+            "avg(span.duration)",
+            "p50(span.duration)",
+            "p75(span.duration)",
+            "p90(span.duration)",
+            "p95(span.duration)",
+            "p99(span.duration)",
+        ]
+
+        for y_axis in y_axes:
+            response = self._do_request(
+                data={
+                    "start": self.start,
+                    "end": self.end,
+                    "interval": "1h",
+                    "yAxis": y_axis,
+                    "project": self.project.id,
+                    "dataset": "spans",
+                },
+            )
+            assert response.status_code == 200, (y_axis, response.content)
+            assert response.data["meta"] == {
+                "dataset": "spans",
+                "start": self.start.timestamp() * 1000,
+                "end": self.end.timestamp() * 1000,
+            }
+            assert len(response.data["timeseries"]) == 1
+
+            timeseries = response.data["timeseries"][0]
+            assert len(timeseries["values"]) == 6
+            assert timeseries["axis"] == y_axis
+            assert timeseries["accuracy"]["sampleCount"] == _timeseries(
+                self.start, 3_600_000, event_counts
+            )
+            assert timeseries["accuracy"]["sampleRate"] == _timeseries(
+                self.start, 3_600_000, [pytest.approx(0.1) if val else 0 for val in event_counts]
+            )
+            for confidence, value in zip(timeseries["accuracy"]["confidence"], event_counts):
+                if value:
+                    assert confidence["value"] in ("high", "low")
+                else:
+                    assert confidence["value"] is None
+
+    def test_extrapolation_with_multiaxis(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                            "measurements": {"client_sample_rate": {"value": 0.1}},
+                        },
+                        duration=count,
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()", "p95()"],
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 2
+
+        for index, y_axis in enumerate(["count()", "p95()"]):
+            timeseries = response.data["timeseries"][index]
+            assert len(timeseries["values"]) == 6
+            assert timeseries["axis"] == y_axis
+            assert timeseries["accuracy"]["sampleCount"] == _timeseries(
+                self.start, 3_600_000, event_counts
+            )
+            assert timeseries["accuracy"]["sampleRate"] == _timeseries(
+                self.start, 3_600_000, [pytest.approx(0.1) if val else 0 for val in event_counts]
+            )
+            for confidence, value in zip(timeseries["accuracy"]["confidence"], event_counts):
+                if value:
+                    assert confidence["value"] in ("high", "low")
+                else:
+                    assert confidence["value"] is None
+
+    def test_top_events_with_extrapolation(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {"transaction": "foo", "status": "success"},
+                        "measurements": {"client_sample_rate": {"value": 0.1}},
+                    },
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {
+                        "sentry_tags": {"transaction": "bar", "status": "success"},
+                        "measurements": {"client_sample_rate": {"value": 0.1}},
+                    },
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {
+                        "segment_name": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "measurements": {"client_sample_rate": {"value": 0.1}},
+                    },
+                    start_ts=self.start + timedelta(minutes=1),
+                ),
+            ],
+            is_eap=True,
+        )
+        event_counts = [0, 1, 0, 0, 0, 0]
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 3
+
+        for index, groupby in enumerate(["foo", "bar", None]):
+            timeseries = response.data["timeseries"][index]
+            assert len(timeseries["values"]) == 6
+            assert timeseries["axis"] == "count()"
+            if groupby is not None:
+                assert timeseries["groupBy"] == [{"transaction": groupby}]
+            else:
+                assert timeseries["groupBy"] is None
+            assert timeseries["accuracy"]["sampleCount"] == _timeseries(
+                self.start, 60_000, event_counts
+            )
+            assert timeseries["accuracy"]["sampleRate"] == _timeseries(
+                self.start, 60_000, [pytest.approx(0.1) if val else 0 for val in event_counts]
+            )
+            for confidence, value in zip(timeseries["accuracy"]["confidence"], event_counts):
+                if value:
+                    assert confidence["value"] in ("high", "low")
+                else:
+                    assert confidence["value"] is None
+
+    def test_comparison_delta(self):
+        event_counts = [6, 0, 6, 4, 0, 4]
+        spans = []
+        for current_period in [True, False]:
+            for hour, count in enumerate(event_counts):
+                count = count if current_period else int(count / 2)
+                spans.extend(
+                    [
+                        self.create_span(
+                            {"description": "foo", "sentry_tags": {"status": "success"}},
+                            start_ts=(
+                                self.start + timedelta(hours=hour, minutes=minute)
+                                if current_period
+                                else self.two_days_ago + timedelta(hours=hour, minutes=minute)
+                            ),
+                        )
+                        for minute in range(count)
+                    ],
+                )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "comparisonDelta": 24 * 60 * 60,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(
+            self.start, 3_600_000, event_counts, [value / 2 for value in event_counts]
+        )
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+    def test_comparison_delta_with_empty_comparison_values(self):
+        event_counts = [6, 0, 6, 4, 0, 4]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {"description": "foo", "sentry_tags": {"status": "success"}},
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "comparisonDelta": 24 * 60 * 60,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["axis"] == "count()"
+        assert timeseries["values"] == _timeseries(
+            self.start, 3_600_000, event_counts, [0] * len(event_counts)
+        )
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 3_600_000,
+        }
+
+    def test_invalid_intervals(self):
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(minutes=6),
+                "interval": "20s",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 400, response.content
+
+    def test_project_filters(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {"description": "foo", "sentry_tags": {"status": "success"}},
+                        start_ts=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        for querystring in [f"project:{self.project.slug}", f"project:[{self.project.slug}]"]:
+            response = self._do_request(
+                data={
+                    "start": self.start,
+                    "end": self.end,
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "query": querystring,
+                    "project": self.project.id,
+                    "dataset": "spans",
+                },
+            )
+            assert response.status_code == 200, response.content
+            assert response.data["meta"] == {
+                "dataset": "spans",
+                "start": self.start.timestamp() * 1000,
+                "end": self.end.timestamp() * 1000,
+            }
+            assert len(response.data["timeseries"]) == 1
+
+            timeseries = response.data["timeseries"][0]
+            assert len(timeseries["values"]) == 6
+            assert timeseries["axis"] == "count()"
+            assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+            assert timeseries["meta"] == {
+                "valueType": "integer",
+                "interval": 3_600_000,
+            }
+
+    def test_nonexistent_project_filter(self):
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "query": "project:foobar",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 400, response.content
+        assert "Unknown value foobar" in response.data["detail"]
+
+    def test_device_class_filter(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success", "device.class": "1"},
+                        },
+                        start_ts=self.day_ago + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=True)
+
+        for querystring in ["device.class:low", "device.class:[low,medium]"]:
+            response = self._do_request(
+                data={
+                    "start": self.start,
+                    "end": self.end,
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "query": querystring,
+                    "project": self.project.id,
+                    "dataset": "spans",
+                },
+            )
+            assert response.status_code == 200, response.content
+            assert response.data["meta"] == {
+                "dataset": "spans",
+                "start": self.start.timestamp() * 1000,
+                "end": self.end.timestamp() * 1000,
+            }
+            assert len(response.data["timeseries"]) == 1
+
+            timeseries = response.data["timeseries"][0]
+            assert len(timeseries["values"]) == 6
+            assert timeseries["axis"] == "count()"
+            assert timeseries["values"] == _timeseries(self.start, 3_600_000, event_counts)
+            assert timeseries["meta"] == {
+                "valueType": "integer",
+                "interval": 3_600_000,
+            }
+
+    def test_top_events_filters_out_groupby_even_when_its_just_one_row(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo", "status": "success"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo", "status": "success"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo", "status": "success"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo", "status": "success"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count(span.self_time)",
+                "field": ["transaction", "count(span.self_time)"],
+                "query": "count(span.self_time):>4",
+                "orderby": ["-count(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 5,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 0
+
+    def test_interval_larger_than_period_uses_default_period(self):
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "12h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+
+        timeseries = response.data["timeseries"][0]
+        assert timeseries["axis"] == "count()"
+        assert len(timeseries["values"]) == 73
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 300_000,
+        }
+
+    def test_cache_miss_rate(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "data": {"cache.hit": False},
+                    },
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {
+                        "data": {"cache.hit": True},
+                    },
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {
+                        "data": {"cache.hit": False},
+                    },
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {
+                        "data": {"cache.hit": True},
+                    },
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {
+                        "data": {"cache.hit": True},
+                    },
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=3)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "cache_miss_rate()",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "cache_miss_rate()"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0.0, 1.0, 0.25])
+        assert timeseries["meta"] == {
+            "valueType": "percentage",
+            "interval": 60_000,
+        }
+
+    def test_trace_status_rate(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "unauthenticated"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.start + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "unknown"}},
+                    start_ts=self.start + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"sentry_tags": {"trace.status": "ok"}},
+                    start_ts=self.start + timedelta(minutes=2),
+                ),
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=3)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "trace_status_rate(ok)",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "trace_status_rate(ok)"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0.0, 0.5, 0.75])
+        assert timeseries["meta"] == {
+            "valueType": "percentage",
+            "interval": 60_000,
+        }
+
+    def test_count_op(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.publish"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.publish"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"op": "queue.publish", "sentry_tags": {"op": "queue.publish"}},
+                    start_ts=self.start + timedelta(minutes=2),
+                ),
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=3)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count_op(queue.publish)",
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeseries"]) == 1
+
+        timeseries = response.data["timeseries"][0]
+        assert len(timeseries["values"]) == 3
+        assert timeseries["axis"] == "count_op(queue.publish)"
+        assert timeseries["values"] == _timeseries(self.start, 60_000, [0.0, 2.0, 1.0])
+        assert timeseries["meta"] == {
+            "valueType": "integer",
+            "interval": 60_000,
+        }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -362,7 +362,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 self.create_span(
                     {"sentry_tags": {"transaction": "foo", "status": "success"}},
                     start_ts=self.start + timedelta(minutes=1),
-                    duration=2000,
+                    duration=2001,
                 ),
                 self.create_span(
                     {"sentry_tags": {"transaction": "bar", "status": "success"}},
@@ -372,10 +372,12 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 self.create_span(
                     {"sentry_tags": {"transaction": "baz", "status": "success"}},
                     start_ts=self.start + timedelta(minutes=1),
+                    duration=1999,
                 ),
                 self.create_span(
                     {"sentry_tags": {"transaction": "qux", "status": "success"}},
                     start_ts=self.start + timedelta(minutes=1),
+                    duration=1998,
                 ),
             ],
             is_eap=True,
@@ -447,7 +449,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 self.create_span(
                     {"sentry_tags": {"transaction": transaction, "status": "success"}},
                     start_ts=self.start + timedelta(minutes=1),
-                    duration=2000,
+                    duration=2000 if transaction == "foo" else 1999,
                 )
                 for transaction in ["foo", "bar"]
             ],
@@ -985,7 +987,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                         "measurements": {"client_sample_rate": {"value": 0.1}},
                     },
                     start_ts=self.start + timedelta(minutes=1),
-                    duration=2000,
+                    duration=1999,
                 ),
                 self.create_span(
                     {
@@ -994,6 +996,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                         "measurements": {"client_sample_rate": {"value": 0.1}},
                     },
                     start_ts=self.start + timedelta(minutes=1),
+                    duration=1998,
                 ),
             ],
             is_eap=True,


### PR DESCRIPTION
- This thoroughly tests the timeseries endpoint on the spans dataset so we should be able to start using it in the frontend
- Adds comparisonValue and AccuracyData support
- Cleans up the serialization between top & axis timeseries so the code can be shared
- groupby is `None` when isOther=True