### PR TITLE
feat(partnerships): backend service for partnership methods

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1760,6 +1760,10 @@ SENTRY_DIGESTS_OPTIONS: dict[str, Any] = {}
 SENTRY_QUOTAS = "sentry.quotas.Quota"
 SENTRY_QUOTA_OPTIONS: dict[str, str] = {}
 
+# Partnership backend
+SENTRY_PARTNERSHIPS = "sentry.partnerships.Partnership"
+SENTRY_PARTNERSHIP_OPTIONS: dict[str, str] = {}
+
 # Cache for Relay project configs
 SENTRY_RELAY_PROJECTCONFIG_CACHE = "sentry.relay.projectconfig_cache.redis.RedisProjectConfigCache"
 SENTRY_RELAY_PROJECTCONFIG_CACHE_OPTIONS: dict[str, str] = {}

--- a/src/sentry/partnerships/__init__.py
+++ b/src/sentry/partnerships/__init__.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+from sentry.utils.services import LazyServiceWrapper
+
+from .base import Partnership
+
+backend = LazyServiceWrapper(
+    Partnership, settings.SENTRY_PARTNERSHIPS, settings.SENTRY_PARTNERSHIP_OPTIONS
+)
+backend.expose(locals())

--- a/src/sentry/partnerships/base.py
+++ b/src/sentry/partnerships/base.py
@@ -1,0 +1,19 @@
+from collections.abc import Sequence
+
+from sentry.relay.types import RuleCondition
+from sentry.utils.services import Service
+
+
+class Partnership(Service):
+    """
+    Partnership handles the partnership between the Sentry org and a partner.
+    Based on the partnership agreementsome behavior is enabled or disabled.
+    """
+
+    __all__ = "get_inbound_filters"
+
+    def __init__(self, **options):
+        pass
+
+    def get_inbound_filters(self, org) -> Sequence[tuple[str, RuleCondition]]:
+        return []

--- a/src/sentry/partnerships/base.py
+++ b/src/sentry/partnerships/base.py
@@ -1,6 +1,4 @@
-from collections.abc import Sequence
-
-from sentry.relay.types import RuleCondition
+from sentry.relay.types import GenericFilter
 from sentry.utils.services import Service
 
 
@@ -10,10 +8,10 @@ class Partnership(Service):
     Based on the partnership agreementsome behavior is enabled or disabled.
     """
 
-    __all__ = "get_inbound_filters"
+    __all__ = ("get_inbound_filters",)
 
     def __init__(self, **options):
         pass
 
-    def get_inbound_filters(self, org) -> Sequence[tuple[str, RuleCondition]]:
+    def get_inbound_filters(self, org) -> list[GenericFilter]:
         return []

--- a/src/sentry/partnerships/base.py
+++ b/src/sentry/partnerships/base.py
@@ -1,3 +1,4 @@
+from sentry.models.organization import Organization
 from sentry.relay.types import GenericFilter
 from sentry.utils.services import Service
 
@@ -5,7 +6,8 @@ from sentry.utils.services import Service
 class Partnership(Service):
     """
     Partnership handles the partnership between the Sentry org and a partner.
-    Based on the partnership agreementsome behavior is enabled or disabled.
+    Based on the partnership agreement some behavior on Sentry might be different
+    from the default behavior without the partnership.
     """
 
     __all__ = ("get_inbound_filters",)
@@ -13,5 +15,5 @@ class Partnership(Service):
     def __init__(self, **options):
         pass
 
-    def get_inbound_filters(self, org) -> list[GenericFilter]:
+    def get_inbound_filters(self, organization: Organization) -> list[GenericFilter]:
         return []

--- a/tests/sentry/partnerships/test_base.py
+++ b/tests/sentry/partnerships/test_base.py
@@ -1,0 +1,11 @@
+from sentry.partnerships.base import Partnership
+from sentry.testutils.cases import TestCase
+
+
+class PartnershipTest(TestCase):
+    def setUp(self):
+        self.backend = Partnership()
+
+    def test_get_inbound_filters(self):
+        org = self.create_organization()
+        assert self.backend.get_inbound_filters(org) == []

--- a/tests/sentry/partnerships/test_base.py
+++ b/tests/sentry/partnerships/test_base.py
@@ -8,4 +8,4 @@ class PartnershipTest(TestCase):
 
     def test_get_inbound_filters(self):
         org = self.create_organization()
-        assert self.backend.get_inbound_filters(org) == []
+        assert self.backend.get_inbound_filters(organization=org) == []


### PR DESCRIPTION
This PR is milestone 2 of this tech spec, Sentry side: https://www.notion.so/sentry/Nintendo-inbound-filter-1b58b10e4b5d80dc9090ec64d2825349?pvs=4#1ba8b10e4b5d802ba55fc0313f98f6cd

Getsenrty implementation: https://github.com/getsentry/getsentry/pull/17033
In the next PR I'll add it to project config code.