### PR TITLE
ref(insights): show empty feedback chart if no data

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
-import useHaveSelectedProjectsSetupFeedback from 'sentry/components/feedback/useFeedbackOnboarding';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -93,8 +92,6 @@ function ViewSpecificCharts({
   setFilters: (filter: string[]) => void;
   view: DomainView | '';
 }) {
-  const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
-
   switch (view) {
     case FRONTEND_LANDING_SUB_PATH:
       return (
@@ -119,14 +116,9 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
-          {/* only show this chart if the project has user feedback set up */}
-          {hasSetupOneFeedback && (
-            <Fragment>
-              <ModuleLayout.Third>
-                <NewAndResolvedIssueChart type="feedback" />
-              </ModuleLayout.Third>
-            </Fragment>
-          )}
+          <ModuleLayout.Third>
+            <NewAndResolvedIssueChart type="feedback" />
+          </ModuleLayout.Third>
           <ModuleLayout.Third>
             <GiveFeedbackSection />
           </ModuleLayout.Third>
@@ -166,14 +158,9 @@ function ViewSpecificCharts({
             <UserHealthRateChart />
           </ModuleLayout.Third>
 
-          {/* only show this chart if the project has user feedback set up */}
-          {hasSetupOneFeedback && (
-            <Fragment>
-              <ModuleLayout.Third>
-                <NewAndResolvedIssueChart type="feedback" />
-              </ModuleLayout.Third>
-            </Fragment>
-          )}
+          <ModuleLayout.Third>
+            <NewAndResolvedIssueChart type="feedback" />
+          </ModuleLayout.Third>
           <ModuleLayout.Third>
             <GiveFeedbackSection />
           </ModuleLayout.Third>


### PR DESCRIPTION

since conditionally rendering charts is not an existing insights pattern

![SCR-20250325-kfke](https://github.com/user-attachments/assets/36fcc0d7-1dc8-42b5-a487-32af39df4a5b)
