### PR TITLE
feat(eap-trace-waterfall): Auto expanding eap traces with low transaction count

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -14,7 +14,9 @@ import {
 import {EntryType, type EventTransaction} from 'sentry/types/event';
 import type {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {TraceView} from 'sentry/views/performance/newTraceDetails/index';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
+  makeEAPSpan,
   makeEventTransaction,
   makeSpan,
   makeTraceError,
@@ -120,6 +122,15 @@ function mockTraceMetaResponse(resp?: Partial<ResponseType>) {
 function mockTraceTagsResponse(resp?: Partial<ResponseType>) {
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/events-facets/',
+    method: 'GET',
+    asyncDelay: 1,
+    ...(resp ?? {body: []}),
+  });
+}
+
+function mockProjectsResponse(resp?: Partial<ResponseType>) {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/projects/',
     method: 'GET',
     asyncDelay: 1,
     ...(resp ?? {body: []}),
@@ -347,6 +358,45 @@ async function pageloadTestSetup() {
   // Awaits for the placeholder rendering rows to be removed
   try {
     await within(virtualizedContainer).findAllByText(/transaction-op-/i, undefined, {
+      timeout: 5000,
+    });
+  } catch (e) {
+    printVirtualizedList(virtualizedContainer);
+    throw e;
+  }
+  return {...value, virtualizedContainer, virtualizedScrollContainer};
+}
+
+async function eapTraceTestSetup(trace: TraceTree.EAPSpan[]) {
+  mockPerformanceSubscriptionDetailsResponse();
+  mockProjectsResponse();
+
+  MockApiClient.addMockResponse({
+    url: '/projects/org-slug//',
+    method: 'GET',
+    body: [],
+  });
+
+  mockTraceResponse({
+    body: trace,
+  });
+
+  mockTraceMetaResponse();
+  mockTraceRootFacets();
+  mockTraceRootEvent('eap-transaction-id-0');
+  mockTraceEventDetails();
+  mockEventsResponse();
+
+  const value = render(<TraceView />, {
+    router,
+    organization: {slug: 'org-slug', features: ['trace-view-new-ui']},
+  });
+  const virtualizedContainer = getVirtualizedContainer();
+  const virtualizedScrollContainer = getVirtualizedScrollContainer();
+
+  // Awaits for the placeholder rendering rows to be removed
+  try {
+    await within(virtualizedContainer).findAllByText(/eap-transaction-op-0/i, undefined, {
       timeout: 5000,
     });
   } catch (e) {
@@ -1199,6 +1249,91 @@ describe('trace view', () => {
         await waitFor(async () => {
           expect(await screen.findAllByText('No Instrumentation')).toHaveLength(2);
         });
+      });
+
+      // Auto expand transactions
+      it('auto expands eap-transactions if there are less than 3', async () => {
+        const {container} = await eapTraceTestSetup([
+          makeEAPSpan({
+            op: 'eap-transaction-op-0',
+            event_id: 'eap-transaction-id-0',
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'eap-span-id-0',
+                op: 'eap-span-op-0',
+              }),
+              makeEAPSpan({
+                event_id: 'eap-span-id-1',
+                op: 'eap-span-op-1',
+              }),
+            ],
+          }),
+          makeEAPSpan({
+            op: 'eap-transaction-op-1',
+            event_id: 'eap-transaction-id-1',
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'eap-span-id-2',
+                op: 'eap-span-op-2',
+              }),
+            ],
+          }),
+        ]);
+
+        // Awaits for the placeholder rendering rows to be removed
+        await within(container).findAllByText(/eap-transaction-op-0/i);
+
+        // Check that 6 rows are rendered.
+        // 1 trace root, 2 eap-transactions, 3 eap-spans
+        const rows = getVirtualizedRows(container);
+        expect(rows).toHaveLength(6);
+      });
+
+      // Auto expand transactions
+      it('does not auto expand eap-transactions if there are more than 2', async () => {
+        const {container} = await eapTraceTestSetup([
+          makeEAPSpan({
+            op: 'eap-transaction-op-0',
+            event_id: 'eap-transaction-id-0',
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'eap-span-id-0',
+                op: 'eap-span-op-0',
+              }),
+              makeEAPSpan({
+                event_id: 'eap-span-id-1',
+                op: 'eap-span-op-1',
+              }),
+            ],
+          }),
+          makeEAPSpan({
+            op: 'eap-transaction-op-1',
+            event_id: 'eap-transaction-id-1',
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'eap-span-id-2',
+                op: 'eap-span-op-2',
+              }),
+            ],
+          }),
+          makeEAPSpan({
+            op: 'eap-transaction-op-2',
+            event_id: 'eap-transaction-id-2',
+            is_transaction: true,
+          }),
+        ]);
+
+        // Awaits for the placeholder rendering rows to be removed
+        await within(container).findAllByText(/eap-transaction-op-0/i);
+
+        // Check that 4 rows are rendered.
+        // 1 trace root, 3 eap-transactions
+        const rows = getVirtualizedRows(container);
+        expect(rows).toHaveLength(4);
       });
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/generalInfo.tsx
@@ -108,7 +108,7 @@ export function GeneralInfo(props: GeneralInfoProps) {
     throw new Error('Expected a trace node');
   }
 
