### PR TITLE
fix(replays): Avoid changing replay state on window focus

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -496,7 +496,12 @@ export function Provider({
     [organization, user.email, analyticsContext, getCurrentPlayerTime, isVideoReplay]
   );
 
+  // Pause the replay when the tab is not active
   useEffect(() => {
+    if (!isPlaying) {
+      return () => {};
+    }
+
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible' && replayerRef.current) {
         togglePlayPause(false);
@@ -508,7 +513,7 @@ export function Provider({
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [togglePlayPause]);
+  }, [togglePlayPause, isPlaying]);
 
   // Initialize replayer for Video Replays
   useEffect(() => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -496,7 +496,7 @@ export function Provider({
     [organization, user.email, analyticsContext, getCurrentPlayerTime, isVideoReplay]
   );
 
-  // Pause the replay when the tab is not active
+  // Pause the replay when the tab loses focus
   useEffect(() => {
     if (!isPlaying) {
       return () => {};


### PR DESCRIPTION
On issue details there was a tiny lag when switching tabs when a complex replay was visible. Tracked it down to pausing the replay when it was already paused.
