### PR TITLE
feat(ui): Make ProjectList a common component

### DIFF
--- a/static/app/components/projectList.spec.tsx
+++ b/static/app/components/projectList.spec.tsx
@@ -1,0 +1,42 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectList} from 'sentry/components/projectList';
+
+describe('ProjectList', function () {
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [
+        {id: '1', slug: 'project1'},
+        {id: '2', slug: 'project2'},
+        {id: '3', slug: 'project3'},
+      ],
+    });
+  });
+
+  it('renders all projects when there is no overflow', async function () {
+    render(
+      <ProjectList projectSlugs={['project1', 'project2']} maxVisibleProjects={2} />
+    );
+
+    expect(await screen.findAllByRole('img')).toHaveLength(2);
+  });
+
+  it('renders the collapsed projects when there is overflow', async function () {
+    render(
+      <ProjectList
+        projectSlugs={['project1', 'project2', 'project3']}
+        maxVisibleProjects={2}
+      />
+    );
+
+    // Should show project 1 and the collapsed badge
+    expect(await screen.findAllByRole('img')).toHaveLength(1);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+
+    // Hovering should show the collapsed projects
+    await userEvent.hover(screen.getByText('+2'));
+    expect(await screen.findByText('project2')).toBeInTheDocument();
+    expect(await screen.findByText('project3')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/projectList.stories.tsx
+++ b/static/app/components/projectList.stories.tsx
@@ -1,0 +1,49 @@
+import {Fragment} from 'react';
+
+import {ProjectList} from 'sentry/components/projectList';
+import JSXProperty from 'sentry/components/stories/jsxProperty';
+import Matrix from 'sentry/components/stories/matrix';
+import storyBook from 'sentry/stories/storyBook';
+
+const PROJECT_SLUGS = ['sentry', 'javascript', 'snuba', 'seer'];
+
+export default storyBook('ProjectList', story => {
+  story('Configuring the number of visible projects', () => (
+    <Fragment>
+      <p>
+        The number of visible projects is configurable with the{' '}
+        <JSXProperty name="maxVisibleProjects" value /> prop.
+      </p>
+      <p>The default is 2.</p>
+      <Matrix
+        propMatrix={{
+          maxVisibleProjects: [1, 2, 3, 4],
+        }}
+        render={props => <ProjectList {...props} projectSlugs={PROJECT_SLUGS} />}
+        selectedProps={['maxVisibleProjects']}
+      />
+    </Fragment>
+  ));
+
+  story('Custom tooltip', () => (
+    <Fragment>
+      <p>
+        The tooltip text is also configurable with the{' '}
+        <JSXProperty name="collapsedProjectsTooltip" value /> prop.
+      </p>
+      <ProjectList
+        projectSlugs={PROJECT_SLUGS}
+        collapsedProjectsTooltip={projects => (
+          <div>
+            Look at all my other projects!
+            <ul>
+              {projects.map(project => (
+                <li key={project.slug}>{project.slug}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      />
+    </Fragment>
+  ));
+});

--- a/static/app/components/projectList.tsx
+++ b/static/app/components/projectList.tsx
@@ -1,0 +1,127 @@
+import type {ReactNode} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {Tooltip} from 'sentry/components/tooltip';
+import {space} from 'sentry/styles/space';
+import type {Project} from 'sentry/types/project';
+import useProjects from 'sentry/utils/useProjects';
+
+type ProjectListProps = {
+  projectSlugs: string[];
+  className?: string;
+  collapsedProjectsTooltip?: (projects: Array<Project | {slug: string}>) => ReactNode;
+  maxVisibleProjects?: number;
+};
+
+function DefaultCollapsedProjectsTooltip({
+  projects,
+}: {
+  projects: Array<Project | {slug: string}>;
+}) {
+  return (
+    <CollapsedProjects>
+      {projects.map(project => (
+        <ProjectBadge key={project.slug} project={project} avatarSize={16} />
+      ))}
+    </CollapsedProjects>
+  );
+}
+export function ProjectList({
+  projectSlugs,
+  maxVisibleProjects = 2,
+  collapsedProjectsTooltip,
+  className,
+}: ProjectListProps) {
+  const {projects} = useProjects({slugs: projectSlugs});
+
+  const projectAvatars = projectSlugs.map(slug => {
+    return projects.find(project => project.slug === slug) ?? {slug};
+  });
+  const numProjects = projectAvatars.length;
+  const numVisibleProjects =
+    maxVisibleProjects - numProjects >= 0 ? numProjects : maxVisibleProjects - 1;
+  const visibleProjectAvatars = projectAvatars.slice(0, numVisibleProjects).reverse();
+  const collapsedProjectAvatars = projectAvatars.slice(numVisibleProjects);
+  const numCollapsedProjects = collapsedProjectAvatars.length;
+
+  return (
+    <ProjectListWrapper className={className}>
+      {numCollapsedProjects > 0 && (
+        <Tooltip
+          skipWrapper
+          isHoverable
+          disabled={collapsedProjectsTooltip === null}
+          title={
+            collapsedProjectsTooltip ? (
+              collapsedProjectsTooltip(collapsedProjectAvatars)
+            ) : (
+              <DefaultCollapsedProjectsTooltip projects={collapsedProjectAvatars} />
+            )
+          }
+        >
+          <CollapsedBadge size={20} fontSize={10} data-test-id="collapsed-projects-badge">
+            +{numCollapsedProjects}
+          </CollapsedBadge>
+        </Tooltip>
+      )}
+      {visibleProjectAvatars.map(project => (
+        <StyledProjectBadge
+          key={project.slug}
+          hideName
+          project={project}
+          avatarSize={16}
+          avatarProps={{hasTooltip: true, tooltip: project.slug}}
+        />
+      ))}
+    </ProjectListWrapper>
+  );
+}
+
+const ProjectListWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+  padding-right: 8px;
+`;
+
+const CollapsedProjects = styled('div')`
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+const AvatarStyle = (p: any) => css`
+  border: 2px solid ${p.theme.background};
+  margin-right: -8px;
+  cursor: default;
+
+  &:hover {
+    z-index: 1;
+  }
+`;
+
+const StyledProjectBadge = styled(ProjectBadge)`
+  overflow: hidden;
+  z-index: 0;
+  ${AvatarStyle}
+`;
+
+const CollapsedBadge = styled('div')<{fontSize: number; size: number}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  text-align: center;
+  font-weight: ${p => p.theme.fontWeightBold};
+  background-color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.fontSize}px;
+  width: ${p => p.size}px;
+  height: ${p => p.size}px;
+  border-radius: ${p => p.theme.borderRadius};
+  ${AvatarStyle}
+`;

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -10,6 +10,7 @@ import Link from 'sentry/components/links/link';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import PerformanceDuration from 'sentry/components/performanceDuration';
+import {ProjectList} from 'sentry/components/projectList';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
@@ -66,116 +67,31 @@ export function ProjectsRenderer({
   projectSlugs,
   maxVisibleProjects = 2,
 }: ProjectsRendererProps) {
-  const organization = useOrganization();
-
   return (
-    <Projects orgId={organization.slug} slugs={projectSlugs}>
-      {({projects}) => {
-        // ensure that projectAvatars is in the same order as the projectSlugs prop
-        const projectAvatars = projectSlugs.map(slug => {
-          return projects.find(project => project.slug === slug) ?? {slug};
-        });
-        const numProjects = projectAvatars.length;
-        const numVisibleProjects =
-          maxVisibleProjects - numProjects >= 0 ? numProjects : maxVisibleProjects - 1;
-        const visibleProjectAvatars = projectAvatars
-          .slice(0, numVisibleProjects)
-          .reverse();
-        const collapsedProjectAvatars = projectAvatars.slice(numVisibleProjects);
-        const numCollapsedProjects = collapsedProjectAvatars.length;
-
-        return (
-          <ProjectList>
-            {numCollapsedProjects > 0 && (
-              <Tooltip
-                skipWrapper
-                title={
-                  <CollapsedProjects>
-                    {tn(
-                      'This trace contains %s more project.',
-                      'This trace contains %s more projects.',
-                      numCollapsedProjects
-                    )}
-                    {collapsedProjectAvatars.map(project => (
-                      <ProjectBadge
-                        key={project.slug}
-                        project={project}
-                        avatarSize={16}
-                      />
-                    ))}
-                  </CollapsedProjects>
-                }
-              >
-                <CollapsedBadge
-                  size={20}
-                  fontSize={10}
-                  data-test-id="collapsed-projects-badge"
-                >
-                  +{numCollapsedProjects}
-                </CollapsedBadge>
-              </Tooltip>
-            )}
-            {visibleProjectAvatars.map(project => (
-              <StyledProjectBadge
-                key={project.slug}
-                hideName
-                project={project}
-                avatarSize={16}
-                avatarProps={{hasTooltip: true, tooltip: project.slug}}
-              />
-            ))}
-          </ProjectList>
-        );
-      }}
-    </Projects>
+    <ProjectList
+      maxVisibleProjects={maxVisibleProjects}
+      projectSlugs={projectSlugs}
+      collapsedProjectsTooltip={projects => (
+        <CollapsedProjects>
+          {tn(
+            'This trace contains %s more project.',
+            'This trace contains %s more projects.',
+            projects.length
+          )}
+          {projects.map(project => (
+            <ProjectBadge key={project.slug} project={project} avatarSize={16} />
+          ))}
+        </CollapsedProjects>
+      )}
+    />
   );
 }
-
-const ProjectList = styled('div')`
-  display: flex;
-  align-items: center;
-  flex-direction: row-reverse;
-  justify-content: flex-end;
-  padding-right: 8px;
-`;
 
 const CollapsedProjects = styled('div')`
   width: 200px;
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
-`;
-
-const AvatarStyle = (p: any) => css`
-  border: 2px solid ${p.theme.background};
-  margin-right: -8px;
-  cursor: default;
-
-  &:hover {
-    z-index: 1;
-  }
-`;
-
-const StyledProjectBadge = styled(ProjectBadge)`
-  overflow: hidden;
-  z-index: 0;
-  ${AvatarStyle}
-`;
-
-const CollapsedBadge = styled('div')<{fontSize: number; size: number}>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  text-align: center;
-  font-weight: ${p => p.theme.fontWeightBold};
-  background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.fontSize}px;
-  width: ${p => p.size}px;
-  height: ${p => p.size}px;
-  border-radius: ${p => p.theme.borderRadius};
-  ${AvatarStyle}
 `;
 
 interface ProjectRendererProps {


### PR DESCRIPTION
I wish to use this component in issues, so I think it makes sense to extract it to a common component. Added a storybook entry and converted the existing usage (the traces table) to the new component.

![CleanShot 2025-03-26 at 12 39 23](https://github.com/user-attachments/assets/ce907259-639a-4de3-9b76-2a57204e8896)

Existing usage:

![CleanShot 2025-03-26 at 12 42 17](https://github.com/user-attachments/assets/042a6e6c-87ab-4934-b38e-2d76e075fc9f)

