### PR TITLE
🔧 chore: remove consent prompt from azure devops auth flow

### DIFF
--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -228,15 +228,19 @@ class VSTSNewIdentityProvider(OAuth2Provider):
 
 class VSTSOAuth2LoginView(OAuth2LoginView):
     def get_authorize_params(self, state, redirect_uri):
-        return {
+        params = {
             "client_id": self.client_id,
             "response_type": "code",
             "redirect_uri": redirect_uri,
             "response_mode": "query",
             "scope": self.get_scope(),
             "state": state,
-            "prompt": "consent",
         }
+
+        if options.get("vsts.consent-prompt"):
+            params["prompt"] = "consent"
+
+        return params
 
 
 class VSTSNewOAuth2CallbackView(OAuth2CallbackView):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -672,6 +672,13 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Add consent prompt for Azure DevOps Integration
+register(
+    "vsts.consent-prompt",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # PagerDuty Integration
 register("pagerduty.app-id", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -18,6 +18,7 @@ from sentry.identity.vsts.provider import (
 )
 from sentry.integrations.vsts.integration import AccountConfigView, AccountForm
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
@@ -67,9 +68,60 @@ class TestVSTSOAuthCallbackView(TestCase):
 
 
 @control_silo_test
+@override_options({"vsts.consent-prompt": True})
 class TestVSTSNewOAuth2CallbackView(TestCase):
     @responses.activate
     def test_exchange_token(self):
+        view = VSTSNewOAuth2CallbackView(
+            access_token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            client_id="vsts-new-client-id",
+            client_secret="vsts-new-client-secret",
+        )
+        request = Mock()
+        pipeline = Mock(
+            config={
+                "redirect_url": reverse(
+                    "sentry-extension-setup", kwargs={"provider_id": "vsts_new"}
+                )
+            },
+            provider=Mock(key="vsts_new"),
+        )
+
+        responses.add(
+            responses.POST,
+            "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            json={
+                "access_token": "xxxxxxxxx",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "zzzzzzzzzz",
+            },
+        )
+
+        result = view.exchange_token(request, pipeline, "oauth-code")
+        mock_request = responses.calls[0].request
+        req_params = parse_qs(mock_request.body)
+
+        # Verify the correct parameters are sent
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["client_id"] == ["vsts-new-client-id"]
+        assert req_params["client_secret"] == ["vsts-new-client-secret"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["prompt"] == ["consent"]
+
+        # Verify the redirect URI is correctly constructed with absolute_uri
+        assert req_params["redirect_uri"][0] == absolute_uri(
+            reverse("sentry-extension-setup", kwargs={"provider_id": "vsts_new"})
+        )
+
+        # Verify the response is correctly parsed
+        assert result["access_token"] == "xxxxxxxxx"
+        assert result["token_type"] == "Bearer"
+        assert result["expires_in"] == 3600
+        assert result["refresh_token"] == "zzzzzzzzzz"
+
+    @responses.activate
+    def test_exchange_token_without_consent_prompt(self):
         view = VSTSNewOAuth2CallbackView(
             access_token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
             client_id="vsts-new-client-id",


### PR DESCRIPTION
there is a chance that we are passing `consent:prompt` which is preventing some people from installing the integration. i am going to launch not passing the consent behind a flag