### PR TITLE
chore: Cleanup session-replay-timeline-gap feature BE

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -336,8 +336,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:session-replay-issue-emails", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Disable select orgs from ingesting mobile replay events.
     manager.add("organizations:session-replay-video-disabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable replay player timeline gaps
-    manager.add("organizations:session-replay-timeline-gap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable linking from 'new issue' slack notifs to the issue replay list


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/87759

Followups:
- https://github.com/getsentry/sentry-options-automator/pull/3382