### PR TITLE
feat(auto_source_config): Derive in-app stack trace rules

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -37,6 +37,7 @@ from sentry.grouping.variants import (
     HashedChecksumVariant,
     SaltedComponentVariant,
 )
+from sentry.issues.auto_source_code_config.constants import DERIVED_ENHANCEMENTS_OPTION_KEY
 from sentry.models.grouphash import GroupHash
 
 if TYPE_CHECKING:
@@ -87,6 +88,7 @@ class GroupingConfigLoader:
         }
 
     def _get_enhancements(self, project: Project) -> str:
+        derived_enhancements = project.get_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
         project_enhancements = project.get_option("sentry:grouping_enhancements")
 
         config_id = self._get_config_id(project)
@@ -100,15 +102,27 @@ class GroupingConfigLoader:
         cache_prefix = self.cache_prefix
         cache_prefix += f"{LATEST_VERSION}:"
         cache_key = (
-            cache_prefix + md5_text(f"{enhancements_base}|{project_enhancements}").hexdigest()
+            cache_prefix
+            + md5_text(
+                f"{enhancements_base}|{derived_enhancements}|{project_enhancements}"
+            ).hexdigest()
         )
         enhancements = cache.get(cache_key)
         if enhancements is not None:
             return enhancements
 
         try:
+            # Automatic enhancements are always applied first, so they take precedence over
+            # project-specific enhancements.
+            enhancements_string = project_enhancements or ""
+            if derived_enhancements:
+                enhancements_string = (
+                    f"{derived_enhancements}\n{enhancements_string}"
+                    if enhancements_string
+                    else derived_enhancements
+                )
             enhancements = Enhancements.from_config_string(
-                project_enhancements, bases=[enhancements_base] if enhancements_base else []
+                enhancements_string, bases=[enhancements_base] if enhancements_base else []
             ).base64_string
         except InvalidEnhancerConfig:
             enhancements = get_default_enhancements()
