### PR TITLE
ref(onboarding): use djangos update_or_create ORM method pt2

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -61,10 +61,10 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
         cache_key = f"organizationonboardingtask:{organization_id}:{task}"
 
         if cache.get(cache_key) is None:
-            _, created = self.create_or_update(
+            _, created = self.update_or_create(
                 organization_id=organization_id,
                 task=task,
-                values=kwargs,
+                defaults=kwargs,
             )
 
             # Store marker to prevent running all the time


### PR DESCRIPTION
`record` method is often called in onboarding tasks and causes a lot of unnecessary rollbacks and load on our system.

Continuation of https://github.com/getsentry/sentry/pull/87835