### PR TITLE
fix(autofix): Fix 3 dot menu in summary being clipped

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -387,6 +387,11 @@ const TooltipWrapper = styled('div')`
   position: absolute;
   top: -${space(0.5)};
   right: 0;
+
+  ul {
+    max-height: none !important;
+    overflow: visible !important;
+  }
 `;
 
 const StyledIconEllipsis = styled(IconEllipsis)`

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -402,7 +402,7 @@ const StyledButton = styled(Button)`
 
 const StyledCard = styled('div')`
   background: ${p => p.theme.backgroundElevated};
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(2)} ${space(3)};


### PR DESCRIPTION
The menu is no longer constrained by the summary card's height, so it looks normal.

<img width="282" alt="Screenshot 2025-03-24 at 2 33 26 PM" src="https://github.com/user-attachments/assets/86dfb80f-52f5-4b7c-99df-2b83073be8a7" />
