### PR TITLE
chore(issues): Remove the streamline UI flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -142,8 +142,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-platform-deletion-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new trace view on performance issues
     manager.add('organizations:issue-details-new-performance-trace-view', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables opt-in access to the streamlined issue details UI for all users of an organization
-    manager.add("organizations:issue-details-streamline", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables streamlined issue details UI for all users of an organization without opt-out
     manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables access to the issue details tour


### PR DESCRIPTION
The opt-in is no longer dependent on this flag, so it is safe to remove.

1. Remove the usage of the flag - https://github.com/getsentry/sentry/pull/87893
2. Unregister the flag from flagpole - https://github.com/getsentry/sentry-options-automator/pull/3396
3. Unregister the flag from the app - This PR