### PR TITLE
chore: use signal.send_robust() instead of signal.send() in post_save signal

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -612,7 +612,7 @@ def process_group_resolution(
     group.substatus = None
     group.resolved_at = now
     if affected and not options.get("groups.enable-post-update-signal"):
-        post_save.send(
+        post_save.send_robust(
             sender=Group,
             instance=group,
             created=False,

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -98,7 +98,7 @@ def update(instance: BaseModel, using: str | None = None, **kwargs: Any) -> int:
     for k, v in kwargs.items():
         setattr(instance, k, _handle_value(instance, v))
     if affected == 1:
-        post_save.send(
+        post_save.send_robust(
             sender=instance.__class__,
             instance=instance,
             created=False,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1619,7 +1619,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             sender="handle_regression",
         )
         if not options.get("groups.enable-post-update-signal"):
-            post_save.send(
+            post_save.send_robust(
                 sender=Group,
                 instance=group,
                 created=False,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -161,7 +161,7 @@ def create_incident(
             IncidentProject.objects.bulk_create(incident_projects)
             # `bulk_create` doesn't send `post_save` signals, so we manually fire them here.
             for incident_project in incident_projects:
-                post_save.send(
+                post_save.send_robust(
                     sender=type(incident_project), instance=incident_project, created=True
                 )
 

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -349,7 +349,7 @@ def manage_issue_states(
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ESCALATING
             if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
+                post_save.send_robust(
                     sender=Group,
                     instance=group,
                     created=False,
@@ -390,7 +390,7 @@ def manage_issue_states(
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
             if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
+                post_save.send_robust(
                     sender=Group,
                     instance=group,
                     created=False,
@@ -411,7 +411,7 @@ def manage_issue_states(
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
             if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
+                post_save.send_robust(
                     sender=Group,
                     instance=group,
                     created=False,

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -165,7 +165,7 @@ def handle_status_update(
             )
 
         if not options.get("groups.enable-post-update-signal"):
-            post_save.send(
+            post_save.send_robust(
                 sender=Group,
                 instance=group,
                 created=False,

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -156,7 +156,7 @@ class UpdateGroupsTest(TestCase):
         assert group.status == GroupStatus.IGNORED
         assert group.substatus == GroupSubStatus.FOREVER
         assert send_robust.called
-        post_save.send.assert_called_with(
+        post_save.send_robust.assert_called_with(
             sender=Group,
             instance=group,
             created=False,


### PR DESCRIPTION
- Using send() may lead to some signal receivers not receiving the signal for processing. send_robust catches these errors and makes sure that all connected receivers receive the request.
- See [django docs](https://docs.djangoproject.com/en/5.1/topics/signals/#django.dispatch.Signal.send_robust) for more details about how this works. 