@@ -441,7 +455,7 @@ def get_grouping_variants_for_event(
 
 
 def get_contributing_variant_and_component(
-    variants: dict[str, BaseVariant]
+    variants: dict[str, BaseVariant],
 ) -> tuple[BaseVariant, ContributingComponent | None]:
     if len(variants) == 1:
         contributing_variant = list(variants.values())[0]

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -112,7 +112,7 @@ class GroupingConfigLoader:
             return enhancements
 
         try:
-            # Automatic enhancements are always applied first, so they take precedence over
+            # Automatic enhancements are always applied first, so they can be overridden by
             # project-specific enhancements.
             enhancements_string = project_enhancements or ""
             if derived_enhancements:

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -595,10 +595,10 @@ def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
 
     parts = module.split(".")
     # Take the first two parts of the module
-    stack_root = ".".join(parts[:2])
-    file_path = "/".join(parts[2:]) + "/" + abs_path
+    stack_root = "/".join(parts[:2])
+    file_path = "/".join(parts[:-1]) + "/" + abs_path
 
-    # com.example.foo.Bar$InnerClass ->
+    # com.example.foo.Bar$InnerClass, Bar.kt ->
     #    stack_root: com/example/
     #    file_path:  com/example/foo/Bar.kt
     return stack_root, file_path

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -593,9 +593,12 @@ def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
     if "." not in module:
         raise DoesNotFollowJavaPackageNamingConvention
 
-    # If module has a dot, take everything before the last dot
-    # com.example.foo.Bar$InnerClass -> com/example/foo
-    stack_root = module.rsplit(".", 1)[0].replace(".", "/")
-    file_path = f"{stack_root}/{abs_path}"
+    parts = module.split(".")
+    # Take the first two parts of the module
+    stack_root = ".".join(parts[:2])
+    file_path = "/".join(parts[2:]) + "/" + abs_path
 
+    # com.example.foo.Bar$InnerClass ->
+    #    stack_root: com/example/
+    #    file_path:  com/example/foo/Bar.kt
     return stack_root, file_path

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 METRIC_PREFIX = "auto_source_code_config"
+DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
 SUPPORTED_INTEGRATIONS = ["github"]
 
 # Any new languages should also require updating the stacktraceLink.tsx

--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -1,0 +1,58 @@
+import logging
+from collections.abc import Sequence
+
+from sentry.issues.auto_source_code_config.code_mapping import CodeMapping
+from sentry.issues.auto_source_code_config.utils import PlatformConfig
+from sentry.models.project import Project
+from sentry.utils import metrics
+
+from .constants import DERIVED_ENHANCEMENTS_OPTION_KEY, METRIC_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+def save_in_app_stack_trace_rules(
+    project: Project, code_mappings: Sequence[CodeMapping], platform_config: PlatformConfig
+) -> list[str]:
+    """Save in app stack trace rules for a given project"""
+    rules = set()
+    for code_mapping in code_mappings:
+        try:
+            rules.add(generate_rule_for_code_mapping(code_mapping))
+        except ValueError:
+            pass
+    if not platform_config.is_dry_run_platform():
+        project.update_option(DERIVED_ENHANCEMENTS_OPTION_KEY, "\n".join(rules))
+
+    metrics.incr(
+        key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
+        amount=len(rules),
+        tags={
+            "platform": platform_config.platform,
+            "dry_run": platform_config.is_dry_run_platform(),
+        },
+        sample_rate=1.0,
+    )
+    return list(rules)
+
+
+# XXX: This is very Java specific. If we want to support other languages, we need to
+# come up with a better way to generate the rule.
+def generate_rule_for_code_mapping(code_mapping: CodeMapping) -> str:
+    """Generate a rule for a given code mapping"""
+    stacktrace_root = code_mapping.stacktrace_root
+    if stacktrace_root == "":
+        raise ValueError("Stacktrace root is empty")
+
+    parts = stacktrace_root.rstrip("/").split("/", 2)
+    # We only want the first two parts
+    module = ".".join(parts[:2])
+
+    if module == "":
+        raise ValueError("Module is empty")
+
+    # a/ -> a.**
+    # x/y/ -> x.y.**
+    # com/example/foo/bar/ -> com.example.**
+    # uk/co/example/foo/bar/ -> uk.co.**
+    return f"stack.module:{module}.** +app"

--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -15,25 +15,31 @@ def save_in_app_stack_trace_rules(
     project: Project, code_mappings: Sequence[CodeMapping], platform_config: PlatformConfig
 ) -> list[str]:
     """Save in app stack trace rules for a given project"""
-    rules = set()
+    rules_from_code_mappings = set()
     for code_mapping in code_mappings:
         try:
-            rules.add(generate_rule_for_code_mapping(code_mapping))
+            rules_from_code_mappings.add(generate_rule_for_code_mapping(code_mapping))
         except ValueError:
             pass
-    if not platform_config.is_dry_run_platform():
-        project.update_option(DERIVED_ENHANCEMENTS_OPTION_KEY, "\n".join(rules))
 
+    current_enhancements = project.get_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
+    current_rules = set(current_enhancements.split("\n")) if current_enhancements else set()
+
+    united_rules = rules_from_code_mappings.union(current_rules)
+    if not platform_config.is_dry_run_platform() and united_rules != current_rules:
+        project.update_option(DERIVED_ENHANCEMENTS_OPTION_KEY, "\n".join(sorted(united_rules)))
+
+    new_rules_added = united_rules - current_rules
     metrics.incr(
         key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
-        amount=len(rules),
+        amount=len(new_rules_added),
         tags={
             "platform": platform_config.platform,
             "dry_run": platform_config.is_dry_run_platform(),
         },
         sample_rate=1.0,
     )
-    return list(rules)
+    return list(new_rules_added)
 
 
 # XXX: This is very Java specific. If we want to support other languages, we need to

--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -39,7 +39,7 @@ def save_in_app_stack_trace_rules(
 # XXX: This is very Java specific. If we want to support other languages, we need to
 # come up with a better way to generate the rule.
 def generate_rule_for_code_mapping(code_mapping: CodeMapping) -> str:
-    """Generate a rule for a given code mapping"""
+    """Generate an in-app rule for a given code mapping"""
     stacktrace_root = code_mapping.stacktrace_root
     if stacktrace_root == "":
         raise ValueError("Stacktrace root is empty")

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -25,6 +25,7 @@ from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 
 from .constants import METRIC_PREFIX
+from .in_app_stack_trace_rules import save_in_app_stack_trace_rules
 from .integration_utils import (
     InstallationCannotGetTreesError,
     InstallationNotFoundError,
@@ -192,8 +193,9 @@ def create_configurations(
 
     in_app_stack_trace_rules: list[str] = []
     if platform_config.creates_in_app_stack_trace_rules():
-        # XXX: This will be changed on the next PR
-        pass
+        in_app_stack_trace_rules = save_in_app_stack_trace_rules(
+            project, code_mappings, platform_config
+        )
 
     # We return this to allow tests running in dry-run mode to assert
     # what would have been created.

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -53,6 +53,7 @@ OPTION_KEYS = frozenset(
         "sentry:grouping_enhancements_base",
         "sentry:secondary_grouping_config",
         "sentry:secondary_grouping_expiry",
+        "sentry:derived_grouping_enhancements",
         "sentry:similarity_backfill_completed",
         "sentry:fingerprinting_rules",
         "sentry:relay_pii_config",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -30,6 +30,7 @@ register(
 )
 
 register(key="sentry:grouping_enhancements", default="")
+register(key="sentry:derived_grouping_enhancements", default="")
 
 # server side fingerprinting defaults.
 register(key="sentry:fingerprinting_rules", default="")

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -694,9 +694,8 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
                 frames=frames,
                 platform=self.platform,
                 expected_new_code_mappings=[
-                    self.code_mapping(
-                        stack_root="uk/co/example/foo/", source_root="src/uk/co/example/foo/"
-                    ),
+                    # XXX: Notice that we loose "example"
+                    self.code_mapping(stack_root="uk/co/", source_root="src/uk/co/"),
                 ],
                 expected_in_app_stack_trace_rules=["stack.module:uk.co.** +app"],
             )
@@ -743,9 +742,7 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
                 frames=frames,
                 platform=self.platform,
                 expected_new_code_mappings=[
-                    self.code_mapping(
-                        stack_root="com/example/foo/", source_root="src/com/example/foo/"
-                    ),
+                    self.code_mapping(stack_root="com/example/", source_root="src/com/example/"),
                 ],
                 expected_num_code_mappings=1,
                 expected_in_app_stack_trace_rules=[expected_in_app_rule],

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -124,12 +124,13 @@ class BaseDeriveCodeMappings(TestCase):
                         assert cm.stacktrace_root == expected_cm["stack_root"]
                         assert cm.source_path == expected_cm["source_root"]
                         assert cm.repo.name == expected_cm["repo_name"]
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
-                    )
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
-                    )
+
+                mock_incr.assert_any_call(
+                    key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                )
+                mock_incr.assert_any_call(
+                    key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
+                )
 
                 if expected_in_app_stack_trace_rules:
                     assert sorted(in_app_stack_trace_rules) == sorted(
@@ -170,15 +171,15 @@ class BaseDeriveCodeMappings(TestCase):
                         sample_rate=1.0,
                     )
 
-            if Repository.objects.all().count() > starting_repositories_count:
-                mock_incr.assert_any_call(
-                    key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
-                )
+                if Repository.objects.all().count() > starting_repositories_count:
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                    )
 
-            if code_mappings.count() > starting_code_mappings_count:
-                mock_incr.assert_any_call(
-                    key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
-                )
+                if code_mappings.count() > starting_code_mappings_count:
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
+                    )
 
             # Returning these to inspect the results
             return event

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -771,7 +771,7 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
             assert event.data["metadata"]["in_app_frame_mix"] == "system-only"
             assert len(event.data["hashes"]) == 1  # Only system hash
             system_only_hash = event.data["hashes"][0]
