### PR TITLE
feat(dashboards): Implement basic `Samples` plottable

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -16,7 +16,6 @@ import type {
   LegendComponentOption,
   LineSeriesOption,
   SeriesOption,
-  TooltipComponentFormatterCallback,
   TooltipComponentFormatterCallbackParams,
   TooltipComponentOption,
   VisualMapComponentOption,
@@ -113,10 +112,7 @@ interface TooltipOption
     seriesParamsOrParam: TooltipComponentFormatterCallbackParams
   ) => string;
   markerFormatter?: (marker: string, label?: string) => string;
-  nameFormatter?: (
-    name: string,
-    seriesParams?: TooltipComponentFormatterCallback<any>
-  ) => string;
+  nameFormatter?: (name: string, seriesParams?: CallbackDataParams) => string;
   /**
    * If true does not display sublabels with a value of 0.
    */

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -16,6 +16,7 @@ import type {
   LegendComponentOption,
   LineSeriesOption,
   SeriesOption,
+  TooltipComponentFormatterCallback,
   TooltipComponentFormatterCallbackParams,
   TooltipComponentOption,
   VisualMapComponentOption,
@@ -112,7 +113,10 @@ interface TooltipOption
     seriesParamsOrParam: TooltipComponentFormatterCallbackParams
   ) => string;
   markerFormatter?: (marker: string, label?: string) => string;
-  nameFormatter?: (name: string, seriesParams?: CallbackDataParams) => string;
+  nameFormatter?: (
+    name: string,
+    seriesParams?: TooltipComponentFormatterCallback<any>
+  ) => string;
   /**
    * If true does not display sublabels with a value of 0.
    */

--- a/static/app/utils/tabularData/scaleTabularDataColumn.spec.tsx
+++ b/static/app/utils/tabularData/scaleTabularDataColumn.spec.tsx
@@ -1,0 +1,132 @@
+import type {TabularData} from 'sentry/views/dashboards/widgets/common/types';
+
+import {DurationUnit, RateUnit, SizeUnit} from '../discover/fields';
+
+import {scaleTabularDataColumn} from './scaleTabularDataColumn';
+
+describe('scaleTabularDataColumn', () => {
+  describe('does not scale unscalable types', () => {
+    const tabularData: TabularData = {
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'max(trace.id)': 'afbad',
+        },
+      ],
+      meta: {
+        fields: {
+          'max(trace.id)': 'string',
+        },
+        units: {},
+      },
+    };
+
+    it.each([RateUnit.PER_MINUTE, DurationUnit.SECOND, SizeUnit.GIBIBYTE, null] as const)(
+      'Does not scale strings to %s',
+      unit => {
+        expect(scaleTabularDataColumn(tabularData, 'max(trace.id)', unit)).toEqual(
+          tabularData
+        );
+      }
+    );
+  });
+
+  it('does not scale duration units from second to gigabyte', () => {
+    const tabularData: TabularData = {
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'p99(span.duration)': 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': DurationUnit.SECOND,
+        },
+      },
+    };
+
+    expect(
+      scaleTabularDataColumn(tabularData, 'p99(span.duration)', SizeUnit.GIGABYTE)
+    ).toEqual(tabularData);
+  });
+
+  it('scales duration units from second to millisecond', () => {
+    const tabularData: TabularData = {
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'p99(span.duration)': 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': DurationUnit.SECOND,
+        },
+      },
+    };
+
+    expect(
+      scaleTabularDataColumn(tabularData, 'p99(span.duration)', DurationUnit.MILLISECOND)
+    ).toEqual({
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'p99(span.duration)': 17000,
+        },
+      ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': DurationUnit.MILLISECOND,
+        },
+      },
+    });
+  });
+
+  it('scales size units from mebibyte to byte', () => {
+    const tabularData: TabularData = {
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'p50(attachment.size)': 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'p50(attachment.size)': 'size',
+        },
+        units: {
+          'p50(attachment.size)': SizeUnit.MEBIBYTE,
+        },
+      },
+    };
+
+    expect(
+      scaleTabularDataColumn(tabularData, 'p50(attachment.size)', SizeUnit.BYTE)
+    ).toEqual({
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          'p50(attachment.size)': 17825792,
+        },
+      ],
+      meta: {
+        fields: {
+          'p50(attachment.size)': 'size',
+        },
+        units: {
+          'p50(attachment.size)': SizeUnit.BYTE,
+        },
+      },
+    });
+  });
+});

