### PR TITLE
Update default masking options to correct naming in onboarding flyout for Android

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -123,8 +123,8 @@ const getReplaySetupSnippetXml = () => `
 <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />`;
 
 const getReplayConfigurationSnippet = () => `
-options.sessionReplay.redactAllText = true
-options.sessionReplay.redactAllImages = true`;
+options.sessionReplay.maskAllText = true
+options.sessionReplay.maskAllImages = true`;
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   install: params =>


### PR DESCRIPTION

As per https://docs.sentry.io/platforms/android/session-replay/#privacy

