### PR TITLE
feat(releases): allow finalized query in releases endpoint

### DIFF
--- a/src/sentry/api/release_search.py
+++ b/src/sentry/api/release_search.py
@@ -11,6 +11,7 @@ from sentry.search.events.constants import (
 )
 
 RELEASE_FREE_TEXT_KEY = "release_free_text"
+FINALIZED_KEY = "finalized"
 INVALID_SEMVER_MESSAGE = (
     'Invalid format of semantic version. For searching non-semver releases, use "release:" instead.'
 )
@@ -23,6 +24,7 @@ release_search_config = SearchConfig.create_from(
         SEMVER_ALIAS,
         SEMVER_BUILD_ALIAS,
         SEMVER_PACKAGE_ALIAS,
+        FINALIZED_KEY,
     },
     allow_boolean=False,
     free_text_key=RELEASE_FREE_TEXT_KEY,


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/86258

allow query `finalized:true` or `finalized:false` on the `/releases/` endpoint
a release is finalized if its `dateReleased` property is set.