### PR TITLE
feat(autofix): Repository configuration for autofix

### DIFF
--- a/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
+++ b/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
@@ -79,7 +79,6 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
 
         const initialSettings: Record<string, RepoSettings> = {};
         repositories.forEach(repo => {
-          // Initialize settings for all available repositories
           initialSettings[repo.externalId] = {
             branch: '',
             instructions: '',

--- a/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
+++ b/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
@@ -1,0 +1,539 @@
+import {type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
+import {useKeyboard} from '@react-aria/interactions';
+
+import {Button} from 'sentry/components/core/button';
+import {InputGroup} from 'sentry/components/core/input/inputGroup';
+import type {RepoSettings} from 'sentry/components/events/autofix/types';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {IconAdd, IconChevron, IconSearch, IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Project} from 'sentry/types/project';
+import useOverlay from 'sentry/utils/useOverlay';
+
+import {SelectableRepoItem} from './components/SelectableRepoItem';
+import {SelectedRepoItem} from './components/SelectedRepoItem';
+import {useOrganizationRepositories} from './hooks/useOrganizationRepositories';
+import {useProjectPreferences} from './hooks/useProjectPreferences';
+import {useSaveProjectPreferences} from './hooks/useSaveProjectPreferences';
+
+const MAX_REPOS_LIMIT = 8;
+
+const withUnits = (value: any) => (typeof value === 'string' ? value : `${value}px`);
+
+function AutofixPreferenceDropdown({project}: {project: Project}) {
+  const {data: repositories, isFetching: isFetchingRepositories} =
+    useOrganizationRepositories();
+  const {data: preferences, isLoading: isLoadingPreferences} =
+    useProjectPreferences(project);
+  const savePreferences = useSaveProjectPreferences(project);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
+  const [repoSettings, setRepoSettings] = useState<Record<string, RepoSettings>>({});
+  const [showAddRepositories, setShowAddRepositories] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (preferences?.repositories && repositories) {
+      const preferencesMap = new Map(
+        preferences.repositories.map(repo => [
+          repo.external_id,
+          {
+            branch: repo.branch_name || '',
+            instructions: repo.instructions || '',
+          },
+        ])
+      );
+
+      setSelectedRepoIds(preferences.repositories.map(repo => repo.external_id));
+
+      const initialSettings: Record<string, RepoSettings> = {};
+      repositories.forEach(repo => {
+        initialSettings[repo.externalId] = preferencesMap.get(repo.externalId) || {
+          branch: '',
+          instructions: '',
+        };
+      });
+
+      setRepoSettings(initialSettings);
+    }
+  }, [preferences, repositories]);
+
+  const savePreferencesToServer = useCallback(
+    (updatedIds?: string[], updatedSettings?: Record<string, RepoSettings>) => {
+      if (!repositories) {
+        return;
+      }
+
+      const idsToUse = updatedIds || selectedRepoIds;
+      const settingsToUse = updatedSettings || repoSettings;
+      const selectedRepos = repositories.filter(repo =>
+        idsToUse.includes(repo.externalId)
+      );
+
+      const reposData = selectedRepos.map(repo => {
+        const [owner, name] = (repo.name || '/').split('/');
+        return {
+          provider: repo.provider?.name?.toLowerCase() || '',
+          owner: owner || '',
+          name: name || repo.name || '',
+          external_id: repo.externalId,
+          branch_name: settingsToUse[repo.externalId]?.branch || '',
+          instructions: settingsToUse[repo.externalId]?.instructions || '',
+        };
+      });
+
+      savePreferences.mutate({
+        repositories: reposData,
+      });
+    },
+    [repositories, selectedRepoIds, repoSettings, savePreferences]
+  );
+
+  const saveScrollPosition = useCallback(() => {
+    if (!contentRef.current) {
+      return 0;
+    }
+    return contentRef.current.scrollTop;
+  }, []);
+
+  const restoreScrollPosition = useCallback((position: number) => {
+    if (!contentRef.current) {
+      return;
+    }
+    contentRef.current.scrollTop = position;
+  }, []);
+
+  const toggleRepositorySelection = useCallback(
+    (repoId: string) => {
+      const scrollPosition = saveScrollPosition();
+
+      setSelectedRepoIds(prevSelectedIds => {
+        if (prevSelectedIds.includes(repoId)) {
+          const newIds = prevSelectedIds.filter(id => id !== repoId);
+          setTimeout(() => savePreferencesToServer(newIds), 500);
+          return newIds;
+        }
+        if (prevSelectedIds.length >= MAX_REPOS_LIMIT) {
+          setTimeout(() => {
+            setShowAddRepositories(false);
+          }, 300);
+          return prevSelectedIds;
+        }
+
+        if (prevSelectedIds.length === MAX_REPOS_LIMIT - 1) {
+          setTimeout(() => {
+            setShowAddRepositories(false);
+          }, 300);
+        }
+
+        const newIds = [...prevSelectedIds, repoId];
+        setTimeout(() => savePreferencesToServer(newIds), 500);
+        return newIds;
+      });
+
+      setTimeout(() => {
+        restoreScrollPosition(scrollPosition);
+      }, 0);
+    },
+    [saveScrollPosition, restoreScrollPosition, savePreferencesToServer]
+  );
+
+  const removeRepository = useCallback(
+    (repoId: string) => {
+      const scrollPosition = saveScrollPosition();
+
+      setSelectedRepoIds(prevSelectedIds => {
+        const newIds = prevSelectedIds.filter(id => id !== repoId);
+        setTimeout(() => savePreferencesToServer(newIds), 500);
+        return newIds;
+      });
+
+      setTimeout(() => {
+        restoreScrollPosition(scrollPosition);
+      }, 0);
+    },
+    [saveScrollPosition, restoreScrollPosition, savePreferencesToServer]
+  );
+
+  const updateRepoSettings = useCallback(
+    (repoId: string, settings: RepoSettings) => {
+      setRepoSettings(prev => {
+        const newSettings = {
+          ...prev,
+          [repoId]: settings,
+        };
+
+        setTimeout(() => savePreferencesToServer(undefined, newSettings), 500);
+
+        return newSettings;
+      });
+    },
+    [savePreferencesToServer]
+  );
+
+  const {selectedRepositories, unselectedRepositories, filteredRepositories} =
+    useMemo(() => {
+      if (!repositories || repositories.length === 0) {
+        return {
+          selectedRepositories: [],
+          unselectedRepositories: [],
+          filteredRepositories: [],
+        };
+      }
+
+      const selected = repositories.filter(repo =>
+        selectedRepoIds.includes(repo.externalId)
+      );
+      const unselected = repositories.filter(
+        repo => !selectedRepoIds.includes(repo.externalId)
+      );
+
+      let filtered = unselected;
+      if (showAddRepositories && searchQuery.trim()) {
+        const query = searchQuery.toLowerCase();
+        filtered = unselected.filter(repo => repo.name.toLowerCase().includes(query));
+      } else if (!showAddRepositories && searchQuery.trim()) {
+        const query = searchQuery.toLowerCase();
+        filtered = selected.filter(repo => repo.name.toLowerCase().includes(query));
+      } else if (showAddRepositories) {
+        filtered = unselected;
+      } else {
+        filtered = selected;
+      }
+
+      filtered = filtered.filter(
+        repo => repo.provider?.id && repo.provider.id !== 'unknown'
+      );
+
+      return {
+        selectedRepositories: selected,
+        unselectedRepositories: unselected,
+        filteredRepositories: filtered,
+      };
+    }, [repositories, selectedRepoIds, searchQuery, showAddRepositories]);
+
+  const sectionTitle = showAddRepositories
+    ? t('Add repositories')
+    : selectedRepoIds.length === 0
+      ? t('No Repositories Selected')
+      : selectedRepoIds.length === 1
+        ? t('1 Selected Repository')
+        : t('%s Selected Repositories', selectedRepoIds.length);
+
+  const toggleAddRepositoriesView = useCallback(() => {
+    setShowAddRepositories(!showAddRepositories);
+    setSearchQuery('');
+
+    setTimeout(() => {
+      if (contentRef.current) {
+        contentRef.current.scrollTop = 0;
+      }
+    }, 0);
+  }, [showAddRepositories]);
+
+  const isRepoLimitReached = selectedRepoIds.length >= MAX_REPOS_LIMIT;
+
+  const handleSearchChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      e.stopPropagation();
+      const scrollPosition = saveScrollPosition();
+      setSearchQuery(e.target.value);
+      setTimeout(() => restoreScrollPosition(scrollPosition), 0);
+    },
+    [saveScrollPosition, restoreScrollPosition]
+  );
+
+  const {
+    isOpen,
+    state: overlayState,
+    triggerProps,
+    overlayProps,
+  } = useOverlay({
+    type: 'menu',
+    position: 'bottom-start',
+    offset: 4,
+    isDismissable: true,
+    shouldCloseOnBlur: true,
+    onOpenChange: open => {
+      if (open && searchRef.current) {
+        setTimeout(() => {
+          searchRef.current?.focus();
+        }, 0);
+      }
+    },
+  });
+
+  const {keyboardProps} = useKeyboard({
+    onKeyDown: e => {
+      if (e.key === 'Escape') {
+        overlayState.close();
+      }
+    },
+  });
+
+  return (
+    <DropdownWrap>
+      <Button
+        {...triggerProps}
+        size="xs"
+        title={t('Autofix Settings')}
+        aria-label={t('Autofix Settings')}
+        icon={<IconSettings />}
+      />
+
+      <StyledPositionWrapper
+        zIndex={theme.zIndex?.tooltip}
+        visible={isOpen}
+        {...overlayProps}
+      >
+        <StyledOverlay
+          width="480px"
+          maxHeight="32rem"
+          data-menu-has-header
+          data-menu-has-search
+        >
+          <FocusScope contain={isOpen}>
+            <div {...keyboardProps}>
+              <ContentContainer ref={contentRef} className="scrollable-content">
+                <ContentHeader>
+                  <ContentTitle>{t('Autofix Settings')}</ContentTitle>
+                </ContentHeader>
+                <SectionHeader>
+                  <SectionTitle>
+                    {sectionTitle}
+                    {!showAddRepositories && (
+                      <QuestionTooltip
+                        title={t(
+                          'Below are the repositories that Autofix will work on. Autofix will only be able to see code and make PRs to the repositories that you select here.'
+                        )}
+                        size="sm"
+                      />
+                    )}
+                  </SectionTitle>
+                  <AddReposButton
+                    size="xs"
+                    icon={
+                      showAddRepositories ? <IconChevron direction="left" /> : <IconAdd />
+                    }
+                    title={
+                      showAddRepositories
+                        ? ''
+                        : isRepoLimitReached
+                          ? t('Max repositories reached')
+                          : unselectedRepositories?.length === 0
+                            ? t('No repositories to add')
+                            : ''
+                    }
+                    disabled={
+                      !showAddRepositories &&
+                      (isRepoLimitReached || unselectedRepositories?.length === 0)
+                    }
+                    onClick={toggleAddRepositoriesView}
+                  >
+                    {showAddRepositories ? t('Back to selected') : t('Add repositories')}
+                  </AddReposButton>
+                </SectionHeader>
+                {showAddRepositories && (
+                  <SearchContainer>
+                    <InputGroup>
+                      <InputGroup.LeadingItems disablePointerEvents>
+                        <IconSearch size="sm" />
+                      </InputGroup.LeadingItems>
+                      <InputGroup.Input
+                        ref={searchRef}
+                        type="text"
+                        placeholder={t('Search repositories...')}
+                        value={searchQuery}
+                        onChange={handleSearchChange}
+                      />
+                    </InputGroup>
+                  </SearchContainer>
+                )}
+                {isFetchingRepositories || isLoadingPreferences ? (
+                  <LoadingContainer>
+                    <StyledLoadingIndicator size={48} />
+                    <LoadingMessage>
+                      {t('Loading all your messy repositories...')}
+                    </LoadingMessage>
+                  </LoadingContainer>
+                ) : filteredRepositories.length === 0 ? (
+                  <EmptyMessage>
+                    {showAddRepositories
+                      ? unselectedRepositories.length > 0
+                        ? t('No matching repositories found.')
+                        : t('All repositories have been added.')
+                      : selectedRepositories.length > 0
+                        ? t('No matching repositories found.')
+                        : t(
+                            'No repositories selected. Click "Add repositories" to get started.'
+                          )}
+                  </EmptyMessage>
+                ) : (
+                  <ReposContainer>
+                    {showAddRepositories
+                      ? filteredRepositories.map(repo => (
+                          <SelectableRepoItem
+                            key={repo.id}
+                            repo={repo}
+                            isSelected={selectedRepoIds.includes(repo.externalId)}
+                            onToggle={() => toggleRepositorySelection(repo.externalId)}
+                          />
+                        ))
+                      : filteredRepositories.map(repo => (
+                          <SelectedRepoItem
+                            key={repo.id}
+                            repo={repo}
+                            settings={
+                              repoSettings[repo.externalId] || {
+                                branch: '',
+                                instructions: '',
+                              }
+                            }
+                            onSettingsChange={settings =>
+                              updateRepoSettings(repo.externalId, settings)
+                            }
+                            onRemove={() => removeRepository(repo.externalId)}
+                          />
+                        ))}
+                  </ReposContainer>
+                )}
+              </ContentContainer>
+            </div>
+          </FocusScope>
+        </StyledOverlay>
+      </StyledPositionWrapper>
+    </DropdownWrap>
+  );
+}
+
+export default React.memo(AutofixPreferenceDropdown);
+
+const DropdownWrap = styled('div')`
+  position: relative;
+  width: max-content;
+`;
+
+const StyledPositionWrapper = styled(PositionWrapper, {
+  shouldForwardProp: prop => isPropValid(prop),
+})<{visible?: boolean}>`
+  min-width: 100%;
+  display: ${p => (p.visible ? 'block' : 'none')};
+`;
+
+const StyledOverlay = styled(Overlay, {
+  shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop),
+})<{
+  maxHeight?: string | number;
+  maxWidth?: string | number;
+  minWidth?: string | number;
+  width?: string | number;
+}>`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  ${p => p.width && `width: ${withUnits(p.width)};`}
+  ${p => p.minWidth && `min-width: ${withUnits(p.minWidth)};`}
+  max-width: ${p => (p.maxWidth ? `min(${withUnits(p.maxWidth)}, 100%)` : `100%`)};
+  max-height: ${p => (p.maxHeight ? `${withUnits(p.maxHeight)}` : 'auto')};
+
+  & > div {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+const ContentContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  padding: ${space(2)};
+  height: 100%;
+  overflow-y: auto;
+  max-height: 30rem;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const ContentHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${space(1.5)};
+  border-bottom: 1px solid ${p => p.theme.border};
+  padding-bottom: ${space(1)};
+`;
+
+const ContentTitle = styled('h3')`
+  margin: 0;
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: 600;
+`;
+
+const SectionHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${space(1.5)};
+`;
+
+const SectionTitle = styled('h4')`
+  display: flex;
+  align-items: center;
+  margin: 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: 600;
+  gap: ${space(0.5)};
+`;
+
+const AddReposButton = styled(Button)`
+  flex-shrink: 0;
+`;
+
+const SearchContainer = styled('div')`
+  margin-bottom: ${space(1.5)};
+`;
+
+const ReposContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const EmptyMessage = styled('div')`
+  padding: ${space(2)};
+  color: ${p => p.theme.subText};
+  text-align: center;
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const LoadingContainer = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: ${space(4)};
+  width: 100%;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;
+
+const LoadingMessage = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;

