### PR TITLE
fix(releases): fix newGroups calculation on release meta and remove usages of release new_groups

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -104,7 +104,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "version": release.version,
                 "versionInfo": expose_version_info(release.version_info),
                 "projects": projects,
-                "newGroups": release.new_groups,
+                "newGroups": sum(project["newGroups"] for project in projects),
                 "deployCount": release.total_deploys,
                 "commitCount": release.commit_count,
                 "released": release.date_released or release.date_added,

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -202,7 +202,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)
         release = Release.objects.create(
-            organization_id=project.organization_id, version=uuid4().hex, new_groups=1
+            organization_id=project.organization_id, version=uuid4().hex
         )
         release.add_project(project)
         commit_author = CommitAuthor.objects.create(
@@ -242,7 +242,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         self.create_member(user=user, organization=project.organization)
         self.create_member(user=otheruser, organization=project.organization)
         release = Release.objects.create(
-            organization_id=project.organization_id, version=uuid4().hex, new_groups=1
+            organization_id=project.organization_id, version=uuid4().hex
         )
         release.add_project(project)
         commit_author = CommitAuthor.objects.create(
@@ -285,7 +285,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         project = self.create_project()
         self.create_member(user=otheruser, organization=project.organization)
         release = Release.objects.create(
-            organization_id=project.organization_id, version=uuid4().hex, new_groups=1
+            organization_id=project.organization_id, version=uuid4().hex
         )
         release.add_project(project)
         commit_author = CommitAuthor.objects.create(
@@ -322,7 +322,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         project = self.create_project()
         self.create_member(user=otheruser, organization=project.organization)
         release = Release.objects.create(
-            organization_id=project.organization_id, version=uuid4().hex, new_groups=1
+            organization_id=project.organization_id, version=uuid4().hex
         )
         release.add_project(project)
         commit = Commit.objects.create(

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -351,7 +351,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)
         release = Release.objects.create(
-            organization_id=project.organization_id, version=uuid4().hex, new_groups=1
+            organization_id=project.organization_id, version=uuid4().hex
         )
         release.add_project(project)
         commit_author1 = CommitAuthor.objects.create(
@@ -397,6 +397,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         result = serialize(release, user)
         assert len(result["authors"]) == 1
         assert result["authors"][0]["email"] == "stebe@sentry.io"
+        assert result["newGroups"] == 1
 
     def test_with_deploy(self):
         user = self.create_user()


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry/issues/87322
- [notion doc](https://www.notion.so/sentry/Removing-new_groups-field-from-Release-model-1c28b10e4b5d801d8598dd15e7a5b215?showMoveTo=true&saveParent=true) for context & plan

on the `releases/meta/` endpoint, the value for `newGroups` incorrect, as seen in this [API request](https://sentry.sentry.io/api/0/organizations/sentry/releases/frontend%4085a177005793f32687cdd7d9776191ee51153e5f/meta/) -- the project has 1 `newGroup` but the overall release meta `newGroups == 0`.

the overall meta `newGroups` should be the same as the sum of `newGroups` across all release projects, which this PR fixes.

https://github.com/getsentry/sentry/blob/b88166941846ce4fdb4e2001453e421b41ba7e10/tests/sentry/api/serializers/test_release.py#L76-L77

the `new_groups` field on the `Release` model was deprecated and will be removed in a subsequent migration.

https://github.com/getsentry/sentry/blob/b88166941846ce4fdb4e2001453e421b41ba7e10/src/sentry/models/release.py#L210-L211
