### PR TITLE
feat(billing): Add profile duration constants

### DIFF
--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -1277,6 +1277,15 @@ class GSBanner extends Component<Props, State> {
       product: DataCategory.UPTIME,
       categories: [DataCategory.UPTIME],
     },
+    // TODO(Continuous Profiling)
+    '/profile-duration/': {
+      product: DataCategory.PROFILE_DURATION,
+      categories: [DataCategory.PROFILE_DURATION],
+    },
+    '/profile-duration-ui/': {
+      product: DataCategory.PROFILE_DURATION_UI,
+      categories: [DataCategory.PROFILE_DURATION_UI],
+    },
   };
 
   renderProductTrialAlerts() {

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -348,6 +348,8 @@ describe('ProductSelectionAvailability', function () {
         reservedAttachments: 0,
         reservedMonitorSeats: 0,
         reservedUptime: 0,
+        reservedProfileDuration: 0,
+        reservedProfileDurationUI: 0,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -30,6 +30,8 @@ const PRODUCTS = {
   [DataCategory.ATTACHMENTS]: 'Attachments',
   [DataCategory.SPANS]: 'Spans',
   [DataCategory.UPTIME]: 'Uptime Monitoring',
+  [DataCategory.PROFILE_DURATION]: 'Profile Hours',
+  [DataCategory.PROFILE_DURATION_UI]: 'UI Profile Hours',
 };
 
 const PRODUCT_URLS = {
@@ -42,6 +44,8 @@ const PRODUCT_URLS = {
     'https://docs.sentry.io/product/accounts/quotas/manage-attachments-quota/',
   [DataCategory.SPANS]: 'https://docs.sentry.io/product/performance/', // TODO: update with real docs link
   [DataCategory.UPTIME]: 'https://docs.sentry.io/product/alerts/uptime-monitoring/',
+  [DataCategory.PROFILE_DURATION]: 'https://docs.sentry.io/product/explore/profiling/', // TODO(Continuous Profiling)
+  [DataCategory.PROFILE_DURATION_UI]: 'https://docs.sentry.io/product/explore/profiling/', // TODO(Continuous Profiling)
 };
 
 export interface ProductTrialAlertProps {

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -217,6 +217,8 @@ describe('ProductUnavailableCTA', function () {
         reservedAttachments: 0,
         reservedMonitorSeats: 0,
         reservedUptime: 0,
+        reservedProfileDuration: 0,
+        reservedProfileDurationUI: 0,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/upgradeNowModal/types.tsx
+++ b/static/gsApp/components/upgradeNowModal/types.tsx
@@ -2,6 +2,8 @@ export type Reservations = {
   reservedAttachments: number;
   reservedErrors: number;
   reservedMonitorSeats: number;
+  reservedProfileDuration: number | undefined;
+  reservedProfileDurationUI: number | undefined;
   reservedReplays: number;
   reservedTransactions: number;
   reservedUptime: number | undefined;

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -21,7 +21,7 @@ const mockReservations: Reservations = {
   reservedMonitorSeats: 1,
   reservedTransactions: 100000,
   reservedUptime: 1,
-  reservedProfileDuration: 1,
+  reservedProfileDuration: 0,
   reservedProfileDurationUI: undefined,
 };
 

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -21,6 +21,8 @@ const mockReservations: Reservations = {
   reservedMonitorSeats: 1,
   reservedTransactions: 100000,
   reservedUptime: 1,
+  reservedProfileDuration: 1,
+  reservedProfileDurationUI: undefined,
 };
 
 const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -59,6 +59,8 @@ describe('useUpgradeNowParams', () => {
           reservedAttachments: 1,
           reservedMonitorSeats: 1,
           reservedUptime: 1,
+          reservedProfileDuration: 1,
+          reservedProfileDurationUI: undefined,
         },
       })
     );

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -59,7 +59,7 @@ describe('useUpgradeNowParams', () => {
           reservedAttachments: 1,
           reservedMonitorSeats: 1,
           reservedUptime: 1,
-          reservedProfileDuration: 1,
+          reservedProfileDuration: 0,
           reservedProfileDurationUI: undefined,
         },
       })

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -97,6 +97,8 @@ function useUpgradeNowParams({organization, subscription, enabled = true}: Opts)
         reservedAttachments: reserved.attachments,
         reservedMonitorSeats: reserved.monitorSeats,
         reservedUptime: reserved.uptime,
+        reservedProfileDuration: reserved.profileDuration,
+        reservedProfileDurationUI: reserved.profileDurationUI,
       },
     };
   }, [billingConfig, isPending, subscription, enabled]);

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -709,6 +709,7 @@ export enum CreditType {
   SPAN = 'span',
   SPAN_INDEXED = 'spanIndexed',
   PROFILE_DURATION = 'profileDuration',
+  PROFILE_DURATION_UI = 'profileDurationUI',
   ATTACHMENT = 'attachment',
   REPLAY = 'replay',
   MONITOR_SEAT = 'monitorSeat',
@@ -742,6 +743,7 @@ interface RecurringEventCredit extends BaseRecurringCredit {
     | CreditType.TRANSACTION
     | CreditType.SPAN
     | CreditType.PROFILE_DURATION
+    | CreditType.PROFILE_DURATION_UI
     | CreditType.ATTACHMENT
     | CreditType.REPLAY;
 }

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
@@ -18,7 +18,6 @@ describe('UsageCard', () => {
       plan: 'am2_team',
     });
 
-    subscription.planDetails.billingInterval = 'monthly';
     subscription.planDetails.categories = ['errors'];
 
     const prepaid = 100_000;
@@ -51,7 +50,6 @@ describe('UsageCard', () => {
       onDemandMaxSpend: 1000,
     });
 
-    subscription.planDetails.billingInterval = 'monthly';
     subscription.planDetails.categories = ['errors'];
 
     const prepaid = 100_000;

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
@@ -17,10 +17,22 @@ describe('UsageCard', () => {
       planTier: 'am2',
       plan: 'am2_team',
     });
+
+    subscription.planDetails.billingInterval = 'monthly';
+    subscription.planDetails.categories = ['errors'];
+
     const prepaid = 100_000;
+    subscription.planDetails.planCategories = {
+      errors: [{events: prepaid, price: 1500, unitPrice: 0.015, onDemandPrice: 0.02}],
+    };
+
     subscription.categories.errors = MetricHistoryFixture({
       prepaid,
       reserved: prepaid,
+      usage: 0, // 0% usage
+      free: 0,
+      onDemandQuantity: 0,
+      onDemandSpendUsed: 0,
     });
 
     render(<UsageCard organization={organization} subscription={subscription} />);
@@ -38,10 +50,22 @@ describe('UsageCard', () => {
       plan: 'am2_team',
       onDemandMaxSpend: 1000,
     });
+
+    subscription.planDetails.billingInterval = 'monthly';
+    subscription.planDetails.categories = ['errors'];
+
     const prepaid = 100_000;
+    subscription.planDetails.planCategories = {
+      errors: [{events: prepaid, price: 1500, unitPrice: 0.015, onDemandPrice: 0.02}],
+    };
+
     subscription.categories.errors = MetricHistoryFixture({
       prepaid,
       reserved: prepaid,
+      usage: 0, // 0% usage
+      free: 0,
+      onDemandQuantity: 0,
+      onDemandSpendUsed: 0,
     });
 
     render(<UsageCard organization={organization} subscription={subscription} />);

--- a/static/gsApp/views/subscriptionPage/planMigrationActive/index.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/planMigrationActive/index.spec.tsx
@@ -652,14 +652,6 @@ describe('PlanMigrationActive cohort 8', function () {
     expect(screen.queryByTestId('new-profileDuration')).not.toBeInTheDocument();
   });
 
-  it('does render profile duration row', function () {
-    migration.cohort!.nextPlan!.reserved.profileDuration = 1;
-
-    renderSimple();
-    expect(screen.queryByTestId('current-profileDuration')).toHaveTextContent(/1 hour/);
-    expect(screen.queryByTestId('new-profileDuration')).toHaveTextContent(/1 hour/);
-  });
-
   it('renders replays credit message', function () {
     renderSimple();
     expect(screen.getByTestId('recurring-credits')).toHaveTextContent(

--- a/static/gsApp/views/subscriptionPage/utils.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/utils.spec.tsx
@@ -14,6 +14,7 @@ describe('calculateTotalSpend', () => {
       plan: 'am2_f',
       onDemandSpendUsed: 0,
     });
+    subscription.planDetails.categories = ['errors'];
     subscription.categories.errors!.onDemandSpendUsed = 0;
     subscription.planDetails.planCategories.errors = [
       {events: 100_000, price: 10000, unitPrice: 0.1, onDemandPrice: 0.2},
@@ -34,6 +35,7 @@ describe('calculateTotalSpend', () => {
       planTier: 'am2',
       plan: 'am2_f',
     });
+    subscription.planDetails.categories = ['errors'];
     subscription.categories.errors!.onDemandSpendUsed = 10_000;
     subscription.planDetails.planCategories.errors = [
       {events: 100_000, price: 10000, unitPrice: 0.1, onDemandPrice: 0.2},
@@ -56,6 +58,7 @@ describe('calculateTotalSpend', () => {
       planTier: 'am2',
       plan: 'am2_f',
     });
+    subscription.planDetails.categories = ['errors'];
     subscription.planDetails.billingInterval = 'annual';
     const monthlyPrice = 10000;
     subscription.planDetails.planCategories.errors = [

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -9,7 +9,6 @@ const AM2_CATEGORIES = [
   'attachments',
   'monitorSeats',
   'profileDuration',
-  'profileDurationUI',
   'uptime',
 ];
 
@@ -20,7 +19,6 @@ const AM2_CATEGORY_DISPLAY_NAMES = {
   attachments: {singular: 'attachment', plural: 'attachments'},
   monitorSeats: {singular: 'cron monitor', plural: 'cron monitors'},
   profileDuration: {plural: 'profile hours', singular: 'profile hour'},
-  profileDurationUI: {plural: 'ui profile hours', singular: 'ui profile hour'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
 };
 
@@ -754,13 +752,6 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
     },
   },
   am2_f: {
@@ -833,13 +824,6 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -1519,13 +1503,6 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
     },
   },
   am2_t: {
@@ -1598,13 +1575,6 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -2284,13 +2254,6 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
     },
   },
   am2_business_auf: {
@@ -2964,13 +2927,6 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
     },
   },
   am2_sponsored: {
@@ -3007,7 +2963,6 @@ const AM2_PLANS: Record<string, Plan> = {
       monitorSeats: [{events: 500, unitPrice: 0, price: 0}],
       uptime: [{events: 500, unitPrice: 0, price: 0}],
       profileDuration: [{events: 0, unitPrice: 0, price: 0}],
-      profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
   },
@@ -3044,7 +2999,6 @@ const AM2_PLANS: Record<string, Plan> = {
       monitorSeats: [{events: 10, unitPrice: 0, price: 0}],
       uptime: [{events: 10, unitPrice: 0, price: 0}],
       profileDuration: [{events: 0, unitPrice: 0, price: 0}],
-      profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
   },
@@ -3523,13 +3477,6 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -4063,13 +4010,6 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -4624,13 +4564,6 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
     },
   },
   am2_business_ent_auf: {
@@ -4703,13 +4636,6 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -9,6 +9,7 @@ const AM2_CATEGORIES = [
   'attachments',
   'monitorSeats',
   'profileDuration',
+  'profileDurationUI',
   'uptime',
 ];
 
@@ -19,6 +20,7 @@ const AM2_CATEGORY_DISPLAY_NAMES = {
   attachments: {singular: 'attachment', plural: 'attachments'},
   monitorSeats: {singular: 'cron monitor', plural: 'cron monitors'},
   profileDuration: {plural: 'profile hours', singular: 'profile hour'},
+  profileDurationUI: {plural: 'ui profile hours', singular: 'ui profile hour'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
 };
 
@@ -747,7 +749,14 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 1,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
         },
@@ -825,7 +834,14 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 1,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
         },
@@ -1498,7 +1514,14 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 1,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
         },
@@ -1575,6 +1598,13 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -2254,6 +2284,13 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
     },
   },
   am2_business_auf: {
@@ -2927,6 +2964,13 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
     },
   },
   am2_sponsored: {
@@ -2963,6 +3007,7 @@ const AM2_PLANS: Record<string, Plan> = {
       monitorSeats: [{events: 500, unitPrice: 0, price: 0}],
       uptime: [{events: 500, unitPrice: 0, price: 0}],
       profileDuration: [{events: 0, unitPrice: 0, price: 0}],
+      profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
   },
@@ -2999,6 +3044,7 @@ const AM2_PLANS: Record<string, Plan> = {
       monitorSeats: [{events: 10, unitPrice: 0, price: 0}],
       uptime: [{events: 10, unitPrice: 0, price: 0}],
       profileDuration: [{events: 0, unitPrice: 0, price: 0}],
+      profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
   },
@@ -3477,6 +3523,13 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -4010,6 +4063,13 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -4564,6 +4624,13 @@ const AM2_PLANS: Record<string, Plan> = {
           price: 0,
         },
       ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
     },
   },
   am2_business_ent_auf: {
@@ -4636,6 +4703,13 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -657,12 +657,21 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 50,
+          events: 0,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
         },
       ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+
       spans: [
         {
           events: 10000000,
@@ -1192,10 +1201,18 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 50,
+          events: 0,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
         },
       ],
       attachments: [
@@ -1355,7 +1372,15 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 100,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1448,7 +1473,15 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 100,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1533,7 +1566,15 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 50,
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1624,6 +1665,14 @@ const AM3_PLANS: Record<string, Plan> = {
           onDemandPrice: 0,
         },
       ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
       spans: [
         {
           events: 0,
@@ -1702,6 +1751,14 @@ const AM3_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -2125,11 +2182,13 @@ const AM3_PLANS: Record<string, Plan> = {
           price: 0,
           onDemandPrice: 78.0,
         },
+      ],
+      profileDurationUI: [
         {
-          events: 50,
-          unitPrice: 60.0,
+          events: 0,
+          unitPrice: 0,
           price: 0,
-          onDemandPrice: 78.0,
+          onDemandPrice: 0,
         },
       ],
       attachments: [
@@ -2613,10 +2672,18 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 50,
+          events: 0,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
+        },
+      ],
+      profileDurationUI: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
         },
       ],
       attachments: [
@@ -2783,6 +2850,14 @@ const AM3_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
+        {
+          events: 0,
+          unitPrice: 0,
+          price: 0,
+          onDemandPrice: 0,
+        },
+      ],
+      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -657,21 +657,12 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
+          events: 50,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-
       spans: [
         {
           events: 10000000,
@@ -1201,18 +1192,10 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
+          events: 50,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
-        },
-      ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
         },
       ],
       attachments: [
@@ -1372,15 +1355,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-      profileDurationUI: [
-        {
-          events: 0,
+          events: 100,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1473,15 +1448,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-      profileDurationUI: [
-        {
-          events: 0,
+          events: 100,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1566,15 +1533,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-      profileDurationUI: [
-        {
-          events: 0,
+          events: 50,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -1665,14 +1624,6 @@ const AM3_PLANS: Record<string, Plan> = {
           onDemandPrice: 0,
         },
       ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
       spans: [
         {
           events: 0,
@@ -1751,14 +1702,6 @@ const AM3_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,
@@ -2182,13 +2125,11 @@ const AM3_PLANS: Record<string, Plan> = {
           price: 0,
           onDemandPrice: 78.0,
         },
-      ],
-      profileDurationUI: [
         {
-          events: 0,
-          unitPrice: 0,
+          events: 50,
+          unitPrice: 60.0,
           price: 0,
-          onDemandPrice: 0,
+          onDemandPrice: 78.0,
         },
       ],
       attachments: [
@@ -2672,18 +2613,10 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
       profileDuration: [
         {
-          events: 0,
+          events: 50,
           unitPrice: 60.0,
           price: 0,
           onDemandPrice: 78.0,
-        },
-      ],
-      profileDurationUI: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
         },
       ],
       attachments: [
@@ -2850,14 +2783,6 @@ const AM3_PLANS: Record<string, Plan> = {
         },
       ],
       profileDuration: [
-        {
-          events: 0,
-          unitPrice: 0,
-          price: 0,
-          onDemandPrice: 0,
-        },
-      ],
-      profileDurationUI: [
         {
           events: 0,
           unitPrice: 0,


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/16966

Adds support for `PROFILE_DURATION` data categories.

Follow up items:
Update documentation links
Confirm the expectations in the Upgrade Now tests (currently undefined)
