### PR TITLE
ref(groupreference): Correctly find markdown linked group IDs

### DIFF
--- a/src/sentry/utils/groupreference.py
+++ b/src/sentry/utils/groupreference.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sentry.models.group import Group
 
+_markdown_strip_re = re.compile(r"\[([^]]+)\]\([^)]+\)", re.I)
+
 _fixes_re = re.compile(
     r"\b(?:Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved):?\s+([A-Za-z0-9_\-\s\,]+)\b",
     re.I,
@@ -18,6 +20,12 @@ def find_referenced_groups(text: str | None, org_id: int) -> set[Group]:
 
     if not text:
         return set()
+
+    # XXX(epurkhiser): Currently we only strip markdown links from our text. It
+    # may make sense in the future to strip more, but we do offer users the
+    # ability to copy and paste sentry issues as markdown, so we should at
+    # least cover this case.
+    text = _markdown_strip_re.sub(r"\1", text)
 
     results = set()
     for fmatch in _fixes_re.finditer(text):

--- a/tests/sentry/models/test_commit.py
+++ b/tests/sentry/models/test_commit.py
@@ -77,3 +77,21 @@ class FindReferencedGroupsTest(TestCase):
         assert len(groups) == 2
         assert group in groups
         assert group2 in groups
+
+    def test_markdown_links(self):
+        group = self.create_group()
+        group2 = self.create_group()
+
+        repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            message=f"Foo Biz\n\nFixes [{group.qualified_short_id}](https://sentry.io/), [{group2.qualified_short_id}](https://sentry.io/)",
+        )
+
+        groups = commit.find_referenced_groups()
+        assert len(groups) == 2
+        assert group in groups
+        assert group2 in groups


### PR DESCRIPTION
When using something like `Fixes [SENTRY-123](https://sentry.io/my-group)` we
want to make sure we still detect the group ID.

To do this we first strip out markdown links from the text.