### PR TITLE
fix(feedback): use feedback field defns for search suggestions

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -208,6 +208,7 @@ export default function FeedbackSearch() {
   return (
     <SearchQueryBuilder
       initialQuery={decodeScalar(locationQuery.query, '')}
+      fieldDefinitionGetter={getFeedbackFieldDefinition}
       filterKeys={filterKeys}
       filterKeySections={filterKeySections}
       getTagValues={getTagValues}


### PR DESCRIPTION
When migrating to the new search bar we forgot this prop. Without it we're defaulting to [event field descriptions](https://github.com/getsentry/sentry/blob/77a0ca36442d198437197ece52f4d8f39ef34360/static/app/utils/fields/index.ts#L2533-L2535)

Before
![Screenshot 2025-03-25 at 2 49 00 PM](https://github.com/user-attachments/assets/97b1e892-536c-450e-b268-500ac26971a3)

AFter (sorry ss is different zoom)
![Screenshot 2025-03-25 at 2 49 15 PM](https://github.com/user-attachments/assets/7a2ad271-8e4b-401e-96a8-2d99119a478f)
