### PR TITLE
:wrench: chore: add ecosystem to notifications codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -389,7 +389,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/identity/                                                @getsentry/enterprise
 /src/sentry/integrations/                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 /src/sentry/mail/                                                    @getsentry/alerts-notifications
-/src/sentry/notifications/                                           @getsentry/alerts-notifications
+/src/sentry/notifications/                                           @getsentry/alerts-notifications @getsentry/ecosystem
 /src/sentry/notifications/models/                                    @getsentry/ecosystem
 /src/sentry/notifications/notifications/                             @getsentry/ecosystem
 /src/sentry/pipeline/                                                @getsentry/ecosystem


### PR DESCRIPTION
i made and will be making changes here changes here and it doesn't automagically tag ecosystem