### PR TITLE
feat(eap-spans): add alias for span.system

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -289,6 +289,12 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.span_ops.ops.ui",
             search_type="millisecond",
         ),
+        ResolvedAttribute(
+            public_alias="span.system",
+            internal_name="db.system",
+            search_type="string",
+            secondary_alias=True,
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("environment"),
         simple_sentry_field("messaging.destination.name"),


### PR DESCRIPTION
Currently the db module relies on `span.system` for the `postgres`, `mongodb`, `mysql`, selector

In the long term we'll use `db.system` for this, however to support db module with eap today, we need to alias db.system to span.system