### PR TITLE
ref(eap): Update Span Category dropdown query for SES Table

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -92,6 +92,7 @@ export type SpanStringFields =
   | 'timestamp'
   | 'trace'
   | 'transaction'
+  | 'transaction.span_id'
   | 'transaction.id'
   | 'transaction.method'
   | 'release'

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -149,6 +149,7 @@ export function ServiceEntrySpansTable({
   } = useServiceEntrySpansQuery({
     query: eventViewQuery.formatString(),
     sort: selected.sort,
+    transactionName,
   });
 
   const consolidatedData = tableData?.map(row => {

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -28,7 +28,11 @@ import useProjects from 'sentry/utils/useProjects';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {type EAPSpanResponse, ModuleName} from 'sentry/views/insights/types';
+import {
+  type EAPSpanResponse,
+  ModuleName,
+  SpanIndexedField,
+} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -128,7 +132,8 @@ export function ServiceEntrySpansTable({
 
   const projectSlug = projects.find(p => p.id === `${eventView.project}`)?.slug;
   const cursor = decodeScalar(location.query?.[CURSOR_NAME]);
-  const {selected, options} = getOTelTransactionsListSort(location);
+  const spanCategory = decodeScalar(location.query?.[SpanIndexedField.SPAN_CATEGORY]);
+  const {selected, options} = getOTelTransactionsListSort(location, spanCategory);
 
   const p95 = totalValues?.['p95()'] ?? 0;
   const eventViewQuery = new MutableSearch(eventView.query);
@@ -364,38 +369,47 @@ function CustomPagination({
   );
 }
 
-// TODO: The span ops breakdown filter will not work here due to OTLP changes.
-// this may need to be adjusted in the future to handle the new breakdown filter that will replace it.
-function getOTelFilterOptions(): DropdownOption[] {
+function getOTelFilterOptions(spanCategory?: string): DropdownOption[] {
   return [
     {
       sort: {kind: 'asc', field: 'span.duration'},
       value: TransactionFilterOptions.FASTEST,
-      label: t('Fastest Service Entry Spans'),
+      label: spanCategory
+        ? t('Fastest %s Service Entry Spans', spanCategory)
+        : t('Fastest Service Entry Spans'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.SLOW,
-      label: t('Slow Service Entry Spans (p95)'),
+      label: spanCategory
+        ? t('Slow %s Service Entry Spans (p95)', spanCategory)
+        : t('Slow Service Entry Spans (p95)'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.OUTLIER,
-      label: t('Outlier Service Entry Spans (p100)'),
+      label: spanCategory
+        ? t('Outlier %s Service Entry Spans (p100)', spanCategory)
+        : t('Outlier Service Entry Spans (p100)'),
     },
     {
       sort: {kind: 'desc', field: 'timestamp'},
       value: TransactionFilterOptions.RECENT,
-      label: t('Recent Service Entry Spans'),
+      label: spanCategory
+        ? t('Recent %s Service Entry Spans', spanCategory)
+        : t('Recent Service Entry Spans'),
     },
   ];
 }
 
-function getOTelTransactionsListSort(location: Location): {
+function getOTelTransactionsListSort(
+  location: Location,
+  spanCategory?: string
+): {
   options: DropdownOption[];
   selected: DropdownOption;
 } {
-  const sortOptions = getOTelFilterOptions();
+  const sortOptions = getOTelFilterOptions(spanCategory);
   const urlParam = decodeScalar(
     location.query.showTransactions,
     TransactionFilterOptions.SLOW

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -27,13 +27,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   type EAPSpanResponse,
   ModuleName,
   SpanIndexedField,
 } from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {useServiceEntrySpansQuery} from 'sentry/views/performance/otlp/useServiceEntrySpansQuery';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
 // TODO: When supported, also add span operation breakdown as a field
@@ -104,7 +104,6 @@ const COLUMN_ORDER: Column[] = [
   },
 ];
 
-const LIMIT = 5;
 const PAGINATION_CURSOR_SIZE = 'xs';
 const CURSOR_NAME = 'serviceEntrySpansCursor';
 
@@ -147,32 +146,10 @@ export function ServiceEntrySpansTable({
     pageLinks,
     meta,
     error,
-  } = useEAPSpans(
-    {
-      search: eventViewQuery.formatString(),
-      fields: [
-        'span_id',
-        'user.id',
-        'user.email',
-        'user.username',
-        'user.ip',
-        'span.duration',
-        'trace',
-        'timestamp',
-        'replayId',
-        'profile.id',
-        'profiler.id',
-        'thread.id',
-        'precise.start_ts',
-        'precise.finish_ts',
-      ],
-      sorts: [selected.sort],
-      limit: LIMIT,
-      cursor,
-    },
-    'api.performance.service-entry-spans-table',
-    true
-  );
+  } = useServiceEntrySpansQuery({
+    query: eventViewQuery.formatString(),
+    sort: selected.sort,
+  });
 
   const consolidatedData = tableData?.map(row => {
     const user =

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -150,6 +150,8 @@ export function ServiceEntrySpansTable({
     query: eventViewQuery.formatString(),
     sort: selected.sort,
     transactionName,
+    p95,
+    selected,
   });
 
   const consolidatedData = tableData?.map(row => {

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -375,9 +375,8 @@ function getOTelFilterOptions(spanCategory?: string): DropdownOption[] {
     {
       sort: {kind: 'desc', field: 'timestamp'},
       value: TransactionFilterOptions.RECENT,
-      label: spanCategory
-        ? t('Recent %s Service Entry Spans', spanCategory)
-        : t('Recent Service Entry Spans'),
+      // The category does not apply to this option
+      label: t('Recent Service Entry Spans'),
     },
   ];
 }

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -55,6 +55,11 @@ export function useServiceEntrySpansQuery({
   // - Then make a second query to fetch the table data for these spans
   // - If no span category is selected, only one query is made to fetch the table data.
 
+  const categorizedSpanQueryFields: EAPSpanProperty[] = ['transaction.span_id'];
+  if (selected.value !== TransactionFilterOptions.RECENT) {
+    categorizedSpanQueryFields.push('sum(span.self_time)');
+  }
+
   const categorizedSpansQuery = new MutableSearch(
     `transaction:${transactionName} span.category:${spanCategoryUrlParam}`
   );
@@ -69,8 +74,13 @@ export function useServiceEntrySpansQuery({
   } = useEAPSpans(
     {
       search: categorizedSpansQuery,
-      fields: ['transaction.span_id', 'sum(span.self_time)'],
-      sorts: [{field: 'sum(span.self_time)', kind: sort.kind}],
+      fields: categorizedSpanQueryFields,
+      sorts: [
+        {
+          field: `${selected.value === TransactionFilterOptions.RECENT ? 'timestamp' : 'sum(span.self_time)'}`,
+          kind: sort.kind,
+        },
+      ],
       limit: LIMIT,
       cursor,
       pageFilters: selection,

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -1,23 +1,48 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Options = {
   query: string;
   sort: Sort;
+
+  transactionName: string;
 };
 
 const LIMIT = 5;
 const CURSOR_NAME = 'serviceEntrySpansCursor';
 
-export function useServiceEntrySpansQuery({query, sort}: Options) {
+export function useServiceEntrySpansQuery({query, transactionName, sort}: Options) {
   const location = useLocation();
   const spanCategoryUrlParam = decodeScalar(
     location.query?.[SpanIndexedField.SPAN_CATEGORY]
   );
   const cursor = decodeScalar(location.query?.[CURSOR_NAME]);
+  const {selection} = usePageFilters();
+
+  // If a span category is selected, we must query the data differently for this to work on the EAP dataset.
+  // - Make an initial query to fetch service entry spans with the highest cumulative durations of spans that have the span category.
+  // - Then make a second query to fetch the table data for these spans
+  // - If no span category is selected, only one query is made to fetch the table data.
+
+  const {data: categorizedSpanIds, isLoading: isCategorizedSpanIdsLoading} = useEAPSpans(
+    {
+      search: `transaction:${transactionName} span.category:${spanCategoryUrlParam}`,
+      fields: ['transaction.span_id', 'sum(span.self_time)'],
+      sorts: [{field: 'sum(span.self_time)', kind: 'desc'}],
+      limit: LIMIT,
+      cursor,
+      pageFilters: selection,
+      enabled: !!spanCategoryUrlParam,
+    },
+    'api.performance.service-entry-spans-table',
+    true
+  );
+
+  console.dir(categorizedSpanIds);
 
   const {data, isLoading, pageLinks, meta, error} = useEAPSpans(
     {
@@ -41,6 +66,7 @@ export function useServiceEntrySpansQuery({query, sort}: Options) {
       sorts: [sort],
       limit: LIMIT,
       cursor,
+      pageFilters: selection,
     },
     'api.performance.service-entry-spans-table',
     true

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -1,0 +1,56 @@
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {SpanIndexedField} from 'sentry/views/insights/types';
+
+type Options = {
+  query: string;
+  sort: Sort;
+};
+
+const LIMIT = 5;
+const CURSOR_NAME = 'serviceEntrySpansCursor';
+
+export function useServiceEntrySpansQuery({query, sort}: Options) {
+  const location = useLocation();
+  const spanCategoryUrlParam = decodeScalar(
+    location.query?.[SpanIndexedField.SPAN_CATEGORY]
+  );
+  const cursor = decodeScalar(location.query?.[CURSOR_NAME]);
+
+  const {data, isLoading, pageLinks, meta, error} = useEAPSpans(
+    {
+      search: query,
+      fields: [
+        'span_id',
+        'user.id',
+        'user.email',
+        'user.username',
+        'user.ip',
+        'span.duration',
+        'trace',
+        'timestamp',
+        'replayId',
+        'profile.id',
+        'profiler.id',
+        'thread.id',
+        'precise.start_ts',
+        'precise.finish_ts',
+      ],
+      sorts: [sort],
+      limit: LIMIT,
+      cursor,
+    },
+    'api.performance.service-entry-spans-table',
+    true
+  );
+
+  return {
+    data,
+    isLoading,
+    pageLinks,
+    meta,
+    error,
+  };
+}

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -92,10 +92,9 @@ export function useServiceEntrySpansQuery({
 
   const specificSpansQuery = new MutableSearch('');
   if (categorizedSpanIds && !isCategorizedSpanIdsLoading) {
-    let spanIdsString = categorizedSpanIds
+    const spanIdsString = categorizedSpanIds
       .map(datum => datum['transaction.span_id'])
       .join(',');
-    spanIdsString = spanIdsString.slice(0, -1);
     specificSpansQuery.addFilterValue('span_id', `[${spanIdsString}]`);
   }
 

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
-import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconFilter} from 'sentry/icons';

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -7,6 +7,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconFilter} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -26,9 +27,16 @@ const LIMIT = 10;
 const ALLOWED_CATEGORIES = ['http', 'db', 'browser', 'resource', 'ui'];
 
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
-  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
-  const {selection} = usePageFilters();
   const location = useLocation();
+  const spanCategoryUrlParam = decodeScalar(
+    location.query?.[SpanIndexedField.SPAN_CATEGORY]
+  );
+
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(
+    spanCategoryUrlParam
+  );
+
+  const {selection} = usePageFilters();
   const navigate = useNavigate();
 
   const query = new MutableSearch('');


### PR DESCRIPTION
Builds upon https://github.com/getsentry/sentry/pull/87857 

Allows the span category filters to work alongside the other filter options for the service entry spans table. For the time being, the logic works as follows:

- If no span category is selected, display the span samples in the same manner as usual
- If a span category is selected:
  - Make an initial query to fetch service entry spans with the highest cumulative durations (sum of span.self_time) for spans matching the selected category
  - Use the span IDs from this result to make a second query that fetches the complete span data for display in the table
  - The "Recent" filter option ignores span category selection and shows the most recent spans regardless of category
  - For the "Slow" filter option, the p95 duration filter is applied to spans within the selected category