### PR TITLE
feat(billing): default enterprise trial to 28 days - frontend

### DIFF
--- a/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
@@ -360,4 +360,71 @@ describe('TrialSubscriptionAction', function () {
     await userEvent.click(trialTierInputs[1]!);
     expect(screen.getByText('am3')).toBeInTheDocument();
   });
+
+  it('defaults 14-day trial for self-serve', function () {
+    jest.mock('sentry/components/core/alert');
+
+    openAdminConfirmModal({
+      onConfirm,
+      renderModalSpecificContent: deps => (
+        <TrialSubscriptionAction
+          subscription={SubscriptionFixture({
+            organization,
+            plan: 'am3_business',
+            isEnterpriseTrial: false,
+          })}
+          {...deps}
+        />
+      ),
+    });
+
+    renderGlobalModal();
+    const daysInput = screen.getByRole('spinbutton', {name: 'Number of Days'});
+    expect(daysInput).toHaveValue(14);
+  });
+
+  it('defaults 28-day trial for isEnterpriseTrial', function () {
+    jest.mock('sentry/components/core/alert');
+
+    openAdminConfirmModal({
+      onConfirm,
+      renderModalSpecificContent: deps => (
+        <TrialSubscriptionAction
+          subscription={SubscriptionFixture({
+            organization,
+            plan: 'am3_business',
+            isEnterpriseTrial: true,
+          })}
+          {...deps}
+        />
+      ),
+    });
+
+    renderGlobalModal();
+    const daysInput = screen.getByRole('spinbutton', {name: 'Number of Days'});
+    expect(daysInput).toHaveValue(28);
+  });
+
+  it('defaults 28-day trial for startEnterpriseTrial', function () {
+    jest.mock('sentry/components/core/alert');
+
+    openAdminConfirmModal({
+      onConfirm,
+      renderModalSpecificContent: deps => (
+        <TrialSubscriptionAction
+          subscription={SubscriptionFixture({
+            organization,
+            plan: 'am3_business',
+            isEnterpriseTrial: false,
+          })}
+          startEnterpriseTrial
+          {...deps}
+        />
+      ),
+    });
+
+    renderGlobalModal();
+    const daysInput = screen.getByRole('spinbutton', {name: 'Number of Days'});
+    expect(daysInput).toHaveValue(28);
+  });
 });

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -29,7 +29,10 @@ type State = {
  */
 class TrialSubscriptionAction extends Component<Props, State> {
   state: State = {
-    trialDays: 14,
+    trialDays:
+      this.props.subscription.isEnterpriseTrial || this.props.startEnterpriseTrial
+        ? 28
+        : 14,
     trialTier: PlanTier.AM3,
     trialPlanOverride: undefined,
   };


### PR DESCRIPTION
Default enterprise trials to 28 days
See https://linear.app/getsentry/issue/BIL-347/update-trial-lengths
To be merged at launch