### PR TITLE
fix: Fix loading state for "Event Grouping Information" in new issue UI

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -10,7 +10,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import GroupingConfigSelect from './groupingConfigSelect';
 import GroupingVariant from './groupingVariant';
@@ -53,7 +52,6 @@ export default function GroupingInfo({
   group,
 }: GroupingSummaryProps) {
   const [configOverride, setConfigOverride] = useState<string | null>(null);
-  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping} =
     useEventGroupingInfo({
@@ -79,7 +77,7 @@ export default function GroupingInfo({
 
   return (
     <Fragment>
-      {hasStreamlinedUI && (
+      {(isSuccess || hasPerformanceGrouping) && (
         <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
       )}
       <ConfigHeader>

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import GroupingConfigSelect from './groupingConfigSelect';
 import GroupingVariant from './groupingVariant';
@@ -52,6 +53,7 @@ export default function GroupingInfo({
   group,
 }: GroupingSummaryProps) {
   const [configOverride, setConfigOverride] = useState<string | null>(null);
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping} =
     useEventGroupingInfo({
@@ -77,7 +79,7 @@ export default function GroupingInfo({
 
   return (
     <Fragment>
-      {(isSuccess || hasPerformanceGrouping) && (
+      {hasStreamlinedUI && (isSuccess || hasPerformanceGrouping) && (
         <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
       )}
       <ConfigHeader>


### PR DESCRIPTION
This PR fixes the loading state for the "Event Grouping Information" section of the new issue UI.
Previously, it would show "Grouped by: nothing" while data is being fetched, until this is replaced by something new.

With this change, we only show this once fetching has finished. I also removed a check that is no longer needed (for the streamlined issue UI), as as far as I can tell we only ever show use this component when this is enabled anyhow?