### PR TITLE
feat(pipeline): Add in pipeline SecondaryNav

### DIFF
--- a/static/app/components/nav/constants.tsx
+++ b/static/app/components/nav/constants.tsx
@@ -9,6 +9,7 @@ export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
   [PrimaryNavGroup.DASHBOARDS]: t('Dashboards'),
   [PrimaryNavGroup.INSIGHTS]: t('Insights'),
   [PrimaryNavGroup.SETTINGS]: t('Settings'),
+  [PrimaryNavGroup.PIPELINE]: t('Pipeline'),
 };
 
 export const PRIMARY_SIDEBAR_WIDTH = 66;

--- a/static/app/components/nav/types.tsx
+++ b/static/app/components/nav/types.tsx
@@ -9,4 +9,5 @@ export enum PrimaryNavGroup {
   EXPLORE = 'explorer',
   INSIGHTS = 'insights',
   SETTINGS = 'settings',
+  PIPELINE = 'pipeline'
 }

--- a/static/app/components/nav/types.tsx
+++ b/static/app/components/nav/types.tsx
@@ -9,5 +9,5 @@ export enum PrimaryNavGroup {
   EXPLORE = 'explorer',
   INSIGHTS = 'insights',
   SETTINGS = 'settings',
-  PIPELINE = 'pipeline'
+  PIPELINE = 'pipeline',
 }

