### PR TITLE
chore: use send_robust for alert_rule_created signal

### DIFF
--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -64,7 +64,7 @@ def create_default_rules(project: Project, default_rules=True, RuleModel=Rule, *
 
     # When a user creates a new project and opts to set up an issue alert within it,
     # the corresponding task in the quick start sidebar is automatically marked as complete.
-    alert_rule_created.send(
+    alert_rule_created.send_robust(
         user=user,
         project=project,
         rule_id=rule.id,


### PR DESCRIPTION
- Using send() may lead to some signal receivers not receiving the signal for processing. send_robust catches these errors and makes sure that all connected receivers receive the request.
- See [django docs](https://docs.djangoproject.com/en/5.1/topics/signals/#django.dispatch.Signal.send_robust) for more details about how this works.