### PR TITLE
chore(fe): Convert `<TicketRuleModal />` to an FC

### DIFF
--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -1,13 +1,17 @@
-import type {PropsWithChildren, ReactElement} from 'react';
-import styled from '@emotion/styled';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import TicketRuleModal from 'sentry/components/externalIssues/ticketRuleModal';
-import {makeCloseButton} from 'sentry/components/globalModal/components';
+import {
+  makeClosableHeader,
+  makeCloseButton,
+  ModalBody,
+  ModalFooter,
+} from 'sentry/components/globalModal/components';
 import type {IssueAlertRuleAction} from 'sentry/types/alerts';
 import type {IssueConfigField} from 'sentry/types/integrations';
 
@@ -15,65 +19,61 @@ jest.unmock('sentry/utils/recreateRoute');
 jest.mock('sentry/actionCreators/indicator');
 jest.mock('sentry/actionCreators/onboardingTasks');
 
+const defaultIssueConfig = [
+  {
+    name: 'project',
+    label: 'Jira Project',
+    choices: [['10000', 'TEST']],
+    default: '10000',
+    type: 'select',
+    updatesForm: true,
+  },
+  {
+    name: 'issuetype',
+    label: 'Issue Type',
+    default: '10001',
+    type: 'select',
+    choices: [
+      ['10001', 'Improvement'],
+      ['10002', 'Task'],
+      ['10003', 'Sub-task'],
+      ['10004', 'New Feature'],
+      ['10005', 'Bug'],
+      ['10000', 'Epic'],
+    ],
+    updatesForm: true,
+    required: true,
+  },
+];
+
 describe('ProjectAlerts -> TicketRuleModal', function () {
+  const organization = OrganizationFixture();
+  const router = RouterFixture();
+  const onSubmitAction = jest.fn();
   const closeModal = jest.fn();
-  const modalElements = {
-    Header: (p: PropsWithChildren) => p.children as ReactElement,
-    Body: (p: PropsWithChildren) => p.children,
-    Footer: (p: PropsWithChildren) => p.children,
-  };
 
   afterEach(function () {
     closeModal.mockReset();
     MockApiClient.clearMockResponses();
   });
 
-  const doSubmit = async () =>
-    await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
-
   const submitSuccess = async () => {
-    await doSubmit();
+    await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
     expect(addSuccessMessage).toHaveBeenCalled();
     expect(closeModal).toHaveBeenCalled();
   };
 
   const addMockConfigsAPICall = (otherField = {}) => {
     return MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/1/?ignored=Sprint',
+      url: '/organizations/org-slug/integrations/1/',
       method: 'GET',
       body: {
-        createIssueConfig: [
-          {
-            name: 'project',
-            label: 'Jira Project',
-            choices: [['10000', 'TEST']],
-            default: '10000',
-            type: 'select',
-            updatesForm: true,
-          },
-          {
-            name: 'issuetype',
-            label: 'Issue Type',
-            default: '10001',
-            type: 'select',
-            choices: [
-              ['10001', 'Improvement'],
-              ['10002', 'Task'],
-              ['10003', 'Sub-task'],
-              ['10004', 'New Feature'],
-              ['10005', 'Bug'],
-              ['10000', 'Epic'],
-            ],
-            updatesForm: true,
-            required: true,
-          },
-          otherField,
-        ],
+        createIssueConfig: [...defaultIssueConfig, otherField],
       },
     });
   };
 
