### PR TITLE
feat(dashboards): Add title decorations to widget titles

### DIFF
--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -2,8 +2,8 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
@@ -32,7 +32,7 @@ export default storyBook('Widget', (story, APIReference) => {
         <SmallSizingWindow>
           <Widget
             Title={<Widget.WidgetTitle title="epm() : /insights/frontend/assets" />}
-            TitleDecorators={[<LoadingIndicator key="loading-indicator" mini relative />]}
+            TitleBadges={[<Tag key="frontend">frontend</Tag>]}
             Actions={
               <Widget.WidgetToolbar>
                 <Button size="xs">Say More</Button>
@@ -69,11 +69,11 @@ export default storyBook('Widget', (story, APIReference) => {
           left, and are always visible. The title is truncated to fit. The contents of the{' '}
           <code>Actions</code> prop are shown in the top right, and only shown on hover.
           You can set the <code>revealActions</code> prop to <code>"always"</code> to
-          always show the actions. Actions are not truncated. The{' '}
-          <code>TitleDecorators</code> prop is shown to the immediate right of the title,
-          and are always visible. The contents of <code>Visualization</code> are always
-          visible, shown below the title and actions. The layout expands both horizontally
-          and vertically to fit the parent.
+          always show the actions. Actions are not truncated. The <code>TitleBadges</code>{' '}
+          prop is shown to the immediate right of the title, and are always visible. The
+          contents of <code>Visualization</code> are always visible, shown below the title
+          and actions. The layout expands both horizontally and vertically to fit the
+          parent.
         </p>
 
         <p>
@@ -109,7 +109,7 @@ import {Widget} from './widget';
 
 <Widget
   Title={<Widget.WidgetTitle title="epm() : /insights/frontend/assets" />}
-  TitleDecorators={[<LoadingIndicator key="loading-indicator" mini relative />]}
+  TitleBadges={[<Tag key="frontend">frontend</Tag>]}
   Actions={
     <Widget.WidgetToolbar>
       <Button size="xs">Say More</Button>

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {Button} from 'sentry/components/core/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
@@ -31,6 +32,7 @@ export default storyBook('Widget', (story, APIReference) => {
         <SmallSizingWindow>
           <Widget
             Title={<Widget.WidgetTitle title="epm() : /insights/frontend/assets" />}
+            TitleDecorators={[<LoadingIndicator key="loading-indicator" mini relative />]}
             Actions={
               <Widget.WidgetToolbar>
                 <Button size="xs">Say More</Button>
@@ -67,9 +69,11 @@ export default storyBook('Widget', (story, APIReference) => {
           left, and are always visible. The title is truncated to fit. The contents of the{' '}
           <code>Actions</code> prop are shown in the top right, and only shown on hover.
           You can set the <code>revealActions</code> prop to <code>"always"</code> to
-          always show the actions. Actions are not truncated. The contents of{' '}
-          <code>Visualization</code> are always visible, shown below the title and
-          actions. The layout expands both horizontally and vertically to fit the parent.
+          always show the actions. Actions are not truncated. The{' '}
+          <code>TitleDecorators</code> prop is shown to the immediate right of the title,
+          and are always visible. The contents of <code>Visualization</code> are always
+          visible, shown below the title and actions. The layout expands both horizontally
+          and vertically to fit the parent.
         </p>
 
         <p>
@@ -105,6 +109,7 @@ import {Widget} from './widget';
 
 <Widget
   Title={<Widget.WidgetTitle title="epm() : /insights/frontend/assets" />}
+  TitleDecorators={[<LoadingIndicator key="loading-indicator" mini relative />]}
   Actions={
     <Widget.WidgetToolbar>
       <Button size="xs">Say More</Button>

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -28,7 +28,7 @@ export interface Widget {
   /**
    * Placed to the immediate right of the title
    */
-  TitleDecorators?: React.ReactNode;
+  TitleBadges?: React.ReactNode;
   /**
    * Placed in the main area of the frame
    */
@@ -72,9 +72,7 @@ function WidgetLayout(props: Widget) {
     >
       <Header noPadding={props.noHeaderPadding}>
         {props.Title && <Fragment>{props.Title}</Fragment>}
-        {props.TitleDecorators && (
-          <TitleDecorators>{props.TitleDecorators}</TitleDecorators>
-        )}
+        {props.TitleBadges && <TitleBadges>{props.TitleBadges}</TitleBadges>}
         {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
       </Header>
 
@@ -111,7 +109,7 @@ export {exported as Widget};
 
 const HEADER_HEIGHT = '26px';
 
-const TitleDecorators = styled('div')`
+const TitleBadges = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -26,6 +26,10 @@ export interface Widget {
    */
   Title?: React.ReactNode;
   /**
+   * Placed to the immediate right of the title
+   */
+  TitleDecorators?: React.ReactNode;
+  /**
    * Placed in the main area of the frame
    */
   Visualization?: React.ReactNode;
@@ -68,6 +72,9 @@ function WidgetLayout(props: Widget) {
     >
       <Header noPadding={props.noHeaderPadding}>
         {props.Title && <Fragment>{props.Title}</Fragment>}
+        {props.TitleDecorators && (
+          <TitleDecorators>{props.TitleDecorators}</TitleDecorators>
+        )}
         {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
       </Header>
 
@@ -103,6 +110,12 @@ const exported = Object.assign(WidgetLayout, {
 export {exported as Widget};
 
 const HEADER_HEIGHT = '26px';
+
+const TitleDecorators = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
 
 const TitleHoverItems = styled('div')`
   display: flex;


### PR DESCRIPTION
The intended use of this is to show a loading indicator in the header title for progressive loading UI. e.g.

<img width="774" alt="Screenshot 2025-03-24 at 1 35 54 PM" src="https://github.com/user-attachments/assets/b59c32eb-27ad-4868-8dec-463722fea6d4" />
