### PR TITLE
feat(logs): Add a "give feedback" to logs page

### DIFF
--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -30,7 +30,7 @@ function FeedbackButton() {
         openForm?.({
           messagePlaceholder: t('How can we make logs work better for you?'),
           tags: {
-            ['feedback.source']: 'trace-view',
+            ['feedback.source']: 'logs-listing',
             ['feedback.owner']: 'performance',
           },
         })

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -1,15 +1,45 @@
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
+
+function FeedbackButton() {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+  return (
+    <Button
+      size="xs"
+      aria-label="trace-view-feedback"
+      icon={<IconMegaphone size="xs" />}
+      onClick={() =>
+        openForm?.({
+          messagePlaceholder: t('How can we make logs work better for you?'),
+          tags: {
+            ['feedback.source']: 'trace-view',
+            ['feedback.owner']: 'performance',
+          },
+        })
+      }
+    >
+      {t('Give Feedback')}
+    </Button>
+  );
+}
 
 export default function LogsPage() {
   const organization = useOrganization();
@@ -29,6 +59,11 @@ export default function LogsPage() {
                 <FeatureBadge type="experimental" />
               </Layout.Title>
             </Layout.HeaderContent>
+            <Layout.HeaderActions>
+              <ButtonBar>
+                <FeedbackButton />
+              </ButtonBar>
+            </Layout.HeaderActions>
           </Layout.Header>
           <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
             <LogsPageParamsProvider>


### PR DESCRIPTION
We'd like to get user feedback on the logs page once we launch.