### PR TITLE
settings: fix chonk icon color

### DIFF
--- a/static/app/components/emptyMessage.tsx
+++ b/static/app/components/emptyMessage.tsx
@@ -54,7 +54,7 @@ const EmptyMessage = styled(
 `;
 
 const IconWrapper = styled('div')`
-  color: ${p => p.theme.gray200};
+  color: ${p => (p.theme.isChonk ? p.theme.gray300 : p.theme.gray200)};
   margin-bottom: ${space(1)};
 `;
 

--- a/static/app/components/emptyMessage.tsx
+++ b/static/app/components/emptyMessage.tsx
@@ -54,7 +54,7 @@ const EmptyMessage = styled(
 `;
 
 const IconWrapper = styled('div')`
-  color: ${p => (p.theme.isChonk ? p.theme.gray300 : p.theme.gray200)};
+  color: ${p => (p.theme.isChonk ? p.theme.gray400 : p.theme.gray200)};
   margin-bottom: ${space(1)};
 `;
 


### PR DESCRIPTION
gray200 on light background is nearly invisible

Before
![CleanShot 2025-03-24 at 09 17 28@2x](https://github.com/user-attachments/assets/7063535d-f1dd-4c7b-b265-432baf927a75)

After
![CleanShot 2025-03-24 at 09 17 12@2x](https://github.com/user-attachments/assets/2fd75a2e-902a-4d95-b310-885e6f655e2c)
