### PR TITLE
:wrench: chore(aci): losen discord action config schema

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/discord_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/discord_handler.py
@@ -12,7 +12,7 @@ class DiscordActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
     provider_slug = "discord"
 
-    # Main difference between the discord and slack action config schemas is that the target_display is null
+    # Main difference between the discord and slack action config schemas is that the target_display is possibly null
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "The configuration schema for a Discord Action",
@@ -20,7 +20,7 @@ class DiscordActionHandler(IntegrationActionHandler):
         "properties": {
             "target_identifier": {"type": "string"},
             "target_display": {
-                "type": ["null"],
+                "type": ["string", "null"],
             },
             "target_type": {
                 "type": ["integer"],


### PR DESCRIPTION
during the metric alert dry run, we found that for metric alerts, we stored the same value for `target_identifier` and `target_display`, even though we only ask for the `channel_id` from the user (we never ask for `channel_name`)

so that we can migrate the discord actions, i loosen the typing on `target_display` so it can also be a str.

the NOA however will not be reading from `target_identifier`