### PR TITLE
fix(stories): don't make every keystroke push to the history stack

### DIFF
--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -52,9 +52,12 @@ export default function Stories() {
   const navigate = useNavigate();
   const onSearchInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        query: {...location.query, query: e.target.value, name: location.query.name},
-      });
+      navigate(
+        {
+          query: {...location.query, query: e.target.value, name: location.query.name},
+        },
+        {replace: true}
+      );
     },
     [location.query, navigate]
   );


### PR DESCRIPTION
pushing to the history stack on every keystroke means we can't use the back button to navigate between stories we've visited, as every click on the back button will just remove one character from the search input

using `replace` makes sure we will only get a new history entry when we actually click on a story
