### PR TITLE
feat(org member invite): OrganizationMemberInviteIndex endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -17,10 +17,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.api.endpoints.organization_member.index import (
-    ROLE_CHOICES,
-    OrganizationMemberRequestSerializer,
-)
+from sentry.api.endpoints.organization_member.index import OrganizationMemberRequestSerializer
+from sentry.api.endpoints.organization_member.utils import ROLE_CHOICES
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberWithRolesSerializer
 from sentry.apidocs.constants import (

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -12,6 +12,11 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.bases.organizationmember import MemberAndStaffPermission
+from sentry.api.endpoints.organization_member.utils import (
+    ERR_RATE_LIMITED,
+    ROLE_CHOICES,
+    MemberConflictValidationError,
+)
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberSerializer
@@ -33,40 +38,6 @@ from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
 from . import get_allowed_org_roles, save_team_assignments
-
-ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
-
-# Required to explicitly define roles w/ descriptions because OrganizationMemberSerializer
-# has the wrong descriptions, includes deprecated admin, and excludes billing
-ROLE_CHOICES = [
-    ("billing", "Can manage payment and compliance details."),
-    (
-        "member",
-        "Can view and act on events, as well as view most other data within the organization.",
-    ),
-    (
-        "manager",
-        """Has full management access to all teams and projects. Can also manage
-        the organization's membership.""",
-    ),
-    (
-        "owner",
-        """Has unrestricted access to the organization, its data, and its
-        settings. Can add, modify, and delete projects and members, as well as
-        make billing and plan changes.""",
-    ),
-    (
-        "admin",
-        """Can edit global integrations, manage projects, and add/remove teams.
-        They automatically assume the Team Admin role for teams they join.
-        Note: This role can no longer be assigned in Business and Enterprise plans. Use `TeamRoles` instead.
-        """,
-    ),
-]
-
-
-class MemberConflictValidationError(serializers.ValidationError):
-    pass
 
 
 @extend_schema_serializer(

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -23,6 +23,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.authenticators import available_authenticators
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
+from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 from sentry.models.team import Team, TeamStatus
 from sentry.roles import organization_roles, team_roles
 from sentry.search.utils import tokenize_query
@@ -109,6 +110,8 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
     regenerate = serializers.BooleanField(required=False)
 
     def validate_email(self, email):
+        # TODO (mifu67): once we remove invite fields from OrganizationMember model,
+        # remove all checks for these fields on the model
         users = user_service.get_many_by_email(
             emails=[email],
             is_active=True,
@@ -131,6 +134,24 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
                 raise MemberConflictValidationError(
                     "There is an existing invite request for %s" % email
                 )
+
+        # check for OrganizationMemberInvites
+        queryset = OrganizationMemberInvite.objects.filter(
+            Q(email=email),
+            organization=self.context["organization"],
+        )
+        if queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
+            raise MemberConflictValidationError("The user %s has already been invited" % email)
+
+        if not self.context.get("allow_existing_invite_request"):
+            if queryset.filter(
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value)
+            ).exists():
+                raise MemberConflictValidationError(
+                    "There is an existing invite request for %s" % email
+                )
+
         return email
 
     def validate_role(self, role):

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -136,15 +136,15 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
                 )
 
         # check for OrganizationMemberInvites
-        queryset = OrganizationMemberInvite.objects.filter(
+        invite_queryset = OrganizationMemberInvite.objects.filter(
             Q(email=email),
             organization=self.context["organization"],
         )
-        if queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
+        if invite_queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
             raise MemberConflictValidationError("The user %s has already been invited" % email)
 
         if not self.context.get("allow_existing_invite_request"):
-            if queryset.filter(
+            if invite_queryset.filter(
                 Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
                 | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value)
             ).exists():

--- a/src/sentry/api/endpoints/organization_member/utils.py
+++ b/src/sentry/api/endpoints/organization_member/utils.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+
+ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
+
+# Required to explicitly define roles w/ descriptions because OrganizationMemberSerializer
+# has the wrong descriptions, includes deprecated admin, and excludes billing
+ROLE_CHOICES = [
+    ("billing", "Can manage payment and compliance details."),
+    (
+        "member",
+        "Can view and act on events, as well as view most other data within the organization.",
+    ),
+    (
+        "manager",
+        """Has full management access to all teams and projects. Can also manage
+        the organization's membership.""",
+    ),
+    (
+        "owner",
+        """Has unrestricted access to the organization, its data, and its
+        settings. Can add, modify, and delete projects and members, as well as
+        make billing and plan changes.""",
+    ),
+    (
+        "admin",
+        """Can edit global integrations, manage projects, and add/remove teams.
+        They automatically assume the Team Admin role for teams they join.
+        Note: This role can no longer be assigned in Business and Enterprise plans. Use `TeamRoles` instead.
+        """,
+    ),
+]
+
+
+class MemberConflictValidationError(serializers.ValidationError):
+    pass

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -49,11 +49,6 @@ class OrganizationMemberInviteRequestSerializer(serializers.Serializer):
         write_only=True,
         help_text="Whether or not to send an invite notification through email. Defaults to True.",
     )
-    reinvite = serializers.BooleanField(
-        required=False,
-        help_text="Whether or not to re-invite a user who has already been invited to the organization. Defaults to True.",
-    )
-    regenerate = serializers.BooleanField(required=False)
 
     def validate_email(self, email):
         users = user_service.get_many_by_email(

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -156,7 +156,9 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
             for omi in existing_invite:
                 omi.delete()
 
-            teams = [team.id for team in result.get("teams", [])]
+            teams = []
+            for team in result.get("teams", []):
+                teams.append({"id": team.id, "slug": team.slug})
 
             omi = OrganizationMemberInvite(
                 organization=organization,

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -165,7 +165,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
                 email=result["email"],
                 role=result["role"],
                 inviter_id=request.user.id,
-                teams=teams,
+                organization_member_team_data=teams,
             )
 
             omi.save()

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -278,7 +278,11 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
     def _request_to_invite_member(self, request: Request, organization) -> Response:
         serializer = OrganizationMemberInviteRequestSerializer(
             data=request.data,
-            context={"organization": organization, "allowed_roles": roles.get_all()},
+            context={
+                "organization": organization,
+                "allow_retired_roles": not features.has("organizations:team-roles", organization),
+                "allowed_roles": roles.get_all(),
+            },
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -254,7 +254,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
             omi = OrganizationMemberInvite(
                 organization=organization,
                 email=result["email"],
-                role=result["role"],
+                role=result["orgRole"],
                 inviter_id=request.user.id,
                 organization_member_team_data=teams,
             )

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -122,7 +122,6 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
             context={
                 "organization": organization,
                 "allowed_roles": allowed_roles,
-                "allow_retired_roles": not features.has("organizations:team-roles", organization),
                 "is_integration_token": request.access.is_integration_token,
                 "is_member": is_member,
                 "actor": request.user,
@@ -163,7 +162,6 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
             data=request.data,
             context={
                 "organization": organization,
-                "allow_retired_roles": not features.has("organizations:team-roles", organization),
                 "allowed_roles": roles.get_all(),
                 "actor": request.user,
             },
@@ -184,8 +182,6 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         queryset = OrganizationMemberInvite.objects.filter(organization=organization).order_by(
             "invite_status", "email"
         )
-        if not request.access.has_scope("member:write"):
-            queryset = queryset.filter(invite_status=InviteStatus.APPROVED.value)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -13,7 +13,11 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.bases.organizationmember import MemberAndStaffPermission
 from sentry.api.endpoints.organization_member import get_allowed_org_roles
-from sentry.api.endpoints.organization_member.index import OrganizationMemberRequestSerializer
+from sentry.api.endpoints.organization_member.utils import (
+    ERR_RATE_LIMITED,
+    ROLE_CHOICES,
+    MemberConflictValidationError,
+)
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organizationmemberinvite import (
@@ -21,11 +25,98 @@ from sentry.api.serializers.models.organizationmemberinvite import (
 )
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberinvite import InviteStatus, OrganizationMemberInvite
+from sentry.models.team import Team, TeamStatus
 from sentry.roles import organization_roles
 from sentry.signals import member_invited
+from sentry.users.api.parsers.email import AllowedEmailField
+from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
-ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
+
+class OrganizationMemberInviteRequestSerializer(serializers.Serializer):
+    email = AllowedEmailField(
+        max_length=75, required=True, help_text="The email address to send the invitation to."
+    )
+    orgRole = serializers.ChoiceField(
+        choices=ROLE_CHOICES,
+        default=organization_roles.get_default().id,
+        required=False,
+        help_text="The organization-level role of the new member. Roles include:",  # choices will follow in the docs
+    )
+    teams = serializers.ListField(required=False, allow_null=False, default=[])
+    sendInvite = serializers.BooleanField(
+        required=False,
+        default=True,
+        write_only=True,
+        help_text="Whether or not to send an invite notification through email. Defaults to True.",
+    )
+    reinvite = serializers.BooleanField(
+        required=False,
+        help_text="Whether or not to re-invite a user who has already been invited to the organization. Defaults to True.",
+    )
+    regenerate = serializers.BooleanField(required=False)
+
+    def validate_email(self, email):
+        users = user_service.get_many_by_email(
+            emails=[email],
+            is_active=True,
+            organization_id=self.context["organization"].id,
+            is_verified=False,
+        )
+        member_queryset = OrganizationMember.objects.filter(
+            Q(user_id__in=[u.id for u in users]),
+            organization=self.context["organization"],
+        )
+
+        if member_queryset.exists():
+            raise MemberConflictValidationError("The user %s is already a member" % email)
+
+        # check for existing invites
+        invite_queryset = OrganizationMemberInvite.objects.filter(
+            Q(email=email),
+            organization=self.context["organization"],
+        )
+        if invite_queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
+            raise MemberConflictValidationError("The user %s has already been invited" % email)
+
+        if not self.context.get("allow_existing_invite_request"):
+            if invite_queryset.filter(
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value)
+            ).exists():
+                raise MemberConflictValidationError(
+                    "There is an existing invite request for %s" % email
+                )
+
+        return email
+
+    def validate_orgRole(self, role):
+        if role == "billing" and features.has(
+            "organizations:invite-billing", self.context["organization"]
+        ):
+            return role
+        role_obj = next((r for r in self.context["allowed_roles"] if r.id == role), None)
+        if role_obj is None:
+            raise serializers.ValidationError(
+                "You do not have permission to set that org-level role"
+            )
+        if not self.context.get("allow_retired_roles", True) and role_obj.is_retired:
+            raise serializers.ValidationError(
+                f"The role '{role}' is deprecated and may no longer be assigned."
+            )
+        return role
+
+    def validate_teams(self, teams):
+        valid_teams = list(
+            Team.objects.filter(
+                organization=self.context["organization"], status=TeamStatus.ACTIVE, slug__in=teams
+            )
+        )
+
+        if len(valid_teams) != len(teams):
+            raise serializers.ValidationError("Invalid teams")
+
+        return valid_teams
 
 
 @region_silo_endpoint
@@ -83,7 +174,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
                 )
             allowed_roles = [organization_roles.get("member")]
 
-        serializer = OrganizationMemberRequestSerializer(
+        serializer = OrganizationMemberInviteRequestSerializer(
             data=request.data,
             context={
                 "organization": organization,

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -231,7 +231,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         with transaction.atomic(router.db_for_write(OrganizationMemberInvite)):
             teams = []
             for team in result.get("teams", []):
-                teams.append({"id": team.id, "slug": team.slug})
+                teams.append({"id": team.id, "slug": team.slug, "role": None})
 
             omi = OrganizationMemberInvite(
                 organization=organization,

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -1,0 +1,203 @@
+from django.conf import settings
+from django.db import router, transaction
+from django.db.models import Q
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log, features, ratelimits
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organizationmember import MemberAndStaffPermission
+from sentry.api.endpoints.organization_member import get_allowed_org_roles
+from sentry.api.endpoints.organization_member.index import OrganizationMemberRequestSerializer
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberinvite import InviteStatus, OrganizationMemberInvite
+from sentry.roles import organization_roles
+from sentry.signals import member_invited
+from sentry.utils import metrics
+
+ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Organizations"])
+class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
+    # TODO (mifu67): make these PUBLIC once ready
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (MemberAndStaffPermission,)
+    owner = ApiOwner.ENTERPRISE
+
+    def get(self, request: Request, organization) -> Response:
+        """
+        List all organization member invites.
+        """
+        queryset = OrganizationMemberInvite.objects.filter(organization=organization).order_by(
+            "invite_status", "email"
+        )
+        if not request.access.has_scope("member:write"):
+            queryset = queryset.filter(invite_status=InviteStatus.APPROVED.value)
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            on_results=lambda x: serialize(x, request.user, OrganizationMemberInviteSerializer()),
+            paginator_cls=OffsetPaginator,
+        )
+
+    def post(self, request: Request, organization) -> Response:
+        assigned_org_role = (
+            request.data.get("orgRole")
+            or request.data.get("role")
+            or organization_roles.get_default().id
+        )
+        billing_bypass = assigned_org_role == "billing" and features.has(
+            "organizations:invite-billing", organization
+        )
+        if not billing_bypass and not features.has(
+            "organizations:invite-members", organization, actor=request.user
+        ):
+            return Response(
+                {"organization": "Your organization is not allowed to invite members"}, status=403
+            )
+
+        allowed_roles = get_allowed_org_roles(request, organization, creating_org_invite=True)
+
+        # We allow requests from integration tokens to invite new members as the member role only
+        if not allowed_roles and request.access.is_integration_token:
+            # Error if the assigned role is not a member
+            if assigned_org_role != "member":
+                raise serializers.ValidationError(
+                    "Integration tokens are restricted to inviting new members with the member role only."
+                )
+            allowed_roles = [organization_roles.get("member")]
+
+        serializer = OrganizationMemberRequestSerializer(
+            data=request.data,
+            context={
+                "organization": organization,
+                "allowed_roles": allowed_roles,
+                "allow_existing_invite_request": True,
+                "allow_retired_roles": not features.has("organizations:team-roles", organization),
+            },
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        result = serializer.validated_data
+
+        if ratelimits.for_organization_member_invite(
+            organization=organization,
+            email=result["email"],
+            user=request.user,
+            auth=request.auth,
+        ):
+            metrics.incr(
+                "member-invite.attempt",
+                instance="rate_limited",
+                skip_internal=True,
+                sample_rate=1.0,
+            )
+            return Response({"detail": ERR_RATE_LIMITED}, status=429)
+
+        is_member = not request.access.has_scope("member:admin") and (
+            request.access.has_scope("member:invite")
+        )
+        # if Open Team Membership is disabled and Member Invites are enabled, members can only invite members to teams they are in
+        members_can_only_invite_to_members_teams = (
+            not organization.flags.allow_joinleave and not organization.flags.disable_member_invite
+        )
+        has_teams = bool(result.get("teamRoles") or result.get("teams"))
+
+        if is_member and members_can_only_invite_to_members_teams and has_teams:
+            requester_teams = set(
+                OrganizationMember.objects.filter(
+                    organization=organization,
+                    user_id=request.user.id,
+                    user_is_active=True,
+                ).values_list("teams__slug", flat=True)
+            )
+            team_slugs = list(
+                set(
+                    [team.slug for team, _ in result.get("teamRoles", [])]
+                    + [team.slug for team in result.get("teams", [])]
+                )
+            )
+            # ensure that the requester is a member of all teams they are trying to assign
+            if not requester_teams.issuperset(team_slugs):
+                return Response(
+                    {"detail": "You cannot assign members to teams you are not a member of."},
+                    status=400,
+                )
+
+        if has_teams and not organization_roles.get(assigned_org_role).is_team_roles_allowed:
+            return Response(
+                {
+                    "email": f"The user with a '{assigned_org_role}' role cannot have team-level permissions."
+                },
+                status=400,
+            )
+
+        with transaction.atomic(router.db_for_write(OrganizationMemberInvite)):
+            # remove any invitation requests for this email before inviting
+            existing_invite = OrganizationMemberInvite.objects.filter(
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value),
+                email=result["email"],
+                organization=organization,
+            )
+            for omi in existing_invite:
+                omi.delete()
+
+            if "teamRoles" in result or "teams" in result:
+                teams = (
+                    [team for team, _ in result.get("teamRoles")]
+                    if "teamRoles" in result and result["teamRoles"]
+                    else result.get("teams")
+                )
+            else:
+                # TODO: change JSON field to list and not dict
+                # team roles are not set on invite
+                teams = []
+
+            omi = OrganizationMemberInvite(
+                organization=organization,
+                email=result["email"],
+                role=result["role"],
+                inviter_id=request.user.id,
+                teams=teams,
+            )
+
+            # OrganizationMemberIndexEndpoint has a check for settings.SENTRY_ENABLE_INVITES before
+            # generating token and saving. Do we need to account for this?
+            omi.save()
+
+        if settings.SENTRY_ENABLE_INVITES and result.get("sendInvite"):
+            referrer = request.query_params.get("referrer")
+            omi.send_invite_email(referrer)
+            member_invited.send_robust(
+                member=omi, user=request.user, sender=self, referrer=request.data.get("referrer")
+            )
+
+        self.create_audit_entry(
+            request=request,
+            organization_id=organization.id,
+            target_object=omi.id,
+            data=omi.get_audit_log_data(),
+            event=(
+                audit_log.get_event_id("MEMBER_INVITE")
+                if settings.SENTRY_ENABLE_INVITES
+                else audit_log.get_event_id("MEMBER_ADD")
+            ),
+        )
+
+        return Response(serialize(omi), status=201)

--- a/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
@@ -1,0 +1,133 @@
+from django.db.models import Q
+from rest_framework import serializers
+
+from sentry import features
+from sentry.api.endpoints.organization_member.utils import (
+    ROLE_CHOICES,
+    MemberConflictValidationError,
+)
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberinvite import InviteStatus, OrganizationMemberInvite
+from sentry.models.team import Team, TeamStatus
+from sentry.roles import organization_roles
+from sentry.users.api.parsers.email import AllowedEmailField
+from sentry.users.services.user.service import user_service
+
+
+class OrganizationMemberInviteRequestValidator(serializers.Serializer):
+    email = AllowedEmailField(
+        max_length=75, required=True, help_text="The email address to send the invitation to."
+    )
+    orgRole = serializers.ChoiceField(
+        choices=ROLE_CHOICES,
+        default=organization_roles.get_default().id,
+        required=False,
+        help_text="The organization-level role of the new member. Roles include:",  # choices will follow in the docs
+    )
+    teams = serializers.ListField(required=False, allow_null=False, default=[])
+
+    def validate_email(self, email):
+        users = user_service.get_many_by_email(
+            emails=[email],
+            is_active=True,
+            organization_id=self.context["organization"].id,
+            is_verified=False,
+        )
+        member_queryset = OrganizationMember.objects.filter(
+            Q(user_id__in=[u.id for u in users]),
+            organization=self.context["organization"],
+        )
+
+        if member_queryset.exists():
+            raise MemberConflictValidationError("The user %s is already a member" % email)
+
+        # check for existing invites
+        invite_queryset = OrganizationMemberInvite.objects.filter(
+            Q(email=email),
+            organization=self.context["organization"],
+        )
+        if invite_queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
+            raise MemberConflictValidationError("The user %s has already been invited" % email)
+
+        if invite_queryset.filter(
+            Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+            | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value)
+        ).exists():
+            raise MemberConflictValidationError(
+                "There is an existing invite request for %s" % email
+            )
+
+        return email
+
+    def validate_orgRole(self, role):
+        if role == "billing" and features.has(
+            "organizations:invite-billing", self.context["organization"]
+        ):
+            return role
+
+        allowed_roles = self.context["allowed_roles"]
+        # We allow requests from integration tokens to invite new members as the member role only
+        if not allowed_roles and self.context.get("is_integration_token", False):
+            allowed_roles = [organization_roles.get("member")]
+        # Error if the assigned role is not a member and the request is made via integration token
+        if self.context.get("is_integration_token", False) and role != "member":
+            raise serializers.ValidationError(
+                "Integration tokens are restricted to inviting new members with the member role only."
+            )
+
+        role_obj = next((r for r in allowed_roles if r.id == role), None)
+        if role_obj is None:
+            raise serializers.ValidationError(
+                "You do not have permission to invite a member with that org-level role"
+            )
+        if not self.context.get("allow_retired_roles", True) and role_obj.is_retired:
+            raise serializers.ValidationError(
+                f"The role '{role}' is deprecated, and members may no longer be invited with it."
+            )
+        return role
+
+    def validate_teams(self, teams):
+        valid_teams = list(
+            Team.objects.filter(
+                organization=self.context["organization"], status=TeamStatus.ACTIVE, slug__in=teams
+            )
+        )
+
+        if len(valid_teams) != len(teams):
+            raise serializers.ValidationError("Invalid teams")
+
+        organization = self.context["organization"]
+
+        members_can_only_invite_to_members_teams = (
+            not organization.flags.allow_joinleave and not organization.flags.disable_member_invite
+        )
+        has_teams = bool(valid_teams)
+
+        if (
+            self.context.get("is_member", False)
+            and members_can_only_invite_to_members_teams
+            and has_teams
+        ):
+            requester_teams = set(
+                OrganizationMember.objects.filter(
+                    organization=organization,
+                    user_id=self.context["actor"].id,
+                    user_is_active=True,
+                ).values_list("teams__slug", flat=True)
+            )
+            team_slugs = [team.slug for team in valid_teams]
+            # ensure that the requester is a member of all teams they are trying to assign
+            if not requester_teams.issuperset(team_slugs):
+                raise serializers.ValidationError(
+                    "You cannot assign members to teams you are not a member of."
+                )
+
+        if (
+            has_teams
+            and not organization_roles.get(self.initial_data.get("orgRole")).is_team_roles_allowed
+        ):
+            raise serializers.ValidationError(
+                f"The user with a '{self.initial_data.get("orgRole")}' role cannot have team-level permissions."
+            )
+
+        return valid_teams

--- a/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
@@ -80,7 +80,10 @@ class OrganizationMemberInviteRequestValidator(serializers.Serializer):
             raise serializers.ValidationError(
                 "You do not have permission to invite a member with that org-level role"
             )
-        if not self.context.get("allow_retired_roles", True) and role_obj.is_retired:
+        if (
+            not features.has("organizations:team-roles", self.context["organization"])
+            and role_obj.is_retired
+        ):
             raise serializers.ValidationError(
                 f"The role '{role}' is deprecated, and members may no longer be invited with it."
             )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -16,6 +16,9 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
     OrganizationEventsRootCauseAnalysisEndpoint,
 )
 from sentry.api.endpoints.organization_fork import OrganizationForkEndpoint
+from sentry.api.endpoints.organization_member_invite.index import (
+    OrganizationMemberInviteIndexEndpoint,
+)
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
 from sentry.api.endpoints.organization_plugins_configs import OrganizationPluginsConfigsEndpoint
 from sentry.api.endpoints.organization_plugins_index import OrganizationPluginsEndpoint
@@ -1690,6 +1693,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/members/$",
         OrganizationMemberIndexEndpoint.as_view(),
         name="sentry-api-0-organization-member-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/invited-members/$",
+        OrganizationMemberInviteIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-member-invite-index",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/external-users/$",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -198,6 +198,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # This spec version includes the environment in the query hash
     manager.add("organizations:on-demand-metrics-query-spec-version-two", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use the new OrganizationMemberInvite endpoints
+    manager.add('organizations:new-organization-member-invite', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display new Source map uploads view in settings
     manager.add('organizations:new-source-map-uploads-view', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display on demand metrics related UI elements

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -163,3 +163,17 @@ class OrganizationMemberInvite(DefaultFieldsModel):
             return (self.pk, ImportKind.Existing)
 
         return super().write_relocation_import(scope, flags)
+
+    def get_audit_log_data(self):
+        teams = self.organization_member_team_data
+        return {
+            "email": self.get_email(),
+            "user": self.user_id,
+            "teams": [t["id"] for t in teams],
+            "teams_slugs": [t["slug"] for t in teams],
+            "has_global_access": self.has_global_access,
+            "role": self.role,
+            "invite_status": (
+                invite_status_names[self.invite_status] if self.invite_status is not None else None
+            ),
+        }

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -171,7 +171,5 @@ class OrganizationMemberInvite(DefaultFieldsModel):
             "teams": [t["id"] for t in teams],
             "teams_slugs": [t["slug"] for t in teams],
             "role": self.role,
-            "invite_status": (
-                invite_status_names[self.invite_status] if self.invite_status is not None else None
-            ),
+            "invite_status": (invite_status_names[self.invite_status]),
         }

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -167,11 +167,9 @@ class OrganizationMemberInvite(DefaultFieldsModel):
     def get_audit_log_data(self):
         teams = self.organization_member_team_data
         return {
-            "email": self.get_email(),
-            "user": self.user_id,
+            "email": self.email,
             "teams": [t["id"] for t in teams],
             "teams_slugs": [t["slug"] for t in teams],
-            "has_global_access": self.has_global_access,
             "role": self.role,
             "invite_status": (
                 invite_status_names[self.invite_status] if self.invite_status is not None else None

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from sentry.integrations.types import ExternalProviders
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
     MemberWriteRoleRecipientStrategy,
@@ -24,7 +25,9 @@ if TYPE_CHECKING:
 class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC):
     RoleBasedRecipientStrategyClass = MemberWriteRoleRecipientStrategy
 
-    def __init__(self, pending_member: OrganizationMember, requester: User):
+    def __init__(
+        self, pending_member: OrganizationMember | OrganizationMemberInvite, requester: User
+    ):
         super().__init__(pending_member.organization, requester)
         self.pending_member = pending_member
 

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -23,10 +23,8 @@ from sentry import audit_log, roles
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organizationmember import OrganizationMemberEndpoint
-from sentry.api.endpoints.organization_member.index import (
-    ROLE_CHOICES,
-    OrganizationMemberRequestSerializer,
-)
+from sentry.api.endpoints.organization_member.index import OrganizationMemberRequestSerializer
+from sentry.api.endpoints.organization_member.utils import ROLE_CHOICES
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/endpoints/test_organization_member_invite_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_index.py
@@ -355,7 +355,9 @@ class OrganizationMemberInviteListPostTest(APITestCase):
         omi = OrganizationMemberInvite.objects.get(id=response.data["id"])
         assert omi.email == "mifu@email.com"
         assert omi.role == "member"
-        assert omi.organization_member_team_data == [{"id": self.team.id, "slug": self.team.slug}]
+        assert omi.organization_member_team_data == [
+            {"id": self.team.id, "role": None, "slug": self.team.slug}
+        ]
         assert omi.inviter_id == self.user.id
 
         mock_send_invite_email.assert_called_once()
@@ -383,7 +385,9 @@ class OrganizationMemberInviteListPostTest(APITestCase):
         omi = OrganizationMemberInvite.objects.get(id=response.data["id"])
         assert omi.email == "mifu@email.com"
         assert omi.role == "member"
-        assert omi.organization_member_team_data == [{"id": self.team.id, "slug": self.team.slug}]
+        assert omi.organization_member_team_data == [
+            {"id": self.team.id, "role": None, "slug": self.team.slug}
+        ]
         assert omi.inviter_id == self.user.id
 
         assert not mock_send_invite_email.mock_calls
@@ -398,7 +402,9 @@ class OrganizationMemberInviteListPostTest(APITestCase):
         omi = OrganizationMemberInvite.objects.get(id=response.data["id"])
         assert omi.email == "mifu@email.com"
         assert omi.role == "member"
-        assert omi.organization_member_team_data == [{"id": self.team.id, "slug": self.team.slug}]
+        assert omi.organization_member_team_data == [
+            {"id": self.team.id, "role": None, "slug": self.team.slug}
+        ]
         assert omi.inviter_id == self.user.id
 
         mock_send_invite_email.assert_called_with("test_referrer")
@@ -444,7 +450,9 @@ class OrganizationMemberInviteListPostTest(APITestCase):
         omi = OrganizationMemberInvite.objects.get(id=response.data["id"])
         assert omi.email == "mifu@email.com"
         assert omi.role == "member"
-        assert omi.organization_member_team_data == [{"id": self.team.id, "slug": self.team.slug}]
+        assert omi.organization_member_team_data == [
+            {"id": self.team.id, "slug": self.team.slug, "role": None}
+        ]
 
         mock_send_invite_email.assert_called_once()
 

--- a/tests/sentry/api/endpoints/test_organization_member_invite_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_index.py
@@ -376,26 +376,6 @@ class OrganizationMemberInviteListPostTest(APITestCase):
         assert omi.inviter_id == self.user.id
 
     @patch.object(OrganizationMemberInvite, "send_invite_email")
-    def test_no_send_invite(self, mock_send_invite_email):
-        data = {
-            "email": "mifu@email.com",
-            "orgRole": "member",
-            "teams": [self.team.slug],
-            "sendInvite": False,
-        }
-        response = self.get_success_response(self.organization.slug, **data)
-
-        omi = OrganizationMemberInvite.objects.get(id=response.data["id"])
-        assert omi.email == "mifu@email.com"
-        assert omi.role == "member"
-        assert omi.organization_member_team_data == [
-            {"id": self.team.id, "role": None, "slug": self.team.slug}
-        ]
-        assert omi.inviter_id == self.user.id
-
-        assert not mock_send_invite_email.mock_calls
-
-    @patch.object(OrganizationMemberInvite, "send_invite_email")
     def test_referrer_param(self, mock_send_invite_email):
         data = {"email": "mifu@email.com", "orgRole": "member", "teams": [self.team.slug]}
         response = self.get_success_response(
@@ -431,7 +411,7 @@ class OrganizationMemberInviteListPostTest(APITestCase):
             extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
             status_code=400,
         )
-        assert response.data[0] == err_message
+        assert response.data["orgRole"][0] == err_message
 
         data = {"email": "dog@woof.com", "orgRole": "manager", "teams": [self.team.slug]}
         response = self.get_error_response(
@@ -440,7 +420,7 @@ class OrganizationMemberInviteListPostTest(APITestCase):
             extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
             status_code=400,
         )
-        assert response.data[0] == err_message
+        assert response.data["orgRole"][0] == err_message
 
         data = {"email": "mifu@email.com", "orgRole": "member", "teams": [self.team.slug]}
         response = self.get_success_response(

--- a/tests/sentry/api/endpoints/test_organization_member_invite_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_index.py
@@ -5,6 +5,7 @@ from sentry.models.organizationmemberinvite import InviteStatus, OrganizationMem
 from sentry.roles import organization_roles
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 
 
 def mock_organization_roles_get_factory(original_organization_roles_get):
@@ -18,6 +19,7 @@ def mock_organization_roles_get_factory(original_organization_roles_get):
     return wrapped_method
 
 
+@apply_feature_flag_on_cls("organizations:new-organization-member-invite")
 class OrganizationMemberInviteListTest(APITestCase):
     endpoint = "sentry-api-0-organization-member-invite-index"
 
@@ -46,6 +48,7 @@ class OrganizationMemberInviteListTest(APITestCase):
         assert not response.data[0].get("token")
 
 
+@apply_feature_flag_on_cls("organizations:new-organization-member-invite")
 class OrganizationMemberInvitePermissionRoleTest(APITestCase):
     endpoint = "sentry-api-0-organization-member-invite-index"
     method = "post"
@@ -194,6 +197,7 @@ class OrganizationMemberInvitePermissionRoleTest(APITestCase):
         assert response.data["email"] == "eric@localhost"
 
 
+@apply_feature_flag_on_cls("organizations:new-organization-member-invite")
 class OrganizationMemberInvitePostTest(APITestCase):
     endpoint = "sentry-api-0-organization-member-invite-index"
     method = "post"

--- a/tests/sentry/api/endpoints/test_organization_member_invite_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_index.py
@@ -1,0 +1,184 @@
+from dataclasses import replace
+from unittest.mock import patch
+
+from django.core import mail
+
+from sentry import roles
+from sentry.api.endpoints.accept_organization_invite import get_invite_state
+from sentry.api.endpoints.organization_member_invite.index import (
+    OrganizationMemberInviteRequestSerializer,
+)
+from sentry.api.invite_helper import ApiInviteHelper
+from sentry.models.organizationmember import InviteStatus, OrganizationMember
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.roles import organization_roles
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers import Feature, with_feature
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.users.models.authenticator import Authenticator
+from sentry.users.models.useremail import UserEmail
+
+
+def mock_organization_roles_get_factory(original_organization_roles_get):
+    def wrapped_method(role):
+        # emulate the 'member' role not having team-level permissions
+        role_obj = original_organization_roles_get(role)
+        if role == "member":
+            return replace(role_obj, is_team_roles_allowed=False)
+        return role_obj
+
+    return wrapped_method
+
+
+class OrganizationMemberInviteRequestSerializerTest(TestCase):
+    def test_valid(self):
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {
+            "email": "mifu@email.com",
+            "orgRole": "member",
+            "teams": [self.team.slug],
+        }
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data["teams"][0] == self.team
+
+    def test_member_with_email_exists(self):
+        org = self.create_organization()
+        user = self.create_user()
+        self.create_member(organization=org, user=user)
+
+        context = {"organization": org, "allowed_roles": [roles.get("member")]}
+        data = {"email": user.email, "orgRole": "member", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {"email": [f"The user {user.email} is already a member"]}
+
+    def test_invite_with_email_exists(self):
+        email = "mifu@email.com"
+        self.create_member_invite(organization=self.organization, email=email)
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {"email": email, "orgRole": "member", "teamRoles": []}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {"email": [f"The user {email} has already been invited"]}
+
+    def test_invalid_team_invites(self):
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {"email": "mifu@email.com", "orgRole": "member", "teams": ["faketeam"]}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {"teams": ["Invalid teams"]}
+
+    def test_invalid_org_role(self):
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {"email": "mifu@email.com", "orgRole": "owner", "teamRoles": []}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "orgRole": ["You do not have permission to set that org-level role"]
+        }
+
+    @with_feature({"organizations:team-roles": False})
+    def test_deprecated_org_role_without_flag(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("admin"), roles.get("member")],
+        }
+        data = {"email": "mifu@email.com", "orgRole": "admin", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert serializer.is_valid()
+
+    @with_feature("organizations:team-roles")
+    def test_deprecated_org_role_with_flag(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("admin"), roles.get("member")],
+        }
+        data = {"email": "mifu@email.com", "orgRole": "admin", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert serializer.is_valid()
+
+    @with_feature("organizations:invite-billing")
+    def test_valid_invite_billing_member(self):
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {
+            "email": "bill@localhost",
+            "orgRole": "billing",
+            "teamRoles": [],
+        }
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert serializer.is_valid()
+
+    def test_invalid_invite_billing_member(self):
+        context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}
+        data = {
+            "email": "bill@localhost",
+            "orgRole": "billing",
+            "teamRoles": [],
+        }
+
+        serializer = OrganizationMemberInviteRequestSerializer(context=context, data=data)
+        assert not serializer.is_valid()
+
+
+class OrganizationMemberInviteListTest(APITestCase):
+    endpoint = "sentry-api-0-organization-member-invite-index"
+
+    def setUp(self):
+        self.approved_invite = self.create_member_invite(
+            organization=self.organization, email="user1@email.com"
+        )
+        self.requested_invite = self.create_member_invite(
+            organization=self.organization,
+            email="user2@email.com",
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+
+    def test_simple(self):
+        # if requestor doesn't have org admin permissions, only list approved invites
+        user = self.create_user("mifu@email.com", username="mifu")
+        self.create_member(organization=self.organization, user=user)
+        self.login_as(user)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["email"] == self.approved_invite.email
+        # make sure we don't serialize token
+        assert not response.data[0].get("token")
+
+    def test_staff(self):
+        self.login_as(self.user)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 2
+        assert response.data[0]["email"] == self.approved_invite.email
+        assert response.data[0]["inviteStatus"] == "approved"
+        assert response.data[1]["email"] == self.requested_invite.email
+        assert response.data[1]["inviteStatus"] == "requested_to_be_invited"
+
+    def test_org_owner(self):
+        user = self.create_user("supreme-mifu@email.com", username="powerful mifu")
+        self.create_member(organization=self.organization, user=user, role="owner")
+        self.login_as(user)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 2
+        assert response.data[0]["email"] == self.approved_invite.email
+        assert response.data[0]["inviteStatus"] == "approved"
+        assert response.data[1]["email"] == self.requested_invite.email
+        assert response.data[1]["inviteStatus"] == "requested_to_be_invited"

--- a/tests/sentry/api/endpoints/test_organization_member_invite_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_index.py
@@ -32,19 +32,6 @@ class OrganizationMemberInviteListTest(APITestCase):
         )
 
     def test_simple(self):
-        # if requester doesn't have org admin permissions, only list approved invites
-        user = self.create_user("mifu@email.com", username="mifu")
-        self.create_member(organization=self.organization, user=user)
-        self.login_as(user)
-
-        response = self.get_success_response(self.organization.slug)
-
-        assert len(response.data) == 1
-        assert response.data[0]["email"] == self.approved_invite.email
-        # make sure we don't serialize token
-        assert not response.data[0].get("token")
-
-    def test_staff(self):
         self.login_as(self.user)
 
         response = self.get_success_response(self.organization.slug)
@@ -55,31 +42,8 @@ class OrganizationMemberInviteListTest(APITestCase):
         assert response.data[1]["email"] == self.requested_invite.email
         assert response.data[1]["inviteStatus"] == "requested_to_be_invited"
 
-    def test_org_owner(self):
-        user = self.create_user("supreme-mifu@email.com", username="powerful mifu")
-        self.create_member(organization=self.organization, user=user, role="owner")
-        self.login_as(user)
-
-        response = self.get_success_response(self.organization.slug)
-
-        assert len(response.data) == 2
-        assert response.data[0]["email"] == self.approved_invite.email
-        assert response.data[0]["inviteStatus"] == "approved"
-        assert response.data[1]["email"] == self.requested_invite.email
-        assert response.data[1]["inviteStatus"] == "requested_to_be_invited"
-
-    def test_org_manager(self):
-        user = self.create_user("manager-mifu@email.com", username="strong mifu")
-        self.create_member(organization=self.organization, user=user, role="manager")
-        self.login_as(user)
-
-        response = self.get_success_response(self.organization.slug)
-
-        assert len(response.data) == 2
-        assert response.data[0]["email"] == self.approved_invite.email
-        assert response.data[0]["inviteStatus"] == "approved"
-        assert response.data[1]["email"] == self.requested_invite.email
-        assert response.data[1]["inviteStatus"] == "requested_to_be_invited"
+        # make sure we don't serialize token
+        assert not response.data[0].get("token")
 
 
 class OrganizationMemberInvitePermissionRoleTest(APITestCase):

--- a/tests/sentry/api/validators/test_organization_member_invite_validator.py
+++ b/tests/sentry/api/validators/test_organization_member_invite_validator.py
@@ -108,7 +108,6 @@ class OrganizationMemberInviteRequestValidatorTest(TestCase):
             "organization": self.organization,
             "allowed_roles": [roles.get("admin"), roles.get("member")],
             "actor": self.user,
-            "allow_retired_roles": False,
         }
         data = {"email": "mifu@email.com", "orgRole": "admin", "teams": []}
 

--- a/tests/sentry/api/validators/test_organization_member_invite_validator.py
+++ b/tests/sentry/api/validators/test_organization_member_invite_validator.py
@@ -1,0 +1,164 @@
+from sentry import roles
+from sentry.api.serializers.rest_framework.organizationmemberinvite import (
+    OrganizationMemberInviteRequestValidator,
+)
+from sentry.models.organizationmemberinvite import InviteStatus
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+
+
+class OrganizationMemberInviteRequestValidatorTest(TestCase):
+    def test_valid(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {
+            "email": "mifu@email.com",
+            "orgRole": "member",
+            "teams": [self.team.slug],
+        }
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data["teams"][0] == self.team
+
+    def test_member_with_email_exists(self):
+        org = self.create_organization()
+        user = self.create_user()
+        self.create_member(organization=org, user=user)
+
+        context = {
+            "organization": org,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": user.email, "orgRole": "member", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {"email": [f"The user {user.email} is already a member"]}
+
+    def test_invite_with_email_exists(self):
+        email = "mifu@email.com"
+        self.create_member_invite(organization=self.organization, email=email)
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": email, "orgRole": "member", "teamRoles": []}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {"email": [f"The user {email} has already been invited"]}
+
+    def test_invalid_team_invites(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": "mifu@email.com", "orgRole": "member", "teams": ["faketeam"]}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {"teams": ["Invalid teams"]}
+
+    def test_invalid_org_role(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": "mifu@email.com", "orgRole": "owner", "teamRoles": []}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "orgRole": ["You do not have permission to invite a member with that org-level role"]
+        }
+
+    def test_cannot_invite_with_existing_request(self):
+        email = "test@gmail.com"
+
+        self.create_member_invite(
+            email=email,
+            organization=self.organization,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": email, "orgRole": "member", "teams": [self.team.slug]}
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "email": ["There is an existing invite request for test@gmail.com"]
+        }
+
+    @with_feature({"organizations:team-roles": False})
+    def test_deprecated_org_role_without_flag(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("admin"), roles.get("member")],
+            "actor": self.user,
+            "allow_retired_roles": False,
+        }
+        data = {"email": "mifu@email.com", "orgRole": "admin", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "orgRole": [
+                "The role 'admin' is deprecated, and members may no longer be invited with it."
+            ]
+        }
+
+    @with_feature("organizations:team-roles")
+    def test_deprecated_org_role_with_flag(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("admin"), roles.get("member")],
+            "actor": self.user,
+        }
+        data = {"email": "mifu@email.com", "orgRole": "admin", "teams": []}
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert serializer.is_valid()
+
+    @with_feature("organizations:invite-billing")
+    def test_valid_invite_billing_member(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {
+            "email": "bill@localhost",
+            "orgRole": "billing",
+            "teamRoles": [],
+        }
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert serializer.is_valid()
+
+    def test_invalid_invite_billing_member(self):
+        context = {
+            "organization": self.organization,
+            "allowed_roles": [roles.get("member")],
+            "actor": self.user,
+        }
+        data = {
+            "email": "bill@localhost",
+            "orgRole": "billing",
+            "teamRoles": [],
+        }
+
+        serializer = OrganizationMemberInviteRequestValidator(context=context, data=data)
+        assert not serializer.is_valid()


### PR DESCRIPTION
- GET: Lists all invites (approved and requests). If org manager/admin, show all invites; otherwise, show only approved invites
- POST: Create new invite, preserving member invite member functionality

Created `endpoints/organization_member/utils.py` to hold values accessible to both `OrganizationMember*` and `OrganizationMemberInvite*` endpoints (at least until the end of the API rollout period).