### PR TITLE
feat(grouping): add more in-app exclusion rules for Rust

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -34,11 +34,12 @@ family:native path:/usr/local/lib/**                                 -app
 family:native path:/usr/local/Cellar/**                              -app
 family:native package:linux-gate.so*                                 -app
 
-# rust common modules
+# rust common modules/functions
 family:native function:std::*                                     -app
 family:native function:core::*                                    -app
 family:native function:alloc::*                                   -app
 family:native function:__rust_*                                   -app
+family:native function:rust_begin_unwind                          -app
 
 # rust borders
 family:native function:std::panicking::begin_panic                ^-group -group ^-app -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -46,6 +46,8 @@ family:native function:std::panicking::begin_panic                ^-group -group
 family:native function:core::panicking::begin_panic               ^-group -group ^-app -app
 family:native function:failure::backtrace::Backtrace::new         ^-group -group ^-app -app
 family:native function:error_chain::make_backtrace                ^-group -group ^-app -app
+family:native function:std::panicking::panic_fmt                  ^-app -app
+family:native function:core::panicking::panic_fmt                 ^-app -app
 
 # C++ borders
 family:native function:_CxxThrowException                         ^-group -group ^-app -app


### PR DESCRIPTION
<!-- Describe your PR here. -->
- `rust_begin_unwind` is often the top "in app" frame for Rust panics, which makes it end up in the top level issue description even though it's not informative at all
- `panic_fmt` is another possible entrypoint for panics that we were not considering. At the moment it's redundant to add it, as the only possible frame that is not in app above it is the aforementioned `rust_begin_unwind`, but could be useful if new versions of Rust introduce other "intermediate" frames with a different name
- I did not use `^-group -group` to not break grouping for existing events