### PR TITLE
fix(schema-hints): Separate logs and explore default tags

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -24,7 +24,10 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import SchemaHintsDrawer from 'sentry/views/explore/components/schemaHintsDrawer';
-import {SCHEMA_HINTS_LIST_ORDER_KEYS} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
+import {
+  getSchemaHintsListOrder,
+  SchemaHintsSources,
+} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
 export const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
@@ -34,6 +37,7 @@ interface SchemaHintsListProps extends SchemaHintsPageParams {
   stringTags: TagCollection;
   supportedAggregates: AggregationKey[];
   isLoading?: boolean;
+  source?: SchemaHintsSources;
 }
 
 export interface SchemaHintsPageParams {
@@ -75,6 +79,7 @@ function SchemaHintsList({
   isLoading,
   exploreQuery,
   setExploreQuery,
+  source = SchemaHintsSources.EXPLORE,
 }: SchemaHintsListProps) {
   const schemaHintsContainerRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
@@ -89,6 +94,8 @@ function SchemaHintsList({
   const filterTagsSorted = useMemo(() => {
     const filterTags: TagCollection = {...functionTags, ...numberTags, ...stringTags};
     filterTags.has = getHasTag({...stringTags});
+
+    const SCHEMA_HINTS_LIST_ORDER_KEYS = getSchemaHintsListOrder(source);
 
     const schemaHintsPresetTags = getTagsFromKeys(
       SCHEMA_HINTS_LIST_ORDER_KEYS,
@@ -106,7 +113,7 @@ function SchemaHintsList({
     const otherTags = getTagsFromKeys(otherKeys, filterTags);
 
     return [...schemaHintsPresetTags, ...sectionSortedTags, ...otherTags];
-  }, [numberTags, stringTags, functionTags]);
+  }, [functionTags, numberTags, stringTags, source]);
 
   const [visibleHints, setVisibleHints] = useState([seeFullListTag]);
 

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -95,20 +95,17 @@ function SchemaHintsList({
     const filterTags: TagCollection = {...functionTags, ...numberTags, ...stringTags};
     filterTags.has = getHasTag({...stringTags});
 
-    const SCHEMA_HINTS_LIST_ORDER_KEYS = getSchemaHintsListOrder(source);
+    const schemaHintsListOrder = getSchemaHintsListOrder(source);
 
-    const schemaHintsPresetTags = getTagsFromKeys(
-      SCHEMA_HINTS_LIST_ORDER_KEYS,
-      filterTags
-    );
+    const schemaHintsPresetTags = getTagsFromKeys(schemaHintsListOrder, filterTags);
 
     const sectionKeys = SPANS_FILTER_KEY_SECTIONS.flatMap(
       section => section.children
-    ).filter(key => !SCHEMA_HINTS_LIST_ORDER_KEYS.includes(key));
+    ).filter(key => !schemaHintsListOrder.includes(key));
     const sectionSortedTags = getTagsFromKeys(sectionKeys, filterTags);
 
     const otherKeys = Object.keys(filterTags).filter(
-      key => !sectionKeys.includes(key) && !SCHEMA_HINTS_LIST_ORDER_KEYS.includes(key)
+      key => !sectionKeys.includes(key) && !schemaHintsListOrder.includes(key)
     );
     const otherTags = getTagsFromKeys(otherKeys, filterTags);
 

--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -30,7 +30,7 @@ const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.TIMESTAMP,
 ];
 
-export const SCHEMA_HINTS_LIST_ORDER_KEYS = [
+const SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS = [
   ...new Set([
     ...FRONTEND_HINT_KEYS,
     ...MOBILE_HINT_KEYS,
@@ -38,3 +38,20 @@ export const SCHEMA_HINTS_LIST_ORDER_KEYS = [
     ...COMMON_HINT_KEYS,
   ]),
 ];
+
+const SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE = [
+  ...new Set([...FRONTEND_HINT_KEYS, ...MOBILE_HINT_KEYS, ...COMMON_HINT_KEYS]),
+];
+
+export enum SchemaHintsSources {
+  EXPLORE = 'explore',
+  LOGS = 'logs',
+}
+
+export const getSchemaHintsListOrder = (source: SchemaHintsSources) => {
+  if (source === SchemaHintsSources.LOGS) {
+    return SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS;
+  }
+
+  return SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE;
+};

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -17,6 +17,7 @@ import {useSchemaHintsOnLargeScreen} from 'sentry/views/explore/components/schem
 import SchemaHintsList, {
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHintsList';
+import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {
   useLogsFields,
@@ -114,6 +115,7 @@ export function LogsTabContent({
               isLoading={numberTagsLoading || stringTagsLoading}
               exploreQuery={logsSearch.formatString()}
               setExploreQuery={setLogsQuery}
+              source={SchemaHintsSources.LOGS}
             />
           </SchemaHintsSection>
         </Feature>

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -34,6 +34,7 @@ import SchemaHintsList, {
   SCHEMA_HINTS_DRAWER_WIDTH,
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHintsList';
+import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import {
   PageParamsProvider,
   useExploreDataset,
@@ -249,6 +250,7 @@ export function SpansTabContentImpl({
             isLoading={numberTagsLoading || stringTagsLoading}
             exploreQuery={query}
             setExploreQuery={setQuery}
+            source={SchemaHintsSources.EXPLORE}
           />
         </SchemaHintsSection>
       </Feature>


### PR DESCRIPTION
Some of the logs tags were leaking into schema hints on the traces page. I've added the ability to create a list of 'default' tags depending on which page the schema hints is on. I've also added a `source` param to schema hints to pass in the page. Here's what it looks like now:

| Before | ![image](https://github.com/user-attachments/assets/6fcf00a1-bd1f-47d5-af60-17e499d0726b) |
|--------|--------|
|  **After** | ![image](https://github.com/user-attachments/assets/4651fad6-d86e-42ef-9778-3794cef4591f) | 