--- a/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
@@ -53,7 +53,6 @@ export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
   );
 }
 
-// Styled components
 const BaseRepoContainer = styled('div')`
   display: flex;
   flex-direction: column;

--- a/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
@@ -1,0 +1,133 @@
+import styled from '@emotion/styled';
+
+import type {Repository} from 'sentry/components/events/autofix/types';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  isSelected: boolean;
+  onToggle: () => void;
+  repo: Repository;
+}
+
+export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
+  const isGithub = repo.provider?.name?.toLowerCase() === 'github';
+
+  const tooltipMessage = isGithub
+    ? ''
+    : t('Support for %s will be coming soon', repo.provider?.name || t('this provider'));
+
+  const repoContent = (
+    <RepoListItemContainer
+      selected={isSelected}
+      onClick={() => isGithub && onToggle()}
+      disabled={!isGithub}
+      role="button"
+      tabIndex={0}
+      data-repo-id={repo.externalId}
+    >
+      <RepoHeader>
+        <RepoInfoWrapper>
+          <RepoName>{repo.name}</RepoName>
+          <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
+        </RepoInfoWrapper>
+        <ActionContainer>
+          {isSelected ? (
+            <SelectedIndicator>{t('Added')}</SelectedIndicator>
+          ) : (
+            isGithub && <AddIcon size="xs" />
+          )}
+        </ActionContainer>
+      </RepoHeader>
+    </RepoListItemContainer>
+  );
+
+  return isGithub ? (
+    repoContent
+  ) : (
+    <Tooltip title={tooltipMessage} showUnderline={false}>
+      {repoContent}
+    </Tooltip>
+  );
+}
+
+// Styled components
+const BaseRepoContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const RepoListItemContainer = styled(BaseRepoContainer)<{
+  selected: boolean;
+  disabled?: boolean;
+}>`
+  cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+  transition: background-color 0.1s ease;
+  border: 1px solid ${p => (p.selected ? p.theme.purple300 : p.theme.border)};
+  opacity: ${p => (p.disabled ? 0.65 : 1)};
+
+  &:hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+
+  ${p =>
+    p.selected &&
+    `
+    background-color: ${p.theme.surface100};
+  `}
+`;
+
+const RepoHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${space(1)};
+`;
+
+const RepoInfoWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-left: ${space(1)};
+`;
+
+const RepoName = styled('div')`
+  font-weight: 600;
+`;
+
+const RepoProvider = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  margin-top: ${space(0.25)};
+`;
+
+const SelectedIndicator = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: 600;
+  color: ${p => p.theme.activeText};
+  background-color: ${p => p.theme.active};
+  padding: ${space(0.25)} ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const ActionContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const AddIcon = styled(IconAdd)`
+  color: ${p => p.theme.gray300};
+  visibility: hidden;
+
+  ${RepoListItemContainer}:hover & {
+    visibility: visible;
+  }
+
+  &:hover {
+    color: ${p => p.theme.purple300};
+  }
+`;

