### PR TITLE
fix(releases): fix summation of release meta newGroups

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -104,6 +104,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "version": release.version,
                 "versionInfo": expose_version_info(release.version_info),
                 "projects": projects,
+                # This value is deprecated. Read from the `ReleaseProject` model instead.
                 "newGroups": sum(project["newGroups"] for project in projects),
                 "deployCount": release.total_deploys,
                 "commitCount": release.commit_count,

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -104,7 +104,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "version": release.version,
                 "versionInfo": expose_version_info(release.version_info),
                 "projects": projects,
-                "newGroups": release.new_groups,
+                "newGroups": sum(project["newGroups"] for project in projects),
                 "deployCount": release.total_deploys,
                 "commitCount": release.commit_count,
                 "released": release.date_released or release.date_added,


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/87322

the `release.new_groups` value can be incorrect as seen in this [API request.](https://sentry.sentry.io/api/0/organizations/sentry/releases/frontend%4085a177005793f32687cdd7d9776191ee51153e5f/meta/) (the project has 1 `newGroup` but the overall release meta `newGroups == 0`.)

the overall meta `newGroups` _should_ theoretically be the same as the sum of `newGroups` across all release projects:

https://github.com/getsentry/sentry/blob/b88166941846ce4fdb4e2001453e421b41ba7e10/tests/sentry/api/serializers/test_release.py#L76-L77

apparently this field on the release was deprecated:

https://github.com/getsentry/sentry/blob/b88166941846ce4fdb4e2001453e421b41ba7e10/src/sentry/models/release.py#L210-L211


 in the case that the two values are not matching, let's favor summation over the project `newGroups` rather than relying on `release.new_groups`.