### PR TITLE
feat(react19): Wrap deprecated forms with `withFormContext`

### DIFF
--- a/static/app/components/core/select/async.tsx
+++ b/static/app/components/core/select/async.tsx
@@ -12,7 +12,7 @@ import type {ControlProps, GeneralSelectValue} from './';
 import {Select} from './';
 
 export type Result = {
-  label: string;
+  label: string | React.ReactNode;
   value: string;
 };
 

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -3,7 +3,9 @@ import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
-import SelectAsyncField from 'sentry/components/deprecatedforms/selectAsyncField';
+import SelectAsyncField, {
+  type SelectAsyncFieldProps,
+} from 'sentry/components/deprecatedforms/selectAsyncField';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
@@ -27,7 +29,9 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
     setVersion(selection as string);
   };
 
-  const onAsyncFieldResults = (results: Release[]) => {
+  const onAsyncFieldResults: SelectAsyncFieldProps['onResults'] = (
+    results: Release[]
+  ) => {
     return results.map(release => {
       const isAuthor = release.authors.some(
         author => author.email && author.email === currentUser?.email

--- a/static/app/components/deprecatedforms/booleanField.tsx
+++ b/static/app/components/deprecatedforms/booleanField.tsx
@@ -1,5 +1,6 @@
 import {Checkbox} from 'sentry/components/core/checkbox';
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconQuestion} from 'sentry/icons';
 import {defined} from 'sentry/utils';
@@ -15,7 +16,7 @@ type State = InputField['state'] & {
 /**
  * @deprecated Do not use this
  */
-export default class BooleanField extends InputField<Props, State> {
+class BooleanField extends InputField<Props, State> {
   coerceValue(initialValue: string | number) {
     const value = super.coerceValue(initialValue);
     return value ? true : false;
@@ -71,3 +72,8 @@ export default class BooleanField extends InputField<Props, State> {
     return 'checkbox';
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(BooleanField);

--- a/static/app/components/deprecatedforms/dateTimeField.tsx
+++ b/static/app/components/deprecatedforms/dateTimeField.tsx
@@ -1,6 +1,9 @@
 import InputField from 'sentry/components/deprecatedforms/inputField';
 
-export default class DateTimeField extends InputField {
+/**
+ * @deprecated Do not use this
+ */
+export class DateTimeField extends InputField {
   getType() {
     return 'datetime-local';
   }

--- a/static/app/components/deprecatedforms/emailField.tsx
+++ b/static/app/components/deprecatedforms/emailField.tsx
@@ -1,12 +1,18 @@
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
 // XXX: This is ONLY used in GenericField. If we can delete that this can go.
 
 /**
  * @deprecated Do not use this
  */
-export default class EmailField extends InputField {
+class EmailField extends InputField {
   getType() {
     return 'email';
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(EmailField);

--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
 import {Button} from 'sentry/components/core/button';
-import type {FormContextData} from 'sentry/components/deprecatedforms/formContext';
 import FormContext from 'sentry/components/deprecatedforms/formContext';
 import FormState from 'sentry/components/forms/state';
 import {t} from 'sentry/locale';
@@ -41,9 +40,6 @@ type FormClassState = {
   state: FormState;
 };
 
-// Re-export for compatibility alias.
-export type Context = FormContextData;
-
 class Form<
   Props extends FormProps = FormProps,
   State extends FormClassState = FormClassState,
@@ -62,8 +58,8 @@ class Form<
     ),
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.state = {
       data: {...this.props.initialData},
       errors: {},

--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -1,6 +1,6 @@
 import BooleanField from 'sentry/components/deprecatedforms/booleanField';
 import EmailField from 'sentry/components/deprecatedforms/emailField';
-import type FormField from 'sentry/components/deprecatedforms/formField';
+import type {FormFieldProps} from 'sentry/components/deprecatedforms/formField';
 import NumberField from 'sentry/components/deprecatedforms/numberField';
 import PasswordField from 'sentry/components/deprecatedforms/passwordField';
 import SelectAsyncField from 'sentry/components/deprecatedforms/selectAsyncField';
@@ -54,7 +54,7 @@ type Props = {
   config: Config | SelectFieldConfig | AsyncSelectFieldConfig;
   formData: FormData;
   formState: (typeof FormState)[keyof typeof FormState];
-  onChange: FormField['props']['onChange'];
+  onChange: FormFieldProps['onChange'];
   formErrors?: Record<PropertyKey, string>;
 };
 

--- a/static/app/components/deprecatedforms/inputField.tsx
+++ b/static/app/components/deprecatedforms/inputField.tsx
@@ -1,7 +1,9 @@
 import {Input} from 'sentry/components/core/input';
-import FormField from 'sentry/components/deprecatedforms/formField';
+import FormField, {
+  type FormFieldProps,
+} from 'sentry/components/deprecatedforms/formField';
 
-type InputFieldProps = FormField['props'] & {
+type InputFieldProps = FormFieldProps & {
   autoComplete?: string;
   inputStyle?: Record<PropertyKey, unknown>;
   min?: number;

--- a/static/app/components/deprecatedforms/numberField.tsx
+++ b/static/app/components/deprecatedforms/numberField.tsx
@@ -1,4 +1,5 @@
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
 type Props = {
   max?: number;
@@ -10,7 +11,7 @@ type Props = {
 /**
  * @deprecated Do not use this
  */
-export default class NumberField extends InputField<Props> {
+export class NumberField extends InputField<Props> {
   coerceValue(value: any) {
     const intValue = parseInt(value, 10);
 
@@ -35,3 +36,8 @@ export default class NumberField extends InputField<Props> {
     };
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(NumberField);

--- a/static/app/components/deprecatedforms/passwordField.tsx
+++ b/static/app/components/deprecatedforms/passwordField.tsx
@@ -1,11 +1,11 @@
-import type {Context} from 'sentry/components/deprecatedforms/form';
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import FormState from 'sentry/components/forms/state';
 
 type Props = InputField['props'] & {
-  prefix: string;
   formState?: (typeof FormState)[keyof typeof FormState];
   hasSavedValue?: boolean;
+  prefix?: string;
 };
 
 type State = InputField['state'] & {
@@ -14,15 +14,19 @@ type State = InputField['state'] & {
 
 // TODO(dcramer): im not entirely sure this is working correctly with
 // value propagation in all scenarios
-export default class PasswordField extends InputField<Props, State> {
+
+/**
+ * @deprecated Do not use this
+ */
+class PasswordField extends InputField<Props, State> {
   static defaultProps = {
     ...InputField.defaultProps,
     hasSavedValue: false,
     prefix: '',
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     this.state = {...this.state, editing: false};
   }
@@ -71,10 +75,15 @@ export default class PasswordField extends InputField<Props, State> {
     return (
       <div className="form-password saved">
         <span>
-          {this.props.prefix + new Array(21 - this.props.prefix.length).join('*')}
+          {this.props.prefix + new Array(21 - this.props.prefix!.length).join('*')}
         </span>
         {!this.props.disabled && <a onClick={this.startEdit}>Edit</a>}
       </div>
     );
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(PasswordField);

--- a/static/app/components/deprecatedforms/selectAsyncField.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.tsx
@@ -1,6 +1,23 @@
-import {SelectAsync} from 'sentry/components/core/select/async';
-import SelectField from 'sentry/components/deprecatedforms/selectField';
+import {
+  SelectAsync,
+  type SelectAsyncControlProps,
+} from 'sentry/components/core/select/async';
+import {
+  SelectField,
+  type SelectFieldProps,
+} from 'sentry/components/deprecatedforms/selectField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
+export interface SelectAsyncFieldProps
+  extends SelectFieldProps,
+    Omit<SelectAsyncControlProps, 'value' | 'forwardedRef' | 'onQuery' | 'onResults'> {
+  onQuery?: SelectAsyncControlProps['onQuery'];
+  onResults?: SelectAsyncControlProps['onResults'];
+}
+
+/**
+ * @deprecated Do not use this
+ */
 class SelectAsyncField extends SelectField {
   static defaultProps = {
     ...SelectField.defaultProps,
@@ -38,4 +55,9 @@ class SelectAsyncField extends SelectField {
   }
 }
 
-export default SelectAsyncField;
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(SelectAsyncField) as React.ComponentType<
+  Omit<SelectAsyncFieldProps, 'formContext'>
+>;

--- a/static/app/components/deprecatedforms/selectCreatableField.tsx
+++ b/static/app/components/deprecatedforms/selectCreatableField.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 
 import {Select} from 'sentry/components/core/select';
 import {StyledForm} from 'sentry/components/deprecatedforms/form';
-import SelectField from 'sentry/components/deprecatedforms/selectField';
+import {SelectField} from 'sentry/components/deprecatedforms/selectField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import type {SelectValue} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
@@ -16,11 +17,11 @@ import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
  *
  * This is used in some integrations
  */
-export default class SelectCreatableField extends SelectField {
+class SelectCreatableField extends SelectField {
   options: Array<SelectValue<any>> | undefined;
 
-  constructor(props: any, context: any) {
-    super(props, context);
+  constructor(props: SelectCreatableField['props']) {
+    super(props);
 
     // We only want to parse options once because react-select relies
     // on `options` mutation when you create a new option
@@ -29,13 +30,13 @@ export default class SelectCreatableField extends SelectField {
     this.options = this.getOptions(props);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: any, nextContext: any) {
-    const newError = this.getError(nextProps, nextContext);
+  UNSAFE_componentWillReceiveProps(nextProps: SelectCreatableField['props']) {
+    const newError = this.getError(nextProps);
     if (newError !== this.state.error) {
       this.setState({error: newError});
     }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      const newValue = this.getValue(nextProps, nextContext);
+    if (this.props.value !== nextProps.value || defined(nextProps.formContext.form)) {
+      const newValue = this.getValue(nextProps);
       // This is the only thing that is different from parent, we compare newValue against coerced value in state
       // To remain compatible with react-select, we need to store the option object that
       // includes `value` and `label`, but when we submit the format, we need to coerce it
@@ -91,3 +92,8 @@ const StyledSelectControl = styled(Select)`
     margin-bottom: 15px;
   }
 `;
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(SelectCreatableField);

--- a/static/app/components/deprecatedforms/selectField.tsx
+++ b/static/app/components/deprecatedforms/selectField.tsx
@@ -1,31 +1,46 @@
 import styled from '@emotion/styled';
 
-import type {ControlProps} from 'sentry/components/core/select';
 import {Select} from 'sentry/components/core/select';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import {defined} from 'sentry/utils';
 
 import {StyledForm} from './form';
-import FormField from './formField';
+import FormField, {type FormFieldProps} from './formField';
 
-type SelectProps = Omit<ControlProps, 'onChange' | 'name'>;
-type FormProps = FormField['props'];
+// Combined interface for SelectField props
+export interface SelectFieldProps extends FormFieldProps {
+  // Modified to accept various choice formats
+  choices?: Array<[value: any, label: string | number]> | string[][] | string[];
+  clearable?: boolean;
+  // legacy prop for backward compatibility
+  creatable?: boolean;
+  // Additional select behavior
+  defaultValue?: any;
+  isLoading?: boolean;
+  multi?: boolean;
+  multiple?: boolean;
+  // Core select properties
+  options?: Array<{label: string; value: any}>;
+  placeholder?: string;
+}
 
-type Props = FormProps & SelectProps;
-
-export default class SelectField extends FormField<Props> {
+/**
+ * @deprecated Do not use this
+ */
+export class SelectField extends FormField<SelectFieldProps> {
   static defaultProps = {
     ...FormField.defaultProps,
     clearable: true,
     multiple: false,
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps: any, nextContext: any) {
-    const newError = this.getError(nextProps, nextContext);
+  UNSAFE_componentWillReceiveProps(nextProps: SelectFieldProps) {
+    const newError = this.getError(nextProps);
     if (newError !== this.state.error) {
       this.setState({error: newError});
     }
-    if (this.props.value !== nextProps.value || defined(nextContext.form)) {
-      const newValue = this.getValue(nextProps, nextContext);
+    if (this.props.value !== nextProps.value || defined(nextProps.formContext.form)) {
+      const newValue = this.getValue(nextProps);
       // This is the only thing that is different from parent, we compare newValue against coerced value in state
       // To remain compatible with react-select, we need to store the option object that
       // includes `value` and `label`, but when we submit the format, we need to coerce it
@@ -44,8 +59,8 @@ export default class SelectField extends FormField<Props> {
   }
 
   // Overriding this so that we can support `multi` fields through property
-  getValue(props: any, context: any) {
-    const form = (context || this.context)?.form;
+  getValue(props: SelectFieldProps) {
+    const form = (props.formContext || this.props.formContext)?.form;
     props = props || this.props;
 
     // Don't use `isMultiple` here because we're taking props from args as well
@@ -81,7 +96,7 @@ export default class SelectField extends FormField<Props> {
     return value;
   }
 
-  isMultiple(props?: any) {
+  isMultiple(props?: SelectFieldProps) {
     props = props || this.props;
     // this is to maintain compatibility with the 'multi' prop
     return props.multi || props.multiple;
@@ -138,3 +153,8 @@ const StyledSelectControl = styled(Select)`
     margin-bottom: 15px;
   }
 `;
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(SelectField);

--- a/static/app/components/deprecatedforms/textField.tsx
+++ b/static/app/components/deprecatedforms/textField.tsx
@@ -1,4 +1,5 @@
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
 type Props = InputField['props'] & {
   spellCheck?: string;
@@ -9,7 +10,7 @@ type Props = InputField['props'] & {
 /**
  * @deprecated Do not use this
  */
-export default class TextField extends InputField<Props> {
+class TextField extends InputField<Props> {
   getAttributes() {
     return {
       spellCheck: this.props.spellCheck,
@@ -20,3 +21,8 @@ export default class TextField extends InputField<Props> {
     return 'text';
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(TextField);

--- a/static/app/components/deprecatedforms/textareaField.tsx
+++ b/static/app/components/deprecatedforms/textareaField.tsx
@@ -1,5 +1,6 @@
 import {TextArea} from 'sentry/components/core/textarea';
 import InputField from 'sentry/components/deprecatedforms/inputField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
 type State = InputField['state'] & {
   value?: string;
@@ -10,7 +11,7 @@ type State = InputField['state'] & {
 /**
  * @deprecated Do not use this
  */
-export default class TextareaField extends InputField<InputField['props'], State> {
+class TextareaField extends InputField<InputField['props'], State> {
   getField() {
     return (
       <TextArea
@@ -32,3 +33,8 @@ export default class TextareaField extends InputField<InputField['props'], State
     return '';
   }
 }
+
+/**
+ * @deprecated Do not use this
+ */
+export default withFormContext(TextareaField);

--- a/static/app/components/deprecatedforms/withFormContext.tsx
+++ b/static/app/components/deprecatedforms/withFormContext.tsx
@@ -1,0 +1,32 @@
+import {useContext} from 'react';
+
+import type {FormContextData} from 'sentry/components/deprecatedforms/formContext';
+import FormContext from 'sentry/components/deprecatedforms/formContext';
+import getDisplayName from 'sentry/utils/getDisplayName';
+
+type InjectedFormContextProps = {
+  formContext?: FormContextData;
+};
+
+/**
+ * Wrap deprecated form components with form context
+ * @deprecated Do not use this
+ */
+export default function withFormContext<P extends InjectedFormContextProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  type Props = Omit<P, keyof InjectedFormContextProps> &
+    Partial<InjectedFormContextProps>;
+
+  function Wrapper(props: Props) {
+    const formContext = useContext(FormContext);
+
+    const allProps = {formContext, ...props} as P;
+
+    return <WrappedComponent {...(allProps as P as any)} />;
+  }
+
+  Wrapper.displayName = `withFormContext(${getDisplayName(WrappedComponent)})`;
+
+  return Wrapper;
+}

--- a/static/gsAdmin/components/changeContractEndDateAction.tsx
+++ b/static/gsAdmin/components/changeContractEndDateAction.tsx
@@ -3,14 +3,17 @@ import moment from 'moment-timezone';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
-import DateTimeField from 'sentry/components/deprecatedforms/dateTimeField';
+import {DateTimeField} from 'sentry/components/deprecatedforms/dateTimeField';
 import Form from 'sentry/components/deprecatedforms/form';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
-class DateField extends DateTimeField {
+class DateFieldNoContext extends DateTimeField {
   getType() {
     return 'date';
   }
 }
+
+const DateField = withFormContext(DateFieldNoContext);
 
 type Props = {
   contractPeriodEnd: string;

--- a/static/gsAdmin/components/changeDatesAction.tsx
+++ b/static/gsAdmin/components/changeDatesAction.tsx
@@ -3,8 +3,9 @@ import {Fragment} from 'react';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {type ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
-import DateTimeField from 'sentry/components/deprecatedforms/dateTimeField';
+import {DateTimeField} from 'sentry/components/deprecatedforms/dateTimeField';
 import Form from 'sentry/components/deprecatedforms/form';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import useApi from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
@@ -17,11 +18,13 @@ type Props = {
 
 type ModalProps = Props & ModalRenderProps;
 
-class DateField extends DateTimeField {
+class DateFieldNoContext extends DateTimeField {
   getType() {
     return 'date';
   }
 }
+
+const DateField = withFormContext(DateFieldNoContext);
 
 function ChangeDatesModal({
   orgId,

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -7,11 +7,14 @@ import {openModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
 import BooleanField from 'sentry/components/deprecatedforms/booleanField';
-import DateTimeField from 'sentry/components/deprecatedforms/dateTimeField';
+import {DateTimeField} from 'sentry/components/deprecatedforms/dateTimeField';
 import Form from 'sentry/components/deprecatedforms/form';
 import InputField from 'sentry/components/deprecatedforms/inputField';
-import NumberField from 'sentry/components/deprecatedforms/numberField';
+import NumberField, {
+  NumberField as NumberFieldNoContext,
+} from 'sentry/components/deprecatedforms/numberField';
 import SelectField from 'sentry/components/deprecatedforms/selectField';
+import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 import {space} from 'sentry/styles/space';
 import withApi from 'sentry/utils/withApi';
 
@@ -28,19 +31,21 @@ import {
 const CPE_DECIMAL_PRECISION = 8;
 
 // TODO: replace with modern fields so we don't need these workarounds
-class DateField extends DateTimeField {
+class DateFieldNoContext extends DateTimeField {
   getType() {
     return 'date';
   }
 }
 
+const DateField = withFormContext(DateFieldNoContext);
+
 type DollarsAndCentsFieldProps = {
   max?: number;
   min?: number;
   step?: any;
-} & NumberField['props'];
+} & NumberFieldNoContext['props'];
 
-class DollarsField extends NumberField {
+class DollarsFieldNoContext extends NumberFieldNoContext {
   getField() {
     return (
       <div className="dollars-field-container">
@@ -51,7 +56,9 @@ class DollarsField extends NumberField {
   }
 }
 
-class DollarsAndCentsField extends InputField<DollarsAndCentsFieldProps> {
+const DollarsField = withFormContext(DollarsFieldNoContext);
+
+class DollarsAndCentsFieldNoContext extends InputField<DollarsAndCentsFieldProps> {
   getField() {
     return (
       <div className="dollars-cents-field-container">
@@ -80,6 +87,8 @@ class DollarsAndCentsField extends InputField<DollarsAndCentsFieldProps> {
     };
   }
 }
+
+const DollarsAndCentsField = withFormContext(DollarsAndCentsFieldNoContext);
 
 type Props = {
   api: Client;


### PR DESCRIPTION
React 19's types remove the 2nd argument from the constructor `constructor(props: Props, context: Context)` and nextContext in UNSAFE_componentWillReceiveProps.

It is easier to wrap these components in a HoC that provides the props then it is to remove all the inheritance used in the class components.

Fixes this type error in react 19 that errors on every line these components are used and on the constructor itself.
```
  Its type 'typeof NumberField' is not a valid JSX element type.
    Types of construct signatures are incompatible.
      Type 'new (props: Props, context?: any) => NumberField' is not assignable to type 'new (props: any) => Component<any, any, any>'.
        Construct signature return types 'NumberField' and 'Component<any, any, any>' are incompatible.
          The types of 'UNSAFE_componentWillReceiveProps' are incompatible between these types.
            Type '(nextProps: Props, nextContext: FormContextData) => void' is not assignable to type '(nextProps: Readonly<any>) => void'.
              Target signature provides too few arguments. Expected 2 or more, but got 1.
```

Part of https://github.com/getsentry/frontend-tsc/issues/68
