### PR TITLE
feat(replays): Skip project option query if its not needed

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+from collections.abc import Generator
+from typing import Any, TypedDict
 
 import sentry_sdk
 
@@ -155,6 +156,53 @@ def report_hydration_error(
         )
 
 
+class RageClickIssue(TypedDict):
+    component_name: str
+    node: dict[str, Any]
+    project_id: int
+    replay_event: dict[str, Any]
+    replay_id: str
+    selector: str
+    timestamp: int
+    url: str
+
+
+def gen_rage_clicks(
+    event_meta: ParsedEventMeta,
+    project_id: int,
+    replay_id: str,
+    replay_event: dict[str, Any] | None,
+) -> Generator[RageClickIssue]:
+    if not replay_event:
+        return None
+
+    for click in filter(lambda c: c.is_rage and c.url, event_meta.click_events):
+        yield {
+            "component_name": click.component_name,
+            "node": {
+                "id": click.node_id,
+                "tagName": click.tag,
+                "attributes": {
+                    "id": click.id,
+                    "class": " ".join(click.classes),
+                    "aria-label": click.aria_label,
+                    "role": click.role,
+                    "alt": click.alt,
+                    "data-testid": click.testid,
+                    "title": click.title,
+                    "data-sentry-component": click.component_name,
+                },
+                "textContent": click.text,
+            },
+            "project_id": project_id,
+            "replay_event": replay_event,
+            "replay_id": replay_id,
+            "selector": click.selector,
+            "timestamp": click.timestamp,
+            "url": str(click.url),
+        }
+
+
 @sentry_sdk.trace
 def report_rage_click(
     event_meta: ParsedEventMeta,
@@ -162,39 +210,22 @@ def report_rage_click(
     replay_id: str,
     replay_event: dict[str, Any] | None,
 ) -> None:
-    clicks = list(filter(lambda c: c.is_rage and c.url, event_meta.click_events))
-
-    # Eagerly exit to prevent unnecessary I/O.
-    if len(clicks) == 0 or not replay_event or not _should_report_rage_click_issue(project):
+    clicks = list(gen_rage_clicks(event_meta, project.id, replay_id, replay_event))
+    if len(clicks) == 0 or not _should_report_rage_click_issue(project):
         return None
 
     metrics.incr("replay.rage_click_detected", amount=len(clicks))
 
     for click in clicks:
-        node = {
-            "id": click.node_id,
-            "tagName": click.tag,
-            "attributes": {
-                "id": click.id,
-                "class": " ".join(click.classes),
-                "aria-label": click.aria_label,
-                "role": click.role,
-                "alt": click.alt,
-                "data-testid": click.testid,
-                "title": click.title,
-                "data-sentry-component": click.component_name,
-            },
-            "textContent": click.text,
-        }
         report_rage_click_issue_with_replay_event(
-            project.id,
-            replay_id,
-            click.timestamp,
-            click.selector,
-            str(click.url),
-            node,
-            click.component_name,
-            replay_event,
+            click["project_id"],
+            click["replay_id"],
+            click["timestamp"],
+            click["selector"],
+            click["url"],
+            click["node"],
+            click["component_name"],
+            click["replay_event"],
         )
 
 

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -135,6 +135,8 @@ def report_hydration_error(
     replay_id: str,
     replay_event: dict[str, Any] | None,
 ) -> None:
+    metrics.incr("replay.hydration_error_breadcrumb", amount=len(event_meta.hydration_errors))
+
     # Eagerly exit to prevent unnecessary I/O.
     if (
         len(event_meta.hydration_errors) == 0
@@ -142,8 +144,6 @@ def report_hydration_error(
         or not _should_report_hydration_error_issue(project)
     ):
         return None
-
-    metrics.incr("replay.hydration_error_breadcrumb", amount=len(event_meta.hydration_errors))
 
     for error in event_meta.hydration_errors:
         report_hydration_error_issue_with_replay_event(

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -162,7 +162,7 @@ def report_rage_click(
     replay_id: str,
     replay_event: dict[str, Any] | None,
 ) -> None:
-    clicks = list(filter(lambda c: c.is_rage and click.url, event_meta.click_events))
+    clicks = list(filter(lambda c: c.is_rage and c.url, event_meta.click_events))
 
     # Eagerly exit to prevent unnecessary I/O.
     if len(clicks) == 0 or not replay_event or not _should_report_rage_click_issue(project):
@@ -191,7 +191,7 @@ def report_rage_click(
             replay_id,
             click.timestamp,
             click.selector,
-            click.url,
+            str(click.url),
             node,
             click.component_name,
             replay_event,

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -5,24 +5,24 @@ from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventM
 def test_gen_rage_clicks():
     # No clicks.
     meta = ParsedEventMeta([], [], [], [], [], [])
-    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a": "b"}))) == 0
 
     # Not a rage click and not URL.
     meta.click_events.append(
         ClickEvent("", "", [], "", "", 0, 0, 0, "", "", "", "", "", 0, "", url="")
     )
-    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a": "b"}))) == 0
 
     # Rage click but not url.
     meta.click_events.append(
         ClickEvent("", "", [], "", "", 0, 1, 0, "", "", "", "", "", 0, "", url="")
     )
-    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a": "b"}))) == 0
 
     # Rage click and url specified.
     meta.click_events.append(
         ClickEvent("", "", [], "", "", 0, 1, 0, "", "", "", "", "", 0, "", url="t")
     )
-    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 1
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a": "b"}))) == 1
     assert len(list(gen_rage_clicks(meta, 1, "1", {}))) == 0
     assert len(list(gen_rage_clicks(meta, 1, "1", None))) == 0

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -1,0 +1,28 @@
+from sentry.replays.usecases.ingest.event_logger import gen_rage_clicks
+from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
+
+
+def test_gen_rage_clicks():
+    # No clicks.
+    meta = ParsedEventMeta([], [], [], [], [], [])
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+
+    # Not a rage click and not URL.
+    meta.click_events.append(
+        ClickEvent("", "", [], "", "", 0, 0, 0, "", "", "", "", "", 0, "", url="")
+    )
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+
+    # Rage click but not url.
+    meta.click_events.append(
+        ClickEvent("", "", [], "", "", 0, 1, 0, "", "", "", "", "", 0, "", url="")
+    )
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 0
+
+    # Rage click and url specified.
+    meta.click_events.append(
+        ClickEvent("", "", [], "", "", 0, 1, 0, "", "", "", "", "", 0, "", url="t")
+    )
+    assert len(list(gen_rage_clicks(meta, 1, "1", {"a", "b"}))) == 1
+    assert len(list(gen_rage_clicks(meta, 1, "1", {}))) == 0
+    assert len(list(gen_rage_clicks(meta, 1, "1", None))) == 0


### PR DESCRIPTION
We're querying for the project option regardless of if there are any messages to emit.