### PR TITLE
ref(issue-views): Send -1 in projects if isAllProjects is true

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -55,7 +55,6 @@ class GroupSearchViewSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
         if self.has_global_views is False:
             is_all_projects = False
-
             projects = list(obj.projects.values_list("id", flat=True))
             num_projects = len(projects)
             if num_projects != 1:
@@ -63,7 +62,9 @@ class GroupSearchViewSerializer(Serializer):
 
         else:
             is_all_projects = obj.is_all_projects
-            projects = list(obj.projects.values_list("id", flat=True))
+            projects = (
+                [-1] if obj.is_all_projects else list(obj.projects.values_list("id", flat=True))
+            )
 
         return {
             "id": str(obj.id),

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -173,7 +173,11 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                             "name": view.name,
                             "query": view.query,
                             "querySort": view.query_sort,
-                            "projects": list(view.projects.values_list("id", flat=True)),
+                            "projects": (
+                                [-1]
+                                if view.is_all_projects
+                                else list(view.projects.values_list("id", flat=True))
+                            ),
                             "isAllProjects": view.is_all_projects,
                             "environments": view.environments,
                             "timeFilters": view.time_filters,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -630,7 +630,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         view["projects"] = [-1]
         response = self.get_success_response(self.organization.slug, views=views)
         assert len(response.data) == 3
-        assert response.data[0]["projects"] == []
+        assert response.data[0]["projects"] == [-1]
         assert response.data[0]["isAllProjects"] is True
 
     @with_feature({"organizations:issue-stream-custom-views": True})
@@ -898,7 +898,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[1]["isAllProjects"] is False
 
         assert response.data[2]["timeFilters"] == {"period": "30d"}
-        assert response.data[2]["projects"] == []
+        assert response.data[2]["projects"] == [-1]
         assert response.data[2]["environments"] == ["development"]
         assert response.data[2]["isAllProjects"] is True
 


### PR DESCRIPTION
This PR makes a minor refactor — the views in the response of the `group-search-view` endpoints have been updated so that if the `isAllProjects` parameter is true, we send [-1] for the projects. This will allow the frontend to completely ignore isAllProjects param, thus moving the project normalization completely over to the backend. 

In the next PR, I will remove isAllProjects from the expected response type in the frontend. After that I'll remove it from the returned response on the backend. 