### PR TITLE
Update default masking options to correct naming in onboarding flyout.tsx

### DIFF
--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -174,8 +174,8 @@ SentrySDK.start(configureOptions: { options in
 })`;
 
 const getReplayConfigurationSnippet = () => `
-options.sessionReplay.redactAllText = true
-options.sessionReplay.redactAllImages = true`;
+options.sessionReplay.maskAllText = true
+options.sessionReplay.maskAllImages = true`;
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   install: params =>


### PR DESCRIPTION
As per https://docs.sentry.io/platforms/apple/guides/ios/session-replay/#privacy

