### PR TITLE
ref(grouping): Import `Event` as type in strategy modules

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any, Generic, Protocol, Self, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Protocol, Self, TypeVar, overload
 
 from sentry import projectoptions
-from sentry.eventstore.models import Event
 from sentry.grouping.component import (
     BaseGroupingComponent,
     ExceptionGroupingComponent,
@@ -16,6 +15,10 @@ from sentry.grouping.enhancer import Enhancements
 from sentry.interfaces.base import Interface
 from sentry.interfaces.exception import SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+
 
 STRATEGIES: dict[str, Strategy[Any]] = {}
 

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import posixpath
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from sentry.eventstore.models import Event
 from sentry.grouping.component import (
     ChainedExceptionGroupingComponent,
     ContextLineGroupingComponent,
@@ -29,6 +30,10 @@ from sentry.interfaces.exception import Exception as ChainedException
 from sentry.interfaces.exception import SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace
 from sentry.interfaces.threads import Threads
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+
 
 _ruby_anon_func = re.compile(r"_\d{2,}")
 _filename_version_re = re.compile(

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from itertools import islice
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sentry import analytics
-from sentry.eventstore.models import Event
 from sentry.grouping.component import MessageGroupingComponent
 from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.base import (
@@ -14,6 +15,9 @@ from sentry.grouping.strategies.base import (
 from sentry.interfaces.message import Message
 from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
 
 
 @metrics.wraps("grouping.normalize_message_for_grouping")

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -5,9 +5,8 @@ import logging
 import re
 from collections import Counter
 from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from sentry.eventstore.models import Event
 from sentry.grouping.component import (
     ChainedExceptionGroupingComponent,
     ContextLineGroupingComponent,
@@ -36,6 +35,10 @@ from sentry.interfaces.exception import Mechanism, SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace
 from sentry.interfaces.threads import Threads
 from sentry.stacktraces.platform import get_behavior_family_for_platform
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -1,6 +1,7 @@
-from typing import Any
+from __future__ import annotations
 
-from sentry.eventstore.models import Event
+from typing import TYPE_CHECKING, Any
+
 from sentry.grouping.component import (
     CSPGroupingComponent,
     ExpectCTGroupingComponent,
@@ -18,6 +19,9 @@ from sentry.grouping.strategies.base import (
     strategy,
 )
 from sentry.interfaces.security import Csp, ExpectCT, ExpectStaple, Hpkp
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
 
 
 @strategy(ids=["expect-ct:v1"], interface=ExpectCT, score=1000)

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -1,6 +1,7 @@
-from typing import Any
+from __future__ import annotations
 
-from sentry.eventstore.models import Event
+from typing import TYPE_CHECKING, Any
+
 from sentry.grouping.component import (
     ContextLineGroupingComponent,
     FilenameGroupingComponent,
@@ -13,6 +14,9 @@ from sentry.grouping.strategies.base import (
     strategy,
 )
 from sentry.interfaces.template import Template
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
 
 
 @strategy(ids=["template:v1"], interface=Template, score=1100)


### PR DESCRIPTION
This switches the import of the `Event` class in the grouping strategy modules to a type-only import, in order to prevent a circular dependency in an upcoming PR.