### PR TITLE
chore(aci): rename job to event data

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -29,8 +29,8 @@ class AgeComparisonConditionHandler(DataConditionHandler[WorkflowEventData]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         first_seen = event.group.first_seen
         current_time = timezone.now()
         comparison_type = comparison["comparison_type"]

--- a/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/anomaly_detection_handler.py
@@ -11,6 +11,6 @@ class AnomalyDetectionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         # this is a placeholder
         return False

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -35,8 +35,8 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
         return assignee_list
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         target_type = AssigneeTargetType(comparison.get("target_type"))
         assignees = AssignedToConditionHandler.get_assignees(event.group)
 

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -50,8 +50,8 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
         return attribute_values
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         attribute = comparison.get("attribute", "")
         attribute_values = EventAttributeConditionHandler.get_attribute_values(event, attribute)
 

--- a/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
@@ -10,8 +10,8 @@ class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowEventD
     group = DataConditionHandler.Group.ACTION_FILTER
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         if event.occurrence is None or event.occurrence.evidence_data is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
@@ -10,6 +10,6 @@ class EventSeenCountConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         return event.group.times_seen == comparison

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -12,10 +12,10 @@ class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEve
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        state = job.group_state
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        state = event_data.group_state
         if state is None or state["is_new"]:
             return False
 
-        is_escalating = bool(job.has_reappeared or job.has_escalated)
-        return is_escalating and job.event.group.priority == PriorityLevel.HIGH
+        is_escalating = bool(event_data.has_reappeared or event_data.has_escalated)
+        return is_escalating and event_data.event.group.priority == PriorityLevel.HIGH

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -5,12 +5,12 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
-def is_new_event(job: WorkflowEventData) -> bool:
-    state = job.group_state
+def is_new_event(event_data: WorkflowEventData) -> bool:
+    state = event_data.group_state
     if state is None:
         return False
 
-    if job.workflow_env is None:
+    if event_data.workflow_env is None:
         return state["is_new"]
 
     return state["is_new_group_environment"]
@@ -22,5 +22,5 @@ class FirstSeenEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        return is_new_event(job)
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        return is_new_event(event_data)

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -20,8 +20,8 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        group = job.event.group
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        group = event_data.event.group
 
         try:
             value: GroupCategory = GroupCategory(int(comparison["value"]))

--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -21,8 +21,8 @@ class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowEventData]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        group: Group = job.event.group
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        group: Group = event_data.event.group
         try:
             value = int(comparison["value"])
         except (TypeError, ValueError, KeyError):

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_equals.py
@@ -11,6 +11,6 @@ class IssuePriorityCondition(DataConditionHandler[WorkflowEventData]):
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        group = job.event.group
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        group = event_data.event.group
         return group.priority == comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_resolution_condition_handler.py
@@ -10,6 +10,6 @@ class IssueResolutionConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        group = job.event.group
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        group = event_data.event.group
         return group.status == comparison

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -33,12 +33,12 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         release_age_type = comparison["release_age_type"]
         age_comparison = comparison["age_comparison"]
         environment_name = comparison["environment"]
 
-        event = job.event
+        event = event_data.event
 
         if follows_semver_versioning_scheme(event.organization.id, event.project.id):
             order_type = LatestReleaseOrders.SEMVER

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -46,10 +46,10 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
 
-        latest_release = get_latest_release_for_env(job.workflow_env, event)
+        latest_release = get_latest_release_for_env(event_data.workflow_env, event)
         if not latest_release:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -23,8 +23,8 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         level_name = event.get_tag("level")
         if level_name is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -13,9 +13,9 @@ class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventDat
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        is_new = is_new_event(job)
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        is_new = is_new_event(event_data)
+        event = event_data.event
         if not event.project.flags.has_high_priority_alerts:
             return is_new
 

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -11,8 +11,8 @@ class ReappearedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        has_reappeared = job.has_reappeared
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        has_reappeared = event_data.has_reappeared
         if has_reappeared is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -11,8 +11,8 @@ class RegressionEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        state = job.group_state
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        state = event_data.group_state
         if state is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -49,8 +49,8 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     }
 
     @staticmethod
-    def evaluate_value(job: WorkflowEventData, comparison: Any) -> bool:
-        event = job.event
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        event = event_data.event
         raw_tags = event.tags
         key = comparison["key"]
         match = comparison["match"]

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -66,10 +66,10 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, job: WorkflowEventData, detector: Detector) -> None:
+    def trigger(self, event_data: WorkflowEventData, detector: Detector) -> None:
         # get the handler for the action type
         handler = self.get_handler()
