### PR TITLE
feat(ui): Remove sprintf-js dependency for Jed.sprintf

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "reflux": "0.4.1",
     "screenfull": "^6.0.2",
     "scroll-to-element": "^2.0.0",
-    "sprintf-js": "1.0.3",
     "style-loader": "^3.3.4",
     "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",

--- a/static/app/components/customIgnoreDurationModal.tsx
+++ b/static/app/components/customIgnoreDurationModal.tsx
@@ -1,7 +1,5 @@
 import {Fragment, useRef, useState} from 'react';
 import moment from 'moment-timezone';
-// @ts-expect-error TS(7016): Could not find a declaration file for module 'spri... Remove this comment to see the full error message
-import {sprintf} from 'sprintf-js';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
@@ -16,6 +14,11 @@ type Props = ModalRenderProps & {
 };
 
 export default function CustomIgnoreDurationModal(props: Props) {
+  const [defaultDate] = useState(() => {
+    // Give the user a sane starting point to select a date
+    // (prettier than the empty date/time inputs):
+    return moment().add(14, 'days').startOf('minute').toDate();
+  });
   const [dateWarning, setDateWarning] = useState<boolean>(false);
   const {Header, Body, Footer, onSelected, closeModal} = props;
   const label = t('Ignore this issue until \u2026');
@@ -49,21 +52,8 @@ export default function CustomIgnoreDurationModal(props: Props) {
     closeModal();
   };
 
-  // Give the user a sane starting point to select a date
-  // (prettier than the empty date/time inputs):
-  const defaultDate = new Date();
-  defaultDate.setDate(defaultDate.getDate() + 14);
-  defaultDate.setSeconds(0);
-  defaultDate.setMilliseconds(0);
-
-  const defaultDateVal = sprintf(
-    '%d-%02d-%02d',
-    defaultDate.getUTCFullYear(),
-    defaultDate.getUTCMonth() + 1,
-    defaultDate.getUTCDate()
-  );
-
-  const defaultTimeVal = sprintf('%02d:00', defaultDate.getUTCHours());
+  const defaultDateVal = moment(defaultDate).format('YYYY-MM-DD');
+  const defaultTimeVal = moment(defaultDate).format('HH:00');
 
   return (
     <Fragment>

--- a/static/app/locale.spec.tsx
+++ b/static/app/locale.spec.tsx
@@ -1,3 +1,6 @@
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'jed'... Remove this comment to see the full error message
+import Jed from 'jed';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -93,5 +96,9 @@ describe('locale.gettextComponentTemplate', () => {
     expect(container.innerHTML).toBe(
       '<div><b>text with <a href="/link">another</a> group</b></div>'
     );
+  });
+
+  it('should use Jed.sprintf', () => {
+    expect(Jed.sprintf('%s %s', 'hello', 'world')).toBe('hello world');
   });
 });

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -1,8 +1,6 @@
 import {cloneElement, Fragment, isValidElement} from 'react';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'jed'... Remove this comment to see the full error message
 import Jed from 'jed';
-// @ts-expect-error TS(7016): Could not find a declaration file for module 'spri... Remove this comment to see the full error message
-import {sprintf} from 'sprintf-js';
 
 import toArray from 'sentry/utils/array/toArray';
 import localStorage from 'sentry/utils/localStorage';
@@ -96,7 +94,7 @@ function formatForReact(formatString: string, args: FormatArg[]): React.ReactNod
   let cursor = 0;
 
   // always re-parse, do not cache, because we change the match
-  sprintf.parse(formatString).forEach((match: any, idx: number) => {
+  Jed.sprintf.parse(formatString).forEach((match: any, idx: number) => {
     if (typeof match === 'string') {
       nodes.push(match);
       return;
@@ -122,7 +120,9 @@ function formatForReact(formatString: string, args: FormatArg[]): React.ReactNod
       // array with two items in.
       match[2] = null;
       match[1] = 1;
-      nodes.push(<Fragment key={idx++}>{sprintf.format([match], [null, arg])}</Fragment>);
+      nodes.push(
+        <Fragment key={idx++}>{Jed.sprintf.format([match], [null, arg])}</Fragment>
+      );
     }
   });
 
@@ -322,7 +322,7 @@ export function format(formatString: string, args: FormatArg[]): React.ReactNode
     return formatForReact(formatString, args);
   }
 
-  return sprintf(formatString, ...args) as string;
+  return Jed.sprintf(formatString, ...args) as string;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11333,7 +11333,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-sprintf-js@1.0.3, sprintf-js@~1.0.2:
+sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=


### PR DESCRIPTION
Jed already has an implementation of sprintf. Remove from one modal and use Jed.sprintf directly. Read more about the jed modifications here https://github.com/messageformat/Jed/blob/master/jed.js#L325-L360 

it might benefit us to rewrite jed in more modern syntax and pull the regexes up.
