### PR TITLE
Revert "Revert "fix(mep): Do not allow `!has` in metrics requests (#8…

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -12,9 +12,10 @@ from parsimonious.exceptions import IncompleteParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor
 
-from sentry.exceptions import InvalidSearchQuery
+from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.search.events.constants import (
     DURATION_UNITS,
+    NOT_HAS_FILTER_ERROR_MESSAGE,
     OPERATOR_NEGATION_MAP,
     SEARCH_MAP,
     SEMVER_ALIAS,
@@ -623,10 +624,16 @@ class SearchConfig[TAllowBoolean: (Literal[True], Literal[False]) = Literal[True
     # Whether to wrap free_text_keys in asterisks
     wildcard_free_text: bool = False
 
+    # Disallow the use of the !has filter
+    allow_not_has_filter: bool = True
+
     @overload
     @classmethod
     def create_from[
-        TBool: (Literal[True], Literal[False])
+        TBool: (
+            Literal[True],
+            Literal[False],
+        )
     ](
         cls: type[SearchConfig[Any]],
         search_config: SearchConfig[Any],
@@ -638,7 +645,10 @@ class SearchConfig[TAllowBoolean: (Literal[True], Literal[False]) = Literal[True
     @overload
     @classmethod
     def create_from[
-        TBool: (Literal[True], Literal[False])
+        TBool: (
+            Literal[True],
+            Literal[False],
+        )
     ](
         cls: type[SearchConfig[Any]],
         search_config: SearchConfig[TBool],
@@ -660,7 +670,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
     # a way to represent positional-heterogenous lists -- but they are
     # actually lists
 
-    unwrapped_exceptions = (InvalidSearchQuery,)
+    unwrapped_exceptions = (InvalidSearchQuery, IncompatibleMetricsQuery)
 
     def __init__(
         self,
@@ -1220,6 +1230,16 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
     ) -> SearchFilter:
         # the key is has here, which we don't need
         negation, _, _, _, (search_key,) = children
+
+        # Some datasets do not support the !has filter, but we allow
+        # team_key_transaction because we control that field and special
+        # case the way it's processed in search
+        if (
+            not self.config.allow_not_has_filter
+            and is_negated(negation)
+            and search_key.name != TEAM_KEY_TRANSACTION_ALIAS
+        ):
+            raise IncompatibleMetricsQuery(NOT_HAS_FILTER_ERROR_MESSAGE)
 
         # if it matched search value instead, it's not a valid key
         if isinstance(search_key, SearchValue):

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -4,6 +4,9 @@ from typing import Literal, TypedDict
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import DATASETS
 
+NOT_HAS_FILTER_ERROR_MESSAGE = """
+"!has" filter is not supported in this search.
+"""
 RATE_LIMIT_ERROR_MESSAGE = """
 Rate limit exceeded. Please try your query with a smaller date range or fewer projects.
 """

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -138,6 +138,7 @@ class DiscoverDatasetConfig(DatasetConfig):
             TRACE_PARENT_SPAN_ALIAS: self._trace_parent_span_converter,
             "performance.issue_ids": self._performance_issue_ids_filter_converter,
             EVENT_TYPE_ALIAS: self._event_type_filter_converter,
+            "transaction": self._transaction_filter_converter,
         }
 
     @property
@@ -1956,5 +1957,22 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ["transaction"],
             ]:
                 return None
+
+        return self.builder.default_filter_converter(search_filter)
+
+    def _transaction_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        if self.builder.dataset == Dataset.Transactions:
+            operator = search_filter.operator
+            value = search_filter.value.value
+
+            if operator in ("=", "!=") and value == "":
+                # !has:transaction
+                if operator == "=":
+                    raise InvalidSearchQuery(
+                        "All events have a transaction so this query wouldn't return anything"
+                    )
+                else:
+                    # All events have a "transaction" since we map null -> unparam so no need to filter
+                    return None
 
         return self.builder.default_filter_converter(search_filter)

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -80,6 +80,7 @@ def query(
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
+                parser_config_overrides={"allow_not_has_filter": False},
             ),
         )
         if referrer is None:
@@ -185,6 +186,7 @@ def bulk_timeseries_query(
                         functions_acl=functions_acl,
                         allow_metric_aggregates=allow_metric_aggregates,
                         use_metrics_layer=use_metrics_layer,
+                        parser_config_overrides={"allow_not_has_filter": False},
                     ),
                 )
                 snql_query = metrics_query.get_snql_query()
@@ -294,6 +296,7 @@ def timeseries_query(
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
                     on_demand_metrics_type=on_demand_metrics_type,
                     transform_alias_to_input_format=transform_alias_to_input_format,
+                    parser_config_overrides={"allow_not_has_filter": False},
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
@@ -452,6 +455,7 @@ def top_events_timeseries(
             on_demand_metrics_enabled=on_demand_metrics_enabled,
             on_demand_metrics_type=on_demand_metrics_type,
             transform_alias_to_input_format=transform_alias_to_input_format,
+            parser_config_overrides={"allow_not_has_filter": False},
         ),
     )
     if len(top_events["data"]) == limit and include_other:

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1721,7 +1721,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
-        response = self.do_request(query)
+        response = self.do_request(
+            query, features={"organizations:performance-discover-dataset-selector": True}
+        )
         assert response.status_code == 400, response.content
 
     def test_apdex_transaction_threshold(self):
@@ -2258,16 +2260,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "transaction",
                     "p50()",
                 ],
+                # Doing !has on the metrics dataset doesn't really make sense
                 "query": "!has:transaction.status",
                 "dataset": "metrics",
             }
         )
 
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        assert len(data) == 0
-        meta = response.data["meta"]
-        assert meta["isMetricsData"]
+        assert response.status_code == 400, response.content
 
         response = self.do_request(
             {
@@ -3639,6 +3638,47 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[1]["avg(span.self_time)"] == 2.5
         assert data[2]["span.module"] == "other"
         assert data[2]["avg(span.self_time)"] == 4
+
+    def test_metrics_enhanced_with_has_filter_falls_back_to_indexed_data(self):
+        transaction_data = load_data("transaction")
+        self.store_event(
+            {
+                **transaction_data,
+                "tags": {"existingTag": "true"},
+                "start_timestamp": before_now(days=1, minutes=1).isoformat(),
+                "timestamp": before_now(days=1).isoformat(),
+                "measurements": {"time_to_initial_display": {"value": 222}},
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(6):
+            timestamp = self.min_ago
+            self.store_transaction_metric(
+                111,
+                metric="measurements.time_to_initial_display",
+                timestamp=timestamp,
+                tags={"existingTag": "true"},
+            )
+        query = {
+            "field": ["avg(measurements.time_to_initial_display)"],
+            "query": "has:existingTag !has:nonExistingTag",
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "dataset": "metricsEnhanced",
+        }
+        response = self.do_request(
+            query,
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+
+        # The request fell back to indexed data because !has is not supported in metrics
+        assert response.data["meta"]["isMetricsData"] is False
+
+        # First bucket, where the transaction should be
+        assert response.data["data"][0]["avg(measurements.time_to_initial_display)"] == 222
 
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetrics(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1036,6 +1036,90 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         # First bucket, where the transaction should be
         assert response.data["data"][0][1][0]["count"] == 1
 
+    def test_metrics_enhanced_with_has_filter_falls_back_to_indexed_data(self):
+        transaction_data = load_data("transaction")
+        self.store_event(
+            {
+                **transaction_data,
+                "tags": {"existingTag": "true"},
+                "start_timestamp": before_now(days=1, minutes=1).isoformat(),
+                "timestamp": before_now(days=1).isoformat(),
+                "measurements": {"time_to_initial_display": {"value": 222}},
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_transaction_metric(
+                111,
+                metric="measurements.time_to_initial_display",
+                timestamp=timestamp,
+                tags={"existingTag": "true"},
+            )
+        query = {
+            "field": ["avg(measurements.time_to_initial_display)"],
+            "query": "has:existingTag !has:nonExistingTag",
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "dataset": "metricsEnhanced",
+            "yAxis": ["avg(measurements.time_to_initial_display)"],
+        }
+        response = self.do_request(query, **self.additional_params)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+
+        # The request fell back to indexed data because the tag doesn't exist in the metrics indexer
+        assert response.data["meta"]["isMetricsData"] is False
+
+        # First bucket, where the transaction should be
+        assert response.data["data"][0][1][0]["count"] == 222
+
+    def test_top_events_with_metrics_enhanced_with_has_filter_falls_back_to_indexed_data(self):
+        transaction_data = load_data("transaction")
+        self.store_event(
+            {
+                **transaction_data,
+                "tags": {"existingTag": "true"},
+                "start_timestamp": before_now(days=1, minutes=1).isoformat(),
+                "timestamp": before_now(days=1).isoformat(),
+                "measurements": {"time_to_initial_display": {"value": 222}},
+                "transaction": "foo_transaction",
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_transaction_metric(
+                111,
+                metric="measurements.time_to_initial_display",
+                timestamp=timestamp,
+                tags={"existingTag": "true"},
+            )
+        query = {
+            "field": ["avg(measurements.time_to_initial_display)", "transaction"],
+            "query": "has:existingTag !has:nonExistingTag",
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "dataset": "metricsEnhanced",
+            "yAxis": ["avg(measurements.time_to_initial_display)"],
+            "topEvents": 1,
+        }
+        response = self.do_request(query, **self.additional_params)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["foo_transaction"]["data"]) == 2
+
+        data_series = response.data["foo_transaction"]
+
+        # The request fell back to indexed data because the tag doesn't exist in the metrics indexer
+        assert data_series["meta"]["isMetricsData"] is False
+
+        # First bucket, where the transaction should be
+        assert data_series["data"][0][1][0]["count"] == 222
+
 
 class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandWidgets(
     MetricsEnhancedPerformanceTestCase


### PR DESCRIPTION
Revert the revert. This is a take 2 of #87585 which I reverted because I thought it caused a CI issue. It did not so I'm re-introducing it.