-        handler.execute(job, self, detector)
+        handler.execute(event_data, self, detector)
 
 
 @receiver(pre_save, sender=Action)

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -69,7 +69,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return {"name": self.name}
 
     def evaluate_trigger_conditions(
-        self, job: WorkflowEventData
+        self, event_data: WorkflowEventData
     ) -> tuple[bool, list[DataCondition]]:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
@@ -82,9 +82,9 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True, []
 
-        workflow_job = replace(job, workflow_env=self.environment)
+        workflow_event_data = replace(event_data, workflow_env=self.environment)
         (evaluation, _), remaining_conditions = process_data_condition_group(
-            self.when_condition_group.id, workflow_job
+            self.when_condition_group.id, workflow_event_data
         )
         return evaluation, remaining_conditions
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -13,8 +13,8 @@ from sentry.workflow_engine.types import DetectorGroupKey, WorkflowEventData
 logger = logging.getLogger(__name__)
 
 
-def get_detector_by_event(job: WorkflowEventData) -> Detector:
-    evt = job.event
+def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
+    evt = event_data.event
     issue_occurrence = evt.occurrence
 
     if issue_occurrence is None:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -18,6 +18,7 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Detector,
     Workflow,
+    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
@@ -93,6 +94,12 @@ def evaluate_workflows_action_filters(
         )
         .prefetch_related("workflowdataconditiongroup_set")
         .distinct()
+    )
+
+    workflow_to_dcg = dict(
+        WorkflowDataConditionGroup.objects.filter(
+            condition_group_id__in=action_conditions
+        ).values_list("condition_group_id", "workflow_id")
     )
 
     for action_condition in action_conditions:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -18,7 +18,6 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Detector,
     Workflow,
-    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
@@ -94,12 +93,6 @@ def evaluate_workflows_action_filters(
         )
         .prefetch_related("workflowdataconditiongroup_set")
         .distinct()
-    )
-
-    workflow_to_dcg = dict(
-        WorkflowDataConditionGroup.objects.filter(
-            condition_group_id__in=action_conditions
-        ).values_list("condition_group_id", "workflow_id")
     )
 
     for action_condition in action_conditions:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -55,7 +55,7 @@ class ActionHandler:
     group: ClassVar[Group]
 
     @staticmethod
-    def execute(job: WorkflowEventData, action: Action, detector: Detector) -> None:
+    def execute(event_data: WorkflowEventData, action: Action, detector: Detector) -> None:
         raise NotImplementedError
 
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -44,7 +44,9 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.workflow.environment)
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.workflow.environment
+        )
         self.handler = DiscordMetricAlertHandler()
 
     @mock.patch(
@@ -84,7 +86,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.DiscordMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -45,7 +45,9 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.workflow.environment)
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.workflow.environment
+        )
         self.handler = MSTeamsMetricAlertHandler()
 
     @mock.patch(
@@ -85,7 +87,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.MSTeamsMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -45,7 +45,9 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
-        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.workflow.environment)
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.workflow.environment
+        )
         self.handler = SlackMetricAlertHandler()
 
     @mock.patch(
@@ -85,7 +87,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.SlackMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -22,7 +22,7 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get"
@@ -32,7 +32,9 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
-            IssueAlertRegistryHandler.handle_workflow_action(self.job, self.action, self.detector)
+            IssueAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector
+            )
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get"
@@ -47,7 +49,9 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.return_value = mock_handler
 
         with pytest.raises(NotificationHandlerException):
-            IssueAlertRegistryHandler.handle_workflow_action(self.job, self.action, self.detector)
+            IssueAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector
+            )
 
         mock_logger.exception.assert_called_once_with(
             "Error invoking issue alert handler",
@@ -62,7 +66,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
@@ -72,7 +76,9 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
-            MetricAlertRegistryHandler.handle_workflow_action(self.job, self.action, self.detector)
+            MetricAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector
+            )
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
@@ -87,7 +93,9 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         mock_registry_get.return_value = mock_handler
 
         with pytest.raises(NotificationHandlerException):
-            MetricAlertRegistryHandler.handle_workflow_action(self.job, self.action, self.detector)
+            MetricAlertRegistryHandler.handle_workflow_action(
+                self.event_data, self.action, self.detector
+            )
 
         mock_logger.exception.assert_called_once_with(
             "Error invoking metric alert handler",

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -207,13 +207,25 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             data={"tags": "environment,user,my_tag"},
         )
 
