### PR TITLE
fix(releases): Release bubbles match issue details bar charts buckets

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -259,6 +259,17 @@ export function EventGraph({
     releases: hasReleaseBubblesSeries && showReleasesAs !== 'line' ? [] : releases,
   });
 
+  //
+  const lastEventSeries = eventSeries.at(-1);
+  const penultEventSeries = eventSeries.at(-2);
+  const lastEventSeriesTimestamp = lastEventSeries && (lastEventSeries.name as number);
+  const penultEventSeriesTimestamp =
+    penultEventSeries && (penultEventSeries.name as number);
+  const eventSeriesInterval =
+    lastEventSeriesTimestamp &&
+    penultEventSeriesTimestamp &&
+    lastEventSeriesTimestamp - penultEventSeriesTimestamp;
+
   const {
     connectReleaseBubbleChartRef,
     releaseBubbleEventHandlers,
@@ -279,10 +290,14 @@ export function EventGraph({
         />
       );
     },
+    alignInMiddle: true,
     legendSelected: legendSelected.Releases,
     desiredBuckets: eventSeries.length,
     minTime: eventSeries.length && (eventSeries.at(0)?.name as number),
-    maxTime: eventSeries.length && (eventSeries.at(-1)?.name as number),
+    maxTime:
+      lastEventSeriesTimestamp && eventSeriesInterval
+        ? lastEventSeriesTimestamp + eventSeriesInterval
+        : undefined,
     releases: hasReleaseBubblesSeries && showReleasesAs !== 'line' ? releases : [],
     projects: eventView.project,
     environments: eventView.environment,

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -259,7 +259,7 @@ export function EventGraph({
     releases: hasReleaseBubblesSeries && showReleasesAs !== 'line' ? [] : releases,
   });
 
-  //
+  // Do some manipulation to make sure the release buckets match up to `eventSeries`
   const lastEventSeries = eventSeries.at(-1);
   const penultEventSeries = eventSeries.at(-2);
   const lastEventSeriesTimestamp = lastEventSeries && (lastEventSeries.name as number);


### PR DESCRIPTION
On issue details, ensure that the release bubbles buckets match up with the bar charts. That is, the buckets need to have the same starting and ending timestamps.

This also required an additional flag to draw bubbles that match up to bar charts. ECharts draws bar charts so that the middle of the bar chart lines up with the starting timestamp. The release bubbles was drawn so that starting timestamp lined up with the start of the release bubble. Now in issue details, we pass a flag to shift release bubbles by 50% of its width so that it matches ECharts bar chart behavior.
