### PR TITLE
chore(integrations): move some installation failures to halts

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -367,7 +367,7 @@ class OAuth2CallbackView(PipelineView):
 
             if error:
                 logger.info("identity.token-exchange-error", extra={"error": error})
-                lifecycle.record_failure(
+                lifecycle.record_halt(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
                 return pipeline.error(f"{ERR_INVALID_STATE}\nError: {error}")
@@ -382,12 +382,15 @@ class OAuth2CallbackView(PipelineView):
                         "code": code,
                     },
                 )
-                lifecycle.record_failure(
+                lifecycle.record_halt(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
                 return pipeline.error(ERR_INVALID_STATE)
 
             if code is None:
+                lifecycle.record_halt(
+                    "no_code_provided", extra={"failure_info": "no_code_provided"}
+                )
                 return pipeline.error("no code was provided")
 
         # separate lifecycle event inside exchange_token

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -274,6 +274,20 @@ class IntegrationPipelineViewType(StrEnum):
     ACCOUNT_CONFIG = "account_config"
 
 
+class IntegrationPipelineErrorReason(StrEnum):
+    # OAuth identity
+    TOKEN_EXCHANGE_ERROR = "token_exchange_error"
+    TOKEN_EXCHANGE_MISMATCHED_STATE = "token_exchange_mismatched_state"
+
+
+class IntegrationPipelineHaltReason(StrEnum):
+    # OAuth identity
+    NO_CODE_PROVIDED = "no_code_provided"
+
+    # VSTS
+    NO_ACCOUNTS = "no_accounts"
+
+
 @dataclass
 class IntegrationPipelineViewEvent(IntegrationEventLifecycleMetric):
     """An instance to be recorded of a user going through an integration pipeline view (step)."""

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -688,7 +688,7 @@ class AccountConfigView(PipelineView):
                 "accounts": accounts,
             }
             if not accounts or not accounts.get("value"):
-                lifecycle.record_failure("no_accounts", extra=extra)
+                lifecycle.record_halt("no_accounts", extra=extra)
                 return render_to_response(
                     template="sentry/integrations/vsts-config.html",
                     context={"no_accounts": True},

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -34,6 +34,7 @@ from sentry.integrations.services.repository import RpcRepository, repository_se
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.metrics import (
+    IntegrationPipelineHaltReason,
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
@@ -688,7 +689,7 @@ class AccountConfigView(PipelineView):
                 "accounts": accounts,
             }
             if not accounts or not accounts.get("value"):
-                lifecycle.record_halt("no_accounts", extra=extra)
+                lifecycle.record_halt(IntegrationPipelineHaltReason.NO_ACCOUNTS, extra=extra)
                 return render_to_response(
                     template="sentry/integrations/vsts-config.html",
                     context={"no_accounts": True},

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -17,7 +17,7 @@ from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
 from sentry.silo.base import SiloMode
-from sentry.testutils.asserts import assert_failure_metric
+from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity
@@ -186,7 +186,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert resp.status_code == 200, resp.content
         assert b"No accounts found" in resp.content
 
-        assert_failure_metric(mock_record, "no_accounts")
+        assert_halt_metric(mock_record, "no_accounts")
 
     @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
     def test_webhook_subscription_created_once(self, mock_get_scopes):


### PR DESCRIPTION
OAuth callback (failure for now, splitting the reason into 2. Feels like this should be halt but keeping for now)
- We should always be sending the `code` to the external provider. If they send back to us an `error`, it's (usually) because the user is missing permissions or something, not due to the `code` being bad
- if they send us back a mismatched `code`, then we can't proceed with installation which should be a halt, that's not on us

VSTS no accounts
- We send them to a page that says "No accounts found. Please check that you are an Azure DevOps account owner." We can't proceed with installation because we can't find any accounts, that is also not on us