+        self.group, self.event, self.group_event = self.create_group_event(
+            group_type_id=MetricIssuePOC.type_id,
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         self.handler = TestHandler()
 
     def test_missing_occurrence_raises_value_error(self):
-        self.job.event.occurrence = None
+        self.event_data.event.occurrence = None
 
         with pytest.raises(ValueError):
-            self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+            self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
     def test_get_incident_status(self):
         # Initial priority is high -> incident is critical
@@ -323,7 +335,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
 
     @mock.patch.object(TestHandler, "send_alert")
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
 
@@ -384,6 +396,19 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             config={"target_identifier": "service123", "target_type": ActionTarget.SPECIFIC},
             data={"priority": "default"},
         )
+        self.snuba_query = self.create_snuba_query()
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         self.handler = PagerDutyMetricAlertHandler()
 
     @mock.patch(
@@ -420,7 +445,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.PagerDutyMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
         (
@@ -482,6 +507,21 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             config={"target_identifier": "team123", "target_type": ActionTarget.SPECIFIC},
             data={"priority": "P1"},
         )
+        self.snuba_query = self.create_snuba_query()
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.create_issue_occurrence(
+                initial_issue_priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data={
+                    "snuba_query_id": self.snuba_query.id,
+                    "metric_value": 123.45,
+                },
+            ),
+        )
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.workflow.environment
+        )
         self.handler = OpsgenieMetricAlertHandler()
 
     @mock.patch(
@@ -518,7 +558,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         "sentry.notifications.notification_action.metric_alert_registry.OpsgenieMetricAlertHandler.send_alert"
     )
     def test_invoke_legacy_registry(self, mock_send_alert):
-        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+        self.handler.invoke_legacy_registry(self.event_data, self.action, self.detector)
 
         assert mock_send_alert.call_count == 1
         (

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -72,7 +72,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         )
 
         self.save_group_with_open_period(self.group)
-        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
+        self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
 
     def save_group_with_open_period(self, group: Group) -> None:
         # test a new group has an open period

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -15,12 +15,12 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         self.action = Action(type=Action.Type.DISCORD)
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     def test_execute_without_group_type(self):
         """Test that execute does nothing when detector has no group_type"""
         self.detector.type = ""
