### PR TITLE
ref(releases): add status to release table

### DIFF
--- a/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
@@ -13,7 +13,7 @@ export default function ReleaseSessionPercentageChart() {
 
   return (
     <InsightsAreaChartWidget
-      title={t('Release Adoption')}
+      title={t('Percent Sessions by Release')}
       description={t(
         'The percentage of total sessions that each release accounted for. The 5 most recent releases are shown.'
       )}

--- a/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
@@ -13,7 +13,7 @@ export default function ReleaseSessionPercentageChart() {
 
   return (
     <InsightsAreaChartWidget
-      title={t('Percent Sessions by Release')}
+      title={t('Release Adoption')}
       description={t(
         'The percentage of total sessions that each release accounted for. The 5 most recent releases are shown.'
       )}

--- a/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
+++ b/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
@@ -14,7 +14,7 @@ export default function FilterReleaseDropdown({
   } = usePageFilters();
 
   const finalizedOptions = [t('Not Finalized'), t('Finalized')];
-  const statusOptions = [t('Active'), t('Archived')];
+  const statusOptions = [t('Open'), t('Archived')];
   const stageOptions = [t('Adopted'), t('Replaced'), t('Low Adoption')];
 
   const arrayToOptions = ({

--- a/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
@@ -30,13 +30,12 @@ export default function ReleaseHealth({filters}: {filters: string[]}) {
             crash_free_sessions: 'percentage',
             sessions: 'integer',
             error_count: 'integer',
-            lifespan: 'duration',
+            status: 'string',
             adoption: 'percentage',
           },
           units: {
             crash_free_sessions: '%',
             adoption: '%',
-            lifespan: 'millisecond',
           },
         }}
       />

--- a/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import Count from 'sentry/components/count';
-import Duration from 'sentry/components/duration';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
 import GridEditable from 'sentry/components/gridEditable';
@@ -28,11 +27,11 @@ type ReleaseHealthItem = {
   crash_free_sessions: number;
   date: string;
   error_count: number;
-  lifespan: number | undefined;
   project: ReleaseProject;
   project_id: number;
   release: string;
   sessions: number;
+  status: string;
 };
 
 interface Props {
@@ -54,7 +53,7 @@ const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseHealthItem>> = [
   {key: 'crash_free_sessions', name: 'crash free rate'},
   {key: 'sessions', name: 'total sessions'},
   {key: 'error_count', name: 'new issues'},
-  {key: 'lifespan', name: 'lifespan'},
+  {key: 'status', name: 'status'},
 ];
 
 export default function ReleaseHealthTable({
@@ -91,21 +90,6 @@ export default function ReleaseHealthTable({
   const renderBodyCell = useCallback(
     (column: Column, dataRow: ReleaseHealthItem) => {
       const value = dataRow[column.key];
-
-      if (column.key === 'lifespan') {
-        return value === undefined ? (
-          // the last lifespan in the table is rendered as '--' since there's nothing previous to compare it to
-          '--'
-        ) : (
-          <CellWrapper>
-            <Duration
-              precision="hours"
-              abbreviation
-              seconds={(value as number) * (1 / 1000)}
-            />
-          </CellWrapper>
-        );
-      }
 
       if (column.key === 'adoption' || column.key === 'crash_free_sessions') {
         return `${(value as number).toFixed(2)}%`;

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -38,12 +38,12 @@ export default function useOrganizationReleases({
   }
 
   let status;
-  const hasActive = filters.includes('Active');
+  const hasOpen = filters.includes('Open');
   const hasArchived = filters.includes('Archived');
 
-  if (hasActive && !hasArchived) {
+  if (hasOpen && !hasArchived) {
     status = 'open';
-  } else if (!hasActive && hasArchived) {
+  } else if (!hasOpen && hasArchived) {
     status = 'archived';
   } else {
     // if both or neither are selected, it's the same as not selecting any
@@ -84,18 +84,8 @@ export default function useOrganizationReleases({
   const releaseData =
     isPending || !data
       ? []
-      : data.map((release, index, releases) => {
+      : data.map(release => {
           const projSlug = release.projects[0]?.slug;
-          const currentDate = new Date(release.dateCreated);
-
-          const previousDate =
-            index < releases.length - 1
-              ? new Date(releases[index + 1]?.dateCreated ?? 0)
-              : null;
-
-          const lifespan = previousDate
-            ? Math.floor(currentDate.getTime() - previousDate.getTime())
-            : undefined;
 
           return {
             project: release.projects[0]!,
@@ -109,7 +99,7 @@ export default function useOrganizationReleases({
             error_count: release.projects[0]?.newGroups ?? 0,
             project_id: release.projects[0]?.id ?? 0,
             adoption: release.projects[0]?.healthData?.adoption ?? 0,
-            lifespan,
+            status: release.status,
           };
         });
 


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/88150
- adds status (open or archived) to the table since we allow filtering by it.
- renames "active" in the dropdown to "open" is that's what is returned on the release item.
- also removes lifespan because it's not a finalized concept and we should redefine it, and also return it from the backend.

<img width="1215" alt="SCR-20250327-nusj" src="https://github.com/user-attachments/assets/945cc9f8-6a9b-4652-bea3-fb858aa5dbdf" />

<img width="264" alt="SCR-20250327-nvuk" src="https://github.com/user-attachments/assets/fe9293de-1771-40ae-88d2-f90e9f34b3a1" />
