### PR TITLE
chore(logs): Remove sentry. prefix from trace item details

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -89,7 +89,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
             "itemId": resp["itemId"],
             "timestamp": resp["timestamp"],
             "attributes": {
-                attr["name"]: convert_rpc_attribute_to_json(attr["value"])
+                attr["name"].removeprefix("sentry."): convert_rpc_attribute_to_json(attr["value"])
                 for attr in resp["attributes"]
             },
         }


### PR DESCRIPTION
We do not want to expose `sentry.blah` to the frontend.