### PR TITLE
fix(dashboards): Fix an infinite loop on org dashboards

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -468,8 +468,7 @@ export function isWidgetUsingTransactionName(widget: Widget) {
 
 export function hasSavedPageFilters(dashboard: DashboardDetails) {
   return !(
-    dashboard.projects &&
-    dashboard.projects.length === 0 &&
+    (dashboard.projects === undefined || dashboard.projects.length === 0) &&
     dashboard.environment === undefined &&
     dashboard.start === undefined &&
     dashboard.end === undefined &&


### PR DESCRIPTION
Not sure why this started to happen after https://github.com/getsentry/sentry/pull/86531 - but there's an infinite redirect from [this useEffect in orgDashboards](https://github.com/getsentry/sentry/blob/8bcc3f4919783894250c4040d329f1e4e86a5c8e/static/app/views/dashboards/orgDashboards.tsx#L92-L127).

The `selectedDashboard` being passed to `hasSavedPageFilters` does not have a `projects` property on it and so is incorrectly returning true.

Fixes JAVASCRIPT-2Y6A