### PR TITLE
feat(tour): Allow some elements to not render a tooltip at all

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -126,6 +126,8 @@ export interface TourElementProps<T extends TourEnumType>
   children: React.ReactNode;
   /**
    * The description of the tour step.
+   * If null, a tooltip will not be displayed. This is useful if there are multiple
+   * elements you want to focus on in a single step.
    */
   description: React.ReactNode;
   /**
@@ -134,6 +136,8 @@ export interface TourElementProps<T extends TourEnumType>
   id: TourStep<T>['id'];
   /**
    * The title of the tour step.
+   * If null, a tooltip will not be displayed. This is useful if there are multiple
+   * elements you want to focus on in a single step.
    */
   title: React.ReactNode;
   /**
@@ -310,7 +314,7 @@ export function TourGuide({
       >
         {children}
       </Wrapper>
-      {isOpen
+      {isOpen && defined(title) && defined(description)
         ? createPortal(
             <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
               <ClassNames>

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -254,6 +254,60 @@ export const MY_TOUR_KEY = 'tour.my_tour';
       </TourProvider>
     </Fragment>
   ));
+
+  story('Multiple highlighted elements', () => (
+    <Fragment>
+      <p>
+        Most of the time you'll want to highlight a single element. But if you need to
+        highlight multiple elements, you can do so by using the same step ID for each
+        element. Any that you do not want a tooltip for should pass null for the
+        title/description.
+      </p>
+      <TourProvider>
+        <TourElement<MyTour>
+          id={MyTour.NAME}
+          title={null}
+          description={null}
+          tourContext={MyTourContext}
+        >
+          <Input placeholder="Step 1: First Name" />
+        </TourElement>
+        <TourElement<MyTour>
+          id={MyTour.NAME}
+          title={'Name Time!'}
+          description={'Look at all these name inputs!'}
+          tourContext={MyTourContext}
+          position="right"
+        >
+          <Input placeholder="Step 1: Middle Name" />
+        </TourElement>
+        <TourElement<MyTour>
+          id={MyTour.NAME}
+          title={null}
+          description={null}
+          tourContext={MyTourContext}
+        >
+          <Input placeholder="Step 1: Last Name" />
+        </TourElement>
+        <TourElement<MyTour>
+          id={MyTour.EMAIL}
+          title={'Email Time!'}
+          description={'This is the description of the email tour step.'}
+          tourContext={MyTourContext}
+        >
+          <Input placeholder="Step 2: Email" type="email" />
+        </TourElement>
+        <TourElement<MyTour>
+          id={MyTour.PASSWORD}
+          title={'Password Time!'}
+          description={'This is the description of the password tour step.'}
+          tourContext={MyTourContext}
+        >
+          <Input placeholder="Step 3: Password" type="password" />
+        </TourElement>
+      </TourProvider>
+    </Fragment>
+  ));
 });
 
 function StartTourButton() {


### PR DESCRIPTION
For the navigation tour, we want to both the selected primary item and the elements in the secondary sidebar, so multiple tour elements needs to be used. 

This PR prevents the tooltip from being rendered if nothing is passed for the title or description. That allows us to highlight multiple elements where only one displays a tooltip.

![CleanShot 2025-03-21 at 16 35 25@2x](https://github.com/user-attachments/assets/89c13c37-bdc2-41d0-ba0f-bfecffb5bad0)
