### PR TITLE
🐛 fix(unfurl): update discover unfurl links

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -328,7 +328,7 @@ discover_link_regex = re.compile(
 )
 
 customer_domain_discover_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/discover/(results|homepage)"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/discover/(results|homepage)"
 )
 
 explore_link_regex = re.compile(

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -160,7 +160,7 @@ def _unfurl_discover(
             try:
                 response = client.get(
                     auth=ApiKey(organization_id=org.id, scope_list=["org:read"]),
-                    path=f"/organizations/{org_slug}/discover/saved/{query_id}/",
+                    path=f"/organizations/{org_slug}/explore/saved/{query_id}/",
                 )
 
             except Exception:
@@ -324,11 +324,11 @@ def map_discover_query_args(url: str, args: Mapping[str, str | None]) -> Mapping
 
 
 discover_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/discover/(results|homepage)"
 )
 
 customer_domain_discover_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/discover/(results|homepage)"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/discover/(results|homepage)"
 )
 
 discover_handler = Handler(

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -160,7 +160,7 @@ def _unfurl_discover(
             try:
                 response = client.get(
                     auth=ApiKey(organization_id=org.id, scope_list=["org:read"]),
-                    path=f"/organizations/{org_slug}/explore/saved/{query_id}/",
+                    path=f"/organizations/{org_slug}/discover/saved/{query_id}/",
                 )
 
             except Exception:
@@ -324,15 +324,28 @@ def map_discover_query_args(url: str, args: Mapping[str, str | None]) -> Mapping
 
 
 discover_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/discover/(results|homepage)"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
 )
 
 customer_domain_discover_link_regex = re.compile(
     r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/discover/(results|homepage)"
 )
 
+explore_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
+)
+
+customer_domain_explore_link_regex = re.compile(
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/discover/(results|homepage)"
+)
+
 discover_handler = Handler(
     fn=unfurl_discover,
-    matcher=[discover_link_regex, customer_domain_discover_link_regex],
+    matcher=[
+        discover_link_regex,
+        customer_domain_discover_link_regex,
+        explore_link_regex,
+        customer_domain_explore_link_regex,
+    ],
     arg_mapper=map_discover_query_args,
 )

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -332,7 +332,7 @@ customer_domain_discover_link_regex = re.compile(
 )
 
 explore_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/discover/(results|homepage)"
 )
 
 customer_domain_explore_link_regex = re.compile(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -166,6 +166,20 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 {"org_slug": "org1", "query": QueryDict("project=1&yAxis=count()")},
             ),
         ),
+        (
+            "https://sentry.io/organizations/org1/explore/discover/results/?project=1&yAxis=count()",
+            (
+                LinkType.DISCOVER,
+                {"org_slug": "org1", "query": QueryDict("project=1&yAxis=count()")},
+            ),
+        ),
+        (
+            "https://org1.sentry.io/explore/discover/results/?project=1&yAxis=count()",
+            (
+                LinkType.DISCOVER,
+                {"org_slug": "org1", "query": QueryDict("project=1&yAxis=count()")},
+            ),
+        ),
     ],
 )
 def test_match_link(url, expected):


### PR DESCRIPTION
for the new nav, we moved discover from `/discover/` to `/explore/discover/`

as a consequence, we need to update the regex for unfurl.

before i write tests, i want to make sure this is the correct new urls that we will need to handle