### PR TITLE
Show logs in span details in trace view

### DIFF
--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -26,7 +26,7 @@ const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.SEVERITY_TEXT,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.PROJECT_ID,
-  OurLogKnownFieldKey.SPAN_ID,
+  OurLogKnownFieldKey.PARENT_SPAN_ID,
   OurLogKnownFieldKey.TIMESTAMP,
 ];
 

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -53,7 +53,6 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.PROJECT_ID,
   OurLogKnownFieldKey.SENTRY_PROJECT_ID,
-  OurLogKnownFieldKey.SPAN_ID,
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.ITEM_TYPE,
 ];

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -55,23 +55,31 @@ export interface LogsPageParamsProviderProps {
   analyticsPageSource: LogsAnalyticsPageSource;
   children: React.ReactNode;
   isOnEmbeddedView?: boolean;
+  limitToProjectIds?: number[];
+  limitToSpanId?: string;
   limitToTraceId?: string;
 }
 
 export function LogsPageParamsProvider({
   children,
   limitToTraceId,
+  limitToSpanId,
+  limitToProjectIds,
   isOnEmbeddedView,
   analyticsPageSource,
 }: LogsPageParamsProviderProps) {
   const location = useLocation();
   const logsQuery = decodeLogsQuery(location);
   const search = new MutableSearch(logsQuery);
-  const baseSearch = limitToTraceId
-    ? new MutableSearch('').addFilterValues(OurLogKnownFieldKey.TRACE_ID, [
-        limitToTraceId,
-      ])
-    : undefined;
+  let baseSearch: MutableSearch | undefined = undefined;
+  if (limitToSpanId && limitToTraceId) {
+    baseSearch = baseSearch ?? new MutableSearch('');
+    baseSearch.addFilterValue(OurLogKnownFieldKey.TRACE_ID, limitToTraceId);
+    baseSearch.addFilterValue(OurLogKnownFieldKey.PARENT_SPAN_ID, limitToSpanId);
+  } else if (limitToTraceId) {
+    baseSearch = baseSearch ?? new MutableSearch('');
+    baseSearch.addFilterValue(OurLogKnownFieldKey.TRACE_ID, limitToTraceId);
+  }
   const isTableEditingFrozen = isOnEmbeddedView;
   const fields = isTableEditingFrozen
     ? defaultLogFields()
@@ -79,7 +87,9 @@ export function LogsPageParamsProvider({
   const sortBys = isTableEditingFrozen
     ? [logsTimestampDescendingSortBy]
     : getLogSortBysFromLocation(location, fields);
-  const projectIds = isOnEmbeddedView ? [-1] : decodeProjects(location);
+  const projectIds = isOnEmbeddedView
+    ? (limitToProjectIds ?? [-1])
+    : decodeProjects(location);
 
   const cursor = getLogCursorFromLocation(location);
 

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -19,7 +19,7 @@ export enum OurLogKnownFieldKey {
   ORGANIZATION_ID = 'sentry.organization_id',
   PROJECT_ID = 'project_id',
   SENTRY_PROJECT_ID = 'sentry.project_id',
-  SPAN_ID = 'sentry.span_id',
+  PARENT_SPAN_ID = 'sentry.trace.parent_span_id',
   TIMESTAMP = 'timestamp',
   ITEM_TYPE = 'sentry.item_type',
 }
@@ -32,7 +32,6 @@ export type OurLogsKnownFieldResponseMap = {
   [OurLogKnownFieldKey.SEVERITY_TEXT]: string;
   [OurLogKnownFieldKey.ORGANIZATION_ID]: number;
   [OurLogKnownFieldKey.PROJECT_ID]: number;
-  [OurLogKnownFieldKey.SPAN_ID]: string;
   [OurLogKnownFieldKey.TIMESTAMP]: string;
 };
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import React, {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -16,8 +16,16 @@ import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
+import {
+  LogsPageDataProvider,
+  useLogsPageData,
+} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
@@ -182,6 +190,14 @@ function SpanSections({
   );
 }
 
+function LogDetails() {
+  const {logsData} = useLogsPageData();
+  if (!logsData.data?.length) {
+    return null;
+  }
+  return <LogsTable tableData={logsData} />;
+}
+
 function LegacySpanSections({
   node,
   organization,
@@ -260,6 +276,7 @@ export function SpanNodeDetails({
   TraceTreeNode<TraceTree.Span> | TraceTreeNode<TraceTree.EAPSpan>
 >) {
   const location = useLocation();
+  const {traceSlug} = useParams<{traceSlug: string}>();
   const hasNewTraceUi = useHasTraceNewUi();
   const {projects} = useProjects();
   const issues = useMemo(() => {
@@ -281,7 +298,18 @@ export function SpanNodeDetails({
           onTabScrollToNode={onTabScrollToNode}
         />
         <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasNewTraceUi}>
-          <div>TO DO: EAP Span Details</div>
+          <LogsPageParamsProvider
+            isOnEmbeddedView
+            limitToTraceId={traceSlug}
+            limitToSpanId={node.value.event_id}
+            limitToProjectIds={[node.value.project_id]}
+            analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
+          >
+            <LogsPageDataProvider>
+              <LogDetails />
+              <div>TO DO: EAP Span Details</div>
+            </LogsPageDataProvider>
+          </LogsPageParamsProvider>
         </TraceDrawerComponents.BodyContainer>
       </TraceDrawerComponents.DetailContainer>
     );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -18,7 +18,6 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {
   LogsPageDataProvider,
@@ -272,11 +271,11 @@ export function SpanNodeDetails({
   organization,
   onTabScrollToNode,
   onParentClick,
+  traceId,
 }: TraceTreeNodeDetailsProps<
   TraceTreeNode<TraceTree.Span> | TraceTreeNode<TraceTree.EAPSpan>
 >) {
   const location = useLocation();
-  const {traceSlug} = useParams<{traceSlug: string}>();
   const hasNewTraceUi = useHasTraceNewUi();
   const {projects} = useProjects();
   const issues = useMemo(() => {
@@ -300,7 +299,7 @@ export function SpanNodeDetails({
         <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasNewTraceUi}>
           <LogsPageParamsProvider
             isOnEmbeddedView
-            limitToTraceId={traceSlug}
+            limitToTraceId={traceId}
             limitToSpanId={node.value.event_id}
             limitToProjectIds={[node.value.project_id]}
             analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
@@ -25,6 +25,7 @@ export interface TraceTreeNodeDetailsProps<T> {
   onTabScrollToNode: (node: TraceTreeNode<any>) => void;
   organization: Organization;
   replay: ReplayRecord | null;
+  traceId: string;
 }
 
 export function TraceTreeNodeDetails(props: TraceTreeNodeDetailsProps<any>) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -58,6 +58,7 @@ type TraceDrawerProps = {
   trace: TraceTree;
   traceEventView: EventView;
   traceGridRef: HTMLElement | null;
+  traceId: string;
   traceType: TraceShape;
 };
 
@@ -466,6 +467,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
                     organization={organization}
                     onParentClick={onParentClick}
                     node={traceState.tabs.current_tab.node}
+                    traceId={props.traceId}
                     onTabScrollToNode={props.onTabScrollToNode}
                   />
                 )

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -959,6 +959,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           meta={props.meta}
           traceType={shape}
           trace={props.tree}
+          traceId={props.traceSlug}
           traceGridRef={traceGridRef}
           manager={viewManager}
           scheduler={traceScheduler}

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -115,7 +115,7 @@ export interface TraceWaterfallProps {
   source: string;
   trace: UseApiQueryResult<TraceTree.Trace, RequestError>;
   traceEventView: EventView;
-  traceSlug: string | undefined;
+  traceSlug: string;
   tree: TraceTree;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -225,7 +225,7 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
     >
       <TraceViewWaterfallWrapper>
         <TraceWaterfall
-          traceSlug={firstTrace?.traceSlug}
+          traceSlug={replayTraces[0].traceSlug}
           trace={trace}
           tree={tree}
           rootEvent={rootEvent}

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -214,7 +214,7 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
   const performanceActive =
     organization.features.includes('performance-view') && hasPerformance;
 
-  if (replayTraces.length === 0) {
+  if (!firstTrace) {
     return <TracesNotFound performanceActive={performanceActive} />;
   }
 
@@ -225,7 +225,7 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
     >
       <TraceViewWaterfallWrapper>
         <TraceWaterfall
-          traceSlug={replayTraces[0].traceSlug}
+          traceSlug={firstTrace.traceSlug}
           trace={trace}
           tree={tree}
           rootEvent={rootEvent}

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -225,7 +225,7 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
     >
       <TraceViewWaterfallWrapper>
         <TraceWaterfall
-          traceSlug={undefined}
+          traceSlug={firstTrace?.traceSlug}
           trace={trace}
           tree={tree}
           rootEvent={rootEvent}


### PR DESCRIPTION
Now that we can correlate logs with spans, let's show the logs tab in the span details in the trace details page.