### PR TITLE
feat(insights): implement `opportunity_score` function

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -181,7 +181,6 @@ def opportunity_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
 
     weight = WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[web_vital]
 
-    # TODO: We should be multiplying by the weight in the formula, but we can't until https://github.com/getsentry/eap-planning/issues/202
     return Column.BinaryFormula(
         left=Column(formula=score_ratio),
         op=Column.BinaryFormula.OP_MULTIPLY,

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -4,6 +4,7 @@ from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
     AttributeConditionalAggregation,
 )
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -28,6 +29,7 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.constants import RESPONSE_CODE_MAP
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
 from sentry.search.eap.utils import literal_validator
+from sentry.search.events.constants import WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS
 
 
 def get_total_span_count(settings: ResolverSettings) -> Column:
@@ -149,8 +151,7 @@ def opportunity_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
     score_attribute = cast(AttributeKey, args[0])
     ratio_attribute = transform_vital_score_to_ratio([score_attribute])
 
-    # TODO: We should be multiplying by the weight in the formula, but we can't until https://github.com/getsentry/eap-planning/issues/202
-    return Column.BinaryFormula(
+    score_ratio = Column.BinaryFormula(
         left=Column(
             conditional_aggregation=AttributeConditionalAggregation(
                 aggregate=Function.FUNCTION_COUNT,
@@ -172,6 +173,19 @@ def opportunity_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
                 extrapolation_mode=extrapolation_mode,
             )
         ),
+    )
+    web_vital = score_attribute.name.split(".")[-1]
+
+    if web_vital == "total":
+        return score_ratio
+
+    weight = WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[web_vital]
+
+    # TODO: We should be multiplying by the weight in the formula, but we can't until https://github.com/getsentry/eap-planning/issues/202
+    return Column.BinaryFormula(
+        left=Column(formula=score_ratio),
+        op=Column.BinaryFormula.OP_MULTIPLY,
+        right=Column(literal=LiteralValue(val_double=weight)),
     )
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 import urllib3
 
-from sentry.search.events.constants import WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS
 from sentry.testutils.helpers import parse_link_header
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
@@ -3201,14 +3200,11 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             }
         )
 
-        lcp_score = (
-            0.27 / WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS["lcp"]
-        )  # TODO: we should multiplying by the weight in the formula, but we can't until https://github.com/getsentry/eap-planning/issues/202
         assert response.status_code == 200, response.content
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        self.assertAlmostEqual(data[0]["opportunity_score(measurements.score.lcp)"], lcp_score)
+        self.assertAlmostEqual(data[0]["opportunity_score(measurements.score.lcp)"], 0.27)
         assert data[0]["opportunity_score(measurements.score.total)"] == 1.57
         assert meta["dataset"] == self.dataset
 


### PR DESCRIPTION
We now have multiplication! This implements the remaining of the `opportunity_score` function
closes https://github.com/getsentry/team-visibility/issues/41