### PR TITLE
fix(issues) - Correct issues endpoint postgres timeout error handling

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -29,7 +29,7 @@ from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
-from sentry.api.utils import get_date_range_from_stats_period
+from sentry.api.utils import get_date_range_from_stats_period, handle_query_errors
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.models.environment import Environment
@@ -41,7 +41,6 @@ from sentry.models.project import Project
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import FIRST_RELEASE_FILTERS, get_search_filter
-from sentry.snuba import discover
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
 
@@ -366,14 +365,15 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
             return Response(serialize(groups, request.user, serializer(), request=request))
 
         try:
-            cursor_result, query_kwargs = self._search(
-                request,
-                organization,
-                projects,
-                environments,
-                {"count_hits": True, "date_to": end, "date_from": start},
-            )
-        except (ValidationError, discover.InvalidSearchQuery) as exc:
+            with handle_query_errors():
+                cursor_result, query_kwargs = self._search(
+                    request,
+                    organization,
+                    projects,
+                    environments,
+                    {"count_hits": True, "date_to": end, "date_from": start},
+                )
+        except ValidationError as exc:
             return Response({"detail": str(exc)}, status=400)
 
         results = list(cursor_result)

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -204,6 +204,9 @@ class HandleQueryErrorsTest(APITestCase):
         class TimeoutError(OperationalError):
             pgcode = psycopg2.errorcodes.QUERY_CANCELED
 
+            def __str__(self):
+                return "canceling statement due to statement timeout"
+
         # Test when option is disabled (default)
         try:
             with handle_query_errors():
@@ -222,6 +225,21 @@ class HandleQueryErrorsTest(APITestCase):
                     str(e)
                     == "Query timeout. Please try with a smaller date range or fewer conditions."
                 )
+
+    def test_handle_postgres_user_cancel(self):
+        class UserCancelError(OperationalError):
+            pgcode = psycopg2.errorcodes.QUERY_CANCELED
+
+            def __str__(self):
+                return "canceling statement due to user request"
+
+        # Should propagate the error regardless of the feature flag
+        with override_options({"api.postgres-query-timeout-error-handling.enabled": True}):
+            try:
+                with handle_query_errors():
+                    raise UserCancelError()
+            except Exception as e:
+                assert isinstance(e, UserCancelError)  # Should propagate original error
 
     @patch("sentry.api.utils.ParseError")
     def test_handle_other_operational_error(self, mock_parse_error):


### PR DESCRIPTION
follow up on #87691, it turns out the organization/issues endpoint actually did not use handle_query_errors and so this fix did not catch. added it now to the endpoint, aligning it with the other endpoints we have there. Also made the catch more specific, as QUERY_CANCELED from postgres are not always timeouts, same code is used for user cancelations, which do not apply to the error message we are converting to. Added endpoint tests as well to cover this.