### PR TITLE
fix(superuser): Being superuser:read even if you're org owner results in fewer permissions

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -1039,6 +1039,8 @@ def from_request(
         superuser_scopes = get_superuser_scopes(auth_state, request.user, organization)
         if scopes:
             superuser_scopes = superuser_scopes.union(set(scopes))
+        if member and (member_scopes := member.get_scopes()):
+            superuser_scopes = superuser_scopes.union(set(member_scopes))
 
         return OrganizationGlobalAccess(
             organization=organization,

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -901,6 +901,10 @@ def from_request_org_and_scopes(
     rpc_user_org_context: RpcUserOrganizationContext | None = None,
     scopes: Iterable[str] | None = None,
 ) -> Access:
+    """
+    Note that `scopes` is usually None because request.auth is not set at `get_authorization_header`
+    when the request is made from the frontend using cookies
+    """
     is_superuser = is_active_superuser(request)
     is_staff = is_active_staff(request)
 
@@ -929,6 +933,8 @@ def from_request_org_and_scopes(
         superuser_scopes = get_superuser_scopes(auth_state, request.user, rpc_user_org_context)
         if scopes:
             superuser_scopes = superuser_scopes.union(set(scopes))
+        if member and member.scopes:
+            superuser_scopes = superuser_scopes.union(set(member.scopes))
 
         return ApiBackedOrganizationGlobalAccess(
             rpc_user_organization_context=rpc_user_org_context,

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -587,7 +587,8 @@ class FromRequestTest(AccessFactoryTestCase):
         # superuser in organization
         member = self.create_member(user=self.superuser, organization=self.org, role="member")
 
-        # get current silo
+        # If superuser is a member of the organization, it should have both
+        # the member scopes and the superuser scopes
         result = self.from_request(request, self.org)
         assert result.scopes == set(member.get_scopes()).union(SUPERUSER_READONLY_SCOPES)
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -587,15 +587,16 @@ class FromRequestTest(AccessFactoryTestCase):
         # superuser in organization
         member = self.create_member(user=self.superuser, organization=self.org, role="member")
 
+        # get current silo
         result = self.from_request(request, self.org)
-        assert result.scopes == SUPERUSER_READONLY_SCOPES
+        assert result.scopes == set(member.get_scopes()).union(SUPERUSER_READONLY_SCOPES)
 
         # readonly scopes does not override owner scopes if passed in
         with assume_test_silo_mode(SiloMode.REGION):
             member.update(role="owner")
 
         result = self.from_request(request, self.org, scopes=member.get_scopes())
-        assert result.scopes == set(member.get_scopes()).union({"org:superuser"})
+        assert result.scopes == set(member.get_scopes()).union(SUPERUSER_READONLY_SCOPES)
 
     @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)


### PR DESCRIPTION
If you're in superuser mode with only `superuser.read` permissions, and you're browsing a Sentry organization where you're the owner, you'll find that you have fewer permissions than expected.


### Before
![Screenshot 2025-03-23 at 4 50 25 PM](https://github.com/user-attachments/assets/a4046a4e-aaa9-43ee-98d4-b16acb55abc5)


### After
![Screenshot 2025-03-23 at 4 49 41 PM](https://github.com/user-attachments/assets/c859b0db-623f-405c-91d8-85969ea5ff1c)
