### PR TITLE
ref(flags): fix analytic for setup sidebar

### DIFF
--- a/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
+++ b/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
@@ -17,14 +17,12 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 
 export default function FeatureFlagInlineCTA({projectId}: {projectId: string}) {
   const organization = useOrganization();
-  const {activateSidebar} = useFeatureFlagOnboarding();
+  const {activateSidebar} = useFeatureFlagOnboarding({
+    analyticsSurface: 'issue_details.flags_section',
+  });
 
   function handleSetupButtonClick(e: any) {
     trackAnalytics('flags.setup_modal_opened', {organization});
-    trackAnalytics('flags.setup_sidebar_opened', {
-      organization,
-      surface: 'issue_details.flags_section',
-    });
     activateSidebar(e);
   }
 

--- a/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
+++ b/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
@@ -21,7 +21,10 @@ export default function FeatureFlagInlineCTA({projectId}: {projectId: string}) {
 
   function handleSetupButtonClick(e: any) {
     trackAnalytics('flags.setup_modal_opened', {organization});
-    trackAnalytics('flags.cta_setup_button_clicked', {organization});
+    trackAnalytics('flags.setup_sidebar_opened', {
+      organization,
+      surface: 'issue_details.flags_section',
+    });
     activateSidebar(e);
   }
 

--- a/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
+++ b/static/app/components/events/featureFlags/featureFlagInlineCTA.tsx
@@ -21,11 +21,6 @@ export default function FeatureFlagInlineCTA({projectId}: {projectId: string}) {
     analyticsSurface: 'issue_details.flags_section',
   });
 
-  function handleSetupButtonClick(e: any) {
-    trackAnalytics('flags.setup_modal_opened', {organization});
-    activateSidebar(e);
-  }
-
   const {isLoading, isError, isPromptDismissed, dismissPrompt, snoozePrompt} = usePrompt({
     feature: 'issue_feature_flags_inline_onboarding',
     organization,
@@ -83,7 +78,7 @@ export default function FeatureFlagInlineCTA({projectId}: {projectId: string}) {
             )}
           </BannerDescription>
           <ActionButton>
-            <Button onClick={handleSetupButtonClick} priority="primary">
+            <Button onClick={activateSidebar} priority="primary">
               {t('Set Up Now')}
             </Button>
             <LinkButton

--- a/static/app/components/events/featureFlags/useFeatureFlagOnboarding.tsx
+++ b/static/app/components/events/featureFlags/useFeatureFlagOnboarding.tsx
@@ -8,7 +8,16 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 const FLAG_HASH = '#flag-sidequest';
 
-export function useFeatureFlagOnboarding() {
+export type FeatureFlagOnboardingSurface =
+  | 'issue_details.flags_section'
+  | 'issue_details.flags_drawer'
+  | 'org_settings';
+
+export function useFeatureFlagOnboarding({
+  analyticsSurface,
+}: {
+  analyticsSurface: FeatureFlagOnboardingSurface;
+}) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -17,9 +26,10 @@ export function useFeatureFlagOnboarding() {
       SidebarPanelStore.activatePanel(SidebarPanelKey.FEATURE_FLAG_ONBOARDING);
       trackAnalytics('flags.view-setup-sidebar', {
         organization,
+        surface: analyticsSurface,
       });
     }
-  }, [location.hash, organization]);
+  }, [location.hash, organization, analyticsSurface]);
 
   const activateSidebar = useCallback((event: React.MouseEvent) => {
     event.preventDefault();

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -1,3 +1,5 @@
+import type {FeatureFlagOnboardingSurface} from 'sentry/components/events/featureFlags/useFeatureFlagOnboarding';
+
 export type FeatureFlagEventParameters = {
   'flags.cta_dismissed': {type: string};
   'flags.cta_setup_button_clicked': Record<string, unknown>;
@@ -10,12 +12,6 @@ export type FeatureFlagEventParameters = {
     direction: 'next' | 'prev';
     surface: 'settings' | 'flag_drawer';
   };
-  'flags.setup_sidebar_opened': {
-    surface:
-      | 'issue_details.flags_section'
-      | 'issue_details.flags_drawer'
-      | 'org_settings';
-  };
   'flags.sort_flags': {sortMethod: string};
   'flags.table_rendered': {
     numFlags: number;
@@ -23,7 +19,9 @@ export type FeatureFlagEventParameters = {
     projectSlug: string;
   };
   'flags.view-all-clicked': Record<string, unknown>;
-  'flags.view-setup-sidebar': Record<string, unknown>;
+  'flags.view-setup-sidebar': {
+    surface: FeatureFlagOnboardingSurface;
+  };
 };
 
 export type FeatureFlagEventKey = keyof FeatureFlagEventParameters;
@@ -35,7 +33,6 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.table_rendered': 'Flag Table Rendered',
   'flags.cta_setup_button_clicked': 'Flag CTA Setup Button Clicked',
   'flags.cta_dismissed': 'Flag CTA Dismissed',
-  'flags.setup_sidebar_opened': 'Feature Flag Setup Sidebar Opened',
   'flags.logs-paginated': 'Feature Flag Logs Paginated',
   'flags.view-setup-sidebar': 'Viewed Feature Flag Onboarding Sidebar',
 };

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -10,6 +10,9 @@ export type FeatureFlagEventParameters = {
     direction: 'next' | 'prev';
     surface: 'settings' | 'flag_drawer';
   };
+  'flags.setup_sidebar_opened': {
+    surface: 'issue_details.flags_section' | 'issue_details.flags_drawer';
+  };
   'flags.sort_flags': {sortMethod: string};
   'flags.table_rendered': {
     numFlags: number;
@@ -29,6 +32,7 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.table_rendered': 'Flag Table Rendered',
   'flags.cta_setup_button_clicked': 'Flag CTA Setup Button Clicked',
   'flags.cta_dismissed': 'Flag CTA Dismissed',
+  'flags.setup_sidebar_opened': 'Feature Flag Setup Sidebar Opened',
   'flags.logs-paginated': 'Feature Flag Logs Paginated',
   'flags.view-setup-sidebar': 'Viewed Feature Flag Onboarding Sidebar',
 };

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -11,7 +11,10 @@ export type FeatureFlagEventParameters = {
     surface: 'settings' | 'flag_drawer';
   };
   'flags.setup_sidebar_opened': {
-    surface: 'issue_details.flags_section' | 'issue_details.flags_drawer';
+    surface:
+      | 'issue_details.flags_section'
+      | 'issue_details.flags_drawer'
+      | 'org_settings';
   };
   'flags.sort_flags': {sortMethod: string};
   'flags.table_rendered': {

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -2,7 +2,6 @@ import type {FeatureFlagOnboardingSurface} from 'sentry/components/events/featur
 
 export type FeatureFlagEventParameters = {
   'flags.cta_dismissed': {type: string};
-  'flags.cta_setup_button_clicked': Record<string, unknown>;
   'flags.event_and_suspect_flags_found': {
     numEventFlags: number;
     numSuspectFlags: number;
@@ -31,7 +30,6 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.sort_flags': 'Sorted Flags',
   'flags.event_and_suspect_flags_found': 'Number of Event and Suspect Flags',
   'flags.table_rendered': 'Flag Table Rendered',
-  'flags.cta_setup_button_clicked': 'Flag CTA Setup Button Clicked',
   'flags.cta_dismissed': 'Flag CTA Dismissed',
   'flags.logs-paginated': 'Feature Flag Logs Paginated',
   'flags.view-setup-sidebar': 'Viewed Feature Flag Onboarding Sidebar',

--- a/static/app/views/settings/featureFlags/index.tsx
+++ b/static/app/views/settings/featureFlags/index.tsx
@@ -10,14 +10,15 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 export default function OrganizationFeatureFlagsIndex() {
   const organization = useOrganization();
-  const {activateSidebar} = useFeatureFlagOnboarding();
+  const {activateSidebar} = useFeatureFlagOnboarding({
+    analyticsSurface: 'org_settings',
+  });
 
   return (
     <Fragment>
@@ -49,10 +50,6 @@ export default function OrganizationFeatureFlagsIndex() {
               aria-label={t('Set Up Evaluation Tracking')}
               onClick={mouseEvent => {
                 activateSidebar(mouseEvent);
-                trackAnalytics('flags.setup_sidebar_opened', {
-                  organization,
-                  surface: 'org_settings',
-                });
               }}
             >
               {t('Set Up Project')}

--- a/static/app/views/settings/featureFlags/index.tsx
+++ b/static/app/views/settings/featureFlags/index.tsx
@@ -10,6 +10,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -48,6 +49,10 @@ export default function OrganizationFeatureFlagsIndex() {
               aria-label={t('Set Up Evaluation Tracking')}
               onClick={mouseEvent => {
                 activateSidebar(mouseEvent);
+                trackAnalytics('flags.setup_sidebar_opened', {
+                  organization,
+                  surface: 'org_settings',
+                });
               }}
             >
               {t('Set Up Project')}


### PR DESCRIPTION
This analytic can be used to track when the sidebar is opened for flag SDK (eval tracking) setup instructions. We were using the wrong event name. Also adds a `analyticsSurface` prop to track this in other places like settings, or [flag drawer CTA](https://github.com/getsentry/sentry/pull/87354).

Also cleans up an event `cta_setup_button_clicked` that's redundant after the `surface` addition. Updating [dashboard here](https://app.amplitude.com/analytics/sentry/chart/nkrnlxcj?bulk=true&s.name=User+Properties&e.0.appId=209453&e.0.group_type=User&e.0.subprop_op=is+not&e.0.subprop_key=user_email&e.0.subprop_value.0=bruno.garcia%40sentry.io&e.0.subprop_value.1=ryan.albrecht%40sentry.io&e.0.subprop_value.2=michelle.zhang%40sentry.io&e.0.subprop_value.3=jasmin.kassas%40sentry.io&e.0.subprop_value.4=catherine.lee%40sentry.io&e.0.subprop_value.5=colton.allen%40sentry.io&e.0.subprop_value.6=andrew.liu%40sentry.io&e.0.subprop_value.7=billy.vong%40sentry.io&e.0.subprop_value.8=jesse.box%40sentry.io&e.0.subprop_type=event&e.0.functionality=FILTER&e.0.isPinned=true&e.0.id=288582&linkingDashboardId=ia38xeat)  

<img width="1234" alt="Screenshot 2025-03-24 at 10 08 11 AM" src="https://github.com/user-attachments/assets/1c18c413-983b-4aac-9135-ed74fa02ae66" />
