### PR TITLE
fix(members): Allow searched members to leave orgs

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -665,5 +665,29 @@ describe('OrganizationMembersList', function () {
 
       (isDemoModeActive as jest.Mock).mockReset();
     });
+
+    it('allows you to leave as a member after searching', async function () {
+      const searchQuery = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/members/',
+        method: 'GET',
+        body: [currentUser],
+        match: [MockApiClient.matchQuery({query: currentUser.name})],
+      });
+      const ownerQuery = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/members/',
+        method: 'GET',
+        body: [members[2]],
+        match: [MockApiClient.matchQuery({query: 'role:owner'})],
+      });
+      const searchRouter = RouterFixture({location: {query: {query: currentUser.name}}});
+      render(<OrganizationMembersList />, {organization, router: searchRouter});
+      renderGlobalModal({router});
+
+      expect(await screen.findByText('Members')).toBeInTheDocument();
+      expect(searchQuery).toHaveBeenCalled();
+      expect(ownerQuery).toHaveBeenCalled();
+      const leaveButton = screen.getByRole('button', {name: 'Leave'});
+      expect(leaveButton).toBeEnabled();
+    });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -677,7 +677,7 @@ describe('OrganizationMembersList', function () {
         url: '/organizations/org-slug/members/',
         method: 'GET',
         body: [members[2]],
-        match: [MockApiClient.matchQuery({query: 'role:owner'})],
+        match: [MockApiClient.matchQuery({query: 'role:owner isInvited:false'})],
       });
       const searchRouter = RouterFixture({location: {query: {query: currentUser.name}}});
       render(<OrganizationMembersList />, {organization, router: searchRouter});

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -84,11 +84,11 @@ function OrganizationMembersList() {
   );
   const {data: currentMember} = useApiQuery<Member>(
     [`/organizations/${organization.slug}/members/me/`],
-    {staleTime: 0}
+    {staleTime: 30000}
   );
   const {
     data: members = [],
-    isLoading: isLoadingMembers,
+    isPending: isPendingMembers,
     refetch: refetchMembers,
     getResponseHeader,
   } = useApiQuery<Member[]>(
@@ -101,7 +101,7 @@ function OrganizationMembersList() {
     }),
     {staleTime: 0}
   );
-  const {data: activeOwnerMembers = [], isLoading: isLoadingOwners} = useApiQuery<
+  const {data: activeOwnerMembers = [], isPending: isPendingOwners} = useApiQuery<
     Member[]
   >(
     getMembersQueryKey({
@@ -111,7 +111,7 @@ function OrganizationMembersList() {
       // We also filter out active invites, so only active users are included.
       query: {query: 'role:owner isInvited:false'},
     }),
-    {staleTime: 0}
+    {staleTime: 30000}
   );
 
   const [invited, setInvited] = useState<{
@@ -369,7 +369,7 @@ function OrganizationMembersList() {
       <Panel data-test-id="org-member-list">
         <MemberListHeader members={membersToShow} organization={organization} />
         <PanelBody>
-          {isLoadingMembers || isLoadingOwners ? (
+          {isPendingMembers || isPendingOwners ? (
             <LoadingIndicator />
           ) : (
             <Fragment>


### PR DESCRIPTION
The search bar on the members list will filter the list down, and the check for other owners only has access to that filtered list, meaning it doesn't find another owner and thus disables the `Leave` button incorrectly.

Instead, we'll fetch the owners separately (excluding invites), and if any of those results aren't the current user, we should allow them to leave. 

**Before**
<img width="861" alt="image" src="https://github.com/user-attachments/assets/edf17aac-4251-4e01-8e19-fa2015862cd1" />


**After**
<img width="852" alt="Screenshot 2025-03-27 at 11 08 00 AM" src="https://github.com/user-attachments/assets/055a5384-39b0-4113-bc05-dc0fb04c78fa" />



