### PR TITLE
ref(grouping): Change designations for enhancement actions and rules

### DIFF
--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -24,8 +24,8 @@ class EnhancementRule:
                 self._other_matchers.append(matcher)
 
         self.actions = actions
-        self._is_updater = any(action.is_updater for action in actions)
-        self._is_modifier = any(action.is_modifier for action in actions)
+        self.has_classifier_actions = any(action.is_classifier for action in actions)
+        self.has_contributes_actions = any(action.sets_contributes for action in actions)
 
     @property
     def matcher_description(self) -> str:
@@ -33,15 +33,15 @@ class EnhancementRule:
         actions = " ".join(str(action) for action in self.actions)
         return f"{matchers} {actions}"
 
-    def _as_modifier_rule(self) -> EnhancementRule | None:
-        actions = [action for action in self.actions if action.is_modifier]
+    def as_classifier_rule(self) -> EnhancementRule | None:
+        actions = [action for action in self.actions if action.is_classifier]
         if actions:
             return EnhancementRule(self.matchers, actions)
         else:
             return None
 
-    def _as_updater_rule(self) -> EnhancementRule | None:
-        actions = [action for action in self.actions if action.is_updater]
+    def as_contributes_rule(self) -> EnhancementRule | None:
+        actions = [action for action in self.actions if action.sets_contributes]
         if actions:
             return EnhancementRule(self.matchers, actions)
         else:

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -16,6 +16,7 @@ from sentry.grouping.enhancer import (
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import ReturnValueCache, _cached, create_match_frame
+from sentry.grouping.enhancer.parser import parse_enhancements
 from sentry.testutils.cases import TestCase
 
 
@@ -567,6 +568,52 @@ family:javascript,native -group
 )
 def test_keep_profiling_rules(test_input, expected):
     assert keep_profiling_rules(test_input) == expected
+
+
+class EnhancementsTest(TestCase):
+    def test_differentiates_between_classifier_and_contributes_rules(self):
+        rules_text = """
+            function:sit              +app                  # should end up in classifiers
+            function:roll_over        category=trick        # should end up in classifiers
+            function:shake            +group                # should end up in contributes
+            function:lie_down         max-frames=11         # should end up in contributes
+            function:stay             min-frames=12         # should end up in contributes
+            function:kangaroo         -app -group           # should end up in both
+            """
+        rules = parse_enhancements(rules_text)
+
+        expected_results = [
+            # (has_classifier_actions, has_contributes_actions, classifier_actions, contributes_actions)
+            (True, False, ["+app"], None),
+            (True, False, ["category=trick"], None),
+            (False, True, None, ["+group"]),
+            (False, True, None, ["max-frames=11"]),
+            (False, True, None, ["min-frames=12"]),
+            (True, True, ["-app"], ["-group"]),
+        ]
+
+        for i, expected in enumerate(expected_results):
+            (
+                expected_has_classifier_actions_value,
+                expected_has_contributes_actions_value,
+                expected_as_classifier_rule_actions,
+                expected_as_contributes_rule_actions,
+            ) = expected
+            rule = rules[i]
+
+            classifier_rule = rule.as_classifier_rule()
+            classifier_rule_actions = (
+                [str(action) for action in classifier_rule.actions] if classifier_rule else None
+            )
+            contributes_rule = rule.as_contributes_rule()
+            contributes_rule_actions = (
+                [str(action) for action in contributes_rule.actions] if contributes_rule else None
+            )
+
+            assert rule.has_classifier_actions == expected_has_classifier_actions_value
+            assert rule.has_contributes_actions == expected_has_contributes_actions_value
+            assert classifier_rule_actions == expected_as_classifier_rule_actions
+            assert contributes_rule_actions == expected_as_contributes_rule_actions
 
 
 @dataclass

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -27,7 +27,13 @@ def dump_obj(obj):
     for key, value in obj.__dict__.items():
         if key.startswith("_"):
             continue
-        elif key == "rust_enhancements":
+        elif key in [
+            "rust_enhancements",
+            "is_classifier",
+            "sets_contributes",
+            "has_classifier_actions",
+            "has_contributes_actions",
+        ]:
             continue
         elif isinstance(value, list):
             rv[key] = [dump_obj(x) for x in value]


### PR DESCRIPTION
In our current grouping enhancements code, we designate actions (and thereby rules containing said actions) as "modifiers" and/or "updaters," and we provide the ability to split a rule which is both into a modifier version and an updater version. There are two problems with that: 1) Updating and modifying are effectively synonymous concepts, and so it's not at all clear what it means to be one or the other. 2) We actually shouldn't even have this code anymore, because it's a relic of both the pre-rust-enhancements era and the hierarchical grouping era, and is no longer used.

Rather than remove the code, though, we can actually repurpose it. During ingest, we run the stacktrace through the rules twice, once to assign `in_app` and `category` values to frames, and once to set `contributes` values on both the frames and the overall stacktrace. Being able to split a given set of rules into ones useful for the first task and ones useful for the second task would actually be helpful, because at each stage it would allow us to avoid checking rules we know won't apply. It also would solve the problem of "marked in-app by rule x" hints clobbering "ignored by rule x" hints (and vice versa) in cases where a single rule has both effects.

This PR therefore changes the existing designations from `is_modifier` and `is_updater` to `is_classifier` and `sets_contributes` (for actions) and `has_classifier_actions` and `has_contributes_actions` (for rules). Further changes to use this information will come in follow-up PRs.

Note to reviewers: I super don't love the non-parallel naming with `is_classifier` and `sets_contributes`, but I struggled to find anything with parallel structure that wasn't horribly ungrammatical. Definitely open to ideas here.
