### PR TITLE
fix: Improve react-query devtool colors

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -177,6 +177,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
     background-color: transparent;
   }
   .tsqd-queries-container code {
+    /* Don't override colors inside @tanstack/react-query-devtools */
     background-color: unset;
     color: inherit;
   }

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -176,6 +176,10 @@ const styles = (theme: Theme, isDark: boolean) => css`
   code {
     background-color: transparent;
   }
+  .tsqd-queries-container code {
+    background-color: unset;
+    color: inherit;
+  }
 
   ${prismStyles(theme)}
 


### PR DESCRIPTION
Before:
<img width="771" alt="SCR-20250326-izri" src="https://github.com/user-attachments/assets/4b18a65a-48be-4182-a585-6371812f9eb3" />

After:
<img width="512" alt="SCR-20250326-kcxi" src="https://github.com/user-attachments/assets/97aa3237-dc99-42b3-8619-e16031e5267b" />
