### PR TITLE
ref(aci): replace workflow with workflow_env on WorkflowEventData

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -111,10 +111,7 @@ class BaseIssueAlertHandler(ABC):
         :param job: WorkflowEventData
         :return: Rule instance
         """
-        workflow = job.workflow
-        environment_id = None
-        if workflow and workflow.environment:
-            environment_id = workflow.environment.id
+        environment_id = job.workflow_env.id if job.workflow_env else None
 
         # TODO(iamrajjoshi): Remove the project null check once https://github.com/getsentry/sentry/pull/85240/files is merged
         if detector.project is None:

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -10,8 +10,7 @@ def is_new_event(job: WorkflowEventData) -> bool:
     if state is None:
         return False
 
-    workflow = job.workflow
-    if workflow is None or workflow.environment_id is None:
+    if job.workflow_env is None:
         return state["is_new"]
 
     return state["is_new_group_environment"]

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -48,10 +48,8 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
         event = job.event
-        workflow = job.workflow
-        environment = workflow.environment if workflow else None
 
-        latest_release = get_latest_release_for_env(environment, event)
+        latest_release = get_latest_release_for_env(job.workflow_env, event)
         if not latest_release:
             return False
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -82,7 +82,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True, []
 
-        workflow_job = replace(job, workflow=self)
+        workflow_job = replace(job, workflow_env=self.environment)
         (evaluation, _), remaining_conditions = process_data_condition_group(
             self.when_condition_group.id, workflow_job
         )

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -10,8 +10,9 @@ if TYPE_CHECKING:
     from sentry.deletions.base import ModelRelation
     from sentry.eventstore.models import GroupEvent
     from sentry.eventstream.base import GroupState
+    from sentry.models.environment import Environment
     from sentry.snuba.models import SnubaQueryEventType
-    from sentry.workflow_engine.models import Action, Detector, Workflow
+    from sentry.workflow_engine.models import Action, Detector
     from sentry.workflow_engine.models.data_condition import Condition
 
 T = TypeVar("T")
@@ -39,7 +40,7 @@ class WorkflowEventData:
     group_state: GroupState | None = None
     has_reappeared: bool | None = None
     has_escalated: bool | None = None
-    workflow: Workflow | None = None
+    workflow_env: Environment | None = None
 
 
 class ActionHandler:

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -72,7 +72,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
 
         class TestHandler(BaseIssueAlertHandler):
             @classmethod
@@ -126,8 +126,8 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
 
     def test_create_rule_instance_from_action_no_environment(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
-        workflow = self.create_workflow()
-        job = WorkflowEventData(event=self.group_event, workflow=workflow)
+        self.create_workflow()
+        job = WorkflowEventData(event=self.group_event, workflow_env=None)
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector, job)
 
         assert isinstance(rule, Rule)

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -165,7 +165,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         self.handler = TestHandler()
 
     def test_missing_occurrence_raises_value_error(self):
@@ -355,7 +355,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         self.handler = PagerDutyMetricAlertHandler()
 
     @mock.patch(

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_metric_alert.py
@@ -458,7 +458,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow=self.workflow)
+        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.workflow.environment)
         self.handler = OpsgenieMetricAlertHandler()
 
     @mock.patch(

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -6,7 +6,6 @@ from jsonschema import ValidationError
 from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -27,7 +26,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
                     "is_new_group_environment": True,
                 }
             ),
-            workflow=Workflow(environment_id=None),
+            workflow_env=None,
         )
         self.dc = self.create_data_condition(
             type=self.condition,
@@ -70,7 +69,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_with_environment(self):
-        self.job = replace(self.job, workflow=Workflow(environment_id=1))
+        self.job = replace(self.job, workflow_env=self.environment)
         assert self.job.group_state
 
         self.assert_passes(self.dc, self.job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -9,7 +9,6 @@ from sentry.rules.filters.latest_release import LatestReleaseFilter, get_project
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -140,9 +139,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
             date_added=datetime(2020, 9, 3, 3, 8, 24, 880386, tzinfo=UTC),
         )
 
-        self.job = WorkflowEventData(
-            event=self.group_event, workflow=Workflow(environment_id=self.environment.id)
-        )
+        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
 
         self.event.data["tags"] = (("release", new_release.version),)
         self.assert_passes(self.dc, self.job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -5,7 +5,6 @@ from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssueCondition
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -26,7 +25,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
                     "is_new_group_environment": True,
                 }
             ),
-            workflow=Workflow(environment_id=1),
+            workflow_env=self.environment,
         )
         self.dc = self.create_data_condition(
             type=self.condition,


### PR DESCRIPTION
We only use the workflow environment on the workflow in `WorkflowEventData`, so we can replace workflow with `workflow_env`.