### PR TITLE
:wrench: chore(integration middleware): mark organization integration doesn't exist as a halt

### DIFF
--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -315,7 +315,7 @@ class BaseRequestParser(ABC):
                 lifecycle.record_halt(
                     halt_reason=MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST
                 )
-                raise OrganizationIntegration.DoesNotExist()
+                return []
 
             organization_ids = [oi.organization_id for oi in organization_integrations]
             return organization_mapping_service.get_many(organization_ids=organization_ids)
@@ -329,8 +329,11 @@ class BaseRequestParser(ABC):
         if not organizations:
             organizations = self.get_organizations_from_integration()
 
+        if len(organizations) == 0:
+            return []
+
         region_names = find_regions_for_orgs([org.id for org in organizations])
         return sorted([get_region_by_name(name) for name in region_names], key=lambda r: r.name)
 
     def get_default_missing_integration_response(self) -> HttpResponse:
-        return HttpResponse(status=400)
+        return HttpResponse(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -17,7 +17,11 @@ from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.webhookpayload import WebhookPayload
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
-from sentry.integrations.middleware.metrics import MiddlewareOperationEvent, MiddlewareOperationType
+from sentry.integrations.middleware.metrics import (
+    MiddlewareHaltReason,
+    MiddlewareOperationEvent,
+    MiddlewareOperationType,
+)
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -308,6 +312,9 @@ class BaseRequestParser(ABC):
             )
 
             if organization_integrations.count() == 0:
+                lifecycle.record_halt(
+                    halt_reason=MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST
+                )
                 raise OrganizationIntegration.DoesNotExist()
 
             organization_ids = [oi.organization_id for oi in organization_integrations]

--- a/src/sentry/integrations/middleware/metrics.py
+++ b/src/sentry/integrations/middleware/metrics.py
@@ -43,3 +43,11 @@ class MiddlewareOperationEvent(EventLifecycleMetric):
             "integration_name": self.get_integration_name(),
             "region": self.get_region(),
         }
+
+
+class MiddlewareHaltReason(StrEnum):
+    """
+    Reasons why a middleware operation may halt without success/failure.
+    """
+
+    ORG_INTEGRATION_DOES_NOT_EXIST = "org_integration_does_not_exist"

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -20,7 +20,6 @@ from sentry.integrations.middleware.hybrid_cloud.parser import (
     create_async_request_payload,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.integrations.web.discord_extension_configuration import (
     DiscordExtensionConfigurationView,
@@ -123,7 +122,10 @@ class DiscordRequestParser(BaseRequestParser):
 
         try:
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+        except Integration.DoesNotExist:
+            return self.get_default_missing_integration_response()
+
+        if len(regions) == 0:
             return self.get_default_missing_integration_response()
 
         if is_discord_interactions_endpoint and self.discord_request:

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -14,7 +14,6 @@ from sentry.integrations.github.webhook import (
 )
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.silo.base import control_silo_function
 
@@ -62,7 +61,10 @@ class GithubRequestParser(BaseRequestParser):
                 return self.get_default_missing_integration_response()
 
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+        except Integration.DoesNotExist:
+            return self.get_default_missing_integration_response()
+
+        if len(regions) == 0:
             return self.get_default_missing_integration_response()
 
         return self.get_response_from_webhookpayload(

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -11,7 +11,6 @@ from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, get_gitlab_external_id
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.silo.base import control_silo_function
@@ -72,7 +71,10 @@ class GitlabRequestParser(BaseRequestParser):
                 return self.get_default_missing_integration_response()
 
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+        except Integration.DoesNotExist:
+            return self.get_default_missing_integration_response()
+
+        if len(regions) == 0:
             return self.get_default_missing_integration_response()
 
         try:

--- a/src/sentry/middleware/integrations/parsers/jira.py
+++ b/src/sentry/middleware/integrations/parsers/jira.py
@@ -62,7 +62,7 @@ class JiraRequestParser(BaseRequestParser):
 
         if len(regions) == 0:
             logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
-            return self.get_response_from_control_silo()
+            return self.get_default_missing_integration_response()
 
         if len(regions) > 1:
             # Since Jira is region_restricted (see JiraIntegrationProvider) we can just pick the

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -103,9 +103,6 @@ class MsTeamsRequestParser(BaseRequestParser):
             return self.get_default_missing_integration_response()
 
         if len(regions) == 0:
-            return self.get_default_missing_integration_response()
-
-        if len(regions) == 0:
             with sentry_sdk.isolation_scope() as scope:
                 scope.set_extra("view_class", self.view_class)
                 scope.set_extra("request_method", self.request.method)
@@ -118,7 +115,7 @@ class MsTeamsRequestParser(BaseRequestParser):
                     )
                 )
             logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
-            return self.get_response_from_control_silo()
+            return self.get_default_missing_integration_response()
 
         if self._check_if_event_should_be_sync(data=self.request_data):
             logger.info(

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -12,7 +12,6 @@ from django.http.response import HttpResponseBase
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.msteams import parsing
 from sentry.integrations.msteams.webhook import MsTeamsEvents, MsTeamsWebhookEndpoint
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
@@ -95,12 +94,15 @@ class MsTeamsRequestParser(BaseRequestParser):
                 return self.get_default_missing_integration_response()
 
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist) as err:
+        except Integration.DoesNotExist as err:
             logger.info(
                 "Error in handling",
                 exc_info=err,
                 extra={"request_data": self.request_data},
             )
+            return self.get_default_missing_integration_response()
+
+        if len(regions) == 0:
             return self.get_default_missing_integration_response()
 
         if len(regions) == 0:

--- a/src/sentry/middleware/integrations/parsers/vsts.py
+++ b/src/sentry/middleware/integrations/parsers/vsts.py
@@ -9,7 +9,6 @@ from django.http.response import HttpResponseBase
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.vsts.webhooks import WorkItemWebhook, get_vsts_external_id
 from sentry.silo.base import control_silo_function
 
@@ -42,7 +41,10 @@ class VstsRequestParser(BaseRequestParser):
                 return self.get_default_missing_integration_response()
 
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+        except Integration.DoesNotExist:
+            return self.get_default_missing_integration_response()
+
+        if len(regions) == 0:
             return self.get_default_missing_integration_response()
 
         return self.get_response_from_webhookpayload(

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -183,8 +183,8 @@ class BaseRequestParserTest(TestCase):
             oi_params={"status": ObjectStatus.DISABLED},
         )
         parser = ExampleRequestParser(self.request, self.response_handler)
-        with pytest.raises(OrganizationIntegration.DoesNotExist):
-            parser.get_organizations_from_integration(integration)
+        organizations = parser.get_organizations_from_integration(integration)
+        assert len(organizations) == 0
 
         assert mock_record.call_count == 2
         assert_halt_metric(mock_record, MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST)

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -187,4 +187,4 @@ class BaseRequestParserTest(TestCase):
             parser.get_organizations_from_integration(integration)
 
         assert mock_record.call_count == 2
-        assert_halt_metric(mock_record, MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST.value)
+        assert_halt_metric(mock_record, MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST)

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -3,6 +3,7 @@ from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from rest_framework import status
 
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.integrations.models.integration import Integration
@@ -46,7 +47,7 @@ class GithubRequestParserTest(TestCase):
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_regions(region_config)
@@ -64,7 +65,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
 
@@ -78,7 +79,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
 
@@ -100,7 +101,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
 
@@ -126,7 +127,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 202
+        assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.content == b""
         assert_webhook_payloads_for_mailbox(
             request=request,
@@ -148,7 +149,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
@@ -163,7 +164,7 @@ class GithubRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -5,6 +5,7 @@ from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from rest_framework import status
 
 from fixtures.gitlab import EXTERNAL_ID, PUSH_EVENT, WEBHOOK_SECRET, WEBHOOK_TOKEN
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -63,7 +64,7 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_EVENT="lol",
         )
         response = self.run_parser(request)
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
             response.reason_phrase == "The customer needs to set a Secret Token in their webhook."
         )