--- a/static/app/views/pipeline/navigation.spec.tsx
+++ b/static/app/views/pipeline/navigation.spec.tsx
@@ -1,0 +1,96 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import Nav from 'sentry/components/nav';
+import {NavContextProvider} from 'sentry/components/nav/context';
+import PipelineSecondaryNav from 'sentry/views/pipeline/navigation';
+
+jest.mock('sentry/utils/analytics', () => ({
+  trackAnalytics: jest.fn(),
+}));
+
+const ALL_AVAILABLE_FEATURES = ['codecov-ui'];
+
+describe('PipelineSecondaryNav', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/assistant/`,
+      body: [],
+    });
+  });
+
+  it('renders the passed children', () => {
+    render(
+      <NavContextProvider>
+        <Nav />
+        <PipelineSecondaryNav>
+          <p>Test content</p>
+        </PipelineSecondaryNav>
+        <div id="main" />
+      </NavContextProvider>
+    );
+
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('renders the correct coverage link', () => {
+    render(
+      <NavContextProvider>
+        <Nav />
+        <PipelineSecondaryNav>
+          <p>Test content</p>
+        </PipelineSecondaryNav>
+        <div id="main" />
+      </NavContextProvider>,
+      {
+        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        disableRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/test-org-slug/pipeline/coverage/',
+          },
+        },
+      }
+    );
+
+    const coverageLink = screen.getByText('Coverage');
+    expect(coverageLink).toBeInTheDocument();
+    // TODO: @nicholas-codecov this link should appear once routes have been added
+    expect(coverageLink).not.toHaveAttribute('href');
+  });
+
+  it('renders the correct tests link', () => {
+    render(
+      <NavContextProvider>
+        <Nav />
+        <PipelineSecondaryNav>
+          <p>Test content</p>
+        </PipelineSecondaryNav>
+        <div id="main" />
+      </NavContextProvider>,
+      {
+        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        disableRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/test-org-slug/pipeline/tests/',
+          },
+        },
+      }
+    );
+
+    const testsLink = screen.getByText('Tests');
+    expect(testsLink).toBeInTheDocument();
+    // TODO: @nicholas-codecov this link should appear once routes have been added
+    expect(testsLink).not.toHaveAttribute('href');
+  });
+});

--- a/static/app/views/pipeline/navigation.tsx
+++ b/static/app/views/pipeline/navigation.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
+import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makePipelinePathname} from 'sentry/views/pipeline/pathnames';
 import {COVERAGE_BASE_URL, TESTS_BASE_URL} from 'sentry/views/pipeline/settings';
@@ -30,8 +31,8 @@ function PipelineSecondaryNav({children}: PipelineSecondaryNavProps) {
         </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
-            <SecondaryNav.Item to={coveragePathname}>Coverage</SecondaryNav.Item>
-            <SecondaryNav.Item to={testsPathname}>Tests</SecondaryNav.Item>
+            <SecondaryNav.Item to={coveragePathname}>{t('Coverage')}</SecondaryNav.Item>
+            <SecondaryNav.Item to={testsPathname}>{t('Tests')}</SecondaryNav.Item>
           </SecondaryNav.Section>
         </SecondaryNav.Body>
       </SecondaryNav>

--- a/static/app/views/pipeline/navigation.tsx
+++ b/static/app/views/pipeline/navigation.tsx
@@ -1,0 +1,43 @@
+import {Fragment} from 'react';
+
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
+import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makePipelinePathname} from 'sentry/views/pipeline/pathnames';
+import {COVERAGE_BASE_URL, TESTS_BASE_URL} from 'sentry/views/pipeline/settings';
+
+type PipelineSecondaryNavProps = {
+  children: React.ReactNode;
+};
+
+function PipelineSecondaryNav({children}: PipelineSecondaryNavProps) {
+  const organization = useOrganization();
+  const coveragePathname = makePipelinePathname({
+    organization,
+    path: `/${COVERAGE_BASE_URL}/`,
+  });
+  const testsPathname = makePipelinePathname({
+    organization,
+    path: `/${TESTS_BASE_URL}/`,
+  });
+
+  return (
+    <Fragment>
+      <SecondaryNav group={PrimaryNavGroup.PIPELINE}>
+        <SecondaryNav.Header>
+          {NAV_GROUP_LABELS[PrimaryNavGroup.PIPELINE]}
+        </SecondaryNav.Header>
+        <SecondaryNav.Body>
+          <SecondaryNav.Section>
+            <SecondaryNav.Item to={coveragePathname}>Coverage</SecondaryNav.Item>
+            <SecondaryNav.Item to={testsPathname}>Tests</SecondaryNav.Item>
+          </SecondaryNav.Section>
+        </SecondaryNav.Body>
+      </SecondaryNav>
+      {children}
+    </Fragment>
+  );
+}
+
+export default PipelineSecondaryNav;

--- a/static/app/views/pipeline/pathnames.spec.ts
+++ b/static/app/views/pipeline/pathnames.spec.ts
@@ -1,4 +1,4 @@
-import {Organization} from 'sentry/types/organization';
+import type {Organization} from 'sentry/types/organization';
 import {makePipelinePathname} from 'sentry/views/pipeline/pathnames';
 
 const testOrg = {

--- a/static/app/views/pipeline/pathnames.spec.ts
+++ b/static/app/views/pipeline/pathnames.spec.ts
@@ -1,0 +1,36 @@
+import {Organization} from 'sentry/types/organization';
+import {makePipelinePathname} from 'sentry/views/pipeline/pathnames';
+
+const testOrg = {
+  slug: 'test-org-slug',
+} as Organization;
+
+interface TestCase {
+  expected: string;
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}
+
+const testCases: TestCase[] = [
+  {
+    organization: testOrg,
+    path: '/',
+    expected: '/organizations/test-org-slug/pipeline/',
+  },
+  {
+    organization: testOrg,
+    path: '/test/',
+    expected: '/organizations/test-org-slug/pipeline/test/',
+  },
+];
+
+describe('makePipelinePathname', () => {
+  describe.each(testCases)(
+    'when the organization is $organization and the path is $path',
+    ({organization, path, expected}) => {
+      it('generates the correct url', () => {
+        expect(makePipelinePathname({organization, path})).toEqual(expected);
+      });
+    }
+  );
+});

--- a/static/app/views/pipeline/pathnames.ts
+++ b/static/app/views/pipeline/pathnames.ts
@@ -1,0 +1,12 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {PIPELINE_BASE_URL} from 'sentry/views/pipeline/settings';
+
+interface MakePipelinePathnameArgs {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}
+
+export function makePipelinePathname({path, organization}: MakePipelinePathnameArgs) {
+  return normalizeUrl(`/organizations/${organization.slug}/${PIPELINE_BASE_URL}${path}`);
+}

--- a/static/app/views/pipeline/settings.tsx
+++ b/static/app/views/pipeline/settings.tsx
@@ -1,0 +1,10 @@
+import {t} from 'sentry/locale';
+
+export const PIPELINE_PAGE_TITLE = t('Pipeline');
+export const PIPELINE_BASE_URL = 'pipeline';
+
+export const COVERAGE_PAGE_TITLE = t('Coverage Analytics');
+export const COVERAGE_BASE_URL = 'coverage';
+
+export const TESTS_PAGE_TITLE = t('Test Analytics');
+export const TESTS_BASE_URL = 'tests';


### PR DESCRIPTION
This PR adds in a `SecondaryNav` component for Pipeline, while adding in some supporting functionality, and adding some constants to `components/nav/constants`