### PR TITLE
feat(tour): Track more tour analytics

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -382,8 +382,9 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
-  'tour-guide.dismiss': {id?: string};
-  'tour-guide.open': {id?: string};
+  'tour-guide.dismiss': {id?: string; step_count?: number; tour_key?: string};
+  'tour-guide.finish': {id?: string; step_count?: number; tour_key?: string};
+  'tour-guide.open': {id?: string; step_count?: number; tour_key?: string};
   'whats_new.link_clicked': Pick<Broadcast, 'title'> &
     Partial<Pick<Broadcast, 'category'>>;
 };
@@ -546,5 +547,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.comment_updated': 'Issue Details: Comment Updated',
   'tour-guide.open': 'Tour Guide: Opened',
   'tour-guide.dismiss': 'Tour Guide: Dismissed',
+  'tour-guide.finish': 'Tour Guide: Finished',
   'whats_new.link_clicked': "What's New: Link Clicked",
 };


### PR DESCRIPTION
- Adds `tour_key` to each event so we can differentiate between tours (like issue details and the nav)
- Adds `step_count` because why not, might be useful
- Adds an event when the user clicked "finish tour", figured that might also be useful