### PR TITLE
ref: Make `includeAllArgs` mandatory in `doEventsRequest()` and iterate on types

### DIFF
--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -35,6 +35,7 @@ describe('Events ActionCreator', function () {
   it('requests events stats with relative period', async function () {
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       includePrevious: false,
       period: '7d',
       partial: true,
@@ -55,6 +56,7 @@ describe('Events ActionCreator', function () {
   it('sets useRpc param', async function () {
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       includePrevious: false,
       period: '7d',
       partial: true,
@@ -76,6 +78,7 @@ describe('Events ActionCreator', function () {
   it('requests events stats with relative period including previous period', async function () {
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       includePrevious: true,
       period: '7d',
       partial: true,
@@ -98,6 +101,7 @@ describe('Events ActionCreator', function () {
     const end = new Date('2017-10-17T00:00:00.000Z');
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       includePrevious: false,
       start,
       end,
@@ -123,6 +127,7 @@ describe('Events ActionCreator', function () {
     const end = new Date('2017-10-17T00:00:00.000Z');
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       includePrevious: true,
       start,
       end,
@@ -145,6 +150,7 @@ describe('Events ActionCreator', function () {
   it('spreads query extras', async function () {
     await doEventsRequest<false>(api, {
       ...opts,
+      includeAllArgs: false,
       queryExtras: {useOnDemandMetrics: 'true'},
       partial: true,
     });

--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -32,8 +32,8 @@ describe('Events ActionCreator', function () {
     });
   });
 
-  it('requests events stats with relative period', function () {
-    doEventsRequest(api, {
+  it('requests events stats with relative period', async function () {
+    await doEventsRequest<false>(api, {
       ...opts,
       includePrevious: false,
       period: '7d',
@@ -52,8 +52,8 @@ describe('Events ActionCreator', function () {
     );
   });
 
-  it('sets useRpc param', function () {
-    doEventsRequest(api, {
+  it('sets useRpc param', async function () {
+    await doEventsRequest<false>(api, {
       ...opts,
       includePrevious: false,
       period: '7d',
@@ -73,8 +73,8 @@ describe('Events ActionCreator', function () {
     );
   });
 
-  it('requests events stats with relative period including previous period', function () {
-    doEventsRequest(api, {
+  it('requests events stats with relative period including previous period', async function () {
+    await doEventsRequest<false>(api, {
       ...opts,
       includePrevious: true,
       period: '7d',
@@ -93,10 +93,10 @@ describe('Events ActionCreator', function () {
     );
   });
 
-  it('requests events stats with absolute period', function () {
+  it('requests events stats with absolute period', async function () {
     const start = new Date('2017-10-12T12:00:00.000Z');
     const end = new Date('2017-10-17T00:00:00.000Z');
-    doEventsRequest(api, {
+    await doEventsRequest<false>(api, {
       ...opts,
       includePrevious: false,
       start,
@@ -121,7 +121,7 @@ describe('Events ActionCreator', function () {
   it('requests events stats with absolute period including previous period', async function () {
     const start = new Date('2017-10-12T12:00:00.000Z');
     const end = new Date('2017-10-17T00:00:00.000Z');
-    await doEventsRequest(api, {
+    await doEventsRequest<false>(api, {
       ...opts,
       includePrevious: true,
       start,
@@ -143,7 +143,7 @@ describe('Events ActionCreator', function () {
   });
 
   it('spreads query extras', async function () {
-    await doEventsRequest(api, {
+    await doEventsRequest<false>(api, {
       ...opts,
       queryExtras: {useOnDemandMetrics: 'true'},
       partial: true,

--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -2,7 +2,7 @@ import type {LocationDescriptor} from 'history';
 import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import type {ApiResult, Client, ResponseMeta} from 'sentry/api';
+import type {ApiResult, Client} from 'sentry/api';
 import {canIncludePreviousPeriod} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import type {DateString} from 'sentry/types/core';
@@ -113,9 +113,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean>(
     useRpc,
   }: EventsStatsOptions<IncludeAllArgsType>
 ): IncludeAllArgsType extends true
-  ? Promise<
-      [EventsStats | MultiSeriesEventsStats, string | undefined, ResponseMeta | undefined]
-    >
+  ? Promise<ApiResult<EventsStats | MultiSeriesEventsStats>>
   : Promise<EventsStats | MultiSeriesEventsStats> => {
   const pathname =
     generatePathname?.(organization) ??

--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -61,7 +61,7 @@ type Options = {
   yAxis?: string | string[];
 };
 
-export type EventsStatsOptions<T extends boolean> = {includeAllArgs?: T} & Options;
+export type EventsStatsOptions<T extends boolean> = {includeAllArgs: T} & Options;
 
 /**
  * Make requests to `events-stats` endpoint
@@ -83,7 +83,7 @@ export type EventsStatsOptions<T extends boolean> = {includeAllArgs?: T} & Optio
  * @param {Record<string, string>} options.queryExtras A list of extra query parameters
  * @param {(org: OrganizationSummary) => string} options.generatePathname A function that returns an override for the pathname
  */
-export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
+export const doEventsRequest = <IncludeAllArgsType extends boolean>(
   api: Client,
   {
     organization,

--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -28,6 +28,7 @@ describe('EventsRequest', function () {
     query: '',
     children: () => null,
     partial: false,
+    includeAllArgs: false,
     includeTransformedData: true,
   };
 

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -104,7 +104,6 @@ type DefaultProps = {
    * e.g. 24h, 7d, 30d
    */
   period?: string | null;
-
   /**
    * Absolute start date for query
    */

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -334,7 +334,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
     } else {
       try {
         api.clear();
-        timeseriesData = await doEventsRequest(api, props);
+        timeseriesData = await doEventsRequest<false>(api, props);
       } catch (resp) {
         if (resp?.responseJSON?.detail) {
           errorMessage = resp.responseJSON.detail;

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -65,6 +65,7 @@ export type RenderProps = LoadingStatus &
   };
 
 type DefaultProps = {
+  includeAllArgs: false;
   /**
    * Include data for previous period
    */
@@ -103,6 +104,7 @@ type DefaultProps = {
    * e.g. 24h, 7d, 30d
    */
   period?: string | null;
+
   /**
    * Absolute start date for query
    */
@@ -277,6 +279,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
     comparisonDelta: undefined,
     limit: 15,
     query: '',
+    includeAllArgs: false,
     includePrevious: true,
     includeTransformedData: true,
   };

--- a/static/app/components/charts/onDemandMetricRequest.tsx
+++ b/static/app/components/charts/onDemandMetricRequest.tsx
@@ -7,7 +7,8 @@ import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organizatio
 export class OnDemandMetricRequest extends EventsRequest {
   fetchExtrapolatedData = async (): Promise<EventsStats> => {
     const {api, organization, ...props} = this.props;
-    const retVal = await doEventsRequest(api, {
+
+    const retVal = await doEventsRequest<false>(api, {
       ...props,
       organization,
       generatePathname: () =>

--- a/static/app/components/charts/onDemandMetricRequest.tsx
+++ b/static/app/components/charts/onDemandMetricRequest.tsx
@@ -7,7 +7,6 @@ import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organizatio
 export class OnDemandMetricRequest extends EventsRequest {
   fetchExtrapolatedData = async (): Promise<EventsStats> => {
     const {api, organization, ...props} = this.props;
-
     const retVal = await doEventsRequest<false>(api, {
       ...props,
       organization,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -571,6 +571,7 @@ class TriggersChart extends PureComponent<Props, State> {
     if (isOnDemandMetricAlert) {
       const {sampleRate} = this.state;
       const baseProps: EventsRequestProps = {
+        includeAllArgs: false,
         api,
         organization,
         query,

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -634,8 +634,9 @@ export async function doOnDemandMetricsRequest(
     const fetchEstimatedStats = () =>
       `/organizations/${requestData.organization.slug}/metrics-estimation-stats/`;
 
-    const response = await doEventsRequest<false>(api, {
+    const response = await doEventsRequest<true>(api, {
       ...requestData,
+      includeAllArgs: true,
       queryExtras: {
         ...requestData.queryExtras,
         useOnDemandMetrics: true,
@@ -645,21 +646,18 @@ export async function doOnDemandMetricsRequest(
       generatePathname: isEditing ? fetchEstimatedStats : undefined,
     });
 
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     response[0] = {...response[0]};
 
     if (
       hasDatasetSelector(requestData.organization) &&
       widgetType === WidgetType.DISCOVER
     ) {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      const meta = response[0].meta ?? {};
+      const meta: any = response[0].meta ?? {};
       meta.discoverSplitDecision = 'transaction-like';
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+
       response[0] = {...response[0], ...{meta}};
     }
 
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     return [response[0], response[1], response[2]];
   } catch (err) {
     Sentry.captureMessage('Failed to fetch metrics estimation stats', {extra: err});

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -654,7 +654,6 @@ export async function doOnDemandMetricsRequest(
     ) {
       const meta: any = response[0].meta ?? {};
       meta.discoverSplitDecision = 'transaction-like';
-
       response[0] = {...response[0], ...{meta}};
     }
 

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -472,6 +472,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           return (
             <EventsRequest
               {...pick(provided, eventsRequestQueryProps)}
+              includeAllArgs={false}
               yAxis={yAxis}
               limit={1}
               includePrevious={includePreviousParam}

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -47,6 +47,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
           {({queryBatching}) => (
             <EventsRequest
               {...pick(provided, eventsRequestQueryProps)}
+              includeAllArgs={false}
               limit={1}
               queryBatching={queryBatching}
               includePrevious

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -154,6 +154,7 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
           return (
             <EventsRequest
               {...pick(prunedProvided, eventsRequestQueryProps)}
+              includeAllArgs={false}
               limit={5}
               includePrevious={false}
               includeTransformedData

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -202,6 +202,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
           return (
             <EventsRequest
               {...requestProps}
+              includeAllArgs={false}
               limit={1}
               currentSeriesNames={[sortField!]}
               includePrevious={false}


### PR DESCRIPTION
`doEventsRequest()` previously allowed the prop `includeAllArgs` to be optional, and was typed based on whether that field was set to `true` or `false | undefined`.

Now the field is required, no longer optional.

I also made sure to be explicit about setting the generic, so TS doesn't have to infer it, in order to make all the callsites as explicit as possible. So you don't need to look at `props` or something to figure out what the return type will be. 

The async test stuff seemed to improve some flakeyness I was seeing too.