-        self.action.trigger(self.job, self.detector)
+        self.action.trigger(self.event_data, self.detector)
         # Test passes if no exception is raised
 
     @mock.patch(
@@ -34,11 +34,11 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        self.action.trigger(self.job, self.detector)
+        self.action.trigger(self.event_data, self.detector)
 
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
         mock_handler.handle_workflow_action.assert_called_once_with(
-            self.job, self.action, self.detector
+            self.event_data, self.action, self.detector
         )
 
     @mock.patch(
@@ -52,11 +52,11 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        self.action.trigger(self.job, self.detector)
+        self.action.trigger(self.event_data, self.detector)
 
         mock_registry_get.assert_called_once_with(MetricIssuePOC.slug)
         mock_handler.handle_workflow_action.assert_called_once_with(
-            self.job, self.action, self.detector
+            self.event_data, self.action, self.detector
         )
 
     @mock.patch(
@@ -66,7 +66,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
     @mock.patch("sentry.notifications.notification_action.utils.logger")
     def test_execute_unknown_group_type(self, mock_logger, mock_registry_get):
         """Test that execute does nothing when detector has no group_type"""
-        self.action.trigger(self.job, self.detector)
+        self.action.trigger(self.event_data, self.detector)
 
         mock_logger.exception.assert_called_once_with(
             "No notification handler found for detector type: %s",

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -17,11 +17,11 @@ class TestAgeComparisonCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.payload = {
             "id": AgeComparisonFilter.id,
             "comparison_type": AgeComparisonType.OLDER,
@@ -84,12 +84,12 @@ class TestAgeComparisonCondition(ConditionTestCase):
         self.dc.save()
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=3))
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group.update(
             first_seen=datetime.now(timezone.utc) - timedelta(hours=10, milliseconds=1)
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_newer_applies_correctly(self):
         self.dc.comparison.update(
@@ -98,7 +98,7 @@ class TestAgeComparisonCondition(ConditionTestCase):
         self.dc.save()
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=3))
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=10))
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -18,7 +18,7 @@ class TestAssignedToCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -59,30 +59,30 @@ class TestAssignedToCondition(ConditionTestCase):
     def test_assigned_to_member_passes(self):
         GroupAssignee.objects.create(user_id=self.user.id, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Member", "target_identifier": self.user.id})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_assigned_to_member_fails(self):
         user = self.create_user()
         GroupAssignee.objects.create(user_id=user.id, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Member", "target_identifier": self.user.id})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_assigned_to_team_passes(self):
         GroupAssignee.objects.create(team=self.team, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Team", "target_identifier": self.team.id})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_assigned_to_team_fails(self):
         team = self.create_team(self.organization)
         GroupAssignee.objects.create(team=team, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Team", "target_identifier": self.team.id})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_assigned_to_no_one_passes(self):
         self.dc.update(comparison={"target_type": "Unassigned"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_assigned_to_no_one_fails(self):
         GroupAssignee.objects.create(user_id=self.user.id, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Unassigned"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -89,7 +89,7 @@ class TestEventAttributeCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowEventData(
+        self.event_data = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {
@@ -201,24 +201,24 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "asdf",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_equals(self):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "platform", "value": "php"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "platform", "value": "python"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_not_equals(self):
         self.dc.comparison.update(
             {"match": MatchType.NOT_EQUAL, "attribute": "platform", "value": "php"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -227,7 +227,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "python",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_starts_with(self):
         self.dc.comparison.update(
@@ -237,7 +237,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "ph",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -246,7 +246,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "py",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_start_with(self):
         self.dc.comparison.update(
@@ -256,7 +256,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "ph",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -265,13 +265,13 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "py",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_ends_with(self):
         self.dc.comparison.update(
             {"match": MatchType.ENDS_WITH, "attribute": "platform", "value": "hp"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -280,7 +280,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "thon",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_end_with(self):
         self.dc.comparison.update(
@@ -290,7 +290,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "hp",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -299,24 +299,24 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "thon",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_contains(self):
         self.dc.comparison.update(
             {"match": MatchType.CONTAINS, "attribute": "platform", "value": "p"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.CONTAINS, "attribute": "platform", "value": "z"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_contains_message(self):
         self.dc.comparison.update(
             {"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         # Validate that this searches message in the same way that snuba does
         self.event = self.get_event(message="")
@@ -325,7 +325,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         # The search should also include info from the exception if present
         self.dc.comparison.update(
@@ -335,7 +335,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "SyntaxError",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -344,7 +344,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "not present",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_contain(self):
         self.dc.comparison.update(
@@ -354,7 +354,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "p",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -363,7 +363,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "z",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_message(self):
         self.dc.comparison.update(
@@ -373,12 +373,12 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "hello world",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "message", "value": "php"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_environment(self):
         self.dc.comparison.update(
@@ -388,7 +388,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "production",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -397,7 +397,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "staging",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_compares_case_insensitive(self):
         self.dc.comparison.update(
@@ -407,7 +407,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "PRODUCTION",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_compare_int_value(self):
         self.event.data["extra"]["number"] = 1
@@ -415,18 +415,18 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "extra.number", "value": "1"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_http_method(self):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "http.method", "value": "GET"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "http.method", "value": "POST"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_http_url(self):
         self.dc.comparison.update(
@@ -436,7 +436,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "http://example.com/",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -445,7 +445,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "http://foo.com/",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_http_status_code(self):
         self.dc.comparison.update(
@@ -455,7 +455,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "500",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -464,14 +464,14 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "400",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_user_id(self):
         self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "user.id", "value": "1"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "user.id", "value": "2"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_user_ip_address(self):
         self.dc.comparison.update(
@@ -481,7 +481,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "127.0.0.1",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -490,7 +490,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "2",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_user_email(self):
         self.dc.comparison.update(
@@ -500,12 +500,12 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo@example.com",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "user.email", "value": "2"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_user_username(self):
         self.dc.comparison.update(
@@ -515,12 +515,12 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "user.username", "value": "2"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_exception_type(self):
         self.dc.comparison.update(
@@ -530,7 +530,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "SyntaxError",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -539,7 +539,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "TypeError",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch("sentry.eventstore.models.get_interfaces", return_value={})
     def test_exception_type_keyerror(self, mock_get_interfaces):
@@ -550,7 +550,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "SyntaxError",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_error_handled(self):
         self.error_setup()
@@ -561,7 +561,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "False",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -570,7 +570,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "True",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_error_handled_not_defined(self):
         self.dc.comparison.update(
@@ -580,7 +580,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "True",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch("sentry.eventstore.models.get_interfaces", return_value={})
     def test_error_handled_keyerror(self, mock_get_interfaces):
@@ -592,7 +592,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "False",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_error_unhandled(self):
         self.error_setup()
@@ -603,7 +603,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "True",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -612,7 +612,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "False",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_exception_value(self):
         self.dc.comparison.update(
@@ -622,7 +622,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "hello world",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -631,7 +631,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo bar",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_sdk_name(self):
         self.dc.comparison.update(
@@ -641,7 +641,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "sentry.javascript.react",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -650,7 +650,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "sentry.python",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_filename(self):
         """Stacktrace.filename should match frames anywhere in the stack."""
@@ -683,7 +683,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_passes(self.dc, self.job)
+            self.assert_passes(self.dc, self.event_data)
 
         # non-matching filename
         self.dc.comparison.update(
@@ -693,7 +693,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo.php",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_attributeerror(self):
         self.event = self.get_event(
@@ -718,7 +718,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_does_not_pass(self.dc, self.job)
+            self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_module(self):
         """Stacktrace.module should match frames anywhere in the stack."""
@@ -751,7 +751,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_passes(self.dc, self.job)
+            self.assert_passes(self.dc, self.event_data)
 
         # non-matching module
         self.dc.comparison.update(
@@ -761,7 +761,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_code(self):
         """Stacktrace.code should match frames anywhere in the stack."""
@@ -809,7 +809,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_passes(self.dc, self.job)
+            self.assert_passes(self.dc, self.event_data)
 
         # non-matching code
         self.dc.comparison.update(
@@ -819,7 +819,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "foo",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_abs_path(self):
         """Stacktrace.abs_path should match frames anywhere in the stack."""
@@ -864,7 +864,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_passes(self.dc, self.job)
+            self.assert_passes(self.dc, self.event_data)
 
         # non-matching abs_path
         self.dc.comparison.update(
@@ -874,7 +874,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "path/to/foo.php",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_stacktrace_package(self):
         """Stacktrace.package should match frames anywhere in the stack."""
@@ -913,7 +913,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "value": value,
                 }
             )
-            self.assert_passes(self.dc, self.job)
+            self.assert_passes(self.dc, self.event_data)
 
         # non-matching filename
         self.dc.comparison.update(
@@ -923,18 +923,18 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "package/otherotherpackage.lib",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_extra_simple_value(self):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "foo"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "bar"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_extra_nested_value(self):
         self.dc.comparison.update(
@@ -944,7 +944,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "baz",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -953,27 +953,27 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "bar",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_extra_nested_list(self):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "baz"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "bar"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_event_type(self):
         self.event.data["type"] = "error"
         self.setup_group_event_and_job()
         self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "type", "value": "error"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "type", "value": "csp"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_device_screen_width_pixels(self):
         self.dc.comparison.update(
@@ -983,7 +983,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "1920",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -992,7 +992,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "400",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_device_screen_height_pixels(self):
         self.dc.comparison.update(
@@ -1002,7 +1002,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "1080",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1011,7 +1011,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "400",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_device_screen_dpi(self):
         self.dc.comparison.update(
@@ -1021,7 +1021,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "123",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1030,7 +1030,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "400",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_device_screen_density(self):
         self.dc.comparison.update(
@@ -1040,7 +1040,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "2.5",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1049,7 +1049,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "400",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_app_in_foreground(self):
         self.dc.comparison.update(
@@ -1059,7 +1059,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "True",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1068,7 +1068,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "False",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_os_distribution_name_and_version(self):
         self.dc.comparison.update(
@@ -1078,7 +1078,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "ubuntu",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1087,7 +1087,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "slackware",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1096,7 +1096,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "22.04",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1105,7 +1105,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "20.04",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_unreal_crash_type(self):
         self.dc.comparison.update(
@@ -1115,7 +1115,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "Crash",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1124,7 +1124,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "NoCrash",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_error_with_none(self):
         self.event = self.get_event(
@@ -1157,21 +1157,21 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "SyntaxError",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_is_set(self):
         self.dc.comparison.update({"match": MatchType.IS_SET, "attribute": "platform"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.IS_SET, "attribute": "missing"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_not_set(self):
         self.dc.comparison.update({"match": MatchType.NOT_SET, "attribute": "platform"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.NOT_SET, "attribute": "missing"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_attr_is_in(self):
         self.dc.comparison.update(
@@ -1181,7 +1181,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "php, python",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1190,7 +1190,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "python, ruby",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_attr_not_in(self):
         self.dc.comparison.update(
@@ -1200,7 +1200,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "php, python",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -1209,4 +1209,4 @@ class TestEventAttributeCondition(ConditionTestCase):
                 "value": "python, ruby",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -17,7 +17,7 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(
+        self.event_data = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {
@@ -65,26 +65,26 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
             dc.save()
 
     def test(self):
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_group_state_is_new(self):
-        assert self.job.group_state
-        self.job.group_state["is_new"] = True
-        self.assert_does_not_pass(self.dc, self.job)
+        assert self.event_data.group_state
+        self.event_data.group_state["is_new"] = True
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_is_escalating(self):
-        self.job = replace(self.job, has_reappeared=False, has_escalated=True)
-        self.assert_passes(self.dc, self.job)
+        self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=True)
+        self.assert_passes(self.dc, self.event_data)
 
-        self.job = replace(self.job, has_reappeared=True, has_escalated=False)
-        self.assert_passes(self.dc, self.job)
+        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=False)
+        self.assert_passes(self.dc, self.event_data)
 
-        self.job = replace(self.job, has_reappeared=False, has_escalated=False)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=False)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_priority(self):
         self.group_event.group.priority = PriorityLevel.LOW
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.priority = PriorityLevel.MEDIUM
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -16,7 +16,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(
+        self.event_data = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {
@@ -62,26 +62,26 @@ class TestFirstSeenEventCondition(ConditionTestCase):
             dc.save()
 
     def test(self):
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
-        assert self.job.group_state
-        self.job.group_state["is_new"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        assert self.event_data.group_state
+        self.event_data.group_state["is_new"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_with_environment(self):
-        self.job = replace(self.job, workflow_env=self.environment)
-        assert self.job.group_state
+        self.event_data = replace(self.event_data, workflow_env=self.environment)
+        assert self.event_data.group_state
 
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
-        self.job.group_state["is_new"] = False
-        self.job.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.job)
+        self.event_data.group_state["is_new"] = False
+        self.event_data.group_state["is_new_group_environment"] = True
+        self.assert_passes(self.dc, self.event_data)
 
-        self.job.group_state["is_new"] = True
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new"] = True
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)
 
-        self.job.group_state["is_new"] = False
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new"] = False
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -19,7 +19,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -57,11 +57,11 @@ class TestIssueCategoryCondition(ConditionTestCase):
 
     def test_valid_input_values(self):
         self.dc.update(comparison={"value": 1})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
         self.dc.update(comparison={"value": str(GroupCategory.ERROR.value)})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
         self.dc.update(comparison={"value": GroupCategory.ERROR.value})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_fail_on_invalid_data(self):
         data_cases = [
@@ -74,7 +74,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
 
         for data_case in data_cases:
             self.dc.update(comparison=data_case)
-            self.assert_does_not_pass(self.dc, self.job)
+            self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_group_event(self):
         assert self.event.group is not None

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -17,7 +17,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.group.times_seen_pending = 0
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
@@ -55,22 +55,22 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
 
     def test_compares_correctly(self):
         self.group.update(times_seen=11)
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.group.update(times_seen=10)
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.group.update(times_seen=8)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_uses_pending(self):
         self.group.update(times_seen=8)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group.times_seen_pending = 3
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_fails_on_bad_data(self):
         self.dc.update(comparison={"value": "bad data"})
         self.group.update(times_seen=10)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
@@ -14,7 +14,7 @@ class TestIssuePriorityCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.metric_alert = self.create_alert_rule()
         self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
             alert_rule=self.metric_alert, label="warning"
@@ -38,9 +38,9 @@ class TestIssuePriorityCondition(ConditionTestCase):
         data_condition_critical = data_condition_critical_tuple[1]
 
         self.group.update(priority=PriorityLevel.MEDIUM)
-        self.assert_passes(data_condition_warning, self.job)
-        self.assert_does_not_pass(data_condition_critical, self.job)
+        self.assert_passes(data_condition_warning, self.event_data)
+        self.assert_does_not_pass(data_condition_critical, self.event_data)
 
         self.group.update(priority=PriorityLevel.HIGH)
-        self.assert_passes(data_condition_critical, self.job)
-        self.assert_does_not_pass(data_condition_warning, self.job)
+        self.assert_passes(data_condition_critical, self.event_data)
+        self.assert_does_not_pass(data_condition_warning, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_resolution_condition_handler.py
@@ -8,7 +8,7 @@ class TestIssueResolutionChangeCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=1,
@@ -17,10 +17,10 @@ class TestIssueResolutionChangeCondition(ConditionTestCase):
 
     def test_evaluate_value(self):
         self.group_event.group.status = 1
-        result = self.dc.evaluate_value(self.job)
+        result = self.dc.evaluate_value(self.event_data)
         assert result is self.dc.get_condition_result()
 
     def test_evaluate_value__not_matching_comparison(self):
         self.group_event.group.status = 2
-        result = self.dc.evaluate_value(self.job)
+        result = self.dc.evaluate_value(self.event_data)
         assert result is None

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -23,7 +23,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison=True,
@@ -67,7 +67,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         new_release.add_project(self.project)
 
         self.event.data["tags"] = (("release", new_release.version),)
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_latest_release_no_match(self):
         old_release = Release.objects.create(
@@ -85,7 +85,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         new_release.add_project(self.project)
 
         self.event.data["tags"] = (("release", old_release.version),)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_caching(self):
         old_release = Release.objects.create(
@@ -95,7 +95,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         )
         old_release.add_project(self.project)
         self.event.data["tags"] = (("release", old_release.version),)
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         new_release = Release.objects.create(
             organization_id=self.organization.id,
@@ -108,7 +108,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         cache_key = get_project_release_cache_key(self.event.group.project_id)
         assert cache.get(cache_key) is None
 
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         # ensure we clear the cache when a release is deleted
         new_release.safe_delete()
@@ -116,7 +116,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
         assert cache.get(cache_key) is None
 
         # rule should pass again because the latest release is oldRelease
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_latest_release_with_environment(self):
         self.create_release(
@@ -139,18 +139,18 @@ class TestLatestReleaseCondition(ConditionTestCase):
             date_added=datetime(2020, 9, 3, 3, 8, 24, 880386, tzinfo=UTC),
         )
 
-        self.job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
+        self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
 
         self.event.data["tags"] = (("release", new_release.version),)
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.event.data["tags"] = (("release", other_env_release.version),)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch("sentry.search.utils.get_latest_release")
     def test_release_does_not_exist(self, mock_get_latest_release):
         mock_get_latest_release.side_effect = Release.DoesNotExist
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch.object(Release.objects, "get", return_value=None)
     def test_no_release_object(self, mock_get):
@@ -161,4 +161,4 @@ class TestLatestReleaseCondition(ConditionTestCase):
         )
         newRelease.add_project(self.project)
 
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -19,7 +19,7 @@ class TestLevelCondition(ConditionTestCase):
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     def setUp(self):
         super().setUp()
@@ -83,36 +83,36 @@ class TestLevelCondition(ConditionTestCase):
 
     def test_equals(self):
         self.dc.comparison.update({"match": MatchType.EQUAL, "level": 20})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.EQUAL, "level": 30})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_greater_than(self):
         self.dc.comparison.update({"match": MatchType.GREATER_OR_EQUAL, "level": 40})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.GREATER_OR_EQUAL, "level": 20})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.GREATER_OR_EQUAL, "level": 10})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_less_than(self):
         self.dc.comparison.update({"match": MatchType.LESS_OR_EQUAL, "level": 40})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.LESS_OR_EQUAL, "level": 20})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.LESS_OR_EQUAL, "level": 10})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_without_tag(self):
         self.event = self.store_event(data={}, project_id=self.project.id)
         self.setup_group_event_and_job()
         self.dc.comparison.update({"match": MatchType.EQUAL, "level": 20})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     # This simulates the following case:
     # - Rule is setup to accept >= error
@@ -134,8 +134,8 @@ class TestLevelCondition(ConditionTestCase):
 
         self.event = wevent
         self.setup_group_event_and_job()
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.event = eevent
         self.setup_group_event_and_job()
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -15,7 +15,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = WorkflowEventData(
+        self.event_data = WorkflowEventData(
             event=self.group_event,
             group_state=GroupState(
                 {
@@ -64,43 +64,43 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
         self.project.flags.has_high_priority_alerts = True
         self.project.save()
 
-        assert self.job.group_state
+        assert self.event_data.group_state
 
         # This will only pass for new issues
         self.group_event.group.update(priority=PriorityLevel.HIGH)
-        self.job.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.job)
+        self.event_data.group_state["is_new_group_environment"] = True
+        self.assert_passes(self.dc, self.event_data)
 
         # These will never pass
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.update(priority=PriorityLevel.MEDIUM)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.update(priority=PriorityLevel.LOW)
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_without_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = False
         self.project.save()
 
-        assert self.job.group_state
+        assert self.event_data.group_state
 
         self.group_event.group.update(priority=PriorityLevel.HIGH)
-        self.job.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.job)
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new_group_environment"] = True
+        self.assert_passes(self.dc, self.event_data)
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.update(priority=PriorityLevel.MEDIUM)
-        self.job.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.job)
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new_group_environment"] = True
+        self.assert_passes(self.dc, self.event_data)
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.update(priority=PriorityLevel.LOW)
-        self.job.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.job)
-        self.job.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.job)
+        self.event_data.group_state["is_new_group_environment"] = True
+        self.assert_passes(self.dc, self.event_data)
+        self.event_data.group_state["is_new_group_environment"] = False
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -33,7 +33,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.event = self.get_event()
         self.group = self.create_group(project=self.project)
         self.group_event = self.event.for_group(self.group)
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},
@@ -157,7 +157,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"}
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -166,7 +166,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry.other.example",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_equal(self):
         self.dc.comparison.update(
@@ -176,7 +176,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry.example",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -185,7 +185,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry.other.example",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_starts_with(self):
         self.dc.comparison.update(
@@ -195,12 +195,12 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry.",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.STARTS_WITH, "key": "logger", "value": "bar."}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_start_with(self):
         self.dc.comparison.update(
@@ -210,7 +210,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry.",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -219,7 +219,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "bar.",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_ends_with(self):
         self.dc.comparison.update(
@@ -229,10 +229,10 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": ".example",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.ENDS_WITH, "key": "logger", "value": ".foo"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_end_with(self):
         self.dc.comparison.update(
@@ -242,7 +242,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": ".example",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -251,7 +251,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": ".foo",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_contains(self):
         self.dc.comparison.update(
@@ -261,12 +261,12 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {"match": MatchType.CONTAINS, "key": "logger", "value": "bar.foo"}
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_does_not_contain(self):
         self.dc.comparison.update(
@@ -276,7 +276,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "sentry",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -285,21 +285,21 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "bar.foo",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_is_set(self):
         self.dc.comparison.update({"match": MatchType.IS_SET, "key": "logger"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.IS_SET, "key": "missing"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_is_not_set(self):
         self.dc.comparison.update({"match": MatchType.NOT_SET, "key": "logger"})
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update({"match": MatchType.NOT_SET, "key": "missing"})
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_is_in(self):
         self.dc.comparison.update(
@@ -309,7 +309,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "bar.foo, wee, wow",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -318,7 +318,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "foo.bar",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
     def test_not_in(self):
         self.dc.comparison.update(
@@ -328,7 +328,7 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "bar.foo, wee, wow",
             }
         )
-        self.assert_passes(self.dc, self.job)
+        self.assert_passes(self.dc, self.event_data)
 
         self.dc.comparison.update(
             {
@@ -337,4 +337,4 @@ class TestTaggedEventCondition(ConditionTestCase):
                 "value": "foo.bar",
             }
         )
-        self.assert_does_not_pass(self.dc, self.job)
+        self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -14,24 +14,24 @@ class WorkflowTest(BaseWorkflowTest):
         )
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
-        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.job)
+        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
         assert evaluation is True
 
     def test_evaluate_trigger_conditions__condition_new_event__False(self):
         # Update event to have been seen before
         self.group_event.group.times_seen = 5
 
-        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.job)
+        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
         assert evaluation is False
 
     def test_evaluate_trigger_conditions__no_conditions(self):
         self.workflow.when_condition_group = None
         self.workflow.save()
 
-        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.job)
+        evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
         assert evaluation is True
 
     def test_evaluate_trigger_conditions__slow_condition(self):
@@ -42,7 +42,9 @@ class WorkflowTest(BaseWorkflowTest):
             type=Condition.EVENT_FREQUENCY_COUNT, comparison={"interval": "1d", "value": 7}
         )
         self.data_condition_group.conditions.add(slow_condition)
-        evaluation, remaining_conditions = self.workflow.evaluate_trigger_conditions(self.job)
+        evaluation, remaining_conditions = self.workflow.evaluate_trigger_conditions(
+            self.event_data
+        )
 
         assert evaluation is True
         assert remaining_conditions == [slow_condition]

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -25,7 +25,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
-        self.job = WorkflowEventData(event=self.group_event)
+        self.event_data = WorkflowEventData(event=self.group_event)
 
     def test(self):
         # test default frequency when no workflow.config set


### PR DESCRIPTION
It's not a `WorkflowJob` anymore so we should stop calling it job everywhere. Replace it with `event_data` -- also open to suggestions :D