### PR TITLE
fix(react19): Export our own ReducerAction

### DIFF
--- a/static/app/types/reducerAction.tsx
+++ b/static/app/types/reducerAction.tsx
@@ -1,0 +1,5 @@
+/**
+ * React 19 stopped exporting the ReducerAction type, so we need to define our own
+ */
+export type ReducerAction<R extends React.Reducer<any, any>> =
+  R extends React.Reducer<any, infer A> ? A : never;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
@@ -1,5 +1,6 @@
 import {createContext} from 'react';
 
+import type {ReducerAction} from 'sentry/types/reducerAction';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 import {makeCombinedReducers} from 'sentry/utils/useCombinedReducer';
 import type {
@@ -64,7 +65,7 @@ export type FlamegraphStateValue = [
 ];
 
 export type FlamegraphStateDispatch = React.Dispatch<
-  UndoableReducerAction<React.ReducerAction<FlamegraphReducer>>
+  UndoableReducerAction<ReducerAction<FlamegraphReducer>>
 >;
 
 export const FlamegraphStateValueContext = createContext<FlamegraphStateValue | null>(

--- a/static/app/utils/useCombinedReducer.tsx
+++ b/static/app/utils/useCombinedReducer.tsx
@@ -1,5 +1,7 @@
-import type {Reducer, ReducerAction} from 'react';
+import type {Reducer} from 'react';
 import {useReducer} from 'react';
+
+import type {ReducerAction} from 'sentry/types/reducerAction';
 
 type ReducersObject<S = any, A = any> = {
   [K in keyof S]: Reducer<S, A>;

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -1,12 +1,7 @@
 import type React from 'react';
-import {
-  type ReducerAction,
-  type ReducerState,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {type ReducerState, useCallback, useMemo, useRef, useState} from 'react';
+
+import type {ReducerAction} from 'sentry/types/reducerAction';
 
 /**
  * A hook that wraps a reducer to provide an observer pattern for the state.
@@ -18,11 +13,11 @@ import {
  */
 
 export interface DispatchingReducerMiddleware<R extends React.Reducer<any, any>> {
-  ['before action']: (S: Readonly<ReducerState<R>>, A: React.ReducerAction<R>) => void;
+  ['before action']: (S: Readonly<ReducerState<R>>, A: ReducerAction<R>) => void;
   ['before next state']: (
     P: Readonly<React.ReducerState<R>>,
     S: Readonly<React.ReducerState<R>>,
-    A: React.ReducerAction<R>
+    A: ReducerAction<R>
   ) => void;
 }
 

--- a/static/app/utils/useUndoableReducer.spec.tsx
+++ b/static/app/utils/useUndoableReducer.spec.tsx
@@ -153,20 +153,14 @@ describe('makeUndoableReducer', () => {
     const simpleReducer = (state: number, action: {type: 'add'} | {type: 'subtract'}) =>
       action.type === 'add' ? state + 1 : state - 1;
 
-    const {result} = renderHook(
-      (args: Parameters<typeof useReducer>) => useReducer(args[0], args[1]),
-      {
-        initialProps: [
-          makeUndoableReducer(makeCombinedReducers({simple: simpleReducer})),
-          {
-            previous: undefined,
-            current: {
-              simple: 0,
-            },
-            next: undefined,
-          },
-        ],
-      }
+    const {result} = renderHook(() =>
+      useReducer(makeUndoableReducer(makeCombinedReducers({simple: simpleReducer})), {
+        previous: undefined,
+        current: {
+          simple: 0,
+        },
+        next: undefined,
+      })
     );
 
     act(() => result.current[1]({type: 'add'}));
@@ -184,20 +178,14 @@ describe('makeUndoableReducer', () => {
       math: (state: number, action: {type: 'add'} | {type: 'subtract'}) =>
         action.type === 'add' ? state + 1 : state - 1,
     });
-    const {result} = renderHook(
-      (args: Parameters<typeof useReducer>) => useReducer(args[0], args[1]),
-      {
-        initialProps: [
-          makeUndoableReducer(combinedReducers),
-          {
-            previous: undefined,
-            current: {
-              math: 0,
-            },
-            next: undefined,
-          },
-        ],
-      }
+    const {result} = renderHook(() =>
+      useReducer(makeUndoableReducer(combinedReducers), {
+        previous: undefined,
+        current: {
+          math: 0,
+        },
+        next: undefined,
+      })
     );
 
     act(() => result.current[1]({type: 'add'}));

--- a/static/app/utils/useUndoableReducer.tsx
+++ b/static/app/utils/useUndoableReducer.tsx
@@ -1,5 +1,7 @@
-import type {ReducerAction, ReducerState} from 'react';
+import type {ReducerState} from 'react';
 import {useMemo, useReducer} from 'react';
+
+import type {ReducerAction} from 'sentry/types/reducerAction';
 
 export type UndoableNode<S> = {
   current: S;


### PR DESCRIPTION
The types for react 19 remove the ReducerAction type and change reducer types a little and it errors in a few places.

part of https://github.com/getsentry/frontend-tsc/issues/68