### PR TITLE
fix(react19): Remove context from constructor of plugins

### DIFF
--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -56,8 +56,8 @@ type State = {
 } & PluginComponentBase['state'];
 
 class IssueActions extends PluginComponentBase<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     this.createIssue = this.onSave.bind(this, this.createIssue.bind(this));
     this.linkIssue = this.onSave.bind(this, this.linkIssue.bind(this));

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -39,8 +39,8 @@ class PluginSettings<
   P extends Props = Props,
   S extends State = State,
 > extends PluginComponentBase<P, S> {
-  constructor(props: P, context: any) {
-    super(props, context);
+  constructor(props: P) {
+    super(props);
 
     Object.assign(this.state, {
       fieldList: null,

--- a/static/app/plugins/jira/components/settings.tsx
+++ b/static/app/plugins/jira/components/settings.tsx
@@ -25,8 +25,8 @@ const PAGE_FIELD_LIST = {
 };
 
 class Settings extends DefaultSettings<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     Object.assign(this.state, {
       page: 0,

--- a/static/app/plugins/pluginComponentBase.tsx
+++ b/static/app/plugins/pluginComponentBase.tsx
@@ -22,12 +22,12 @@ type Props = Record<string, unknown>;
 
 type State = {state: FormState};
 
-class PluginComponentBase<
+abstract class PluginComponentBase<
   P extends Props = Props,
   S extends State = State,
 > extends Component<P, S> {
-  constructor(props: P, context: any) {
-    super(props, context);
+  constructor(props: P) {
+    super(props);
 
     [
       'onLoadSuccess',


### PR DESCRIPTION
These components have no context. Errors in react 19

part of https://github.com/getsentry/frontend-tsc/issues/68
