### PR TITLE
feat(billing): Combine pending changes with same effective date

### DIFF
--- a/static/gsAdmin/components/customers/pendingChanges.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.tsx
@@ -351,13 +351,21 @@ function getChanges(subscription: Subscription, planMigrations: PlanMigration[])
   const effectiveDate = activeMigration?.effectiveAt ?? pendingChanges.effectiveDate;
 
   const regularChanges = getRegularChanges(subscription);
-  if (regularChanges.length > 0) {
-    changeSet.push({effectiveDate, items: regularChanges});
-  }
-
   const onDemandChanges = getOnDemandChanges(subscription);
-  if (onDemandChanges.length) {
-    changeSet.push({effectiveDate: onDemandEffectiveDate, items: onDemandChanges});
+
+  if (effectiveDate === onDemandEffectiveDate) {
+    const combinedChanges = [...regularChanges, ...onDemandChanges];
+    if (combinedChanges.length > 0) {
+      changeSet.push({effectiveDate, items: combinedChanges});
+    }
+  } else {
+    if (regularChanges.length > 0) {
+      changeSet.push({effectiveDate, items: regularChanges});
+    }
+
+    if (onDemandChanges.length > 0) {
+      changeSet.push({effectiveDate: onDemandEffectiveDate, items: onDemandChanges});
+    }
   }
 
   return changeSet;


### PR DESCRIPTION
# before 
![Screenshot 2025-03-27 at 3 33 22 PM](https://github.com/user-attachments/assets/1fbb1869-4362-44b3-9e3a-2a60136ea125)

# after

![Screenshot 2025-03-27 at 3 32 51 PM](https://github.com/user-attachments/assets/e5c02541-a335-4d5e-9df3-cad11906c55d)
