### PR TITLE
chore(taskworker): Bump taskworker rebalance after

### DIFF
--- a/src/sentry/taskworker/constants.py
+++ b/src/sentry/taskworker/constants.py
@@ -4,7 +4,7 @@ The fallback/default processing_deadline that tasks
 will use if neither the TaskNamespace or Task define a deadline
 """
 
-DEFAULT_REBALANCE_AFTER = 2048
+DEFAULT_REBALANCE_AFTER = 4096
 """
 The number of tasks a worker will process before it
 selects a new broker instance.


### PR DESCRIPTION
Selecting a new taskbroker instance every 2048 will probably be too quick. On average, taskworker can complete (fetch -> completion) a task in 80ms. That means taskworker will roll the dice every ~2.5 minutes. We should bump this up (to ~5 min) to avoid over-shuffling.  