### PR TITLE
ref: Refactor doSessionsRequest() & doReleaseHealthRequest() to pass `includeAllArgs=true`

### DIFF
--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -1,4 +1,4 @@
-import type {Client, ResponseMeta} from 'sentry/api';
+import type {ApiResult, Client} from 'sentry/api';
 import {getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {DateString} from 'sentry/types/core';
@@ -12,7 +12,6 @@ export type DoReleaseHealthRequestOptions = {
   end?: DateString;
   environment?: readonly string[];
   groupBy?: string[];
-  includeAllArgs?: boolean;
   includeSeries?: number;
   includeTotals?: number;
   interval?: string;
@@ -41,12 +40,11 @@ export const doReleaseHealthRequest = (
     orderBy,
     project,
     query,
-    includeAllArgs = false,
     statsPeriodStart,
     statsPeriodEnd,
     ...dateTime
   }: DoReleaseHealthRequestOptions
-): Promise<SessionApiResponse | [SessionApiResponse, string, ResponseMeta]> => {
+): Promise<ApiResult<SessionApiResponse>> => {
   const {start, end, statsPeriod} = normalizeDateTimeParams(dateTime, {
     allowEmptyPeriod: true,
   });
@@ -74,5 +72,5 @@ export const doReleaseHealthRequest = (
 
   const pathname = `/organizations/${orgSlug}/metrics/data/`;
 
-  return api.requestPromise(pathname, {includeAllArgs, query: urlQuery});
+  return api.requestPromise(pathname, {includeAllArgs: true, query: urlQuery});
 };

--- a/static/app/actionCreators/sessions.tsx
+++ b/static/app/actionCreators/sessions.tsx
@@ -1,4 +1,4 @@
-import type {Client} from 'sentry/api';
+import type {ApiResult, Client} from 'sentry/api';
 import {getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {DateString} from 'sentry/types/core';
@@ -12,7 +12,6 @@ export type DoSessionsRequestOptions = {
   end?: DateString;
   environment?: readonly string[];
   groupBy?: string[];
-  includeAllArgs?: boolean;
   includeSeries?: boolean;
   includeTotals?: boolean;
   interval?: string;
@@ -38,7 +37,6 @@ export const doSessionsRequest = (
     project,
     orderBy,
     query,
-    includeAllArgs = false,
     includeSeries,
     includeTotals,
     statsPeriodStart,
@@ -46,7 +44,7 @@ export const doSessionsRequest = (
     limit,
     ...dateTime
   }: DoSessionsRequestOptions
-): Promise<SessionApiResponse> => {
+): Promise<ApiResult<SessionApiResponse>> => {
   const {start, end, statsPeriod} = normalizeDateTimeParams(dateTime, {
     allowEmptyPeriod: true,
   });
@@ -73,7 +71,7 @@ export const doSessionsRequest = (
   );
 
   return api.requestPromise(`/organizations/${orgSlug}/sessions/`, {
-    includeAllArgs,
+    includeAllArgs: true,
     query: urlQuery,
   });
 };

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
@@ -62,15 +62,16 @@ export function ProjectAnrScoreCard({
       includeSeries: false,
     };
 
-    doSessionsRequest(api, {...requestData, ...normalizeDateTimeParams(datetime)}).then(
-      response => {
-        if (unmounted) {
-          return;
-        }
-
-        setSessionsData(response);
+    doSessionsRequest(api, {
+      ...requestData,
+      ...normalizeDateTimeParams(datetime),
+    }).then(([response]) => {
+      if (unmounted) {
+        return;
       }
-    );
+
+      setSessionsData(response);
+    });
     return () => {
       unmounted = true;
     };
@@ -108,7 +109,7 @@ export function ProjectAnrScoreCard({
         ...requestData,
         start: previousStart,
         end: previousEnd,
-      }).then(response => {
+      }).then(([response]) => {
         if (unmounted) {
           return;
         }


### PR DESCRIPTION
There were a bunch of `any` types in here, and some janky method signatures because both these methods accepted `includeAllArgs:false` to be passed in.

Instead of allowing for that flexibility, lets just hard-code `includeAllArgs:true` and simplify all the types along the way.

Notice some improvements:
- we're returning `ApiResult<...>` instead of manually writing out the tuple
- `requestData: any;` and `requester: any;` are gone, meaning we have typesafe params at the site of the method calls
- Whatever `requestData.field` is doing, i didn't want to change it too much. `injectedFields.push` seems pointless; but i'm not breaking it.
-  We can easily unpack the `ApiResult` tuple with `.then(([response]) => {...`