### PR TITLE
feat(crons): Restrict date picker to 30 days

### DIFF
--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -148,7 +148,7 @@ function MonitorDetails({params, location}: Props) {
       <Layout.Body>
         <Layout.Main>
           <StyledPageFilterBar condensed>
-            <DatePageFilter />
+            <DatePageFilter maxPickableDays={30} />
             <EnvironmentPageFilter />
           </StyledPageFilterBar>
           {monitor.status === 'disabled' && (

--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -160,7 +160,7 @@ function CronsOverview() {
             <PageFilterBar>
               <ProjectPageFilter resetParamsOnChange={['cursor']} />
               <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
-              <DatePageFilter />
+              <DatePageFilter maxPickableDays={30} />
             </PageFilterBar>
             <SearchBar
               query={decodeScalar(qs.parse(location.search)?.query, '')}


### PR DESCRIPTION
Fixes [NEW-206: Update UI to limit date filtering to 30 days](https://linear.app/getsentry/issue/NEW-206/update-ui-to-limit-date-filtering-to-30-days)

Needs https://github.com/getsentry/sentry/pull/87917 to be completely correct.