### PR TITLE
fix(pagerduty): Respect max length for summary field

### DIFF
--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -9,12 +9,14 @@ import sentry_sdk
 from sentry.integrations.pagerduty.actions import PagerDutyNotifyServiceForm
 from sentry.integrations.pagerduty.client import (
     PAGERDUTY_DEFAULT_SEVERITY,
+    PAGERDUTY_SUMMARY_MAX_LENGTH,
     PagerdutySeverity,
     build_pagerduty_event_payload,
 )
 from sentry.models.rule import Rule
 from sentry.rules.actions import IntegrationEventAction
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils.strings import truncatechars
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
 
@@ -95,7 +97,9 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
             rule = rules[0] if rules else None
 
             if rule and rule.label:
-                data["payload"]["summary"] = f"[{rule.label}]: {data['payload']['summary']}"
+                data["payload"]["summary"] = truncatechars(
+                    f"[{rule.label}]: {data['payload']['summary']}", PAGERDUTY_SUMMARY_MAX_LENGTH
+                )
 
             try:
                 resp = client.send_trigger(data=data)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -19,6 +19,7 @@ LEVEL_SEVERITY_MAP: dict[str, PagerdutySeverity] = {
     "fatal": "critical",
 }
 PAGERDUTY_DEFAULT_SEVERITY: PagerdutySeverity = "default"  # represents using LEVEL_SEVERITY_MAP
+PAGERDUTY_SUMMARY_MAX_LENGTH = 1024
 
 
 class PagerDutyClient(ApiClient):
@@ -50,7 +51,7 @@ def build_pagerduty_event_payload(
     group = event.group
     level = event.get_tag("level") or "error"
     custom_details = serialize(event, None, ExternalEventSerializer())
-    summary = custom_details["message"][:1024] or custom_details["title"]
+    summary = custom_details["message"][:PAGERDUTY_SUMMARY_MAX_LENGTH] or custom_details["title"]
 
     link_params = {"referrer": "pagerduty_integration"}
     if notification_uuid:


### PR DESCRIPTION
Didn't port over the magic number, so we were sending some invalid payloads to PD. 
Fixed that and made it non-magical.

Fixes [SENTRY-3QXC](https://sentry.sentry.io/issues/6458733611/)