### PR TITLE
fix(insights): Add types and error handling to sample series hover

### DIFF
--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -44,7 +44,25 @@ export type EChartEventHandler<P> = (params: P, instance: ECharts) => void;
 
 export type EChartChartReadyHandler = (instance: ECharts) => void;
 
-export type EChartHighlightHandler = EChartEventHandler<any>;
+/**
+ * Incomplete type for the "highlight" event handler in ECharts. This is taken
+ * from a combination of the ECharts documentation page, and data seen in running code
+ * in handlers attached to line charts and pie charts.
+ */
+export interface EChartsHighlightEventParam {
+  type: 'highlight';
+  batch?: Array<{
+    dataIndex: number;
+    dataIndexInside: number;
+    escapeConnect: boolean;
+    notBlur: boolean;
+    seriesIndex: number;
+    type: string;
+  }>;
+  name?: string;
+}
+
+export type EChartHighlightHandler = EChartEventHandler<EChartsHighlightEventParam>;
 
 /**
  * XXX: These are incomplete types and can also vary depending on the component type

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -319,7 +319,7 @@ export function CacheSamplePanel() {
               onHighlight={highlights => {
                 const firstHighlight = highlights[0];
 
-                if (!firstHighlight) {
+                if (!firstHighlight || !firstHighlight.dataPoint) {
                   setHighlightedSpanId(undefined);
                   return;
                 }

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -4,6 +4,7 @@ import type {
   EChartHighlightHandler,
   Series,
 } from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -145,8 +146,20 @@ function DurationChart({
     }
   };
 
-  const handleChartHighlight: EChartHighlightHandler = e => {
-    const {seriesIndex} = e.batch[0];
+  const handleChartHighlight: EChartHighlightHandler = event => {
+    // ignore mouse hovering over the chart legend
+    if (!event.batch) {
+      return;
+    }
+
+    const firstEventData = event.batch[0];
+
+    if (!defined(firstEventData)) {
+      return;
+    }
+
+    const {seriesIndex} = firstEventData;
+
     const isSpanSample =
       seriesIndex > 1 && seriesIndex < 2 + sampledSpanDataSeries.length;
     if (isSpanSample && onMouseOverSample) {

--- a/static/app/views/insights/http/components/charts/durationChartWithSamples.tsx
+++ b/static/app/views/insights/http/components/charts/durationChartWithSamples.tsx
@@ -1,6 +1,11 @@
 import type {ComponentProps} from 'react';
 
-import type {EChartHighlightHandler, Series} from 'sentry/types/echarts';
+import type {
+  EChartHighlightHandler,
+  EChartsHighlightEventParam,
+  Series,
+  SeriesDataUnit,
+} from 'sentry/types/echarts';
 import {AVG_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
@@ -9,15 +14,13 @@ import {CHART_HEIGHT} from 'sentry/views/insights/http/settings';
 
 interface Props {
   isLoading: boolean;
+  onHighlight: (
+    data: Array<{dataPoint: SeriesDataUnit | undefined; series: Series}>,
+    event: EChartsHighlightEventParam
+  ) => void;
   series: Series[];
   error?: Error | null;
-  onHighlight?: (highlights: Highlight[], event: Event) => void; // TODO: Correctly type this
   scatterPlot?: ComponentProps<typeof Chart>['scatterPlot'];
-}
-
-interface Highlight {
-  dataPoint: Series['data'][number];
-  series: Series[];
 }
 
 export function DurationChartWithSamples({
@@ -37,13 +40,13 @@ export function DurationChartWithSamples({
     // TODO: Gross hack. Even though `scatterPlot` is a separate prop, it's just an array of `Series` that gets appended to the main series. To find the point that was hovered, we re-construct the correct series order. It would have been cleaner to just pass the scatter plot as its own, single series
     const allSeries = [...series, ...(scatterPlot ?? [])];
 
-    const highlightedDataPoints = event.batch.map((batch: any) => {
-      let {seriesIndex} = batch;
-      const {dataIndex} = batch;
+    const highlightedDataPoints = event.batch.map(eventData => {
+      let {seriesIndex} = eventData;
+      const {dataIndex} = eventData;
       // TODO: More hacks. The Chart component partitions the data series into a complete and incomplete series. Wrap the series index to work around overflowing index.
       seriesIndex = seriesIndex % allSeries.length;
 
-      const highlightedSeries = allSeries?.[seriesIndex];
+      const highlightedSeries = allSeries?.[seriesIndex]!;
       const highlightedDataPoint = highlightedSeries?.data?.[dataIndex];
 
       return {series: highlightedSeries, dataPoint: highlightedDataPoint};

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -396,7 +396,7 @@ export function HTTPSamplesPanel() {
                   onHighlight={highlights => {
                     const firstHighlight = highlights[0];
 
-                    if (!firstHighlight) {
+                    if (!firstHighlight || !firstHighlight.dataPoint) {
                       setHighlightedSpanId(undefined);
                       return;
                     }

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -289,7 +289,7 @@ export function MessageSpanSamplesPanel() {
               onHighlight={highlights => {
                 const firstHighlight = highlights[0];
 
-                if (!firstHighlight) {
+                if (!firstHighlight || !firstHighlight.dataPoint) {
                   setHighlightedSpanId(undefined);
                   return;
                 }


### PR DESCRIPTION
While working on sample plottables for the new charts, I added some slightly better types to chart highlight events. This immediately revealed some wild hacks and broken behaviour in some Insights charts. I will be ripping those out _very soon_ but in the meantime, this PR adds some more error handling and fixes some off-by-series-count errors.
