### PR TITLE
fix(issues): Prevent tiny github icon

### DIFF
--- a/static/app/components/pullRequestLink.tsx
+++ b/static/app/components/pullRequestLink.tsx
@@ -60,6 +60,10 @@ const ExternalPullLink = styled(ExternalLink)`
   display: inline-flex;
   align-items: center;
   gap: ${space(0.5)};
+
+  svg {
+    flex-shrink: 0;
+  }
 `;
 
 export default PullRequestLink;


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/a9286c15-864b-48bb-a105-98274271e5d5)


after
![image](https://github.com/user-attachments/assets/faf0c794-184c-47f9-9bbd-f738880a3b90)
