### PR TITLE
ref(aci): tagged event and event attribute subfilters for event frequency conditions

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -38,7 +38,7 @@ attribute_registry = Registry[AttributeHandler]()
 
 
 # Maps attributes to snuba columns
-ATTR_CHOICES = {
+ATTR_CHOICES: dict[str, Columns | None] = {
     "message": Columns.MESSAGE,
     "platform": Columns.PLATFORM,
     "environment": Columns.MESSAGE,

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -6,6 +6,9 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
     percent_increase,
 )
+from sentry.workflow_engine.handlers.condition.event_attribute_handler import (
+    EventAttributeConditionHandler,
+)
 from sentry.workflow_engine.handlers.condition.tagged_event_handler import (
     TaggedEventConditionHandler,
 )
@@ -27,7 +30,12 @@ class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
             "value": {"type": "integer", "minimum": 0},
             "filters": {
                 "type": "array",
-                "items": TaggedEventConditionHandler.comparison_json_schema,
+                "items": {
+                    "anyOf": [
+                        TaggedEventConditionHandler.comparison_json_schema,
+                        EventAttributeConditionHandler.comparison_json_schema,
+                    ],
+                },
             },
         },
         "required": ["interval", "value"],
@@ -55,7 +63,12 @@ class EventFrequencyPercentHandler(DataConditionHandler[list[int]]):
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
             "filters": {
                 "type": "array",
-                "items": TaggedEventConditionHandler.comparison_json_schema,
+                "items": {
+                    "anyOf": [
+                        TaggedEventConditionHandler.comparison_json_schema,
+                        EventAttributeConditionHandler.comparison_json_schema,
+                    ],
+                },
             },
         },
         "required": ["interval", "value", "comparison_interval"],
@@ -81,7 +94,12 @@ class PercentSessionsCountHandler(EventFrequencyCountHandler):
             "value": {"type": "number", "minimum": 0, "maximum": 100},
             "filters": {
                 "type": "array",
-                "items": TaggedEventConditionHandler.comparison_json_schema,
+                "items": {
+                    "anyOf": [
+                        TaggedEventConditionHandler.comparison_json_schema,
+                        EventAttributeConditionHandler.comparison_json_schema,
+                    ],
+                },
             },
         },
         "required": ["interval", "value"],
@@ -102,7 +120,12 @@ class PercentSessionsPercentHandler(EventFrequencyPercentHandler):
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
             "filters": {
                 "type": "array",
-                "items": TaggedEventConditionHandler.comparison_json_schema,
+                "items": {
+                    "anyOf": [
+                        TaggedEventConditionHandler.comparison_json_schema,
+                        EventAttributeConditionHandler.comparison_json_schema,
+                    ],
+                },
             },
         },
         "required": ["interval", "value", "comparison_interval"],

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -358,20 +358,22 @@ def create_event_unique_user_frequency_condition_with_conditions(
 
     if conditions:
         for condition in conditions:
-            if condition["id"] in (EventAttributeFilter.id, TaggedEventFilter.id):
-                match = MatchType(condition["match"])
-                comparison_filter = {
-                    "match": match,
-                    "key": (
-                        condition["attribute"]
-                        if condition["id"] == EventAttributeFilter.id
-                        else condition["key"]
-                    ),
-                }
-                if match not in {MatchType.IS_SET, MatchType.NOT_SET}:
-                    comparison_filter["value"] = condition["value"]
-            else:
-                raise ValueError(f"Unsupported nested condition: {condition["id"]}")
+            condition_id = condition["id"]
+            comparison_filter: dict[str, Any] = {}
+
+            match condition_id:
+                case EventAttributeFilter.id:
+                    comparison_filter["attribute"] = condition["attribute"]
+                case TaggedEventFilter.id:
+                    comparison_filter["key"] = condition["key"]
+                case _:
+                    raise ValueError(f"Unsupported condition: {condition_id}")
+
+            match = MatchType(condition["match"])
+            comparison_filter["match"] = match
+
+            if match not in {MatchType.IS_SET, MatchType.NOT_SET}:
+                comparison_filter["value"] = condition["value"]
 
             comparison_filters.append(comparison_filter)
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -52,8 +52,17 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
                 "interval": self.payload["interval"],
                 "value": self.payload["value"],
                 "filters": [
-                    {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},
-                    {"match": MatchType.IS_SET, "key": "environment"},
+                    {
+                        "match": MatchType.EQUAL,
+                        "key": "LOGGER",
+                        "value": "sentry.example",
+                    },  # TaggedEvent
+                    {"match": MatchType.IS_SET, "key": "environment"},  # TaggedEvent
+                    {
+                        "match": MatchType.EQUAL,
+                        "attribute": "platform",
+                        "value": "python",
+                    },  # EventAttribute
                 ],
             },
             condition_result=True,
