### PR TITLE
ref: fix sdk test which fails on its own

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -637,6 +637,9 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
                 )
 
 
+_AMBIGUOUS_ORG_CUTOFF = 50
+
+
 def bind_ambiguous_org_context(
     orgs: Sequence[Organization] | Sequence[RpcOrganization] | list[str], source: str | None = None
 ) -> None:
@@ -658,8 +661,10 @@ def bind_ambiguous_org_context(
     # Right now there is exactly one Integration instance shared by more than 30 orgs (the generic
     # GitLab integration, at the moment shared by ~500 orgs), so 50 should be plenty for all but
     # that one instance
-    if len(orgs) > 50:
-        org_slugs = org_slugs[:49] + [f"... ({len(orgs) - 49} more)"]
+    if len(orgs) > _AMBIGUOUS_ORG_CUTOFF:
+        org_slugs = org_slugs[: _AMBIGUOUS_ORG_CUTOFF - 1] + [
+            f"... ({len(orgs) - (_AMBIGUOUS_ORG_CUTOFF - 1)} more)"
+        ]
 
     scope = Scope.get_isolation_scope()
 


### PR DESCRIPTION
and speed it up so it is not so slow!

previously failing with:

```console
$ pytest $(tail -1 testlist6)
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 1 item                                                               

tests/sentry/utils/test_sdk.py E                                         [100%]

==================================== ERRORS ====================================
_ ERROR at setup of BindAmbiguousOrgContextTest.test_truncates_list_at_50_entries _
tests/sentry/utils/test_sdk.py:421: in setUpClass
    cls.orgs = [Factories.create_organization() for _ in [None] * 52]
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/contextlib.py:85: in inner
    return func(*args, **kwds)
src/sentry/testutils/factories.py:371: in create_organization
    org.handle_async_replication(org.id)
src/sentry/models/organization.py:279: in handle_async_replication
    organization_mapping_service.upsert(organization_id=self.id, update=update)
src/sentry/hybridcloud/rpc/service.py:354: in remote_method
    return dispatch_remote_call(
src/sentry/hybridcloud/rpc/service.py:476: in dispatch_remote_call
    return remote_silo_call.dispatch(use_test_client)
src/sentry/hybridcloud/rpc/service.py:511: in dispatch
    serial_response = self._send_to_remote_silo(use_test_client)
src/sentry/hybridcloud/rpc/service.py:572: in _send_to_remote_silo
    response = self._fire_test_request(headers, data)
src/sentry/hybridcloud/rpc/service.py:631: in _fire_test_request
    in_test_assert_no_transaction(
src/sentry/db/postgres/transactions.py:101: in in_test_assert_no_transaction
    assert not hybrid_cloud.simulated_transaction_watermarks.connection_transaction_depth_above_watermark(
E   AssertionError: remote service method to /api/0/internal/rpc/organization_mapping/upsert/ called inside transaction!  Move service calls to outside of transactions.
=========================== short test summary info ============================
ERROR tests/sentry/utils/test_sdk.py::BindAmbiguousOrgContextTest::test_truncates_list_at_50_entries - AssertionError: remote service method to /api/0/internal/rpc/organization_m...
=============================== 1 error in 5.00s ===============================
```

<!-- Describe your PR here. -->