### PR TITLE
ref(insights): move healthy legend option to end

### DIFF
--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -45,10 +45,10 @@ export default function useSessionHealthBreakdown({type}: {type: 'count' | 'rate
 
   // Create a map of status to their data
   const statusData = {
-    healthy: getSessionStatusSeries('healthy', sessionData.groups),
     crashed: getSessionStatusSeries('crashed', sessionData.groups),
     errored: getSessionStatusSeries('errored', sessionData.groups),
     abnormal: getSessionStatusSeries('abnormal', sessionData.groups),
+    healthy: getSessionStatusSeries('healthy', sessionData.groups),
   };
 
   const createDatapoints = (data: number[]) =>

--- a/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
@@ -45,10 +45,10 @@ export default function useUserHealthBreakdown({type}: {type: 'count' | 'rate'})
 
   // Create a map of status to their data
   const statusData = {
-    healthy: getCountStatusSeries('healthy', userData.groups),
     crashed: getCountStatusSeries('crashed', userData.groups),
     errored: getCountStatusSeries('errored', userData.groups),
     abnormal: getCountStatusSeries('abnormal', userData.groups),
+    healthy: getCountStatusSeries('healthy', userData.groups),
   };
 
   const createDatapoints = (data: number[]) =>


### PR DESCRIPTION
since we are hiding the healthy series by default, move the more relevant options to the front of the legend.

<img width="815" alt="SCR-20250325-kjcg" src="https://github.com/user-attachments/assets/d60e3d20-e9eb-4b19-b1e2-5fc4e53b3818" />