@@ -80,7 +81,7 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         response = self.run_parser(request)
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.reason_phrase == "The customer's Secret Token is malformed."
         assert_no_webhook_payloads()
 
@@ -105,7 +106,7 @@ class GitlabRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
 
@@ -125,7 +126,7 @@ class GitlabRequestParserTest(TestCase):
         response = parser.get_response()
 
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 202
+        assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.content == b""
         assert len(responses.calls) == 0
         assert_webhook_payloads_for_mailbox(
@@ -182,7 +183,7 @@ class GitlabRequestParserTest(TestCase):
             response = parser.get_response()
 
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 202
+        assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.content == b""
         assert len(responses.calls) == 0
         assert_webhook_payloads_for_mailbox(
@@ -208,7 +209,7 @@ class GitlabRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
@@ -246,7 +247,7 @@ class GitlabRequestParserTest(TestCase):
         response = parser.get_response()
 
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 202
+        assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.content == b""
         assert len(responses.calls) == 0
         assert_webhook_payloads_for_mailbox(

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -62,12 +62,12 @@ class SlackRequestParserTest(TestCase):
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/slack/commands/",
-            status=201,
+            status=status.HTTP_201_CREATED,
             body=b"region_response",
         )
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 201
+        assert response.status_code == status.HTTP_201_CREATED
         assert response.content == b"region_response"
         assert len(responses.calls) == 1
         assert_no_webhook_payloads()
@@ -81,7 +81,7 @@ class SlackRequestParserTest(TestCase):
         )
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 401
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert response.content == b"error_response"
         assert len(responses.calls) == 2
         assert_no_webhook_payloads()
@@ -103,7 +103,7 @@ class SlackRequestParserTest(TestCase):
         # Passes through to control silo
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -132,14 +132,13 @@ class SlackRequestParserTest(TestCase):
         )
         assert response.status_code == status.HTTP_200_OK
 
-    @patch("sentry.middleware.integrations.parsers.slack.convert_to_async_slack_response")
-    @patch.object(
-        SlackRequestParser,
-        "get_regions_from_organizations",
-        side_effect=OrganizationIntegration.DoesNotExist(),
+    @patch(
+        "sentry.integrations.slack.requests.base.SlackRequest._check_signing_secret",
+        return_value=True,
     )
+    @patch("sentry.middleware.integrations.parsers.slack.convert_to_async_slack_response")
     def test_skips_async_response_if_org_integration_missing(
-        self, mock_slack_task, mock_get_regions
+        self, mock_slack_task, mock_signing_secret
     ):
         response_url = "https://hooks.slack.com/commands/TXXXXXXX1/1234567890123/something"
         data = {


### PR DESCRIPTION
https://sentry.sentry.io/issues/6243970798/ makes up 90% of errors in our sentry project, lets mark this as a halt.

instead of raising an error, lets return an empty list and handle at the callee site

closes https://sentry.sentry.io/issues/6243970798/