### PR TITLE
feat(ourlogs): UI changes for log attr aliasing

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -650,7 +650,7 @@ const SPECIAL_FIELDS: SpecialFields = {
   user: {
     sortField: 'user',
     renderFunc: data => {
-      if (data.user) {
+      if (data.user?.split) {
         const [key, value] = data.user.split(':');
         const userObj = {
           id: '',


### PR DESCRIPTION
### Summary
This allows both sides (object and array) so it's forward compatible and doesn't break when #88129 merges. The other side can be removed after.


#### Other
- Fix a bug where `.split` is called on a custom user attribute that isn't splittable.
