### PR TITLE
feat(tags): Adds sampling to project tag keys endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -41,7 +41,7 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
             include_values_seen = request.GET.get("includeValuesSeen") != "0"
 
-            if True or features.has("organizations:tag-key-sample-n", project.organization):
+            if features.has("organizations:tag-key-sample-n", project.organization):
                 # Tag queries longer than 14 days tend to time out for large customers. For getting a list of tags, clamping to 14 days is a reasonable compromise of speed vs. completeness
                 (start, end) = clamp_date_range(
                     default_start_end_dates(),

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -419,7 +419,7 @@ class SnubaTagStorage(TagStorage):
 
         organization_id = get_organization_id_from_project_ids(get_project_list(project_id))
         organization = Organization.objects.get_from_cache(id=organization_id)
-        if True or features.has("organizations:tag-key-sample-n", organization):
+        if features.has("organizations:tag-key-sample-n", organization):
             # Add static sample amount to the query. Turbo will sample at 10% by
             # default, but organizations with many events still get timeouts. A
             # static sample creates more consistent performance.

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -236,11 +236,13 @@ class SnubaTagStorage(TagStorage):
         tenant_ids=None,
         **kwargs,
     ):
-        optimize_kwargs = {}
-        if kwargs.get("turbo"):
-            optimize_kwargs["turbo"] = True
-        if kwargs.get("sample"):
-            optimize_kwargs["sample"] = kwargs.get("sample")
+        optimize_kwargs: _OptimizeKwargs = {}
+        if turbo := kwargs.get("turbo"):
+            if isinstance(turbo, bool):
+                optimize_kwargs["turbo"] = turbo
+        if sample := kwargs.get("sample"):
+            if isinstance(sample, int):
+                optimize_kwargs["sample"] = sample
 
         return self.__get_tag_keys_for_projects(
             get_project_list(project_id),


### PR DESCRIPTION
Updates the project `/tags` endpoint to clamp timerange and sample events when feature flagged with `organizations:tag-key-sample-n`.

These changes were copied over from the organization level `/tags` endpoint
https://github.com/getsentry/sentry/pull/80332
https://github.com/getsentry/sentry/pull/81363