### PR TITLE
feat(alerts): Allow test notifications to include titles

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -193,6 +193,30 @@ describe('IssueRuleEditor', function () {
       expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByTestId('project-permission-alert')).not.toBeInTheDocument();
     });
+
+    it('allows test notifications', async () => {
+      const {organization, project} = createWrapper();
+      const mockTestNotification = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/rule-actions/`,
+        method: 'POST',
+        body: {},
+      });
+      await userEvent.click(screen.getByText('Send Test Notification'));
+      expect(mockTestNotification).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${project.slug}/rule-actions/`,
+        expect.objectContaining({
+          data: {
+            actions: [
+              {
+                id: 'sentry.rules.actions.notify_event.NotifyEventAction',
+                name: 'Send a notification (for all legacy integrations)',
+              },
+            ],
+            name: 'My alert rule',
+          },
+        })
+      );
+    });
   });
 
   describe('Edit Rule', function () {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -433,6 +433,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
         method: 'POST',
         data: {
           actions: rule?.actions ?? [],
+          name: rule?.name,
         },
       })
       .then(() => {


### PR DESCRIPTION
Some notifications may change their content depending on the title of the alert. This is the case for PagerDuty as per the change in https://github.com/getsentry/sentry/pull/87786. For users to better understand what they can expect when using the test notification button, if they've set up an alert name we should use it, that way it'll appear in the test notification as well.

If the user is setting up an issue alert for the first time, the test notification will use the label `Test Alert` (per the change here https://github.com/getsentry/sentry/pull/87786 -- not included in this PR)