-            first_enhancements_hash = event.data["grouping_config"]["enhancements"]
+            first_enhancements_base64_string = event.data["grouping_config"]["enhancements"]
             group_id = event.group_id
 
             # Running a second time will not create any new configurations, however,
@@ -783,7 +783,7 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
             assert event.data["metadata"]["in_app_frame_mix"] == "mixed"
             second_enhancements_hash = event.data["grouping_config"]["enhancements"]
             # The enhancements now contain the automatic rule (+app)
-            assert second_enhancements_hash != first_enhancements_hash
+            assert second_enhancements_hash != first_enhancements_base64_string
             assert len(event.data["hashes"]) == 2
             event.data["hashes"].remove(system_only_hash)
             in_app_hash = event.data["hashes"][0]
@@ -799,5 +799,5 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
             assert event.group_id == group_id  # It still belongs to the same group
             assert event.data["hashes"] == [system_only_hash]
             # The enhancements now contain the automatic rule (+app) and the developer's rule (-app)
-            assert event.data["grouping_config"]["enhancements"] != first_enhancements_hash
+            assert event.data["grouping_config"]["enhancements"] != first_enhancements_base64_string
             assert event.data["grouping_config"]["enhancements"] != second_enhancements_hash

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.issues.auto_source_code_config.constants import METRIC_PREFIX
+from sentry.issues.auto_source_code_config.constants import (
+    DERIVED_ENHANCEMENTS_OPTION_KEY,
+    METRIC_PREFIX,
+)
 from sentry.issues.auto_source_code_config.integration_utils import InstallationNotFoundError
 from sentry.issues.auto_source_code_config.task import DeriveCodeMappingsErrorReason, process_event
 from sentry.issues.auto_source_code_config.utils import PlatformConfig
