### PR TITLE
fix(issues): Switch to lower fidelity graph on small screens

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -1,6 +1,14 @@
-import {type CSSProperties, useEffect, useMemo, useState} from 'react';
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useResizeObserver} from '@react-aria/utils';
 import Color from 'color';
 
 import {BarChart, type BarChartSeries} from 'sentry/components/charts/barChart';
@@ -71,14 +79,30 @@ function createSeriesAndCount(stats: EventsStats) {
 export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
   const theme = useTheme();
   const organization = useOrganization();
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const location = useLocation();
   const [visibleSeries, setVisibleSeries] = useState<EventGraphSeries>(
     EventGraphSeries.EVENT
   );
-  const eventView = useIssueDetailsEventView({group});
   const config = getConfigForIssueType(group, group.project);
   const {dispatch} = useIssueDetails();
   const {currentTab} = useGroupDetailsRoute();
+  const [isSmallContainer, setIsSmallContainer] = useState(false);
+
+  const onResize = useCallback(() => {
+    if (!chartContainerRef.current) {
+      return;
+    }
+
+    const {width} = chartContainerRef.current.getBoundingClientRect();
+    setIsSmallContainer(width < 450);
+  }, []);
+
+  useResizeObserver({
+    ref: chartContainerRef,
+    onResize,
+  });
+  const eventView = useIssueDetailsEventView({group, isSmallContainer});
 
   const {
     data: groupStats = {},
@@ -330,7 +354,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
             label={t('Users')}
           />
         </SummaryContainer>
-        <LoadingChartContainer>
+        <LoadingChartContainer ref={chartContainerRef}>
           <Placeholder height="96px" testId="event-graph-loading" />
         </LoadingChartContainer>
       </GraphWrapper>
@@ -361,7 +385,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
           count={String(userCount)}
         />
       </SummaryContainer>
-      <ChartContainer role="figure">
+      <ChartContainer role="figure" ref={chartContainerRef}>
         <BarChart
           height={100}
           series={series}

--- a/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
@@ -17,8 +17,10 @@ import {useGroupDefaultStatsPeriod} from 'sentry/views/issueDetails/useGroupDefa
 export function useIssueDetailsEventView({
   group,
   queryProps,
+  isSmallContainer = false,
 }: {
   group: Group;
+  isSmallContainer?: boolean;
   queryProps?: Partial<SavedQuery>;
 }) {
   const searchQuery = useEventQuery({groupId: group.id});
@@ -41,7 +43,8 @@ export function useIssueDetailsEventView({
       end: periodQuery?.end,
       period: periodQuery?.statsPeriod,
     },
-    'issues'
+    // Switch to low fidelity intervals on small screens
+    isSmallContainer ? 'low' : 'issues'
   );
   const config = getConfigForIssueType(group, group.project);
 


### PR DESCRIPTION
Bigger and fewer buckets on smaller screens. Just using the existing "low" fidelity

before
![image](https://github.com/user-attachments/assets/524f8ac5-5b30-4623-82d4-8f937db91ad3)

after
![image](https://github.com/user-attachments/assets/59be8e21-242f-4892-9403-4532b9c349cf)
