### PR TITLE
fix(insights): Resets cursor query param on Web Vitals sort links

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -121,7 +121,7 @@ export function PagePerformanceTable() {
 
       return {
         ...location,
-        query: {...location.query, sort: newSort},
+        query: {...location.query, sort: newSort, cursor: undefined},
       };
     }
     const sortableFields = SORTABLE_FIELDS;


### PR DESCRIPTION
Updates the sort links in the Web Vitals Page Summary table to reset pagination cursors when clicked.