### PR TITLE
fix(flamegraph): Bad matching of profile sample to reference

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -255,7 +255,7 @@ export class Flamegraph {
         depth: 0,
         start: value,
         end: value,
-        profileIds: profile.callTreeNodeProfileIdMap.get(node),
+        profileIds: Array.from(profile.callTreeNodeProfileIdMap.get(node) || []),
       };
 
       if (parent) {

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -46,8 +46,10 @@ export class Profile {
     negativeSamplesCount: 0,
   };
 
-  callTreeNodeProfileIdMap: Map<CallTreeNode, Profiling.ProfileReference[] | string[]> =
-    new Map();
+  callTreeNodeProfileIdMap: Map<
+    CallTreeNode,
+    Set<Profiling.ProfileReference> | Set<string>
+  > = new Map();
 
   constructor({
     duration,


### PR DESCRIPTION
Profile samples are sorted in flamegraph mode but we were using the unsorted list of references. This resulted in an incorrect matching between samples and references.