### PR TITLE
feat(breadcrumbs): Don't show `__span` property in breadcrumbs

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -67,9 +67,16 @@ export default function BreadcrumbItemContent({
       )}
     </BreadcrumbText>
   ) : null;
-  const defaultData = defined(bc.data) ? (
+
+  const cleanedBreadcrumbData = cleanBreadcrumbData(bc.data);
+
+  const defaultData = defined(cleanedBreadcrumbData) ? (
     <Timeline.Data>
-      <StructuredData value={bc.data} meta={meta?.data} {...structuredDataProps} />
+      <StructuredData
+        value={cleanedBreadcrumbData}
+        meta={meta?.data}
+        {...structuredDataProps}
+      />
     </Timeline.Data>
   ) : null;
 
@@ -124,7 +131,12 @@ function HTTPCrumbContent({
   structuredDataProps: typeof DEFAULT_STRUCTURED_DATA_PROPS;
   meta?: Record<string, any>;
 }) {
-  const {method, url, status_code: statusCode, ...otherData} = breadcrumb?.data ?? {};
+  const {
+    method,
+    url,
+    status_code: statusCode,
+    ...otherData
+  } = cleanBreadcrumbData(breadcrumb?.data) ?? {};
   const isValidUrl = !meta && defined(url) && isUrl(url);
   return (
     <Fragment>
@@ -206,6 +218,26 @@ function ExceptionCrumbContent({
       ) : null}
     </Fragment>
   );
+}
+
+function cleanBreadcrumbData<B extends Record<string, any> | undefined | null>(
+  breadcrumbData: B
+): B {
+  if (!breadcrumbData) {
+    return breadcrumbData;
+  }
+
+  const cleanedBreadcrumbData = {...breadcrumbData};
+
+  // The JS SDK emits the __span property since forever (3+ years).
+  // Originally it was introduced to potentially be able to go from the breadcrumb to a particular span within a trace.
+  // Up until now, this link wasn't built. Showing the span property is extremely noisy within the interface so we hide it.
+  // We can at any point in time use this data again to link to a trace, however, to be able to link to a trace we need to be sure that the trace actually exists.
+  if ('__span' in cleanedBreadcrumbData) {
+    delete cleanedBreadcrumbData.__span;
+  }
+
+  return cleanedBreadcrumbData;
 }
 
 const Link = styled('a')`


### PR DESCRIPTION
Hides the `__span` property from breadcrumbs because it is useless.

The SDK emits this property for over 3 years now. It was originally introduced to be able to link from breadcrumbs to specific spans within a trace. This link was never built and the property has been polluting the issues page ever since.

Before

![Screenshot 2025-03-26 at 14 43 42](https://github.com/user-attachments/assets/f5de0b76-ed66-4f2c-9b6c-092ceac22d80)

After: 

![Screenshot 2025-03-26 at 14 44 06](https://github.com/user-attachments/assets/449aed9b-4e57-4776-bab7-4a8ea3364fee)

