### PR TITLE
feat(eap-spans): add attributes for span operation breakdowns

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -264,6 +264,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="messaging.message.retry.count",
             search_type="number",
         ),
+        ResolvedAttribute(
+            public_alias="spans.http",
+            internal_name="sentry.span_ops.ops.http",
+            search_type="percentage",
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("environment"),
         simple_sentry_field("messaging.destination.name"),

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -265,9 +265,29 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="number",
         ),
         ResolvedAttribute(
+            public_alias="spans.browser",
+            internal_name="sentry.span_ops.ops.browser",
+            search_type="millisecond",
+        ),
+        ResolvedAttribute(
+            public_alias="spans.db",
+            internal_name="sentry.span_ops.ops.db",
+            search_type="millisecond",
+        ),
+        ResolvedAttribute(
             public_alias="spans.http",
             internal_name="sentry.span_ops.ops.http",
-            search_type="percentage",
+            search_type="millisecond",
+        ),
+        ResolvedAttribute(
+            public_alias="spans.resource",
+            internal_name="sentry.span_ops.ops.resource",
+            search_type="millisecond",
+        ),
+        ResolvedAttribute(
+            public_alias="spans.ui",
+            internal_name="sentry.span_ops.ops.ui",
+            search_type="millisecond",
         ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("environment"),


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/4600/ extracts the span op breakdowns into their own measurement so that they end up being stored in the eap dataset.

This PR adds public alias's for each breakdown, which will eventually be consumed the transaction summary page once migrated to eap.