### PR TITLE
fix(aci): type tsdb_function correctly, don't use as class var

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -15,6 +15,7 @@ ONE_DAY = ONE_HOUR * 24
 
 TSDBKey = TypeVar("TSDBKey", str, int)
 TSDBItem = TypeVar("TSDBItem", str, int)
+SnubaCondition = tuple[str, str, Any]
 
 
 class IncrMultiOptions(TypedDict):
@@ -446,7 +447,7 @@ class BaseTSDB(Service):
         jitter_value: int | None = None,
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, Any]] | None = None,
+        conditions: list[SnubaCondition] | None = None,
     ) -> dict[int, int]:
         range_set = self.get_range(
             model,
@@ -546,7 +547,7 @@ class BaseTSDB(Service):
         jitter_value: int | None = None,
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, Any]] | None = None,
+        conditions: list[SnubaCondition] | None = None,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range with optional conditions

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -446,7 +446,7 @@ class BaseTSDB(Service):
         jitter_value: int | None = None,
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, str]] | None = None,
+        conditions: list[tuple[str, str, Any]] | None = None,
     ) -> dict[int, int]:
         range_set = self.get_range(
             model,

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -546,7 +546,7 @@ class BaseTSDB(Service):
         jitter_value: int | None = None,
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, str]] | None = None,
+        conditions: list[tuple[str, str, Any]] | None = None,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range with optional conditions

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -530,7 +530,7 @@ class RedisTSDB(BaseTSDB):
         jitter_value: int | None = None,
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, str]] | None = None,
+        conditions: list[tuple[str, str, Any]] | None = None,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range.

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -13,7 +13,14 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes
 from redis.client import Script
 
-from sentry.tsdb.base import BaseTSDB, IncrMultiOptions, TSDBItem, TSDBKey, TSDBModel
+from sentry.tsdb.base import (
+    BaseTSDB,
+    IncrMultiOptions,
+    SnubaCondition,
+    TSDBItem,
+    TSDBKey,
+    TSDBModel,
+)
 from sentry.utils.dates import to_datetime
 from sentry.utils.redis import check_cluster_versions, get_cluster_from_options, load_redis_script
 from sentry.utils.versioning import Version
@@ -530,7 +537,7 @@ class RedisTSDB(BaseTSDB):
         jitter_value: int | None = None,
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
-        conditions: list[tuple[str, str, Any]] | None = None,
+        conditions: list[SnubaCondition] | None = None,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range.

--- a/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
@@ -25,14 +25,13 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
 )
 from sentry.rules.match import MatchType
-from sentry.tsdb.base import TSDBModel
+from sentry.tsdb.base import SnubaCondition, TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
 from sentry.utils.snuba import options_override
 from sentry.workflow_engine.models.data_condition import Condition
 
 QueryFilter = dict[str, Any]
-SnubaCondition = tuple[str, str, Any]
 
 
 class TSDBFunction(Protocol):

--- a/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
@@ -1,9 +1,9 @@
 import contextlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, Literal, TypedDict
+from typing import Any, ClassVar, Literal, Protocol, TypedDict
 
 from django.core.cache import cache
 from django.db.models import QuerySet
@@ -32,7 +32,24 @@ from sentry.utils.snuba import options_override
 from sentry.workflow_engine.models.data_condition import Condition
 
 QueryFilter = dict[str, Any]
-SnubaCondition = tuple[str, str, str | None]
+SnubaCondition = tuple[str, str, Any]
+
+
+class TSDBFunction(Protocol):
+    def __call__(
+        self,
+        model: TSDBModel,
+        keys: list[int],
+        start: datetime,
+        end: datetime,
+        rollup: int | None = None,
+        environment_id: int | None = None,
+        use_cache: bool = False,
+        jitter_value: int | None = None,
+        tenant_ids: dict[str, str | int] | None = None,
+        referrer_suffix: str | None = None,
+        conditions: list[SnubaCondition] | None = None,
+    ) -> dict[int, int]: ...
 
 
 class InvalidFilter(Exception):
@@ -52,7 +69,6 @@ class _QSTypedDict(TypedDict):
 
 class BaseEventFrequencyQueryHandler(ABC):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
-    tsdb_function: ClassVar[Callable[..., Any]]
 
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
         """
@@ -75,7 +91,7 @@ class BaseEventFrequencyQueryHandler(ABC):
 
     def get_snuba_query_result(
         self,
-        tsdb_function: Callable[..., Any],
+        tsdb_function: TSDBFunction,
         keys: list[int],
         group_id: int,
         organization_id: int,
@@ -102,6 +118,7 @@ class BaseEventFrequencyQueryHandler(ABC):
 
     def get_chunked_result(
         self,
+        tsdb_function: TSDBFunction,
         model: TSDBModel,
         group_ids: list[int],
         organization_id: int,
@@ -116,7 +133,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         conditions = self.get_extra_snuba_conditions(model, filters) if filters else []
         for group_chunk in chunked(group_ids, SNUBA_LIMIT):
             result = self.get_snuba_query_result(
-                tsdb_function=self.tsdb_function,
+                tsdb_function=tsdb_function,
                 model=model,
                 keys=[group_id for group_id in group_chunk],
                 group_id=group_id,
@@ -301,8 +318,6 @@ slow_condition_query_handler_registry = Registry[type[BaseEventFrequencyQueryHan
 @slow_condition_query_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
 class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
-    tsdb_function = tsdb.backend.get_sums
-
     def batch_query(
         self,
         group_ids: set[int],
@@ -325,6 +340,7 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
             model = get_issue_tsdb_group_model(category)
             try:
                 results = self.get_chunked_result(
+                    tsdb_function=tsdb.backend.get_sums,
                     model=model,
                     group_ids=issue_ids,
                     organization_id=organization_id,
@@ -347,8 +363,6 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
-    tsdb_function = tsdb.backend.get_distinct_counts_totals
-
     def batch_query(
         self,
         group_ids: set[int],
@@ -371,6 +385,7 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
             model = get_issue_tsdb_user_group_model(category)
             try:
                 results = self.get_chunked_result(
+                    tsdb_function=tsdb.backend.get_distinct_counts_totals,
                     model=model,
                     group_ids=issue_ids,
                     organization_id=organization_id,
@@ -393,7 +408,6 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.PERCENT_SESSIONS_PERCENT)
 class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = PERCENT_INTERVALS
-    tsdb_function = tsdb.backend.get_sums
 
     def get_session_count(
         self, project_id: int, environment_id: int | None, start: datetime, end: datetime
@@ -460,6 +474,7 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
             model = get_issue_tsdb_group_model(category)
             # InvalidFilter should not be raised for errors
             results = self.get_chunked_result(
+                tsdb_function=tsdb.backend.get_sums,
                 model=model,
                 group_ids=issue_ids,
                 organization_id=organization_id,


### PR DESCRIPTION
Fixes SENTRY-3R0P

The `Delegator` is added in getsentry, and has additional checks to make sure backend service functions are used correctly.

When `tsdb_function` is used as a `ClassVar`, calling `self.tsdb_function()` will pass `self` as an extra argument into the function, which causes the error. Use the `tsdb_functions` directly instead of storing them as class vars, and improve typing for these functions.