### PR TITLE
chore(issue-details): Update conditions for tag preview

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -270,6 +270,20 @@ export default function IssueTagsPreview({
     return uniqueTags.slice(0, 4);
   }, [tags, project?.platform, highlightTagKeys]);
 
+  if (
+    searchQuery ||
+    isScreenSmall ||
+    (!isPending && !isHighlightPending && tagsToPreview.length === 0)
+  ) {
+    return (
+      <IssueTagButton
+        tags={tagsToPreview}
+        searchQuery={searchQuery}
+        isScreenSmall={isScreenSmall}
+      />
+    );
+  }
+
   if (isPending || isHighlightPending) {
     return (
       <Fragment>
@@ -283,16 +297,6 @@ export default function IssueTagsPreview({
 
   if (isError) {
     return null;
-  }
-
-  if (tagsToPreview.length === 0 || searchQuery || isScreenSmall) {
-    return (
-      <IssueTagButton
-        tags={tagsToPreview}
-        searchQuery={searchQuery}
-        isScreenSmall={isScreenSmall}
-      />
-    );
   }
 
   return (


### PR DESCRIPTION
this pr updates the order of conditions for the tag preview in the streamlined issues page. previously, we would use the loading state for the tag preview when we knew we wouldn't show it (small screens, search query) which looked a little weird. now, if we know that we won't show the tag preview, we won't show the tag preview placeholder. 