### PR TITLE
ref(ui): replace color theme.gray300 with theme.subText

### DIFF
--- a/static/app/components/activity/item/index.tsx
+++ b/static/app/components/activity/item/index.tsx
@@ -144,15 +144,15 @@ const StyledActivityAvatar = styled(ActivityAvatar)`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledDateTimeWindow = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledActivityBubble = styled(ActivityBubble)`

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -287,7 +287,7 @@ class AvatarChooser extends Component<Props, State> {
 
 const AvatarHelp = styled('p')`
   margin-right: auto;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: 14px;
   width: 50%;
 `;

--- a/static/app/components/avatarUploader.tsx
+++ b/static/app/components/avatarUploader.tsx
@@ -482,7 +482,7 @@ const Resizer = styled('div')<{position: Position}>`
   width: 10px;
   height: 10px;
   position: absolute;
-  background-color: ${p => p.theme.gray300};
+  background-color: ${p => p.theme.subText};
   cursor: ${p => `${p.position}-resize`};
   ${p => resizerPositions[p.position].map(pos => `${pos}: -5px;`)}
 `;

--- a/static/app/components/charts/errorPanel.tsx
+++ b/static/app/components/charts/errorPanel.tsx
@@ -13,7 +13,7 @@ const ErrorPanel = styled('div')<{height?: string}>`
   position: relative;
   border-color: transparent;
   margin-bottom: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;
 

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -164,5 +164,5 @@ const ChartWrapper = styled('div')`
 
 const GraphText = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -194,7 +194,7 @@ const CollapsedAvatarsCicle = styled('div')<{size: number}>`
   text-align: center;
   font-weight: ${p => p.theme.fontWeightBold};
   background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => Math.floor(p.size / 2.3)}px;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
@@ -209,7 +209,7 @@ const CollapsedAvatarPill = styled('div')`
   align-items: center;
   gap: ${space(0.25)};
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   height: 24px;
   padding: 0 ${space(1)};
   background-color: ${p => p.theme.surface400};

--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -2248,14 +2248,14 @@ const SearchIconContainer = styled('div')`
   display: flex;
   padding: ${space(0.5)} 0;
   margin: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const SearchLabel = styled('label')`
   display: flex;
   padding: ${space(0.5)} 0;
   margin: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const InputWrapper = styled('div')`

--- a/static/app/components/deprecatedSmartSearchBar/searchBarDatePicker.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/searchBarDatePicker.tsx
@@ -185,7 +185,7 @@ const Input = styled('input')`
   padding: 0 ${space(1)};
   background: ${p => p.theme.backgroundSecondary};
   border: 1px solid ${p => p.theme.border};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   box-shadow: none;
 `;
 
@@ -197,7 +197,7 @@ const DatePickerFooter = styled('div')`
 `;
 
 const UtcPickerLabel = styled('label')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   white-space: nowrap;
   display: flex;
   align-items: center;

--- a/static/app/components/deprecatedSmartSearchBar/searchDropdown.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/searchDropdown.tsx
@@ -503,7 +503,7 @@ const Info = styled('div')`
   display: flex;
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.innerBorder};
@@ -517,7 +517,7 @@ const SearchDropdownGroupTitle = styled('header')`
   align-items: center;
 
   background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeMedium};
 
@@ -641,7 +641,7 @@ const DropdownFooter = styled(`div`)`
 `;
 
 const HotkeyGlyphWrapper = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-right: ${space(0.5)};
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -530,7 +530,7 @@ const ReorderGroup = styled(Reorder.Group<Node<DraggableTabListItemProps>>)`
 
 const AddViewButton = styled(Button)`
   display: flex;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: normal;
   border-radius: ${p => `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`};
   padding: ${space(1)} ${space(1)};

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -451,7 +451,7 @@ const StyledInput = styled(Input)`
     font-size: 13px;
     padding: ${space(1)};
     font-weight: ${p => p.theme.fontWeightNormal};
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -49,7 +49,7 @@ export const EmptyStreamWrapper = styled('div')`
 const SmallMessage = styled('div')`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   line-height: 1em;
 `;

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -90,7 +90,7 @@ function Spacer({width}: {width: string}) {
 const Subtitle = styled('em')`
   ${p => p.theme.overflowEllipsis};
   display: inline-block;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-style: normal;
   height: 100%;
 `;

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -784,7 +784,7 @@ const SelectionButton = styled('button')`
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   opacity: 0;
   transition:
     opacity 0.2s ease,
@@ -804,7 +804,7 @@ const SelectionButton = styled('button')`
 `;
 
 const StyledIconChevron = styled(IconChevron)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   flex-shrink: 0;
   opacity: 1;
   transition: opacity 0.2s ease;
@@ -827,7 +827,7 @@ const InstructionsInput = styled(Input)`
   flex-grow: 1;
 
   &::placeholder {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -158,7 +158,7 @@ const StyledTimelineHeader = styled('div')<{isActive?: boolean}>`
 `;
 
 const StyledIconChevron = styled(IconChevron)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   flex-shrink: 0;
   margin-right: ${space(0.25)};
 `;

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -369,7 +369,7 @@ export const BreadcrumbLevel = styled('div')<{level: BreadcrumbLevelType}>`
       case BreadcrumbLevelType.DEBUG:
       case BreadcrumbLevelType.INFO:
       case BreadcrumbLevelType.LOG:
-        return p.theme.gray300;
+        return p.theme.subText;
     }
   }};
   display: ${p => (p.level === BreadcrumbLevelType.UNDEFINED ? 'none' : 'block')};

--- a/static/app/components/events/eventAnnotation.tsx
+++ b/static/app/components/events/eventAnnotation.tsx
@@ -6,10 +6,10 @@ const EventAnnotation = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
   border-left: 1px solid ${p => p.theme.innerBorder};
   padding-left: ${space(1)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   a {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
 
     &:hover {
       color: ${p => p.theme.subText};

--- a/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
@@ -182,6 +182,6 @@ const ChangeContainer = styled(NumberContainer)<{
   change: 'positive' | 'neutral' | 'negative';
 }>`
   ${p => p.change === 'positive' && `color: ${p.theme.red300};`}
-  ${p => p.change === 'neutral' && `color: ${p.theme.gray300};`}
+  ${p => p.change === 'neutral' && `color: ${p.theme.subText};`}
   ${p => p.change === 'negative' && `color: ${p.theme.green300};`}
 `;

--- a/static/app/components/events/eventStatisticalDetector/eventThroughput.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventThroughput.tsx
@@ -386,5 +386,5 @@ const CompareLabel = styled('div')<{change?: 'increase' | 'decrease'}>`
       ? p.theme.red300
       : p.change === 'decrease'
         ? p.theme.green300
