### PR TITLE
feat(autofix): Allow autofix on issues without stacktrace

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -72,7 +72,7 @@ export function useGroupSummary(
   forceEvent = false
 ) {
   const organization = useOrganization();
-  const aiConfig = useAiConfig(group, event, project);
+  const aiConfig = useAiConfig(group, project);
   const enabled = aiConfig.hasSummary;
   const queryClient = useQueryClient();
   const queryKey = makeGroupSummaryQueryKey(
@@ -121,7 +121,7 @@ export function GroupSummary({
   const organization = useOrganization();
   const [forceEvent, setForceEvent] = useState(false);
   const openFeedbackForm = useFeedbackForm();
-  const aiConfig = useAiConfig(group, event, project);
+  const aiConfig = useAiConfig(group, project);
   const {data, isPending, isError, refresh} = useGroupSummary(
     group,
     event,

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -88,7 +88,7 @@ export default function GroupSidebar({
 
   const location = useLocation();
 
-  const {areAiFeaturesAllowed} = useAiConfig(group, event, project);
+  const {areAiFeaturesAllowed} = useAiConfig(group, project);
 
   const onAssign: OnAssignCallback = (type, _assignee, suggestedAssignee) => {
     const {alert_date, alert_rule_id, alert_type} = location.query;

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -1,5 +1,4 @@
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
-import {EntryType, type Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -7,37 +6,13 @@ import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
-// Autofix requires the event to have stack trace frames in order to work correctly.
-function hasStacktraceWithFrames(event: Event) {
-  for (const entry of event.entries) {
-    if (entry.type === EntryType.EXCEPTION) {
-      if (entry.data.values?.some(value => value.stacktrace?.frames?.length)) {
-        return true;
-      }
-    }
-
-    if (entry.type === EntryType.THREADS) {
-      if (entry.data.values?.some(thread => thread.stacktrace?.frames?.length)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-export const useAiConfig = (
-  group: Group,
-  event: Event | undefined | null,
-  project: Project
-) => {
+export const useAiConfig = (group: Group, project: Project) => {
   const organization = useOrganization();
   const {data: autofixSetupData, isPending: isAutofixSetupLoading} = useAutofixSetup({
     groupId: group.id,
   });
 
   const isSampleError = useIsSampleEvent();
-  const hasStacktrace = event && hasStacktraceWithFrames(event);
 
   const issueTypeConfig = getConfigForIssueType(group, project);
 
@@ -53,8 +28,7 @@ export const useAiConfig = (
   const hasGenAIConsent = autofixSetupData?.genAIConsent.ok ?? organization.genAIConsent;
 
   const hasSummary = hasGenAIConsent && isSummaryEnabled && areAiFeaturesAllowed;
-  const hasAutofix =
-    isAutofixEnabled && areAiFeaturesAllowed && hasStacktrace && !isSampleError;
+  const hasAutofix = isAutofixEnabled && areAiFeaturesAllowed && !isSampleError;
   const hasGithubIntegration = autofixSetupData?.integration.ok;
 
   const needsGenAIConsent =

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -128,7 +128,7 @@ const AiSetupDataConsent = HookOrDefault({
 
 export function SeerDrawer({group, project, event}: SeerDrawerProps) {
   const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
-  const aiConfig = useAiConfig(group, event, project);
+  const aiConfig = useAiConfig(group, project);
 
   useRouteAnalyticsParams({autofix_status: autofixData?.status ?? 'none'});
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -54,7 +54,7 @@ function SeerSectionContent({
   group: Group;
   project: Project;
 }) {
-  const aiConfig = useAiConfig(group, event, project);
+  const aiConfig = useAiConfig(group, project);
 
   if (!event) {
     return <Placeholder height="160px" />;
@@ -97,7 +97,7 @@ export default function SeerSection({
   // We don't use this on the streamlined UI, since the section folds.
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const aiConfig = useAiConfig(group, event, project);
+  const aiConfig = useAiConfig(group, project);
   const issueTypeConfig = getConfigForIssueType(group, project);
   const showCtaButton =
     aiConfig.needsGenAIConsent ||


### PR DESCRIPTION
Removes frontend gating for errors without stacktrace. Should go in after the backend PR is deployed.