### PR TITLE
fix(autofix): Safely handle thread metadata in profile construction

### DIFF
--- a/src/sentry/seer/autofix.py
+++ b/src/sentry/seer/autofix.py
@@ -438,10 +438,14 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
         return []
 
     # Find the MainThread ID
-    thread_metadata = profile.get("thread_metadata", {})
+    thread_metadata = profile.get("thread_metadata", {}) or {}
     main_thread_id = next(
-        (key for key, value in thread_metadata.items() if value["name"] == "MainThread"), None
+        (key for key, value in thread_metadata.items() if value.get("name") == "MainThread"), None
     )
+    if (
+        not main_thread_id and len(thread_metadata) == 1
+    ):  # if there is only one thread, use that as the main thread
+        main_thread_id = list(thread_metadata.keys())[0]
 
     # Sort samples chronologically
     sorted_samples = sorted(samples, key=lambda x: x["elapsed_since_start_ns"])

--- a/tests/sentry/seer/test_autofix.py
+++ b/tests/sentry/seer/test_autofix.py
@@ -91,7 +91,7 @@ class TestConvertProfileToExecutionTree(TestCase):
                 ],
                 "stacks": [[0]],
                 "samples": [{"stack_id": 0, "thread_id": "2", "elapsed_since_start_ns": 10000000}],
-                "thread_metadata": {"2": {"name": "WorkerThread"}},
+                "thread_metadata": {"2": {"name": "WorkerThread"}, "3": {"name": "WorkerThread2"}},
             }
         }
 


### PR DESCRIPTION
Null safety and fallback if no main thread found.