### PR TITLE
feat(new-trace): Enabling scroll to sibling autogroup children

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1044,7 +1044,9 @@ describe('trace view', () => {
     });
 
     it('scrolls to child of sibling autogroup node', async () => {
-      mockQueryString('?node=span-http0&node=txn-1');
+      // Passing an invalid targetId to the query string will still scroll to the child of the parent autogroup node
+      // as path is prioritized over targetId/eventId
+      mockQueryString('?node=span-http0&node=txn-1&targetId=doesnotexist');
 
       const {virtualizedContainer} = await completeTestSetup();
       await within(virtualizedContainer).findAllByText(/Autogrouped/i);

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -589,10 +589,11 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     // just gives us the first match which may not be the one the user is looking for.
     if (node) {
       if (isAutogroupedNode(node) && type !== 'ag') {
+        const id = path ?? eventId!;
         if (isParentAutogroupedNode(node)) {
           node = TraceTree.FindByID(node.head, path ?? eventId!) ?? node;
         } else if (isSiblingAutogroupedNode(node)) {
-          node = node.children.find(n => TraceTree.FindByID(n, eventId ?? path!)) ?? node;
+          node = node.children.find(n => TraceTree.FindByID(n, id)) ?? node;
         }
       }
     }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -591,7 +591,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       if (isAutogroupedNode(node) && type !== 'ag') {
         const id = path ?? eventId!;
         if (isParentAutogroupedNode(node)) {
-          node = TraceTree.FindByID(node.head, path ?? eventId!) ?? node;
+          node = TraceTree.FindByID(node.head, id) ?? node;
         } else if (isSiblingAutogroupedNode(node)) {
           node = node.children.find(n => TraceTree.FindByID(n, id)) ?? node;
         }


### PR DESCRIPTION
With this merged, we will scroll to spans embedded under sibling auto-grouped nodes:
- We were searching for the node initially by `path` first, then `eventId`.
- And looking for auto-grouped node children by `eventId` first then `path`.  This led to a mismatch.