--- a/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -13,17 +14,17 @@ interface Props {
 }
 
 export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
-  const isGithub = repo.provider?.name?.toLowerCase() === 'github';
+  const isSupportedProvider = isSupportedAutofixProvider(repo.provider?.name || '');
 
-  const tooltipMessage = isGithub
+  const tooltipMessage = isSupportedProvider
     ? ''
     : t('Support for %s will be coming soon', repo.provider?.name || t('this provider'));
 
   const repoContent = (
     <RepoListItemContainer
       selected={isSelected}
-      onClick={() => isGithub && onToggle()}
-      disabled={!isGithub}
+      onClick={() => isSupportedProvider && onToggle()}
+      disabled={!isSupportedProvider}
       role="button"
       tabIndex={0}
       data-repo-id={repo.externalId}
@@ -33,14 +34,14 @@ export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
           <RepoName>{repo.name}</RepoName>
           <RightAlign>
             <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
-            {isGithub && <AddIcon size="xs" />}
+            {isSupportedProvider && <AddIcon size="xs" />}
           </RightAlign>
         </RepoInfoWrapper>
       </RepoHeader>
     </RepoListItemContainer>
   );
 
-  return isGithub ? (
+  return isSupportedProvider ? (
     repoContent
   ) : (
     <Tooltip title={tooltipMessage} showUnderline={false}>
@@ -93,7 +94,7 @@ const RepoInfoWrapper = styled('div')`
 `;
 
 const RepoName = styled('div')`
-  font-weight: 600;
+  font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 const RepoProvider = styled('div')`

--- a/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
@@ -31,15 +31,11 @@ export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
       <RepoHeader>
         <RepoInfoWrapper>
           <RepoName>{repo.name}</RepoName>
-          <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
+          <RightAlign>
+            <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
+            {isGithub && <AddIcon size="xs" />}
+          </RightAlign>
         </RepoInfoWrapper>
-        <ActionContainer>
-          {isSelected ? (
-            <SelectedIndicator>{t('Added')}</SelectedIndicator>
-          ) : (
-            isGithub && <AddIcon size="xs" />
-          )}
-        </ActionContainer>
       </RepoHeader>
     </RepoListItemContainer>
   );
@@ -85,13 +81,15 @@ const RepoHeader = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: ${space(1)};
+  padding: ${space(1)} ${space(1.5)};
 `;
 
 const RepoInfoWrapper = styled('div')`
   display: flex;
-  flex-direction: column;
-  margin-left: ${space(1)};
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
 `;
 
 const RepoName = styled('div')`
@@ -104,29 +102,16 @@ const RepoProvider = styled('div')`
   margin-top: ${space(0.25)};
 `;
 
-const SelectedIndicator = styled('span')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  font-weight: 600;
-  color: ${p => p.theme.activeText};
-  background-color: ${p => p.theme.active};
-  padding: ${space(0.25)} ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
-`;
-
-const ActionContainer = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
 const AddIcon = styled(IconAdd)`
   color: ${p => p.theme.gray300};
-  visibility: hidden;
 
   ${RepoListItemContainer}:hover & {
-    visibility: visible;
-  }
-
-  &:hover {
     color: ${p => p.theme.purple300};
   }
+`;
+
+const RightAlign = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;

--- a/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectableRepoItem.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 
-import type {Repository} from 'sentry/components/events/autofix/types';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Repository} from 'sentry/types/integrations';
 
 interface Props {
   isSelected: boolean;

--- a/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
@@ -1,0 +1,310 @@
+import {type ChangeEvent, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {InputGroup} from 'sentry/components/core/input/inputGroup';
+import type {RepoSettings, Repository} from 'sentry/components/events/autofix/types';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {IconChevron as IconExpandToggle, IconClose, IconCommit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  onRemove: () => void;
+  onSettingsChange: (settings: RepoSettings) => void;
+  repo: Repository;
+  settings: RepoSettings;
+}
+
+export function SelectedRepoItem({repo, onRemove, settings, onSettingsChange}: Props) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [isEditingBranch, setIsEditingBranch] = useState(false);
+  const [branchInputValue, setBranchInputValue] = useState(settings.branch);
+  const [instructionsValue, setInstructionsValue] = useState(settings.instructions);
+  const [originalValues, setOriginalValues] = useState({
+    branch: settings.branch,
+    instructions: settings.instructions,
+  });
+  const [isDirty, setIsDirty] = useState(false);
+
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  useEffect(() => {
+    setBranchInputValue(settings.branch);
+    setInstructionsValue(settings.instructions);
+    setOriginalValues({
+      branch: settings.branch,
+      instructions: settings.instructions,
+    });
+    setIsDirty(false);
+  }, [settings.branch, settings.instructions]);
+
+  useEffect(() => {
+    const newIsDirty =
+      branchInputValue !== originalValues.branch ||
+      instructionsValue !== originalValues.instructions;
+    setIsDirty(newIsDirty);
+  }, [branchInputValue, instructionsValue, originalValues]);
+
+  const handleBranchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    setBranchInputValue(e.target.value);
+  };
+
+  const handleInstructionsChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    e.stopPropagation();
+    setInstructionsValue(e.target.value);
+  };
+
+  const saveChanges = () => {
+    onSettingsChange({
+      branch: branchInputValue,
+      instructions: instructionsValue,
+    });
+    setIsEditingBranch(false);
+  };
+
+  const cancelChanges = () => {
+    setBranchInputValue(originalValues.branch);
+    setInstructionsValue(originalValues.instructions);
+    setIsEditingBranch(false);
+    setIsDirty(false);
+  };
+
+  return (
+    <SelectedRepoContainer>
+      <SelectedRepoHeader onClick={toggleExpanded}>
+        <RepoNameAndExpandToggle>
+          <StyledIconExpandToggle direction={isExpanded ? 'down' : 'right'} size="xs" />
+          <RepoInfoWrapper>
+            <RepoName>{repo.name}</RepoName>
+            <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
+          </RepoInfoWrapper>
+        </RepoNameAndExpandToggle>
+        <RemoveButton
+          size="xs"
+          borderless
+          icon={<IconClose size="xs" />}
+          onClick={e => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          aria-label={t('Remove repository')}
+          title={t('Remove repository')}
+        />
+      </SelectedRepoHeader>
+      {isExpanded && (
+        <ExpandedContent>
+          <RepoForm>
+            <RepositorySettingsSection>
+              <SettingsGroup>
+                <BranchInputLabel>
+                  {t('Branch that Autofix works on')}
+                  <QuestionTooltip
+                    title={t(
+                      'Optionally provide a specific branch that Autofix will work on. If left blank, Autofix will use the default branch of the repository.'
+                    )}
+                    size="sm"
+                  />
+                </BranchInputLabel>
+
+                <BranchInputContainer>
+                  <InputGroup>
+                    <InputGroup.LeadingItems disablePointerEvents>
+                      <IconCommit size="sm" />
+                    </InputGroup.LeadingItems>
+                    <InputGroup.Input
+                      type="text"
+                      value={isEditingBranch ? branchInputValue : settings.branch}
+                      onChange={handleBranchInputChange}
+                      onFocus={() => !isEditingBranch && setIsEditingBranch(true)}
+                      placeholder={t('Default branch')}
+                      autoFocus={isEditingBranch && !settings.branch}
+                    />
+                    {(isEditingBranch ? branchInputValue : settings.branch) && (
+                      <InputGroup.TrailingItems>
+                        <ClearButton
+                          size="xs"
+                          borderless
+                          icon={<IconClose size="xs" />}
+                          onClick={() => {
+                            setBranchInputValue('');
+                            if (!isEditingBranch) {
+                              setIsEditingBranch(true);
+                            }
+                            setIsDirty(true);
+                          }}
+                          aria-label={t('Clear branch and use default')}
+                          title={t('Clear branch and use default')}
+                        />
+                      </InputGroup.TrailingItems>
+                    )}
+                  </InputGroup>
+                </BranchInputContainer>
+              </SettingsGroup>
+
+              <SettingsGroup>
+                <BranchInputLabel>{t('Instructions for Autofix')}</BranchInputLabel>
+                <StyledTextArea
+                  value={instructionsValue}
+                  onChange={handleInstructionsChange}
+                  placeholder={t(
+                    'Any special instructions for Autofix in this repository...'
+                  )}
+                  rows={3}
+                />
+              </SettingsGroup>
+            </RepositorySettingsSection>
+
+            {isDirty && (
+              <FormActions>
+                <Button size="xs" onClick={cancelChanges}>
+                  {t('Cancel')}
+                </Button>
+                <Button size="xs" priority="primary" onClick={saveChanges}>
+                  {t('Save')}
+                </Button>
+              </FormActions>
+            )}
+          </RepoForm>
+        </ExpandedContent>
+      )}
+    </SelectedRepoContainer>
+  );
+}
+
+// Styled components
+const BaseRepoContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const SelectedRepoContainer = styled(BaseRepoContainer)``;
+
+const SelectedRepoHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${space(1.5)};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const RepoNameAndExpandToggle = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIconExpandToggle = styled(IconExpandToggle)`
+  margin-right: ${space(0.5)};
+`;
+
+const RemoveButton = styled(Button)`
+  color: ${p => p.theme.gray300};
+
+  &:hover {
+    color: ${p => p.theme.red300};
+  }
+`;
+
+const RepoInfoWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-left: ${space(1)};
+`;
+
+const RepoName = styled('div')`
+  font-weight: 600;
+`;
+
+const RepoProvider = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  margin-top: ${space(0.25)};
+`;
+
+const ExpandedContent = styled('div')`
+  padding: ${space(1.5)};
+  background-color: ${p => p.theme.background};
+  border-top: 1px solid ${p => p.theme.border};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const RepositorySettingsSection = styled('div')``;
+
+const SettingsGroup = styled('div')`
+  margin-bottom: ${space(2)};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const BranchInputLabel = styled('label')`
+  display: flex;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray500};
+  margin-bottom: ${space(0.5)};
+  gap: ${space(0.5)};
+`;
+
+const BranchInputContainer = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+`;
+
+const RepoForm = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const FormActions = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${space(1)};
+  margin-top: ${space(2)};
+  border-top: 1px solid ${p => p.theme.border};
+  padding-top: ${space(2)};
+`;
+
+const StyledTextArea = styled('textarea')`
+  width: 100%;
+  padding: ${space(1)};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  font-size: ${p => p.theme.fontSizeMedium};
+  background-color: ${p => p.theme.background};
+  resize: vertical;
+  min-height: 80px;
+
+  &:focus {
+    outline: none;
+    border-color: ${p => p.theme.focus};
+    box-shadow: ${p => p.theme.focusBorder};
+  }
+
+  &::placeholder {
+    color: ${p => p.theme.gray300};
+  }
+`;
+
+const ClearButton = styled(Button)`
+  color: ${p => p.theme.gray300};
+
+  &:hover {
+    color: ${p => p.theme.gray500};
+  }
+`;

--- a/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
@@ -176,7 +176,6 @@ export function SelectedRepoItem({repo, onRemove, settings, onSettingsChange}: P
   );
 }
 
-// Styled components
 const BaseRepoContainer = styled('div')`
   display: flex;
   flex-direction: column;