@@ -98,6 +101,7 @@ class BaseDeriveCodeMappings(TestCase):
             ),
             patch("sentry.utils.metrics.incr") as mock_incr,
         ):
+            starting_enhancements = self.project.get_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
             starting_repositories_count = Repository.objects.all().count()
             starting_code_mappings_count = RepositoryProjectPathConfig.objects.all().count()
             event = self.create_event(frames, platform)
@@ -106,11 +110,13 @@ class BaseDeriveCodeMappings(TestCase):
             )
 
             code_mappings = RepositoryProjectPathConfig.objects.all()
+            current_enhancements = self.project.get_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
 
             if dry_run:
                 # If dry run, no configurations should have been created
                 assert starting_code_mappings_count == code_mappings.count()
                 assert starting_repositories_count == Repository.objects.all().count()
+                assert current_enhancements == starting_enhancements
 
                 if expected_new_code_mappings:
                     assert len(dry_run_code_mappings) == len(expected_new_code_mappings)
@@ -118,13 +124,24 @@ class BaseDeriveCodeMappings(TestCase):
                         assert cm.stacktrace_root == expected_cm["stack_root"]
                         assert cm.source_path == expected_cm["source_root"]
                         assert cm.repo.name == expected_cm["repo_name"]
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                    )
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
+                    )
 
-                mock_incr.assert_any_call(
-                    key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
-                )
-                mock_incr.assert_any_call(
-                    key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
-                )
+                if expected_in_app_stack_trace_rules:
+                    assert sorted(in_app_stack_trace_rules) == sorted(
+                        expected_in_app_stack_trace_rules
+                    )
+                    assert "\n".join(expected_in_app_stack_trace_rules) not in current_enhancements
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
+                        amount=len(expected_in_app_stack_trace_rules),
+                        tags=tags,
+                        sample_rate=1.0,
+                    )
             else:
                 assert code_mappings.count() == expected_num_code_mappings
                 if expected_new_code_mappings:
@@ -139,19 +156,29 @@ class BaseDeriveCodeMappings(TestCase):
                         assert code_mapping is not None
                         assert code_mapping.repository.name == expected_cm["repo_name"]
 
-                if Repository.objects.all().count() > starting_repositories_count:
+                if expected_in_app_stack_trace_rules:
+                    expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
+                    assert current_enhancements == (
+                        f"{starting_enhancements}\n{expected_enhancements}"
+                        if starting_enhancements
+                        else expected_enhancements
+                    )
                     mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                        key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
+                        amount=len(expected_in_app_stack_trace_rules),
+                        tags=tags,
+                        sample_rate=1.0,
                     )
 
-                if code_mappings.count() > starting_code_mappings_count:
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
-                    )
+            if Repository.objects.all().count() > starting_repositories_count:
+                mock_incr.assert_any_call(
+                    key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                )
 
