### PR TITLE
feat(insights): remove spans tab from spans summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -206,7 +206,6 @@ function TransactionHeader({
             <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
             <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
             <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
-            <TabList.Item key={Tab.SPANS}>{t('Spans')}</TabList.Item>
             <TabList.Item
               key={Tab.WEB_VITALS}
               textValue={t('Web Vitals')}

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -206,6 +206,9 @@ function TransactionHeader({
             <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
             <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
             <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
+            <TabList.Item key={Tab.SPANS} hidden>
+              {t('Spans')}
+            </TabList.Item>
             <TabList.Item
               key={Tab.WEB_VITALS}
               textValue={t('Web Vitals')}


### PR DESCRIPTION
Deprecate `spans` tab in the transaction summary page
<img width="574" alt="image" src="https://github.com/user-attachments/assets/c424d071-ddab-4751-958c-41d6fc3d7db2" />

I did check, and I could not find anything that links to this page, but in the odd chance something does I marked the tab as `hidden` so the link still works and we can track page usage to see if it's being accessed

Follow up PR will be created to cleanup remaining code, and remove the tab entirely 