### PR TITLE
ref(onboarding): use Django's update_or_create ORM method

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -433,11 +433,11 @@ def record_member_invited(member, user, **kwargs):
 
 @member_joined.connect(weak=False)
 def record_member_joined(organization_id: int, organization_member_id: int, **kwargs):
-    OrganizationOnboardingTask.objects.create_or_update(
+    OrganizationOnboardingTask.objects.update_or_create(
         organization_id=organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         status=OnboardingTaskStatus.PENDING,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "date_completed": django_timezone.now(),
             "data": {"invited_member_id": organization_member_id},
@@ -590,10 +590,10 @@ def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
     # Please see https://github.com/getsentry/sentry/blob/c06a3aa5fb104406f2a44994d32983e99bc2a479/static/app/components/onboardingWizard/taskConfig.tsx#L351-L352
     if rule_type == "metric":
         return
-    OrganizationOnboardingTask.objects.create_or_update(
+    OrganizationOnboardingTask.objects.update_or_create(
         organization_id=project.organization_id,
         task=OnboardingTask.ALERT_RULE,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "user_id": user.id if user else None,
             "project_id": project.id,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -97,10 +97,10 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
         ),
     )
 
-    _, created = OrganizationOnboardingTask.objects.create_or_update(
+    _, created = OrganizationOnboardingTask.objects.update_or_create(
         organization_id=project.organization_id,
         task=OnboardingTask.FIRST_PROJECT,
-        values={
+        defaults={
             "user_id": user_id,
             "status": OnboardingTaskStatus.COMPLETE,
             "project_id": project.id,
@@ -119,10 +119,10 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
                 level="warning",
             )
 
-        OrganizationOnboardingTask.objects.create_or_update(
+        OrganizationOnboardingTask.objects.update_or_create(
             organization_id=project.organization_id,
             task=OnboardingTask.SECOND_PLATFORM,
-            values={
+            defaults={
                 "user_id": user_id,
                 "status": OnboardingTaskStatus.COMPLETE,
                 "project_id": project.id,


### PR DESCRIPTION
Current implementation of `create_or_update` was done over 13y ago by us before Django even had a support for it.

This is a small step forward in getting rid of the old custom code and using the Django's ORM methods instead of custom ones.

This will also reduce number of rollbacks we are currently doing in the database, since our custom method is doing optimistic writes

**NOTE**: in onboarding receivers there is still one method remaining that uses `create_or_update` (`record_first_event`). It will be tackled as a part of a separate PR to make the review easier, and it requires slightly bigger refactor