### PR TITLE
chore(issue-details): Update suspect commit padding 

### DIFF
--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -92,7 +92,7 @@ function CommitRow({
         <span>
           {customAvatar ? customAvatar : <UserAvatar size={16} user={commit.author} />}
         </span>
-        <Meta>
+        <Meta hasStreamlinedUI>
           <Tooltip
             title={tct(
               'The email [actorEmail] is not a member of your organization. [inviteUser:Invite] them or link additional emails in [accountSettings:account settings].',
@@ -317,7 +317,7 @@ const Meta = styled(TextOverflow)<{hasStreamlinedUI?: boolean}>`
 const StreamlinedCommitRow = styled('div')`
   display: flex;
   flex-direction: column;
-  padding: ${space(0.5)} ${space(1.5)} ${space(1.5)};
+  padding: 0 ${space(1.5)} ${space(1.5)};
 `;
 
 const MetaWrapper = styled('div')`
@@ -326,6 +326,7 @@ const MetaWrapper = styled('div')`
   gap: ${space(0.5)};
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
+  padding-top: ${space(0.25)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)`


### PR DESCRIPTION
before: 
<img width="1105" alt="Screenshot 2025-03-24 at 11 55 29 AM" src="https://github.com/user-attachments/assets/37f7fc74-da33-4d3a-b435-3bd1be56c644" />

after:
<img width="1104" alt="Screenshot 2025-03-24 at 11 55 50 AM" src="https://github.com/user-attachments/assets/a48da4ed-1d0c-45fa-9728-d72832279dcc" />
