### PR TITLE
feat(new-trace-tree): Sorting the children of new parent assigned by …

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.spec.tsx.snap
@@ -51,6 +51,15 @@ trace root
 "
 `;
 
+exports[`TraceTree FromTrace swaps only pageload transaction child with parent http.server transaction 1`] = `
+"
+trace root
+  / - pageload
+    /api-1/ - http.server
+    /api-2/ - http.server
+"
+`;
+
 exports[`TraceTree appendTree appends tree to end of current tree 1`] = `
 "
 trace root

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -443,6 +443,37 @@ describe('TraceTree', () => {
       expect(tree.build().serialize()).toMatchSnapshot();
     });
 
+    it('swaps only pageload transaction child with parent http.server transaction', () => {
+      const tree = TraceTree.FromTrace(
+        makeTrace({
+          transactions: [
+            makeTransaction({
+              'transaction.op': 'http.server',
+              transaction: '/api-1/',
+              start_timestamp: 2,
+              children: [
+                makeTransaction({
+                  'transaction.op': 'pageload',
+                  transaction: '/',
+                  start_timestamp: 1,
+                  children: [
+                    makeTransaction({
+                      'transaction.op': 'http.server',
+                      transaction: '/api-2/',
+                      start_timestamp: 4,
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+        traceMetadata
+      );
+
+      expect(tree.build().serialize()).toMatchSnapshot();
+    });
+
     it('initializes canFetch based on spanChildrenCount', () => {
       const tree = TraceTree.FromTrace(
         makeTrace({

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1788,6 +1788,9 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
     child.reparent_reason = reason;
     parent.reparent_reason = reason;
+
+    // We need to sort the children of the child node as the swap may have broken the chronological order
+    child.children.sort(traceChronologicalSort);
   }
 
   static IsLastChild(n: TraceTreeNode<TraceTree.NodeValue>): boolean {


### PR DESCRIPTION
We make the following swap in the frontend:

- http.server - 1
- - pageload
- - - http.server - 2

to 

- pageload
- - http.server - 2 
- - http.server - 1

This may break order, so we sort chronologically when swapping nodes in the tree. 

Bug:
<img width="1283" alt="Screenshot 2025-03-26 at 2 53 15 PM" src="https://github.com/user-attachments/assets/83c1910f-cb13-4b41-883b-b7d95a48a753" />
