### PR TITLE
ref(ui): Remove unused browserHistory.listen call

### DIFF
--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -6,7 +6,6 @@ import {Alert} from 'sentry/components/core/alert';
 import DetailedError from 'sentry/components/errors/detailedError';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import getDynamicText from 'sentry/utils/getDynamicText';
 
 type DefaultProps = {
@@ -47,18 +46,6 @@ class ErrorBoundary extends Component<Props, State> {
     error: null,
   };
 
-  componentDidMount() {
-    this._isMounted = true;
-    // Listen for route changes so we can clear error
-    this.unlistenBrowserHistory = browserHistory.listen(() => {
-      // Prevent race between component unmount and browserHistory change
-      // Setting state on a component that is being unmounted throws an error
-      if (this._isMounted) {
-        this.setState({error: null});
-      }
-    });
-  }
-
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     const {errorTag} = this.props;
 
@@ -79,16 +66,6 @@ class ErrorBoundary extends Component<Props, State> {
       Sentry.captureException(error);
     });
   }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-    if (this.unlistenBrowserHistory) {
-      this.unlistenBrowserHistory();
-    }
-  }
-
-  private unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
-  private _isMounted = false;
 
   render() {
     const {error} = this.state;


### PR DESCRIPTION
The browserHistory object is actually a `Proxy` object, with logic to
detect when we're calling legacy functions. We don't have a `listen`
function in our proxy. The logic in the proxy is such that when it can't
find the legacy function it will produce a `() => {}` empty do nothing
function (and produce a sentry error).

It doesn't seem like this is needed since it's actually doing nothing,
so let's get rid of it so we can stop producing the sentry error.

Fixes JAVASCRIPT-2XJ0