### PR TITLE
fix(issues): Deduplicate highlight browser and runtime

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -119,6 +119,29 @@ describe('HighlightsIconSummary', function () {
     expect(screen.getByText('15.3')).toBeInTheDocument();
   });
 
+  it('deduplicates browser and runtime contexts', function () {
+    const eventWithDuplicateContexts = EventFixture({
+      contexts: {
+        browser: {
+          type: 'browser',
+          name: 'Chrome',
+          version: '120.0.0',
+        },
+        runtime: {
+          type: 'runtime',
+          name: 'Chrome',
+          version: '120.0.0',
+        },
+      },
+    });
+    render(<HighlightsIconSummary event={eventWithDuplicateContexts} group={group} />);
+
+    // Should only show Chrome once, as runtime context is preferred over browser
+    const chromeElements = screen.getAllByText('Chrome');
+    expect(chromeElements).toHaveLength(1);
+    expect(screen.getByText('120.0.0')).toBeInTheDocument();
+  });
+
   it('hides device for non mobile/native', function () {
     const groupWithPlatform = GroupFixture({
       project: ProjectFixture({

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -53,14 +53,15 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
   // For now, highlight icons are only interpretted from context. We should extend this to tags
   // eventually, but for now, it'll match the previous expectations.
   const items = getOrderedContextItems(event)
-    .map(({alias, type, value}) => ({
-      ...getContextSummary({type, value}),
-      contextTitle: getContextTitle({alias, type, value}),
-      alias,
+    .map(item => ({
+      ...getContextSummary(item),
+      contextTitle: getContextTitle(item),
+      contextType: item.type,
+      alias: item.alias,
       icon: getContextIcon({
-        alias,
-        type,
-        value,
+        alias: item.alias,
+        type: item.type,
+        value: item.value,
         contextIconProps: {
           size: 'md',
         },
@@ -68,8 +69,17 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
     }))
     .filter((item, _index, array) => {
       // Prefer the "os" context for OS information
-      if (item.alias === 'client_os' && array.find(i => i.alias === 'os')) {
+      if (item.contextType === 'client_os' && array.find(i => i.contextType === 'os')) {
         return false;
+      }
+
+      // Prefer the runtime to browser if they're both the same
+      if (item.contextType === 'browser') {
+        // If the runtime is the same as the browser, prefer the runtime
+        const runtime = array.find(i => i.contextType === 'runtime');
+        if (runtime?.title === item.title) {
+          return false;
+        }
       }
 
       const hasData = item.icon !== null && Boolean(item.title || item.subtitle);


### PR DESCRIPTION
If both are for example "Chrome" deduplicate the browser and runtime contexts

![image](https://github.com/user-attachments/assets/a850a840-9941-4e33-8c23-102e55d4a31a)
