### PR TITLE
fix(schema-hints): Make hint pill resemble search colours

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHintsList.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
@@ -77,11 +77,18 @@ describe('SchemaHintsList', () => {
       />
     );
 
-    expect(screen.getByText('stringTag1 is ...')).toBeInTheDocument();
-    expect(screen.getByText('stringTag2 is ...')).toBeInTheDocument();
-    expect(screen.getByText('numberTag1 > ...')).toBeInTheDocument();
-    expect(screen.getByText('numberTag2 > ...')).toBeInTheDocument();
-    expect(screen.getByText('See full list')).toBeInTheDocument();
+    const container = screen.getByLabelText('Schema Hints List');
+    const withinContainer = within(container);
+    expect(withinContainer.getByText('stringTag1')).toBeInTheDocument();
+    expect(withinContainer.getByText('stringTag2')).toBeInTheDocument();
+    // counting the has tag
+    expect(withinContainer.getAllByText('is')).toHaveLength(3);
+    expect(withinContainer.getByText('numberTag1')).toBeInTheDocument();
+    expect(withinContainer.getByText('numberTag2')).toBeInTheDocument();
+    expect(withinContainer.getAllByText('>')).toHaveLength(2);
+    // counting the has tag
+    expect(withinContainer.getAllByText('...')).toHaveLength(5);
+    expect(withinContainer.getByText('See full list')).toBeInTheDocument();
   });
 
   it('should add hint to query when clicked', async () => {
@@ -95,7 +102,7 @@ describe('SchemaHintsList', () => {
       </PageParamsProvider>
     );
 
-    const stringTag1Hint = screen.getByText('stringTag1 is ...');
+    const stringTag1Hint = screen.getByText('stringTag1');
     await userEvent.click(stringTag1Hint);
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -134,12 +141,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(seeFullList);
 
     expect(screen.getByLabelText('Schema Hints Drawer')).toBeInTheDocument();
-    expect(screen.getByText('Filter Attributes')).toBeInTheDocument();
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
+    expect(withinDrawer.getByText('Filter Attributes')).toBeInTheDocument();
     Object.values(mockStringTags).forEach(tag => {
-      expect(screen.getByText(tag.key)).toBeInTheDocument();
+      expect(withinDrawer.getByText(tag.key)).toBeInTheDocument();
     });
     Object.values(mockNumberTags).forEach(tag => {
-      expect(screen.getByText(tag.key)).toBeInTheDocument();
+      expect(withinDrawer.getByText(tag.key)).toBeInTheDocument();
     });
   });
 
@@ -159,15 +167,16 @@ describe('SchemaHintsList', () => {
     await userEvent.click(seeFullList);
 
     expect(screen.getByLabelText('Schema Hints Drawer')).toBeInTheDocument();
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
 
-    const stringTag1Checkbox = screen.getByText('stringTag1');
+    const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({query: {query: 'stringTag1:""'}})
     );
 
-    const numberTag1Checkbox = screen.getByText('numberTag1');
+    const numberTag1Checkbox = withinDrawer.getByText('numberTag1');
     await userEvent.click(numberTag1Checkbox);
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -196,7 +205,8 @@ describe('SchemaHintsList', () => {
     const seeFullList = screen.getByText('See full list');
     await userEvent.click(seeFullList);
 
-    const stringTag1Checkbox = screen.getByText('stringTag1');
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
+    const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -219,7 +229,8 @@ describe('SchemaHintsList', () => {
     const seeFullList = screen.getByText('See full list');
     await userEvent.click(seeFullList);
 
-    const stringTag1Checkbox = screen.getByText('stringTag1');
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
+    const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
     router.push({
@@ -245,12 +256,13 @@ describe('SchemaHintsList', () => {
     const seeFullList = screen.getByText('See full list');
     await userEvent.click(seeFullList);
 
-    const searchInput = screen.getByLabelText('Search attributes');
+    const withinDrawer = within(screen.getByLabelText('Schema Hints Drawer'));
+    const searchInput = withinDrawer.getByLabelText('Search attributes');
     await userEvent.type(searchInput, 'stringTag');
 
-    expect(screen.getByText('stringTag1')).toBeInTheDocument();
-    expect(screen.getByText('stringTag2')).toBeInTheDocument();
-    expect(screen.queryByText('numberTag1')).not.toBeInTheDocument();
-    expect(screen.queryByText('numberTag2')).not.toBeInTheDocument();
+    expect(withinDrawer.getByText('stringTag1')).toBeInTheDocument();
+    expect(withinDrawer.getByText('stringTag2')).toBeInTheDocument();
+    expect(withinDrawer.queryByText('numberTag1')).not.toBeInTheDocument();
+    expect(withinDrawer.queryByText('numberTag2')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -330,7 +330,7 @@ const HintName = styled('span')`
 
 const HintOperator = styled('span')`
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const HintValue = styled('span')`

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -236,6 +236,20 @@ function SchemaHintsList({
     return `${prettifyTagKey(hint.name)} ${hint.kind === FieldKind.MEASUREMENT ? '>' : 'is'} ...`;
   };
 
+  const getHintElement = (hint: Tag) => {
+    if (hint.key === seeFullListTag.key || hint.key === hideListTag.key) {
+      return hint.name;
+    }
+
+    return (
+      <HintTextContainer>
+        <HintName>{prettifyTagKey(hint.name)}</HintName>
+        <HintOperator>{hint.kind === FieldKind.MEASUREMENT ? '>' : 'is'}</HintOperator>
+        <HintValue>...</HintValue>
+      </HintTextContainer>
+    );
+  };
+
   if (isLoading) {
     return (
       <SchemaHintsLoadingContainer>
@@ -245,14 +259,17 @@ function SchemaHintsList({
   }
 
   return (
-    <SchemaHintsContainer ref={schemaHintsContainerRef}>
+    <SchemaHintsContainer
+      ref={schemaHintsContainerRef}
+      aria-label={t('Schema Hints List')}
+    >
       {visibleHints.map(hint => (
         <SchemaHintOption
           key={hint.key}
           data-type={hint.key}
           onClick={() => onHintClick(hint)}
         >
-          {getHintText(hint)}
+          {getHintElement(hint)}
         </SchemaHintOption>
       ))}
     </SchemaHintsContainer>
@@ -298,4 +315,25 @@ const SchemaHintOption = styled(Button)`
   &[aria-selected='true'] {
     background-color: ${p => p.theme.gray100};
   }
+`;
+
+const HintTextContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+`;
+
+const HintName = styled('span')`
+  font-weight: ${p => p.theme.fontWeightNormal};
+  color: ${p => p.theme.textColor};
+`;
+
+const HintOperator = styled('span')`
+  font-weight: ${p => p.theme.fontWeightNormal};
+  color: ${p => p.theme.gray300};
+`;
+
+const HintValue = styled('span')`
+  font-weight: ${p => p.theme.fontWeightNormal};
+  color: ${p => p.theme.purple400};
 `;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -171,10 +171,10 @@ describe('SpansTabContent', function () {
       />,
       {disableRouterMocks: true, router, organization: schemaHintsOrganization}
     );
-    expect(screen.getByText('stringTag1 is ...')).toBeInTheDocument();
-    expect(screen.getByText('stringTag2 is ...')).toBeInTheDocument();
-    expect(screen.getByText('numberTag1 > ...')).toBeInTheDocument();
-    expect(screen.getByText('numberTag2 > ...')).toBeInTheDocument();
+    expect(screen.getByText('stringTag1')).toBeInTheDocument();
+    expect(screen.getByText('stringTag2')).toBeInTheDocument();
+    expect(screen.getByText('numberTag1')).toBeInTheDocument();
+    expect(screen.getByText('numberTag2')).toBeInTheDocument();
     expect(screen.getByText('See full list')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Got a suggestion to make the pill resemble the pills in the search bar so i've done that. Now each part of the displayed hint is a different element because they have to be different colours (which has affected the way we test for them). This is what it looks like:

| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/7e3b3ca7-7a5f-431e-bc81-f4655a136391" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/65f5923e-2e38-40ac-9c17-a7f0e30bbc43" /> | 

(I swear i have to squint to notice a difference, good luck!)