@@ -136,6 +145,18 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
                 condition_result=True,
             )
 
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "comparison_interval": "asdf",
+                    "filters": [{"match": MatchType.EQUAL, "attribute": "platform"}],
+                },
+                condition_result=True,
+            )
+
 
 class TestEventFrequencyPercentCondition(ConditionTestCase):
     def setUp(self):
@@ -175,8 +196,17 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
                 "value": self.payload["value"],
                 "comparison_interval": self.payload["comparisonInterval"],
                 "filters": [
-                    {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},
-                    {"match": MatchType.IS_SET, "key": "environment"},
+                    {
+                        "match": MatchType.EQUAL,
+                        "key": "LOGGER",
+                        "value": "sentry.example",
+                    },  # TaggedEvent
+                    {"match": MatchType.IS_SET, "key": "environment"},  # TaggedEvent
+                    {
+                        "match": MatchType.EQUAL,
+                        "attribute": "platform",
+                        "value": "python",
+                    },  # EventAttribute
                 ],
             },
             condition_result=True,
@@ -255,6 +285,18 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
                     "value": 100,
                     "comparison_interval": "asdf",
                     "filters": [{"match": "asdf", "key": "LOGGER", "value": "sentry.example"}],
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "comparison_interval": "asdf",
+                    "filters": [{"match": MatchType.EQUAL, "attribute": "platform"}],
                 },
                 condition_result=True,
             )
@@ -378,7 +420,7 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
             {"match": MatchType.IS_SET, "key": self.conditions[1]["key"]},
             {
                 "match": MatchType.EQUAL,
-                "key": self.conditions[2]["attribute"],
+                "attribute": self.conditions[2]["attribute"],
                 "value": self.conditions[2]["value"],
             },
         ]

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -103,7 +103,7 @@ class RuleMigrationHelpersTest(TestCase):
             {"match": MatchType.IS_SET, "key": self.filters[1]["key"]},
             {
                 "match": MatchType.EQUAL,
-                "key": self.filters[2]["attribute"],
+                "attribute": self.filters[2]["attribute"],
                 "value": self.filters[2]["value"],
             },
         ]

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -105,7 +105,7 @@ class IssueAlertMigratorTest(TestCase):
             {"match": MatchType.IS_SET, "key": self.filters[1]["key"]},
             {
                 "match": MatchType.EQUAL,
-                "key": self.filters[2]["attribute"],
+                "attribute": self.filters[2]["attribute"],
                 "value": self.filters[2]["value"],
             },
         ]


### PR DESCRIPTION
Event frequency conditions that query Snuba will also include additional query filters for tags and event attributes.

The tag filter is currently implemented -- this queries the `tags` column in Snuba for the `match` and the `value`.
However, for event attributes, each attribute is a separate Snuba column that we need to query separately for the `match` and `value`.

This PR prepares for querying each event attribute filter separately by storing the event attribute filter differently from tagged event filter, using each filter's respective `comparison_json_schema`.