### PR TITLE
fix(react19): Remove context from Subscriptions component

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -26,8 +26,7 @@ export default class Subscriptions extends Component<Props> {
     webhookDisabled: false,
   };
 
-  constructor(props: Props, context: any) {
-    super(props, context);
+  UNSAFE_componentWillMount(): void {
     this.context.form.setValue('events', this.props.events);
   }
 


### PR DESCRIPTION
React 19 types really don't like using context in the constructor. Instead use UNSAFE_componentWillMount which should also be fairly early in the lifecycle.

Similar to #87670

part of https://github.com/getsentry/frontend-tsc/issues/68