-  if (props.tree.eventsCount === 0) {
+  if (props.tree.transactions_count === 0) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
@@ -73,7 +73,7 @@ export function TraceDetails(props: TraceDetailsProps) {
           organization={organization}
           location={location}
           eventView={props.traceEventView}
-          totalValues={props.tree.eventsCount}
+          totalValues={props.tree.transactions_count}
         />
       </TraceDrawerComponents.SectionCardGroup>
     </Fragment>

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -261,7 +261,7 @@ function fetchTrace(
 }
 
 export class TraceTree extends TraceTreeEventDispatcher {
-  eventsCount = 0;
+  transactions_count = 0;
   projects = new Map<number, TraceTree.Project>();
 
   type: 'loading' | 'empty' | 'error' | 'trace' = 'trace';
@@ -274,7 +274,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
   indicators: TraceTree.Indicator[] = [];
 
   list: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
-  events: Map<string, EventTransaction> = new Map();
 
   private _spanPromises: Map<string, Promise<EventTransaction>> = new Map();
   static MISSING_INSTRUMENTATION_THRESHOLD_MS = 100;
@@ -319,7 +318,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
       parent: TraceTreeNode<TraceTree.NodeValue | null>,
       value: TraceTree.Transaction | TraceTree.TraceError | TraceTree.EAPSpan
     ) {
-      tree.eventsCount++;
       tree.projects.set(value.project_id, {
         slug: value.project_slug,
       });
@@ -327,7 +325,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
       let parentNode;
       if (isEAPTransaction(value)) {
         // For collapsed eap-transactions we still render the embedded eap-transactions as visible children.
-        // Mimics the behavior of non-eap traces, enabling a less noisy/summarized view of the trace.
+        // We parent the eap-transactions under the closest collapsed eap-transaction node. Mimics the behavior
+        // of non-eap traces, enabling a less noisy/summarized view of the trace.
         parentNode = TraceTree.ParentEAPTransaction(parent) ?? parent;
       } else {
         parentNode = parent;
@@ -338,6 +337,10 @@ export class TraceTree extends TraceTreeEventDispatcher {
         project_slug: value && 'project_slug' in value ? value.project_slug : undefined,
         event_id: value && 'event_id' in value ? value.event_id : undefined,
       });
+
+      if (isTransactionNode(node) || isEAPTransactionNode(node)) {
+        tree.transactions_count++;
+      }
 
       if (isTransactionNode(node)) {
         const spanChildrenCount =
@@ -1042,7 +1045,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     if (isEAPTransaction(node.value)) {
       if (!node.expanded) {
         // For collapsed eap-transactions we still render the embedded eap-transactions as visible children.
-        // Mimics the behavior of non-eap traces, enabling a less noisy/summarized view of the trace.
+        // Mimics the behavior of non-eap traces, enabling a less noisy/summarized view of the trace
         return node.children.filter(child => isEAPTransaction(child.value));
       }
 


### PR DESCRIPTION
For eap traces with less than 3 transactions, we auto-expand the otherwise collapsed nodes.   