### PR TITLE
fix(issues): Fix sidebar disappearing

### DIFF
--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -101,7 +101,7 @@ const StyledLayoutBody = styled('div')<{
 }>`
   display: grid;
   background-color: ${p => p.theme.background};
-  grid-template-columns: ${p => (p.sidebarOpen ? 'minmax(100px, auto) 325px' : '1fr')};
+  grid-template-columns: ${p => (p.sidebarOpen ? 'minmax(100px, 100%) 325px' : '100%')};
 
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     display: flex;


### PR DESCRIPTION
All events with `auto` or `1fr` grows too big

Before: 
<img width="199" alt="Screenshot 2025-03-25 at 5 00 06 PM" src="https://github.com/user-attachments/assets/b5d13bd3-aedc-43e4-bb2f-26d6a1dd1e1a" />

After:
<img width="160" alt="Screenshot 2025-03-25 at 5 00 11 PM" src="https://github.com/user-attachments/assets/4c21c1c0-1804-4002-9e76-165ec5af2bb9" />
