### PR TITLE
feat(exception-content): Add hint for failed to fetch issues

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -304,4 +304,82 @@ describe('Exception Content', function () {
       expect(screen.getByRole('heading', {name: 'ValueError'})).toBeInTheDocument();
     });
   });
+
+  describe('failed to fetch exceptions', function () {
+    it('displays FailedToFetchHint when a failed to fetch exception is detected', function () {
+      const event = EventFixture({
+        entries: [
+          {
+            type: EntryType.EXCEPTION,
+            data: {
+              values: [
+                {
+                  type: 'TypeError',
+                  value: 'Failed to fetch',
+                  stacktrace: {
+                    frames: [EventStacktraceFrameFixture({platform: null})],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        projectID: project.id,
+      });
+
+      render(
+        <Content
+          type={StackType.ORIGINAL}
+          stackView={StackView.APP}
+          event={event}
+          values={event.entries[0]!.data.values}
+          projectSlug={project.slug}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          /This error might be caused by network connectivity issues, browser extensions, or CORS restrictions/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('does not display FailedToFetchHint for regular exceptions', function () {
+      const event = EventFixture({
+        entries: [
+          {
+            type: EntryType.EXCEPTION,
+            data: {
+              values: [
+                {
+                  type: 'TypeError',
+                  value: 'Some other error',
+                  stacktrace: {
+                    frames: [EventStacktraceFrameFixture({platform: null})],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        projectID: project.id,
+      });
+
+      render(
+        <Content
+          type={StackType.ORIGINAL}
+          stackView={StackView.APP}
+          event={event}
+          values={event.entries[0]!.data.values}
+          projectSlug={project.slug}
+        />
+      );
+
+      expect(
+        screen.queryByText(
+          /This error might be caused by network connectivity issues, browser extensions, or CORS restrictions/i
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -4,11 +4,15 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
+import {FailedToFetchHint} from 'sentry/components/events/interfaces/crashContent/exception/failedToFetchHint';
 import {
   prepareSourceMapDebuggerFrameInformation,
   useSourceMapDebuggerData,
 } from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
-import {renderLinksInText} from 'sentry/components/events/interfaces/crashContent/exception/utils';
+import {
+  isFailedToFetchException,
+  renderLinksInText,
+} from 'sentry/components/events/interfaces/crashContent/exception/utils';
 import {getStacktracePlatform} from 'sentry/components/events/interfaces/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -192,6 +196,11 @@ export function Content({
             exceptionValue
           )}
         </StyledPre>
+        {isFailedToFetchException(exc.type, exc.value) && (
+          <StyledHint>
+            <FailedToFetchHint />
+          </StyledHint>
+        )}
         <ToggleExceptionButton
           {...{collapsedExceptions, toggleException, values, exception: exc}}
         />
@@ -257,4 +266,8 @@ const Title = styled('h5')`
 const ShowRelatedExceptionsButton = styled(Button)`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const StyledHint = styled('div')`
+  margin-top: ${space(1)};
 `;

--- a/static/app/components/events/interfaces/crashContent/exception/failedToFetchHint.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/failedToFetchHint.tsx
@@ -1,0 +1,15 @@
+import {Alert} from 'sentry/components/core/alert';
+import Link from 'sentry/components/links/link';
+
+export function FailedToFetchHint() {
+  return (
+    <Alert type="info">
+      This error might be caused by network connectivity issues, browser extensions, or
+      CORS restrictions. Check out{' '}
+      <Link to="https://sentry.io/answers/failed-to-fetch-javascript/">
+        our troubleshooting article
+      </Link>{' '}
+      on how to resolve this issue.
+    </Alert>
+  );
+}

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -121,3 +121,15 @@ const IconPlacement = styled(IconOpen)`
   margin-left: 5px;
   vertical-align: center;
 `;
+
+const FAILED_TO_FETCH_VALUES = [
+  'Failed to fetch', // chromium
+  'Load failed', // webkit
+  'NetworkError when attempting to fetch resource.', // firefox
+];
+export const isFailedToFetchException = (excType: string, excValue: string): boolean => {
+  return (
+    excType === 'TypeError' &&
+    FAILED_TO_FETCH_VALUES.some(value => excValue.startsWith(value))
+  );
+};


### PR DESCRIPTION
Adds a hint for `Failed to fetch` issues (adapted to browser specifics):

<img width="1121" alt="Screenshot 2025-03-24 at 19 14 27" src="https://github.com/user-attachments/assets/392c14ed-0aad-440b-bfb6-97b743e0c344" />

closes https://github.com/getsentry/sentry/issues/87188