### PR TITLE
fix(autofix): Fix preferences rerendering loop

### DIFF
--- a/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
+++ b/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
@@ -90,7 +90,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
         savePreferences.mutate({repositories: codeMappingRepos});
       }
     }
-  }, [preference, repositories, codeMappingRepos, savePreferences]);
+  }, [preference, repositories, codeMappingRepos, savePreferences.mutate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const savePreferencesToServer = useCallback(
     (updatedIds?: string[], updatedSettings?: Record<string, RepoSettings>) => {
@@ -122,7 +122,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
 
       setShowSaveNotice(true);
     },
-    [repositories, selectedRepoIds, repoSettings, savePreferences]
+    [repositories, selectedRepoIds, repoSettings, savePreferences.mutate] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const saveScrollPosition = useCallback(() => {

--- a/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
+++ b/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
@@ -36,7 +36,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
     codeMappingRepos,
     isLoading: isLoadingPreferences,
   } = useProjectPreferences(project);
-  const savePreferences = useSaveProjectPreferences(project);
+  const {mutate: savePreferences} = useSaveProjectPreferences(project);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
@@ -87,10 +87,10 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
 
         setRepoSettings(initialSettings);
 
-        savePreferences.mutate({repositories: codeMappingRepos});
+        savePreferences({repositories: codeMappingRepos});
       }
     }
-  }, [preference, repositories, codeMappingRepos, savePreferences.mutate]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [preference, repositories, codeMappingRepos, savePreferences]);
 
   const savePreferencesToServer = useCallback(
     (updatedIds?: string[], updatedSettings?: Record<string, RepoSettings>) => {
@@ -116,13 +116,13 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
         };
       });
 
-      savePreferences.mutate({
+      savePreferences({
         repositories: reposData,
       });
 
       setShowSaveNotice(true);
     },
-    [repositories, selectedRepoIds, repoSettings, savePreferences.mutate] // eslint-disable-line react-hooks/exhaustive-deps
+    [repositories, selectedRepoIds, repoSettings, savePreferences]
   );
 
   const saveScrollPosition = useCallback(() => {


### PR DESCRIPTION
So I had to add `savePreferences` to the dependency array because the linter was complaining in the last PR...turns out that completely broke it and made it rerender infinitely. This should fix it.
