### PR TITLE
feat(aci): support for event attribute filters in event frequency conditions

### DIFF
--- a/src/sentry/issues/constants.py
+++ b/src/sentry/issues/constants.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 from sentry.issues.grouptype import GroupCategory
+from sentry.snuba.dataset import Dataset
 from sentry.tsdb.base import TSDBModel
+from sentry.utils.snuba import DATASETS
 
 ISSUE_TSDB_GROUP_MODELS = {
     GroupCategory.ERROR: TSDBModel.group,
 }
 ISSUE_TSDB_USER_GROUP_MODELS = {
     GroupCategory.ERROR: TSDBModel.users_affected_by_group,
+}
+
+# Use this with DATASETS from sentry/utils/snuba.py
+TSDB_MODEL_DATASET = {
+    TSDBModel.group: Dataset.Events,
+    TSDBModel.group_generic: Dataset.IssuePlatform,
+    TSDBModel.users_affected_by_group: Dataset.Events,
+    TSDBModel.users_affected_by_generic_group: Dataset.IssuePlatform,
 }
 
 
@@ -19,3 +29,10 @@ def get_issue_tsdb_user_group_model(issue_category: GroupCategory) -> TSDBModel:
     return ISSUE_TSDB_USER_GROUP_MODELS.get(
         issue_category, TSDBModel.users_affected_by_generic_group
     )
+
+
+def get_dataset_column_name(tsdb_model: TSDBModel, column_name: str) -> str | None:
+    dataset = TSDB_MODEL_DATASET.get(tsdb_model, Dataset.IssuePlatform)
+    col_mapping = DATASETS[dataset]
+
+    return col_mapping.get(column_name)

--- a/src/sentry/issues/constants.py
+++ b/src/sentry/issues/constants.py
@@ -13,7 +13,7 @@ ISSUE_TSDB_USER_GROUP_MODELS = {
 }
 
 # Use this with DATASETS from sentry/utils/snuba.py
-TSDB_MODEL_DATASET = {
+TSDB_MODEL_DATASET: dict[TSDBModel, Dataset] = {
     TSDBModel.group: Dataset.Events,
     TSDBModel.group_generic: Dataset.IssuePlatform,
     TSDBModel.users_affected_by_group: Dataset.Events,

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -41,7 +41,7 @@ attribute_registry = Registry[AttributeHandler]()
 ATTR_CHOICES: dict[str, Columns | None] = {
     "message": Columns.MESSAGE,
     "platform": Columns.PLATFORM,
-    "environment": Columns.MESSAGE,
+    "environment": Columns.ENVIRONMENT,
     "type": Columns.TYPE,
     "error.handled": Columns.ERROR_HANDLED,
     "error.unhandled": Columns.ERROR_HANDLED,

--- a/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
@@ -106,7 +106,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         end: datetime,
         environment_id: int | None,
         referrer_suffix: str,
-        filters: list[tuple[str, str, str | None]] | None = None,
+        filters: list[dict[str, Any]] | None = None,
     ) -> dict[int, int]:
         batch_totals: dict[int, int] = defaultdict(int)
         group_id = group_ids[0]

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -57,6 +57,22 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
                 "fingerprint": ["group-1"],
                 "user": {"id": uuid4().hex},
                 "tags": {"foo": "bar", "baz": "quux", "region": "US"},
+                "platform": "javascript",
+                "contexts": {
+                    "response": {
+                        "type": "response",
+                        "status_code": 200,
+                    },
+                },
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Generic",
+                            "value": "hello world",
+                            "mechanism": {"type": "UncaughtExceptionHandler", "handled": True},
+                        }
+                    ]
+                },
             },
             project_id=self.project.id,
         )
@@ -80,6 +96,13 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
                 "fingerprint": ["group-3"],
                 "user": {"id": uuid4().hex},
                 "tags": {"foo": None, "biz": "baz", "region": "US"},
+                "platform": "javascript",
+                "contexts": {
+                    "response": {
+                        "type": "response",
+                        "status_code": 400,
+                    },
+                },
             },
             project_id=self.project.id,
         )
