### PR TITLE
chore(taskworker) Remove `model` arg compatibilty from process_buffer

### DIFF
--- a/tests/sentry/tasks/test_process_buffer.py
+++ b/tests/sentry/tasks/test_process_buffer.py
@@ -15,26 +15,16 @@ from sentry.testutils.cases import TestCase
 
 
 class ProcessIncrTest(TestCase):
-    @mock.patch("sentry.buffer.backend.process")
-    def test_constraints_model_name(self, process):
+    def test_constraints_model_name(self):
         with pytest.raises(AssertionError) as err:
             process_incr(model_name="group", columns={"times_seen": 1}, filters={"pk": 1})
         assert "model_name must be in form" in str(err)
 
     @mock.patch("sentry.buffer.backend.process")
-    def test_calls_process_with_model(self, process):
-        columns = {"times_seen": 1}
-        filters = {"pk": 1}
-        process_incr(model=Group, columns=columns, filters=filters)
-        process.assert_called_once_with(
-            model=Group, columns=columns, filters=filters, extra=None, signal_only=None
-        )
-
-    @mock.patch("sentry.buffer.backend.process")
     def test_calls_process_with_model_name(self, process):
         columns = {"times_seen": 1}
         filters = {"pk": 1}
-        process_incr(model=None, model_name="sentry.Group", columns=columns, filters=filters)
+        process_incr(model_name="sentry.Group", columns=columns, filters=filters)
         process.assert_called_once_with(
             model=Group, columns=columns, filters=filters, extra=None, signal_only=None
         )


### PR DESCRIPTION
Follow up to #87863 removing the logging and formal parameter.

Refs #81913