### PR TITLE
chore: Bump sentry-sdk to 2.24.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.63
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.7
-sentry-sdk[http2]>=2.23.1
+sentry-sdk[http2]>=2.24.1
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -192,7 +192,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.63
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.23.1
+sentry-sdk==2.24.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.63
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.23.1
+sentry-sdk==2.24.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
This version includes a fix regarding Spotlight which should fix some errors during development of Sentry when Spotlight server was not running and Spotlight was not explicitly disabled.
