### PR TITLE
fix(insights): fix proj selector showing onboarding section

### DIFF
--- a/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
@@ -5,7 +5,10 @@ export default function useProjectHasSessions() {
   const {selection} = usePageFilters();
   const {projects: allProjects} = useProjects();
 
-  const projectIds = selection.projects;
+  const projectIds = selection.projects.length
+    ? selection.projects
+    : allProjects.map(p => p.id);
+
   const projects = projectIds.map(projectId => {
     return allProjects.find(p => p.id === projectId.toString());
   });

--- a/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useProjectHasSessions.tsx
@@ -5,13 +5,14 @@ export default function useProjectHasSessions() {
   const {selection} = usePageFilters();
   const {projects: allProjects} = useProjects();
 
-  const projectIds = selection.projects.length
-    ? selection.projects
-    : allProjects.map(p => p.id);
+  const projectIds = selection.projects;
 
-  const projects = projectIds.map(projectId => {
-    return allProjects.find(p => p.id === projectId.toString());
-  });
+  const projects = projectIds.length
+    ? projectIds.map(projectId => {
+        return allProjects.find(p => p.id === projectId.toString());
+      })
+    : allProjects;
+
   const hasSessionData = projects.some(p => p?.hasSessions);
 
   return hasSessionData;


### PR DESCRIPTION
if no projects are selected (aka all projects are selected), `selection.projects === []` which was leading the onboarding panel to show up mistakenly. in this case, consider all projects instead.