### PR TITLE
chore(exceptions/sentry apps): Set exception level to info

### DIFF
--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -66,7 +66,7 @@ class SentryAppSentryError(SentryAppBaseError):
     status_code = 500
 
     def to_public_dict(self) -> SentryAppPublicErrorBody:
-        error_id = sentry_sdk.capture_exception(self)
+        error_id = sentry_sdk.capture_exception(self, level="info")
         return {
             "detail": f"An issue occured during the integration platform process. Sentry error ID: {error_id}"
         }

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -163,6 +163,7 @@ def retry(
             except ignore:
                 return
             except ignore_and_capture:
+                Scope.set_level("info")
                 capture_exception()
                 return
             except exclude:

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, TypeVar
 
-import sentry_sdk
 from celery import current_task
 from django.conf import settings
 from django.db.models import Model
@@ -164,8 +163,7 @@ def retry(
             except ignore:
                 return
             except ignore_and_capture:
-                sentry_sdk.set_level("info")
-                capture_exception()
+                capture_exception(level="info")
                 return
             except exclude:
                 raise

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, TypeVar
 
+import sentry_sdk
 from celery import current_task
 from django.conf import settings
 from django.db.models import Model
@@ -163,7 +164,7 @@ def retry(
             except ignore:
                 return
             except ignore_and_capture:
-                Scope.set_level("info")
+                sentry_sdk.set_level("info")
                 capture_exception()
                 return
             except exclude:


### PR DESCRIPTION
Since for sentry app SLOs we're resurfacing a lot of old errors for debugging purposes and since we don't want to keep pausing the pipeline, an option to avoid the mess is to capture/send our exceptions at the info level.

Pluses:
* Events at info level aren't acknowledged by our deploy pipeline 

Minuses:
* For sentry apps basically all errors that are labeled our fault will be at info level. (I think this is fine for now as we collect info to debug, we will need to remove this info `flag` in the future when we expect actual 'unexpected' errors)

