### PR TITLE
fix(issues): Replace 'Internal Error' message on Postgres query timeout errors

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -9,8 +9,10 @@ from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any, Literal, overload
 
+import psycopg2.errorcodes
 import sentry_sdk
 from django.conf import settings
+from django.db.utils import OperationalError
 from django.http import HttpRequest
 from django.utils import timezone
 from rest_framework.exceptions import APIException, ParseError, Throttled
@@ -423,6 +425,15 @@ def handle_query_errors() -> Generator[None]:
         else:
             sentry_sdk.capture_exception(error)
         raise APIException(detail=message)
+    except OperationalError as error:
+        if hasattr(error, "pgcode") and error.pgcode == psycopg2.errorcodes.QUERY_CANCELED:
+            if options.get("api.postgres-query-timeout-error-handling.enabled"):
+                sentry_sdk.set_tag("query.error_reason", "Postgres statement timeout")
+                raise Throttled(
+                    detail="Query timeout. Please try with a smaller date range or fewer conditions."
+                )
+        # Let other OperationalErrors propagate as normal
+        raise
 
 
 def update_snuba_params_with_timestamp(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2773,6 +2773,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch for Postgres query timeout error handling
+register(
+    "api.postgres-query-timeout-error-handling.enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # TODO: remove once removed from options
 register(
     "issue_platform.use_kafka_partition_key",


### PR DESCRIPTION
Handle Postgres statement timeout errors on issue search which previously displayed 'Internal Error' but will now show more appropriate message explaining the query took too long and to possibly revise it

Closes: #80166