--- a/static/app/utils/tabularData/scaleTabularDataColumn.tsx
+++ b/static/app/utils/tabularData/scaleTabularDataColumn.tsx
@@ -1,0 +1,95 @@
+import * as Sentry from '@sentry/react';
+import partialRight from 'lodash/partialRight';
+
+import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
+import {convertRate} from 'sentry/utils/unitConversion/convertRate';
+import {convertSize} from 'sentry/utils/unitConversion/convertSize';
+import {
+  isADurationUnit,
+  isARateUnit,
+  isASizeUnit,
+  isAUnitConvertibleFieldType,
+} from 'sentry/views/dashboards/widgets/common/typePredicates';
+import type {
+  TabularData,
+  TabularValueUnit,
+} from 'sentry/views/dashboards/widgets/common/types';
+import {
+  FALLBACK_TYPE,
+  FALLBACK_UNIT_FOR_FIELD_TYPE,
+} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
+
+export function scaleTabularDataColumn(
+  tabularData: Readonly<TabularData>,
+  columnName: string,
+  destinationUnit: TabularValueUnit
+): TabularData {
+  const sourceType = tabularData.meta.fields[columnName] ?? FALLBACK_TYPE;
+
+  // Don't bother trying to convert numbers, dates, etc.
+  if (!isAUnitConvertibleFieldType(sourceType)) {
+    return tabularData;
+  }
+
+  const sourceUnit = tabularData.meta.units[columnName];
+
+  if (!destinationUnit || sourceUnit === destinationUnit) {
+    return tabularData;
+  }
+
+  // Don't bother with invalid conversions
+  if (
+    (sourceType === 'duration' && !isADurationUnit(destinationUnit)) ||
+    (sourceType === 'size' && !isASizeUnit(destinationUnit)) ||
+    (sourceType === 'rate' && !isARateUnit(destinationUnit))
+  ) {
+    Sentry.captureMessage(
+      `Attempted invalid timeseries conversion from ${sourceType} in ${sourceUnit} to ${destinationUnit}`
+    );
+
+    return tabularData;
+  }
+
+  let scaler: (value: number) => number;
+  if (sourceType === 'duration') {
+    scaler = partialRight(
+      convertDuration,
+      sourceUnit ?? FALLBACK_UNIT_FOR_FIELD_TYPE.duration,
+      destinationUnit
+    );
+  } else if (sourceType === 'size') {
+    scaler = partialRight(
+      convertSize,
+      sourceUnit ?? FALLBACK_UNIT_FOR_FIELD_TYPE.size,
+      destinationUnit
+    );
+  } else if (sourceType === 'rate') {
+    scaler = partialRight(
+      convertRate,
+      sourceUnit ?? FALLBACK_UNIT_FOR_FIELD_TYPE.rate,
+      destinationUnit
+    );
+  }
+
+  return {
+    ...tabularData,
+    data: tabularData.data.map(datum => {
+      const value = datum[columnName] ?? null;
+      if (typeof value !== 'number') {
+        return datum;
+      }
+
+      return {
+        ...datum,
+        [columnName]: value === null ? null : scaler(value),
+      };
+    }),
+    meta: {
+      ...tabularData.meta,
+      units: {
+        ...tabularData.meta.units,
+        [columnName]: destinationUnit,
+      },
+    },
+  };
+}

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -43,20 +43,19 @@ export type TimeSeries = {
 
 export type TabularValueType = AttributeValueType;
 export type TabularValueUnit = AttributeValueUnit;
-export type TabularMeta = {
-  fields: {
-    [key: string]: TabularValueType;
-  };
-  units: {
-    [key: string]: TabularValueUnit;
-  };
+export type TabularMeta<TFields extends string = string> = {
+  fields: Record<TFields, TabularValueType>;
+  units: Record<TFields, TabularValueUnit>;
 };
 
-export type TabularRow = Record<string, number | string | undefined>;
+export type TabularRow<TFields extends string = string> = Record<
+  TFields,
+  number | string | null
+>;
 
-export type TabularData = {
-  data: TabularRow[];
-  meta: TabularMeta;
+export type TabularData<TFields extends string = string> = {
+  data: Array<TabularRow<TFields>>;
+  meta: TabularMeta<TFields>;
 };
 
 export type ErrorProp = Error | string;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/spanSamplesWithDurations.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/spanSamplesWithDurations.ts
@@ -1,0 +1,31 @@
+import {DurationUnit} from 'sentry/utils/discover/fields';
+
+import {TabularData} from '../../common/types';
+
+export const spanSamplesWithDurations: TabularData = {
+  meta: {
+    fields: {
+      'p99(span.duration)': 'duration',
+    },
+    units: {
+      'p99(span.duration)': DurationUnit.MILLISECOND,
+    },
+  },
+  data: [
+    {
+      id: 'ad1453eb469473f5',
+      'p99(span.duration)': 170.63336816976206,
+      timestamp: '2024-10-24T16:28:28-04:00',
+    },
+    {
+      id: '8c6aa95b24d15772',
+      'p99(span.duration)': 218.91675989347792,
+      timestamp: '2024-10-25T05:00:01-04:00',
+    },
+    {
+      id: '8831cccebb865893',
+      'p99(span.duration)': 74.50192368733187,
+      timestamp: '2024-10-25T13:21:12-04:00',
+    },
+  ],
+};

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
@@ -1,0 +1,34 @@
+import {useTheme} from '@emotion/react';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {t} from 'sentry/locale';
+
+interface Props {
+  label?: string;
+  value?: number;
+}
+
+export function BaselineMarkLine({value, label}: Props = {}) {
+  const theme = useTheme();
+
+  return MarkLine({
+    data: [
+      {
+        valueDim: 'y',
+        type: 'average',
+        yAxis: value,
+      },
+    ],
+    lineStyle: {
+      color: theme.gray400,
+    },
+    emphasis: {disabled: true},
+    label: {
+      position: 'insideEndBottom',
+      formatter: () => label ?? t('Baseline'),
+      fontSize: 14,
+      color: theme.chartLabel,
+      backgroundColor: theme.chartOther,
+    },
+  });
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -1,0 +1,195 @@
+import type {Theme} from '@emotion/react';
+import type {ScatterSeriesOption, SeriesOption} from 'echarts';
+
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import type {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+import {scaleTabularDataColumn} from 'sentry/utils/tabularData/scaleTabularDataColumn';
+import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
+import {getSampleChartSymbol} from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol';
+import {crossIconPath} from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart/symbol';
+
+import {isAPlottableTimeSeriesValueType} from '../../common/typePredicates';
+import type {
+  TabularData,
+  TabularRow,
+  TabularValueUnit,
+  TimeSeriesValueUnit,
+} from '../../common/types';
+import {FALLBACK_TYPE} from '../settings';
+
+import {BaselineMarkLine} from './baselineMarkline';
+import type {Plottable, PlottableTimeSeriesValueType} from './plottable';
+
+type ScatterPlotDatum = [timestamp: string, value: number, id: string];
+
+type ValidSampleRow = {
+  [key: string]: string | number | null;
+  id: string;
+  timestamp: string;
+};
+
+export type SamplesConfig = {
+  /**
+   * The name of the data attribute to plot. This should be one of the keys in the data that's available in the `samples` parameter that's passed to the constructor.
+   */
+  attributeName: string;
+  /**
+   * Optional alias. If not provided, the series name in the legend will use a default.
+   */
+  alias?: string;
+  /**
+   * Label for the markline that shows the `baselineValue`, if one is provided. Otherwise uses a fallback.
+   */
+  baselineLabel?: string;
+  /**
+   * A baseline value. If provided, the plottable will add a markline to indicate this baseline. Values above and below this baseline will be highlighted accordingly.
+   */
+  baselineValue?: number;
+};
+
+export type SamplesPlottingOptions = {
+  /**
+   * The current theme.
+   */
+  theme: Theme;
+  /**
+   * Final plottable unit. This might be different from the original unit of the data, because we scale all time series to a single common unit.
+   */
+  unit: DurationUnit | SizeUnit | RateUnit | null;
+};
+
+/**
+ * `Samples` is a plottable that represents discontinous individual measurements. These are usually overlaid on top of a continuous aggregate time series.
+ */
+export class Samples implements Plottable {
+  sampleTableData: Readonly<TabularData>;
+  #timestamps: readonly string[];
+  config: Readonly<SamplesConfig>;
+
+  constructor(samples: TabularData, config: SamplesConfig) {
+    this.sampleTableData = samples;
+    this.#timestamps = samples.data
+      .filter(isValidSampleRow)
+      .map(sample => sample.timestamp)
+      .toSorted();
+    this.config = config;
+  }
+
+  get isEmpty(): boolean {
+    return this.sampleTableData.data.every(
+      sample => sample[this.config.attributeName] === null
+    );
+  }
+
+  get needsColor(): boolean {
+    return false;
+  }
+
+  get dataType(): PlottableTimeSeriesValueType {
+    const type = this.sampleTableData.meta.fields[this.config?.attributeName];
+
+    return isAPlottableTimeSeriesValueType(type) ? type : FALLBACK_TYPE;
+  }
+
+  get dataUnit(): TimeSeriesValueUnit {
+    return this.sampleTableData.meta.units[this.config.attributeName] ?? null;
+  }
+
+  get start(): string | null {
+    return this.#timestamps.at(0) ?? null;
+  }
+
+  get end(): string | null {
+    return this.#timestamps.at(-1) ?? null;
+  }
+
+  get label(): string {
+    return this.config?.alias ?? t('%s Samples', this.config.attributeName);
+  }
+
+  scaleAttributeToUnit(destinationUnit: TabularValueUnit): TabularData {
+    if (this.isEmpty) {
+      return this.sampleTableData;
+    }
+
+    return scaleTabularDataColumn(
+      this.sampleTableData,
+      this.config.attributeName,
+      destinationUnit
+    );
+  }
+
+  constrainSamples(
+    boundaryStart: Date | null,
+    boundaryEnd: Date | null
+  ): Readonly<TabularData> {
+    return {
+      ...this.sampleTableData,
+      data: this.sampleTableData.data.filter(sample => {
+        if (!defined(sample.timestamp)) {
+          return false;
+        }
+
+        const ts = new Date(sample.timestamp);
+
+        return (
+          (!boundaryStart || ts >= boundaryStart) && (!boundaryEnd || ts <= boundaryEnd)
+        );
+      }),
+    };
+  }
+
+  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
+    return new Samples(this.constrainSamples(boundaryStart, boundaryEnd), this.config);
+  }
+
+  toSeries(plottingOptions: SamplesPlottingOptions): SeriesOption[] {
+    const {sampleTableData: samples, config} = this;
+    const {theme} = plottingOptions;
+
+    const series: ScatterSeriesOption = {
+      type: 'scatter',
+      name: this.label,
+      data: samples.data.filter(isValidSampleRow).map(sample => {
+        const value = sample[config.attributeName];
+        return [sample.timestamp, value ?? ECHARTS_MISSING_DATA_VALUE, sample.id];
+      }),
+      symbol: (value: ScatterPlotDatum) => {
+        const {symbol} = config.baselineValue
+          ? getSampleChartSymbol(value[1], config.baselineValue, theme)
+          : {symbol: crossIconPath};
+
+        return symbol;
+      },
+      markLine: config.baselineValue
+        ? BaselineMarkLine({value: config.baselineValue, label: config.baselineLabel})
+        : undefined,
+      animation: false,
+      emphasis: {
+        scale: 1.2,
+      },
+      symbolSize: 14,
+      itemStyle: {
+        color: callbackValue => {
+          const value = (callbackValue.data as ScatterPlotDatum)[1];
+
+          const {color} = config.baselineValue
+            ? getSampleChartSymbol(value, config.baselineValue, theme)
+            : {color: theme.gray500};
+          return color;
+        },
+      },
+    };
+
+    return [series];
+  }
+}
+
+function isValidSampleRow(row: TabularRow): row is ValidSampleRow {
+  if (typeof row.id === 'string' && typeof row.timestamp === 'string') {
+    return true;
+  }
+
+  return false;
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -18,9 +18,11 @@ import type {LegendSelection, Release, TimeSeries, TimeSeriesMeta} from '../comm
 
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
 import {sampleThroughputTimeSeries} from './fixtures/sampleThroughputTimeSeries';
+import {spanSamplesWithDurations} from './fixtures/spanSamplesWithDurations';
 import {Area} from './plottables/area';
 import {Bars} from './plottables/bars';
 import {Line} from './plottables/line';
+import {Samples} from './plottables/samples';
 import {TimeSeriesWidgetVisualization} from './timeSeriesWidgetVisualization';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -376,6 +378,34 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
             />
           </FillParent>
         </SmallSizingWindow>
+      </Fragment>
+    );
+  });
+
+  story('Samples', () => {
+    return (
+      <Fragment>
+        <p>
+          <code>Samples</code> plots discontinuous points. It's useful for placing markers
+          for individual events on top of a continuous aggregate series. In the example
+          below, we plot a set of span duration samples on top of an aggregate series of
+          the 99th percentile of those durations. Samples that are faster than a baseline
+          are green, samples that are slower are red.
+        </p>
+
+        <MediumWidget>
+          <TimeSeriesWidgetVisualization
+            plottables={[
+              new Line(sampleDurationTimeSeries),
+              new Samples(spanSamplesWithDurations, {
+                alias: 'Span Samples',
+                attributeName: 'p99(span.duration)',
+                baselineValue: 175,
+                baselineLabel: 'Average',
+              }),
+            ]}
+          />
+        </MediumWidget>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -445,6 +445,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       color,
       yAxisPosition,
       unit: unitForType[plottable.dataType ?? FALLBACK_TYPE],
+      theme,
     });
 
     seriesIndexToPlottableMapRanges.push({

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -339,6 +339,22 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     return getFormatter({
       isGroupedByDate: true,
       showTimeInTooltip: true,
+      nameFormatter: function (name, nameFormatterParams) {
+        if (!nameFormatterParams) {
+          return name;
+        }
+
+        if (
+          nameFormatterParams.seriesType === 'scatter' &&
+          Array.isArray(nameFormatterParams.data)
+        ) {
+          // For scatter series, the third point in the `data` array should be the sample's ID
+          const sampleId = nameFormatterParams.data.at(2);
+          return defined(sampleId) ? sampleId.toString() : name;
+        }
+
+        return name;
+      },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.
 


### PR DESCRIPTION
New plottable! So far all the plottables have been continuous lines. This one is discontinuous, and is used to plot sample values. The core of the PR is the new `Samples` plottable. It implements the `Plottable` interface, just like `Area`, `Line`, and `Bars`. I've only had to make a few changes to the other code:

1. `TimeSeriesWidgetVisualization` passes the current theme to all plottables, so they can use it
2. More specific types for tabular data. I didn't end up using them, but they're handy
3. Some new helpers for scaling tabular data so we can match up units against the other series
4. `TimeSeriesWidgetVisualization` has a new name formatter. If the current data point has a third item and it's a scatter series, treat that as the label. This is way easier than the previous approach of making a series _for every sample_

This doesn't support highlight callbacks, or setting a highlight, I'll do that next.

**e.g.,**
<img width="470" alt="Screenshot 2025-03-26 at 5 04 51 PM" src="https://github.com/user-attachments/assets/fb8556da-4e6d-4846-bc8a-fccb40cb081d" />

