### PR TITLE
ref(issues): Refactor stack trace registers

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -201,6 +201,7 @@ function Content({
       const prevFrame = frames[frameIndex - 1];
       const nextFrame = frames[frameIndex + 1]!;
       const repeatedFrame = isRepeatedFrame(frame, nextFrame);
+      const isLastFrame = frameIndex === frames.length - 1;
 
       if (repeatedFrame) {
         nRepeats++;
@@ -228,7 +229,7 @@ function Content({
             address: frame.instructionAddr,
           }),
           maxLengthOfRelativeAddress: maxLengthOfAllRelativeAddresses,
-          registers: {}, // TODO: Fix registers
+          registers: isLastFrame ? registers : {},
           isFrameAfterLastNonApp: isFrameAfterLastNonApp(),
           includeSystemFrames,
           onFunctionNameToggle: handleToggleFunctionName,
@@ -274,14 +275,7 @@ function Content({
 
       return renderOmittedFrames(firstFrameOmitted, lastFrameOmitted);
     })
-    .filter(frame => !!frame) as React.ReactElement[];
-
-  if (convertedFrames.length > 0 && registers) {
-    const lastFrame = convertedFrames.length - 1;
-    convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame] as any, {
-      registers,
-    });
-  }
+    .filter((frame): frame is React.ReactElement => !!frame);
 
   if (defined(maxDepth)) {
     convertedFrames = convertedFrames.slice(-maxDepth);

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import StacktracePlatformIcon from 'sentry/components/events/interfaces/crashContent/stackTrace/platformIcon';
@@ -185,6 +185,7 @@ export function NativeContent({
       const prevFrame = frames[frameIndex - 1];
       const nextFrame = frames[frameIndex + 1]!;
       const repeatedFrame = isRepeatedFrame(frame, nextFrame);
+      const isLastFrame = frameIndex === frames.length - 1;
 
       if (repeatedFrame) {
         nRepeats++;
@@ -217,7 +218,7 @@ export function NativeContent({
             address: frame.instructionAddr,
           }),
           maxLengthOfRelativeAddress: maxLengthOfAllRelativeAddresses,
-          registers: {},
+          registers: isLastFrame ? registers : {},
           includeSystemFrames,
           onFunctionNameToggle: handleToggleFunctionName,
           showCompleteFunctionName,
@@ -255,18 +256,11 @@ export function NativeContent({
 
       return renderOmittedFrames(firstFrameOmitted, lastFrameOmitted);
     })
-    .filter(frame => !!frame) as React.ReactElement[];
+    .filter((frame): frame is React.ReactElement => !!frame);
 
   const wrapperClassName = `traceback ${
     includeSystemFrames ? 'full-traceback' : 'in-app-traceback'
   } ${className}`;
-
-  if (convertedFrames.length > 0 && registers) {
-    const lastFrame = convertedFrames.length - 1;
-    convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame] as any, {
-      registers,
-    });
-  }
 
   if (defined(maxDepth)) {
     convertedFrames = convertedFrames.slice(-maxDepth);

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'sentry/types/integrations';
 import {CodecovStatusCode, Coverage} from 'sentry/types/integrations';
 import type {PlatformKey} from 'sentry/types/project';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {getFileExtension} from 'sentry/utils/fileExtension';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -33,7 +34,7 @@ type Props = {
   components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
   event: Event;
   frame: Frame;
-  registers: {[key: string]: string};
+  registers: StacktraceType['registers'];
   className?: string;
   emptySourceNotation?: boolean;
   frameMeta?: Record<any, any>;
@@ -196,7 +197,7 @@ function Context({
 
       {hasContextRegisters && (
         <FrameRegisters
-          registers={registers}
+          registers={registers!}
           meta={registersMeta}
           deviceArch={event.contexts?.device?.arch}
         />

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -26,6 +26,7 @@ import type {
 } from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import withOrganization from 'sentry/utils/withOrganization';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
@@ -63,7 +64,7 @@ const VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS = [
 export interface DeprecatedLineProps {
   data: Frame;
   event: Event;
-  registers: Record<string, string>;
+  registers: StacktraceType['registers'];
   emptySourceNotation?: boolean;
   frameMeta?: Record<any, any>;
   frameSourceResolutionResults?: FrameSourceMapDebuggerData;

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
@@ -12,6 +12,8 @@ describe('FrameRegisters', function () {
     };
 
     render(<FrameRegisters registers={registers} />);
+    expect(screen.getByText('r10')).toBeInTheDocument();
+    expect(screen.getByText('0x00007fff9300bf70')).toBeInTheDocument();
   });
 
   it('should skip registers without a value', function () {
@@ -22,6 +24,9 @@ describe('FrameRegisters', function () {
     };
 
     render(<FrameRegisters registers={registers} />);
+    expect(screen.getByText('r10')).toBeInTheDocument();
+    expect(screen.getByText('0x00007fff9300bf70')).toBeInTheDocument();
+    expect(screen.queryByText('r11')).not.toBeInTheDocument();
   });
 });
 
@@ -30,28 +35,24 @@ describe('FrameRegistersValue', function () {
   const numericValue = 10;
 
   describe('with string value', function () {
-    it('should display the hexadecimal value', function () {
+    it('should display the hexadecimal value and toggle to numeric value', async function () {
       render(<FrameRegisterValue value={hexadecimalValue} />);
       expect(screen.getByText(hexadecimalValue)).toBeInTheDocument();
-    });
-
-    it('should display the numeric value', async function () {
-      render(<FrameRegisterValue value={hexadecimalValue} />);
-      await userEvent.click(screen.getByLabelText('Toggle register value format'));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Toggle register value format'})
+      );
       expect(screen.queryByText(hexadecimalValue)).not.toBeInTheDocument();
       expect(screen.getByText(numericValue)).toBeInTheDocument();
     });
   });
 
   describe('with numeric value', function () {
-    it('should display the hexadecimal value', function () {
+    it('should display the hexadecimal value and toggle to numeric value', async function () {
       render(<FrameRegisterValue value={numericValue} />);
       expect(screen.getByText(hexadecimalValue)).toBeInTheDocument();
-    });
-
-    it('should display the numeric value', async function () {
-      render(<FrameRegisterValue value={numericValue} />);
-      await userEvent.click(screen.getByLabelText('Toggle register value format'));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Toggle register value format'})
+      );
       expect(screen.queryByText(hexadecimalValue)).not.toBeInTheDocument();
       expect(screen.getByText(numericValue)).toBeInTheDocument();
     });
@@ -60,14 +61,12 @@ describe('FrameRegistersValue', function () {
   describe('with unknown value', function () {
     const unknownValue = 'xyz';
 
-    it('should display the hexadecimal value', function () {
+    it('should display the hexadecimal value and toggle to numeric value', async function () {
       render(<FrameRegisterValue value={unknownValue} />);
       expect(screen.getByText(unknownValue)).toBeInTheDocument();
-    });
-
-    it('should display the numeric value', async function () {
-      render(<FrameRegisterValue value={unknownValue} />);
-      await userEvent.click(screen.getByLabelText('Toggle register value format'));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Toggle register value format'})
+      );
       expect(screen.getByText(unknownValue)).toBeInTheDocument();
     });
   });

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
@@ -1,29 +1,28 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
 import {getSortedRegisters} from './utils';
 import {FrameRegisterValue} from './value';
 
 type Props = {
-  registers: Record<string, string | null>;
+  registers: NonNullable<StacktraceType['registers']>;
   deviceArch?: string;
   meta?: Record<any, any>;
 };
 
-const CLIPPED_HEIGHT = 120;
+const CLIPPED_HEIGHT = 250;
 
 export function FrameRegisters({registers, deviceArch, meta}: Props) {
-  // make sure that clicking on the registers does not actually do
-  // anything on the containing element.
-  const handlePreventToggling = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
-  };
-
-  const sortedRegisters = getSortedRegisters(registers, deviceArch);
+  const sortedRegisters = useMemo(
+    () => getSortedRegisters(registers, deviceArch),
+    [registers, deviceArch]
+  );
 
   return (
     <Wrapper>
@@ -35,7 +34,7 @@ export function FrameRegisters({registers, deviceArch, meta}: Props) {
               return null;
             }
             return (
-              <Register key={name} onClick={handlePreventToggling}>
+              <Register key={name}>
                 {name}
                 <FrameRegisterValue value={value} meta={meta?.[name]?.['']} />
               </Register>
@@ -51,7 +50,7 @@ const Wrapper = styled('div')`
   padding: ${space(0.5)} ${space(1.5)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    padding: 18px 36px;
+    padding: ${space(1)} ${space(3)} ${space(2)};
   }
 `;
 

--- a/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
@@ -1,3 +1,5 @@
+import type {StacktraceType} from 'sentry/types/stacktrace';
+
 import {
   REGISTERS_ARM,
   REGISTERS_ARM64,
@@ -40,7 +42,7 @@ function getRegisterIndex(register: string, registerMap: Record<string, number>)
 }
 
 export function getSortedRegisters(
-  registers: Record<string, string | null>,
+  registers: NonNullable<StacktraceType['registers']>,
   deviceArch?: string
 ) {
   const entries = Object.entries(registers);

--- a/static/app/components/events/interfaces/frame/frameRegisters/value.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/value.tsx
@@ -1,26 +1,20 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Meta} from 'sentry/types/group';
-
-const REGISTER_VIEWS = [t('Hexadecimal'), t('Numeric')];
 
 type Props = {
   value: string | number;
   meta?: Meta;
 };
 
-type State = {
-  view: number;
-};
-
 export function FrameRegisterValue({meta, value}: Props) {
-  const [state, setState] = useState<State>({view: 0});
+  const [isHexadecimal, setIsHexadecimal] = useState(true);
 
   function formatValue() {
     try {
@@ -29,40 +23,34 @@ export function FrameRegisterValue({meta, value}: Props) {
         return value;
       }
 
-      switch (state.view) {
-        case 1:
-          return `${parsed}`;
-        case 0:
-        default:
-          return `0x${parsed.toString(16).padStart(16, '0')}`;
-      }
+      return isHexadecimal ? `0x${parsed.toString(16).padStart(16, '0')}` : `${parsed}`;
     } catch {
       return value;
     }
   }
 
+  const toggleFormat = () => {
+    setIsHexadecimal(!isHexadecimal);
+  };
+
+  const formatLabel = isHexadecimal ? t('Hexadecimal') : t('Numeric');
+
   return (
     <InlinePre>
       <AnnotatedText value={formatValue()} meta={meta} />
-      <StyledTooltip
-        title={REGISTER_VIEWS[state.view]}
-        containerDisplayMode="inline-flex"
-      >
-        <Toggle
-          onClick={() => {
-            setState({view: (state.view + 1) % REGISTER_VIEWS.length});
-          }}
-          size="xs"
+      <div>
+        <ToggleButton
+          size="zero"
+          borderless
+          icon={<IconSliders size="xs" />}
+          onClick={toggleFormat}
+          title={formatLabel}
           aria-label={t('Toggle register value format')}
         />
-      </StyledTooltip>
+      </div>
     </InlinePre>
   );
 }
-
-const StyledTooltip = styled(Tooltip)`
-  align-items: center;
-`;
 
 const InlinePre = styled('pre')`
   margin: 0;
@@ -75,9 +63,8 @@ const InlinePre = styled('pre')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-const Toggle = styled(IconSliders)`
+const ToggleButton = styled(Button)`
   opacity: 0.33;
-  cursor: pointer;
 
   &:hover {
     opacity: 1;

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import type {Event, Frame} from 'sentry/types/event';
 import {EventOrGroupType} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/project';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {isUrl} from 'sentry/utils/string/isUrl';
@@ -83,8 +84,8 @@ export function hasContextVars(frame: Frame) {
   return !isEmptyObject(frame.vars || {});
 }
 
-export function hasContextRegisters(registers: Record<string, string>) {
-  return !isEmptyObject(registers);
+export function hasContextRegisters(registers: StacktraceType['registers']) {
+  return !isEmptyObject(registers ?? {});
 }
 
 export function hasAssembly(frame: Frame, platform?: string) {
@@ -101,7 +102,7 @@ export function isExpandable({
   isOnlyFrame,
 }: {
   frame: Frame;
-  registers: Record<string, string>;
+  registers: StacktraceType['registers'];
   emptySourceNotation?: boolean;
   isOnlyFrame?: boolean;
   platform?: string;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -36,6 +36,7 @@ import type {
   SentryAppSchemaStacktraceLink,
 } from 'sentry/types/integrations';
 import type {PlatformKey} from 'sentry/types/project';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
@@ -55,7 +56,7 @@ type Props = {
   isFirstInAppFrame: boolean;
   isUsedForGrouping: boolean;
   platform: PlatformKey;
-  registers: Record<string, string>;
+  registers: StacktraceType['registers'];
   emptySourceNotation?: boolean;
   frameMeta?: Record<any, any>;
   hiddenFrameCount?: number;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -14,7 +14,7 @@ import type {Image} from './debugImage';
 import type {IssueAttachment, IssueCategory, IssueType} from './group';
 import type {PlatformKey} from './project';
 import type {Release} from './release';
-import type {RawStacktrace, StackTraceMechanism, StacktraceType} from './stacktrace';
+import type {StackTraceMechanism, StacktraceType} from './stacktrace';
 
 export type Level = 'error' | 'fatal' | 'info' | 'warning' | 'sample' | 'unknown';
 
@@ -161,7 +161,7 @@ export interface Thread {
   crashed: boolean;
   current: boolean;
   id: number;
-  rawStacktrace: RawStacktrace;
+  rawStacktrace: StacktraceType | null;
   stacktrace: StacktraceType | null;
   heldLocks?: Record<string, Lock> | null;
   name?: string | null;
@@ -218,7 +218,7 @@ export enum FrameBadge {
 export type ExceptionValue = {
   mechanism: StackTraceMechanism | null;
   module: string | null;
-  rawStacktrace: RawStacktrace;
+  rawStacktrace: StacktraceType | null;
   stacktrace: StacktraceType | null;
   threadId: number | null;
   type: string;

--- a/static/app/types/stacktrace.tsx
+++ b/static/app/types/stacktrace.tsx
@@ -11,16 +11,14 @@ export enum StackType {
   MINIFIED = 'minified',
 }
 
-export type StacktraceType = {
+export interface StacktraceType {
   framesOmitted: any;
   hasSystemFrames: boolean;
-  registers: Record<string, any> | null;
+  registers: Record<string, string | null> | null;
   frames?: Frame[];
-};
+}
 
-export type RawStacktrace = StacktraceType | null;
-
-type MechanismMeta = {
+interface MechanismMeta {
   errno?: {
     number: number;
     name?: string;
@@ -37,9 +35,9 @@ type MechanismMeta = {
     code_name?: string;
     name?: string;
   };
-};
+}
 
-export type StackTraceMechanism = {
+export interface StackTraceMechanism {
   handled: boolean;
   type: string;
   data?: Record<PropertyKey, string | unknown[] | Record<PropertyKey, unknown> | Date>;
@@ -51,4 +49,4 @@ export type StackTraceMechanism = {
   parent_id?: number;
   source?: string;
   synthetic?: boolean;
-};
+}


### PR DESCRIPTION
Makes the collapse section a little bigger and reduces padding. Reuses the same types everywhere. Removes cloneElement

before
![image](https://github.com/user-attachments/assets/fae30656-fdf5-49cb-9504-7e45f20a6b79)

after - the toggles are now buttons and not a clickable svg
![image](https://github.com/user-attachments/assets/e80d9552-348a-4fb3-ae57-d4a1e4ae6fba)
