### PR TITLE
ref(feedback): hide redundant trace.id from search

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -36,6 +36,8 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
+  // Prefer issue platform 'trace' which has a better description. 'trace.id' tag is for display purposes.
+  'trace.id',
 ];
 
 const getFeedbackFieldDefinition = (key: string) => getFieldDefinition(key, 'feedback');

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -36,7 +36,7 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
-  // Prefer issue platform 'trace' which has a better description. 'trace.id' tag is for display purposes.
+  // Prefer issues 'trace' field which has a better description. 'trace.id' tag is for display purposes only.
   'trace.id',
 ];
 


### PR DESCRIPTION
This tag is attached for display purposes in the UI but we already have a prop for searching it.
![SCR-20250325-mool](https://github.com/user-attachments/assets/cdcb32ad-0593-4ec3-8c8d-44d647850ee7)
