### PR TITLE
feat(vercel-integration): Log if we would set a null auth token via Vercel integration

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import ValidationError
+import sentry_sdk
 
 from sentry import options
 from sentry.constants import ObjectStatus
@@ -280,6 +281,10 @@ class VercelIntegration(IntegrationInstallation):
             )
 
             for env_var, details in env_var_map.items():
+                # We are logging a message because we potentially have a weird bug where auth tokens disappear from vercel
+                if env_var == "SENTRY_AUTH_TOKEN" and details["value"] is None:
+                    sentry_sdk.capture_message("Setting SENTRY_AUTH_TOKEN env var with None value in Vercel integration")
+
                 self.create_env_var(
                     vercel_client,
                     vercel_project_id,

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -5,9 +5,9 @@ from collections.abc import Mapping
 from typing import Any, TypedDict
 from urllib.parse import urlencode
 
+import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import ValidationError
-import sentry_sdk
 
 from sentry import options
 from sentry.constants import ObjectStatus
@@ -283,7 +283,9 @@ class VercelIntegration(IntegrationInstallation):
             for env_var, details in env_var_map.items():
                 # We are logging a message because we potentially have a weird bug where auth tokens disappear from vercel
                 if env_var == "SENTRY_AUTH_TOKEN" and details["value"] is None:
-                    sentry_sdk.capture_message("Setting SENTRY_AUTH_TOKEN env var with None value in Vercel integration")
+                    sentry_sdk.capture_message(
+                        "Setting SENTRY_AUTH_TOKEN env var with None value in Vercel integration"
+                    )
 
                 self.create_env_var(
                     vercel_client,


### PR DESCRIPTION
We seem to have a weird bug where env vars disappears.