### PR TITLE
ref: fix test pollution caused by global mutation of `redis.clusters`

### DIFF
--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import pickle
 from collections import defaultdict
@@ -38,7 +39,7 @@ def _hgetall_decode_keys(client, key, is_redis_cluster):
 class TestRedisBuffer:
     @pytest.fixture(params=["cluster", "blaster"])
     def buffer(self, set_sentry_option, request):
-        value = options.get("redis.clusters")
+        value = copy.deepcopy(options.get("redis.clusters"))
         value["default"]["is_redis_cluster"] = request.param == "cluster"
         set_sentry_option("redis.clusters", value)
         return RedisBuffer()


### PR DESCRIPTION
previously failing with:

```console
$ pytest tests/sentry/buffer/test_redis.py::TestRedisBuffer::test_enqueue[cluster] tests/sentry/rules/processing/test_delayed_processing.py::BulkFetchEventsTest::test_invalid_project
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/sentry/buffer/test_redis.py .                                      [ 50%]
tests/sentry/rules/processing/test_delayed_processing.py F               [100%]

=================================== FAILURES ===================================
___________________ BulkFetchEventsTest.test_invalid_project ___________________
tests/sentry/rules/processing/test_delayed_processing.py:89: in setUp
    self.event_two = self.create_event(
tests/sentry/rules/processing/test_buffer_processing.py:77: in create_event
    return self.store_event(
src/sentry/testutils/cases.py:1152: in store_event
    stored_event = Factories.store_event(*args, **kwargs)
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/contextlib.py:85: in inner
    return func(*args, **kwds)
src/sentry/testutils/factories.py:1035: in store_event
    event = manager.save(project_id)
.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py:829: in func_with_tracing
    return func(*args, **kwargs)
src/sentry/event_manager.py:477: in save
    return self.save_error_events(
.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py:829: in func_with_tracing
    return func(*args, **kwargs)
src/sentry/event_manager.py:525: in save_error_events
    group_info = assign_event_to_group(event=job["event"], job=job, metric_tags=metric_tags)
.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py:829: in func_with_tracing
    return func(*args, **kwargs)
src/sentry/event_manager.py:1207: in assign_event_to_group
    group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
src/sentry/event_manager.py:1339: in handle_existing_grouphash
    is_regression = _process_existing_aggregate(
src/sentry/event_manager.py:1806: in _process_existing_aggregate
    buffer_incr(Group, {"times_seen": 1}, {"id": group.id}, updated_group_values)
src/sentry/tasks/process_buffer.py:97: in buffer_incr
    (buffer_incr_task.delay if settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK else buffer_incr_task)(
.venv/lib/python3.13/site-packages/celery/local.py:182: in __call__
    return self._get_current_object()(*a, **kw)
.venv/lib/python3.13/site-packages/celery/app/task.py:411: in __call__
    return self.run(*args, **kwargs)
src/sentry/tasks/base.py:183: in _wrapped
    result = func(*args, **kwargs)
src/sentry/tasks/process_buffer.py:116: in buffer_incr_task
    buffer.backend.incr(apps.get_model(app_label=app_label, model_name=model_name), *args, **kwargs)
src/sentry/buffer/redis.py:489: in incr
    pipe.hset(key, "e+" + column, json.dumps(self._dump_value(value)))
src/sentry/buffer/redis.py:301: in _dump_value
    raise TypeError(type(value))
E   TypeError: <class 'dict'>
=========================== short test summary info ============================
FAILED tests/sentry/rules/processing/test_delayed_processing.py::BulkFetchEventsTest::test_invalid_project - TypeError: <class 'dict'>
========================= 1 failed, 1 passed in 5.97s ==========================
%4|1743016213.222|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (211 bytes) still in queue or transit: use flush() to wait for outstanding message delivery

```

<!-- Describe your PR here. -->