### PR TITLE
fix(discover): Always use area charts with "Previous Period"

### DIFF
--- a/static/app/views/discover/resultsChart.tsx
+++ b/static/app/views/discover/resultsChart.tsx
@@ -102,9 +102,11 @@ class ResultsChart extends Component<ResultsChartProps> {
     const chartComponent =
       display === DisplayModes.BAR
         ? BarChart
-        : customPerformanceMetricFieldType === 'size' && isTopEvents
+        : display === DisplayModes.PREVIOUS
           ? AreaChart
-          : undefined;
+          : customPerformanceMetricFieldType === 'size' && isTopEvents
+            ? AreaChart
+            : undefined;
     const interval =
       display === DisplayModes.BAR
         ? getInterval(


### PR DESCRIPTION
Fixes a nasty bug with Discover. If someone chooses multiple Y axes and sets the display to "Previous Period", they see something very weird: the "previous period" series are _stacked_ so they have an incorrect position on the chart. This happens because "previous period" values are hard-coded _in multiple places_ to always stack. They really only work when shown next to stacked area or bar charts!

This is very deep down, and hard to rip out. Instead, to fix the issue for the user in question, I'm makes it so "Previous Period" always uses stacked area charts. This has its own problems, but Discover isn't long for this world. Newer UIs allow users to customize the visualization on their own terms instead of using heuristics on the data.

Closes DAIN-122.
Closes https://github.com/getsentry/sentry/issues/87969

**e.g.,**

<img width="934" alt="Screenshot 2025-03-26 at 3 25 10 PM" src="https://github.com/user-attachments/assets/9ea5874c-1656-4ea9-b72f-b1c651059cc6" />
