### PR TITLE
🔧 chore: make retry errors for gitlab record as halt take 2

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -20,12 +20,7 @@ from sentry.integrations.source_code_management.commit_context import (
 from sentry.integrations.source_code_management.repository import RepositoryClient
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
-from sentry.shared_integrations.exceptions import (
-    ApiError,
-    ApiHostError,
-    ApiRetryError,
-    ApiUnauthorized,
-)
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.silo.base import SiloMode, control_silo_function
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
@@ -34,8 +29,6 @@ if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration
 
 logger = logging.getLogger("sentry.integrations.gitlab")
-
-GITLAB_CLOUD_BASE_URL = "https://gitlab.com"
 
 
 class GitLabSetupApiClient(IntegrationProxyClient):
@@ -373,18 +366,12 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         self, files: Sequence[SourceLineInfo], extra: Mapping[str, Any]
     ) -> list[FileBlameInfo]:
         metrics.incr("sentry.integrations.gitlab.get_blame_for_files")
-        try:
-            return fetch_file_blames(
-                self,
-                files,
-                extra={
-                    **extra,
-                    "provider": "gitlab",
-                    "org_integration_id": self.org_integration_id,
-                },
-            )
-        except ApiRetryError as e:
-            if self.base_url != GITLAB_CLOUD_BASE_URL:
-                raise ApiHostError(e)
-            else:
-                raise
+        return fetch_file_blames(
+            self,
+            files,
+            extra={
+                **extra,
+                "provider": "gitlab",
+                "org_integration_id": self.org_integration_id,
+            },
+        )

--- a/src/sentry/integrations/gitlab/constants.py
+++ b/src/sentry/integrations/gitlab/constants.py
@@ -1,0 +1,1 @@
+GITLAB_CLOUD_BASE_URL = "https://gitlab.com"

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -33,9 +33,9 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
+    ApiHostError,
     ApiInvalidRequestError,
     ApiRateLimitedError,
-    ApiRetryError,
 )
 from sentry.users.models.identity import Identity
 from sentry.utils import metrics
@@ -135,7 +135,7 @@ class CommitContextIntegration(ABC):
                     return []
                 else:
                     raise
-            except ApiRetryError as e:
+            except ApiHostError as e:
                 # Ignore retry errors for GitLab
                 # TODO(ecosystem): Remove this once we have a better way to handle this
                 if self.integration_name == ExternalProviderEnum.GITLAB.value:

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -12,6 +12,7 @@ from django.utils import timezone as django_timezone
 
 from sentry import analytics
 from sentry.auth.exceptions import IdentityNotValid
