### PR TITLE
feat(shared-views): Add `PUT` `/group-search-views/:viewId` endpoint for updating a view

### DIFF
--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from sentry import features
 from sentry.api.serializers.rest_framework import ValidationError
+from sentry.models.groupsearchview import GroupSearchViewVisibility
 from sentry.models.project import Project
 from sentry.models.savedsearch import SORT_LITERALS, SortOptions
 
@@ -76,6 +77,24 @@ class GroupSearchViewValidator(serializers.Serializer):
 
 class GroupSearchViewPostValidator(ViewValidator):
     starred = serializers.BooleanField(required=False)
+
+
+class GroupSearchViewDetailsPutValidator(ViewValidator):
+    starred = serializers.BooleanField(required=False)
+    visibility = serializers.ChoiceField(
+        required=False, choices=GroupSearchViewVisibility.as_choices()
+    )
+
+    def validate_visibility(self, value):
+        has_share_access = (
+            self.context["access"].has_scope("team:admin")
+            or self.context["access"].has_scope("org:admin")
+            or self.context["access"].has_scope("org:owner")
+        )
+
+        if value == GroupSearchViewVisibility.ORGANIZATION and not has_share_access:
+            raise ValidationError(detail="You do not have permission to share this view")
+        return value
 
     def validate(self, data):
         return super().validate(data)

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -78,9 +78,11 @@ class GroupSearchViewValidator(serializers.Serializer):
 class GroupSearchViewPostValidator(ViewValidator):
     starred = serializers.BooleanField(required=False)
 
+    def validate(self, data):
+        return super().validate(data)
+
 
 class GroupSearchViewDetailsPutValidator(ViewValidator):
-    starred = serializers.BooleanField(required=False)
     visibility = serializers.ChoiceField(
         required=False, choices=GroupSearchViewVisibility.as_choices()
     )

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -1,3 +1,5 @@
+from typing import Any, NotRequired, TypedDict
+
 from django.db.models import F
 from rest_framework import status
 from rest_framework.request import Request
@@ -8,13 +10,30 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers.base import serialize
+from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
+from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewDetailsPutValidator
+from sentry.issues.endpoints.organization_group_search_views import pick_default_project
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
+from sentry.models.savedsearch import SORT_LITERALS
+
+
+class GroupSearchViewValidatorResponse(TypedDict):
+    id: str
+    name: NotRequired[str]
+    query: NotRequired[str]
+    querySort: NotRequired[SORT_LITERALS]
+    projects: NotRequired[list[int]]
+    isAllProjects: NotRequired[bool]
+    environments: NotRequired[list[str]]
+    timeFilters: NotRequired[dict[str, Any]]
 
 
 class MemberPermission(OrganizationPermission):
     scope_map = {
+        "PUT": ["member:read", "member:write"],
         "DELETE": ["member:read", "member:write"],
     }
 
@@ -22,10 +41,78 @@ class MemberPermission(OrganizationPermission):
 @region_silo_endpoint
 class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)
