### PR TITLE
fix: don't put complete Tag into the QueryKey

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -328,7 +328,11 @@ function useFilterSuggestions({
   );
 
   const queryParams = useMemo(
-    () => [key ? key : {key: keyName, name: keyName}, filterValue] as const,
+    () =>
+      [
+        key ? {key: key.key, name: key.name} : {key: keyName, name: keyName},
+        filterValue,
+      ] as const,
     [filterValue, key, keyName]
   );
 


### PR DESCRIPTION
with #86278, we've refactored that everything used inside the queryFn was also part of the queryKey; however, passing a full tag is not necessary - getTagValues only needs {key, name}, which are also the only required properties of a Tag.

However, a Tag can have more things, including `values`, which can be an Array of (recursive) React Components. We definitely can't add those to the QueryKey, as they can't be serialized and in some cases lead to "Maximum callstack size exceeded" errors

The fix is to always only add {key,name} to the QueryKey, and then only pass that to `getTagValues`
