### PR TITLE
ref(timeseries): Move accuracy into values

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -675,7 +675,6 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         data: Any,
         column: str,
         null_zero: bool = False,
-        convert_to_milliseconds: bool = False,
     ):
         serialized_values = []
         for timestamp, group in itertools.groupby(data, key=lambda r: r["time"]):
@@ -685,7 +684,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     row_value = None
                 serialized_values.append(
                     {
-                        "timestamp": timestamp * (1000 if convert_to_milliseconds else 1),
+                        "timestamp": timestamp,
                         "value": row_value,
                     }
                 )

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -61,11 +61,9 @@ class Row(TypedDict):
     timestamp: float
     value: float
     comparisonValue: NotRequired[float]
-
-
-class Confidence(TypedDict):
-    timestamp: float
-    value: Literal["low", "high"] | None
+    sampleCount: NotRequired[float]
+    sampleRate: NotRequired[float]
+    confidence: NotRequired[Literal["low", "high"] | None]
 
 
 class SeriesMeta(TypedDict):
@@ -76,18 +74,11 @@ class SeriesMeta(TypedDict):
     interval: float
 
 
-class AccuracyData(TypedDict):
-    sampleCount: list[Row]
-    sampleRate: list[Row]
-    confidence: list[Confidence]
-
-
 class TimeSeries(TypedDict):
     values: list[Row]
-    axis: str
+    yaxis: str
     groupBy: NotRequired[list[str]]
     meta: SeriesMeta
-    accuracy: NotRequired[AccuracyData]
 
 
 class StatsResponse(TypedDict):
@@ -358,31 +349,32 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
 
         timeseries = TimeSeries(
             values=[],
-            axis=axis,
+            yaxis=axis,
             meta=series_meta,
         )
 
+        timeseries_values = []
         for row in result.data["data"]:
             value_row = Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
             if "comparisonCount" in row:
                 value_row["comparisonValue"] = row["comparisonCount"]
-            timeseries["values"].append(value_row)
+            timeseries_values.append(value_row)
 
         if "groupby" in result.data:
             timeseries["groupBy"] = result.data["groupby"]
 
         if "processed_timeseries" in result.data:
             processed_timeseries = result.data["processed_timeseries"]
-            timeseries["accuracy"] = AccuracyData(
-                sampleCount=self.serialize_accuracy_data(
-                    processed_timeseries.sample_count, axis, convert_to_milliseconds=True
-                ),
-                sampleRate=self.serialize_accuracy_data(
-                    processed_timeseries.sampling_rate, axis, convert_to_milliseconds=True
-                ),
-                confidence=self.serialize_accuracy_data(
-                    processed_timeseries.confidence, axis, convert_to_milliseconds=True
-                ),
-            )
+            for value, count, rate, confidence in zip(
+                timeseries_values,
+                processed_timeseries.sample_count,
+                processed_timeseries.sampling_rate,
+                processed_timeseries.confidence,
+            ):
+                value["sampleCount"] = count[axis]
+                value["sampleRate"] = rate[axis]
+                value["confidence"] = confidence[axis]
+
+        timeseries["values"] = timeseries_values
 
         return timeseries

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -103,7 +103,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert len(response.data["timeseries"]) == 1
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "count()"
+        assert timeseries["yaxis"] == "count()"
         assert timeseries["values"] == [
             {
                 "timestamp": self.start.timestamp() * 1000,
@@ -143,7 +143,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert len(response.data["timeseries"]) == 2
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "count()"
+        assert timeseries["yaxis"] == "count()"
         assert timeseries["values"] == [
             {
                 "timestamp": self.start.timestamp() * 1000,
@@ -165,7 +165,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
 
         timeseries = response.data["timeseries"][1]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "count_unique(user)"
+        assert timeseries["yaxis"] == "count_unique(user)"
         assert timeseries["values"] == [
             {
                 "timestamp": self.start.timestamp() * 1000,
@@ -208,7 +208,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         assert len(response.data["timeseries"]) == 4
         timeseries = response.data["timeseries"][0]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "count()"
+        assert timeseries["yaxis"] == "count()"
         assert timeseries["groupBy"] == [{"message": "very bad"}]
         assert timeseries["meta"] == {
             "order": 0,
@@ -233,7 +233,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
 
         timeseries = response.data["timeseries"][1]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "p95()"
+        assert timeseries["yaxis"] == "p95()"
         assert timeseries["groupBy"] == [{"message": "very bad"}]
         assert timeseries["meta"] == {
             "order": 0,
@@ -259,7 +259,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
 
         timeseries = response.data["timeseries"][2]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "count()"
+        assert timeseries["yaxis"] == "count()"
         assert timeseries["groupBy"] == [{"message": "oh my"}]
         assert timeseries["meta"] == {
             "order": 1,
@@ -284,7 +284,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
 
         timeseries = response.data["timeseries"][3]
         assert len(timeseries["values"]) == 3
-        assert timeseries["axis"] == "p95()"
+        assert timeseries["yaxis"] == "p95()"
         assert timeseries["groupBy"] == [{"message": "oh my"}]
         assert timeseries["meta"] == {
             "order": 1,


### PR DESCRIPTION
- also renames axis -> yaxis
- TODO: going to follow up in another PR, looks like for some functions the data_points returned by RPC are empty, but when we get accuracy info from it we get count=0, rate=0 confidence=None still 🤔 (this is why I'm ignoring accuracy for a bunch of the tests, functionally the same but this new format is finding some oddities)