@@ -93,6 +116,7 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
         )
         perf_event_data["user"] = {"id": uuid4().hex}
         perf_event_data["environment"] = self.environment.name
+        perf_event_data["platform"] = "python"
 
         # Store a performance event
         self.perf_event = self.create_performance_issue(

--- a/tests/sentry/workflow_engine/handlers/condition/test_slow_condition_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_slow_condition_query_handlers.py
@@ -40,7 +40,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         )
         assert batch_query == {self.event3.group_id: 1}
 
-    def test_batch_query__tag_conditions(self):
+    def test_batch_query__tag_conditions__equal(self):
         batch_query = self.handler().batch_query(
             group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
             start=self.start,
@@ -54,6 +54,77 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             self.perf_event.group_id: 0,
         }
 
+    def test_batch_query__tag_conditions__not_equal(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "ne", "value": "EU"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 1,
+        }
+
+    def test_batch_query__tag_conditions__starts_with(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "sw", "value": "U"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }
+
+    def test_batch_query__tag_conditions__not_starts_with(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "nsw", "value": "E"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 1,
+        }
+
+    def test_batch_query__tag_conditions__ends_with(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "ew", "value": "S"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }
+
+    def test_batch_query__tag_conditions__not_ends_with(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "new", "value": "U"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 1,
+        }
+
+    def test_batch_query__tag_conditions__contains(self):
         batch_query = self.handler().batch_query(
             group_ids={self.event3.group_id},
             start=self.start,
@@ -62,6 +133,82 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             filters=[{"key": "biz", "match": "co", "value": "b"}],
         )
         assert batch_query == {self.event3.group_id: 1}
+
+    def test_batch_query__tag_conditions__not_contains(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event3.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+            filters=[{"key": "biz", "match": "nc", "value": "b"}],
+        )
+        assert batch_query == {self.event3.group_id: 0}
+
+    def test_batch_query__tag_conditions__is_set(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "foo", "match": "is"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 1,
+            self.perf_event.group_id: 1,
+        }
+
+    def test_batch_query__tag_conditions__is_not_set(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "foo", "match": "ns"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 0,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }
+
+    def test_batch_query__tag_conditions__is_in(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "in", "value": "US,EU"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 1,
+            self.perf_event.group_id: 0,
+        }
+
+    def test_batch_query__tag_conditions__is_not_in(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "region", "match": "nin", "value": "US,EU"}],
+        )
+        assert batch_query == {
+            self.event.group_id: 0,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 1,
+        }
+
+    def test_batch_query__tag_conditions__invalid(self):
+        with pytest.raises(ValueError):
+            self.handler().batch_query(
+                group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+                start=self.start,
+                end=self.end,
+                environment_id=self.environment.id,
+                filters=[{"key": "region", "match": "asdf", "value": "U"}],
+            )
 
     def test_batch_query__attribute_conditions(self):
         batch_query = self.handler().batch_query(
@@ -193,7 +340,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
-            filters=[{"attribute": "error.handled", "match": "eq", "value": True}],
+            filters=[{"attribute": "error.unhandled", "match": "eq", "value": False}],
         )
         assert batch_query == {
             self.event.group_id: 1,


### PR DESCRIPTION
Builds off of https://github.com/getsentry/sentry/pull/87807

Event frequency conditions that query Snuba will also include additional query filters for tags and event attributes.

The tag filter is currently implemented -- this queries the tags column in Snuba for the match and the value.
However, for event attributes, each attribute is a separate Snuba column that we need to query separately for the match and value.

Each event attribute is a different column. Depending on whether we are querying the `events` table or `issue platform`, the column might be named differently, so we need to check which issue category we are querying for in order to find the correct column name.

Attributes that might not exist as queryable columns for an issue type, which means there are no events that meet the attribute filter(s), and we should return 0 events for those `group_ids`. Do this by raising an `InvalidFilter` exception when generating extra Snuba conditions, and catching it to return 0s (do this because we expect to receive all `group_ids` in the results).