### PR TITLE
chore: Cleanup user-feedback-trace-section FE

### DIFF
--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -56,10 +56,15 @@ export default function TraceDataSection({
     traceEvents.length,
   ]);
 
-  return organization.features.includes('user-feedback-trace-section') &&
-    !isError &&
-    traceEvents.length > 1 &&
-    !eventIsCrashReportDup(oneOtherIssueEvent, crashReportId) ? (
+  if (
+    isError ||
+    traceEvents.length <= 1 ||
+    eventIsCrashReportDup(oneOtherIssueEvent, crashReportId)
+  ) {
+    return null;
+  }
+
+  return (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />
@@ -67,7 +72,7 @@ export default function TraceDataSection({
         <IssuesTraceDataSection event={eventData} />
       )}
     </Section>
-  ) : null;
+  );
 }
 
 function eventIsCrashReportDup(


### PR DESCRIPTION
This flag is enabled for everyone (see https://github.com/getsentry/sentry-options-automator/pull/3379/files and note that `rollout:100` is set in all conditions)

So we'll remove the flag

Followups:
- https://github.com/getsentry/sentry/pull/87756
- https://github.com/getsentry/sentry-options-automator/pull/3379