### PR TITLE
chore(sentry app): Remove le grande payload in event webhooks

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -315,7 +315,7 @@ def _process_resource_change(
                 data[name] = serialize(instance)
                 instance_cache_key = f"process-resource-change-bound:{instance.id}"
 
-            # Cache the event/issue for 5 minutes
+            # Cache the event data for 5 minutes
             cache.set(key=instance_cache_key, value=data, timeout=300)
 
             for installation in installations:

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -305,20 +305,19 @@ def _process_resource_change(
                 )
                 if event in installation.sentry_app.events
             ]
+            data = {}
+            if isinstance(instance, (Event, GroupEvent)):
+                assert instance.group_id, "group id is required to create webhook event data"
+                data[name] = _webhook_event_data(instance, instance.group_id, instance.project_id)
+            else:
+                data[name] = serialize(instance)
 
             for installation in installations:
-                data = {}
-                if isinstance(instance, (Event, GroupEvent)):
-                    assert instance.group_id, "group id is required to create webhook event data"
-                    data[name] = _webhook_event_data(
-                        instance, instance.group_id, instance.project_id
-                    )
-                else:
-                    data[name] = serialize(instance)
-
                 # Trigger a new task for each webhook
                 send_resource_change_webhook.delay(
-                    installation_id=installation.id, event=str(event), data=data
+                    installation_id=installation.id,
+                    event=str(event),
+                    data=data,
                 )
 
 

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -316,7 +316,7 @@ def _process_resource_change(
                 instance_cache_key = f"process-resource-change-bound:{instance.id}"
 
             # Cache the event/issue for 5 minutes
-            cache.set(instance_cache_key, data, 300)
+            cache.set(key=instance_cache_key, value=data, timeout=300)
 
             for installation in installations:
                 # Trigger a new task for each webhook
@@ -518,8 +518,6 @@ def send_resource_change_webhook(
             raise SentryAppSentryError(
                 message=f"{SentryAppWebhookFailureReason.MISSING_INSTALLATION}"
             )
-
-        cache.get()
 
     send_webhooks(installation, event, data=data)
 


### PR DESCRIPTION
An improvement we can do to hopefully reduce the app platform queue backlogging is reducing the size of the payload we're passing to our `send_resource_change_webhook` task in `process_resource_change_bound`. We can do this by caching the blob to be fetched in the later send tasks. Because we're now passing the cache_key instead, we'll follow these steps for the cutover.

For this we just declare the existence of the cache key so we can pass to the next task. Not doing anything just yet with the info since we could have tasks in the queue which don't have a cache key.