### PR TITLE
feat(tags): Adds an includeValuesSeen param to tags endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -36,6 +36,8 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
             else:
                 backend = tagstore.backend
 
+            include_values_seen = request.GET.get("includeValuesSeen") != "0"
+
             tag_keys = sorted(
                 backend.get_tag_keys(
                     project.id,
@@ -44,7 +46,7 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
                     # We might be able to stop including these values, but this
                     # is a pretty old endpoint, so concerned about breaking
                     # existing api consumers.
-                    include_values_seen=True,
+                    include_values_seen=include_values_seen,
                     **kwargs,
                 ),
                 key=lambda x: x.key,
@@ -56,7 +58,7 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
                 {
                     "key": tagstore.backend.get_standardized_key(tag_key.key),
                     "name": tagstore.backend.get_tag_key_label(tag_key.key),
-                    "uniqueValues": tag_key.values_seen,
+                    **({"uniqueValues": tag_key.values_seen} if include_values_seen else {}),
                     "canDelete": tag_key.key not in PROTECTED_TAG_KEYS and not use_flag_backend,
                 }
             )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -412,6 +412,7 @@ class SnubaTagStorage(TagStorage):
             environment_id and [environment_id],
             denylist=denylist,
             tenant_ids=tenant_ids,
+            include_values_seen=include_values_seen,
         )
 
     def get_tag_keys_for_projects(

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -33,6 +33,31 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
         assert data["bar"]["canDelete"]
         assert data["bar"]["uniqueValues"] == 2
 
+    def test_simple_without_values_seen(self):
+        self.store_event(
+            data={
+                "tags": {"foo": "oof", "bar": "rab"},
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"tags": {"bar": "rab2"}, "timestamp": before_now(minutes=1).isoformat()},
+            project_id=self.project.id,
+        )
+
+        response = self.get_success_response(
+            self.project.organization.slug, self.project.slug, includeValuesSeen=0
+        )
+
+        data = {v["key"]: v for v in response.data}
+        assert len(data) == 3
+
+        assert data["foo"]["canDelete"]
+        assert "uniqueValues" not in data["foo"]
+        assert data["bar"]["canDelete"]
+        assert data["bar"]["uniqueValues"] == 2
+
     def test_simple_flags(self):
         self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -56,7 +56,7 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
         assert data["foo"]["canDelete"]
         assert "uniqueValues" not in data["foo"]
         assert data["bar"]["canDelete"]
-        assert data["bar"]["uniqueValues"] == 2
+        assert "uniqueValues" not in data["bar"]
 
     def test_simple_flags(self):
         self.store_event(


### PR DESCRIPTION
Adds a `includeValuesSeen` query param to the `/tags/` endpoint. Some frontend calls for this endpoint do not use `uniqueValues`, so we can avoid fetching them when not necessary.