### PR TITLE
ref: Remove compatibility shim from sources schema

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -79,8 +79,6 @@ COMMON_SOURCE_PROPERTIES = {
     "name": {"type": "string"},
     "layout": LAYOUT_SCHEMA,
     "filters": FILTERS_SCHEMA,
-    # FIXME: This is temporarily included for backwards compatibility.
-    "filetypes": {"type": "array", "items": {"type": "string", "enum": list(VALID_FILE_TYPES)}},
     "is_public": {"type": "boolean"},
 }
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1216,8 +1216,6 @@ class ProjectUpdateTest(APITestCase):
                 "type": "native",
             },
             "filters": {"filetypes": ["pe"]},
-            # FIXME: This is temporarily included for backwards compatibility.
-            "filetypes": ["pe"],
             "type": "http",
             "url": "http://honk.beep",
             "username": "honkhonk",
@@ -1231,8 +1229,6 @@ class ProjectUpdateTest(APITestCase):
                 "type": "native",
             },
             "filters": {"filetypes": ["pe"]},
-            # FIXME: This is temporarily included for backwards compatibility.
-            "filetypes": ["pe"],
             "type": "http",
             "url": "http://honk.beep",
             "username": "honkhonk",


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/87267.

We temporarily left an incorrect part of the symbol source schema in place while we migrated some user source configs. That migration is now done, so we can remove the shim.