### PR TITLE
fix(new-trace): Enabling scroll to parent-auto-grouped children

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1014,7 +1014,9 @@ describe('trace view', () => {
       expect(rows[4]!.textContent?.includes('Autogrouped')).toBe(true);
     });
     it('scrolls to child of parent autogroup node', async () => {
-      mockQueryString('?node=span-redis0&node=txn-1');
+      // Passing an invalid targetId to the query string will still scroll to the child of the parent autogroup node
+      // as path is prioritized over targetId/eventId
+      mockQueryString('?node=span-redis0&node=txn-1&targetId=doesnotexist');
 
       const {virtualizedContainer} = await completeTestSetup();
       await within(virtualizedContainer).findAllByText(/Autogrouped/i);

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -590,7 +590,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     if (node) {
       if (isAutogroupedNode(node) && type !== 'ag') {
         if (isParentAutogroupedNode(node)) {
-          node = TraceTree.FindByID(node.head, eventId ?? path!) ?? node;
+          node = TraceTree.FindByID(node.head, path ?? eventId!) ?? node;
         } else if (isSiblingAutogroupedNode(node)) {
           node = node.children.find(n => TraceTree.FindByID(n, eventId ?? path!)) ?? node;
         }


### PR DESCRIPTION
With this merged, we will scroll to spans embedded under auto-grouped nodes:
- We were searching for the node initially by `path` first, then `eventId`.
- And looking for auto-grouped node children by `eventId` first then `path`.  This led to a mismatch.
