### PR TITLE
feat(eap): Upgrade op breakdown filter to use `span.category` on EAP

### DIFF
--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -21,6 +21,10 @@ type Props = {
 
 const LIMIT = 10;
 
+// TODO: When the span buffer is finalized, we will be able to expand this list and allow breakdowns on more categories.
+// for now, it will only allow categories that match the hardcoded list of span ops that were supported in the previous iteration
+const ALLOWED_CATEGORIES = ['http', 'db', 'browser', 'resource', 'ui'];
+
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
   const {selection} = usePageFilters();
@@ -47,6 +51,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const {options: categoryOptions} = useCompactSelectOptionsCache(
     data
       .filter(d => !!d[SpanIndexedField.SPAN_CATEGORY])
+      .filter(d => ALLOWED_CATEGORIES.includes(d[SpanIndexedField.SPAN_CATEGORY]))
       .map(d => ({
         value: d[SpanIndexedField.SPAN_CATEGORY],
         label: d[SpanIndexedField.SPAN_CATEGORY],

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -19,7 +19,7 @@ type Props = {
 const LIMIT = 10;
 
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
-  const [category, setCategory] = useState<string | undefined>(undefined);
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
 
   const searchQuery = useMemo(() => {
     const query = new MutableSearch('');
@@ -34,7 +34,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
       search: searchQuery,
       sorts: [{field: 'count()', kind: 'desc'}],
     },
-    'api.transaction-summary.span-category-filter'
+    'api.transaction-summary.span-selectedCategory-filter'
   );
 
   const {options: categoryOptions} = useCompactSelectOptionsCache(
@@ -60,19 +60,19 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   }
 
   const onChange = (selectedOption: SelectOption<string> | null) => {
-    setCategory(selectedOption?.value ?? undefined);
+    setSelectedCategory(selectedOption?.value ?? undefined);
   };
 
   return (
     <CompactSelect
       clearable
       disallowEmptySelection={false}
-      menuTitle={t('Filter by category')}
-      onClear={() => setCategory(undefined)}
+      menuTitle={t('Filter by selectedCategory')}
+      onClear={() => setSelectedCategory(undefined)}
       options={categoryOptions}
-      value={category ?? undefined}
+      value={selectedCategory ?? undefined}
       onChange={onChange}
-      triggerLabel={t('Filter')}
+      triggerLabel={selectedCategory ? selectedCategory : t('Filter')}
       triggerProps={{icon: <IconFilter />, 'aria-label': t('Filter by category')}}
     />
   );

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -8,6 +8,8 @@ import {IconFilter} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -20,6 +22,8 @@ const LIMIT = 10;
 
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const searchQuery = useMemo(() => {
     const query = new MutableSearch('');
@@ -61,6 +65,14 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
 
   const onChange = (selectedOption: SelectOption<string> | null) => {
     setSelectedCategory(selectedOption?.value ?? undefined);
+
+    navigate({
+      ...location,
+      query: {
+        ...location.query,
+        [SpanIndexedField.SPAN_CATEGORY]: selectedOption?.value,
+      },
+    });
   };
 
   return (

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -10,6 +10,7 @@ import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -22,6 +23,7 @@ const LIMIT = 10;
 
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
+  const {selection} = usePageFilters();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -37,6 +39,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
       fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
       search: searchQuery,
       sorts: [{field: 'count()', kind: 'desc'}],
+      pageFilters: selection,
     },
     'api.transaction-summary.span-selectedCategory-filter'
   );
@@ -47,6 +50,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
       .map(d => ({
         value: d[SpanIndexedField.SPAN_CATEGORY],
         label: d[SpanIndexedField.SPAN_CATEGORY],
+        key: d[SpanIndexedField.SPAN_CATEGORY],
         leadingItems: (
           <OperationDot
             backgroundColor={pickBarColor(d[SpanIndexedField.SPAN_CATEGORY])}

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -1,3 +1,11 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
+import {IconFilter} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -10,9 +18,17 @@ type Props = {
 const LIMIT = 10;
 
 export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
-  const searchQuery = new MutableSearch(search);
-  // TODO: this will change to span.name eventually
-  searchQuery.addFilterValue('span.description', serviceEntrySpanName);
+  const [category, setCategory] = useState<string | undefined>(undefined);
+
+  const searchQuery = useMemo(() => {
+    const query = new MutableSearch(search);
+    query.addFilterValue('transaction', serviceEntrySpanName);
+
+    if (category) {
+      query.addFilterValue('span.category', category);
+    }
+    return query;
+  }, [search, serviceEntrySpanName, category]);
 
   const {data, isPending, error} = useEAPSpans(
     {
@@ -20,11 +36,53 @@ export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
       fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
       search: searchQuery,
       sorts: [{field: 'count()', kind: 'desc'}],
+      enabled: !!category,
     },
     'api.transaction-summary.span-category-filter'
   );
 
-  console.dir(data);
+  const options = useMemo(() => {
+    if (isPending || error) {
+      return [];
+    }
 
-  return <div>SpanCategoryFilter</div>;
+    return data
+      .filter(d => !!d[SpanIndexedField.SPAN_CATEGORY])
+      .map(d => ({
+        label: d[SpanIndexedField.SPAN_CATEGORY],
+        value: d[SpanIndexedField.SPAN_CATEGORY],
+        leadingItems: (
+          <OperationDot
+            backgroundColor={pickBarColor(d[SpanIndexedField.SPAN_CATEGORY])}
+          />
+        ),
+      }));
+  }, [data, isPending, error]);
+
+  const onChange = (selectedOption: SelectOption<string> | null) => {
+    console.log('selectedOption', selectedOption);
+    setCategory(selectedOption?.value ?? undefined);
+  };
+
+  return (
+    <CompactSelect
+      clearable
+      // disallowEmptySelection={false}
+      menuTitle={t('Filter by category')}
+      onClear={() => setCategory(undefined)}
+      options={options}
+      value={category ?? undefined}
+      onChange={onChange}
+      triggerLabel={t('Filter')}
+      triggerProps={{icon: <IconFilter />, 'aria-label': t('Filter by category')}}
+    />
+  );
 }
+
+const OperationDot = styled('div')<{backgroundColor: string}>`
+  display: block;
+  width: ${space(1)};
+  height: ${space(1)};
+  border-radius: 100%;
+  background-color: ${p => p.backgroundColor};
+`;

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
@@ -31,17 +31,14 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const searchQuery = useMemo(() => {
-    const query = new MutableSearch('');
-    query.addFilterValue('transaction', serviceEntrySpanName);
-    return query;
-  }, [serviceEntrySpanName]);
+  const query = new MutableSearch('');
+  query.addFilterValue('transaction', serviceEntrySpanName);
 
   const {data, isError} = useEAPSpans(
     {
       limit: LIMIT,
       fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
-      search: searchQuery,
+      search: query,
       sorts: [{field: 'count()', kind: 'desc'}],
       pageFilters: selection,
     },

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -1,0 +1,30 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {SpanIndexedField} from 'sentry/views/insights/types';
+
+type Props = {
+  search: string;
+  serviceEntrySpanName: string;
+};
+
+const LIMIT = 10;
+
+export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
+  const searchQuery = new MutableSearch(search);
+  // TODO: this will change to span.name eventually
+  searchQuery.addFilterValue('span.description', serviceEntrySpanName);
+
+  const {data, isPending, error} = useEAPSpans(
+    {
+      limit: LIMIT,
+      fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
+      search: searchQuery,
+      sorts: [{field: 'count()', kind: 'desc'}],
+    },
+    'api.transaction-summary.span-category-filter'
+  );
+
+  console.dir(data);
+
+  return <div>SpanCategoryFilter</div>;
+}

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -45,7 +45,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
       sorts: [{field: 'count()', kind: 'desc'}],
       pageFilters: selection,
     },
-    'api.transaction-summary.span-selectedCategory-filter'
+    'api.transaction-summary.span-category-filter'
   );
 
   const {options: categoryOptions} = useCompactSelectOptionsCache(

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -23,12 +23,8 @@ export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
   const searchQuery = useMemo(() => {
     const query = new MutableSearch(search);
     query.addFilterValue('transaction', serviceEntrySpanName);
-
-    if (category) {
-      query.addFilterValue('span.category', category);
-    }
     return query;
-  }, [search, serviceEntrySpanName, category]);
+  }, [search, serviceEntrySpanName]);
 
   const {data, isPending, error} = useEAPSpans(
     {
@@ -36,7 +32,6 @@ export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
       fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
       search: searchQuery,
       sorts: [{field: 'count()', kind: 'desc'}],
-      enabled: !!category,
     },
     'api.transaction-summary.span-category-filter'
   );
@@ -60,14 +55,13 @@ export function SpanCategoryFilter({search, serviceEntrySpanName}: Props) {
   }, [data, isPending, error]);
 
   const onChange = (selectedOption: SelectOption<string> | null) => {
-    console.log('selectedOption', selectedOption);
     setCategory(selectedOption?.value ?? undefined);
   };
 
   return (
     <CompactSelect
       clearable
-      // disallowEmptySelection={false}
+      disallowEmptySelection={false}
       menuTitle={t('Filter by category')}
       onClear={() => setCategory(undefined)}
       options={options}

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -79,7 +79,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
     <CompactSelect
       clearable
       disallowEmptySelection={false}
-      menuTitle={t('Filter by selectedCategory')}
+      menuTitle={t('Filter by category')}
       onClear={() => setSelectedCategory(undefined)}
       options={categoryOptions}
       value={selectedCategory ?? undefined}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -245,7 +245,7 @@ function OTelSummaryContentInner({
     <Fragment>
       <Layout.Main>
         <FilterActions>
-          <SpanCategoryFilter search={query} serviceEntrySpanName={transactionName} />
+          <SpanCategoryFilter serviceEntrySpanName={transactionName} />
           <PageFilterBar condensed>
             <EnvironmentPageFilter />
             <DatePageFilter />

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -39,6 +39,7 @@ import {updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import Tags from 'sentry/views/discover/tags';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 import {SpanCategoryFilter} from 'sentry/views/performance/transactionSummary/spanCategoryFilter';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
@@ -101,6 +102,7 @@ function OTelSummaryContentInner({
 }: Props) {
   const navigate = useNavigate();
   const domainViewFilters = useDomainViewFilters();
+  const spanCategory = decodeScalar(location.query?.[SpanIndexedField.SPAN_CATEGORY]);
 
   const handleSearch = useCallback(
     (query: string) => {
@@ -217,6 +219,13 @@ function OTelSummaryContentInner({
   if (spanOperationBreakdownConditions) {
     eventView = eventView.clone();
     eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
+    transactionsListEventView = eventView.clone();
+  }
+
+  if (spanCategory) {
+    eventView = eventView.clone();
+    eventView.query =
+      `${eventView.query} ${SpanIndexedField.SPAN_CATEGORY}:${spanCategory}`.trim();
     transactionsListEventView = eventView.clone();
   }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -40,6 +40,7 @@ import type {TableColumn} from 'sentry/views/discover/table/types';
 import Tags from 'sentry/views/discover/tags';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
+import {SpanCategoryFilter} from 'sentry/views/performance/transactionSummary/spanCategoryFilter';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
   PERCENTILE as VITAL_PERCENTILE,
@@ -97,7 +98,6 @@ function OTelSummaryContentInner({
   error,
   projectId,
   transactionName,
-  onChangeFilter,
 }: Props) {
   const navigate = useNavigate();
   const domainViewFilters = useDomainViewFilters();
@@ -245,11 +245,7 @@ function OTelSummaryContentInner({
     <Fragment>
       <Layout.Main>
         <FilterActions>
-          <Filter
-            organization={organization}
-            currentFilter={spanOperationBreakdownFilter}
-            onChangeFilter={onChangeFilter}
-          />
+          <SpanCategoryFilter search={query} serviceEntrySpanName={transactionName} />
           <PageFilterBar condensed>
             <EnvironmentPageFilter />
             <DatePageFilter />


### PR DESCRIPTION
Addresses https://github.com/getsentry/team-visibility/issues/55

Updates the transaction summary's dropdown filter to use `span.category` instead of span `op`. Since the latter is being deprecated, span category is a valid replacement. The new dropdown queries from the EAP dataset on the current `service entry span` (aka transaction) in order to find all possible categories that can be used, instead of a purely hardcoded list. The options are sorted in descending order based on the number of span samples in each category.

Similar to previous changes to migrate this page to the EAP dataset, this is available only for users with the `performance-transaction-summary-eap` feature flag enabled.

## Caveat
In its current state, this will not work well alongside the Service Entry Spans table, since mimicking the original behaviour requires sorting transactions by their operation breakdowns. In a followup PR, I will update this to work with EAP by adjusting the way the data is queried when a span category is selected.

## Before
![image](https://github.com/user-attachments/assets/e66203d6-be18-40fb-8653-c66bdea46ca7)

## After
![image](https://github.com/user-attachments/assets/7d7c0141-a93c-4bd0-b4b9-f6c658c20918)


## TODO in Followups
- [ ] Modify the service entry span table query when a span category is selected
- [ ] Add tests
