### PR TITLE
fix(issue-details): Update grouping info loading

### DIFF
--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -1,4 +1,5 @@
 import {useEventGroupingInfo} from 'sentry/components/events/groupingInfo/useEventGroupingInfo';
+import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -12,7 +13,7 @@ export function GroupInfoSummary({
   group: Group | undefined;
   projectSlug: string;
 }) {
-  const {groupInfo} = useEventGroupingInfo({
+  const {groupInfo, isPending, hasPerformanceGrouping} = useEventGroupingInfo({
     event,
     group,
     projectSlug,
@@ -25,6 +26,10 @@ export function GroupInfoSummary({
         .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
         .join(', ')
     : t('nothing');
+
+  if (isPending && !hasPerformanceGrouping) {
+    return <Placeholder height="20px" style={{marginBottom: '20px'}} />;
+  }
 
   return (
     <p data-test-id="loaded-grouping-info">


### PR DESCRIPTION
this pr adds a loading state to the grouping info section so the info doesn't change from Nothing to the correct grouping info 