### PR TITLE
:recycle: ref: refactor notification building utils to prevent circular dependencies

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -73,7 +73,12 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
                 color=LEVEL_TO_COLOR[get_color(event_for_tags, self.notification, self.group)],
                 # We can't embed urls in Discord embed footers.
                 footer=DiscordMessageEmbedFooter(
-                    build_footer(self.group, project, self.rules, "{text}")
+                    build_footer(
+                        group=self.group,
+                        project=project,
+                        url_format="{text}",
+                        rules=self.rules,
+                    )
                 ),
                 fields=build_tag_fields(event_for_tags, self.tags),
                 timestamp=timestamp,

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, TypedDict
 
 from sentry import features
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.integrations.slack.message_builder.types import LEVEL_TO_COLOR, SLACK_URL_FORMAT
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
@@ -173,7 +173,7 @@ def build_attachment_text(group: Group, event: Event | GroupEvent | None = None)
 
 
 def build_attachment_replay_link(
-    group: Group, event: Event | GroupEvent | None = None, url_format: str = SLACK_URL_FORMAT
+    group: Group, url_format: str, event: Event | GroupEvent | None = None
 ) -> str | None:
     has_replay = features.has("organizations:session-replay", group.organization)
     has_slack_links = features.has(
@@ -199,8 +199,8 @@ def build_rule_url(rule: Any, group: Group, project: Project) -> str:
 def build_footer(
     group: Group,
     project: Project,
+    url_format: str,
     rules: Sequence[Rule] | None = None,
-    url_format: str = SLACK_URL_FORMAT,
 ) -> str:
     footer = f"{group.qualified_short_id}"
     if rules:
@@ -209,9 +209,6 @@ def build_footer(
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"
         footer += f" via {url_format.format(text=text, url=rule_url)}"
-
-        if url_format == SLACK_URL_FORMAT:
-            footer = url_format.format(text=text, url=rule_url)
 
         if len(rules) > 1:
             footer += f" (+{len(rules) - 1} other)"

--- a/src/sentry/integrations/messaging/types.py
+++ b/src/sentry/integrations/messaging/types.py
@@ -1,0 +1,11 @@
+# Attachment colors used for issues with no actions take.
+
+LEVEL_TO_COLOR = {
+    "_actioned_issue": "#EDEEEF",
+    "_incident_resolved": "#4DC771",
+    "debug": "#FBE14F",
+    "error": "#E03E2F",
+    "fatal": "#FA4747",
+    "info": "#2788CE",
+    "warning": "#FFC227",
+}

--- a/src/sentry/integrations/msteams/card_builder/issues.py
+++ b/src/sentry/integrations/msteams/card_builder/issues.py
@@ -129,7 +129,12 @@ class MSTeamsIssueMessageBuilder(MSTeamsMessageBuilder):
 
         image_column = create_footer_logo_block()
 
-        text = build_footer(self.group, project, self.rules, MSTEAMS_URL_FORMAT)
+        text = build_footer(
+            group=self.group,
+            project=project,
+            url_format=MSTEAMS_URL_FORMAT,
+            rules=self.rules,
+        )
 
         text_column = create_footer_column_block(create_footer_text_block(text))
 

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -1,13 +1,10 @@
 from datetime import datetime
 
 from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
-from sentry.integrations.slack.message_builder.types import (
-    INCIDENT_COLOR_MAPPING,
-    LEVEL_TO_COLOR,
-    SlackBody,
-)
+from sentry.integrations.slack.message_builder.types import INCIDENT_COLOR_MAPPING, SlackBody
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.models.organization import Organization
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -17,7 +17,6 @@ from sentry.integrations.messaging.message_builder import (
     build_attachment_replay_link,
     build_attachment_text,
     build_attachment_title,
-    build_footer,
     format_actor_option_slack,
     format_actor_options_slack,
     get_title_link,
@@ -32,6 +31,7 @@ from sentry.integrations.slack.message_builder.types import (
     SLACK_URL_FORMAT,
     SlackBlock,
 )
+from sentry.integrations.slack.message_builder.util import build_slack_footer
 from sentry.integrations.slack.utils.escape import escape_slack_markdown_text, escape_slack_text
 from sentry.integrations.time_utils import get_approx_start_time, time_since
 from sentry.integrations.types import ExternalProviders
@@ -506,7 +506,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
     def get_footer(self) -> SlackBlock:
         # This link does not contain user input (it's a static label and a url), must not escape it.
-        replay_link = build_attachment_replay_link(self.group, self.event)
+        replay_link = build_attachment_replay_link(
+            group=self.group,
+            url_format=SLACK_URL_FORMAT,
+            event=self.event,
+        )
 
         timestamp = None
         if not self.issue_details:
@@ -517,7 +521,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         footer = (
             self.notification.build_notification_footer(self.recipient, ExternalProviders.SLACK)
             if self.notification and self.recipient
-            else build_footer(self.group, project, self.rules, SLACK_URL_FORMAT)
+            else build_slack_footer(
+                group=self.group,
+                project=project,
+                rules=self.rules,
+            )
         )
 
         if not self.notification:

--- a/src/sentry/integrations/slack/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/slack/message_builder/metric_alerts.py
@@ -1,12 +1,9 @@
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.metric_alerts import metric_alert_unfurl_attachment_info
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
-from sentry.integrations.slack.message_builder.types import (
-    INCIDENT_COLOR_MAPPING,
-    LEVEL_TO_COLOR,
-    SlackBody,
-)
+from sentry.integrations.slack.message_builder.types import INCIDENT_COLOR_MAPPING, SlackBody
 from sentry.integrations.slack.utils.escape import escape_slack_text
 
 

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -7,17 +7,6 @@ SlackAttachment = dict[str, Any]
 SlackBlock = dict[str, Any]
 SlackBody = Union[SlackAttachment, SlackBlock]
 
-# Attachment colors used for issues with no actions take.
-LEVEL_TO_COLOR = {
-    "_actioned_issue": "#EDEEEF",
-    "_incident_resolved": "#4DC771",
-    "debug": "#FBE14F",
-    "error": "#E03E2F",
-    "fatal": "#FA4747",
-    "info": "#2788CE",
-    "warning": "#FFC227",
-}
-
 INCIDENT_COLOR_MAPPING = {
     "Resolved": "_incident_resolved",
     "Warning": "warning",

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -1,0 +1,27 @@
+from collections.abc import Sequence
+
+from sentry.integrations.messaging.message_builder import build_rule_url
+from sentry.integrations.slack.message_builder.types import SLACK_URL_FORMAT
+from sentry.models.group import Group
+from sentry.models.project import Project
+from sentry.models.rule import Rule
+
+
+def build_slack_footer(
+    group: Group,
+    project: Project,
+    rules: Sequence[Rule] | None = None,
+) -> str:
+    footer = f"{group.qualified_short_id}"
+
+    if rules:
+        rule_url = build_rule_url(rules[0], group, project)
+        # If this notification is triggered via the "Send Test Notification"
+        # button then the label is not defined, but the url works.
+        text = rules[0].label if rules[0].label else "Test Alert"
+        footer = SLACK_URL_FORMAT.format(text=text, url=rule_url)
+
+        if len(rules) > 1:
+            footer += f" (+{len(rules) - 1} other)"
+
+    return footer

--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -2,7 +2,7 @@ from rest_framework import status
 
 from sentry import tagstore
 from sentry.integrations.base import FeatureDescription, IntegrationFeatures
-from sentry.integrations.slack.message_builder.types import LEVEL_TO_COLOR
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.plugins.base.structs import Notification
 from sentry.plugins.bases import notify
 from sentry.shared_integrations.exceptions import ApiError

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -140,7 +140,7 @@ class DiscordIssueAlertTest(RuleTestCase):
                 notification_uuid=notification_uuid,
             ),
             "color": LEVEL_TO_COLOR["error"],
-            "footer": {"text": build_footer(self.event.group, self.event.project, None, "{text}")},
+            "footer": {"text": build_footer(self.event.group, self.event.project, "{text}", None)},
             "fields": [],
             "timestamp": self.event.timestamp,
         }

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -22,6 +22,7 @@ from sentry.integrations.messaging.message_builder import (
     build_attachment_text,
     build_attachment_title,
 )
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.issues import (
     SlackIssuesMessageBuilder,
@@ -32,7 +33,6 @@ from sentry.integrations.slack.message_builder.issues import (
     get_tags,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
-from sentry.integrations.slack.message_builder.types import LEVEL_TO_COLOR
 from sentry.integrations.time_utils import time_since
 from sentry.issues.grouptype import (
     FeedbackGroup,

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -5,7 +5,7 @@ import orjson
 import pytest
 import responses
 
-from sentry.integrations.slack.message_builder.types import LEVEL_TO_COLOR
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.shared_integrations.exceptions import ApiError


### PR DESCRIPTION
making my aci life easier

i am running into a lot of circular dependency issues around these methods since we are importing slack specific utils and methods in a generic `messaging` class.