+
+    def put(self, request: Request, organization: Organization, view_id: str) -> Response:
+        """
+        Update an issue view for the current organization member.
+        """
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            view = GroupSearchView.objects.get(
+                id=view_id, organization=organization, user_id=request.user.id
+            )
+        except GroupSearchView.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = GroupSearchViewDetailsPutValidator(
+            data=request.data,
+            context={"organization": organization, "access": request.access},
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        validated_data = serializer.validated_data
+
+        view.name = validated_data["name"]
+        view.query = validated_data["query"]
+        view.query_sort = validated_data["querySort"]
+        view.is_all_projects = validated_data["isAllProjects"]
+        view.environments = validated_data["environments"]
+        view.time_filters = validated_data["timeFilters"]
+        view.projects.set(validated_data["projects"])
+
+        if "starred" in validated_data:
+            if validated_data["starred"]:
+                GroupSearchViewStarred.objects.insert_starred_view(
+                    organization=organization,
+                    user_id=request.user.id,
+                    view=view,
+                )
+            else:
+                GroupSearchViewStarred.objects.filter(
+                    organization=organization,
+                    user_id=request.user.id,
+                    group_search_view=view,
+                ).delete()
+
+        view.visibility = validated_data.get("visibility", view.visibility)
+
+        view.save()
+
+        has_global_views = features.has("organizations:global-views", organization)
+        default_project = None
+        if not has_global_views:
+            default_project = pick_default_project(organization, request.user)
+
+        return Response(
+            serialize(
+                view,
+                request.user,
+                serializer=GroupSearchViewSerializer(
+                    has_global_views=has_global_views, default_project=default_project
+                ),
+            )
+        )
 
     def delete(self, request: Request, organization: Organization, view_id: str) -> Response:
         """

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -111,7 +111,8 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
                 serializer=GroupSearchViewSerializer(
                     has_global_views=has_global_views, default_project=default_project
                 ),
-            )
+            ),
+            status=status.HTTP_200_OK,
         )
 
     def delete(self, request: Request, organization: Organization, view_id: str) -> Response:

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -81,20 +81,6 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         view.time_filters = validated_data["timeFilters"]
         view.projects.set(validated_data["projects"])
 
-        if "starred" in validated_data:
-            if validated_data["starred"]:
-                GroupSearchViewStarred.objects.insert_starred_view(
-                    organization=organization,
-                    user_id=request.user.id,
-                    view=view,
-                )
-            else:
-                GroupSearchViewStarred.objects.filter(
-                    organization=organization,
-                    user_id=request.user.id,
-                    group_search_view=view,
-                ).delete()
-
         view.visibility = validated_data.get("visibility", view.visibility)
 
         view.save()

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -270,51 +270,6 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         assert member_view.visibility == "owner"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_put_with_starred(self) -> None:
-        data = {
-            "name": "Starred View",
-            "query": "is:unresolved",
-            "querySort": "date",
-            "projects": [self.project.id],
-            "environments": [],
-            "timeFilters": {"period": "14d"},
-            "starred": True,
-        }
-
-        response = self.client.put(self.url, data=data)
-        assert response.status_code == 200
-
-        starred_view = GroupSearchViewStarred.objects.filter(
-            organization=self.organization, user_id=self.user.id, group_search_view_id=self.view_id
-        ).first()
-
-        assert starred_view is not None
-
-    @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_put_update_unstar(self) -> None:
-        # First make sure the view is starred
-        data = {
-            "name": "Starred View",
-            "query": "is:unresolved",
-            "projects": [self.project.id],
-            "environments": [],
-            "timeFilters": {"period": "14d"},
-            "starred": True,
-        }
-
-        self.client.put(self.url, data=data)
-
-        data["starred"] = False
-        response = self.client.put(self.url, data=data)
-        assert response.status_code == 200
-
-        starred_view = GroupSearchViewStarred.objects.filter(
-            organization=self.organization, user_id=self.user.id, group_search_view_id=self.view_id
-        ).first()
-
-        assert starred_view is None
-
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_put_nonexistent_view(self) -> None:
         nonexistent_id = "99999"
         url = reverse(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -2,7 +2,9 @@ from django.urls import reverse
 
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
 from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
 
 
@@ -119,3 +121,276 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         assert response.status_code == 404
 
         GroupSearchView.objects.get(id=self.view_id)
+
+
+class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-details"
+    method = "put"
+
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data()
+
+        # Get the first view's ID for testing
+        self.view_id = str(self.base_data["user_one_views"][0].id)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+        )
+
+    @with_feature(
+        {"organizations:issue-stream-custom-views": True, "organizations:global-views": True}
+    )
+    def test_put_view_success(self) -> None:
+        data = {
+            "name": "Updated View Name",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id],
+            "isAllProjects": False,
+            "environments": ["production"],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        # Verify the view was updated
+        updated_view = GroupSearchView.objects.get(id=self.view_id)
+        assert updated_view.name == "Updated View Name"
+        assert updated_view.query == "is:unresolved"
+        assert updated_view.query_sort == "date"
+        assert updated_view.is_all_projects is False
+        assert list(updated_view.projects.values_list("id", flat=True)) == [self.project.id]
+        assert updated_view.environments == ["production"]
+        assert updated_view.time_filters == {"period": "14d"}
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_put_update_projects(self) -> None:
+        second_project = self.create_project(organization=self.organization)
+
+        data = {
+            "name": "Updated Projects View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id, second_project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        # Verify the projects were updated
+        updated_view = GroupSearchView.objects.get(id=self.view_id)
+        assert set(updated_view.projects.values_list("id", flat=True)) == {
+            self.project.id,
+            second_project.id,
+        }
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_put_all_projects(self) -> None:
+        data = {
+            "name": "All Projects View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [-1],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        # Verify isAllProjects was set
+        updated_view = GroupSearchView.objects.get(id=self.view_id)
+        assert updated_view.is_all_projects is True
+        assert updated_view.projects.count() == 0
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_with_visibility(self) -> None:
+        # Make the user a team admin to set the view to organization visibility
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.user.update(is_staff=True)
+
+        data = {
+            "name": "Organization View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+            "visibility": "organization",
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        # Verify visibility was updated
+        updated_view = GroupSearchView.objects.get(id=self.view_id)
+        assert updated_view.visibility == "organization"
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_visibility_without_permission(self) -> None:
+        user_without_permission = self.create_user()
+        self.create_member(organization=self.organization, user=user_without_permission)
+
+        self.login_as(user=user_without_permission)
+
+        member_view = GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=user_without_permission.id,
+            name="Personal View",
+            query="is:unresolved",
+            query_sort="date",
+        )
+
+        data = {
+            "name": "Organization View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+            "visibility": "organization",
+        }
+
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": member_view.id},
+        )
+
+        response = self.client.put(url, data=data)
+        assert response.status_code == 400
+
+        member_view.refresh_from_db()
+        assert member_view.visibility == "owner"
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_with_starred(self) -> None:
+        data = {
+            "name": "Starred View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+            "starred": True,
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        starred_view = GroupSearchViewStarred.objects.filter(
+            organization=self.organization, user_id=self.user.id, group_search_view_id=self.view_id
+        ).first()
+
+        assert starred_view is not None
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_update_unstar(self) -> None:
+        # First make sure the view is starred
+        data = {
+            "name": "Starred View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+            "starred": True,
+        }
+
+        self.client.put(self.url, data=data)
+
+        data["starred"] = False
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 200
+
+        starred_view = GroupSearchViewStarred.objects.filter(
+            organization=self.organization, user_id=self.user.id, group_search_view_id=self.view_id
+        ).first()
+
+        assert starred_view is None
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_nonexistent_view(self) -> None:
+        nonexistent_id = "99999"
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": nonexistent_id},
+        )
+
+        data = {
+            "name": "Updated View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(url, data=data)
+        assert response.status_code == 404
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_view_from_another_user(self) -> None:
+        # Get a view ID from user_two
+        view_id = str(self.base_data["user_two_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        data = {
+            "name": "Updated View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(url, data=data)
+        assert response.status_code == 404
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_invalid_data(self) -> None:
+        # Missing required timeFilters
+        data = {
+            "name": "Invalid View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 400
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_multi_project_without_global_views(self) -> None:
+        second_project = self.create_project(organization=self.organization)
+
+        data = {
+            "name": "Multi Project View",
+            "query": "is:unresolved",
+            "querySort": "date",
+            "projects": [self.project.id, second_project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 400
+        assert "projects" in response.data
+
+    def test_put_without_feature_flag(self) -> None:
+        data = {
+            "name": "Updated View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(self.url, data=data)
+        assert response.status_code == 404


### PR DESCRIPTION
Creates the `PUT` `/group-search-views/:viewId`, which updates a single view. 

This endpoint requires aa fully verbose view as its input — that is, all filter values must be populated, even if they have not been changed. 

In addition to the standard filter params, two non-required params are available to include: 

1. `visibility: {"owner", "organization"}`: Whether or not to change the visibility of the view. Only org members with `team:admin`, `org:admin`, or `org:owner` permissions are allowed to change the visibility of a view from "owner" to "organization" 
2. `starred: bool` : Whether or not to add or remove view from the starred list. 