### PR TITLE
feat(search): Improve responsiveness of command palette

### DIFF
--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -27,12 +27,14 @@ function makeSearchResultsMock(items?: ResultItem[], threshold?: number) {
         sourceType: 'organization',
         title: 'Vandelay Industries - Import',
         model: {slug: 'vdl-imp'},
+        resolvedTs: 0,
       },
       {
         resultType: 'integration',
         model: {slug: 'vdl-exp'},
         sourceType: 'organization',
         title: 'Vandelay Industries - Export',
+        resolvedTs: 0,
       },
     ];
     const results = new Fuse(searchableItems, {
@@ -105,6 +107,7 @@ describe('Search', () => {
                 title: 'Vandelay Industries - Import',
                 to: 'https://vandelayindustries.io/import',
                 model: {slug: 'vdl-imp'},
+                resolvedTs: 0,
               },
             ]),
           ],
@@ -141,6 +144,7 @@ describe('Search', () => {
                 title: 'Vandelay Industries - Import',
                 to: 'https://vandelayindustries.io/import',
                 model: {slug: 'vdl-imp'},
+                resolvedTs: 0,
               },
             ]),
           ],
@@ -171,6 +175,7 @@ describe('Search', () => {
       title: `${i} Vandelay Industries - Import`,
       to: 'https://vandelayindustries.io/import',
       model: {slug: 'vdl-imp'},
+      resolvedTs: 0,
     }));
 
     render(

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -187,12 +187,11 @@ function Search({
                 params={params}
                 sources={sources ?? [ApiSource, FormSource, RouteSource, CommandSource]}
               >
-                {({isLoading, results, hasAnyResults}) => (
+                {({allLoaded, results}) => (
                   <List
                     {...{
-                      isLoading,
+                      allLoaded,
                       results,
-                      hasAnyResults,
                       maxResults,
                       resultFooter,
                       dropdownClassName,

--- a/static/app/components/search/list.tsx
+++ b/static/app/components/search/list.tsx
@@ -23,10 +23,9 @@ interface RenderItemProps {
 type RenderItem = (props: RenderItemProps) => React.ReactNode;
 
 type Props = {
+  allLoaded: boolean;
   getItemProps: AutoCompleteOpts['getItemProps'];
-  hasAnyResults: boolean;
   highlightedIndex: number;
-  isLoading: boolean;
   registerItemCount: AutoCompleteOpts['registerItemCount'];
   registerVisibleItem: AutoCompleteOpts['registerVisibleItem'];
   resultFooter: React.ReactNode;
@@ -46,8 +45,7 @@ function defaultItemRenderer({item, highlighted, itemProps, matches}: RenderItem
 
 function List({
   dropdownClassName,
-  isLoading,
-  hasAnyResults,
+  allLoaded,
   results,
   maxResults,
   getItemProps,
@@ -64,13 +62,17 @@ function List({
     [registerItemCount, resultList.length]
   );
 
+  // Show loading indicator if we're still loading and don't have any results yet
+  const hasResults = results.length > 0;
+  const isLoading = !allLoaded && !hasResults;
+
   return (
     <DropdownBox className={dropdownClassName}>
       {isLoading ? (
         <LoadingWrapper>
           <LoadingIndicator mini hideMessage relative />
         </LoadingWrapper>
-      ) : hasAnyResults ? (
+      ) : hasResults ? (
         resultList.map((result, index) => {
           const {item, matches, refIndex} = result;
           const highlighted = index === highlightedIndex;

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -11,6 +11,7 @@ import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
 import {useUser} from 'sentry/utils/useUser';
 
 import type {ChildProps, ResultItem} from './types';
+import {makeResolvedTs} from './utils';
 
 type Action = {
   action: () => void;
@@ -124,8 +125,9 @@ function CommandSource({searchOptions, query, children}: Props) {
 
   useEffect(() => void createSearch(), [createSearch]);
 
-  const results = useMemo(
-    () =>
+  const results = useMemo(() => {
+    const resolvedTs = makeResolvedTs();
+    return (
       fuzzy
         ?.search(query)
         .filter(({item}) => !item.requiresSuperuser || isSuperuser)
@@ -134,11 +136,12 @@ function CommandSource({searchOptions, query, children}: Props) {
             ...item,
             sourceType: 'command',
             resultType: 'command',
+            resolvedTs,
           } as ResultItem,
           ...rest,
-        })) ?? [],
-    [fuzzy, query, isSuperuser]
-  );
+        })) ?? []
+    );
+  }, [fuzzy, query, isSuperuser]);
 
   return children({isLoading: fuzzy === null, results});
 }

--- a/static/app/components/search/sources/formSource.spec.tsx
+++ b/static/app/components/search/sources/formSource.spec.tsx
@@ -63,6 +63,7 @@ describe('FormSource', function () {
                 resultType: 'field',
                 sourceType: 'field',
                 to: {pathname: '/route/', hash: '#test-field'},
+                resolvedTs: expect.anything(),
               },
             }),
           ],

--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -13,6 +13,7 @@ import withLatestContext from 'sentry/utils/withLatestContext';
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import type {ChildProps, Result, ResultItem} from './types';
+import {makeResolvedTs} from './utils';
 
 type Props = WithRouterProps & {
   /**
@@ -91,6 +92,7 @@ class HelpSource extends Component<Props, State> {
 }
 
 function mapSearchResults(results: SearchResult[]) {
+  const resolvedTs = makeResolvedTs();
   const items: Result[] = [];
 
   results.forEach(section => {
@@ -114,6 +116,7 @@ function mapSearchResults(results: SearchResult[]) {
         extra: hit.context.context1,
         description: hit.text ? dompurify.sanitize(hit.text) : undefined,
         to: hit.url,
+        resolvedTs,
       };
 
       return {item, matches: [title, description], score: 1, refIndex: 0};
@@ -135,6 +138,7 @@ function mapSearchResults(results: SearchResult[]) {
       title: `No results in ${section.name}`,
       sectionHeading: section.name,
       empty: true,
+      resolvedTs,
     };
 
     items.push({item: emptyHeaderItem, score: 1, refIndex: 0});

--- a/static/app/components/search/sources/routeSource.spec.tsx
+++ b/static/app/components/search/sources/routeSource.spec.tsx
@@ -24,6 +24,7 @@ describe('RouteSource', function () {
         sourceType: 'route',
         title: 'Security',
         to: '/settings/account/security/',
+        resolvedTs: expect.anything(),
       });
     });
   });
@@ -57,6 +58,7 @@ describe('RouteSource', function () {
         sourceType: 'route',
         title: 'Spike Protection',
         to: '/settings/spike-protection',
+        resolvedTs: expect.anything(),
       });
     });
   });

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -14,7 +14,7 @@ import projectSettingsNavigation from 'sentry/views/settings/project/navigationC
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
 
 import type {ChildProps, ResultItem} from './types';
-import {strGetFn} from './utils';
+import {makeResolvedTs, strGetFn} from './utils';
 
 type ConfigParams = {
   debugFilesNeedsReview?: boolean;
@@ -75,6 +75,7 @@ type State = {
    * A Fuse instance configured to search NavigationItem's
    */
   fuzzy: undefined | null | Fuse<NavigationItem>;
+  resolvedTs: number;
 };
 
 class RouteSource extends Component<Props, State> {
@@ -84,6 +85,7 @@ class RouteSource extends Component<Props, State> {
 
   state: State = {
     fuzzy: undefined,
+    resolvedTs: 0,
   };
 
   componentDidMount() {
@@ -135,12 +137,14 @@ class RouteSource extends Component<Props, State> {
     };
 
     const fuzzy = await createFuzzySearch(searchMap ?? [], options);
-    this.setState({fuzzy});
+    const resolvedTs = makeResolvedTs();
+
+    this.setState({fuzzy, resolvedTs});
   }
 
   render() {
     const {query, params, children} = this.props;
-    const {fuzzy} = this.state;
+    const {fuzzy, resolvedTs} = this.state;
 
     const results =
       fuzzy?.search(query).map(({item, ...rest}) => ({
@@ -149,6 +153,7 @@ class RouteSource extends Component<Props, State> {
           sourceType: 'route',
           resultType: 'route',
           to: replaceRouterParams(item.path, params),
+          resolvedTs,
         } as ResultItem,
         ...rest,
       })) ?? [];

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -5,6 +5,11 @@ import type {Fuse} from 'sentry/utils/fuzzySearch';
  */
 export type ResultItem = {
   /**
+   * The timestamp of when the result was determined. Used for sorting so that
+   * we do not re-order already resolved results.
+   */
+  resolvedTs: number;
+  /**
    * The type of result eg. settings, help-docs
    */
   resultType:
@@ -50,11 +55,11 @@ export type ResultItem = {
    */
   action?: (item: ResultItem, autocompleteState: any) => void;
   configUrl?: string;
+
   /**
    * The description text to display
    */
   description?: React.ReactNode;
-
   disabled?: boolean;
   empty?: boolean;
   extra?: any;

--- a/static/app/components/search/sources/utils.tsx
+++ b/static/app/components/search/sources/utils.tsx
@@ -15,3 +15,21 @@ export const strGetFn: Fuse.FuseGetFunction<any> = (value, path) => {
   const valueAtPath = get(value, path);
   return typeof valueAtPath === 'string' ? valueAtPath : '';
 };
+
+/**
+ * We compute a `resolvedTs` for each result in the search sources. This value
+ * is used to sort results such that results that resolve later do not get
+ * sorted above results that resolved quicker.
+ *
+ * This threshold is used to ensure that results that resolve in a similar time
+ * to other sources do not end up having their sorting penalized just because
+ * they resolved ever so slightly slower.
+ *
+ * We set this to a number around the "typical human reaction time" which we've
+ * decided here to be 250ms. This seems to "feel" right in terms of the results
+ * not jumping around too much, while still maintaining a good score-sorted
+ * ordering.
+ */
+const RESOLVED_TS_THRESHOLD = 250;
+
+export const makeResolvedTs = () => Math.round(Date.now() / RESOLVED_TS_THRESHOLD);


### PR DESCRIPTION
Prior to this change the command palette needed to wait for all "search sources" to resolve their loading state before it would show results. This resulted in _very slow_ to load results, especially for static results.

This improves things by immediately rendering results as they come in. We sort the results by a new `resolvedTs` field which ensures that as more results come in we do not jump the users cursor around.

The resolvedTs is rounded to a threshold of 250ms so that results that resolve at a similar (but not exactly the same ms) time are still sorted by score. We picked 250ms since that's around the 'human perceived instant' time.