### PR TITLE
fix(aci milestone 3): workflow name bug fixes

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -11,7 +11,7 @@ ACTION_TYPE_TO_STRING = {
     AlertRuleTriggerAction.Type.SLACK.value: "Slack",
     AlertRuleTriggerAction.Type.MSTEAMS.value: "Microsoft Teams",
     AlertRuleTriggerAction.Type.OPSGENIE.value: "Opsgenie",
-    AlertRuleTriggerAction.Type.DISCORD.valud: "Discord",
+    AlertRuleTriggerAction.Type.DISCORD.value: "Discord",
 }
 
 

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -11,6 +11,7 @@ ACTION_TYPE_TO_STRING = {
     AlertRuleTriggerAction.Type.SLACK.value: "Slack",
     AlertRuleTriggerAction.Type.MSTEAMS.value: "Microsoft Teams",
     AlertRuleTriggerAction.Type.OPSGENIE.value: "Opsgenie",
+    AlertRuleTriggerAction.Type.DISCORD.valud: "Discord",
 }
 
 
@@ -27,6 +28,8 @@ def get_action_description(action: AlertRuleTriggerAction) -> str:
             elif action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
                 action_target_team = cast(Team, action.target)
                 return "Email #" + action_target_team.slug
+        else:
+            return "Email [removed]"
     elif action.type == AlertRuleTriggerAction.Type.SENTRY_APP.value:
         return f"Notify {action.target_display}"
 


### PR DESCRIPTION
- If the action is an email action and we can't find the org member/team (if the member has been removed/the team has been deleted), then we should return a placeholder action description
- Add Discord to the action type to string map, since it was missing