### PR TITLE
feat(insights): add give feedback section to session health tab

### DIFF
--- a/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
+++ b/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+import {FeatureFeedback} from 'sentry/components/featureFeedback';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {MIN_HEIGHT, MIN_WIDTH} from 'sentry/views/dashboards/widgets/common/settings';
+
+export default function GiveFeedbackSection() {
+  return (
+    <ChartContainer>
+      <FeedbackHeading>{t(`Are we missing a chart you'd like to see?`)}</FeedbackHeading>
+      <FeatureFeedback
+        featureName="session-health"
+        feedbackTypes={[t('Useful chart'), t('Useless chart'), t('Other')]}
+        buttonProps={{size: 'md'}}
+      />
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled('div')`
+  height: 220px;
+  min-height: ${MIN_HEIGHT}px;
+  min-width: ${MIN_WIDTH}px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+  background: ${p => p.theme.background};
+  gap: ${space(2)};
+`;
+
+const FeedbackHeading = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-weight: bold;
+`;

--- a/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
+++ b/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
@@ -1,19 +1,46 @@
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {FeatureFeedback} from 'sentry/components/featureFeedback';
+import {Button} from 'sentry/components/core/button';
+import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {MIN_HEIGHT, MIN_WIDTH} from 'sentry/views/dashboards/widgets/common/settings';
+
+function FeedbackButton() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <Button
+      ref={buttonRef}
+      icon={<IconMegaphone />}
+      size="md"
+      onClick={() =>
+        openForm({
+          messagePlaceholder: t('How can we make Session Health more useful for you?'),
+          tags: {
+            ['feedback.source']: 'insights.session_health',
+            ['feedback.owner']: 'replay',
+          },
+        })
+      }
+    >
+      {t('Give Feedback')}
+    </Button>
+  );
+}
 
 export default function GiveFeedbackSection() {
   return (
     <ChartContainer>
       <FeedbackHeading>{t(`Are we missing a chart you'd like to see?`)}</FeedbackHeading>
-      <FeatureFeedback
-        featureName="session-health"
-        feedbackTypes={[t('Useful chart'), t('Useless chart'), t('Other')]}
-        buttonProps={{size: 'md'}}
-      />
+      <FeedbackButton />
     </ChartContainer>
   );
 }

--- a/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
+++ b/static/app/views/insights/sessions/components/giveFeedbackSection.tsx
@@ -30,9 +30,11 @@ const ChartContainer = styled('div')`
   border: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.background};
   gap: ${space(2)};
+  padding: ${space(4)};
 `;
 
 const FeedbackHeading = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: bold;
+  text-align: center;
 `;

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -30,6 +30,7 @@ import SessionHealthRateChart from 'sentry/views/insights/sessions/charts/sessio
 import UserHealthCountChart from 'sentry/views/insights/sessions/charts/userHealthCountChart';
 import UserHealthRateChart from 'sentry/views/insights/sessions/charts/userHealthRateChart';
 import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
+import GiveFeedbackSection from 'sentry/views/insights/sessions/components/giveFeedbackSection';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
 import useProjectHasSessions from 'sentry/views/insights/sessions/queries/useProjectHasSessions';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -121,11 +122,20 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
+          {/* only show this chart if the project has user feedback set up */}
+          {hasSetupOneFeedback && (
+            <Fragment>
+              <ModuleLayout.Third>
+                <NewAndResolvedIssueChart type="feedback" />
+              </ModuleLayout.Third>
+            </Fragment>
+          )}
           <ModuleLayout.Third>
-            <NewAndResolvedIssueChart type="feedback" />
+            <GiveFeedbackSection />
           </ModuleLayout.Third>
         </Fragment>
       );
+
     case MOBILE_LANDING_SUB_PATH:
       return (
         <Fragment>
@@ -167,6 +177,9 @@ function ViewSpecificCharts({
               </ModuleLayout.Third>
             </Fragment>
           )}
+          <ModuleLayout.Third>
+            <GiveFeedbackSection />
+          </ModuleLayout.Third>
 
           <ModuleLayout.Full>
             <FilterWrapper>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import useHaveSelectedProjectsSetupFeedback from 'sentry/components/feedback/useFeedbackOnboarding';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {space} from 'sentry/styles/space';
-import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -42,8 +41,6 @@ export function SessionsOverview() {
   // only show onboarding if the project does not have session data
   const hasSessionData = useProjectHasSessions();
   const showOnboarding = !hasSessionData;
-
-  useRouteAnalyticsParams({view});
 
   return (
     <Fragment>


### PR DESCRIPTION
adds a feedback section to the session health tabs for mobile & frontend next to the bottom row of charts:


https://github.com/user-attachments/assets/07bb5942-0fbd-45e7-b09c-dc23d45307fe