--- a/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
@@ -176,15 +176,13 @@ export function SelectedRepoItem({repo, onRemove, settings, onSettingsChange}: P
   );
 }
 
-const BaseRepoContainer = styled('div')`
+const SelectedRepoContainer = styled('div')`
   display: flex;
   flex-direction: column;
   width: 100%;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 `;
-
-const SelectedRepoContainer = styled(BaseRepoContainer)``;
 
 const SelectedRepoHeader = styled('div')`
   display: flex;

--- a/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
@@ -3,11 +3,12 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
-import type {RepoSettings, Repository} from 'sentry/components/events/autofix/types';
+import type {RepoSettings} from 'sentry/components/events/autofix/types';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconChevron as IconExpandToggle, IconClose, IconCommit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Repository} from 'sentry/types/integrations';
 
 interface Props {
   onRemove: () => void;

--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -1,0 +1,29 @@
+import {useCallback, useMemo} from 'react';
+
+import type {Repository} from 'sentry/types/integrations';
+import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useOrganizationRepositories() {
+  const organization = useOrganization();
+
+  const getQueryKey = useCallback(
+    ({cursor, per_page}: {cursor: string; per_page: number}): ApiQueryKey => [
+      `/organizations/${organization.slug}/repos/`,
+      {query: {cursor, per_page}},
+    ],
+    [organization.slug]
+  );
+
+  const {pages, isFetching} = useFetchSequentialPages<Repository[]>({
+    getQueryKey,
+    perPage: 100,
+    enabled: true,
+  });
+
+  return {
+    data: useMemo(() => pages.flat(), [pages]),
+    isFetching,
+  };
+}

--- a/static/app/components/events/autofix/preferences/hooks/useProjectPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useProjectPreferences.ts
@@ -1,4 +1,7 @@
-import type {ProjectPreferences} from 'sentry/components/events/autofix/types';
+import type {
+  ProjectPreferences,
+  SeerRepoDefinition,
+} from 'sentry/components/events/autofix/types';
 import type {Project} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -6,15 +9,16 @@ import useOrganization from 'sentry/utils/useOrganization';
 export function useProjectPreferences(project: Project) {
   const organization = useOrganization();
 
-  const {data, ...rest} = useApiQuery<{preference: ProjectPreferences}>(
-    [`/projects/${organization.slug}/${project.slug}/seer/preferences/`],
-    {
-      staleTime: 60000, // 1 minute
-    }
-  );
+  const {data, ...rest} = useApiQuery<{
+    code_mapping_repos: SeerRepoDefinition[];
+    preference?: ProjectPreferences | null;
+  }>([`/projects/${organization.slug}/${project.slug}/seer/preferences/`], {
+    staleTime: 60000, // 1 minute
+  });
 
   return {
-    data: data?.preference,
+    preference: data?.preference,
+    codeMappingRepos: data?.code_mapping_repos,
     ...rest,
   };
 }

--- a/static/app/components/events/autofix/preferences/hooks/useProjectPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useProjectPreferences.ts
@@ -1,0 +1,20 @@
+import type {ProjectPreferences} from 'sentry/components/events/autofix/types';
+import type {Project} from 'sentry/types/project';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useProjectPreferences(project: Project) {
+  const organization = useOrganization();
+
+  const {data, ...rest} = useApiQuery<{preference: ProjectPreferences}>(
+    [`/projects/${organization.slug}/${project.slug}/seer/preferences/`],
+    {
+      staleTime: 60000, // 1 minute
+    }
+  );
+
+  return {
+    data: data?.preference,
+    ...rest,
+  };
+}

--- a/static/app/components/events/autofix/preferences/hooks/useSaveProjectPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useSaveProjectPreferences.ts
@@ -1,0 +1,29 @@
+import type {ProjectPreferences} from 'sentry/components/events/autofix/types';
+import type {Project} from 'sentry/types/project';
+import {useMutation} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useSaveProjectPreferences(project: Project) {
+  const organization = useOrganization();
+  const api = useApi();
+
+  return useMutation({
+    mutationFn: (data: ProjectPreferences) => {
+      return api
+        .requestPromise(
+          `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+          {
+            method: 'POST',
+            data,
+          }
+        )
+        .then(resp => {
+          if (!resp.ok) {
+            throw new Error('Failed to save preferences');
+          }
+          return resp.json();
+        });
+    },
+  });
+}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -252,3 +252,31 @@ export interface AutofixRepoDefinition {
   owner: string;
   provider: string;
 }
+
+export interface Repository {
+  externalId: string;
+  id: string;
+  name: string;
+  provider?: {
+    id?: string;
+    name?: string;
+  };
+}
+
+export interface RepoSettings {
+  branch: string;
+  instructions: string;
+}
+
+export interface ProjectPreferences {
+  repositories: Array<{
+    external_id: string;
+    name: string;
+    owner: string;
+    provider: string;
+    base_commit_sha?: string;
+    branch_name?: string;
+    instructions?: string;
+    provider_raw?: string;
+  }>;
+}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -268,15 +268,17 @@ export interface RepoSettings {
   instructions: string;
 }
 
+export interface SeerRepoDefinition {
+  external_id: string;
+  name: string;
+  owner: string;
+  provider: string;
+  base_commit_sha?: string;
+  branch_name?: string;
+  instructions?: string;
+  provider_raw?: string;
+}
+
 export interface ProjectPreferences {
-  repositories: Array<{
-    external_id: string;
-    name: string;
-    owner: string;
-    provider: string;
-    base_commit_sha?: string;
-    branch_name?: string;
-    instructions?: string;
-    provider_raw?: string;
-  }>;
+  repositories: SeerRepoDefinition[];
 }

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -128,3 +128,7 @@ export const getCodeChangesIsLoading = (autofixData: AutofixData) => {
 
   return changesStep?.status === AutofixStatus.PROCESSING;
 };
+
+export const isSupportedAutofixProvider = (provider: string) => {
+  return provider.toLowerCase().includes('github');
+};

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -256,6 +256,9 @@ export function GroupSummary({
                 size: 'xs',
                 borderless: true,
                 showChevron: false,
+                style: {
+                  zIndex: 0,
+                },
               }}
               isDisabled={isPending}
               position="bottom-end"

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -12,6 +12,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
+import AutofixPreferenceDropdown from 'sentry/components/events/autofix/preferences/autofixPreferenceDropdown';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
 import useDrawer from 'sentry/components/globalDrawer';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
@@ -204,6 +205,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         {!aiConfig.needsGenAIConsent && (
           <ButtonBarWrapper data-test-id="autofix-button-bar">
             <ButtonBar gap={1}>
+              <AutofixPreferenceDropdown project={project} />
               <AutofixFeedback />
               {aiConfig.hasAutofix && (
                 <Button

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import starImage from 'sentry-images/spot/banner-star.svg';
 
+import Feature from 'sentry/components/acl/feature';
 import {SeerIcon, SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
@@ -205,7 +206,9 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         {!aiConfig.needsGenAIConsent && (
           <ButtonBarWrapper data-test-id="autofix-button-bar">
             <ButtonBar gap={1}>
-              <AutofixPreferenceDropdown project={project} />
+              <Feature features={['organizations:autofix-seer-preferences']}>
+                <AutofixPreferenceDropdown project={project} />
+              </Feature>
               <AutofixFeedback />
               {aiConfig.hasAutofix && (
                 <Button


### PR DESCRIPTION
Adds a preferences dropdown in the seer drawer, where users can configure the repos that Autofix will have access to. They can also provide free-text instructions and set a custom branch.

Loading:
![CleanShot 2025-03-25 at 10 37 47](https://github.com/user-attachments/assets/f58148b6-2196-4467-a8f2-89d4b6b69084)
Searchable list of repos to add:
![CleanShot 2025-03-25 at 11 44 14](https://github.com/user-attachments/assets/a01a0f31-2eaf-4ebc-a703-2acd4940d66c)

After you add one:
![CleanShot 2025-03-25 at 10 38 06](https://github.com/user-attachments/assets/6d76b78c-5a75-4e01-8712-bb1cc99dd9cc)
Editing the repo settings will need to be saved:
![CleanShot 2025-03-25 at 10 38 12](https://github.com/user-attachments/assets/e26c1bf0-691f-4706-abe1-c21bce7c6926)

Max 8 repos: 
![CleanShot 2025-03-25 at 10 45 30](https://github.com/user-attachments/assets/babc30f7-2641-49ec-9729-1db9e394c693)