-  const renderComponent = (
+  const renderTicketRuleModal = async (
     props: Partial<IssueAlertRuleAction> = {},
     otherField: IssueConfigField = {
       label: 'Reporter',
@@ -83,32 +83,29 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       name: 'reporter',
     }
   ) => {
-    const {organization, router} = initializeOrg();
     addMockConfigsAPICall(otherField);
 
-    const body = styled((c: PropsWithChildren) => c.children);
-    return render(
+    const wrapper = render(
       <TicketRuleModal
-        {...modalElements}
-        CloseButton={makeCloseButton(() => {})}
+        Body={ModalBody}
+        Header={makeClosableHeader(closeModal)}
+        Footer={ModalFooter}
+        CloseButton={makeCloseButton(closeModal)}
         closeModal={closeModal}
-        Body={body()}
-        Footer={body()}
-        formFields={{}}
         link=""
         ticketType=""
         instance={{...props.data, integration: 1}}
-        index={0}
-        onSubmitAction={() => {}}
-        organization={organization}
+        onSubmitAction={onSubmitAction}
       />,
-      {router}
+      {router, organization}
     );
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
+    return wrapper;
   };
 
   describe('Create Rule', function () {
-    it('should render the Ticket Rule modal', function () {
-      renderComponent();
+    it('should render the Ticket Rule modal', async function () {
+      await renderTicketRuleModal();
 
       expect(screen.getByRole('button', {name: 'Apply Changes'})).toBeInTheDocument();
       expect(screen.getByRole('textbox', {name: 'Title'})).toBeInTheDocument();
@@ -116,14 +113,14 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     });
 
     it('should save the modal data when "Apply Changes" is clicked with valid data', async function () {
-      renderComponent();
+      await renderTicketRuleModal();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a');
       await submitSuccess();
     });
 
     it('submit button shall be disabled if form is incomplete', async function () {
-      // This doesn't test anything TicketRules specific but I'm leaving it here as an example.
-      renderComponent();
+      await renderTicketRuleModal();
+      await userEvent.click(screen.getByRole('textbox', {name: 'Reporter'}));
       expect(screen.getByRole('button', {name: 'Apply Changes'})).toBeDisabled();
       await userEvent.hover(screen.getByRole('button', {name: 'Apply Changes'}));
       expect(
@@ -132,7 +129,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     });
 
     it('should reload fields when an "updatesForm" field changes', async function () {
-      renderComponent();
+      await renderTicketRuleModal();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a');
 
       addMockConfigsAPICall({
@@ -145,12 +142,11 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
 
       await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
       await selectEvent.select(screen.getByRole('textbox', {name: 'Assignee'}), 'b');
-
       await submitSuccess();
     });
 
     it('should ignore error checking when default is empty array', async function () {
-      renderComponent(undefined, {
+      await renderTicketRuleModal(undefined, {
         label: 'Labels',
         required: false,
         choices: [['bug', `bug`]],
@@ -169,12 +165,12 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     });
 
     it('should persist single select values when the modal is reopened', async function () {
-      renderComponent({data: {reporter: 'a'}});
+      await renderTicketRuleModal({data: {reporter: 'a'}});
       await submitSuccess();
     });
 
     it('should persist multi select values when the modal is reopened', async function () {
-      renderComponent(
+      await renderTicketRuleModal(
         {data: {components: ['a', 'c']}},
         {
           name: 'components',
@@ -194,7 +190,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     });
 
     it('should not persist value when unavailable in new choices', async function () {
-      renderComponent({data: {reporter: 'a'}});
+      await renderTicketRuleModal({data: {reporter: 'a'}});
 
       addMockConfigsAPICall({
         label: 'Reporter',
@@ -222,14 +218,14 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         type: 'string',
         name: 'textField',
       };
-      renderComponent({data: {textField: 'foo'}}, textField);
+      await renderTicketRuleModal({data: {textField: 'foo'}}, textField);
 
       expect(screen.getByRole('textbox', {name: 'Text Field'})).toHaveValue('foo');
       await submitSuccess();
     });
 
     it('should get async options from URL', async function () {
-      renderComponent();
+      await renderTicketRuleModal();
       addMockConfigsAPICall({
         label: 'Assignee',
         required: true,

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -37,7 +37,7 @@ import {
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
-const IGNORED_FIELDS = ['Sprint'];
+export const IGNORED_FIELDS = ['Sprint'];
 
 interface TicketRuleModalProps extends ModalRenderProps {
   instance: IssueAlertRuleAction;
@@ -176,7 +176,7 @@ export default function TicketRuleModal({
           makeIntegrationIssueConfigTicketRuleQueryKey({
             orgSlug: organization.slug,
             integrationId: instance.integration,
-            query: {action, ...dynamicFieldValues},
+            query: initialConfigQuery,
           }),
           existingData => (data ? data : existingData)
         );
@@ -203,6 +203,7 @@ export default function TicketRuleModal({
     instance.integration,
     api,
     endpointString,
+    initialConfigQuery,
   ]);
 
   /**

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -1,59 +1,110 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import type DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import type {RequestOptions, ResponseMeta} from 'sentry/api';
 import type {ExternalIssueFormErrors} from 'sentry/components/externalIssues/abstractExternalIssueForm';
-import AbstractExternalIssueForm from 'sentry/components/externalIssues/abstractExternalIssueForm';
+import {ExternalForm} from 'sentry/components/externalIssues/externalForm';
+import {useAsyncOptionsCache} from 'sentry/components/externalIssues/useAsyncOptionsCache';
+import {
+  getConfigName,
+  getDynamicFields,
+  getFieldProps,
+  getOptions,
+  hasErrorInFields,
+  loadAsyncThenFetchAllFields,
+} from 'sentry/components/externalIssues/utils';
 import type {FormProps} from 'sentry/components/forms/form';
+import FormModel from 'sentry/components/forms/model';
+import type {FieldValue} from 'sentry/components/forms/types';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRuleAction} from 'sentry/types/alerts';
 import type {Choices} from 'sentry/types/core';
-import type {IssueConfigField} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
+import type {IntegrationIssueConfig, IssueConfigField} from 'sentry/types/integrations';
+import {defined} from 'sentry/utils';
+import {
+  type ApiQueryKey,
+  setApiQueryData,
+  useApiQuery,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 
 const IGNORED_FIELDS = ['Sprint'];
 
-type Props = {
-  // Comes from the in-code definition of a `TicketEventAction`.
-  formFields: {[key: string]: any};
-  index: number;
-  // The AlertRuleAction from DB.
+interface TicketRuleModalProps extends ModalRenderProps {
   instance: IssueAlertRuleAction;
   link: string | null;
   onSubmitAction: (
     data: {[key: string]: string},
     fetchedFieldOptionsCache: Record<string, Choices>
   ) => void;
-  organization: Organization;
   ticketType: string;
-} & AbstractExternalIssueForm['props'];
+}
 
-type State = {
-  issueConfigFieldsCache: IssueConfigField[];
-} & AbstractExternalIssueForm['state'];
+function makeIntegrationIssueConfigTicketRuleQueryKey({
+  orgSlug,
+  integrationId,
+  query = {},
+}: {
+  integrationId: string;
+  orgSlug: string;
+  query?: Record<string, string>;
+}): ApiQueryKey {
+  return [
+    `/organizations/${orgSlug}/integrations/${integrationId}/`,
+    {query: {ignored: IGNORED_FIELDS, ...query}},
+  ];
+}
 
-class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
-  getDefaultState(): State {
-    const {instance} = this.props;
-    const issueConfigFieldsCache = Object.values(instance?.dynamic_form_fields || {});
-    return {
-      ...super.getDefaultState(),
-      // fetchedFieldOptionsCache should contain async fields so we
-      // need to filter beforehand. Only async fields have a `url` property.
-      fetchedFieldOptionsCache: Object.fromEntries(
-        issueConfigFieldsCache
-          .filter(field => field.url)
-          .map(field => [field.name, field.choices as Choices])
-      ),
-      issueConfigFieldsCache,
-    };
-  }
+export default function TicketRuleModal({
+  instance,
+  link,
+  onSubmitAction,
+  ticketType,
+  closeModal,
+  Header,
+  Body,
+}: TicketRuleModalProps) {
+  const action = 'create';
+  const title = t('Issue Link Settings');
+  const [model] = useState(() => new FormModel());
+  const queryClient = useQueryClient();
+  const api = useApi({persistInFlight: true});
+  const organization = useOrganization();
 
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {instance} = this.props;
-    const query = (instance.dynamic_form_fields || [])
+  const [hasUpdatedCache, setHasUpdatedCache] = useState(false);
+  const [issueConfigFieldsCache, setIssueConfigFieldsCache] = useState<
+    IssueConfigField[]
+  >(() => {
+    return Object.values(instance?.dynamic_form_fields || {});
+  });
+
+  const initialOptionsCache = useMemo(() => {
+    return Object.fromEntries(
+      issueConfigFieldsCache
+        .filter(field => field.url)
+        .map(field => [field.name, field.choices as Choices])
+    );
+  }, [issueConfigFieldsCache]);
+
+  const {cache, updateCache} = useAsyncOptionsCache(initialOptionsCache);
+  const [isDynamicallyRefetching, setIsDynamicallyRefetching] = useState(false);
+
+  const endpointString = makeIntegrationIssueConfigTicketRuleQueryKey({
+    orgSlug: organization.slug,
+    integrationId: instance.integration,
+  })[0];
+
+  const initialConfigQuery = useMemo(() => {
+    return (instance.dynamic_form_fields || [])
       .filter(field => field.updatesForm)
       .filter(field => instance.hasOwnProperty(field.name))
       .reduce(
@@ -62,95 +113,167 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
           accumulator[name] = instance[name];
           return accumulator;
         },
-        {action: 'create'}
+        {action}
       );
+  }, [instance]);
 
-    return [['integrationDetails', this.getEndPointString(), {query}]];
-  }
+  const {
+    data: integrationDetails,
+    isPending,
+    isError,
+    error,
+  } = useApiQuery<IntegrationIssueConfig>(
+    makeIntegrationIssueConfigTicketRuleQueryKey({
+      orgSlug: organization.slug,
+      integrationId: instance.integration,
+      query: initialConfigQuery,
+    }),
+    {staleTime: Infinity, retry: false}
+  );
 
-  handleReceiveIntegrationDetails = (integrationDetails: any) => {
-    this.setState({
-      issueConfigFieldsCache: integrationDetails[this.getConfigName()],
-    });
-  };
+  // After the first fetch, update this config cache state
+  useEffect(() => {
+    if (isPending || !defined(integrationDetails) || hasUpdatedCache) {
+      return;
+    }
+    const newConfigCache = integrationDetails[getConfigName(action)];
+    if (newConfigCache) {
+      setIssueConfigFieldsCache(newConfigCache);
+      setHasUpdatedCache(true);
+    }
+  }, [isPending, integrationDetails, action, hasUpdatedCache]);
 
-  /**
-   * Get a list of formFields names with valid config data.
-   */
-  getValidAndSavableFieldNames = (): string[] => {
-    const {issueConfigFieldsCache} = this.state;
-    return (issueConfigFieldsCache || [])
+  const dynamicFieldValues = useMemo(() => {
+    return getDynamicFields({action, integrationDetails});
+  }, [action, integrationDetails]);
+
+  const validAndSavableFieldNames = useMemo(() => {
+    return issueConfigFieldsCache
       .filter(field => field.hasOwnProperty('name'))
       .map(field => field.name);
-  };
+  }, [issueConfigFieldsCache]);
 
-  getEndPointString(): string {
-    const {instance, organization} = this.props;
-    return `/organizations/${organization.slug}/integrations/${instance.integration}/?ignored=${IGNORED_FIELDS}`;
-  }
+  /**
+   * XXX: This function seems illegal but it's necessary.
+   * The `dynamicFieldValues` are derived from the intial config fetch, see `getDynamicFields`.
+   * It starts as an object, with keys of certain field names, and empty values.
+   * As the user updates the values, those dynamic fields require a refetch of the config, with what
+   * the user entered as a query param. Since we can't conditionally call hooks, we have to avoid
+   * `useApiQuery`, and instead manually call the api, and update the cache ourselves.
+   */
+  const refetchWithDynamicFields = useCallback(() => {
+    setIsDynamicallyRefetching(true);
+    const requestOptions: RequestOptions = {
+      method: 'GET',
+      query: {action, ...dynamicFieldValues},
+      success: (
+        data: IntegrationIssueConfig,
+        _textStatus: string | undefined,
+        _responseMeta: ResponseMeta | undefined
+      ) => {
+        setApiQueryData(
+          queryClient,
+          makeIntegrationIssueConfigTicketRuleQueryKey({
+            orgSlug: organization.slug,
+            integrationId: instance.integration,
+            query: {action, ...dynamicFieldValues},
+          }),
+          existingData => (data ? data : existingData)
+        );
+        setIsDynamicallyRefetching(false);
+      },
+      error: (err: any) => {
+        // This behavior comes from the DeprecatedAsyncComponent
+        if (err?.responseText) {
+          Sentry.addBreadcrumb({
+            message: err.responseText,
+            category: 'xhr',
+            level: 'error',
+          });
+        }
+        setIsDynamicallyRefetching(false);
+      },
+    };
+    return api.request(endpointString, requestOptions);
+  }, [
+    action,
+    dynamicFieldValues,
+    queryClient,
+    organization.slug,
+    instance.integration,
+    api,
+    endpointString,
+  ]);
 
   /**
    * Clean up the form data before saving it to state.
    */
-  cleanData = (data: {
-    [key: string]: string;
-  }): {
-    [key: string]: any;
-    integration?: string | number;
-  } => {
-    const {instance} = this.props;
-    const {issueConfigFieldsCache} = this.state;
-    const names: string[] = this.getValidAndSavableFieldNames();
-    const formData: {
-      [key: string]: any;
-      integration?: string | number;
-    } = {};
-    if (instance?.hasOwnProperty('integration')) {
-      formData.integration = instance.integration;
-    }
-    formData.dynamic_form_fields = issueConfigFieldsCache;
-    for (const [key, value] of Object.entries(data)) {
-      if (names.includes(key)) {
-        formData[key] = value;
+  const cleanData = useCallback(
+    (data: Record<string, string>) => {
+      const formData: {
+        [key: string]: any;
+        integration?: string | number;
+      } = {};
+      if (instance?.hasOwnProperty('integration')) {
+        formData.integration = instance.integration;
       }
-    }
-    return formData;
-  };
+      formData.dynamic_form_fields = issueConfigFieldsCache;
+      for (const [key, value] of Object.entries(data)) {
+        if (validAndSavableFieldNames.includes(key)) {
+          formData[key] = value;
+        }
+      }
+      return formData;
+    },
+    [validAndSavableFieldNames, issueConfigFieldsCache, instance]
+  );
 
-  onFormSubmit: FormProps['onSubmit'] = (data, _success, _error, e, model) => {
-    const {onSubmitAction, closeModal} = this.props;
-    const {fetchedFieldOptionsCache} = this.state;
+  const onFormSubmit = useCallback<Required<FormProps>['onSubmit']>(
+    (data, _success, _error, e, modelParam) => {
+      // This is a "fake form", so don't actually POST to an endpoint.
+      e.preventDefault();
+      e.stopPropagation();
 
-    // This is a "fake form", so don't actually POST to an endpoint.
-    e.preventDefault();
-    e.stopPropagation();
+      if (modelParam.validateForm()) {
+        onSubmitAction(cleanData(data), cache);
+        addSuccessMessage(t('Changes applied.'));
+        closeModal();
+      }
+    },
+    [cleanData, cache, onSubmitAction, closeModal]
+  );
 
-    if (model.validateForm()) {
-      onSubmitAction(this.cleanData(data), fetchedFieldOptionsCache);
-      addSuccessMessage(t('Changes applied.'));
-      closeModal();
-    }
-  };
+  const onFieldChange = useCallback(
+    (fieldName: string, _value: FieldValue) => {
+      if (dynamicFieldValues.hasOwnProperty(fieldName)) {
+        refetchWithDynamicFields();
+      }
+    },
+    [refetchWithDynamicFields, dynamicFieldValues]
+  );
 
-  getFormProps = (): FormProps => {
-    const {closeModal} = this.props;
-
-    return {
-      ...this.getDefaultFormProps(),
-      cancelLabel: t('Close'),
-      onCancel: closeModal,
-      onSubmit: this.onFormSubmit,
-      submitLabel: t('Apply Changes'),
-    };
-  };
+  const getTicketRuleFieldProps = useCallback(
+    (field: IssueConfigField) => {
+      return getFieldProps({
+        field,
+        loadOptions: (input: string) =>
+          getOptions({
+            field,
+            input,
+            dynamicFieldValues,
+            model,
+            successCallback: updateCache,
+          }),
+      });
+    },
+    [updateCache, dynamicFieldValues, model]
+  );
 
   /**
    * Set the initial data from the Rule, replace `title` and `description` with
    * disabled inputs, and use the cached dynamic choices.
    */
-  cleanFields = (): IssueConfigField[] => {
-    const {instance} = this.props;
-
+  const cleanFields: IssueConfigField[] = useMemo(() => {
     const fields: IssueConfigField[] = [
       {
         name: 'title',
@@ -168,7 +291,11 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       } as IssueConfigField,
     ];
 
-    const cleanedFields = this.loadAsyncThenFetchAllFields()
+    const cleanedFields = loadAsyncThenFetchAllFields({
+      configName: getConfigName(action),
+      integrationDetails: integrationDetails || null,
+      fetchedFieldOptionsCache: cache,
+    })
       // Don't overwrite the default values for title and description.
       .filter(field => !fields.map(f => f.name).includes(field.name))
       .map(field => {
@@ -200,11 +327,11 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         return field;
       });
     return [...fields, ...cleanedFields];
-  };
+  }, [instance, integrationDetails, cache]);
 
-  getErrors() {
+  const formErrors: ExternalIssueFormErrors = useMemo(() => {
     const errors: ExternalIssueFormErrors = {};
-    for (const field of this.cleanFields()) {
+    for (const field of cleanFields) {
       // If the field is a select and has a default value, make sure that the
       // default value exists in the choices. Skip check if the default is not
       // set, an empty string, or an empty array.
@@ -228,36 +355,71 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       }
     }
     return errors;
+  }, [cleanFields]);
+
+  const initialData = useMemo(() => {
+    return cleanFields.reduce<Record<string, FieldValue>>(
+      (accumulator, field: IssueConfigField) => {
+        accumulator[field.name] = field.default;
+        return accumulator;
+      },
+      {}
+    );
+  }, [cleanFields]);
+
+  const hasFormErrors = useMemo(() => {
+    return hasErrorInFields({fields: cleanFields});
+  }, [cleanFields]);
+
+  if (isPending) {
+    return <LoadingIndicator />;
   }
 
-  renderBodyText = () => {
-    // `ticketType` already includes indefinite article.
-    const {ticketType, link} = this.props;
-
-    let body: React.ReactNode;
-    if (link) {
-      body = tct(
-        'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs:stay in sync] with the new Sentry Issue.',
-        {
-          linkToDocs: <ExternalLink href={link} />,
-          ticketType,
-        }
-      );
-    } else {
-      body = tct(
-        'When this alert is triggered [ticketType] will be created with the following fields.',
-        {
-          ticketType,
-        }
-      );
-    }
-
-    return <BodyText>{body}</BodyText>;
-  };
-
-  render() {
-    return this.renderForm(this.cleanFields(), this.getErrors());
+  if (isError) {
+    const errorDetail = error?.responseJSON?.detail;
+    const errorMessage =
+      typeof errorDetail === 'string'
+        ? errorDetail
+        : t('An error occurred loading the issue form');
+    return <LoadingError message={errorMessage} />;
   }
+
+  return (
+    <ExternalForm
+      Header={Header}
+      Body={Body}
+      formFields={cleanFields}
+      errors={formErrors}
+      isLoading={isPending || isDynamicallyRefetching}
+      formProps={{
+        initialData,
+        footerClass: 'modal-footer',
+        onFieldChange,
+        submitDisabled: isPending || hasFormErrors,
+        model,
+        cancelLabel: t('Close'),
+        onCancel: closeModal,
+        onSubmit: onFormSubmit,
+        submitLabel: t('Apply Changes'),
+      }}
+      title={title}
+      navTabs={null}
+      bodyText={
+        <BodyText>
+          {link
+            ? tct(
+                'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs:stay in sync] with the new Sentry Issue.',
+                {linkToDocs: <ExternalLink href={link} />, ticketType}
+              )
+            : tct(
+                'When this alert is triggered [ticketType] will be created with the following fields.',
+                {ticketType}
+              )}
+        </BodyText>
+      }
+      getFieldProps={getTicketRuleFieldProps}
+    />
+  );
 }
 
 const BodyText = styled('div')`
@@ -268,5 +430,3 @@ const FieldErrorLabel = styled('label')`
   padding-bottom: ${space(2)};
   color: ${p => p.theme.errorText};
 `;
-
-export default TicketRuleModal;

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -37,7 +37,7 @@ import {
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export const IGNORED_FIELDS = ['Sprint'];
+const IGNORED_FIELDS = ['Sprint'];
 
 interface TicketRuleModalProps extends ModalRenderProps {
   instance: IssueAlertRuleAction;

--- a/static/app/components/externalIssues/useAsyncOptionsCache.tsx
+++ b/static/app/components/externalIssues/useAsyncOptionsCache.tsx
@@ -7,8 +7,10 @@ import type {IssueConfigField} from 'sentry/types/integrations';
  * Manages state cache of options fetched for async fields.
  * This is used to avoid fetching the same options multiple times.
  */
-export function useAsyncOptionsCache() {
-  const [asyncOptions, setAsyncOptions] = useState<Record<string, Choices>>({});
+export function useAsyncOptionsCache(initialCache?: Record<string, Choices>) {
+  const [asyncOptions, setAsyncOptions] = useState<Record<string, Choices>>(
+    initialCache || {}
+  );
 
   const updateCache = useCallback(
     ({

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -378,13 +378,10 @@ function RuleNode({
             openModal(deps => (
               <TicketRuleModal
                 {...deps}
-                formFields={node.formFields || {}}
                 link={node.link}
                 ticketType={node.ticketType}
                 instance={data}
-                index={index}
                 onSubmitAction={updateParentFromTicketRule}
-                organization={organization}
               />
             ))
           }


### PR DESCRIPTION
Very similar to https://github.com/getsentry/sentry/pull/87293

This will allow us to delete the abstractExternalIssueForm.