### PR TITLE
fix(external-issues): Correctly refetch external field config with dynamic values

### DIFF
--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -8,10 +8,10 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import type {RequestOptions, ResponseMeta} from 'sentry/api';
 import {ExternalForm} from 'sentry/components/externalIssues/externalForm';
 import {useAsyncOptionsCache} from 'sentry/components/externalIssues/useAsyncOptionsCache';
+import {useDynamicFields} from 'sentry/components/externalIssues/useDynamicFields';
 import type {ExternalIssueAction} from 'sentry/components/externalIssues/utils';
 import {
   getConfigName,
-  getDynamicFields,
   getFieldProps,
   getOptions,
   hasErrorInFields,
@@ -119,11 +119,10 @@ export default function ExternalIssueForm({
       retry: false,
     }
   );
-
-  const dynamicFieldValues = useMemo(
-    () => getDynamicFields({action, integrationDetails}),
-    [action, integrationDetails]
-  );
+  const {dynamicFieldValues, setDynamicFieldValue} = useDynamicFields({
+    action,
+    integrationDetails: integrationDetails ?? null,
+  });
 
   /**
    * XXX: This function seems illegal but it's necessary.
@@ -133,51 +132,53 @@ export default function ExternalIssueForm({
    * the user entered as a query param. Since we can't conditionally call hooks, we have to avoid
    * `useApiQuery`, and instead manually call the api, and update the cache ourselves.
    */
-  const refetchWithDynamicFields = useCallback(() => {
-    setIsDynamicallyRefetching(true);
-    const requestOptions: RequestOptions = {
-      method: 'GET',
-      query: {action, ...dynamicFieldValues},
-      success: (
-        data: IntegrationIssueConfig,
-        _textStatus: string | undefined,
-        _responseMeta: ResponseMeta | undefined
-      ) => {
-        setApiQueryData(
-          queryClient,
-          makeIntegrationIssueConfigQueryKey({
-            orgSlug: organization.slug,
-            groupId: group.id,
-            integrationId: integration.id,
-            action,
-          }),
-          existingData => (data ? data : existingData)
-        );
-        setIsDynamicallyRefetching(false);
-      },
-      error: (err: any) => {
-        // This behavior comes from the DeprecatedAsyncComponent
-        if (err?.responseText) {
-          Sentry.addBreadcrumb({
-            message: err.responseText,
-            category: 'xhr',
-            level: 'error',
-          });
-        }
-        setIsDynamicallyRefetching(false);
-      },
-    };
-    return api.request(endpointString, requestOptions);
-  }, [
-    action,
-    dynamicFieldValues,
-    queryClient,
-    organization.slug,
-    group.id,
-    integration.id,
-    api,
-    endpointString,
-  ]);
+  const refetchWithDynamicFields = useCallback(
+    (dynamicValues: Record<string, FieldValue>) => {
+      setIsDynamicallyRefetching(true);
+      const requestOptions: RequestOptions = {
+        method: 'GET',
+        query: {action, ...dynamicValues},
+        success: (
+          data: IntegrationIssueConfig,
+          _textStatus: string | undefined,
+          _responseMeta: ResponseMeta | undefined
+        ) => {
+          setApiQueryData(
+            queryClient,
+            makeIntegrationIssueConfigQueryKey({
+              orgSlug: organization.slug,
+              groupId: group.id,
+              integrationId: integration.id,
+              action,
+            }),
+            existingData => (data ? data : existingData)
+          );
+          setIsDynamicallyRefetching(false);
+        },
+        error: (err: any) => {
+          // This behavior comes from the DeprecatedAsyncComponent
+          if (err?.responseText) {
+            Sentry.addBreadcrumb({
+              message: err.responseText,
+              category: 'xhr',
+              level: 'error',
+            });
+          }
+          setIsDynamicallyRefetching(false);
+        },
+      };
+      return api.request(endpointString, requestOptions);
+    },
+    [
+      action,
+      queryClient,
+      organization.slug,
+      group.id,
+      integration.id,
+      api,
+      endpointString,
+    ]
+  );
 
   const startSpan = useCallback(
     (type: 'load' | 'submit') => {
@@ -253,13 +254,20 @@ export default function ExternalIssueForm({
   );
 
   const onFieldChange = useCallback(
-    (fieldName: string, _value: FieldValue) => {
+    (fieldName: string, value: FieldValue) => {
       if (dynamicFieldValues.hasOwnProperty(fieldName)) {
-        refetchWithDynamicFields();
+        setDynamicFieldValue(fieldName, value);
+        refetchWithDynamicFields({...dynamicFieldValues, [fieldName]: value});
       }
     },
-    [refetchWithDynamicFields, dynamicFieldValues]
+    [dynamicFieldValues, refetchWithDynamicFields, setDynamicFieldValue]
   );
+
+  // Even if we pass onFieldChange as a prop, the model only uses the first instance.
+  // In order to use the correct dynamicFieldValues, we need to set it whenever this function is changed.
+  useEffect(() => {
+    model.setFormOptions({onFieldChange});
+  }, [model, onFieldChange]);
 
   const getExternalIssueFieldProps = useCallback(
     (field: IssueConfigField) => {

--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -44,13 +44,17 @@ const defaultIssueConfig = [
     updatesForm: true,
     required: true,
   },
-];
+] as const;
 
 describe('ProjectAlerts -> TicketRuleModal', function () {
   const organization = OrganizationFixture();
   const router = RouterFixture();
   const onSubmitAction = jest.fn();
   const closeModal = jest.fn();
+  const [
+    issueTypeCode, // 10004
+    issueTypeLabel, // New Feature
+  ] = defaultIssueConfig[1].choices[3];
 
   afterEach(function () {
     closeModal.mockReset();
@@ -138,7 +142,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         match: [
           MockApiClient.matchQuery({
             action: 'create',
-            issuetype: '10001',
+            issuetype: issueTypeCode,
             project: '10000',
           }),
         ],
@@ -157,7 +161,10 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         },
       });
 
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Issue Type'}),
+        issueTypeLabel
+      );
       expect(dynamicQuery).toHaveBeenCalled();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Assignee'}), 'b');
       await submitSuccess();
@@ -169,7 +176,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         match: [
           MockApiClient.matchQuery({
             action: 'create',
-            issuetype: '10001',
+            issuetype: issueTypeCode,
             project: '10000',
           }),
         ],
@@ -194,7 +201,10 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       expect(
         screen.queryAllByText(`Could not fetch saved option for Labels. Please reselect.`)
       ).toHaveLength(0);
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Issue Type'}),
+        issueTypeLabel
+      );
       expect(dynamicQuery).toHaveBeenCalled();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Labels'}), 'bug');
       await submitSuccess();
@@ -233,7 +243,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         match: [
           MockApiClient.matchQuery({
             action: 'create',
-            issuetype: '10001',
+            issuetype: issueTypeCode,
             project: '10000',
           }),
         ],
@@ -254,7 +264,10 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       });
 
       // Switch Issue Type so we refetch the config and update Reporter choices
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Issue Type'}),
+        issueTypeLabel
+      );
       expect(dynamicQuery).toHaveBeenCalled();
       await expect(
         selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a')
@@ -285,7 +298,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         match: [
           MockApiClient.matchQuery({
             action: 'create',
-            issuetype: '10001',
+            issuetype: issueTypeCode,
             project: '10000',
           }),
         ],
@@ -304,7 +317,10 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         },
       });
 
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Issue Type'}),
+        issueTypeLabel
+      );
 
       // Component makes 1 request per character typed.
       let txt = '';