-            if expected_in_app_stack_trace_rules is not None:
-                # XXX: Grab it from the option
-                assert expected_in_app_stack_trace_rules == in_app_stack_trace_rules
+            if code_mappings.count() > starting_code_mappings_count:
+                mock_incr.assert_any_call(
+                    key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
+                )
 
             # Returning these to inspect the results
             return event
@@ -581,13 +608,32 @@ class TestPythonDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
 class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
     platform = "java"
 
-    def test_very_short_module_name(self) -> None:
+    def test_short_packages(self) -> None:
         # No code mapping will be stored, however, we get what would have been created
         self._process_and_assert_configuration_changes(
-            repo_trees={REPO1: ["src/a/Foo.java"]},
-            frames=[self.frame(module="a.Foo", abs_path="Foo.java")],
+            repo_trees={
+                REPO1: [
+                    "src/Foo.java",
+                    "src/a/Bar.java",
+                    "src/x/y/Baz.java",
+                ]
+            },
+            frames=[
+                # This will not create a code mapping because
+                # the stacktrace root would be empty
+                self.frame(module="Foo", abs_path="Foo.java", in_app=True),
+                self.frame(module="a.Bar", abs_path="Bar.java", in_app=True),
+                self.frame(module="x.y.Baz", abs_path="Baz.java", in_app=True),
+            ],
             platform=self.platform,
-            expected_new_code_mappings=[self.code_mapping("a/", "src/a/")],
+            expected_new_code_mappings=[
+                self.code_mapping("a/", "src/a/"),
+                self.code_mapping("x/y/", "src/x/y/"),
+            ],
+            expected_in_app_stack_trace_rules=[
+                "stack.module:a.** +app",
+                "stack.module:x.y.** +app",
+            ],
             expected_num_code_mappings=0,
         )
 
@@ -600,5 +646,153 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
             expected_new_code_mappings=[
                 self.code_mapping("com/example/foo/", "src/com/example/foo/")
             ],
+            # Notice that the in-app stack trace rule does not include "foo" as the stacktrace root does
+            expected_in_app_stack_trace_rules=["stack.module:com.example.** +app"],
             expected_num_code_mappings=0,
         )
