### PR TITLE
feat(releases): add new issues by release chart to mobile insights

### DIFF
--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -2,13 +2,13 @@ import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useReleaseNewIssues from 'sentry/views/insights/sessions/queries/useReleaseNewIssues';
 
-export default function ReleaseNewIssuesChart({type}: {type: 'issue' | 'feedback'}) {
-  const {series, isPending, error} = useReleaseNewIssues({type});
+export default function ReleaseNewIssuesChart() {
+  const {series, isPending, error} = useReleaseNewIssues();
 
   return (
     <InsightsLineChartWidget
-      title={type === 'issue' ? t('Issues per Release') : t('User Feedback per Release')}
-      description={t('New %s counts over time, grouped by release.', type)}
+      title={t('Issues per Release')}
+      description={t('New issue counts over time, grouped by release.')}
       series={series}
       isLoading={isPending}
       legendSelection={{

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -1,0 +1,21 @@
+import {t} from 'sentry/locale';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import useReleaseNewIssues from 'sentry/views/insights/sessions/queries/useReleaseNewIssues';
+
+export default function ReleaseNewIssuesChart() {
+  const {series, isPending, error} = useReleaseNewIssues();
+
+  return (
+    <InsightsLineChartWidget
+      title={t('Issues per Release')}
+      description={t('New issue counts over time, grouped by release.')}
+      series={series}
+      isLoading={isPending}
+      legendSelection={{
+        // disable the 'other' series by default since its large values can cause the other lines to be insignificant
+        ['other']: false,
+      }}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -7,8 +7,8 @@ export default function ReleaseNewIssuesChart({type}: {type: 'issue' | 'feedback
 
   return (
     <InsightsLineChartWidget
-      title={t('Issues per Release')}
-      description={t('New issue counts over time, grouped by release.')}
+      title={type === 'issue' ? t('Issues per Release') : t('User Feedback per Release')}
+      description={t('New %s counts over time, grouped by release.', type)}
       series={series}
       isLoading={isPending}
       legendSelection={{

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -13,7 +13,7 @@ export default function ReleaseNewIssuesChart() {
       isLoading={isPending}
       legendSelection={{
         // disable the 'other' series by default since its large values can cause the other lines to be insignificant
-        ['other']: false,
+        other: false,
       }}
       error={error}
     />

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -2,8 +2,8 @@ import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useReleaseNewIssues from 'sentry/views/insights/sessions/queries/useReleaseNewIssues';
 
-export default function ReleaseNewIssuesChart() {
-  const {series, isPending, error} = useReleaseNewIssues();
+export default function ReleaseNewIssuesChart({type}: {type: 'issue' | 'feedback'}) {
+  const {series, isPending, error} = useReleaseNewIssues({type});
 
   return (
     <InsightsLineChartWidget

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -7,7 +7,7 @@ export default function ReleaseNewIssuesChart() {
 
   return (
     <InsightsLineChartWidget
-      title={t('Issues per Release')}
+      title={t('New Issues by Release')}
       description={t('New issue counts over time, grouped by release.')}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
@@ -5,7 +5,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-export default function useReleaseNewIssues() {
+export default function useReleaseNewIssues({type}: {type: 'issue' | 'feedback'}) {
   const location = useLocation();
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -29,7 +29,7 @@ export default function useReleaseNewIssues() {
       {
         query: {
           ...locationQuery.query,
-          category: 'issue',
+          category: type,
           interval: getInterval(selection.datetime, 'issues-metrics'),
         },
       },

--- a/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
@@ -5,7 +5,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-export default function useReleaseNewIssues({type}: {type: 'issue' | 'feedback'}) {
+export default function useReleaseNewIssues() {
   const location = useLocation();
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -29,7 +29,7 @@ export default function useReleaseNewIssues({type}: {type: 'issue' | 'feedback'}
       {
         query: {
           ...locationQuery.query,
-          category: type,
+          category: 'issue',
           interval: getInterval(selection.datetime, 'issues-metrics'),
         },
       },

--- a/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
@@ -1,0 +1,75 @@
+import {getInterval} from 'sentry/components/charts/utils';
+import type {IssuesMetricsApiResponse} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+export default function useReleaseNewIssues() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const locationQuery = {
+    ...location,
+    query: {
+      ...location.query,
+      width: undefined,
+      cursor: undefined,
+    },
+  };
+
+  const {
+    data: issueData,
+    isPending,
+    error,
+  } = useApiQuery<IssuesMetricsApiResponse>(
+    [
+      `/organizations/${organization.slug}/issues-metrics/`,
+      {
+        query: {
+          ...locationQuery.query,
+          category: 'issue',
+          interval: getInterval(selection.datetime, 'issues-metrics'),
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  if (isPending || !issueData) {
+    return {
+      series: [],
+      isPending,
+      error,
+    };
+  }
+
+  const createSeries = (timeseriesData: (typeof issueData.timeseries)[0]) => {
+    const releaseName = timeseriesData.groupBy[0] || 'unknown';
+    return {
+      data: timeseriesData.values.map(v => ({
+        name: new Date(v.timestamp * 1000).toISOString(),
+        value: v.value,
+      })),
+      seriesName: releaseName,
+      meta: {
+        fields: {
+          [releaseName]: 'integer' as const,
+          time: 'date' as const,
+        },
+        units: {},
+        order: timeseriesData.meta.order,
+        isOther: timeseriesData.meta.isOther,
+      },
+    };
+  };
+
+  return {
+    series: issueData.timeseries
+      .filter(t => t.axis === 'new_issues_count_by_release')
+      .map(createSeries),
+    isPending,
+    error,
+  };
+}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -133,7 +133,7 @@ function ViewSpecificCharts({
             <NewAndResolvedIssueChart type="issue" />
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ReleaseNewIssuesChart type="issue" />
+            <ReleaseNewIssuesChart />
           </ModuleLayout.Third>
 
           <ModuleLayout.Third>
@@ -156,14 +156,11 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
-          {/* only show these charts if the project has user feedback set up */}
+          {/* only show this chart if the project has user feedback set up */}
           {hasSetupOneFeedback && (
             <Fragment>
               <ModuleLayout.Third>
                 <NewAndResolvedIssueChart type="feedback" />
-              </ModuleLayout.Third>
-              <ModuleLayout.Third>
-                <ReleaseNewIssuesChart type="feedback" />
               </ModuleLayout.Third>
             </Fragment>
           )}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -133,7 +133,7 @@ function ViewSpecificCharts({
             <NewAndResolvedIssueChart type="issue" />
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ReleaseNewIssuesChart />
+            <ReleaseNewIssuesChart type="issue" />
           </ModuleLayout.Third>
 
           <ModuleLayout.Third>
@@ -156,11 +156,14 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
-          {/* only show this chart if the project has user feedback set up */}
+          {/* only show these charts if the project has user feedback set up */}
           {hasSetupOneFeedback && (
             <Fragment>
               <ModuleLayout.Third>
                 <NewAndResolvedIssueChart type="feedback" />
+              </ModuleLayout.Third>
+              <ModuleLayout.Third>
+                <ReleaseNewIssuesChart type="feedback" />
               </ModuleLayout.Third>
             </Fragment>
           )}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import useHaveSelectedProjectsSetupFeedback from 'sentry/components/feedback/useFeedbackOnboarding';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -20,6 +21,7 @@ import {
 import CrashFreeSessionsChart from 'sentry/views/insights/sessions/charts/crashFreeSessionsChart';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
 import NewAndResolvedIssueChart from 'sentry/views/insights/sessions/charts/newAndResolvedIssueChart';
+import ReleaseNewIssuesChart from 'sentry/views/insights/sessions/charts/releaseNewIssuesChart';
 import ReleaseSessionCountChart from 'sentry/views/insights/sessions/charts/releaseSessionCountChart';
 import ReleaseSessionPercentageChart from 'sentry/views/insights/sessions/charts/releaseSessionPercentageChart';
 import SessionHealthCountChart from 'sentry/views/insights/sessions/charts/sessionHealthCountChart';
@@ -90,6 +92,8 @@ function ViewSpecificCharts({
   setFilters: (filter: string[]) => void;
   view: DomainView | '';
 }) {
+  const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
+
   switch (view) {
     case FRONTEND_LANDING_SUB_PATH:
       return (
@@ -128,7 +132,9 @@ function ViewSpecificCharts({
           <ModuleLayout.Third>
             <NewAndResolvedIssueChart type="issue" />
           </ModuleLayout.Third>
-          <ModuleLayout.Third>Coming soon: New issues per release</ModuleLayout.Third>
+          <ModuleLayout.Third>
+            <ReleaseNewIssuesChart />
+          </ModuleLayout.Third>
 
           <ModuleLayout.Third>
             <ReleaseSessionCountChart />
@@ -150,9 +156,14 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
-          <ModuleLayout.Third>
-            <NewAndResolvedIssueChart type="feedback" />
-          </ModuleLayout.Third>
+          {/* only show this chart if the project has user feedback set up */}
+          {hasSetupOneFeedback && (
+            <Fragment>
+              <ModuleLayout.Third>
+                <NewAndResolvedIssueChart type="feedback" />
+              </ModuleLayout.Third>
+            </Fragment>
+          )}
 
           <ModuleLayout.Full>
             <FilterWrapper>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/84864

### new issues per release chart on mobile insights:

<img width="1168" alt="SCR-20250324-kdmw" src="https://github.com/user-attachments/assets/0c1fe8b8-bbdd-440a-a319-dc80ec5ff80b" />

### "other" series is disabled by default since it was causing the other lines to render insignificant due to its large values


https://github.com/user-attachments/assets/544528f0-3f47-41b9-ab27-27bd9f508e9e



### placement on mobile insights tab:

![SCR-20250324-kxya 12 13 10 PM](https://github.com/user-attachments/assets/5040e6b7-b0b4-492e-8150-d62602b5bd13)
