### PR TITLE
fix(js): Remove getsentry import

### DIFF
--- a/static/app/components/nav/primary/help.tsx
+++ b/static/app/components/nav/primary/help.tsx
@@ -11,8 +11,6 @@ import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {activateZendesk, zendeskIsLoaded} from 'sentry/utils/zendesk';
 
-import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
-
 function getContactSupportItem({
   organization,
 }: {
@@ -30,7 +28,7 @@ function getContactSupportItem({
       label: t('Contact Support'),
       onAction() {
         activateZendesk();
-        trackGetsentryAnalytics('zendesk_link.clicked', {
+        trackAnalytics('zendesk_link.clicked', {
           organization,
           source: 'sidebar',
         });


### PR DESCRIPTION
Did not need to be using the getsentry function here, was copied over mistakenly.