### PR TITLE
ref(tour): Remove  isAvailable state

### DIFF
--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -26,39 +26,10 @@ describe('Tour Components', () => {
   });
 
   describe('TourContextProvider', () => {
-    it('renders children regardless of availability', () => {
-      mockUseTourReducer.mockReturnValue(emptyTourContext);
-
-      const {container: availableContainer} = render(
-        <TourContextProvider<TestTour>
-          isAvailable
-          isCompleted={false}
-          orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
-        >
-          <div>Child Content</div>
-        </TourContextProvider>
-      );
-      expect(within(availableContainer).getByText('Child Content')).toBeInTheDocument();
-
-      const {container: unavailableContainer} = render(
-        <TourContextProvider<TestTour>
-          isAvailable={false}
-          isCompleted={false}
-          orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
-        >
-          <div>Child Content</div>
-        </TourContextProvider>
-      );
-      expect(within(unavailableContainer).getByText('Child Content')).toBeInTheDocument();
-    });
-
     it('renders children regardless of completion', () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
       render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -79,7 +50,6 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          isAvailable
           tourContext={TestTourContext}
         >
           <div>Child Content</div>
@@ -91,7 +61,6 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          isAvailable
           tourContext={TestTourContext}
           omitBlur
         >
@@ -120,7 +89,6 @@ describe('Tour Components', () => {
           tourKey={tourKey}
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          isAvailable
           tourContext={TestTourContext}
         >
           <div>Child Content</div>
@@ -140,7 +108,6 @@ describe('Tour Components', () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
       const {unmount: unmountInactive} = render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -166,7 +133,6 @@ describe('Tour Components', () => {
       });
       render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -194,7 +160,6 @@ describe('Tour Components', () => {
       });
       const {unmount: unmountFirstStep} = render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -229,7 +194,6 @@ describe('Tour Components', () => {
 
       const {unmount: unmountSecondStep} = render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -260,7 +224,6 @@ describe('Tour Components', () => {
 
       render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -290,7 +253,6 @@ describe('Tour Components', () => {
       });
       render(
         <TourContextProvider<TestTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
@@ -342,7 +304,6 @@ describe('Tour Components', () => {
       render(
         <TourContextProvider<TestTour>
           tourKey={tourKey}
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -34,10 +34,6 @@ export interface TourContextProviderProps<T extends TourEnumType> {
    */
   children: React.ReactNode;
   /**
-   * Whether the tour can be accessed by the user
-   */
-  isAvailable: TourState<T>['isAvailable'];
-  /**
    * Whether the tour has been completed.
    */
   isCompleted: TourState<T>['isCompleted'];
@@ -61,7 +57,6 @@ export interface TourContextProviderProps<T extends TourEnumType> {
 
 export function TourContextProvider<T extends TourEnumType>({
   children,
-  isAvailable,
   isCompleted,
   tourKey,
   tourContext,
@@ -71,7 +66,6 @@ export function TourContextProvider<T extends TourEnumType>({
   const organization = useOrganization();
   const {mutate} = useMutateAssistant();
   const tourContextValue = useTourReducer<T>({
-    isAvailable,
     isCompleted,
     isRegistered: false,
     orderedStepIds,

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -334,7 +334,6 @@ function TourProvider({
     <SizingWindow>
       <BlurBoundary>
         <TourContextProvider<MyTour>
-          isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_MY_TOUR}
           tourContext={MyTourContext}

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -27,10 +27,6 @@ type TourSetStepAction<T extends TourEnumType> = {
 type TourEndAction = {
   type: 'END_TOUR';
 };
-type TourSetAvailabilityAction = {
-  isAvailable: boolean;
-  type: 'SET_AVAILABILITY';
-};
 type TourSetRegistrationAction = {
   isRegistered: boolean;
   type: 'SET_REGISTRATION';
@@ -46,7 +42,6 @@ export type TourAction<T extends TourEnumType> =
   | TourPreviousStepAction
   | TourSetStepAction<T>
   | TourEndAction
-  | TourSetAvailabilityAction
   | TourSetRegistrationAction
   | TourSetCompletionAction;
 
@@ -55,10 +50,6 @@ export interface TourState<T extends TourEnumType> {
    * The current active tour step. If this is null, the tour is not active.
    */
   currentStepId: TourStep<T>['id'] | null;
-  /**
-   * Whether the tour is available to the user. Should be set by flags or other conditions.
-   */
-  isAvailable: boolean;
   /**
    * Whether the tour has been completed.
    */
@@ -91,8 +82,8 @@ function tourReducer<T extends TourEnumType>(
   const completeTourState = {...state, currentStepId: null, isCompleted: true};
   switch (action.type) {
     case 'START_TOUR': {
-      // If the tour is not available, or not all steps are registered, do nothing
-      if (!state.isAvailable || !state.isRegistered) {
+      // If steps are not all registered, do nothing
+      if (!state.isRegistered) {
         return state;
       }
       // If the stepId is provided, set the current step to the stepId
@@ -157,8 +148,6 @@ function tourReducer<T extends TourEnumType>(
       return {...state, isCompleted: action.isCompleted};
     case 'SET_REGISTRATION':
       return {...state, isRegistered: action.isRegistered};
-    case 'SET_AVAILABILITY':
-      return {...state, isAvailable: action.isAvailable};
     default:
       return state;
   }
@@ -195,7 +184,6 @@ export function useTourReducer<T extends TourEnumType>(
       dispatch,
       handleStepRegistration,
       currentStepId: state.currentStepId,
-      isAvailable: state.isAvailable,
       isRegistered: state.isRegistered,
       isCompleted: state.isCompleted,
       orderedStepIds: state.orderedStepIds,
@@ -205,7 +193,6 @@ export function useTourReducer<T extends TourEnumType>(
       handleStepRegistration,
       initialState.tourKey,
       state.currentStepId,
-      state.isAvailable,
       state.isRegistered,
       state.isCompleted,
       state.orderedStepIds,

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -23,6 +23,7 @@ import {
   IssueDetailsTourModal,
   IssueDetailsTourModalCss,
 } from 'sentry/views/issueDetails/issueDetailsTourModal';
+import {useIssueDetailsTourAvailable} from 'sentry/views/issueDetails/useIssueDetailsTourAvailable';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export function NewIssueExperienceButton() {
@@ -31,7 +32,6 @@ export function NewIssueExperienceButton() {
   const {
     dispatch: tourDispatch,
     currentStepId,
-    isAvailable: isTourAvailable,
     isRegistered: isTourRegistered,
     isCompleted: isTourCompleted,
   } = useIssueDetailsTour();
@@ -75,6 +75,8 @@ export function NewIssueExperienceButton() {
         userStreamlinePreference === null,
     });
   }, [mutateUserOptions, organization, hasStreamlinedUI, userStreamlinePreference]);
+
+  const isTourAvailable = useIssueDetailsTourAvailable();
 
   // The promotional modal should only appear if:
   //  - The tour is available to this user
@@ -124,12 +126,6 @@ export function NewIssueExperienceButton() {
         aria-label={t('Switch to the new issue experience')}
         onClick={() => {
           handleToggle();
-          tourDispatch({
-            type: 'SET_AVAILABILITY',
-            isAvailable:
-              location.hash === '#tour' ||
-              organization.features.includes('issue-details-streamline-tour'),
-          });
         }}
       >
         {t('Try New UI')}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -69,7 +69,6 @@ import {Tab} from 'sentry/views/issueDetails/types';
 import {makeFetchGroupQueryKey, useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
-import {useIssueDetailsTourAvailable} from 'sentry/views/issueDetails/useIssueDetailsTourAvailable';
 import {
   getGroupReprocessingStatus,
   markEventSeen,
@@ -753,7 +752,6 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
     // Prevent tour from showing until assistant data is loaded
     return issueDetailsTourData?.seen ?? true;
   }, [assistantData]);
-  const isIssueDetailsTourAvailable = useIssueDetailsTourAvailable();
 
   const project = projects.find(({slug}) => slug === projectSlug);
   const projectWithFallback = project ?? projects[0];
@@ -824,7 +822,6 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
   return (
     <TourContextProvider<IssueDetailsTour>
       tourKey={ISSUE_DETAILS_TOUR_GUIDE_KEY}
-      isAvailable={isIssueDetailsTourAvailable}
       isCompleted={isIssueDetailsTourCompleted}
       orderedStepIds={ORDERED_ISSUE_DETAILS_TOUR}
       tourContext={IssueDetailsTourContext}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -69,6 +69,7 @@ import {Tab} from 'sentry/views/issueDetails/types';
 import {makeFetchGroupQueryKey, useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
+import {useIssueDetailsTourAvailable} from 'sentry/views/issueDetails/useIssueDetailsTourAvailable';
 import {
   getGroupReprocessingStatus,
   markEventSeen,
@@ -726,7 +727,6 @@ function GroupDetailsContent({
 function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsState) {
   const projectSlug = props.group?.project?.slug;
   const api = useApi();
-  const location = useLocation();
   const organization = useOrganization();
   const [injectedEvent, setInjectedEvent] = useState(null);
   const {
@@ -734,7 +734,6 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
     initiallyLoaded: projectsLoaded,
     fetchError: errorFetchingProjects,
   } = useProjects({slugs: projectSlug ? [projectSlug] : []});
-  const hasStreamlinedUI = useHasStreamlinedUI();
 
   // Preload detailed project data for highlighted data section
   useDetailedProject(
@@ -754,15 +753,7 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
     // Prevent tour from showing until assistant data is loaded
     return issueDetailsTourData?.seen ?? true;
   }, [assistantData]);
-  const isIssueDetailsTourAvailable = useMemo(() => {
-    if (!hasStreamlinedUI) {
-      return false;
-    }
-    return (
-      location.hash === '#tour' ||
-      organization.features.includes('issue-details-streamline-tour')
-    );
-  }, [hasStreamlinedUI, location.hash, organization.features]);
+  const isIssueDetailsTourAvailable = useIssueDetailsTourAvailable();
 
   const project = projects.find(({slug}) => slug === projectSlug);
   const projectWithFallback = project ?? projects[0];

--- a/static/app/views/issueDetails/useIssueDetailsTourAvailable.tsx
+++ b/static/app/views/issueDetails/useIssueDetailsTourAvailable.tsx
@@ -1,0 +1,18 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
+
+export function useIssueDetailsTourAvailable() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const hasStreamlinedUI = useHasStreamlinedUI();
+
+  if (!hasStreamlinedUI) {
+    return false;
+  }
+
+  return (
+    location.hash === '#tour' ||
+    organization.features.includes('issue-details-streamline-tour')
+  );
+}


### PR DESCRIPTION
While refactoring part of the tour state to include callbacks, I realized that `isAvailable` doesn't actually need to be stateful. To me it makes more sense to control this from outside the tour component. I can't find any reason for why it needs to be part of the component state, but let me know if I'm missing something.

For issue details I extracted the logic into `useIssueDetailsTourAvailable()` which is used to determine whether or not to start the tour. 