### PR TITLE
fix(flamegraph): Better positioning of flamegraph tooltip

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -42,17 +42,28 @@ function computeBestTooltipPlacement(
 
   const canvasBounds = canvas.canvas.getBoundingClientRect();
 
-  const left =
+  let left =
     // Cursor is relative to canvasBounds, not window
     cursorLeft + canvasBounds.left > window.innerWidth / 2
-      ? cursorLeft - tooltip.width
-      : cursorLeft + CURSOR_LEFT_OFFSET_PX;
+      ? cursorLeft - tooltip.width // place tooltip to the right of cursor
+      : cursorLeft + CURSOR_LEFT_OFFSET_PX; // placetooltip on the left of cursor
+
+  if (
+    // the tooltip is overflowing on the left
+    left + canvasBounds.left < WIDTH_OFFSET ||
+    // the tooltip is overflowing on the right
+    left + canvasBounds.left + tooltip.width >= window.innerWidth - WIDTH_OFFSET
+  ) {
+    // align the tooltip to the left edge, this means it's still possible that we
+    // overflow on the right in some cases
+    left = -canvasBounds.left + WIDTH_OFFSET;
+  }
 
   const top =
     // Cursor is relative to canvasBounds, not window
     cursorTop + canvasBounds.top > window.innerHeight / 2
-      ? cursorTop - tooltip.height
-      : cursorTop + CURSOR_TOP_OFFSET_PX;
+      ? cursorTop - tooltip.height // place tooltip above cursor
+      : cursorTop + CURSOR_TOP_OFFSET_PX; // place tooltip below cursor
 
   return `translate(${left}px, ${top}px)`;
 }

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -101,6 +101,7 @@ function BoundTooltip({
   const containerBoundsRef = useRef<Rect>(DEFAULT_BOUNDS);
 
   if (containerBoundsRef.current.isEmpty()) {
+    // using the innerWidth and innerHeight here because we only want the size of the visible portions
     containerBoundsRef.current = new Rect(0, 0, window.innerWidth, window.innerHeight);
   }
 

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -153,7 +153,7 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     props.canvasPoolManager,
     flamegraphCanvas,
@@ -225,7 +225,6 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
         disableCallOrderSort
         disableColorCoding
         scheduler={props.scheduler}
-        canvasBounds={flamegraphCanvasBounds}
         canvasPoolManager={props.canvasPoolManager}
         flamegraph={flamegraph}
         flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -1194,18 +1194,13 @@ export function ContinuousFlamegraph(): ReactElement {
     return [spansCanvasRef];
   }, [spansCanvasRef]);
 
-  const spansCanvasBounds = useResizeCanvasObserver(
-    spansCanvases,
-    canvasPoolManager,
-    spansCanvas,
-    spansView
-  );
+  useResizeCanvasObserver(spansCanvases, canvasPoolManager, spansCanvas, spansView);
 
   const uiFramesCanvases = useMemo(() => {
     return [uiFramesCanvasRef];
   }, [uiFramesCanvasRef]);
 
-  const uiFramesCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     uiFramesCanvases,
     canvasPoolManager,
     uiFramesCanvas,
@@ -1216,7 +1211,7 @@ export function ContinuousFlamegraph(): ReactElement {
     return [batteryChartCanvasRef];
   }, [batteryChartCanvasRef]);
 
-  const batteryChartCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     batteryChartCanvases,
     canvasPoolManager,
     batteryChartCanvas,
@@ -1227,7 +1222,7 @@ export function ContinuousFlamegraph(): ReactElement {
     return [cpuChartCanvasRef];
   }, [cpuChartCanvasRef]);
 
-  const cpuChartCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     cpuChartCanvases,
     canvasPoolManager,
     cpuChartCanvas,
