### PR TITLE
chore(ourlogs): Send trace ID with details request

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -39,6 +39,10 @@ export interface UseTraceItemDetailsProps {
    */
   referrer: string;
   /**
+   * Every trace item belongs to a trace.
+   */
+  traceId: string;
+  /**
    * The trace item ID representing an EAP trace item.
    */
   traceItemId: string;
@@ -65,6 +69,7 @@ type TraceItemDetailsUrlParams = {
 type TraceItemDetailsQueryParams = {
   dataset: EAPDataset;
   referrer: string;
+  traceId: string;
 };
 
 export type TraceItemResponseAttribute =
@@ -91,6 +96,7 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
   const queryParams: TraceItemDetailsQueryParams = {
     referrer: props.referrer,
     dataset: props.dataset,
+    traceId: props.traceId,
   };
 
   const result = useApiQuery<TraceItemDetailsResponse>(
@@ -123,6 +129,7 @@ function traceItemDetailsQueryKey({
   const query: Record<string, string | string[]> = {
     dataset: queryParams.dataset,
     referrer: queryParams.referrer,
+    trace_id: queryParams.traceId,
   };
 
   return [
@@ -134,6 +141,7 @@ function traceItemDetailsQueryKey({
 export function usePrefetchTraceItemDetailsOnHover({
   traceItemId,
   projectId,
+  traceId,
   dataset,
   referrer,
   hoverPrefetchDisabled,
@@ -169,6 +177,7 @@ export function usePrefetchTraceItemDetailsOnHover({
             queryParams: {
               dataset,
               referrer,
+              traceId,
             },
           }),
           queryFn: fetchDataQuery,

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -6,10 +6,11 @@ import {
 } from 'sentry/views/explore/constants';
 import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
-export const LogAttributesHumanLabel: Record<OurLogFieldKey, string> = {
+export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = {
   [OurLogKnownFieldKey.TIMESTAMP]: t('Timestamp'),
   [OurLogKnownFieldKey.SEVERITY_TEXT]: t('Severity'),
   [OurLogKnownFieldKey.BODY]: t('Message'),
+  [OurLogKnownFieldKey.TRACE_ID]: t('Trace'),
 };
 
 /**
@@ -18,6 +19,7 @@ export const LogAttributesHumanLabel: Record<OurLogFieldKey, string> = {
 export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.PROJECT_ID,
+  OurLogKnownFieldKey.TRACE_ID,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
 ];
 

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -85,6 +85,7 @@ export function LogRowContent({
   const hoverProps = usePrefetchLogTableRowOnHover({
     logId: String(dataRow[OurLogKnownFieldKey.ID]),
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
+    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
     sharedHoverTimeoutRef,
   });
 
@@ -171,8 +172,9 @@ function LogRowDetails({
   );
   const missingLogId = !dataRow[OurLogKnownFieldKey.ID];
   const {data, isPending} = useExploreLogsTableRow({
-    log_id: String(dataRow[OurLogKnownFieldKey.ID] ?? ''),
-    project_id: String(dataRow[OurLogKnownFieldKey.PROJECT_ID] ?? ''),
+    logId: String(dataRow[OurLogKnownFieldKey.ID] ?? ''),
+    projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID] ?? ''),
+    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID] ?? ''),
     enabled: !missingLogId,
   });
 

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -51,13 +51,15 @@ export function useExploreLogsTable(options: Parameters<typeof useOurlogs>[0]) {
 }
 
 export function useExploreLogsTableRow(props: {
-  log_id: string | number;
-  project_id: string;
+  logId: string | number;
+  projectId: string;
+  traceId: string;
   enabled?: boolean;
 }) {
   return useTraceItemDetails({
-    traceItemId: String(props.log_id),
-    projectId: props.project_id,
+    traceItemId: String(props.logId),
+    projectId: props.projectId,
+    traceId: props.traceId,
     dataset: DiscoverDatasets.OURLOGS,
     referrer: 'api.explore.log-item-details',
   });
@@ -66,17 +68,20 @@ export function useExploreLogsTableRow(props: {
 export function usePrefetchLogTableRowOnHover({
   logId,
   projectId,
+  traceId,
   hoverPrefetchDisabled,
   sharedHoverTimeoutRef,
 }: {
   logId: string | number;
   projectId: string;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  traceId: string;
   hoverPrefetchDisabled?: boolean;
 }) {
   return usePrefetchTraceItemDetailsOnHover({
     traceItemId: String(logId),
     projectId,
+    traceId,
     dataset: DiscoverDatasets.OURLOGS,
     hoverPrefetchDisabled,
     sharedHoverTimeoutRef,


### PR DESCRIPTION
For performance, we want to send the trace_id to the backend when we are searching for a particular trace item.