### PR TITLE
chore: use send_robust for user_feedback_received signal

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -135,7 +135,7 @@ def save_userreport(
             if report_instance.group_id:
                 report_instance.notify()
 
-        user_feedback_received.send(project=project, sender=save_userreport)
+        user_feedback_received.send_robust(project=project, sender=save_userreport)
 
         logger.info(
             "ingest.user_report",

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -190,7 +190,7 @@ class ErrorPageEmbedView(View):
                 if report.group_id:
                     report.notify()
 
-            user_feedback_received.send(
+            user_feedback_received.send_robust(
                 project=Project.objects.get(id=report.project_id),
                 sender=self,
             )


### PR DESCRIPTION
- Using send() may lead to some signal receivers not receiving the signal for processing. send_robust catches these errors and makes sure that all connected receivers receive the request.
- See [django docs](https://docs.djangoproject.com/en/5.1/topics/signals/#django.dispatch.Signal.send_robust) for more details about how this works.