### PR TITLE
fix(schema-hints): Virtualize tag list in drawer

### DIFF
--- a/static/app/views/explore/components/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHintsDrawer.tsx
@@ -33,7 +33,6 @@ function SchemaHintsDrawer({
 }: SchemaHintsDrawerProps) {
   const organization = useOrganization();
   const [searchQuery, setSearchQuery] = useState('');
-  // const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const selectedFilterKeys = useMemo(() => {
@@ -154,7 +153,7 @@ function SchemaHintsDrawer({
   return (
     <Fragment>
       <DrawerHeader hideBar />
-      <DrawerBody style={{height: '100%'}}>
+      <StyledDrawerBody>
         <HeaderContainer>
           <SchemaHintsHeader>{t('Filter Attributes')}</SchemaHintsHeader>
           <StyledInputGroup>
@@ -186,7 +185,7 @@ function SchemaHintsDrawer({
             </AllItemsContainer>
           </ScrollContainer>
         </StyledMultipleCheckbox>
-      </DrawerBody>
+      </StyledDrawerBody>
     </Fragment>
   );
 }
@@ -211,6 +210,10 @@ export const useSchemaHintsOnLargeScreen = () => {
 
 const SchemaHintsHeader = styled('h4')`
   margin: 0;
+`;
+
+const StyledDrawerBody = styled(DrawerBody)`
+  height: 100%;
 `;
 
 const HeaderContainer = styled('div')`


### PR DESCRIPTION
The schema hints drawer was really slow in terms of rendering and searching. One of the reasons was because there were so many tags that were being shown and rendered all at once. I've virtualized the list so that only the hints that fit in the drawer are rendered. This has made the drawer a little faster and the searching _way_ faster! (Side note: I am aware that selecting a list item is not functioning properly, I am working on a fix for that).