### PR TITLE
feat(ourlogs): Add analytics for logs explorer page

### DIFF
--- a/static/app/components/events/breadcrumbs/combinedBreadcrumbsAndLogsSection.tsx
+++ b/static/app/components/events/breadcrumbs/combinedBreadcrumbsAndLogsSection.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import type {BreadcrumbsDataSectionProps} from 'sentry/components/events/breadcrumbs/breadcrumbsDataSection';
 import BreadcrumbsDataSection from 'sentry/components/events/breadcrumbs/breadcrumbsDataSection';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsIssuesSection} from 'sentry/views/explore/logs/logsIssuesSection';
@@ -26,6 +27,7 @@ export function CombinedBreadcrumbsAndLogsSection({
     <LogsPageParamsProvider
       isOnEmbeddedView
       limitToTraceId={event.contexts?.trace?.trace_id}
+      analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
     >
       <CombinedBreadcrumbsAndLogsSectionContent
         event={event}

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -11,6 +11,10 @@ import {
   featureFlagEventMap,
   type FeatureFlagEventParameters,
 } from 'sentry/utils/analytics/featureFlagAnalyticsEvents';
+import {
+  logsAnalyticsEventMap,
+  type LogsAnalyticsEventParameters,
+} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {navigationAnalyticsEventMap} from 'sentry/utils/analytics/navigationAnalyticsEvents';
 import {
   quickStartEventMap,
@@ -97,6 +101,7 @@ interface EventParameters
     IntegrationEventParameters,
     ProjectCreationEventParameters,
     SignupAnalyticsParameters,
+    LogsAnalyticsEventParameters,
     TracingEventParameters,
     StatsEventParameters,
     QuickStartEventParameters,
@@ -117,6 +122,7 @@ const allEventMap: Record<string, string | null> = {
   ...performanceEventMap,
   ...tracingEventMap,
   ...profilingEventMap,
+  ...logsAnalyticsEventMap,
   ...releasesEventMap,
   ...replayEventMap,
   ...searchEventMap,

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -1,0 +1,31 @@
+export enum LogsAnalyticsPageSource {
+  EXPLORE_LOGS = 'explore',
+  ISSUE_DETAILS = 'issue details',
+  TRACE_DETAILS = 'trace details',
+}
+
+export type LogsAnalyticsEventParameters = {
+  'logs.explorer.metadata': {
+    columns: string[];
+    columns_count: number;
+    dataset: string;
+    has_exceeded_performance_usage_limit: boolean | null;
+    page_source: LogsAnalyticsPageSource;
+    query_status: 'success' | 'error' | 'pending';
+    table_result_length: number;
+    table_result_missing_root: number;
+    user_queries: string;
+    user_queries_count: number;
+  };
+  'logs.table.row_expanded': {
+    log_id: string;
+    page_source: LogsAnalyticsPageSource;
+  };
+};
+
+export type LogsAnalyticsEventKey = keyof LogsAnalyticsEventParameters;
+
+export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null> = {
+  'logs.explorer.metadata': 'Log Explorer Pageload Metadata',
+  'logs.table.row_expanded': 'Expanded Log Row Details',
+};

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -3,6 +3,7 @@ import type {Location} from 'history';
 
 import type {CursorHandler} from 'sentry/components/pagination';
 import {defined} from 'sentry/utils';
+import type {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {decodeProjects} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
@@ -26,6 +27,7 @@ const LOGS_CURSOR_KEY = 'logsCursor';
 export const LOGS_FIELDS_KEY = 'logsFields';
 
 interface LogsPageParams {
+  readonly analyticsPageSource: LogsAnalyticsPageSource;
   readonly cursor: string;
   readonly fields: string[];
   readonly isTableEditingFrozen: boolean | undefined;
@@ -50,6 +52,7 @@ const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
   });
 
 export interface LogsPageParamsProviderProps {
+  analyticsPageSource: LogsAnalyticsPageSource;
   children: React.ReactNode;
   isOnEmbeddedView?: boolean;
   limitToTraceId?: string;
@@ -59,6 +62,7 @@ export function LogsPageParamsProvider({
   children,
   limitToTraceId,
   isOnEmbeddedView,
+  analyticsPageSource,
 }: LogsPageParamsProviderProps) {
   const location = useLocation();
   const logsQuery = decodeLogsQuery(location);
@@ -89,6 +93,7 @@ export function LogsPageParamsProvider({
         isTableEditingFrozen,
         baseSearch,
         projectIds,
+        analyticsPageSource,
       }}
     >
       {children}
@@ -253,6 +258,11 @@ export function useSetLogsSortBys() {
     },
     [setPageParams, currentPageSortBys]
   );
+}
+
+export function useLogsAnalyticsPageSource() {
+  const {analyticsPageSource} = useLogsPageParams();
+  return analyticsPageSource;
 }
 
 function getLogCursorFromLocation(location: Location): string {

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -3,11 +3,16 @@ import * as Sentry from '@sentry/react';
 
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {
+  useLogsFields,
+  useLogsSearch,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {
   useExploreDataset,
   useExploreFields,
@@ -19,12 +24,28 @@ import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/vi
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
+import type {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
 import type {ReadableExploreQueryParts} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {usePerformanceSubscriptionDetails} from 'sentry/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails';
 
 const {info, fmt} = Sentry._experiment_log;
+
+interface UseTrackAnalyticsProps {
+  aggregatesTableResult: AggregatesTableResult;
+  dataset: DiscoverDatasets;
+  fields: string[];
+  interval: string;
+  page_source: 'explore' | 'compare';
+  query: string;
+  queryType: 'aggregate' | 'samples' | 'traces';
+  spansTableResult: SpansTableResult;
+  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
+  visualizes: Visualize[];
+  title?: string;
+  tracesTableResult?: TracesTableResult;
+}
 
 export function useTrackAnalytics({
   queryType,
@@ -39,20 +60,7 @@ export function useTrackAnalytics({
   visualizes,
   page_source,
   interval,
-}: {
-  aggregatesTableResult: AggregatesTableResult;
-  dataset: DiscoverDatasets;
-  fields: string[];
-  interval: string;
-  page_source: 'explore' | 'compare';
-  query: string;
-  queryType: 'aggregate' | 'samples' | 'traces';
-  spansTableResult: SpansTableResult;
-  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
-  visualizes: Visualize[];
-  title?: string;
-  tracesTableResult?: TracesTableResult;
-}) {
+}: UseTrackAnalyticsProps) {
   const organization = useOrganization();
 
   const {
@@ -284,14 +292,15 @@ export function useAnalytics({
   tracesTableResult,
   timeseriesResult,
   interval,
-}: {
-  aggregatesTableResult: AggregatesTableResult;
-  interval: string;
-  queryType: 'aggregate' | 'samples' | 'traces';
-  spansTableResult: SpansTableResult;
-  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
-  tracesTableResult: TracesTableResult;
-}) {
+}: Pick<
+  UseTrackAnalyticsProps,
+  | 'queryType'
+  | 'aggregatesTableResult'
+  | 'spansTableResult'
+  | 'tracesTableResult'
+  | 'timeseriesResult'
+  | 'interval'
+>) {
   const dataset = useExploreDataset();
   const title = useExploreTitle();
   const query = useExploreQuery();
@@ -322,14 +331,16 @@ export function useCompareAnalytics({
   spansTableResult,
   timeseriesResult,
   interval,
-}: {
-  aggregatesTableResult: AggregatesTableResult;
+}: Pick<
+  UseTrackAnalyticsProps,
+  | 'queryType'
+  | 'aggregatesTableResult'
+  | 'spansTableResult'
+  | 'timeseriesResult'
+  | 'interval'
+> & {
   index: number;
-  interval: string;
   query: ReadableExploreQueryParts;
-  queryType: 'aggregate' | 'samples' | 'traces';
-  spansTableResult: SpansTableResult;
-  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
 }) {
   const dataset = DiscoverDatasets.SPANS_EAP_RPC;
   const query = queryParts.query;
@@ -354,6 +365,80 @@ export function useCompareAnalytics({
     interval,
     page_source: 'compare',
   });
+}
+
+export function useLogAnalytics({
+  logsTableResult,
+  source,
+}: {
+  logsTableResult: UseExploreLogsTableResult;
+  source: LogsAnalyticsPageSource;
+}) {
+  const organization = useOrganization();
+
+  const {
+    data: {hasExceededPerformanceUsageLimit},
+    isLoading: isLoadingSubscriptionDetails,
+  } = usePerformanceSubscriptionDetails();
+
+  const dataset = DiscoverDatasets.OURLOGS;
+  const search = useLogsSearch();
+  const query = search.formatString();
+  const fields = useLogsFields();
+  const page_source = source;
+
+  const tableError = logsTableResult.error?.message ?? '';
+  const query_status = tableError ? 'error' : 'success';
+
+  useEffect(() => {
+    if (logsTableResult.isPending || isLoadingSubscriptionDetails) {
+      return;
+    }
+
+    const columns = fields as unknown as string[];
+    trackAnalytics('log.explorer.metadata', {
+      organization,
+      dataset,
+      result_mode: 'aggregates',
+      columns,
+      columns_count: columns.length,
+      query_status,
+      table_result_length: logsTableResult.data?.length || 0,
+      table_result_missing_root: 0,
+      user_queries: search.formatString(),
+      user_queries_count: search.tokens.length,
+      has_exceeded_performance_usage_limit: hasExceededPerformanceUsageLimit,
+      page_source,
+    });
+
+    info(
+      fmt`log.explorer.metadata:
+      organization: ${organization.slug}
+      dataset: ${dataset}
+      query: ${query}
+      fields: ${fields}
+      query_status: ${query_status}
+      result_length: ${String(logsTableResult.data?.length || 0)}
+      user_queries: ${search.formatString()}
+      user_queries_count: ${String(search.tokens.length)}
+      has_exceeded_performance_usage_limit: ${String(hasExceededPerformanceUsageLimit)}
+      page_source: ${page_source}
+    `,
+      {isAnalytics: true}
+    );
+  }, [
+    organization,
+    dataset,
+    fields,
+    query,
+    hasExceededPerformanceUsageLimit,
+    isLoadingSubscriptionDetails,
+    query_status,
+    page_source,
+    logsTableResult.isPending,
+    logsTableResult.data?.length,
+    search,
+  ]);
 }
 
 function computeConfidence(

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -7,6 +7,7 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -66,7 +67,9 @@ export default function LogsPage() {
             </Layout.HeaderActions>
           </Layout.Header>
           <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-            <LogsPageParamsProvider>
+            <LogsPageParamsProvider
+              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+            >
               <LogsTabContent
                 defaultPeriod={defaultPeriod}
                 maxPickableDays={maxPickableDays}

--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   LogsPageParamsProvider,
@@ -25,7 +26,7 @@ export function LogsIssuesSection({
   limitToTraceId,
 }: {
   initialCollapse: boolean;
-} & Omit<LogsPageParamsProviderProps, 'children'>) {
+} & Omit<LogsPageParamsProviderProps, 'children' | 'analyticsPageSource'>) {
   const organization = useOrganization();
   const feature = organization.features.includes('ourlogs-enabled');
   const tableData = useExploreLogsTable({enabled: feature, limit: 10});
@@ -50,6 +51,7 @@ export function LogsIssuesSection({
       initialCollapse={initialCollapse}
     >
       <LogsPageParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
         isOnEmbeddedView={isOnEmbeddedView}
         limitToTraceId={limitToTraceId}
       >

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -11,6 +11,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import {IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {
   useLogsFields,
@@ -19,6 +20,7 @@ import {
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useLogAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
@@ -44,6 +46,11 @@ export function LogsTabContent({
 
   const {attributes: stringTags} = useTraceItemAttributes('string');
   const {attributes: numberTags} = useTraceItemAttributes('number');
+
+  useLogAnalytics({
+    logsTableResult: tableData,
+    source: LogsAnalyticsPageSource.EXPLORE_LOGS,
+  });
 
   const openColumnEditor = useCallback(() => {
     openModal(

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -7,11 +7,15 @@ import {IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {TableRow} from 'sentry/views/explore/components/table';
-import {useLogsFields} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {
+  useLogsAnalyticsPageSource,
+  useLogsFields,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {HiddenLogDetailFields} from 'sentry/views/explore/logs/constants';
 import {
   LogAttributesRendererMap,
@@ -58,8 +62,16 @@ export function LogRowContent({
   const location = useLocation();
   const organization = useOrganization();
   const fields = useLogsFields();
+  const analyticsPageSource = useLogsAnalyticsPageSource();
   const [expanded, setExpanded] = useState<boolean>(false);
-  const onClickExpand = useCallback(() => setExpanded(e => !e), []);
+  const onClickExpand = useCallback(() => {
+    setExpanded(e => !e);
+    trackAnalytics('logs.table.row_expanded', {
+      log_id: String(dataRow[OurLogKnownFieldKey.ID]),
+      page_source: analyticsPageSource,
+      organization,
+    });
+  }, [dataRow, organization, analyticsPageSource]);
   const theme = useTheme();
 
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -35,7 +35,7 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
   if (baseSearch) {
     search.tokens.push(...baseSearch.tokens);
   }
-  const {data, meta, isError, isPending, pageLinks} = useOurlogs(
+  const {data, meta, isError, isPending, pageLinks, error} = useOurlogs(
     {
       ...options,
       cursor,
@@ -47,7 +47,7 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
     'api.explore.logs-table'
   );
 
-  return {data, meta, isError, isPending, pageLinks};
+  return {data, meta, isError, isPending, pageLinks, error};
 }
 
 export function useExploreLogsTableRow(props: {

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {
   LogsPageDataProvider,
   useLogsPageData,
@@ -28,7 +29,11 @@ export function TraceViewLogsDataProvider({
   children,
 }: UseTraceViewLogsDataProps) {
   return (
-    <LogsPageParamsProvider isOnEmbeddedView limitToTraceId={traceSlug}>
+    <LogsPageParamsProvider
+      isOnEmbeddedView
+      limitToTraceId={traceSlug}
+      analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
+    >
       <LogsPageDataProvider>{children}</LogsPageDataProvider>
     </LogsPageParamsProvider>
   );


### PR DESCRIPTION
### Summary
This adds analytics for:
- Visits made to Logs page
- Expanding Log records

Includes sources to determine on which page expanding log records were activated.