-        : p.theme.gray300};
+        : p.theme.subText};
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -310,7 +310,7 @@ const Time = styled('div')`
 const StyledIconSort = styled(IconSort)`
   transition: 0.15s color;
   :hover {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
@@ -101,7 +101,7 @@ const CodeFilename = styled('span')`
 
 const ImageColumn = styled(Column)`
   font-family: ${p => p.theme.text.familyMono};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   overflow: hidden;
   flex-direction: column;

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
@@ -72,7 +72,7 @@ const Register = styled('div')`
   gap: ${space(0.5)};
   grid-template-columns: 3em 1fr;
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     text-align: right;

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -78,5 +78,5 @@ const OpenInLink = styled(ExternalLink)`
   display: flex;
   gap: ${space(0.75)};
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1879,7 +1879,7 @@ const InstructionList = styled('ul')`
 `;
 
 const ScrapingSymbolificationErrorMessage = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   border-left: 2px solid ${p => p.theme.gray200};
   padding-left: ${space(1)};
   margin-top: -${space(1)};

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1825,8 +1825,8 @@ const ListItemTitle = styled('p')<{status: 'none' | 'checked' | 'alert' | 'quest
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p =>
     ({
-      none: p.theme.gray300,
-      question: p.theme.gray300,
+      none: p.theme.subText,
+      question: p.theme.subText,
       checked: p.theme.green300,
       alert: p.theme.yellow400,
     })[p.status]};

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -722,7 +722,7 @@ const TimeAxis = styled('div')<{hasProfileMeasurementsChart: boolean}>`
   border-top: 1px solid ${p => p.theme.border};
   height: ${TIME_AXIS_HEIGHT}px;
   background-color: ${p => p.theme.background};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: 10px;
   ${p => p.theme.fontWeightNormal};
   font-variant-numeric: tabular-nums;

--- a/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
@@ -145,7 +145,7 @@ const OperationsBreakdown = styled('div')`
 `;
 
 const Dur = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-variant-numeric: tabular-nums;
 `;
 

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -444,7 +444,7 @@ const ThreadStateWrapper = styled('div')`
 
 const LockReason = styled(TextOverflow)`
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -338,7 +338,7 @@ const OpsName = styled('div')`
 `;
 
 const Dur = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-variant-numeric: tabular-nums;
 `;
 

--- a/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
@@ -11,7 +11,7 @@ const SectionWrapper = styled('section')`
 
 const SectionTitle = styled('h3')`
   margin: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   text-transform: capitalize;
 

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -130,7 +130,7 @@ const File = styled(StyledPanel)`
 `;
 
 const NoPreviewFound = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -248,7 +248,7 @@ const ContactRow = styled(TextOverflow)`
 
 const ShortId = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledTimeSince = styled(TimeSince)`

--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -139,7 +139,7 @@ const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
 `;
 
 const Description = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
   line-height: 1.4em;
 `;

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -174,7 +174,7 @@ const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
 `;
 
 const Description = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
   line-height: 1.4em;
 `;

--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -102,7 +102,7 @@ function SeenInfo({
 }
 
 const dateTimeCss = (p: any) => css`
-  color: ${p.theme.gray300};
+  color: ${p.theme.subText};
   font-size: ${p.theme.fontSizeMedium};
   display: flex;
   justify-content: center;

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -228,7 +228,7 @@ const CommitDate = styled(({date, ...props}: any) => (
   <div {...props}>{moment(date).fromNow()}</div>
 ))`
   margin-top: ${space(0.5)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const CommitReasonItem = styled('div')`
@@ -263,7 +263,7 @@ const OwnershipTag = styled(
 
 const ViewMoreButton = styled(Button)`
   border: none;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: ${space(0.25)} ${space(0.5)};
   margin: ${space(1)} ${space(0.25)} ${space(0.25)} 0;

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -292,7 +292,7 @@ const TitleType = styled('div')`
 const TitleDescription = styled('div')`
   ${p => p.theme.overflowEllipsis};
   display: flex;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-align: right;
   font-size: ${p => p.theme.fontSizeMedium};
   ${p => p.theme.overflowEllipsis};
@@ -374,18 +374,18 @@ const LegendText = styled('span')<{unfocus: boolean}>`
 const LegendPercent = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
   margin-left: ${space(1)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-align: right;
   flex-grow: 1;
 `;
 
 const ExpandToggleButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-left: ${space(0.5)};
 `;
 
 const NotApplicableLabel = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledSummary = styled('summary')`

--- a/static/app/components/helpSearch.tsx
+++ b/static/app/components/helpSearch.tsx
@@ -73,7 +73,7 @@ const SectionHeading = styled('div')`
 
 const Count = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Empty = styled('div')`

--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -133,7 +133,7 @@ const DisplayName = styled('span')`
 const Description = styled('div')`
   font-size: 0.875em;
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   line-height: 14px;
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/components/idBadge/userBadge.tsx
+++ b/static/app/components/idBadge/userBadge.tsx
@@ -62,7 +62,7 @@ const Name = styled('span')<{hideEmail: boolean}>`
 const Email = styled('div')`
   font-size: 0.875em;
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   ${p => p.theme.overflowEllipsis};
 `;
 

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -262,7 +262,7 @@ const MenuListItem = styled('li')<MenuListItemProps>`
     padding: ${space(0.25)} ${space(0.5)};
     font-size: ${p.theme.fontSizeSmall};
     line-height: 1.4;
-    color: ${p.theme.gray300};
+    color: ${p.theme.subText};
   `}
 
   ${getChildStyles}

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -128,7 +128,7 @@ const SearchLabel = styled('label')`
   display: flex;
   padding: ${space(0.5)} 0;
   margin: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export const modalCss = css`

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -186,7 +186,7 @@ const ExploreParamSection = styled('span')`
 
 const ExploreParamTitle = styled('span')`
   font-size: ${p => p.theme.form.sm.fontSize};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   white-space: nowrap;
   padding-top: 3px;
 `;

--- a/static/app/components/modals/featureTourModal.tsx
+++ b/static/app/components/modals/featureTourModal.tsx
@@ -223,7 +223,7 @@ const StepCounter = styled('div')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightBold};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 // Styled components that can be used to build tour content.

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -365,7 +365,7 @@ const MemberEmail = styled('div')`
   max-width: 150px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-overflow: ellipsis;
   overflow: hidden;
 `;

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -238,7 +238,7 @@ const Description = styled('div')`
 `;
 
 const Author = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (

--- a/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
@@ -103,7 +103,7 @@ const QueryCountBubble = styled(motion.span)`
   justify-content: center;
   border-radius: 10px;
   border: 1px solid ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-left: 0;
   font-weight: ${p => p.theme.fontWeightBold};
 `;

--- a/static/app/components/performance/waterfall/messageRow.tsx
+++ b/static/app/components/performance/waterfall/messageRow.tsx
@@ -9,7 +9,7 @@ export const MessageRow = styled(Row)`
   line-height: ${ROW_HEIGHT}px;
   padding-left: ${space(1)};
   padding-right: ${space(1)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   background-color: ${p => p.theme.backgroundSecondary};
   outline: 1px solid ${p => p.theme.border};
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -132,7 +132,7 @@ const PillValue = styled(PillName)`
   .external-icon {
     display: inline;
     margin: 0 0 0 ${space(1)};
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     &:hover {
       color: ${p => p.theme.textColor};
     }

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -92,7 +92,7 @@ const Counter = styled('div')`
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   padding: 0 1px;
   position: absolute;
   right: -1px;

--- a/static/app/components/replays/configureReplayCard.tsx
+++ b/static/app/components/replays/configureReplayCard.tsx
@@ -120,7 +120,7 @@ const ButtonTitle = styled('div')`
 `;
 
 const ButtonSubtitle = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -106,7 +106,7 @@ const ButtonTitle = styled('div')`
 `;
 
 const ButtonSubtitle = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/components/replays/header/errorCounts.tsx
+++ b/static/app/components/replays/header/errorCounts.tsx
@@ -104,7 +104,7 @@ const Count = styled('span')`
 `;
 
 const ErrorCount = styled(Count)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const ColumnTooltipContent = styled(CountTooltipContent)`

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -111,7 +111,7 @@ const KeyMetrics = styled('dl')`
   gap: 0 ${space(3)};
   align-items: center;
   align-self: end;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
@@ -137,7 +137,7 @@ const Count = styled('span')`
 `;
 
 const ClickCount = styled(Count)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   display: flex;
   gap: ${space(0.75)};
   align-items: center;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -130,7 +130,7 @@ const StyledScrubber = styled('div')`
 `;
 
 const Numeric = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   font-variant-numeric: tabular-nums;
   font-weight: ${p => p.theme.fontWeightBold};

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -149,7 +149,7 @@ function ResolutionBox(props: Props) {
 }
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-left: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -107,7 +107,7 @@ const SearchDetail = styled('div')`
 
 const ExtraDetail = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-top: ${space(0.5)};
 `;
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/date.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/date.tsx
@@ -122,6 +122,6 @@ const AbsoluteDateOption = styled('div')`
   align-items: center;
 
   svg {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;

--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -385,7 +385,7 @@ const Unit = styled('span')`
 
 const LogicBoolean = styled('span')<{invalid: boolean}>`
   font-weight: ${p => p.theme.fontWeightBold};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   ${p => p.invalid && `color: ${p.theme.red400}`}
 `;
 
@@ -398,11 +398,11 @@ const DateTime = styled('span')`
 `;
 
 const ListComma = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Paren = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const InList = styled('span')`

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -206,7 +206,7 @@ const Heading = styled('div')`
 const Remaining = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   display: grid;
   grid-template-columns: max-content max-content;
   gap: ${space(0.75)};

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -142,7 +142,7 @@ export default SwitchOrganization;
 
 const StyledIconAdd = styled(IconAdd)`
   margin-right: ${space(1)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const MenuItemLabelWithIcon = styled('span')`
@@ -153,7 +153,7 @@ const MenuItemLabelWithIcon = styled('span')`
 `;
 
 const SubMenuCaret = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   transition: 0.1s color linear;
 
   &:hover,

--- a/static/app/components/sidebar/sidebarPanelEmpty.tsx
+++ b/static/app/components/sidebar/sidebarPanelEmpty.tsx
@@ -4,7 +4,7 @@ const SidebarPanelEmpty = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   padding: 0 60px;
   text-align: center;
   min-height: 150px;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -923,7 +923,7 @@ const SecondaryCount = styled(({value, ...p}: any) => <Count {...p} value={value
     content: '/';
     padding-left: ${space(0.25)};
     padding-right: 2px;
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 
@@ -936,7 +936,7 @@ const CountTooltipContent = styled('div')`
   align-items: center;
 
   h4 {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     font-size: ${p => p.theme.fontSizeExtraSmall};
     text-transform: uppercase;
     grid-column: 1 / -1;

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -210,7 +210,7 @@ const FloatingTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})
   &[aria-selected='false'] {
     border-top: 1px solid transparent;
   }
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   border-radius: 6px;
   padding: ${space(0.5)} ${space(1)};
   transform: translateY(1px);

--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -222,7 +222,7 @@ const TitleType = styled('div')`
 
 const TitleDescription = styled('div')`
   display: flex;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-align: right;
 `;
 

--- a/static/app/components/timeRangeSelector/dateRange.tsx
+++ b/static/app/components/timeRangeSelector/dateRange.tsx
@@ -259,7 +259,7 @@ const StyledTimePicker = styled(TimePicker)`
 `;
 
 const UtcPicker = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   white-space: nowrap;
   display: flex;
   align-items: center;

--- a/static/app/components/timeRangeSelector/timePicker.tsx
+++ b/static/app/components/timeRangeSelector/timePicker.tsx
@@ -117,7 +117,7 @@ const Input = styled('input')`
     width: 100%;
     background: ${p => p.theme.backgroundSecondary};
     border: 1px solid ${p => p.theme.border};
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     padding: ${space(0.25)} ${space(0.5)};
     box-shadow: none;
     font-variant-numeric: tabular-nums;

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -224,7 +224,7 @@ const ConnectRepo = styled('div')`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 

--- a/static/app/components/workflowEngine/useBulkActions.tsx
+++ b/static/app/components/workflowEngine/useBulkActions.tsx
@@ -103,7 +103,7 @@ const Heading = styled(motion.div)`
 `;
 
 const Subtext = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
   align-self: center;
   text-transform: none;

--- a/static/app/styles/typography.stories.tsx
+++ b/static/app/styles/typography.stories.tsx
@@ -543,10 +543,10 @@ const FixedExternalLink = styled(ExternalLink)`
 `;
 
 const FooterLink = styled(Link)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   :hover {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     text-decoration: underline ${p => p.theme.gray200};
   }
 `;

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -131,7 +131,7 @@ type FieldFormatters = {
 export type FieldTypes = keyof FieldFormatters;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 const emptyValue = <EmptyValueContainer>{t('(no value)')}</EmptyValueContainer>;
 const emptyStringValue = <EmptyValueContainer>{t('(empty string)')}</EmptyValueContainer>;

--- a/static/app/utils/discover/styles.tsx
+++ b/static/app/utils/discover/styles.tsx
@@ -24,7 +24,7 @@ export const NumberContainer = styled('div')`
 `;
 
 export const FieldDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-variant-numeric: tabular-nums;
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -37,7 +37,7 @@ const StyledLink = styled(Link)`
 `;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export default ViewReplayLink;

--- a/static/app/utils/performance/regression/table.tsx
+++ b/static/app/utils/performance/regression/table.tsx
@@ -79,7 +79,7 @@ export const NumericColumnLabel = styled('div')`
 const ChangeLabel = styled('div')<{isNeutral: boolean; isPositive: boolean}>`
   color: ${p => {
     if (p.isNeutral) {
-      return p.theme.gray300;
+      return p.theme.subText;
     }
     if (p.isPositive) {
       return p.theme.red300;

--- a/static/app/utils/performance/regression/table.tsx
+++ b/static/app/utils/performance/regression/table.tsx
@@ -97,7 +97,7 @@ const Change = styled('span')`
 `;
 
 const ChangeDescription = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   white-space: nowrap;
   grid-column: span 3;
   text-align: right;

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -366,7 +366,7 @@ const AlertName = styled('div')`
 `;
 
 const AlertIncidentDate = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const ProjectBadgeContainer = styled('div')`

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -211,7 +211,7 @@ const StyledPanelTable = styled(PanelTable)<{expanded: boolean; isEmpty: boolean
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Cell = styled('div')`

--- a/static/app/views/auth/loginForm.tsx
+++ b/static/app/views/auth/loginForm.tsx
@@ -150,7 +150,7 @@ const ProviderWrapper = styled('div')`
 `;
 
 const LostPasswordLink = styled(Link)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 
   &:hover {

--- a/static/app/views/auth/registerForm.tsx
+++ b/static/app/views/auth/registerForm.tsx
@@ -94,7 +94,7 @@ function RegisterForm({authConfig}: Props) {
 }
 
 const PrivacyPolicyLink = styled(ExternalLink)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   &:hover {
     color: ${p => p.theme.textColor};

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -169,7 +169,7 @@ const CardHeader = styled('div')`
 const Detail = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   ${p => p.theme.overflowEllipsis};
   line-height: 1.5;
 `;

--- a/static/app/views/dashboards/manage/templateCard.tsx
+++ b/static/app/views/dashboards/manage/templateCard.tsx
@@ -54,7 +54,7 @@ const Title = styled('div')`
 const Detail = styled(Title)`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const ButtonContainer = styled('div')`

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -254,7 +254,7 @@ function WidgetBuilderSlideout({
 export default WidgetBuilderSlideout;
 
 const CloseButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   height: fit-content;
   &:hover {
     color: ${p => p.theme.gray400};

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -175,7 +175,7 @@ const WidgetTitle = styled('h3')`
 
 const WidgetDescription = styled('p')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-bottom: 0;
 `;
 

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/card.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/card.tsx
@@ -45,7 +45,7 @@ const Heading = styled('div')`
 `;
 
 const SubHeading = styled('small')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const IconWrapper = styled('div')<{backgroundColor: string}>`

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -355,5 +355,5 @@ export const WidgetTitleRow = styled('span')`
 
 export const WidgetDescription = styled('small')`
   ${p => p.theme.overflowEllipsis}
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -96,5 +96,5 @@ export const WidgetTitleRow = styled('span')`
 
 export const WidgetDescription = styled('small')`
   ${p => p.theme.overflowEllipsis}
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/discover/eventDetails/linkedIssue.tsx
+++ b/static/app/views/discover/eventDetails/linkedIssue.tsx
@@ -127,7 +127,7 @@ const StyledShortId = styled(ShortId)`
 `;
 
 const IssueCardFooter = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   padding: ${space(0.5)} ${space(1)};
 `;

--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -285,7 +285,7 @@ const StyledGraphContainer = styled((props: any) => (
 `;
 
 const StyledErrorMessage = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-left: 4px;
 `;
 

--- a/static/app/views/discover/querycard.tsx
+++ b/static/app/views/discover/querycard.tsx
@@ -114,7 +114,7 @@ const QueryTitle = styled('div')`
 const QueryDetail = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   line-height: 1.5;
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/views/discover/resultsChart.tsx
+++ b/static/app/views/discover/resultsChart.tsx
@@ -320,6 +320,6 @@ const NoChartContainer = styled('div')<{height?: string}>`
   position: relative;
   border-color: transparent;
   margin-bottom: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;

--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -238,7 +238,7 @@ class ResultsHeader extends Component<Props, State> {
 const Subtitle = styled('h4')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: ${space(0.5)} 0 0 0;
 `;
 

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -439,7 +439,7 @@ const DropdownTitle = styled('header')`
   align-items: center;
 
   background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeMedium};
 
@@ -476,7 +476,7 @@ const Info = styled('div')`
   display: flex;
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/views/explore/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.tsx
@@ -109,6 +109,6 @@ const InsufficientSamples = styled('span')`
 `;
 
 const Container = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -154,7 +154,7 @@ export const ColoredLogText = styled('span')<{
 `;
 
 export const LogDate = styled('span')<{align?: 'left' | 'center' | 'right'}>`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-align: ${p => p.align || 'left'};
 `;
 

--- a/static/app/views/explore/multiQueryMode/queryConstructors/styles.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/styles.tsx
@@ -13,7 +13,7 @@ export const SectionHeader = styled('div')`
 `;
 
 export const SectionLabel = styled('h6')<{disabled?: boolean}>`
-  color: ${p => (p.disabled ? p.theme.gray300 : p.theme.gray500)};
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray500)};
   font-size: ${p => p.theme.form.md.fontSize};
   margin: 0;
   text-decoration: underline dotted

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -159,7 +159,7 @@ const CollapsedBadge = styled('div')<{fontSize: number; size: number}>`
   text-align: center;
   font-weight: ${p => p.theme.fontWeightBold};
   background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.fontSize}px;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
@@ -370,7 +370,7 @@ export function SpanBreakdownSliceRenderer({
 
 const Subtext = styled('span')`
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 const FlexContainer = styled('div')`
   display: flex;

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -43,7 +43,7 @@ export const StyledPanelItem = styled(PanelItem)<{
 `;
 
 export const MoreMatchingSpans = styled(StyledPanelItem)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export const WrappingText = styled('div')`
@@ -90,13 +90,13 @@ export const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName:
 export const EmptyStateText = styled('div')<{
   size: 'fontSizeExtraLarge' | 'fontSizeMedium';
 }>`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme[p.size]};
   padding-bottom: ${space(1)};
 `;
 
 export const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export const SpanPanelContent = styled('div')`

--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -17,21 +17,21 @@ export const ToolbarHeader = styled('div')`
 `;
 
 export const ToolbarLabel = styled('h6')<{disabled?: boolean; underlined?: boolean}>`
-  color: ${p => (p.disabled ? p.theme.gray300 : p.theme.gray500)};
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray500)};
   font-size: ${p => p.theme.form.md.fontSize};
   margin: 0;
   ${p =>
     !defined(p.underlined) || p.underlined
-      ? `text-decoration: underline dotted ${p.disabled ? p.theme.gray300 : p.theme.gray300}`
+      ? `text-decoration: underline dotted ${p.disabled ? p.theme.disabled : p.theme.gray300}`
       : ''};
 `;
 
 export const ToolbarHeaderButton = styled(Button)<{disabled?: boolean}>`
-  color: ${p => (p.disabled ? p.theme.gray300 : p.theme.gray500)};
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray500)};
 `;
 
 export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`
-  color: ${p => (p.disabled ? p.theme.gray300 : p.theme.linkColor)};
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.linkColor)};
 `;
 
 export const ToolbarFooter = styled('div')<{disabled?: boolean}>`

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -217,7 +217,7 @@ const TriggerLabel = styled('span')`
 `;
 
 const Disabled = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const FullWidthTooltip = styled(Tooltip)`

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -138,6 +138,6 @@ const StyledChartPanel = styled(ChartPanel)`
 const PerformanceScoreSubtext = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-bottom: ${space(1)};
 `;

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -144,7 +144,7 @@ const PerformanceScoreLabel = styled('div')`
 const PerformanceScoreSubtext = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-bottom: ${space(1)};
 `;
 

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -521,7 +521,7 @@ const ChartContainer = styled('div')`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const TableContainer = styled('div')`

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -395,7 +395,7 @@ const TooltipRow = styled('div')`
 `;
 
 const TooltipValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export default PerformanceScoreRingWithTooltips;

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -394,5 +394,5 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -712,7 +712,7 @@ const StyledProjectAvatar = styled(ProjectAvatar)`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const SearchBarContainer = styled('div')`

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -289,7 +289,7 @@ const MeterBarFooterContainer = styled('div')<{
 `;
 
 const NoValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.headerFontSize};
 `;
 

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -218,7 +218,7 @@ export const DismissButton = styled(Button)`
 
 export const PagesTooltip = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline dotted ${p => p.theme.gray300};
 `;
 

--- a/static/app/views/insights/common/components/detailPanel.tsx
+++ b/static/app/views/insights/common/components/detailPanel.tsx
@@ -128,7 +128,7 @@ export default function Detail({
 }
 
 const CloseButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   &:hover {
     color: ${p => p.theme.gray400};
   }
@@ -136,7 +136,7 @@ const CloseButton = styled(Button)`
 `;
 
 const PanelButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   &:hover {
     color: ${p => p.theme.gray400};
   }

--- a/static/app/views/insights/common/components/metricReadout.tsx
+++ b/static/app/views/insights/common/components/metricReadout.tsx
@@ -181,7 +181,7 @@ const ReadoutWrapper = styled('div')`
 `;
 
 const ReadoutTitle = styled('h3')<{alignment: 'left' | 'right'}>`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
   white-space: nowrap;

--- a/static/app/views/insights/common/components/miniChartPanel.tsx
+++ b/static/app/views/insights/common/components/miniChartPanel.tsx
@@ -55,7 +55,7 @@ const PanelBody = styled('div')`
 `;
 
 const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   display: inline-block;
 `;

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -215,7 +215,7 @@ const SupportedSdkContainer = styled('div')`
   flex-direction: column;
   gap: ${space(1)};
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const SupportedSdkList = styled('div')`

--- a/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
+++ b/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
@@ -82,7 +82,7 @@ const Bar = styled('h4')`
 `;
 
 const Deemphasize = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const TruncatedLink = styled(Link)`

--- a/static/app/views/insights/common/views/spanSummaryPage/block.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/block.tsx
@@ -42,7 +42,7 @@ const BlockWrapper = styled('div')`
 `;
 
 const BlockTitle = styled('h3')<{alignment: 'left' | 'right'}>`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
   white-space: nowrap;

--- a/static/app/views/insights/common/views/spans/selectors/emptyOption.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/emptyOption.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {t} from 'sentry/locale';
 
 export const EmptyContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export function DefaultEmptyOption() {

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -104,7 +104,7 @@ const Emphasize = styled('span')`
 `;
 
 const Deemphasize = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const PushRight = styled('span')`
@@ -155,7 +155,7 @@ const DeemphasizedExternalLink = styled(ExternalLink)`
   display: flex;
   align-items: center;
   gap: ${space(0.75)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledIconWrapper = styled('span')`

--- a/static/app/views/insights/mobile/appStarts/components/breakdown.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/breakdown.tsx
@@ -120,7 +120,7 @@ const StartupType = styled('div')`
 `;
 
 const StartupCount = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StartupName = styled('div')`

--- a/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
@@ -189,7 +189,7 @@ const StyledCompactSelect = styled(CompactSelect)`
 `;
 
 const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   display: inline-block;
 `;

--- a/static/app/views/insights/pages/backend/laravel/pathsTable.tsx
+++ b/static/app/views/insights/pages/backend/laravel/pathsTable.tsx
@@ -421,7 +421,7 @@ const CellExpander = styled('div')`
 
 const ControllerText = styled('div')`
   ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   min-width: 0px;
 `;

--- a/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/queriesWidget.tsx
@@ -228,7 +228,7 @@ export function QueriesWidget({query}: {query?: string}) {
 
 const ControllerText = styled('div')`
   ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1;
   min-width: 0px;

--- a/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
@@ -195,5 +195,5 @@ const AlignRight = styled('span')`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/insights/queues/components/tables/queuesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.tsx
@@ -245,5 +245,5 @@ const AlignRight = styled('span')`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/insights/queues/components/tables/transactionsTable.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.tsx
@@ -265,5 +265,5 @@ const AlignRight = styled('span')`
 `;
 
 const NoValue = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/issueDetails/participantList.tsx
+++ b/static/app/views/issueDetails/participantList.tsx
@@ -134,7 +134,7 @@ const ListTitle = styled('div')`
   align-items: center;
   padding: ${space(1)} ${space(1.5)};
   background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-transform: uppercase;
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/views/issueDetails/reprocessingProgress.tsx
+++ b/static/app/views/issueDetails/reprocessingProgress.tsx
@@ -51,7 +51,7 @@ const Wrapper = styled('div')`
 `;
 
 const Content = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   display: grid;
   gap: ${space(1.5)};

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -287,14 +287,14 @@ const JsonLinkWrapper = styled('div')`
 `;
 
 const JsonLink = styled(ExternalLink)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline;
   text-decoration-color: ${p => Color(p.theme.gray300).alpha(0.5).string()};
 
   :hover {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     text-decoration: underline;
-    text-decoration-color: ${p => p.theme.gray300};
+    text-decoration-color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/header/attachmentsBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/attachmentsBadge.tsx
@@ -57,7 +57,7 @@ export function AttachmentsBadge({group}: {group: Group}) {
 }
 
 const AttachmentButton = styled(LinkButton)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline;
   text-decoration-style: dotted;
 `;

--- a/static/app/views/issueDetails/streamline/header/replayBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/replayBadge.tsx
@@ -46,7 +46,7 @@ export function ReplayBadge({group, project}: {group: Group; project: Project}) 
 }
 
 const ReplayButton = styled(LinkButton)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline;
   text-decoration-style: dotted;
 `;

--- a/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
@@ -40,7 +40,7 @@ export function UserFeedbackBadge({group, project}: {group: Group; project: Proj
 }
 
 const UserFeedbackButton = styled(LinkButton)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline;
   text-decoration-style: dotted;
 `;

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -155,7 +155,7 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
 
 const ItemTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 

--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -112,7 +112,7 @@ function ReleaseText({project, release}: {project: Project; release?: Release}) 
 
 const ReleaseWrapper = styled('span')`
   a {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     text-decoration: underline;
     text-decoration-style: dotted;
   }

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -696,6 +696,6 @@ const StyledRuleSpan = styled('span')`
 `;
 
 const ReleaseVersion = styled(Version)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: underline;
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -118,7 +118,7 @@ const ListTitle = styled('div')`
   align-items: center;
   padding: ${space(1)} ${space(1.5)};
   background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-transform: uppercase;
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -206,7 +206,7 @@ const ExpandButton = styled(Button)`
   bottom: -${space(1)};
   right: 0;
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   border: none;
   box-shadow: none;
 

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -109,6 +109,6 @@ const QueryCountBubble = styled(motion.span)`
   justify-content: center;
   border-radius: 10px;
   border: 1px solid ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-left: 0;
 `;

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -201,7 +201,7 @@ const SubText = styled('span')`
 `;
 
 const SubHeaderText = styled(motion.h6)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const ButtonWrapper = styled('div')`

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -73,7 +73,7 @@ export const RightAlignedCell = styled('div')`
 `;
 
 export const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   display: inline-block;
 `;
@@ -251,14 +251,14 @@ const StyledEmptyStateWarning = styled(EmptyStateWarning)`
 
 const PrimaryMessage = styled('span')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightBold};
   margin: 0 auto ${space(1)};
 `;
 
 const SecondaryMessage = styled('p')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   max-width: 300px;
 `;
 

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -94,6 +94,6 @@ export function HistogramWidget(props: PerformanceWidgetProps) {
 }
 
 const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -173,7 +173,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
 
 const EventsRequest = withApi(_EventsRequest);
 export const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1522,7 +1522,7 @@ const TraceStylingWrapper = styled('div')`
     display: inline-block;
     transform-origin: left center;
     font-size: ${p => p.theme.fontSizeExtraSmall};
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
     position: absolute;

--- a/static/app/views/performance/newTraceDetails/traceConfigurations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceConfigurations.tsx
@@ -204,7 +204,7 @@ const ButtonTitle = styled('div')`
 `;
 
 const ButtonSubtitle = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -147,7 +147,7 @@ const VitalPillValue = styled('div')`
 `;
 
 const NoValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.headerFontSize};
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -385,5 +385,5 @@ const DescriptionWrapper = styled('div')`
 `;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
@@ -70,7 +70,7 @@ const LoadingContainer = styled('div')<{animate: boolean; error?: boolean}>`
   position: absolute;
   height: auto;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   z-index: 30;
   padding: 24px;
   background-color: ${p => p.theme.background};

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsHeader.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsHeader.tsx
@@ -157,7 +157,7 @@ export const SpanLabelContainer = styled('div')`
 `;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const emptyValue = <EmptyValueContainer>{t('(unnamed span)')}</EmptyValueContainer>;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
@@ -106,7 +106,7 @@ export const SpanLabelContainer = styled('div')`
 `;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const emptyValue = <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -350,7 +350,7 @@ const EmptySpanDurationBar = styled('div')`
   background-color: ${p => p.theme.gray100};
   padding-left: ${space(1)};
 
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-variant-numeric: tabular-nums;
   line-height: 1;

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -343,7 +343,7 @@ const LinkContainer = styled('div')<{disabled?: boolean}>`
     p.disabled &&
     `
     opacity: 0.5;
-    color: ${p.theme.gray300};
+    color: ${p.theme.disabled};
     cursor: default;
   `}
 `;

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -676,7 +676,7 @@ const ItemTransactionDurationChange = styled('div')`
 `;
 
 const DurationChange = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0 ${space(1)};
 `;
 

--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -496,7 +496,7 @@ const FunctionTrendsChartContainer = styled('div')`
 `;
 
 const DurationChange = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/app/views/profiling/landing/styles.tsx
+++ b/static/app/views/profiling/landing/styles.tsx
@@ -26,7 +26,7 @@ export const HeaderTitleLegend = styled(_HeaderTitleLegend)`
 `;
 
 export const Subtitle = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   display: inline-block;
 `;

--- a/static/app/views/projectsDashboard/deploys.tsx
+++ b/static/app/views/projectsDashboard/deploys.tsx
@@ -116,7 +116,7 @@ const Environment = styled('div')`
 `;
 
 const DeployTime = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   overflow: hidden;
   text-align: right;
   text-overflow: ellipsis;

--- a/static/app/views/projectsDashboard/noEvents.tsx
+++ b/static/app/views/projectsDashboard/noEvents.tsx
@@ -31,5 +31,5 @@ const EmptyText = styled('div')<Props>`
   margin-left: 4px;
   margin-right: 4px;
   height: ${p => (p.seriesCount > 1 ? '90px' : '150px')};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -367,7 +367,7 @@ const ScoreCardWrapper = styled('div')`
     min-height: auto;
   }
   ${Title} {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
   ${ScoreWrapper} {
     flex-direction: column;
@@ -412,7 +412,7 @@ const DeploysWrapper = styled('div')`
 `;
 
 const ReleaseTitle = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -160,7 +160,7 @@ const IconWrapper = styled('span')`
 
   &,
   a {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     display: flex;
     &:hover {
       cursor: pointer;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -1068,7 +1068,7 @@ const ShowMoreWrapper = styled('div')`
 `;
 
 const ShowMoreTitle = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   display: inline-grid;
   grid-template-columns: auto auto;

--- a/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
@@ -153,7 +153,7 @@ const InnerRow = styled('div')`
 
 const Text = styled('div')<{bold?: boolean; right?: boolean}>`
   text-align: ${p => (p.right ? 'right' : 'left')};
-  color: ${p => (p.bold ? p.theme.textColor : p.theme.gray300)};
+  color: ${p => (p.bold ? p.theme.textColor : p.theme.subText)};
   padding-bottom: ${space(0.25)};
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -509,7 +509,7 @@ const HiddenProjectsMessage = styled('div')`
   overflow: hidden;
   height: 24px;
   line-height: 24px;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   background-color: ${p => p.theme.backgroundSecondary};
   border-bottom-right-radius: ${p => p.theme.borderRadius};
   @media (max-width: ${p => p.theme.breakpoints.medium}) {

--- a/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
@@ -52,7 +52,7 @@ function ReleaseCardCommits({release, withHeading = true}: Props) {
 }
 
 const ReleaseSummaryHeading = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1.2;
   font-weight: ${p => p.theme.fontWeightBold};

--- a/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
@@ -59,11 +59,11 @@ const Wrapper = styled('div')`
 `;
 
 const Period = styled(Link)<{selected: boolean}>`
-  color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
+  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
 
   &:hover,
   &:focus {
-    color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
+    color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
   }
 `;
 

--- a/static/app/views/relocation/components/wrapper.tsx
+++ b/static/app/views/relocation/components/wrapper.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled('div')`
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;
   width: 100%;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   mark {
     border-radius: 8px;
     padding: ${space(0.25)} ${space(0.5)} ${space(0.25)} ${space(0.5)};
@@ -33,7 +33,7 @@ const Wrapper = styled('div')`
     padding-bottom: ${space(1)};
   }
   .encrypt-note {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     padding-top: ${space(1)};
   }
 `;

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -153,7 +153,7 @@ const Wrapper = styled('div')`
   border-radius: 10px;
   max-width: 769px;
   max-height: 525px;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   h2 {
     color: ${p => p.theme.gray500};
   }

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -199,7 +199,7 @@ const Wrapper = styled('div')`
   border-radius: 10px;
   width: 100%;
   font-size: 16px;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   mark {
     border-radius: 8px;
     padding: ${space(0.25)} ${space(0.5)} ${space(0.25)} ${space(0.5)};
@@ -234,7 +234,7 @@ const FinishedWell = styled(Well)`
     font-size: 14px;
   }
   a:hover {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -338,7 +338,7 @@ const EmptyHeader = styled(Flex)`
   justify-content: center;
   align-items: center;
   gap: ${space(1.5)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -188,7 +188,7 @@ const TimeContainer = styled('div')`
   display: flex;
   gap: ${space(1)};
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: 1.4;
 `;

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -368,7 +368,7 @@ const QuestionContent = styled('div')`
 const StyledHeaderContainer = styled(HeaderContainer)`
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   display: flex;
   gap: ${space(0.5)};
   align-items: center;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -442,7 +442,7 @@ const MainLink = styled(Link)`
 const SubText = styled('div')`
   font-size: 0.875em;
   line-height: normal;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   ${p => p.theme.overflowEllipsis};
   display: flex;
   flex-direction: column;

--- a/static/app/views/settings/account/accountAuthorizations.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.tsx
@@ -153,6 +153,6 @@ const Url = styled('div')`
 `;
 
 const DetailRow = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
 `;

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -144,7 +144,7 @@ const Heading = styled('div')`
 `;
 
 const TokenPreview = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const LinkWrapper = styled('div')<{name: string}>`

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -140,7 +140,7 @@ const FieldLabel = styled('div')`
 
 const FieldHelp = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const FieldWrapper = styled('div')`

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
@@ -44,7 +44,7 @@ const CloseIcon = styled('div')`
 const StyledIconClose = styled(IconClose)`
   color: ${p => p.theme.gray200};
   :hover {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
   cursor: pointer;
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -500,7 +500,7 @@ const Suggestion = styled('li')<{active: boolean}>`
 const SuggestionDescription = styled('div')`
   display: flex;
   overflow: hidden;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   line-height: 1.2;
 `;
 

--- a/static/app/views/settings/components/settingsNavItemDeprecated.tsx
+++ b/static/app/views/settings/components/settingsNavItemDeprecated.tsx
@@ -57,7 +57,7 @@ function SettingsNavItemDeprecated({badge, label, index, id, to, ...props}: Prop
 
 const StyledNavItem = styled(RouterNavLink)`
   display: block;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: 14px;
   line-height: 30px;
   position: relative;

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -208,7 +208,7 @@ const StyledCreateTeamLink = styled(Link)`
     p.disabled &&
     css`
       cursor: not-allowed;
-      color: ${p.theme.gray300};
+      color: ${p.theme.disabled};
       opacity: 0.6;
     `};
 `;

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
@@ -85,5 +85,5 @@ const DateTime = styled('div')`
 `;
 
 const SecretPreview = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -185,5 +185,5 @@ export function OrganizationAuthTokensNewAuthToken({
 export default withOrganization(OrganizationAuthTokensNewAuthToken);
 
 const ScopeHelpText = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -105,7 +105,7 @@ const SubscriptionInfo = styled('div')`
 const SubscriptionDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: 1;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const SubscriptionTitle = styled('div')`

--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -372,7 +372,7 @@ const AuthorInfo = styled('div')`
 const CreatedContainer = styled('div')`
   text-transform: uppercase;
   padding-bottom: ${space(1)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: 12px;
 `;

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -197,11 +197,11 @@ export default class InstalledIntegration extends Component<Props> {
 }
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledLinkButton = styled(LinkButton)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const IntegrationItemBox = styled('div')`
@@ -251,7 +251,7 @@ function IntegrationStatus(
 const StyledIntegrationStatus = styled(IntegrationStatus)`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: light;
   text-transform: capitalize;
   &:before {

--- a/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
@@ -188,11 +188,11 @@ const Container = styled('div')`
 `;
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const StyledLinkButton = styled(LinkButton)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const IntegrationFlex = styled('div')`

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -592,7 +592,7 @@ const EmptyResultsContainer = styled('div')`
 const EmptyResultsBody = styled('div')`
   font-size: 16px;
   line-height: 28px;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   padding-bottom: ${space(2)};
 `;
 

--- a/static/app/views/settings/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.tsx
@@ -191,7 +191,7 @@ const IntegrationDetails = styled('div')`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   &:before {
     content: '|';
     color: ${p => p.theme.gray200};
@@ -200,7 +200,7 @@ const StyledLink = styled(Link)`
 `;
 
 const LearnMore = styled(Link)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 type PublishStatusProps = {status: SentryApp['status']; theme?: any};

--- a/static/app/views/settings/organizationIntegrations/integrationServerlessRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationServerlessRow.tsx
@@ -186,7 +186,7 @@ const Name = styled(`span`)`
 const RuntimeAndVersion = styled('div')`
   display: flex;
   flex-direction: row;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const DetailWrapper = styled('div')`

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigRow.tsx
@@ -90,7 +90,7 @@ const RepoName = styled(`span`)`
 const ProjectAndBranch = styled('div')`
   display: flex;
   flex-direction: row;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 // match the line height of the badge

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -428,7 +428,7 @@ const InstallButton = styled(Button)`
 `;
 
 const StyledUninstallButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   background: ${p => p.theme.background};
 
   border: ${p => `1px solid ${p.theme.gray300}`};

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -329,7 +329,7 @@ const Subtitle = styled('div')`
   align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   gap: ${space(0.5)};
 `;
 
@@ -338,7 +338,7 @@ const MemberEmail = styled('div')`
   max-width: 70%;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-overflow: ellipsis;
   overflow: hidden;
 `;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -423,7 +423,7 @@ function OrganizationMemberDetail() {
 export default OrganizationMemberDetail;
 
 const ExtraHeaderText = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeLarge};
 `;

--- a/static/app/views/settings/organizationRelay/list/cardHeader.tsx
+++ b/static/app/views/settings/organizationRelay/list/cardHeader.tsx
@@ -88,7 +88,7 @@ const KeyName = styled('div')`
 
 const DateCreated = styled('div')`
   grid-row: 2/3;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
@@ -45,7 +45,7 @@ const StyledPanelItem = styled(PanelItem)`
 `;
 
 const TypeAndStatus = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
   flex-wrap: wrap;

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -170,7 +170,7 @@ const CollapsedBadge = styled('div')<{fontSize: number; size: number}>`
   text-align: center;
   font-weight: ${p => p.theme.fontWeightBold};
   background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.fontSize}px;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
@@ -381,7 +381,7 @@ export function SpanBreakdownSliceRenderer({
 
 const Subtext = styled('span')`
   font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 const FlexContainer = styled('div')`
   display: flex;

--- a/static/app/views/traces/styles.tsx
+++ b/static/app/views/traces/styles.tsx
@@ -43,7 +43,7 @@ export const StyledPanelItem = styled(PanelItem)<{
 `;
 
 export const MoreMatchingSpans = styled(StyledPanelItem)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export const WrappingText = styled('div')`
@@ -91,13 +91,13 @@ export const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName:
 export const EmptyStateText = styled('div')<{
   size: 'fontSizeExtraLarge' | 'fontSizeMedium';
 }>`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme[p.size]};
   padding-bottom: ${space(1)};
 `;
 
 export const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export const SpanPanelContent = styled('div')`

--- a/static/gsApp/components/codecovPromotionModal.tsx
+++ b/static/gsApp/components/codecovPromotionModal.tsx
@@ -145,7 +145,7 @@ const PriceWrapper = styled('div')`
 
 const SeatText = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const OffsetIconArrow = styled(IconArrow)`

--- a/static/gsApp/components/dataConsentModal.tsx
+++ b/static/gsApp/components/dataConsentModal.tsx
@@ -174,7 +174,7 @@ const InfoHeader = styled('div')`
 
 const ConsentHeader = styled('p')`
   font-weight: bold;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-transform: uppercase;
   margin-bottom: ${space(1)};
 `;
@@ -204,13 +204,13 @@ const ConsentLabelHeader = styled('div')`
 `;
 const ConsentLabelBody = styled('p')`
   margin-bottom: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const StyledIconWrapper = styled('span')`
   margin-left: ${space(3)};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Footer = styled('div')`

--- a/static/gsApp/components/features/insightsUpsellPage.tsx
+++ b/static/gsApp/components/features/insightsUpsellPage.tsx
@@ -324,7 +324,7 @@ const FeatureListItem = styled('li')<{isSelected: boolean}>`
   display: flex;
   align-items: center;
   gap: ${space(2)};
-  color: ${p => (p.isSelected ? p.theme.gray500 : p.theme.gray300)};
+  color: ${p => (p.isSelected ? p.theme.gray500 : p.theme.subText)};
   ${p => p.isSelected && `font-weight: ${p.theme.fontWeightBold};`}
   cursor: pointer;
   :hover {

--- a/static/gsApp/components/partnerPlanEndingModal.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.tsx
@@ -260,7 +260,7 @@ const PathHeading = styled('h5')`
 const SubHeading = styled('div')`
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-transform: uppercase;
 `;
 

--- a/static/gsApp/components/profiling/profilingUpgradeModal.tsx
+++ b/static/gsApp/components/profiling/profilingUpgradeModal.tsx
@@ -154,7 +154,7 @@ const UpsellContent = styled('div')`
 `;
 
 const Note = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 

--- a/static/gsApp/components/promotionPriceDisplay.tsx
+++ b/static/gsApp/components/promotionPriceDisplay.tsx
@@ -46,7 +46,7 @@ const Amount = styled('div')<{promo?: boolean}>`
   font-size: 30px;
   font-weight: ${p => (p.promo ? 'bold' : 'none')};
   text-decoration: ${p => (p.promo ? 'none' : 'line-through')};
-  color: ${p => (p.promo ? p.theme.headingColor : p.theme.gray300)};
+  color: ${p => (p.promo ? p.theme.headingColor : p.theme.subText)};
 `;
 
 const BillingInterval = styled('div')`

--- a/static/gsApp/components/upgradeNowModal/index.tsx
+++ b/static/gsApp/components/upgradeNowModal/index.tsx
@@ -140,7 +140,7 @@ const UpsellContent = styled('div')`
 `;
 
 const Note = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 

--- a/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
+++ b/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
@@ -160,7 +160,7 @@ const CTASecondary = styled('div')`
 
 const Note = styled('p')`
   text-align: center;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   margin-block: ${space(4)};
 `;

--- a/static/gsApp/components/upsellModal/featureList.tsx
+++ b/static/gsApp/components/upsellModal/featureList.tsx
@@ -119,7 +119,7 @@ const Heading = styled('div')`
 const FeatureLink = styled(motion.div)`
   cursor: pointer;
   transition: color 300ms;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   position: relative;
   display: grid;
   grid-template-columns: max-content auto;

--- a/static/gsApp/views/amCheckout/checkoutOverview.tsx
+++ b/static/gsApp/views/amCheckout/checkoutOverview.tsx
@@ -368,7 +368,7 @@ const DetailTitle = styled('div')<{noBottomMargin?: boolean}>`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-top: ${space(0.25)};
   ${p => !p.noBottomMargin && `margin-bottom: ${space(1)};`}
 `;
@@ -395,7 +395,7 @@ const OnDemandPrice = styled('div')`
 `;
 
 const OriginalPrice = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: line-through;
 `;
 
@@ -416,7 +416,7 @@ const DiscountWrapper = styled('div')`
   align-items: center;
   gap: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const DurationText = styled('div')`
@@ -430,7 +430,7 @@ const ProminantPlanName = styled('span')`
 
 const ChurnPromoText = styled('span')`
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-weight: bold;
 `;
 

--- a/static/gsApp/views/amCheckout/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/moreFeaturesLink.tsx
@@ -28,7 +28,7 @@ const MoreLink = styled(ExternalLink)<{color?: string}>`
   gap: ${space(1)};
   align-items: center;
   align-content: center;
-  color: ${p => p.color ?? p.theme.gray300};
+  color: ${p => p.color ?? p.theme.subText};
 
   &:hover,
   &:focus,

--- a/static/gsApp/views/amCheckout/steps/addDataVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/addDataVolume.tsx
@@ -146,7 +146,7 @@ const LargeTitle = styled(Title)`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 

--- a/static/gsApp/views/amCheckout/steps/onDemandSpend.tsx
+++ b/static/gsApp/views/amCheckout/steps/onDemandSpend.tsx
@@ -136,7 +136,7 @@ const Header = styled('div')`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 
@@ -150,7 +150,7 @@ const InputContainer = styled('div')`
 `;
 
 const InputHeader = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   text-transform: uppercase;
   font-weight: bold;

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -238,12 +238,12 @@ const PlanName = styled('div')`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 
 const PriceHeader = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   text-transform: uppercase;
   font-weight: bold;
@@ -275,7 +275,7 @@ const FeatureList = styled('div')`
   grid-template-rows: auto;
   gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   > a {
     width: fit-content;
@@ -301,7 +301,7 @@ const Title = styled('div')`
 `;
 
 const OriginalTotal = styled('div')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-decoration: line-through;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
@@ -313,6 +313,6 @@ const DiscountWrapper = styled('div')`
 `;
 
 const PercentOff = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -381,7 +381,7 @@ const Title = styled('label')`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 
@@ -400,7 +400,7 @@ const CategoryInfoDescription = styled(Description)`
 const CategoryInfoList = styled('ul')`
   margin: ${space(1)} 0;
   padding: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 
   li {

--- a/static/gsApp/views/amCheckout/steps/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/steps/volumeSliders.tsx
@@ -281,7 +281,7 @@ const Description = styled('div')`
   grid-template-columns: repeat(2, auto);
   justify-content: space-between;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 const Events = styled('div')<{isLegacy: boolean}>`
@@ -305,7 +305,7 @@ const StyledHovercard = styled(Hovercard)`
   width: 400px;
 
   ${Header} {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     text-transform: uppercase;
     font-size: ${p => p.theme.fontSizeSmall};
     border-radius: 6px 6px 0px 0px;

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -257,7 +257,7 @@ const Label = styled('div')`
 const DetailTitle = styled('div')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-bottom: ${space(1)};
   white-space: nowrap;
 `;

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -344,7 +344,7 @@ const Title = styled('div')`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
@@ -383,7 +383,7 @@ const OnDemandInput = styled(Input)`
 const DetailTitle = styled('div')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin-top: ${space(0.5)};
 `;
 

--- a/static/gsApp/views/onDemandBudgets/payAsYouGoBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/payAsYouGoBudgetEdit.tsx
@@ -91,7 +91,7 @@ const InputFields = styled('div')`
 
 const Description = styled(TextBlock)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0;
 `;
 

--- a/static/gsApp/views/spikeProtection/spikeProtectionTimeDetails.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionTimeDetails.tsx
@@ -47,7 +47,7 @@ const SpikeTimeDetailsWrapper = styled('div')`
     white-space: nowrap;
   }
   span {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     display: inline-block;
   }
 `;


### PR DESCRIPTION
in the old design, subText points to gray300, so this is a non-breaking change; however, in chonk, we use a different value that has better contrast. This fixes a lot of issues in chonk where gray300 was too bright for the backgroundColor.

note that this might introduce places where `subText` is not semantically correct, so we might have to add an additional alias later