### PR TITLE
ref(issue-views): Remove isAllProjects from backend response and request type

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -14,7 +14,6 @@ class GroupSearchViewSerializerResponse(TypedDict):
     query: str
     querySort: SORT_LITERALS
     projects: list[int]
-    isAllProjects: bool
     environments: list[str]
     timeFilters: dict
     lastVisited: str | None
@@ -54,14 +53,11 @@ class GroupSearchViewSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
         if self.has_global_views is False:
-            is_all_projects = False
             projects = list(obj.projects.values_list("id", flat=True))
             num_projects = len(projects)
             if num_projects != 1:
                 projects = [projects[0] if num_projects > 1 else self.default_project]
-
         else:
-            is_all_projects = obj.is_all_projects
             projects = (
                 [-1] if obj.is_all_projects else list(obj.projects.values_list("id", flat=True))
             )
@@ -72,7 +68,6 @@ class GroupSearchViewSerializer(Serializer):
             "query": obj.query,
             "querySort": obj.query_sort,
             "projects": projects,
-            "isAllProjects": is_all_projects,
             "environments": obj.environments,
             "timeFilters": obj.time_filters,
             "lastVisited": attrs["last_visited"] if attrs else None,

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -35,7 +35,6 @@ class ViewValidator(serializers.Serializer):
     projects = serializers.ListField(required=True, allow_empty=True)
     environments = serializers.ListField(required=True, allow_empty=True)
     timeFilters = serializers.DictField(required=True, allow_empty=False)
-    isAllProjects = serializers.BooleanField(required=False)
 
     def validate_projects(self, value):
         if not features.has("organizations:global-views", self.context["organization"]) and (
@@ -57,7 +56,7 @@ class ViewValidator(serializers.Serializer):
 
         return value
 
-    def validate(self, data):
+    def validate(self, data) -> GroupSearchViewValidatorResponse:
         if data["projects"] == [-1]:
             data["projects"] = []
             data["isAllProjects"] = True

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -178,7 +178,6 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                                 if view.is_all_projects
                                 else list(view.projects.values_list("id", flat=True))
                             ),
-                            "isAllProjects": view.is_all_projects,
                             "environments": view.environments,
                             "timeFilters": view.time_filters,
                             "dateCreated": view.date_added,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -23,7 +23,6 @@ def are_views_equal(
         and view_1["query"] == view_2["query"]
         and view_1["querySort"] == view_2["querySort"]
         and view_1["position"] == view_2["position"]
-        and view_1["isAllProjects"] == view_2["isAllProjects"]
         and view_1["environments"] == view_2["environments"]
         and view_1["timeFilters"] == view_2["timeFilters"]
         and view_1["projects"] == view_2["projects"]
@@ -264,7 +263,6 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
                 "query": "is:unresolved",
                 "querySort": "date",
                 "projects": [],
-                "isAllProjects": False,
                 "environments": [],
                 "timeFilters": {"period": "14d"},
             }
@@ -599,7 +597,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
                 "query": "is:unresolved",
                 "querySort": "date",
                 "projects": [],
-                "isAllProjects": False,
                 "environments": [],
                 "timeFilters": {"period": "14d"},
             }
@@ -609,7 +606,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         assert response.data[3]["timeFilters"] == {"period": "14d"}
         assert response.data[3]["projects"] == []
         assert response.data[3]["environments"] == []
-        assert response.data[3]["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
@@ -620,7 +616,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         response = self.get_success_response(self.organization.slug, views=views)
         assert len(response.data) == 3
         assert response.data[0]["projects"] == []
-        assert response.data[0]["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
@@ -631,7 +626,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         response = self.get_success_response(self.organization.slug, views=views)
         assert len(response.data) == 3
         assert response.data[0]["projects"] == [-1]
-        assert response.data[0]["isAllProjects"] is True
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
@@ -889,17 +883,14 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[0]["timeFilters"] == {"period": "14d"}
         assert response.data[0]["projects"] == [self.project3.id]
         assert response.data[0]["environments"] == []
-        assert response.data[0]["isAllProjects"] is False
 
         assert response.data[1]["timeFilters"] == {"period": "7d"}
         assert response.data[1]["projects"] == []
         assert response.data[1]["environments"] == ["staging", "production"]
-        assert response.data[1]["isAllProjects"] is False
 
         assert response.data[2]["timeFilters"] == {"period": "30d"}
         assert response.data[2]["projects"] == [-1]
         assert response.data[2]["environments"] == ["development"]
-        assert response.data[2]["isAllProjects"] is True
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
@@ -910,17 +901,14 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[0]["timeFilters"] == {"period": "14d"}
         assert response.data[0]["projects"] == [self.project3.id]
         assert response.data[0]["environments"] == []
-        assert response.data[0]["isAllProjects"] is False
 
         assert response.data[1]["timeFilters"] == {"period": "7d"}
         assert response.data[1]["projects"] == [self.project3.id]
         assert response.data[1]["environments"] == ["staging", "production"]
-        assert response.data[1]["isAllProjects"] is False
 
         assert response.data[2]["timeFilters"] == {"period": "30d"}
         assert response.data[2]["projects"] == [self.project3.id]
         assert response.data[2]["environments"] == ["development"]
-        assert response.data[2]["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
@@ -931,7 +919,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[0]["timeFilters"] == {"period": "14d"}
         assert response.data[0]["projects"] == [self.project2.id]
         assert response.data[0]["environments"] == []
-        assert response.data[0]["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
@@ -949,7 +936,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             # Global views means default project should be "My Projects"
             assert view["projects"] == []
             assert view["environments"] == []
-            assert view["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
@@ -967,7 +953,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             # No global views means default project should be a single project
             assert view["projects"] == [self.project3.id]
             assert view["environments"] == []
-            assert view["isAllProjects"] is False
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
@@ -1012,7 +997,6 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
                 "query": "is:unresolved",
                 "querySort": "date",
                 "projects": [],
-                "isAllProjects": False,
                 "environments": [],
                 "timeFilters": {"period": "14d"},
             }


### PR DESCRIPTION
This PR removes the isAllProjects from the /group-search-view/ respons and from the expected request type. Both have are replaced by project=[-1]