### PR TITLE
fix(trace-view): Hoist out the logs hook from the trace waterfall

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -51,7 +51,7 @@ export function TraceView() {
   );
 }
 
-function InnerTraceView({traceSlug}: {traceSlug?: string}) {
+function InnerTraceView({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {TraceContextPanel} from 'sentry/views/performance/newTraceDetails/traceContextPanel';
 import {TraceViewLogsDataProvider} from 'sentry/views/performance/newTraceDetails/traceOurlogs';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
@@ -40,12 +41,23 @@ function decodeTraceSlug(maybeSlug: string | undefined): string {
 }
 
 export function TraceView() {
-  const organization = useOrganization();
   const params = useParams<{traceSlug?: string}>();
   const traceSlug = useMemo(() => decodeTraceSlug(params.traceSlug), [params.traceSlug]);
+
+  return (
+    <TraceViewLogsDataProvider traceSlug={traceSlug}>
+      <InnerTraceView traceSlug={traceSlug} />
+    </TraceViewLogsDataProvider>
+  );
+}
+
+function InnerTraceView({traceSlug}: {traceSlug?: string}) {
+  const organization = useOrganization();
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
   const hasTraceNewUi = useHasTraceNewUi();
+  const logsTableData = useLogsPageData();
+  const hideTraceWaterfallIfEmpty = logsTableData?.logsData?.data?.length > 0;
 
   const preferences = useMemo(
     () =>
@@ -90,6 +102,7 @@ export function TraceView() {
                   traceSlug={traceSlug}
                   traceEventView={traceEventView}
                   organization={organization}
+                  hideIfNoData={hideTraceWaterfallIfEmpty}
                 />
                 {hasTraceNewUi && <TraceContextPanel tree={tree} rootEvent={rootEvent} />}
               </TraceInnerLayout>

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -36,7 +36,6 @@ import type {DispatchingReducerMiddleware} from 'sentry/utils/useDispatchingRedu
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
   DEFAULT_TRACE_VIEW_PREFERENCES,
@@ -118,6 +117,8 @@ export interface TraceWaterfallProps {
   traceEventView: EventView;
   traceSlug: string | undefined;
   tree: TraceTree;
+  // If set to true, the entire waterfall will not render if it is empty.
+  hideIfNoData?: boolean;
   replayTraces?: ReplayTrace[];
 }
 
@@ -891,9 +892,8 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     [height, traceDispatch, traceGridRef]
   );
 
-  const logsTableData = useLogsPageData();
-  if (props.tree.type === 'empty' && logsTableData?.logsData?.data?.length > 0) {
-    return null; // do not show the main trace details if you are in 'logs mode'
+  if (props.tree.type === 'empty' && props.hideIfNoData) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
On some pages (like replay) - the spans waterfall is embedded without the context provider, which would give this error:

```
Error: useContext for "LogsPageDataContext" must be inside a Provider with a value
```

This hoists out the logic for hiding the waterfall into a property.