+from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.metrics import (
     CommitContextHaltReason,
@@ -42,8 +43,6 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
-
-GITLAB_CLOUD_BASE_URL = "https://gitlab.com"
 
 
 def _debounce_pr_comment_cache_key(pullrequest_id: int) -> str:

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -89,8 +89,6 @@ class CommitContextIntegration(ABC):
     Base class for integrations that include commit context features: suspect commits, suspect PR comments
     """
 
-    base_url: str
-
     @property
     @abstractmethod
     def integration_name(self) -> str:
@@ -143,7 +141,7 @@ class CommitContextIntegration(ABC):
                 # TODO(ecosystem): Remove this once we have a better way to handle this
                 if (
                     self.integration_name == ExternalProviderEnum.GITLAB.value
-                    and self.base_url != GITLAB_CLOUD_BASE_URL
+                    and client.base_url != GITLAB_CLOUD_BASE_URL
                 ):
                     lifecycle.record_halt(e)
                     return []
@@ -395,6 +393,8 @@ class CommitContextIntegration(ABC):
 
 
 class CommitContextClient(ABC):
+    base_url: str
+
     @abstractmethod
     def get_blame_for_files(
         self, files: Sequence[SourceLineInfo], extra: Mapping[str, Any]

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -32,7 +32,11 @@ from sentry.models.pullrequest import (
     PullRequestCommit,
 )
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiInvalidRequestError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import (
+    ApiInvalidRequestError,
+    ApiRateLimitedError,
+    ApiRetryError,
+)
 from sentry.users.models.identity import Identity
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -125,6 +129,14 @@ class CommitContextIntegration(ABC):
                 return []
             except ApiInvalidRequestError as e:
                 # Ignore invalid request errors for GitLab
+                # TODO(ecosystem): Remove this once we have a better way to handle this
+                if self.integration_name == ExternalProviderEnum.GITLAB.value:
+                    lifecycle.record_halt(e)
+                    return []
+                else:
+                    raise
+            except ApiRetryError as e:
+                # Ignore retry errors for GitLab
                 # TODO(ecosystem): Remove this once we have a better way to handle this
                 if self.integration_name == ExternalProviderEnum.GITLAB.value:
                     lifecycle.record_halt(e)

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -23,7 +23,12 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
-from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiHostError,
+    ApiRateLimitedError,
+    ApiRetryError,
+)
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
@@ -607,6 +612,41 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         )
 
         assert resp == []
+
+    @responses.activate
+    def test_retry_error_gitlab_com(self):
+        """Test that ApiRetryError is converted to ApiHostError for cloud installations"""
+        self.gitlab_client.base_url = "https://bufo-bot.gitlab.com"
+        path = "src/file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+
+        responses.add(
+            responses.HEAD,
+            f"https://gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
+            body=ApiRetryError(text="Retry error"),
+        )
+
+        with pytest.raises(ApiHostError) as exc_info:
+            self.gitlab_client.check_file(self.repo, path, ref)
+
+        assert str(exc_info.value) == "Unable to reach host: bufo-bot.gitlab.com"
+
+    @responses.activate
+    def test_retry_error_self_hosted(self):
+        """Test that ApiRetryError is raised normally for self-hosted GitLab"""
+        path = "src/file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+
+        responses.add(
+            responses.HEAD,
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
+            body=ApiRetryError(text="Retry error"),
+        )
+
+        with pytest.raises(ApiRetryError) as exc_info:
+            self.gitlab_client.check_file(self.repo, path, ref)
+
+        assert str(exc_info.value) == "Retry error"
 
 
 @control_silo_test

--- a/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
@@ -2,8 +2,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.source_code_management.commit_context import (
-    GITLAB_CLOUD_BASE_URL,
     CommitContextIntegration,
     SourceLineInfo,
 )

--- a/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
@@ -134,6 +134,10 @@ class CommitContextIntegrationTest(TestCase):
             integration_name = "gitlab"
             base_url = "https://bufo-bot.gitlab.com"
 
+            def __init__(self):
+                super().__init__()
+                self.client.base_url = self.base_url
+
         self.integration = MockGitlabIntegration()
 
         self.integration.client.get_blame_for_files = Mock(
@@ -155,6 +159,10 @@ class CommitContextIntegrationTest(TestCase):
         class MockGitlabIntegration(MockCommitContextIntegration):
             integration_name = "gitlab"
             base_url = GITLAB_CLOUD_BASE_URL
+
+            def __init__(self):
+                super().__init__()
+                self.client.base_url = self.base_url
 
         self.integration = MockGitlabIntegration()
 

--- a/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
@@ -18,10 +18,10 @@ class MockCommitContextIntegration(CommitContextIntegration):
     """Mock implementation for testing"""
 
     integration_name = "mock_integration"
-    base_url = "https://example.com"
 
     def __init__(self):
         self.client = Mock()
+        self.client.base_url = "https://example.com"
 
     def get_client(self):
         return self.client

--- a/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context_slo.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from sentry.integrations.source_code_management.commit_context import (
+    GITLAB_CLOUD_BASE_URL,
     CommitContextIntegration,
     SourceLineInfo,
 )
@@ -17,6 +18,7 @@ class MockCommitContextIntegration(CommitContextIntegration):
     """Mock implementation for testing"""
 
     integration_name = "mock_integration"
+    base_url = "https://example.com"
 
     def __init__(self):
         self.client = Mock()
@@ -124,38 +126,47 @@ class CommitContextIntegrationTest(TestCase):
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_get_blame_for_files_retry_error(self, mock_record):
-        """Test retry error records failure"""
-        from sentry.shared_integrations.exceptions import ApiHostError
+        """Test retry error for Gitlab Self-hosted records halt"""
+        from sentry.shared_integrations.exceptions import ApiRetryError
 
-        self.integration.client.get_blame_for_files = Mock(
-            side_effect=ApiHostError(text="Host error")
-        )
-
-        with pytest.raises(ApiHostError):
-            self.integration.get_blame_for_files([self.source_line], {})
-
-        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
-        assert_failure_metric(mock_record, ApiHostError(text="Host error"))
-
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_get_blame_for_files_retry_error_gitlab(self, mock_record):
-        """Test retry error for GitLab records halt"""
-        from sentry.shared_integrations.exceptions import ApiHostError
-
+        # Because this is Gitlab Self-hosted, this should be halt
         class MockGitlabIntegration(MockCommitContextIntegration):
             integration_name = "gitlab"
+            base_url = "https://bufo-bot.gitlab.com"
 
         self.integration = MockGitlabIntegration()
 
         self.integration.client.get_blame_for_files = Mock(
-            side_effect=ApiHostError(text="Host error")
+            side_effect=ApiRetryError(text="Host error")
         )
 
         result = self.integration.get_blame_for_files([self.source_line], {})
 
         assert result == []
         assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
-        assert_halt_metric(mock_record, ApiHostError(text="Host error"))
+        assert_halt_metric(mock_record, ApiRetryError(text="Host error"))
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_get_blame_for_files_retry_error_gitlab(self, mock_record):
+        """Test retry error for GitLab saas records failure"""
+        from sentry.shared_integrations.exceptions import ApiRetryError
+
+        # Because this is Gitlab SAAS, this should be failure
+        class MockGitlabIntegration(MockCommitContextIntegration):
+            integration_name = "gitlab"
+            base_url = GITLAB_CLOUD_BASE_URL
+
+        self.integration = MockGitlabIntegration()
+
+        self.integration.client.get_blame_for_files = Mock(
+            side_effect=ApiRetryError(text="Host error")
+        )
+
+        with pytest.raises(ApiRetryError):
+            self.integration.get_blame_for_files([self.source_line], {})
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
+        assert_failure_metric(mock_record, ApiRetryError(text="Host error"))
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_get_commit_context_all_frames(self, mock_record):


### PR DESCRIPTION
take 2 of https://github.com/getsentry/sentry/pull/87578, `base_url` is on client.