+
+    def test_multiple_configuration_changes(self) -> None:
+        # Test case with multiple frames from different packages
+        self._process_and_assert_configuration_changes(
+            repo_trees={
+                REPO1: [
+                    "src/com/example/foo/Bar.kt",
+                    "src/com/example/foo/Baz.kt",
+                    "src/com/example/utils/Helper.kt",
+                    "src/org/other/service/Service.kt",
+                    "src/uk/co/example/foo/Bar.kt",
+                ]
+            },
+            frames=[
+                self.frame(module="com.example.foo.Bar", abs_path="Bar.kt"),
+                self.frame(module="com.example.foo.Baz", abs_path="Baz.kt"),
+                self.frame(module="com.example.utils.Helper", abs_path="Helper.kt"),
+                self.frame(module="org.other.service.Service", abs_path="Service.kt"),
+            ],
+            platform=self.platform,
+            expected_new_code_mappings=[
+                self.code_mapping(
+                    stack_root="com/example/foo/", source_root="src/com/example/foo/"
+                ),
+                self.code_mapping(
+                    stack_root="com/example/utils/", source_root="src/com/example/utils/"
+                ),
+                self.code_mapping(
+                    stack_root="org/other/service/", source_root="src/org/other/service/"
+                ),
+            ],
+            # We have three code mappings, but only two in-app stack trace rules
+            # because the "foo" code mapping coalesces with the "com.example.**" rule
+            expected_in_app_stack_trace_rules=[
+                "stack.module:com.example.** +app",
+                "stack.module:org.other.** +app",
+            ],
+            expected_num_code_mappings=4,
+        )
+
+    def test_multiple_tlds(self) -> None:
+        # XXX: Multiple TLDs cause over in-app categorization
+        # Think of uk.co company using packages from another uk.co company
+        # They can still use their project rules to exclude the other uk.co packages
+        frames = [
+            self.frame(module="uk.co.example.foo.Bar", abs_path="Bar.kt", in_app=False),
+            self.frame(module="uk.co.not-example.baz.qux", abs_path="qux.kt", in_app=False),
+        ]
+
+        # Let's pretend we're not running as dry-run
+        with patch(f"{CODE_ROOT}.utils.PlatformConfig.is_dry_run_platform", return_value=False):
+            event = self._process_and_assert_configuration_changes(
+                repo_trees={REPO1: ["src/uk/co/example/foo/Bar.kt"]},
+                frames=frames,
+                platform=self.platform,
+                expected_new_code_mappings=[
+                    self.code_mapping(
+                        stack_root="uk/co/example/foo/", source_root="src/uk/co/example/foo/"
+                    ),
+                ],
+                expected_in_app_stack_trace_rules=["stack.module:uk.co.** +app"],
+            )
+            assert event.data["metadata"]["in_app_frame_mix"] == "system-only"
+
+            event = self._process_and_assert_configuration_changes(
+                repo_trees={REPO1: ["src/uk/co/example/foo/Bar.kt"]},
+                frames=frames,
+                platform=self.platform,
+            )
+            # It's in-app-only because even the not-example package is in-app
+            assert event.data["metadata"]["in_app_frame_mix"] == "in-app-only"
+
+            # The developer can undo our rule
+            self.project.update_option(
+                "sentry:grouping_enhancements",
+                "stack.module:uk.co.not-example.** -app",
+            )
+            event = self._process_and_assert_configuration_changes(
+                repo_trees={REPO1: ["src/uk/co/example/foo/Bar.kt"]},
+                frames=frames,
+                platform=self.platform,
+            )
+            assert event.data["metadata"]["in_app_frame_mix"] == "mixed"
+            event_frames = event.data["stacktrace"]["frames"]
+            assert event_frames[0]["module"] == "uk.co.example.foo.Bar"
+            assert event_frames[0]["in_app"] is True
+            assert event_frames[1]["module"] == "uk.co.not-example.baz.qux"
+            assert event_frames[1]["in_app"] is False
+
+    def test_run_without_dry_run(self) -> None:
+        repo_trees = {REPO1: ["src/com/example/foo/Bar.kt"]}
+        frames = [
+            self.frame(module="com.example.foo.Bar", abs_path="Bar.kt", in_app=False),
+            self.frame(module="com.other.foo.Bar", abs_path="Bar.kt", in_app=False),
+        ]
+        rule = "stack.module:com.example.**"
+        expected_in_app_rule = f"{rule} +app"
+
+        # Let's pretend we're not running as dry-run
+        with patch(f"{CODE_ROOT}.utils.PlatformConfig.is_dry_run_platform", return_value=False):
+            event = self._process_and_assert_configuration_changes(
+                repo_trees=repo_trees,
+                frames=frames,
+                platform=self.platform,
+                expected_new_code_mappings=[
+                    self.code_mapping(
+                        stack_root="com/example/foo/", source_root="src/com/example/foo/"
+                    ),
+                ],
+                expected_num_code_mappings=1,
+                expected_in_app_stack_trace_rules=[expected_in_app_rule],
+            )
+            # The effects of the configuration changes will be noticed on the second event processing
+            assert event.data["metadata"]["in_app_frame_mix"] == "system-only"
+            assert len(event.data["hashes"]) == 1  # Only system hash
+            system_only_hash = event.data["hashes"][0]
+            first_enhancements_hash = event.data["grouping_config"]["enhancements"]
+            group_id = event.group_id
+
+            # Running a second time will not create any new configurations, however,
+            # the rules from the previous run will be applied to the event's stack trace
+            event = self._process_and_assert_configuration_changes(
+                repo_trees=repo_trees, frames=frames, platform=self.platform
+            )
+            assert event.group_id == group_id  # The new rules did not cause new groups
+            assert event.data["metadata"]["in_app_frame_mix"] == "mixed"
+            second_enhancements_hash = event.data["grouping_config"]["enhancements"]
+            # The enhancements now contain the automatic rule (+app)
+            assert second_enhancements_hash != first_enhancements_hash
+            assert len(event.data["hashes"]) == 2
+            event.data["hashes"].remove(system_only_hash)
+            in_app_hash = event.data["hashes"][0]
+            assert in_app_hash != system_only_hash
+
+            # The developer will add a rule to invalidate our automatinc rule (-app)
+            self.project.update_option("sentry:grouping_enhancements", f"{rule} -app")
+            event = self._process_and_assert_configuration_changes(
+                repo_trees=repo_trees, frames=frames, platform=self.platform
+            )
+            # Back to system-only
+            assert event.data["metadata"]["in_app_frame_mix"] == "system-only"
+            assert event.group_id == group_id  # It still belongs to the same group
+            assert event.data["hashes"] == [system_only_hash]
+            # The enhancements now contain the automatic rule (+app) and the developer's rule (-app)
+            assert event.data["grouping_config"]["enhancements"] != first_enhancements_hash
+            assert event.data["grouping_config"]["enhancements"] != second_enhancements_hash

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -167,19 +167,19 @@ class BaseDeriveCodeMappings(TestCase):
                         key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
                     )
 
