### PR TITLE
chore(anomaly detection): Add even more logs

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -215,11 +215,20 @@ class SubscriptionProcessor:
         return threshold
 
     def get_comparison_aggregation_value(
-        self, subscription_update: QuerySubscriptionUpdate
+        self, subscription_update: QuerySubscriptionUpdate, rule: AlertRule | None = None
     ) -> float | None:
         # NOTE (mifu67): we create this helper because we also use it in the new detector processing flow
         aggregation_value = get_aggregation_value_helper(subscription_update)
         if self.alert_rule.comparison_delta is None:
+            if rule:
+                logger.info(
+                    "Returning aggregation value",
+                    extra={
+                        "result": subscription_update,
+                        "aggregation_value": aggregation_value,
+                        "rule_id": rule.id,
+                    },
+                )
             return aggregation_value
 
         # For comparison alerts run a query over the comparison period and use it to calculate the
@@ -340,13 +349,15 @@ class SubscriptionProcessor:
             self.reset_trigger_counts()
         return aggregation_value
 
-    def get_aggregation_value(self, subscription_update: QuerySubscriptionUpdate) -> float | None:
+    def get_aggregation_value(
+        self, subscription_update: QuerySubscriptionUpdate, rule: AlertRule | None = None
+    ) -> float | None:
         if self.subscription.snuba_query.dataset == Dataset.Metrics.value:
             aggregation_value = self.get_crash_rate_alert_metrics_aggregation_value(
                 subscription_update
             )
         else:
-            aggregation_value = self.get_comparison_aggregation_value(subscription_update)
+            aggregation_value = self.get_comparison_aggregation_value(subscription_update, rule)
 
         return aggregation_value
 
@@ -410,7 +421,7 @@ class SubscriptionProcessor:
                 },
             )
 
-        aggregation_value = self.get_aggregation_value(subscription_update)
+        aggregation_value = self.get_aggregation_value(subscription_update, self.alert_rule)
 
         has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -39,11 +39,16 @@ def get_anomaly_data_from_seer(
         "organization_id": subscription.project.organization.id,
         "project_id": subscription.project_id,
         "alert_rule_id": alert_rule.id,
+        "threshold_type": alert_rule.threshold_type,
+        "sensitivity": alert_rule.sensitivity,
+        "seasonality": alert_rule.seasonality,
+        "aggregation_value": aggregation_value,
     }
     if not snuba_query:
         logger.warning("Snuba query is empty", extra=extra_data)
         return None
 
+    extra_data["dataset"] = snuba_query.dataset
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists
     if (
         alert_rule.threshold_type is None
@@ -51,14 +56,10 @@ def get_anomaly_data_from_seer(
         or not alert_rule.seasonality
         or not snuba_query.time_window
     ):
+        logger.info("Missing anomaly detection rule data", extra=extra_data)
         return None
 
     if aggregation_value is None:
-        extra_data["threshold_type"] = alert_rule.threshold_type
-        extra_data["sensitivity"] = alert_rule.sensitivity
-        extra_data["seasonality"] = alert_rule.seasonality
-        extra_data["aggregation_value"] = aggregation_value
-
         metrics.incr("anomaly_detection.aggregation_value.none")
         logger.warning("Aggregation value is none", extra=extra_data)
         aggregation_value = 0
@@ -79,13 +80,15 @@ def get_anomaly_data_from_seer(
         config=anomaly_detection_config,
         context=context,
     )
-    extra_data["dataset"] = snuba_query.dataset
     try:
-        logger.info("Sending subscription update data to Seer", extra=extra_data)
+        data = json.dumps(detect_anomalies_request).encode("utf-8")
+        update_log_data = extra_data.copy()
+        update_log_data["data"] = data
+        logger.info("Sending subscription update data to Seer", extra=update_log_data)
         response = make_signed_seer_api_request(
             SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             SEER_ANOMALY_DETECTION_ENDPOINT_URL,
-            json.dumps(detect_anomalies_request).encode("utf-8"),
+            data,
         )
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -797,11 +797,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         from urllib3.exceptions import TimeoutError
 
         mock_seer_request.side_effect = TimeoutError
+        aggregation_value = 10
         result = get_anomaly_data_from_seer(
             alert_rule=processor.alert_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
-            aggregation_value=10,
+            aggregation_value=aggregation_value,
         )
         timeout_extra = {
             "subscription_id": self.sub.id,
@@ -809,6 +810,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             "organization_id": self.sub.project.organization.id,
             "project_id": self.sub.project_id,
             "alert_rule_id": rule.id,
+            "threshold_type": rule.threshold_type,
+            "sensitivity": rule.sensitivity,
+            "seasonality": rule.seasonality,
+            "aggregation_value": aggregation_value,
         }
         mock_logger.warning.assert_called_with(
             "Timeout error when hitting anomaly detection endpoint",
@@ -967,11 +972,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     def test_seer_call_bad_status(self, mock_logger, mock_seer_request):
         processor = SubscriptionProcessor(self.sub)
         mock_seer_request.return_value = HTTPResponse(status=403)
+        aggregation_value = 10
         result = get_anomaly_data_from_seer(
             alert_rule=self.dynamic_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
-            aggregation_value=10,
+            aggregation_value=aggregation_value,
         )
         mock_logger.info.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
@@ -981,6 +987,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 "organization_id": self.organization.id,
                 "project_id": self.project.id,
                 "alert_rule_id": self.rule.id,
+                "threshold_type": self.rule.threshold_type,
+                "sensitivity": self.rule.sensitivity,
+                "seasonality": self.rule.seasonality,
+                "aggregation_value": aggregation_value,
                 "response_data": None,
             },
         )


### PR DESCRIPTION
While trying to debug https://github.com/getsentry/seer/issues/2143 I hit a wall - it doesn't seem possible for us to have a `None` value so I'm adding a bunch of logs to validate that. 