### PR TITLE
ref: fix usage_accountant-related test pollution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,6 +406,7 @@ module = [
     "sentry.tempest.endpoints.*",
     "sentry.tempest.migrations.*",
     "sentry.testutils.helpers.task_runner",
+    "sentry.testutils.helpers.usage_accountant",
     "sentry.testutils.pytest.json_report_reruns",
     "sentry.testutils.skips",
     "sentry.toolbar.utils.*",

--- a/src/sentry/testutils/helpers/usage_accountant.py
+++ b/src/sentry/testutils/helpers/usage_accountant.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Generator
+
+from arroyo.backends.abstract import Producer
+from arroyo.backends.kafka import KafkaPayload
+from usageaccountant import UsageAccumulator
+
+from sentry.usage_accountant import accountant
+
+
+@contextlib.contextmanager
+def usage_accountant_backend(producer: Producer[KafkaPayload]) -> Generator[None]:
+    assert accountant._accountant_backend is None, accountant._accountant_backend
+    accountant._accountant_backend = UsageAccumulator(producer=producer)
+    try:
+        yield
+    finally:
+        accountant._shutdown()
+        accountant._accountant_backend = None

--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -10,8 +10,7 @@ and the producer needs to be flushed to avoid loosing data.
 import atexit
 import logging
 
-from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaProducer, build_kafka_configuration
 from usageaccountant import UsageAccumulator, UsageUnit
 
 from sentry.conf.types.kafka_definition import Topic
@@ -23,29 +22,7 @@ logger = logging.getLogger(__name__)
 _accountant_backend: UsageAccumulator | None = None
 
 
-def init_backend(producer: Producer[KafkaPayload]) -> None:
-    """
-    This method should be used externally only in tests to fit a
-    mock producer.
-    """
-    global _accountant_backend
-
-    assert _accountant_backend is None, "Accountant already initialized once."
-    _accountant_backend = UsageAccumulator(producer=producer)
-    atexit.register(_shutdown)
-
-
-def reset_backend() -> None:
-    """
-    This method should be used externally only in tests to reset
-    the accountant backend.
-    """
-    global _accountant_backend
-    _accountant_backend = None
-
-
 def _shutdown() -> None:
-    global _accountant_backend
     if _accountant_backend is not None:
         _accountant_backend.flush()
         _accountant_backend.close()


### PR DESCRIPTION
previously failing with:

```console
$ pytest tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py::test_accountant_transaction tests/sentry/usage_accountant/test_accountant.py::test_accountant
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py . [ 50%]
                                                                         [ 50%]
tests/sentry/usage_accountant/test_accountant.py F                       [100%]

=================================== FAILURES ===================================
_______________________________ test_accountant ________________________________
tests/sentry/usage_accountant/test_accountant.py:47: in test_accountant
    accountant.init_backend(producer)
src/sentry/usage_accountant/accountant.py:33: in init_backend
    assert _accountant_backend is None, "Accountant already initialized once."
E   AssertionError: Accountant already initialized once.
=========================== short test summary info ============================
FAILED tests/sentry/usage_accountant/test_accountant.py::test_accountant - AssertionError: Accountant already initialized once.
========================= 1 failed, 1 passed in 5.12s ==========================
```

<!-- Describe your PR here. -->