### PR TITLE
fix(insights): overview page analytics incorrect with all projects selected

### DIFF
--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -40,11 +40,7 @@ export type InsightEventParameters = {
   'insight.vital.overview.toggle_tab': {tab: string};
   'insight.vital.select_browser_value': {browsers: string[]};
   'insight.vital.vital_sidebar_opened': {vital: string};
-  'insights.page_loads.overview': {
-    domain: DomainView | undefined;
-    hasAllProjectsSelected: boolean;
-    platforms: string[];
-  };
+  'insights.page_loads.overview': {domain: DomainView | undefined; platforms: string[]};
 };
 
 export type InsightEventKey = keyof InsightEventParameters;

--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -40,7 +40,11 @@ export type InsightEventParameters = {
   'insight.vital.overview.toggle_tab': {tab: string};
   'insight.vital.select_browser_value': {browsers: string[]};
   'insight.vital.vital_sidebar_opened': {vital: string};
-  'insights.page_loads.overview': {domain: DomainView | undefined; platforms: string[]};
+  'insights.page_loads.overview': {
+    domain: DomainView | undefined;
+    hasAllProjectsSelected: boolean;
+    platforms: string[];
+  };
 };
 
 export type InsightEventKey = keyof InsightEventParameters;

--- a/static/app/views/insights/pages/useOverviewPageTrackAnalytics.ts
+++ b/static/app/views/insights/pages/useOverviewPageTrackAnalytics.ts
@@ -1,6 +1,8 @@
 import {useEffect} from 'react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
+import EventView from 'sentry/utils/discover/eventView';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -10,12 +12,16 @@ export function useOverviewPageTrackPageload() {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const projects = useProjects();
+  const location = useLocation();
   const {view} = useDomainViewFilters();
 
+  const eventView = EventView.fromLocation(location);
+
   const allProjects = projects.initiallyLoaded ? projects.projects : [];
-  const selectedProjects = allProjects.filter(p =>
-    pageFilters.selection.projects.includes(parseInt(`${p.id}`, 10))
-  );
+  const selectedProjects = eventView
+    .getFullSelectedProjects(allProjects)
+    .filter(p => p !== undefined);
+  const hasAllProjectsSelected = pageFilters.selection.projects.length === 0;
 
   // Stringifying this is just to avoid missing dependencies in the useEffect,
   // Any performance implications are negligible for such a small array
@@ -31,6 +37,7 @@ export function useOverviewPageTrackPageload() {
       trackAnalytics(`insights.page_loads.overview`, {
         organization,
         platforms: selectedPlatforms,
+        hasAllProjectsSelected,
         domain: view,
       });
     }
@@ -39,6 +46,7 @@ export function useOverviewPageTrackPageload() {
     pageFilters.isReady,
     projects.initiallyLoaded,
     selectedPlatformsString,
+    hasAllProjectsSelected,
     view,
   ]);
 }

--- a/static/app/views/insights/pages/useOverviewPageTrackAnalytics.ts
+++ b/static/app/views/insights/pages/useOverviewPageTrackAnalytics.ts
@@ -21,7 +21,6 @@ export function useOverviewPageTrackPageload() {
   const selectedProjects = eventView
     .getFullSelectedProjects(allProjects)
     .filter(p => p !== undefined);
-  const hasAllProjectsSelected = pageFilters.selection.projects.length === 0;
 
   // Stringifying this is just to avoid missing dependencies in the useEffect,
   // Any performance implications are negligible for such a small array
@@ -37,7 +36,6 @@ export function useOverviewPageTrackPageload() {
       trackAnalytics(`insights.page_loads.overview`, {
         organization,
         platforms: selectedPlatforms,
-        hasAllProjectsSelected,
         domain: view,
       });
     }
@@ -46,7 +44,6 @@ export function useOverviewPageTrackPageload() {
     pageFilters.isReady,
     projects.initiallyLoaded,
     selectedPlatformsString,
-    hasAllProjectsSelected,
     view,
   ]);
 }


### PR DESCRIPTION
When all projects are selected, the `platforms` array was empty but it should be filled with all platforms the user has. This is because when all projects are selected `pageFilters.selection.projects` is an empty array.

This PR fixes this issue by using a handy method `getFullSelectedProjects` which accounts for all these edge cases.