### PR TITLE
feat(eap-spans): partially implement spm() function

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -384,7 +384,7 @@ def spm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormul
     return Column.BinaryFormula(
         left=Column(
             aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_SUM,
+                aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
                 extrapolation_mode=extrapolation_mode,
             )
@@ -392,7 +392,7 @@ def spm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormul
         op=Column.BinaryFormula.OP_DIVIDE,
         right=Column(
             aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_SUM,
+                aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
                 extrapolation_mode=extrapolation_mode,
             )

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -339,6 +339,26 @@ def time_spent_percentage(args: ResolvedArguments) -> Column.BinaryFormula:
     )
 
 
+def spm(_: ResolvedArguments) -> Column.BinaryFormula:
+    """TODO: This function isn't fully implemented, when https://github.com/getsentry/eap-planning/issues/202 is merged we can properly divide by the period time"""
+
+    return Column.BinaryFormula(
+        left=Column(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
+            )
+        ),
+        op=Column.BinaryFormula.OP_DIVIDE,
+        right=Column(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
+            )
+        ),
+    )
+
+
 SPAN_FORMULA_DEFINITIONS = {
     "http_response_rate": FormulaDefinition(
         default_search_type="percentage",
@@ -461,4 +481,5 @@ SPAN_FORMULA_DEFINITIONS = {
         formula_resolver=time_spent_percentage,
         is_aggregate=True,
     ),
+    "spm": FormulaDefinition(default_search_type="percentage", formula_resolver=spm),
 }

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -377,14 +377,16 @@ def time_spent_percentage(
     )
 
 
-def spm(_: ResolvedArguments) -> Column.BinaryFormula:
+def spm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     """TODO: This function isn't fully implemented, when https://github.com/getsentry/eap-planning/issues/202 is merged we can properly divide by the period time"""
+    extrapolation_mode = settings["extrapolation_mode"]
 
     return Column.BinaryFormula(
         left=Column(
             aggregation=AttributeAggregation(
                 aggregate=Function.FUNCTION_SUM,
                 key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
+                extrapolation_mode=extrapolation_mode,
             )
         ),
         op=Column.BinaryFormula.OP_DIVIDE,
@@ -392,6 +394,7 @@ def spm(_: ResolvedArguments) -> Column.BinaryFormula:
             aggregation=AttributeAggregation(
                 aggregate=Function.FUNCTION_SUM,
                 key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
+                extrapolation_mode=extrapolation_mode,
             )
         ),
     )

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -481,5 +481,7 @@ SPAN_FORMULA_DEFINITIONS = {
         formula_resolver=time_spent_percentage,
         is_aggregate=True,
     ),
-    "spm": FormulaDefinition(default_search_type="percentage", formula_resolver=spm),
+    "spm": FormulaDefinition(
+        default_search_type="percentage", arguments=[], formula_resolver=spm, is_aggregate=True
+    ),
 }

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2192,7 +2192,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             assert response.status_code == 200, response.content
             assert response.data["data"] == [{"foo": "bar", "count()": 1}]
 
-    @pytest.mark.xfail(reason="wip: rate not implemented yet")
+    @pytest.mark.xfail(
+        reason="RPC does not support static number operations (https://github.com/getsentry/eap-planning/issues/202) which is required by this function"
+    )
     def test_spm(self):
         super().test_spm()
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2192,7 +2192,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             assert response.status_code == 200, response.content
             assert response.data["data"] == [{"foo": "bar", "count()": 1}]
 
-    # @pytest.mark.xfail(reason="wip: rate not implemented yet")
+    @pytest.mark.xfail(reason="wip: rate not implemented yet")
     def test_spm(self):
         super().test_spm()
 
@@ -3040,7 +3040,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["count_scores(measurements.score.total)"] == 3
         assert meta["dataset"] == self.dataset
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason="RPC does not support static number operations (https://github.com/getsentry/eap-planning/issues/202) which is required by this function"
     )
     def test_time_spent_percentage(self):

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2192,7 +2192,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             assert response.status_code == 200, response.content
             assert response.data["data"] == [{"foo": "bar", "count()": 1}]
 
-    @pytest.mark.xfail(reason="wip: rate not implemented yet")
+    # @pytest.mark.xfail(reason="wip: rate not implemented yet")
     def test_spm(self):
         super().test_spm()
 
@@ -3041,7 +3041,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert meta["dataset"] == self.dataset
 
     @pytest.mark.skip(
-        reason="RPC does not support static number operations which is required by this function"
+        reason="RPC does not support static number operations (https://github.com/getsentry/eap-planning/issues/202) which is required by this function"
     )
     def test_time_spent_percentage(self):
         spans = []


### PR DESCRIPTION
Work for https://github.com/getsentry/team-visibility/issues/33

Partially implements `spm()` function to prevent `spm is not a function errors` which will allow us to start testing the UI easily.