### PR TITLE
chore(issues): remove usage of `organizations:issue-details-streamline`

### DIFF
--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -182,7 +182,7 @@ describe('SuspectCommits', function () {
   });
 
   describe('StreamlinedSuspectCommits', function () {
-    const organization = OrganizationFixture({features: ['issue-details-streamline']});
+    const organization = OrganizationFixture();
     const project = ProjectFixture();
     const event = EventFixture();
     const group = GroupFixture({firstRelease: {}} as any);

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -1,8 +1,7 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {mockTour} from 'sentry/components/tours/testUtils';
 import ConfigStore from 'sentry/stores/configStore';
@@ -25,7 +24,6 @@ describe('NewIssueExperienceButton', function () {
   const organization = OrganizationFixture();
   const user = UserFixture();
   user.options.prefersIssueDetailsStreamlinedUI = true;
-  const location = LocationFixture({query: {streamline: '1'}});
 
   beforeEach(() => {
     ConfigStore.init();
@@ -70,26 +68,6 @@ describe('NewIssueExperienceButton', function () {
       {organization}
     );
     expect(screen.getByTestId('test-id')).not.toBeEmptyDOMElement();
-  });
-
-  it('does not appear even if user prefers this UI', function () {
-    act(() => ConfigStore.set('user', user));
-    render(
-      <div data-test-id="test-id">
-        <NewIssueExperienceButton />
-      </div>
-    );
-    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
-  });
-
-  it('does not appear when query param is set', function () {
-    render(
-      <div data-test-id="test-id">
-        <NewIssueExperienceButton />
-      </div>,
-      {router: {location}}
-    );
-    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
   });
 
   it('triggers changes to the user config and location', async function () {

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -22,7 +22,7 @@ jest.mock('sentry/views/issueDetails/issueDetailsTour', () => ({
 }));
 
 describe('NewIssueExperienceButton', function () {
-  const organization = OrganizationFixture({features: ['issue-details-streamline']});
+  const organization = OrganizationFixture();
   const user = UserFixture();
   user.options.prefersIssueDetailsStreamlinedUI = true;
   const location = LocationFixture({query: {streamline: '1'}});

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -58,7 +58,6 @@ export function NewIssueExperienceButton() {
   }, [isTourCompleted, organization]);
 
   const hasStreamlinedUI = useHasStreamlinedUI();
-  const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
   const hasNewUIOnly = Boolean(organization.streamlineOnly);
   const user = useUser();
   const userStreamlinePreference = user?.options?.prefersIssueDetailsStreamlinedUI;
@@ -163,9 +162,8 @@ export function NewIssueExperienceButton() {
       label: t('Switch to the old issue experience'),
       // Do not show the toggle out of the new UI if any of these are true:
       //  - The user is on the old UI
-      //  - The org does not have the opt-in flag
       //  - The org has the new UI only option
-      hidden: !hasStreamlinedUI || !hasStreamlinedUIFlag || hasNewUIOnly,
+      hidden: !hasStreamlinedUI || hasNewUIOnly,
       onAction: handleToggle,
     },
     {

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -93,10 +93,9 @@ describe('StreamlinedGroupHeader', () => {
       expect(
         screen.getByRole('button', {name: 'Modify issue assignee'})
       ).toBeInTheDocument();
-
       expect(
-        screen.queryByRole('button', {name: 'Manage issue experience'})
-      ).not.toBeInTheDocument();
+        screen.getByRole('button', {name: 'Manage issue experience'})
+      ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Resolve'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Archive'})).toBeInTheDocument();
     });

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -102,9 +102,6 @@ describe('StreamlinedGroupHeader', () => {
     });
 
     it('displays new experience button if flag is set', async () => {
-      const flaggedOrganization = OrganizationFixture({
-        features: ['issue-details-streamline'],
-      });
       render(
         <StreamlinedGroupHeader
           {...defaultProps}
@@ -112,10 +109,7 @@ describe('StreamlinedGroupHeader', () => {
           project={project}
           event={null}
         />,
-        {
-          organization: flaggedOrganization,
-          router,
-        }
+        {organization, router}
       );
       expect(
         await screen.findByRole('button', {name: 'Manage issue experience'})


### PR DESCRIPTION
This flag is GA'd, so we can remove its usage and begin unregistering it.

1. Remove the usage of the flag - This PR
2. Unregister the flag from flagpole - https://github.com/getsentry/sentry-options-automator/pull/3396
3. Unregister the flag from the app - https://github.com/getsentry/sentry/pull/87894