### PR TITLE
fix(pagefilters): Respect maxPickableDays for default options

### DIFF
--- a/static/app/components/timeRangeSelector/index.spec.tsx
+++ b/static/app/components/timeRangeSelector/index.spec.tsx
@@ -258,6 +258,14 @@ describe('TimeRangeSelector', function () {
     });
   });
 
+  it('respects maxPickableDays for defaults', async () => {
+    renderComponent({maxPickableDays: 30});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    expect(screen.queryByRole('option', {name: 'Last 90 days'})).not.toBeInTheDocument();
+  });
+
   it('respects maxPickableDays for arbitrary time ranges', async () => {
     renderComponent({maxPickableDays: 30});
 

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -296,8 +296,15 @@ export function TimeRangeSelector({
   );
 
   const arbitraryRelativePeriods = getArbitraryRelativePeriod(relative);
+
+  const restrictedDefaultPeriods = Object.fromEntries(
+    Object.entries(DEFAULT_RELATIVE_PERIODS).filter(
+      ([period]) => parsePeriodToHours(period) <= maxPickableDays * 24
+    )
+  );
+
   const defaultRelativePeriods = {
-    ...DEFAULT_RELATIVE_PERIODS,
+    ...restrictedDefaultPeriods,
     ...arbitraryRelativePeriods,
   };
   return (


### PR DESCRIPTION
When maxPickableDays is set to lower than 90 we restrict the `last 90
days` from appearing in the options, and so on.