### PR TITLE
flags(insights): add flags for insights frontend to eap

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -375,10 +375,12 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-addon-modules", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make insights modules restrict queries to 14 days
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Make Insights modules use EAP instead of metrics
+    # Make LLM monitoring module use eap instead of metrics
     manager.add("organizations:insights-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Wip flag for insights modules to use eap
-    manager.add("organizations:insights-use-eap-wip", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Make Insights modules (except llm) use EAP instead of metrics
+    manager.add("organizations:insights-modules-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Make insights overview module use EAP instead of metrics
+    manager.add("organizations:insights-overview-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Related Issues table in Insights modules

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -377,6 +377,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights modules use EAP instead of metrics
     manager.add("organizations:insights-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Wip flag for insights modules to use eap
+    manager.add("organizations:insights-use-eap-wip", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Related Issues table in Insights modules


### PR DESCRIPTION
1. Add flags for both the insights module and overview pages using eap, I separated these as the overview pages have a little more work involved and we can test/release them separately.
2. `organizations:insights-use-eap` only applies to LLM monitoring! I would reuse this flag for modules, but that flag is already released internally and the modules still need to be tested with eap first. I clarified that in the comment.
 
