### PR TITLE
fix(crons): broken urls in emails

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1117,6 +1117,11 @@ urlpatterns += [
                     name="sentry-organization-cron-monitor-details",
                 ),
                 re_path(
+                    r"^(?P<organization_slug>[\w_-]+)/alerts/rules/crons/(?P<project_slug>[\w_-]+)/(?P<monitor_slug>[\w_-]+)/$",
+                    react_page_view,
+                    name="sentry-organization-cron-monitor-details",
+                ),
+                re_path(
                     r"^(?P<organization_slug>[\w_-]+)/restore/$",
                     generic_react_page_view,
                     name="sentry-restore-organization",

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1112,11 +1112,6 @@ urlpatterns += [
                     name="sentry-organization-crons",
                 ),
                 re_path(
-                    r"^(?P<organization_slug>[\w_-]+)/crons/(?P<project_slug>[\w_-]+)/(?P<monitor_slug>[\w_-]+)/$",
-                    react_page_view,
-                    name="sentry-organization-cron-monitor-details",
-                ),
-                re_path(
                     r"^(?P<organization_slug>[\w_-]+)/alerts/rules/crons/(?P<project_slug>[\w_-]+)/(?P<monitor_slug>[\w_-]+)/$",
                     react_page_view,
                     name="sentry-organization-cron-monitor-details",

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import timedelta
 from unittest.mock import Mock, call, patch
 
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
@@ -42,6 +43,12 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor=monitor,
             environment_id=environment_id,
             status=MonitorStatus.OK,
+        )
+
+    def generate_cron_monitor_url(self, org_slug: str, project_slug: str, monitor_slug: str) -> str:
+        return "http://testserver" + reverse(
+            "sentry-organization-cron-monitor-details",
+            args=[org_slug, project_slug, monitor_slug],
         )
 
     def create_monitor_and_env(
@@ -226,7 +233,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         monitor.slug,
                         self.project.slug,
-                        f"http://testserver/organizations/{self.organization.slug}/alerts/rules/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        f"{self.generate_cron_monitor_url(self.organization.slug, self.project.slug, monitor.slug)}?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -237,13 +244,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, third_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -254,13 +261,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, third_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -376,13 +383,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, third_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -226,7 +226,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         monitor.slug,
                         self.project.slug,
-                        f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        f"http://testserver/organizations/{self.organization.slug}/alerts/rules/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -237,13 +237,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -254,13 +254,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -365,7 +365,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         monitor.slug,
                         self.project.slug,
-                        f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        f"http://testserver/organizations/{self.organization.slug}/alerts/rules/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -376,13 +376,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -393,13 +393,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -486,7 +486,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -497,7 +497,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -372,7 +372,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         monitor.slug,
                         self.project.slug,
-                        f"{self.generate_cron_monitor_url(self.organization.slug, self.project.slug, monitor.slug)}??environment={self.environment.name}",
+                        f"{self.generate_cron_monitor_url(self.organization.slug, self.project.slug, monitor.slug)}?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -372,7 +372,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         monitor.slug,
                         self.project.slug,
-                        f"http://testserver/organizations/{self.organization.slug}/alerts/rules/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        f"{self.generate_cron_monitor_url(self.organization.slug, self.project.slug, monitor.slug)}??environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -400,13 +400,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, third_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                 ],
@@ -493,7 +493,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}??environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -504,7 +504,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"http://testserver/organizations/{second_org.slug}/alerts/rules/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}??environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -493,7 +493,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}??environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],
@@ -504,7 +504,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                     (
                         second_monitor.slug,
                         second_project.slug,
-                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}??environment={second_env.name}",
+                        f"{self.generate_cron_monitor_url(second_org.slug, second_project.slug, second_monitor.slug)}?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
                 ],


### PR DESCRIPTION
- The emails sent out from crons currently contain a URL in the format `https://{org_slug}.sentry.io/organizations/{org_slug}/crons/{project_slug}/{monitor_name}/`, however that page was moved to `https://{org_slug}.sentry.io/organizations/org_slug/alerts/rules/crons/{project_slug}/{monitor_name}/` in https://github.com/getsentry/sentry/commit/56b6a20d260a786dba29af920ccc21e89f7e1aec, causing the user to land on a 404 page. 

- This PR adds a route to urls.py that redirects to react_page view to make the reverse-resolution of this route work correctly again (see https://github.com/getsentry/sentry/blob/467126ce1044cedd2b676454be448ded466cedc3/src/sentry/monitors/tasks/detect_broken_monitor_envs.py#L54-L65)
- Uses reverse() to generate the URLs for tests so they don't break everytime we change the URL of the page