### PR TITLE
icons: remap color in chonk

### DIFF
--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -34,8 +34,17 @@ export function SvgIcon({ref, ...props}: IconProps) {
   } = useIconDefaults(props);
 
   const theme = useTheme();
+
+  // Chonk changes the color of the icon to gray300 to differ. We will remap
+  // the color to subText for the time being and remove this when the old theme
+  // aliases are removed.
+
+  let normalizedColor = providedColor;
+  if (theme.isChonk && providedColor === 'gray300') {
+    normalizedColor = 'subText';
+  }
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  const color = theme[providedColor] ?? providedColor;
+  const color = theme[normalizedColor] ?? normalizedColor;
   const size = legacySize ?? theme.iconSizes[providedSize];
 
   // Stroke based icons are only available in Chonk


### PR DESCRIPTION
These keep being added, but doesnt map to correct colors in chonk. I have decided to adjust this from inside the component as renaming would be prone to new icons still having the wrong colors and because we will want to use a semantic naming in the future.

I am noting it down in the todo doc for post release to remove this and simplify the icon colors.