### PR TITLE
feat(pagerduty): Issue alerts will include alert name in summary

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -9,7 +9,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
-from sentry.api.serializers.rest_framework import RuleActionSerializer
+from sentry.api.serializers.rest_framework import DummyRuleSerializer
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
@@ -33,10 +33,11 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             {method} {path}
             {{
                 "actions": []
+                "name": string
             }}
 
         """
-        serializer = RuleActionSerializer(
+        serializer = DummyRuleSerializer(
             context={"project": project, "organization": project.organization}, data=request.data
         )
 
@@ -58,7 +59,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 "frequency": 30,
             }
         )
-        rule = Rule(id=-1, project=project, data=data)
+        rule = Rule(id=-1, project=project, data=data, label=data.get("name"))
 
         test_event = create_sample_event(
             project, platform=project.platform, default="javascript", tagged=True

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -141,7 +141,9 @@ class RulePreviewSerializer(RuleSetSerializer):
 
 
 class DummyRuleSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=256, required=False, allow_null=True, allow_blank=True)
+    name = serializers.CharField(
+        max_length=256, required=False, allow_null=True, allow_blank=True, default="Test Alert"
+    )
     actions = serializers.ListField(child=RuleNodeField(type="action/event"), required=False)
 
     def validate_name(self, name):

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -140,8 +140,14 @@ class RulePreviewSerializer(RuleSetSerializer):
     endpoint = serializers.DateTimeField(required=False, allow_null=True)
 
 
-class RuleActionSerializer(serializers.Serializer):
+class DummyRuleSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=256, required=False, allow_null=True, allow_blank=True)
     actions = serializers.ListField(child=RuleNodeField(type="action/event"), required=False)
+
+    def validate_name(self, name):
+        if name == "" or name is None:
+            return "Test Alert"
+        return name
 
     def validate(self, attrs):
         return validate_actions(attrs)

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -3,6 +3,8 @@ from unittest import mock
 import sentry_sdk
 
 from sentry.integrations.jira.integration import JiraIntegration
+from sentry.integrations.pagerduty.client import PagerDutyClient
+from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
@@ -20,6 +22,27 @@ class ProjectRuleActionsEndpointTest(APITestCase):
     def setUp(self):
         self.login_as(self.user)
 
+    def setup_pd_service(self) -> PagerDutyServiceDict:
+        service_info = {
+            "type": "service",
+            "integration_key": "PND123",
+            "service_name": "Sentry Service",
+        }
+        _integration, org_integration = self.create_provider_integration_for(
+            provider="pagerduty",
+            name="Example PagerDuty",
+            external_id="example-pd",
+            metadata={"services": [service_info]},
+            organization=self.organization,
+            user=self.user,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return add_service(
+                org_integration,
+                service_name=service_info["service_name"],
+                integration_key=service_info["integration_key"],
+            )
+
     @mock.patch.object(NotifyEventAction, "after")
     def test_actions(self, action):
         action_data = [
@@ -29,8 +52,52 @@ class ProjectRuleActionsEndpointTest(APITestCase):
         ]
 
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
-
         assert action.called
+
+    @mock.patch.object(PagerDutyClient, "send_trigger")
+    def test_name_action_default(self, mock_send_trigger):
+        """
+        Tests that label will be used as 'Test Alert' if not present. Uses PagerDuty since those
+        notifications will differ based on the name of the alert.
+        """
+        service_info = self.setup_pd_service()
+        action_data = [
+            {
+                "account": service_info["integration_id"],
+                "service": service_info["id"],
+                "severity": "info",
+                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
+            }
+        ]
+        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
+
+        assert mock_send_trigger.call_count == 1
+        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
+        assert pagerduty_data["payload"]["summary"].startswith("[Test Alert]:")
+
+    @mock.patch.object(PagerDutyClient, "send_trigger")
+    def test_name_action_with_custom_name(self, mock_send_trigger):
+        """
+        Tests that custom names can be provided to the test notification. Uses PagerDuty since those
+        notifications will differ based on the name of the alert.
+        """
+        service_info = self.setup_pd_service()
+        action_data = [
+            {
+                "account": service_info["integration_id"],
+                "service": service_info["id"],
+                "severity": "info",
+                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
+            }
+        ]
+        custom_alert_name = "Check #feed-issues"
+
+        self.get_success_response(
+            self.organization.slug, self.project.slug, actions=action_data, name=custom_alert_name
+        )
+        assert mock_send_trigger.call_count == 1
+        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
+        assert pagerduty_data["payload"]["summary"].startswith(f"[{custom_alert_name}]:")
 
     @mock.patch.object(JiraIntegration, "create_issue")
     @mock.patch.object(sentry_sdk, "capture_exception")


### PR DESCRIPTION
For issue alerts that include a pagerduty notification action, the name of the alert rule will be included in the title.

Also ensures test notifications have a label and can include one from the alert. This will enable users to see what the actual Pagerduty Incident title will be from the `Send Test Notification` button. If they are setting up a notif for the first time and haven't added a name `Test Alert` will be used instead.

Will require a followup FE PR to send the notif title along with the preview alert payload.

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/fb481f48-03c5-4213-93fb-d2c6293f0617" />

**todo**
- [x] Add screenshots
- [x] Add tests