### PR TITLE
fix(schema-hints): Adjust drawer width + add overflow tooltip

### DIFF
--- a/static/app/views/explore/components/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHintsDrawer.tsx
@@ -5,6 +5,7 @@ import {Tag as Badge} from 'sentry/components/core/badge/tag';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -124,7 +125,9 @@ function SchemaHintsDrawer({hints}: SchemaHintsDrawerProps) {
           onChange={() => handleCheckboxChange(hint)}
         >
           <CheckboxLabelContainer>
-            <CheckboxLabel>{prettifyTagKey(hint.key)}</CheckboxLabel>
+            <Tooltip title={prettifyTagKey(hint.key)} showOnlyOnOverflow skipWrapper>
+              <CheckboxLabel>{prettifyTagKey(hint.key)}</CheckboxLabel>
+            </Tooltip>
             <Badge>{hintType}</Badge>
           </CheckboxLabelContainer>
         </StyledMultipleCheckboxItem>

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -32,7 +32,7 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
-export const SCHEMA_HINTS_DRAWER_WIDTH = '35vw';
+export const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
 
 interface SchemaHintsListProps {
   numberTags: TagCollection;


### PR DESCRIPTION
Got some feedback from Dora to [narrow the drawer](https://www.notion.so/sentry/Narrow-the-flyout-1bc8b10e4b5d802f850fdd4cbeb84132?pvs=4) and [show a tooltip on hover](https://www.notion.so/sentry/Add-tooltip-to-show-full-tag-on-hover-for-long-tags-1bc8b10e4b5d8052ad7efeddf9778c8e?pvs=4) for attributes with ellipses. I've set a fixed width to the drawer now. Here's what the improvements look like:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/274c57a3-a029-44b5-8328-1ef470f3297b) | ![image](https://github.com/user-attachments/assets/f3999c9f-da05-4ec7-80fa-890312ed9768) |
| ![image](https://github.com/user-attachments/assets/4c40e320-06d3-4bfc-ae7c-cdd1738ced6b) | ![image](https://github.com/user-attachments/assets/ebedaba5-8ac8-47c9-9fb7-057b17e4b90c) | 