@@ -1237,7 +1232,8 @@ export function ContinuousFlamegraph(): ReactElement {
   const memoryChartCanvases = useMemo(() => {
     return [memoryChartCanvasRef];
   }, [memoryChartCanvasRef]);
-  const memoryChartCanvasBounds = useResizeCanvasObserver(
+
+  useResizeCanvasObserver(
     memoryChartCanvases,
     canvasPoolManager,
     memoryChartCanvas,
@@ -1248,7 +1244,7 @@ export function ContinuousFlamegraph(): ReactElement {
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     canvasPoolManager,
     flamegraphCanvas,
@@ -1451,7 +1447,6 @@ export function ContinuousFlamegraph(): ReactElement {
           hasUIFrames ? (
             <FlamegraphUIFrames
               status={profiles.type}
-              canvasBounds={uiFramesCanvasBounds}
               canvasPoolManager={canvasPoolManager}
               setUIFramesCanvasRef={setUIFramesCanvasRef}
               uiFramesCanvasRef={uiFramesCanvasRef}
@@ -1469,7 +1464,6 @@ export function ContinuousFlamegraph(): ReactElement {
               chartCanvasRef={batteryChartCanvasRef}
               chartCanvas={batteryChartCanvas}
               setChartCanvasRef={setBatteryChartCanvasRef}
-              canvasBounds={batteryChartCanvasBounds}
               chartView={batteryChartView}
               canvasPoolManager={canvasPoolManager}
               chart={batteryChart}
@@ -1491,7 +1485,6 @@ export function ContinuousFlamegraph(): ReactElement {
               chartCanvasRef={memoryChartCanvasRef}
               chartCanvas={memoryChartCanvas}
               setChartCanvasRef={setMemoryChartCanvasRef}
-              canvasBounds={memoryChartCanvasBounds}
               chartView={memoryChartView}
               canvasPoolManager={canvasPoolManager}
               chart={memoryChart}
@@ -1517,7 +1510,6 @@ export function ContinuousFlamegraph(): ReactElement {
               chartCanvasRef={cpuChartCanvasRef}
               chartCanvas={cpuChartCanvas}
               setChartCanvasRef={setCpuChartCanvasRef}
-              canvasBounds={cpuChartCanvasBounds}
               chartView={cpuChartView}
               canvasPoolManager={canvasPoolManager}
               chart={CPUChart}
@@ -1539,7 +1531,6 @@ export function ContinuousFlamegraph(): ReactElement {
         spans={
           spanChart ? (
             <FlamegraphSpans
-              canvasBounds={spansCanvasBounds}
               spanChart={spanChart}
               spansCanvas={spansCanvas}
               spansCanvasRef={spansCanvasRef}
@@ -1572,7 +1563,6 @@ export function ContinuousFlamegraph(): ReactElement {
             <FlamegraphZoomView
               scheduler={scheduler}
               profileGroup={profileGroup}
-              canvasBounds={flamegraphCanvasBounds}
               canvasPoolManager={canvasPoolManager}
               flamegraph={flamegraph}
               flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
@@ -239,7 +239,7 @@ export function DeprecatedAggregateFlamegraph(
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     canvasPoolManager,
     flamegraphCanvas,
@@ -296,7 +296,6 @@ export function DeprecatedAggregateFlamegraph(
       <FlamegraphZoomView
         scheduler={scheduler}
         profileGroup={profileGroup}
-        canvasBounds={flamegraphCanvasBounds}
         canvasPoolManager={canvasPoolManager}
         flamegraph={flamegraph}
         flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
@@ -140,7 +140,7 @@ export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): Reac
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     props.canvasPoolManager,
     flamegraphCanvas,
@@ -181,7 +181,6 @@ export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): Reac
       disableGrid
       disableCallOrderSort
       disableColorCoding
-      canvasBounds={flamegraphCanvasBounds}
       canvasPoolManager={props.canvasPoolManager}
       flamegraph={props.differentialFlamegraph}
       flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -1155,18 +1155,13 @@ function Flamegraph(): ReactElement {
     return [spansCanvasRef];
   }, [spansCanvasRef]);
 
-  const spansCanvasBounds = useResizeCanvasObserver(
-    spansCanvases,
-    canvasPoolManager,
-    spansCanvas,
-    spansView
-  );
+  useResizeCanvasObserver(spansCanvases, canvasPoolManager, spansCanvas, spansView);
 
   const uiFramesCanvases = useMemo(() => {
     return [uiFramesCanvasRef];
   }, [uiFramesCanvasRef]);
 
-  const uiFramesCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     uiFramesCanvases,
     canvasPoolManager,
     uiFramesCanvas,
@@ -1177,7 +1172,7 @@ function Flamegraph(): ReactElement {
     return [batteryChartCanvasRef];
   }, [batteryChartCanvasRef]);
 
-  const batteryChartCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     batteryChartCanvases,
     canvasPoolManager,
     batteryChartCanvas,
@@ -1188,7 +1183,7 @@ function Flamegraph(): ReactElement {
     return [cpuChartCanvasRef];
   }, [cpuChartCanvasRef]);
 
-  const cpuChartCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     cpuChartCanvases,
     canvasPoolManager,
     cpuChartCanvas,
@@ -1198,7 +1193,8 @@ function Flamegraph(): ReactElement {
   const memoryChartCanvases = useMemo(() => {
     return [memoryChartCanvasRef];
   }, [memoryChartCanvasRef]);
-  const memoryChartCanvasBounds = useResizeCanvasObserver(
+
+  useResizeCanvasObserver(
     memoryChartCanvases,
     canvasPoolManager,
     memoryChartCanvas,
@@ -1209,7 +1205,7 @@ function Flamegraph(): ReactElement {
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     canvasPoolManager,
     flamegraphCanvas,
@@ -1412,7 +1408,6 @@ function Flamegraph(): ReactElement {
           hasUIFrames ? (
             <FlamegraphUIFrames
               status={profiles.type}
-              canvasBounds={uiFramesCanvasBounds}
               canvasPoolManager={canvasPoolManager}
               setUIFramesCanvasRef={setUIFramesCanvasRef}
               uiFramesCanvasRef={uiFramesCanvasRef}
@@ -1430,7 +1425,6 @@ function Flamegraph(): ReactElement {
               chartCanvasRef={batteryChartCanvasRef}
               chartCanvas={batteryChartCanvas}
               setChartCanvasRef={setBatteryChartCanvasRef}
-              canvasBounds={batteryChartCanvasBounds}
               chartView={batteryChartView}
               canvasPoolManager={canvasPoolManager}
               chart={batteryChart}
@@ -1452,7 +1446,6 @@ function Flamegraph(): ReactElement {
               chartCanvasRef={memoryChartCanvasRef}
               chartCanvas={memoryChartCanvas}
               setChartCanvasRef={setMemoryChartCanvasRef}
-              canvasBounds={memoryChartCanvasBounds}
               chartView={memoryChartView}
               canvasPoolManager={canvasPoolManager}
               chart={memoryChart}
@@ -1478,7 +1471,6 @@ function Flamegraph(): ReactElement {
               chartCanvasRef={cpuChartCanvasRef}
               chartCanvas={cpuChartCanvas}
               setChartCanvasRef={setCpuChartCanvasRef}
-              canvasBounds={cpuChartCanvasBounds}
               chartView={cpuChartView}
               canvasPoolManager={canvasPoolManager}
               chart={CPUChart}
@@ -1500,7 +1492,6 @@ function Flamegraph(): ReactElement {
         spans={
           spanChart ? (
             <FlamegraphSpans
-              canvasBounds={spansCanvasBounds}
               spanChart={spanChart}
               spansCanvas={spansCanvas}
               spansCanvasRef={spansCanvasRef}
@@ -1533,7 +1524,6 @@ function Flamegraph(): ReactElement {
             <FlamegraphZoomView
               scheduler={scheduler}
               profileGroup={profileGroup}
-              canvasBounds={flamegraphCanvasBounds}
               canvasPoolManager={canvasPoolManager}
               flamegraph={flamegraph}
               flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -17,7 +17,6 @@ import {
   transformMatrixBetweenRect,
 } from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphChartRenderer} from 'sentry/utils/profiling/renderers/chartRenderer';
-import type {Rect} from 'sentry/utils/profiling/speedscope';
 import {formatTo, type ProfilingFormatterUnit} from 'sentry/utils/profiling/units/units';
 
 import {useCanvasScroll} from './interactions/useCanvasScroll';
@@ -31,7 +30,6 @@ import {
 import {FlamegraphChartTooltip} from './flamegraphChartTooltip';
 
 interface FlamegraphChartProps {
-  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   chart: FlamegraphChartModel | null;
   chartCanvas: FlamegraphCanvas | null;
@@ -51,7 +49,6 @@ export function FlamegraphChart({
   chartCanvas,
   chartCanvasRef,
   setChartCanvasRef,
-  canvasBounds,
   noMeasurementMessage,
   configViewUnit,
 }: FlamegraphChartProps) {
@@ -310,7 +307,6 @@ export function FlamegraphChart({
           chartCanvas={chartCanvas}
           chartView={chartView}
           chartRenderer={chartRenderer}
-          canvasBounds={canvasBounds}
           configViewUnit={configViewUnit}
         />
       ) : null}

--- a/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
@@ -8,7 +8,6 @@ import type {CanvasView} from 'sentry/utils/profiling/canvasView';
 import type {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import type {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
 import type {FlamegraphChartRenderer} from 'sentry/utils/profiling/renderers/chartRenderer';
-import type {Rect} from 'sentry/utils/profiling/speedscope';
 import {formatTo, type ProfilingFormatterUnit} from 'sentry/utils/profiling/units/units';
 
 import {
@@ -18,7 +17,6 @@ import {
 } from './flamegraphTooltip';
 
 export interface FlamegraphChartTooltipProps {
-  canvasBounds: Rect;
   chart: FlamegraphChart;
   chartCanvas: FlamegraphCanvas;
   chartRenderer: FlamegraphChartRenderer;
@@ -28,7 +26,6 @@ export interface FlamegraphChartTooltipProps {
 }
 
 export function FlamegraphChartTooltip({
-  canvasBounds,
   configSpaceCursor,
   chartCanvas,
   chart,
@@ -44,12 +41,7 @@ export function FlamegraphChartTooltip({
   }, [chartRenderer, configSpaceCursor, configViewUnit]);
 
   return series.length > 0 ? (
-    <BoundTooltip
-      cursor={configSpaceCursor}
-      canvas={chartCanvas}
-      canvasBounds={canvasBounds}
-      canvasView={chartView}
-    >
+    <BoundTooltip cursor={configSpaceCursor} canvas={chartCanvas} canvasView={chartView}>
       {series.map((p, i) => {
         return (
           <React.Fragment key={i}>

--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -217,7 +217,7 @@ export function FlamegraphPreview({
     setConfigSpaceCursor(null);
   }, []);
 
-  const canvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     canvasPoolManager,
     flamegraphCanvas,
@@ -257,7 +257,6 @@ export function FlamegraphPreview({
           flamegraphCanvas={flamegraphCanvas}
           flamegraphRenderer={flamegraphRenderer}
           flamegraphView={flamegraphView}
-          canvasBounds={canvasBounds}
           platform={undefined}
         />
       ) : null}

--- a/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
@@ -24,7 +24,6 @@ export function formatWeightToTransactionDuration(
 }
 
 export interface FlamegraphSpanTooltipProps {
-  canvasBounds: Rect;
   configSpaceCursor: vec2;
   hoveredNode: SpanChartNode;
   spanChart: SpanChart;
@@ -34,7 +33,6 @@ export interface FlamegraphSpanTooltipProps {
 }
 
 export function FlamegraphSpanTooltip({
-  canvasBounds,
   configSpaceCursor,
   spansCanvas,
   spanChart,
@@ -52,12 +50,7 @@ export function FlamegraphSpanTooltip({
   }, [spansView, hoveredNode]);
 
   return (
-    <BoundTooltip
-      cursor={configSpaceCursor}
-      canvas={spansCanvas}
-      canvasBounds={canvasBounds}
-      canvasView={spansView}
-    >
+    <BoundTooltip cursor={configSpaceCursor} canvas={spansCanvas} canvasView={spansView}>
       <FlamegraphTooltipFrameMainInfo>
         <FlamegraphTooltipColorIndicator
           backgroundImage={

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -44,7 +44,6 @@ import {
 import {FlamegraphSpanTooltip} from './flamegraphSpanTooltip';
 
 interface FlamegraphSpansProps {
-  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   setSpansCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   spanChart: SpanChart;
@@ -57,7 +56,6 @@ interface FlamegraphSpansProps {
 export function FlamegraphSpans({
   spanChart,
   canvasPoolManager,
-  canvasBounds,
   spansView,
   spansCanvas,
   spansCanvasRef,
@@ -535,7 +533,6 @@ export function FlamegraphSpans({
           spansView={spansView}
           spansRenderer={spansRenderer}
           hoveredNode={hoveredNode}
-          canvasBounds={canvasBounds}
         />
       ) : null}
     </Fragment>

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -33,7 +33,6 @@ export function formatWeightToProfileDuration(
 }
 
 export interface FlamegraphTooltipProps {
-  canvasBounds: Rect;
   configSpaceCursor: vec2;
   flamegraph: Flamegraph | DifferentialFlamegraph;
   flamegraphCanvas: FlamegraphCanvas;
@@ -108,7 +107,6 @@ function DifferentialFlamegraphTooltip(props: DifferentialFlamegraphTooltipProps
     <BoundTooltip
       cursor={props.configSpaceCursor}
       canvas={props.flamegraphCanvas}
-      canvasBounds={props.canvasBounds}
       canvasView={props.flamegraphView}
     >
       <FlamegraphTooltipFrameMainInfo>
@@ -140,7 +138,6 @@ interface AggregateFlamegraphTooltipProps extends FlamegraphTooltipProps {
 function AggregateFlamegraphTooltip(props: AggregateFlamegraphTooltipProps) {
   return (
     <BoundTooltip
-      canvasBounds={props.canvasBounds}
       cursor={props.configSpaceCursor}
       canvas={props.flamegraphCanvas}
       canvasView={props.flamegraphView}
@@ -173,7 +170,6 @@ interface FlamechartTooltipProps extends FlamegraphTooltipProps {
 function FlamechartTooltip(props: FlamechartTooltipProps) {
   return (
     <BoundTooltip
-      canvasBounds={props.canvasBounds}
       cursor={props.configSpaceCursor}
       canvas={props.flamegraphCanvas}
       canvasView={props.flamegraphView}

--- a/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
@@ -19,7 +19,6 @@ import {
 } from 'sentry/utils/profiling/gl/utils';
 import {UIFramesRenderer2D} from 'sentry/utils/profiling/renderers/UIFramesRenderer2D';
 import {UIFramesRendererWebGL} from 'sentry/utils/profiling/renderers/uiFramesRendererWebGL';
-import type {Rect} from 'sentry/utils/profiling/speedscope';
 import type {UIFrameNode, UIFrames} from 'sentry/utils/profiling/uiFrames';
 
 import {useCanvasScroll} from './interactions/useCanvasScroll';
@@ -33,7 +32,6 @@ import {
 import {FlamegraphUIFramesTooltip} from './flamegraphUIFramesTooltip';
 
 interface FlamegraphUIFramesProps {
-  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   setUIFramesCanvasRef: (ref: HTMLCanvasElement | null) => void;
   status: RequestState<any>['type'];
@@ -45,7 +43,6 @@ interface FlamegraphUIFramesProps {
 
 export function FlamegraphUIFrames({
   status,
-  canvasBounds,
   uiFrames,
   canvasPoolManager,
   uiFramesView,
@@ -294,7 +291,6 @@ export function FlamegraphUIFrames({
           uiFramesView={uiFramesView}
           uiFramesRenderer={uiFramesRenderer}
           hoveredNode={hoveredNode}
-          canvasBounds={canvasBounds}
         />
       ) : null}
       {/* transaction loads after profile, so we want to show loading even if it's in initial state */}

--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -18,7 +18,6 @@ import {
 } from './flamegraphTooltip';
 
 export interface FlamegraphUIFramesTooltipProps {
-  canvasBounds: Rect;
   configSpaceCursor: vec2;
   hoveredNode: UIFrames['frames'];
   uiFrames: UIFrames;
@@ -28,7 +27,6 @@ export interface FlamegraphUIFramesTooltipProps {
 }
 
 export function FlamegraphUIFramesTooltip({
-  canvasBounds,
   configSpaceCursor,
   uiFramesCanvas,
   uiFrames,
@@ -52,7 +50,6 @@ export function FlamegraphUIFramesTooltip({
     <BoundTooltip
       cursor={configSpaceCursor}
       canvas={uiFramesCanvas}
-      canvasBounds={canvasBounds}
       canvasView={uiFramesView}
     >
       {uiFramesInConfigSpace.map((frame, i) => {

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -74,7 +74,6 @@ function makeSourceCodeLink(frame: FlamegraphFrame['frame']): string | undefined
 }
 
 interface FlamegraphZoomViewProps {
-  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   contextMenu: (props: FlamegraphContextMenuProps) => React.ReactElement | null;
   flamegraph: Flamegraph | DifferentialFlamegraph;
@@ -98,7 +97,6 @@ interface FlamegraphZoomViewProps {
 
 function FlamegraphZoomView({
   canvasPoolManager,
-  canvasBounds,
   flamegraphRenderer,
   flamegraph,
   flamegraphCanvas,
@@ -811,7 +809,6 @@ function FlamegraphZoomView({
           flamegraphCanvas={flamegraphCanvas}
           flamegraphRenderer={flamegraphRenderer}
           flamegraphView={flamegraphView}
-          canvasBounds={canvasBounds}
           platform={profileGroup.metadata.platform}
         />
       ) : null}

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useState} from 'react';
+import {useLayoutEffect} from 'react';
 import type Fuse from 'fuse.js';
 import {mat3, vec2} from 'gl-matrix';
 
@@ -825,9 +825,7 @@ export function useResizeCanvasObserver(
   canvasPoolManager: CanvasPoolManager,
   canvas: FlamegraphCanvas | null,
   view: CanvasView<any> | null
-): Rect {
-  const [bounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
-
+) {
   useLayoutEffect(() => {
     if (!canvas || !canvases.length) {
       return undefined;
@@ -837,12 +835,7 @@ export function useResizeCanvasObserver(
       return undefined;
     }
 
-    const observer = watchForResize(canvases as HTMLCanvasElement[], entries => {
-      // We cannot use the resize observer's reported rect because it does not report x
-      // coordinate that is required to do edge detection.
-      const rect = entries[0]!.target.getBoundingClientRect();
-      setCanvasBounds(new Rect(rect.x, rect.y, rect.width, rect.height));
-
+    const observer = watchForResize(canvases as HTMLCanvasElement[], () => {
       canvas.initPhysicalSpace();
       if (view) {
         view.resizeConfigSpace(canvas);
@@ -854,6 +847,4 @@ export function useResizeCanvasObserver(
       observer.disconnect();
     };
   }, [canvases, canvas, view, canvasPoolManager]);
-
-  return bounds;
 }

--- a/static/app/views/profiling/differentialFlamegraph.tsx
+++ b/static/app/views/profiling/differentialFlamegraph.tsx
@@ -198,7 +198,7 @@ function DifferentialFlamegraphView() {
     return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
   }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
 
-  const flamegraphCanvasBounds = useResizeCanvasObserver(
+  useResizeCanvasObserver(
     flamegraphCanvases,
     canvasPoolManager,
     flamegraphCanvas,
@@ -305,7 +305,6 @@ function DifferentialFlamegraphView() {
               disableGrid
               disableCallOrderSort
               disableColorCoding
-              canvasBounds={flamegraphCanvasBounds}
               canvasPoolManager={canvasPoolManager}
               flamegraph={differentialFlamegraph.differentialFlamegraph}
               flamegraphRenderer={flamegraphRenderer}


### PR DESCRIPTION
The tooltip on the flamegraph was always being positioned below the cursor. This is problematic if the frame is near the bottom of the screen as it'll position the tooltip off screen. This positions the tooltip above the cursor when the cursor is on the bottom half of the screen.