--- a/static/app/components/externalIssues/useDynamicFields.tsx
+++ b/static/app/components/externalIssues/useDynamicFields.tsx
@@ -1,0 +1,31 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import {
+  type ExternalIssueAction,
+  getDynamicFields,
+} from 'sentry/components/externalIssues/utils';
+import type {FieldValue} from 'sentry/components/forms/types';
+import type {IntegrationIssueConfig} from 'sentry/types/integrations';
+
+interface UseDynamicFieldsProps {
+  action: ExternalIssueAction;
+  integrationDetails: IntegrationIssueConfig | null;
+}
+
+export function useDynamicFields({action, integrationDetails}: UseDynamicFieldsProps) {
+  // Manage a state mapping field name to values.
+  const [dynamicFieldValues, setDynamicFieldValues] = useState<
+    Record<string, FieldValue>
+  >({});
+
+  // Update a single entry of the dynamic field state.
+  const setDynamicFieldValue = useCallback((fieldName: string, value: FieldValue) => {
+    setDynamicFieldValues(prev => ({...prev, [fieldName]: value}));
+  }, []);
+
+  // If we ever refetch the action or config, replace the state with the response
+  useEffect(() => {
+    setDynamicFieldValues(getDynamicFields({action, integrationDetails}));
+  }, [action, integrationDetails]);
+  return {dynamicFieldValues, setDynamicFieldValue, setDynamicFieldValues};
+}


### PR DESCRIPTION
The bug came from incorrectly adopting this function from the abstract class: https://github.com/getsentry/sentry/blob/08b3f695f03305ab2b23c8fab9f0ef26e64fdd9a/static/app/components/externalIssues/abstractExternalIssueForm.tsx#L111-L126

Resolves https://github.com/getsentry/sentry/issues/87867

Two things:
1. The model isn't state, so the `onFieldChange` form prop was only being set once, meaning it didn't have access to the latest `dynamicFieldValues`.
2. The new field value wasn't being set on the request prior to making it, meaning we'd repeatedly make requests with the same one, preventing changes on `updatesForm` fields.