### PR TITLE
ref(perf): Rename `Transaction` to `Service Entry Spans` in Summary page

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -113,11 +113,19 @@ export const getTabCrumbs = ({
     view,
   };
 
-  crumbs.push({
-    to: transactionSummaryRouteWithQuery(routeQuery),
-    label: t('Transaction Summary'),
-    preservePageFilters: true,
-  });
+  const isEAP = organization.features.includes('performance-transaction-summary-eap');
+
+  isEAP
+    ? crumbs.push({
+        to: transactionSummaryRouteWithQuery(routeQuery),
+        label: t('Service Entry Span Summary'),
+        preservePageFilters: true,
+      })
+    : crumbs.push({
+        to: transactionSummaryRouteWithQuery(routeQuery),
+        label: t('Transaction Summary'),
+        preservePageFilters: true,
+      });
 
   if (spanSlug) {
     crumbs.push({

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -371,22 +371,22 @@ function getOTelFilterOptions(): DropdownOption[] {
     {
       sort: {kind: 'asc', field: 'span.duration'},
       value: TransactionFilterOptions.FASTEST,
-      label: t('Fastest Transactions'),
+      label: t('Fastest Service Entry Spans'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.SLOW,
-      label: t('Slow Transactions (p95)'),
+      label: t('Slow Service Entry Spans (p95)'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.OUTLIER,
-      label: t('Outlier Transactions (p100)'),
+      label: t('Outlier Service Entry Spans (p100)'),
     },
     {
       sort: {kind: 'desc', field: 'timestamp'},
       value: TransactionFilterOptions.RECENT,
-      label: t('Recent Transactions'),
+      label: t('Recent Service Entry Spans'),
     },
   ];
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -62,7 +62,7 @@ class RelatedIssues extends Component<Props> {
     });
   };
 
-  renderEmptyMessage = () => {
+  renderEmptyMessage = (isEAP: boolean) => {
     const {statsPeriod} = this.props;
 
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -76,7 +76,8 @@ class RelatedIssues extends Component<Props> {
         <PanelBody>
           <EmptyStateWarning>
             <p>
-              {tct('No new issues for this transaction for the [timePeriod].', {
+              {tct('No new issues for this [identifier] for the [timePeriod].', {
+                identifier: isEAP ? 'service entry span' : 'transaction',
                 timePeriod: displayedPeriod,
               })}
             </p>
@@ -93,6 +94,8 @@ class RelatedIssues extends Component<Props> {
       pathname: `/organizations/${organization.slug}/issues/`,
       query: {referrer: 'performance-related-issues', ...queryParams},
     };
+
+    const isEAP = organization.features.includes('performance-transaction-summary-eap');
 
     return (
       <Fragment>
@@ -112,7 +115,7 @@ class RelatedIssues extends Component<Props> {
           <GroupList
             queryParams={queryParams}
             canSelectGroups={false}
-            renderEmptyMessage={this.renderEmptyMessage}
+            renderEmptyMessage={() => this.renderEmptyMessage(isEAP)}
             withChart={false}
             withPagination={false}
             source="performance-related-issues"


### PR DESCRIPTION
The nomenclature of transactions is changing to make more sense with the spans-only push. This PR simply renames all instances in the Transaction Summary Page UI (now referred to as the Service Entry Span Summary Page). This change is only visible for users with the `performance-transaction-summary-eap` feature flag.

Addresses https://github.com/getsentry/team-visibility/issues/56