### PR TITLE
ref: Extract `<ReplayLoadingState>` from ReplaySlugChooser

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -1,7 +1,6 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {Alert} from 'sentry/components/core/alert';
 import type {LinkButtonProps} from 'sentry/components/core/button';
@@ -12,11 +11,10 @@ import {
 import ReplayPreviewPlayer from 'sentry/components/events/eventReplay/replayPreviewPlayer';
 import {StaticReplayPreview} from 'sentry/components/events/eventReplay/staticReplayPreview';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import ArchivedReplayAlert from 'sentry/components/replays/alerts/archivedReplayAlert';
 import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
-import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
@@ -92,12 +90,7 @@ function ReplayClipPreviewPlayer({
   if (replayReaderResult.replayRecord?.is_archived) {
     return (
       <Alert.Container>
-        <Alert type="warning" data-test-id="replay-error">
-          <Flex gap={space(0.5)}>
-            <IconDelete color="gray500" size="sm" />
-            {t('The replay for this event has been deleted.')}
-          </Flex>
-        </Alert>
+        <ArchivedReplayAlert message={t('The replay for this event has been deleted.')} />
       </Alert.Container>
     );
   }

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -2,15 +2,14 @@ import type {ComponentProps} from 'react';
 import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {Alert} from 'sentry/components/core/alert';
 import type {LinkButton} from 'sentry/components/core/button';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
 import {StaticReplayPreview} from 'sentry/components/events/eventReplay/staticReplayPreview';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import ArchivedReplayAlert from 'sentry/components/replays/alerts/archivedReplayAlert';
 import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
-import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -91,12 +90,7 @@ function ReplayPreview({
   if (replayRecord?.is_archived) {
     return (
       <Alert.Container>
-        <Alert type="warning" data-test-id="replay-error">
-          <Flex gap={space(0.5)}>
-            <IconDelete color="gray500" size="sm" />
-            {t('The replay for this event has been deleted.')}
-          </Flex>
-        </Alert>
+        <ArchivedReplayAlert message={t('The replay for this event has been deleted.')} />
       </Alert.Container>
     );
   }

--- a/static/app/components/replays/alerts/archivedReplayAlert.tsx
+++ b/static/app/components/replays/alerts/archivedReplayAlert.tsx
@@ -1,0 +1,20 @@
+import {Flex} from 'sentry/components/container/flex';
+import {Alert} from 'sentry/components/core/alert';
+import {IconDelete} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  message?: string;
+}
+
+export default function ArchivedReplayAlert({message}: Props) {
+  return (
+    <Alert type="warning" data-test-id="replay-archived">
+      <Flex gap={space(0.5)}>
+        <IconDelete color="gray500" size="sm" />
+        {message ?? t('This replay has been deleted.')}
+      </Flex>
+    </Alert>
+  );
+}

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -42,20 +42,24 @@ export default function ReplayLoadingState({
   });
 
   if (readerResult.fetchError) {
-    return (
-      renderError?.(readerResult) ?? <MissingReplayAlert orgSlug={organization.slug} />
+    return renderError ? (
+      renderError(readerResult)
+    ) : (
+      <MissingReplayAlert orgSlug={organization.slug} />
     );
   }
   if (readerResult.fetching) {
-    return renderLoading?.(readerResult) ?? <LoadingIndicator />;
+    return renderLoading ? renderLoading(readerResult) : <LoadingIndicator />;
   }
   if (!readerResult.replay) {
-    return (
-      renderMissing?.(readerResult) ?? <MissingReplayAlert orgSlug={organization.slug} />
+    return renderMissing ? (
+      renderMissing(readerResult)
+    ) : (
+      <MissingReplayAlert orgSlug={organization.slug} />
     );
   }
   if (readerResult.replayRecord?.is_archived) {
-    return renderArchived?.(readerResult) ?? <ArchivedReplayAlert />;
+    return renderArchived ? renderArchived(readerResult) : <ArchivedReplayAlert />;
   }
   return children({replay: readerResult.replay});
 }

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -1,0 +1,61 @@
+import type {ReactNode} from 'react';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import ArchivedReplayAlert from 'sentry/components/replays/alerts/archivedReplayAlert';
+import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
+import type ReplayReader from 'sentry/utils/replays/replayReader';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type ClipWindow = {
+  // When to stop the replay, given it continues into that time
+  endTimestampMs: number;
+
+  // When to start the replay, given its start time is early enough
+  startTimestampMs: number;
+};
+
+type ReplayReaderResult = ReturnType<typeof useLoadReplayReader>;
+
+export default function ReplayLoadingState({
+  children,
+  replaySlug,
+  clipWindow,
+  renderArchived,
+  renderError,
+  renderLoading,
+  renderMissing,
+}: {
+  children: (props: {replay: ReplayReader}) => ReactNode;
+  replaySlug: string;
+  clipWindow?: ClipWindow;
+  renderArchived?: (results: ReplayReaderResult) => ReactNode;
+  renderError?: (results: ReplayReaderResult) => ReactNode;
+  renderLoading?: (results: ReplayReaderResult) => ReactNode;
+  renderMissing?: (results: ReplayReaderResult) => ReactNode;
+}) {
+  const organization = useOrganization();
+  const readerResult = useLoadReplayReader({
+    orgSlug: organization.slug,
+    replaySlug,
+    clipWindow,
+  });
+
+  if (readerResult.fetchError) {
+    return (
+      renderError?.(readerResult) ?? <MissingReplayAlert orgSlug={organization.slug} />
+    );
+  }
+  if (readerResult.fetching) {
+    return renderLoading?.(readerResult) ?? <LoadingIndicator />;
+  }
+  if (!readerResult.replay) {
+    return (
+      renderMissing?.(readerResult) ?? <MissingReplayAlert orgSlug={organization.slug} />
+    );
+  }
+  if (readerResult.replayRecord?.is_archived) {
+    return renderArchived?.(readerResult) ?? <ArchivedReplayAlert />;
+  }
+  return children({replay: readerResult.replay});
+}

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -1,17 +1,15 @@
 import {Fragment, useEffect} from 'react';
 
-import {Flex} from 'sentry/components/container/flex';
 import {Alert} from 'sentry/components/core/alert';
 import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
 import * as Layout from 'sentry/components/layouts/thirds';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
+import ArchivedReplayAlert from 'sentry/components/replays/alerts/archivedReplayAlert';
 import {LocalStorageReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
-import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type {TimeOffsetLocationQueryParams} from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
@@ -121,12 +119,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
       >
         <Layout.Page>
           <Alert.Container>
-            <Alert system type="warning" data-test-id="replay-deleted">
-              <Flex gap={space(0.5)}>
-                <IconDelete color="gray500" size="sm" />
-                {t('This replay has been deleted.')}
-              </Flex>
-            </Alert>
+            <ArchivedReplayAlert />
           </Alert.Container>
         </Layout.Page>
       </Page>


### PR DESCRIPTION
The updated `<ReplayLoadingState>` is more robust, allowing for overrides of all the loading states. These states are inconsistently checked when we load replay data in various parts of the app, and using this helper I intend to fix it. 

I also extracted `<ArchivedReplayAlert />` so I could have a better default; and we've got a tweak to the Props of `<ReplaySlugChooser>` so now it's possible to get the selected `replaySlug` back, instead of auto-loading it. 

This makes it possible in stories to load a replay and set components into `<ReplayLoadingState>` if needed.