-                if expected_in_app_stack_trace_rules:
-                    expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
-                    assert current_enhancements == (
-                        f"{starting_enhancements}\n{expected_enhancements}"
-                        if starting_enhancements
-                        else expected_enhancements
-                    )
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
-                        amount=len(expected_in_app_stack_trace_rules),
-                        tags=tags,
-                        sample_rate=1.0,
-                    )
+            if expected_in_app_stack_trace_rules:
+                expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
+                assert current_enhancements == (
+                    f"{starting_enhancements}\n{expected_enhancements}"
+                    if starting_enhancements
+                    else expected_enhancements
+                )
+                mock_incr.assert_any_call(
+                    key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
+                    amount=len(expected_in_app_stack_trace_rules),
+                    tags=tags,
+                    sample_rate=1.0,
+                )
 
             # Returning these to inspect the results
             return event

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -157,6 +157,16 @@ class BaseDeriveCodeMappings(TestCase):
                         assert code_mapping is not None
                         assert code_mapping.repository.name == expected_cm["repo_name"]
 
+                if Repository.objects.all().count() > starting_repositories_count:
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
+                    )
+
+                if code_mappings.count() > starting_code_mappings_count:
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
+                    )
+
                 if expected_in_app_stack_trace_rules:
                     expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
                     assert current_enhancements == (
@@ -169,16 +179,6 @@ class BaseDeriveCodeMappings(TestCase):
                         amount=len(expected_in_app_stack_trace_rules),
                         tags=tags,
                         sample_rate=1.0,
-                    )
-
-                if Repository.objects.all().count() > starting_repositories_count:
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0
-                    )
-
-                if code_mappings.count() > starting_code_mappings_count:
-                    mock_incr.assert_any_call(
-                        key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
                     )
 
             # Returning these to inspect the results

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -167,19 +167,19 @@ class BaseDeriveCodeMappings(TestCase):
                         key=f"{METRIC_PREFIX}.code_mapping.created", tags=tags, sample_rate=1.0
                     )
 
-            if expected_in_app_stack_trace_rules:
-                expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
-                assert current_enhancements == (
-                    f"{starting_enhancements}\n{expected_enhancements}"
-                    if starting_enhancements
-                    else expected_enhancements
-                )
-                mock_incr.assert_any_call(
-                    key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
-                    amount=len(expected_in_app_stack_trace_rules),
-                    tags=tags,
-                    sample_rate=1.0,
-                )
+                if expected_in_app_stack_trace_rules:
+                    expected_enhancements = "\n".join(expected_in_app_stack_trace_rules)
+                    assert current_enhancements == (
+                        f"{starting_enhancements}\n{expected_enhancements}"
+                        if starting_enhancements
+                        else expected_enhancements
+                    )
+                    mock_incr.assert_any_call(
+                        key=f"{METRIC_PREFIX}.in_app_stack_trace_rules.created",
+                        amount=len(expected_in_app_stack_trace_rules),
+                        tags=tags,
+                        sample_rate=1.0,
+                    )
 
             # Returning these to inspect the results
             return event


### PR DESCRIPTION
This is the logic to mark frames as in-app when the files are found in the developers' GitHub repositories.

This is very important for languages where the SDK or our internal rules cannot determine which frames are in-app and which are not.

The initial language to get support for this is Java.

This will run in dry run mode to discover errors or scaling problems.