### PR TITLE
:wrench: chore(aci): add `provider_slug` to action handler

### DIFF
--- a/src/sentry/workflow_engine/handlers/__init__.py
+++ b/src/sentry/workflow_engine/handlers/__init__.py
@@ -1,9 +1,9 @@
 # Export any handlers we want to include into the registry
 __all__ = [
-    "NotificationActionHandler",
+    "ActionHandler",
     "EventCreatedByDetectorConditionHandler",
     "EventSeenCountConditionHandler",
 ]
 
-from .action import NotificationActionHandler
+from .action import ActionHandler
 from .condition import EventCreatedByDetectorConditionHandler, EventSeenCountConditionHandler

--- a/src/sentry/workflow_engine/handlers/__init__.py
+++ b/src/sentry/workflow_engine/handlers/__init__.py
@@ -1,9 +1,7 @@
 # Export any handlers we want to include into the registry
 __all__ = [
-    "ActionHandler",
     "EventCreatedByDetectorConditionHandler",
     "EventSeenCountConditionHandler",
 ]
 
-from .action import ActionHandler
 from .condition import EventCreatedByDetectorConditionHandler, EventSeenCountConditionHandler

--- a/src/sentry/workflow_engine/handlers/__init__.py
+++ b/src/sentry/workflow_engine/handlers/__init__.py
@@ -2,6 +2,36 @@
 __all__ = [
     "EventCreatedByDetectorConditionHandler",
     "EventSeenCountConditionHandler",
+    "AzureDevopsActionHandler",
+    "DiscordActionHandler",
+    "EmailActionHandler",
+    "GithubActionHandler",
+    "GithubEnterpriseActionHandler",
+    "JiraActionHandler",
+    "JiraServerActionHandler",
+    "MsteamsActionHandler",
+    "OpsgenieActionHandler",
+    "PagerdutyActionHandler",
+    "PluginActionHandler",
+    "SentryAppActionHandler",
+    "SlackActionHandler",
+    "WebhookActionHandler",
 ]
 
+from .action import (
+    AzureDevopsActionHandler,
+    DiscordActionHandler,
+    EmailActionHandler,
+    GithubActionHandler,
+    GithubEnterpriseActionHandler,
+    JiraActionHandler,
+    JiraServerActionHandler,
+    MsteamsActionHandler,
+    OpsgenieActionHandler,
+    PagerdutyActionHandler,
+    PluginActionHandler,
+    SentryAppActionHandler,
+    SlackActionHandler,
+    WebhookActionHandler,
+)
 from .condition import EventCreatedByDetectorConditionHandler, EventSeenCountConditionHandler

--- a/src/sentry/workflow_engine/handlers/action/__init__.py
+++ b/src/sentry/workflow_engine/handlers/action/__init__.py
@@ -1,0 +1,33 @@
+__all__ = [
+    "AzureDevopsActionHandler",
+    "DiscordActionHandler",
+    "EmailActionHandler",
+    "GithubActionHandler",
+    "GithubEnterpriseActionHandler",
+    "JiraActionHandler",
+    "JiraServerActionHandler",
+    "MsteamsActionHandler",
+    "OpsgenieActionHandler",
+    "PagerdutyActionHandler",
+    "PluginActionHandler",
+    "SentryAppActionHandler",
+    "SlackActionHandler",
+    "WebhookActionHandler",
+]
+
+from .notification.handler import (
+    AzureDevopsActionHandler,
+    DiscordActionHandler,
+    EmailActionHandler,
+    GithubActionHandler,
+    GithubEnterpriseActionHandler,
+    JiraActionHandler,
+    JiraServerActionHandler,
+    MsteamsActionHandler,
+    OpsgenieActionHandler,
+    PagerdutyActionHandler,
+    PluginActionHandler,
+    SentryAppActionHandler,
+    SlackActionHandler,
+    WebhookActionHandler,
+)

--- a/src/sentry/workflow_engine/handlers/action/__init__.py
+++ b/src/sentry/workflow_engine/handlers/action/__init__.py
@@ -1,5 +1,5 @@
 __all__ = [
-    "NotificationActionHandler",
+    "ActionHandler",
 ]
 
-from .notification.handler import NotificationActionHandler
+from .notification.handler import ActionHandler

--- a/src/sentry/workflow_engine/handlers/action/__init__.py
+++ b/src/sentry/workflow_engine/handlers/action/__init__.py
@@ -1,5 +1,0 @@
-__all__ = [
-    "ActionHandler",
-]
-
-from .notification.handler import ActionHandler

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -8,7 +8,6 @@ from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.handlers.action.notification.handler import (
     IssueAlertRegistryInvoker,
     MetricAlertRegistryInvoker,
-    NotificationActionHandler,
     NotificationHandlerException,
 )
 from sentry.workflow_engine.models import Action
@@ -28,7 +27,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
     def test_execute_without_group_type(self):
         """Test that execute does nothing when detector has no group_type"""
         self.detector.type = ""
-        NotificationActionHandler.execute(self.job, self.action, self.detector)
+        self.action.trigger(self.job, self.detector)
         # Test passes if no exception is raised
 
     @mock.patch(
@@ -42,7 +41,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        NotificationActionHandler.execute(self.job, self.action, self.detector)
+        self.action.trigger(self.job, self.detector)
 
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
         mock_handler.handle_workflow_action.assert_called_once_with(
@@ -60,7 +59,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler = mock.Mock()
         mock_registry_get.return_value = mock_handler
 
-        NotificationActionHandler.execute(self.job, self.action, self.detector)
+        self.action.trigger(self.job, self.detector)
 
         mock_registry_get.assert_called_once_with(MetricIssuePOC.slug)
         mock_handler.handle_workflow_action.assert_called_once_with(
@@ -74,7 +73,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
     @mock.patch("sentry.workflow_engine.handlers.action.notification.handler.logger")
     def test_execute_unknown_group_type(self, mock_logger, mock_registry_get):
         """Test that execute does nothing when detector has no group_type"""
-        NotificationActionHandler.execute(self.job, self.action, self.detector)
+        self.action.trigger(self.job, self.detector)
 
         mock_logger.exception.assert_called_once_with(
             "No notification handler found for detector type: %s",


### PR DESCRIPTION
this pr defines adds `provider_slug` to action handlers. i will eventually switch this to an enum once ecosystem decides on the 1 enum to rule them all


i decomposed everything to follow solid principles, which means i don't need to have `NotificationAction` ABC anymore.