### PR TITLE
chore(anomaly detection): Move logs outside of try block

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -80,11 +80,11 @@ def get_anomaly_data_from_seer(
         config=anomaly_detection_config,
         context=context,
     )
+    data = json.dumps(detect_anomalies_request).encode("utf-8")
+    update_log_data = extra_data.copy()
+    update_log_data["data"] = data
+    logger.info("Sending subscription update data to Seer", extra=update_log_data)
     try:
-        data = json.dumps(detect_anomalies_request).encode("utf-8")
-        update_log_data = extra_data.copy()
-        update_log_data["data"] = data
-        logger.info("Sending subscription update data to Seer", extra=update_log_data)
         response = make_signed_seer_api_request(
             SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             SEER_ANOMALY_DETECTION_ENDPOINT_URL,


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/87950/files to move the extra logging outside of the try block as I am only getting logs when there wasn't an exception (which is confusing - according to [these logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0A--%20jsonPayload.event%20%3D%20%22Sending%20subscription%20update%20data%20to%20Seer%22%0AjsonPayload.rule_id%3D%22312327%22%20OR%20jsonPayload.rule_id%3D%22301045%22%20OR%20jsonPayload.rule_id%3D%22301915%22%20OR%20jsonPayload.rule_id%3D%22144018%22%20OR%20jsonPayload.rule_id%3D%22317898%22%20OR%20jsonPayload.rule_id%3D%22188607%22%20OR%20jsonPayload.rule_id%3D%22254443%22%0Ajson_payload.aggregation_value%3D%22NULL_VALUE%22%0AjsonPayload.name%3D%22sentry.seer.anomaly_detection.get_anomaly_data%22;summaryFields=jsonPayload%252Fresult%252Fvalues%252Fmeta%252F0%252Fname,jsonPayload%252Fresult%252Fvalues%252Fmeta%252F0%252Ftype:true:32:beginning;lfeCustomFields=jsonPayload%252Faggregation_value;cursorTimestamp=2025-03-26T19:01:59.795540983Z;duration=PT12H?project=internal-sentry&rapt=AEjHL4NYRBUBwzuB8wQQA5pZA8LruSGmSSrsNtYx_XtT-XMtjC4dJ_QUuUStX3yyYLkgad4WsiGf5bPazHT_hsUwxGVj_hEEhIcZJu-iQkczhKd1zUng0eQ&invt=AbtFRQ) means that we are sometimes able to successfully send a null aggregation value to Seer).  