### PR TITLE
feat(issue-summary) Route autofixability requests to severity

### DIFF
--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -120,7 +120,7 @@ def _generate_fixability_score(group_id: int):
     )
 
     response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
+        f"{settings.SEER_SEVERITY_URL}{path}",
         data=body,
         headers={
             "content-type": "application/json;charset=utf-8",


### PR DESCRIPTION
looks like #87822 accidentally routed requests [back to autofix](https://github.com/getsentry/sentry/pull/87822/files#diff-65696416b6b3efa357f5399b595982a8ad2781a85922ebbdb1ab8841a483c8e0R123) pods. this didn't cause errors, but it should be on severity