### PR TITLE
chore(issues): Remove `streamline` query param

### DIFF
--- a/static/app/components/events/packageData.spec.tsx
+++ b/static/app/components/events/packageData.spec.tsx
@@ -1,6 +1,5 @@
 import {DataScrubbingRelayPiiConfigFixture} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
 import {EventFixture} from 'sentry-fixture/event';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
@@ -10,6 +9,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {EventPackageData} from 'sentry/components/events/packageData';
 
 describe('EventPackageData', function () {
+  const router = RouterFixture({});
   const event = EventFixture({
     packages: {
       certifi: '',
@@ -32,36 +32,22 @@ describe('EventPackageData', function () {
   });
 
   it('changes section title depending on the platform', function () {
-    render(<EventPackageData event={event} />, {
-      organization,
-      router: RouterFixture({
-        location: LocationFixture({query: {streamline: '1'}}),
-      }),
-    });
+    render(<EventPackageData event={event} />, {organization, router});
     expect(screen.getByText('Packages')).toBeInTheDocument();
     render(<EventPackageData event={{...event, platform: 'csharp'}} />, {
       organization,
-      router: RouterFixture({
-        location: LocationFixture({query: {streamline: '1'}}),
-      }),
+      router,
     });
     expect(screen.getByText('Assemblies')).toBeInTheDocument();
     render(<EventPackageData event={{...event, platform: 'java'}} />, {
       organization,
-      router: RouterFixture({
-        location: LocationFixture({query: {streamline: '1'}}),
-      }),
+      router,
     });
     expect(screen.getByText('Dependencies')).toBeInTheDocument();
   });
 
   it('displays all the data in column format', async function () {
-    render(<EventPackageData event={event} />, {
-      organization,
-      router: RouterFixture({
-        location: LocationFixture({query: {streamline: '1'}}),
-      }),
-    });
+    render(<EventPackageData event={event} />, {organization, router});
     // Should be collapsed by default
     expect(screen.queryByText(/python/)).not.toBeInTheDocument();
     // Displays when open
@@ -81,12 +67,9 @@ describe('EventPackageData', function () {
   });
 
   it('display redacted data', async function () {
-    render(<EventPackageData event={event} />, {organization});
-
+    render(<EventPackageData event={event} />, {organization, router});
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
-
     await userEvent.hover(screen.getByText(/redacted/));
-
     expect(
       await screen.findByText(
         textWithMarkupMatcher(

--- a/static/app/components/events/packageData.spec.tsx
+++ b/static/app/components/events/packageData.spec.tsx
@@ -8,6 +8,11 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {EventPackageData} from 'sentry/components/events/packageData';
 
+jest.mock('sentry/views/issueDetails/utils', () => ({
+  ...jest.requireActual('sentry/views/issueDetails/utils'),
+  useHasStreamlinedUI: () => true,
+}));
+
 describe('EventPackageData', function () {
   const router = RouterFixture({});
   const event = EventFixture({

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -1,6 +1,5 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
@@ -8,10 +7,16 @@ import {RepositoryFixture} from 'sentry-fixture/repository';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import {CommitRow} from '../commitRow';
 
 import {SuspectCommits} from './suspectCommits';
+
+jest.mock('sentry/views/issueDetails/utils', () => ({
+  ...jest.requireActual('sentry/views/issueDetails/utils'),
+  useHasStreamlinedUI: jest.fn(),
+}));
 
 describe('SuspectCommits', function () {
   describe('SuspectCommits', function () {
@@ -56,11 +61,8 @@ describe('SuspectCommits', function () {
       },
     ];
 
-    afterEach(function () {
-      MockApiClient.clearMockResponses();
-    });
-
     beforeEach(function () {
+      (useHasStreamlinedUI as jest.Mock).mockReturnValue(false);
       MockApiClient.addMockResponse({
         method: 'GET',
         url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
@@ -72,6 +74,11 @@ describe('SuspectCommits', function () {
         url: `/organizations/${organization.slug}/projects/`,
         body: [project],
       });
+    });
+
+    afterEach(function () {
+      MockApiClient.clearMockResponses();
+      jest.clearAllMocks();
     });
 
     it('Renders base commit row', async function () {
@@ -186,7 +193,6 @@ describe('SuspectCommits', function () {
     const project = ProjectFixture();
     const event = EventFixture();
     const group = GroupFixture({firstRelease: {}} as any);
-    const location = LocationFixture({query: {streamline: '1'}});
 
     const committers = [
       {
@@ -224,11 +230,8 @@ describe('SuspectCommits', function () {
       },
     ];
 
-    afterEach(function () {
-      MockApiClient.clearMockResponses();
-    });
-
     beforeEach(function () {
+      (useHasStreamlinedUI as jest.Mock).mockReturnValue(true);
       MockApiClient.addMockResponse({
         method: 'GET',
         url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
@@ -238,6 +241,11 @@ describe('SuspectCommits', function () {
       });
     });
 
+    afterEach(function () {
+      MockApiClient.clearMockResponses();
+      jest.clearAllMocks();
+    });
+
     it('Renders base commit row', async function () {
       render(
         <SuspectCommits
@@ -245,8 +253,7 @@ describe('SuspectCommits', function () {
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
-        />,
-        {router: {location}}
+        />
       );
 
       expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
@@ -261,8 +268,7 @@ describe('SuspectCommits', function () {
           commitRow={QuickContextCommitRow}
           eventId={event.id}
           group={group}
-        />,
-        {router: {location}}
+        />
       );
 
       expect(await screen.findByTestId('quick-context-commit-row')).toBeInTheDocument();
@@ -283,8 +289,7 @@ describe('SuspectCommits', function () {
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
-        />,
-        {router: {location}}
+        />
       );
       expect(
         await screen.findByText('feat: Enhance suggested commits and add to alerts')

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -62,7 +62,7 @@ describe('SuspectCommits', function () {
     ];
 
     beforeEach(function () {
-      (useHasStreamlinedUI as jest.Mock).mockReturnValue(false);
+      jest.mocked(useHasStreamlinedUI).mockReturnValue(false);
       MockApiClient.addMockResponse({
         method: 'GET',
         url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -100,7 +100,7 @@ describe('groupDetails', () => {
 
   beforeEach(() => {
     mockNavigate = jest.fn();
-    (useHasStreamlinedUI as jest.Mock).mockReturnValue(false);
+    jest.mocked(useHasStreamlinedUI).mockReturnValue(false);
     MockApiClient.clearMockResponses();
     OrganizationStore.onUpdate(defaultInit.organization);
     act(() => ProjectsStore.loadInitialData(defaultInit.projects));

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -1,7 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {EventsStatsFixture} from 'sentry-fixture/events';
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
@@ -20,6 +19,11 @@ jest.mock('sentry/utils/useNavigate', () => ({
   useNavigate: () => mockUseNavigate,
 }));
 
+jest.mock('sentry/views/issueDetails/utils', () => ({
+  ...jest.requireActual('sentry/views/issueDetails/utils'),
+  useHasStreamlinedUI: () => true,
+}));
+
 describe('EventDetailsHeader', () => {
   const organization = OrganizationFixture();
   const project = ProjectFixture({
@@ -31,9 +35,7 @@ describe('EventDetailsHeader', () => {
   });
   const event = EventFixture({id: 'event-id'});
   const defaultProps = {group, event, project};
-  const router = RouterFixture({
-    location: LocationFixture({query: {streamline: '1'}}),
-  });
+  const router = RouterFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -1,5 +1,4 @@
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
@@ -19,6 +18,11 @@ jest.mock('sentry/views/issueDetails/issueDetailsTour', () => ({
   useIssueDetailsTour: () => mockTour(),
 }));
 
+jest.mock('sentry/views/issueDetails/utils', () => ({
+  ...jest.requireActual('sentry/views/issueDetails/utils'),
+  useHasStreamlinedUI: () => true,
+}));
+
 describe('StreamlinedGroupHeader', () => {
   const baseUrl = 'BASE_URL/';
   const organization = OrganizationFixture();
@@ -27,9 +31,7 @@ describe('StreamlinedGroupHeader', () => {
     teams: [TeamFixture()],
   });
   const group = GroupFixture({issueCategory: IssueCategory.ERROR, isUnhandled: true});
-  const router = RouterFixture({
-    location: LocationFixture({query: {streamline: '1'}}),
-  });
+  const router = RouterFixture();
 
   describe('JS Project Error Issue', () => {
     const defaultProps = {

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -13,20 +13,6 @@ jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useOrganization');
 
 describe('useHasStreamlinedUI', () => {
-  it("respects the 'streamline' query param", () => {
-    jest.mocked(useOrganization).mockReturnValue(OrganizationFixture());
-
-    const location = LocationFixture({query: {streamline: '1'}});
-    jest.mocked(useLocation).mockReturnValue(location);
-    const {result: queryParamEnabled} = renderHook(useHasStreamlinedUI);
-    expect(queryParamEnabled.current).toBe(true);
-
-    location.query.streamline = '0';
-    jest.mocked(useLocation).mockReturnValue(location);
-    const {result: queryParamDisabled} = renderHook(useHasStreamlinedUI);
-    expect(queryParamDisabled.current).toBe(false);
-  });
-
   it('respects the user preferences', () => {
     ConfigStore.init();
     const user = UserFixture();
@@ -41,30 +27,6 @@ describe('useHasStreamlinedUI', () => {
     act(() => ConfigStore.set('user', user));
     const {result: userPrefersLegacy} = renderHook(useHasStreamlinedUI);
     expect(userPrefersLegacy.current).toBe(false);
-  });
-
-  it('values query param above user preferences and organization flags', () => {
-    const enforceOrg = OrganizationFixture({
-      features: ['issue-details-streamline-enforce'],
-    });
-    jest.mocked(useOrganization).mockReturnValue(enforceOrg);
-
-    ConfigStore.init();
-    const user = UserFixture();
-    user.options.prefersIssueDetailsStreamlinedUI = false;
-    act(() => ConfigStore.set('user', user));
-
-    const location = LocationFixture({query: {streamline: '1'}});
-    jest.mocked(useLocation).mockReturnValue(location);
-    const {result: prefersLegacyButQueryParamEnabled} = renderHook(useHasStreamlinedUI);
-    expect(prefersLegacyButQueryParamEnabled.current).toBe(true);
-
-    user.options.prefersIssueDetailsStreamlinedUI = true;
-    act(() => ConfigStore.set('user', user));
-    location.query.streamline = '0';
-    const {result: prefersStreamlineButQueryParamDisabled} =
-      renderHook(useHasStreamlinedUI);
-    expect(prefersStreamlineButQueryParamDisabled.current).toBe(false);
   });
 
   it('ignores preferences if enforce flag is set and user has not opted out', () => {

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -1,11 +1,9 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {act, renderHook} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
@@ -19,7 +17,7 @@ describe('useHasStreamlinedUI', () => {
     user.options.prefersIssueDetailsStreamlinedUI = true;
     act(() => ConfigStore.set('user', user));
 
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+    jest.mocked(useOrganization).mockReturnValue(OrganizationFixture());
     const {result: userPrefersStreamline} = renderHook(useHasStreamlinedUI);
     expect(userPrefersStreamline.current).toBe(true);
 
@@ -40,7 +38,6 @@ describe('useHasStreamlinedUI', () => {
     user.options.prefersIssueDetailsStreamlinedUI = null;
     act(() => ConfigStore.set('user', user));
 
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
     const {result} = renderHook(useHasStreamlinedUI);
     expect(result.current).toBe(true);
   });
@@ -56,14 +53,11 @@ describe('useHasStreamlinedUI', () => {
     user.options.prefersIssueDetailsStreamlinedUI = false;
     act(() => ConfigStore.set('user', user));
 
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
     const {result} = renderHook(useHasStreamlinedUI);
     expect(result.current).toBe(false);
   });
 
   it('ignores preferences if organization option is set to true', () => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
-
     const streamlineOrg = OrganizationFixture({streamlineOnly: true});
     jest.mocked(useOrganization).mockReturnValue(streamlineOrg);
 
@@ -86,7 +80,6 @@ describe('useHasStreamlinedUI', () => {
   });
 
   it('ignores the option if unset', () => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
     jest
       .mocked(useOrganization)
       .mockReturnValue(OrganizationFixture({streamlineOnly: null}));

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -271,15 +271,9 @@ export function getGroupEventQueryKey({
 }
 
 export function useHasStreamlinedUI() {
-  const location = useLocation();
   const user = useUser();
   const organization = useOrganization();
   const userStreamlinedUIOption = user?.options?.prefersIssueDetailsStreamlinedUI;
-
-  // Allow query param to override all other settings to set the UI.
-  if (defined(location.query.streamline)) {
-    return location.query.streamline === '1';
-  }
 
   // If the organzation option is set to true, the new UI is used.
   if (organization.streamlineOnly) {


### PR DESCRIPTION
The opt-in for the new UI is generally available and appears all the time now. We can remove the query param now since toggling is simpler now.