### PR TITLE
chore(devservices): Bump devservices to 1.0.18

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -37,7 +37,7 @@ cryptography==43.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.0.17
+devservices==1.0.18
 distlib==0.3.8
 distro==1.8.0
 django==5.1.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.16
-devservices>=1.0.17
+devservices>=1.0.18
 
 covdefaults>=2.3.0
 sentry-covdefaults-disable-branch-coverage>=1.0.2


### PR DESCRIPTION
This picks up better observability in sentry for CI runs that use devservices and adds additional information on what devservices is doing behind the scenes for `devservices up`

https://github.com/getsentry/devservices/releases/tag/1.0.18