### PR TITLE
ref(releases): remove usage of newGroups in releases (FE)

### DIFF
--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -113,7 +113,9 @@ function VersionHoverCard({
           <Flex gap={space(2)} justify="space-between">
             <div>
               <h6>{t('New Issues')}</h6>
-              <CountSince>{release.newGroups}</CountSince>
+              <CountSince>
+                {release.projects.reduce((acc, proj) => acc + proj.newGroups, 0)}
+              </CountSince>
             </div>
             <div>
               <h6 style={{textAlign: 'right'}}>{t('Date Created')}</h6>

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -92,7 +92,6 @@ interface ReleaseData {
   firstEvent: string;
   lastEvent: string;
   // TODO(ts)
-  newGroups: number;
   versionInfo: VersionInfo;
   adoptionStages?: Record<
     string,

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -144,7 +144,6 @@ export type ReleaseMeta = {
   commitFilesChanged: number;
   deployCount: number;
   isArtifactBundle: boolean;
-  newGroups: number;
   projects: ReleaseProject[];
   releaseFileCount: number;
   released: string;

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -91,7 +91,6 @@ interface ReleaseData {
   fileCount: number | null;
   firstEvent: string;
   lastEvent: string;
-  // TODO(ts)
   versionInfo: VersionInfo;
   adoptionStages?: Record<
     string,

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
@@ -116,7 +116,6 @@ describe('Quick Context', function () {
           status: ReleaseStatus.ACTIVE,
           commitCount: 4,
           lastCommit: mockedCommit,
-          newGroups: 21,
           authors: [mockedUser1, mockedUser2],
         }),
       });

--- a/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
@@ -22,7 +22,6 @@ const mockedReleaseWithHealth = ReleaseFixture({
   status: ReleaseStatus.ACTIVE,
   commitCount: 4,
   lastCommit: mockedCommit,
-  newGroups: 21,
   authors: [mockedUser1, mockedUser2],
 });
 

--- a/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
@@ -1,6 +1,7 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
+import {ReleaseProjectFixture} from 'sentry-fixture/releaseProject';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
@@ -23,6 +24,12 @@ const mockedReleaseWithHealth = ReleaseFixture({
   commitCount: 4,
   lastCommit: mockedCommit,
   authors: [mockedUser1, mockedUser2],
+  projects: [
+    ReleaseProjectFixture({
+      newGroups: 21,
+      hasHealthData: false,
+    }),
+  ],
 });
 
 const renderReleaseContext = () => {

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -166,7 +166,9 @@ function ReleaseContext(props: BaseContextProps) {
             <ContextHeader>
               <ContextTitle>{t('New Issues')}</ContextTitle>
             </ContextHeader>
-            <ContextBody>{data.newGroups}</ContextBody>
+            <ContextBody>
+              {data.projects.reduce((acc, proj) => acc + proj.newGroups, 0)}
+            </ContextBody>
           </div>
         </ContextRow>
       </ReleaseContextContainer>

--- a/static/app/views/releases/drawer/releasesDrawerDetails.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerDetails.tsx
@@ -61,7 +61,10 @@ export function ReleasesDrawerDetails({release, projectId}: ReleasesDrawerDetail
           <TitleWithBadge>
             <span>{t('New Issues')}</span>
             <Badge type="default">
-              {isLoadingMeta ? '-' : (releaseMeta?.newGroups ?? '0')}
+              {isLoadingMeta
+                ? '-'
+                : (releaseMeta?.projects.reduce((acc, proj) => acc + proj.newGroups, 0) ??
+                  '0')}
             </Badge>
           </TitleWithBadge>
         }

--- a/tests/js/fixtures/release.ts
+++ b/tests/js/fixtures/release.ts
@@ -9,7 +9,6 @@ export function ReleaseFixture(
   healthParams?: Health
 ): ReleaseWithHealth {
   return {
-    newGroups: 0,
     commitCount: 0,
     url: '',
     data: {},

--- a/tests/js/fixtures/releaseMeta.ts
+++ b/tests/js/fixtures/releaseMeta.ts
@@ -30,7 +30,6 @@ export function ReleaseMetaFixture(params: Partial<ReleaseMeta> = {}): ReleaseMe
         platforms: ['javascript'],
       },
     ],
-    newGroups: 0,
     deployCount: 1,
     commitCount: 2,
     released: '2020-03-23T01:02:30Z',

--- a/tests/js/fixtures/releaseProject.ts
+++ b/tests/js/fixtures/releaseProject.ts
@@ -1,8 +1,9 @@
+import { HealthFixture } from 'sentry-fixture/health';
 import type {ReleaseProject} from 'sentry/types/release';
 
 export function ReleaseProjectFixture(
   params: Partial<ReleaseProject> = {}
-): ReleaseProject {
+): Required<ReleaseProject> {
   return {
     id: 2,
     name: 'Project Name',
@@ -11,6 +12,7 @@ export function ReleaseProjectFixture(
     platforms: ['android'],
     slug: 'project-slug',
     hasHealthData: false,
+    healthData: HealthFixture(),
     ...params,
   };
 }


### PR DESCRIPTION
the `release.new_groups` column is going to get deleted soon (it's deprecated):

https://github.com/getsentry/sentry/blob/b88166941846ce4fdb4e2001453e421b41ba7e10/src/sentry/models/release.py#L210-L211

i'm putting out PRs first to remove their usages in sentry. note that the `ReleaseProject` model `newGroups` property is not deprecated and is still readable. the only instances deleted should be those based on the `Release` model.

corresponding BE PR: https://github.com/getsentry/sentry/pull/87943

following this guide: https://develop.sentry.dev/backend/application-domains/database-migrations/#deleting-columns

relates to https://github.com/getsentry/sentry/issues/87322