### PR TITLE
fix(insights): Explore crashes on multi-type chart

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -306,6 +306,37 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               ]}
             />
           </SmallWidget>
+
+          <SmallWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Line({
+                  ...sampleDurationTimeSeries,
+                  field: 'custom_agg(duration)',
+                  meta: {
+                    type: 'number',
+                    unit: null,
+                  },
+                }),
+                new Line({
+                  ...sampleDurationTimeSeries2,
+                  field: 'custom_agg2(duration)',
+                  meta: {
+                    type: 'integer',
+                    unit: null,
+                  },
+                }),
+                new Line({
+                  ...sampleThroughputTimeSeries,
+                  field: 'custom_agg3(duration)',
+                  meta: {
+                    type: 'duration',
+                    unit: DurationUnit.MILLISECOND,
+                  },
+                }),
+              ]}
+            />
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -211,6 +211,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       '`TimeSeriesWidgetVisualization` assigned fallback to left Y axis instead of right Y axis',
       {
         labels: props.plottables.map(plottable => plottable.label),
+        types: props.plottables.map(plottable => plottable.dataType),
+        units: props.plottables.map(plottable => plottable.dataUnit),
         leftYAxisType,
         rightYAxisType,
       }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -41,7 +41,7 @@ import {ReleaseSeries} from './releaseSeries';
 import {FALLBACK_TYPE, FALLBACK_UNIT_FOR_FIELD_TYPE} from './settings';
 import {TimeSeriesWidgetYAxis} from './timeSeriesWidgetYAxis';
 
-const {error, warn} = Sentry._experiment_log;
+const {error, warn, info} = Sentry._experiment_log;
 
 export interface TimeSeriesWidgetVisualizationProps {
   /**
@@ -189,34 +189,54 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     )
     .filter(axisType => !!axisType); // `TimeSeries` allows for a `null` data type , though it's not likely
 
-  // Assign most popular field type to left axis
-  const leftYAxisType = axisTypes.at(0)!;
+  // Partition the types between the two axes
+  let leftYAxisDataTypes: string[] = [];
+  let rightYAxisDataTypes: string[] = [];
 
-  // Assign the rest of the field types to right
-  const rightYAxisTypes = axisTypes.slice(1);
+  if (axisTypes.length === 1) {
+    // The simplest case, there is just one type. Assign it to the left axis
+    leftYAxisDataTypes = axisTypes;
+  } else if (axisTypes.length === 2) {
+    // Also a simple case. If there are only two types, split them evenly
+    leftYAxisDataTypes = axisTypes.slice(0, 1);
+    rightYAxisDataTypes = axisTypes.slice(1, 2);
+  } else if (axisTypes.length > 2 && axisTypes.at(0) === FALLBACK_TYPE) {
+    // There are multiple types, and the most popular one is the fallback. Don't
+    // bother creating a second fallback axis, plot everything on the left
+    leftYAxisDataTypes = axisTypes;
+  } else {
+    // There are multiple types. Assign the most popular type to the left axis,
+    // the rest to the right axis
+    leftYAxisDataTypes = axisTypes.slice(0, 1);
+    rightYAxisDataTypes = axisTypes.slice(1);
+  }
 
-  // Narrow down to just one type for the right Y axis. If there's just one field
-  // type for the right axis, use it. If there are more than one, fall back to a
-  // default. If there are 0, there's no type for the right axis, and we won't
-  // plot one
+  // The left Y axis might be responsible for 1 or more types. If there's just
+  // one, use that type. If it's responsible for more than 1 type, use the
+  // fallback type
+  const leftYAxisType =
+    leftYAxisDataTypes.length === 1 ? leftYAxisDataTypes.at(0)! : FALLBACK_TYPE;
+
+  // The right Y axis might be responsible for 0, 1, or more types. If there are
+  // none, don't set a type at all. If there is 1, use that type. If there are
+  // two or more, use fallback type
   const rightYAxisType =
-    rightYAxisTypes.length === 1
-      ? rightYAxisTypes[0]!
-      : rightYAxisTypes.length > 2
-        ? FALLBACK_TYPE
-        : undefined;
+    rightYAxisDataTypes.length === 0
+      ? undefined
+      : rightYAxisDataTypes.length === 1
+        ? rightYAxisDataTypes.at(0)
+        : FALLBACK_TYPE;
 
-  if (leftYAxisType === FALLBACK_TYPE && rightYAxisType !== FALLBACK_TYPE) {
-    warn(
-      '`TimeSeriesWidgetVisualization` assigned fallback to left Y axis instead of right Y axis',
-      {
-        labels: props.plottables.map(plottable => plottable.label),
-        types: props.plottables.map(plottable => plottable.dataType),
-        units: props.plottables.map(plottable => plottable.dataUnit),
-        leftYAxisType,
-        rightYAxisType,
-      }
-    );
+  if (axisTypes.length > 0) {
+    info('`TimeSeriesWidgetVisualization` assigned axes', {
+      labels: props.plottables.map(plottable => plottable.label),
+      types: props.plottables.map(plottable => plottable.dataType),
+      units: props.plottables.map(plottable => plottable.dataUnit),
+      leftYAxisDataTypes,
+      rightYAxisDataTypes,
+      leftYAxisType,
+      rightYAxisType,
+    });
   }
 
   // Create a map of used units by plottable data type
@@ -380,14 +400,15 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
     let yAxisPosition: 'left' | 'right' = 'left';
 
-    if (plottable.dataType === leftYAxisType) {
-      // This plottable matches the left axis
+    if (leftYAxisDataTypes.includes(plottable.dataType)) {
+      // This plottable is assigned to the left axis
       yAxisPosition = 'left';
-    } else if (rightYAxisTypes.includes(plottable.dataType)) {
-      // This plottable matches the right axis
+    } else if (rightYAxisDataTypes.includes(plottable.dataType)) {
+      // This plottable is assigned to the right axis
       yAxisPosition = 'right';
     } else {
-      // This plottable's type isn't on either axis! Mysterious. If there is a catch-all right axis. Drop it into the first known "fallback" axis.
+      // This plottable's type isn't assignned to either axis! Mysterious.
+      // There's no graceful way to handle this.
       Sentry.withScope(scope => {
         const message =
           '`TimeSeriesWidgetVisualization` Could not assign Plottable to an axis';


### PR DESCRIPTION
Fixes DAIN-118. Corrects for an edge case in the axis assignment by improving the logic. The previous logic attempted to always assign one type to the left axis, and multiple types to the right axis. This isn't really correct, and can create unassigned axis types if the left and right axis are both "fallbacks".

In this PR, the logic is more robust:

- count up all the types that we need to plot
- partition the types between the left and right Y axes depending on how many types there are, and what they are
- creates axes based on axis type assignments
