### PR TITLE
feat: Add iPhone 16e to frontend device list

### DIFF
--- a/static/app/constants/ios-device-list.tsx
+++ b/static/app/constants/ios-device-list.tsx
@@ -71,6 +71,7 @@ const iOSDeviceMapping: Record<string, string> = {
   'iPhone17,2': 'iPhone 16 Pro Max',
   'iPhone17,3': 'iPhone 16',
   'iPhone17,4': 'iPhone 16 Plus',
+  'iPhone17,5': 'iPhone 16e',
   // iPad Pro
   'iPad6,7': 'iPad Pro (12.9-inch)',
   'iPad6,8': 'iPad Pro (12.9-inch)',


### PR DESCRIPTION
Add iPhone 16e to frontend device list.

Related to https://github.com/getsentry/sentry/issues/68258 and https://github.com/getsentry/sentry/pull/87833.