### PR TITLE
fix(autofix): Fix draft PR button not using settings repos

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -179,6 +179,12 @@ describe('AutofixChanges', () => {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: '/issues/123/autofix/update/',
+      method: 'POST',
+      body: {ok: true},
+    });
+
     jest.mocked(useAutofixRepos).mockReturnValue({
       repos: [
         {
@@ -186,14 +192,14 @@ describe('AutofixChanges', () => {
           owner: 'org',
           provider: 'github',
           provider_raw: 'github',
-          external_id: 'repo-123',
+          external_id: '100',
           is_readable: true,
           is_writeable: true,
         },
       ],
       codebases: {
-        'repo-123': {
-          repo_external_id: 'repo-123',
+        '100': {
+          repo_external_id: '100',
           is_readable: true,
           is_writeable: true,
         },

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -24,6 +24,7 @@ import {
   useAutofixRepos,
 } from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
+import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {IconCode, IconCopy, IconOpen} from 'sentry/icons';
@@ -331,14 +332,12 @@ function SetupAndCreateBranchButton({
   onBusyStateChange: (busy: boolean) => void;
   runId: string;
 }) {
-  const {data: setupData} = useAutofixSetup({groupId, checkWriteAccess: true});
+  const {codebases} = useAutofixRepos(groupId);
 
   if (
     !changes.every(
       change =>
-        setupData?.githubWriteIntegration?.repos?.find(
-          repo => `${repo.owner}/${repo.name}` === change.repo_name
-        )?.ok
+        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
     )
   ) {
     return (

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -23,8 +23,6 @@ import {
   useAutofixData,
   useAutofixRepos,
 } from 'sentry/components/events/autofix/useAutofix';
-import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
-import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {IconCode, IconCopy, IconOpen} from 'sentry/icons';

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -382,7 +382,6 @@ function SetupAndCreatePRsButton({
   runId: string;
 }) {
   const {codebases} = useAutofixRepos(groupId);
-
   if (
     !changes.every(
       change =>

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -21,6 +21,7 @@ import {
 import {
   makeAutofixQueryKey,
   useAutofixData,
+  useAutofixRepos,
 } from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -380,13 +381,12 @@ function SetupAndCreatePRsButton({
   onBusyStateChange: (busy: boolean) => void;
   runId: string;
 }) {
-  const {data: autofixData} = useAutofixData({groupId});
+  const {codebases} = useAutofixRepos(groupId);
 
   if (
     !changes.every(
       change =>
-        change.repo_external_id &&
-        autofixData?.codebases?.[change.repo_external_id]?.is_writeable
+        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
     )
   ) {
     return (

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -380,14 +380,13 @@ function SetupAndCreatePRsButton({
   onBusyStateChange: (busy: boolean) => void;
   runId: string;
 }) {
-  const {data: setupData} = useAutofixSetup({groupId, checkWriteAccess: true});
+  const {data: autofixData} = useAutofixData({groupId});
 
   if (
     !changes.every(
       change =>
-        setupData?.githubWriteIntegration?.repos?.find(
-          repo => `${repo.owner}/${repo.name}` === change.repo_name
-        )?.ok
+        change.repo_external_id &&
+        autofixData?.codebases?.[change.repo_external_id]?.is_writeable
     )
   ) {
     return (

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -12,7 +12,6 @@ import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixH
 import AutofixThumbsUpDownButtons from 'sentry/components/events/autofix/autofixThumbsUpDownButtons';
 import {
   type AutofixFeedback,
-  type AutofixRepository,
   type AutofixRootCauseData,
   type AutofixRootCauseSelection,
   AutofixStatus,
@@ -38,7 +37,6 @@ import {AutofixTimeline} from './autofixTimeline';
 type AutofixRootCauseProps = {
   causes: AutofixRootCauseData[];
   groupId: string;
-  repos: AutofixRepository[];
   rootCauseSelection: AutofixRootCauseSelection;
   runId: string;
   agentCommentThread?: CommentThread;

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -45,21 +45,21 @@ describe('AutofixSolution', () => {
         repos={[
           {
             name: 'owner/repo1',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo1',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo1',
+            provider_raw: 'github',
             is_readable: true,
+            is_writeable: true,
           },
           {
             name: 'owner/repo2',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo2',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo2',
+            provider_raw: 'github',
             is_readable: true,
+            is_writeable: true,
           },
         ]}
       />
@@ -76,21 +76,21 @@ describe('AutofixSolution', () => {
         repos={[
           {
             name: 'owner/repo1',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo1',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo1',
+            provider_raw: 'github',
             is_readable: false,
+            is_writeable: false,
           },
           {
             name: 'owner/repo2',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo2',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo2',
+            provider_raw: 'github',
             is_readable: false,
+            is_writeable: false,
           },
         ]}
       />
@@ -107,21 +107,21 @@ describe('AutofixSolution', () => {
         repos={[
           {
             name: 'owner/repo1',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo1',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo1',
+            provider_raw: 'github',
             is_readable: true,
+            is_writeable: true,
           },
           {
             name: 'owner/repo2',
-            default_branch: 'main',
+            owner: 'owner',
             external_id: 'repo2',
-            integration_id: 'integration1',
             provider: 'github',
-            url: 'https://github.com/owner/repo2',
+            provider_raw: 'github',
             is_readable: false,
+            is_writeable: false,
           },
         ]}
       />

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -8,6 +8,9 @@ import {
 
 import {AutofixSolution} from 'sentry/components/events/autofix/autofixSolution';
 import type {AutofixSolutionTimelineEvent} from 'sentry/components/events/autofix/types';
+import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
+
+jest.mock('sentry/components/events/autofix/useAutofix');
 
 describe('AutofixSolution', () => {
   const defaultSolution = [
@@ -26,7 +29,6 @@ describe('AutofixSolution', () => {
     solution: defaultSolution,
     groupId: '123',
     runId: 'run-123',
-    repos: [],
     solutionSelected: false,
   };
 
@@ -36,165 +38,175 @@ describe('AutofixSolution', () => {
       url: '/issues/123/autofix/update/',
       method: 'POST',
     });
+    jest.mocked(useAutofixRepos).mockReset();
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [],
+      codebases: {},
+    });
   });
 
   it('enables Code It Up button when all repos are readable', () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            owner: 'owner',
-            external_id: 'repo1',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: true,
-            is_writeable: true,
-          },
-          {
-            name: 'owner/repo2',
-            owner: 'owner',
-            external_id: 'repo2',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: true,
-            is_writeable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+        {
+          name: 'owner/repo2',
+          owner: 'owner',
+          external_id: 'repo2',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByText('Code It Up');
     expect(codeItUpButton).toBeEnabled();
   });
 
   it('disables Code It Up button when all repos are not readable', () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            owner: 'owner',
-            external_id: 'repo1',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: false,
-            is_writeable: false,
-          },
-          {
-            name: 'owner/repo2',
-            owner: 'owner',
-            external_id: 'repo2',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: false,
-            is_writeable: false,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: false,
+          is_writeable: false,
+        },
+        {
+          name: 'owner/repo2',
+          owner: 'owner',
+          external_id: 'repo2',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: false,
+          is_writeable: false,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByRole('button', {name: 'Code It Up'});
     expect(codeItUpButton).toBeDisabled();
   });
 
   it('enables Code It Up button when at least one repo is readable', () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            owner: 'owner',
-            external_id: 'repo1',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: true,
-            is_writeable: true,
-          },
-          {
-            name: 'owner/repo2',
-            owner: 'owner',
-            external_id: 'repo2',
-            provider: 'github',
-            provider_raw: 'github',
-            is_readable: false,
-            is_writeable: false,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+        {
+          name: 'owner/repo2',
+          owner: 'owner',
+          external_id: 'repo2',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: false,
+          is_writeable: false,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByText('Code It Up');
     expect(codeItUpButton).toBeEnabled();
   });
 
   it('treats repos with is_readable=null as readable', () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo1',
-            is_readable: undefined,
-          },
-          {
-            name: 'owner/repo2',
-            default_branch: 'main',
-            external_id: 'repo2',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo2',
-            is_readable: false,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: undefined,
+          is_writeable: undefined,
+        },
+        {
+          name: 'owner/repo2',
+          owner: 'owner',
+          external_id: 'repo2',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: false,
+          is_writeable: false,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByText('Code It Up');
     expect(codeItUpButton).toBeEnabled();
   });
 
   it('treats repos with is_readable=undefined as readable', () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo1',
-            // is_readable is intentionally undefined
-          },
-          {
-            name: 'owner/repo2',
-            default_branch: 'main',
-            external_id: 'repo2',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo2',
-            is_readable: false,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: undefined,
+          is_writeable: undefined,
+        },
+        {
+          name: 'owner/repo2',
+          owner: 'owner',
+          external_id: 'repo2',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: false,
+          is_writeable: false,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByText('Code It Up');
     expect(codeItUpButton).toBeEnabled();
   });
 
   it('treats empty repos array as having no repository constraints', () => {
-    render(<AutofixSolution {...defaultProps} repos={[]} />);
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     const codeItUpButton = screen.getByText('Code It Up');
     expect(codeItUpButton).toBeEnabled();
@@ -214,22 +226,22 @@ describe('AutofixSolution', () => {
     });
 
     // Use readable repos to enable the button
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo1',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     // Click the Code It Up button
     await userEvent.click(screen.getByRole('button', {name: 'Code It Up'}));
@@ -268,22 +280,22 @@ describe('AutofixSolution', () => {
     });
 
     // Use readable repos to enable the button
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo1',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     // Find the timeline item
     const timelineItem = screen.getByTestId('autofix-solution-timeline-item-0');
@@ -336,22 +348,22 @@ describe('AutofixSolution', () => {
     });
 
     // Use readable repos to enable the button
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo1',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo1',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo1',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     // Find and fill the input
     const input = screen.getByPlaceholderText('Add more instructions...');
@@ -401,22 +413,22 @@ describe('AutofixSolution', () => {
   });
 
   it('allows adding custom instructions with Enter key', async () => {
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        repos={[
-          {
-            name: 'owner/repo',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} />);
 
     // Find and fill the input, then press Enter
     const input = screen.getByPlaceholderText('Add more instructions...');
@@ -439,23 +451,22 @@ describe('AutofixSolution', () => {
       },
     ];
 
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        solution={solutionWithHumanInstruction}
-        repos={[
-          {
-            name: 'owner/repo',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} solution={solutionWithHumanInstruction} />);
 
     // Find the human instruction item
     const humanInstructionElement = screen.getByText('Human instruction');
@@ -507,23 +518,22 @@ describe('AutofixSolution', () => {
       method: 'POST',
     });
 
-    render(
-      <AutofixSolution
-        {...defaultProps}
-        solution={solutionWithActiveStates}
-        repos={[
-          {
-            name: 'owner/repo',
-            default_branch: 'main',
-            external_id: 'repo1',
-            integration_id: 'integration1',
-            provider: 'github',
-            url: 'https://github.com/owner/repo',
-            is_readable: true,
-          },
-        ]}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [
+        {
+          name: 'owner/repo',
+          owner: 'owner',
+          external_id: 'repo1',
+          provider: 'github',
+          provider_raw: 'github',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+      codebases: {},
+    });
+
+    render(<AutofixSolution {...defaultProps} solution={solutionWithActiveStates} />);
 
     // Click Code It Up
     await userEvent.click(screen.getByRole('button', {name: 'Code It Up'}));

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -13,7 +13,6 @@ import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixH
 import AutofixThumbsUpDownButtons from 'sentry/components/events/autofix/autofixThumbsUpDownButtons';
 import {
   type AutofixFeedback,
-  type AutofixRepository,
   type AutofixSolutionTimelineEvent,
   AutofixStatus,
   AutofixStepType,
@@ -22,6 +21,7 @@ import {
 import {
   type AutofixResponse,
   makeAutofixQueryKey,
+  useAutofixRepos,
 } from 'sentry/components/events/autofix/useAutofix';
 import {Timeline} from 'sentry/components/timeline';
 import {
@@ -109,7 +109,6 @@ export function useSelectSolution({groupId, runId}: {groupId: string; runId: str
 
 type AutofixSolutionProps = {
   groupId: string;
-  repos: AutofixRepository[];
   runId: string;
   solution: AutofixSolutionTimelineEvent[];
   solutionSelected: boolean;
@@ -465,10 +464,10 @@ function AutofixSolutionDisplay({
   previousInsightCount,
   customSolution,
   solutionSelected,
-  changesDisabled,
   agentCommentThread,
   feedback,
 }: Omit<AutofixSolutionProps, 'repos'>) {
+  const {repos} = useAutofixRepos(groupId);
   const {mutate: handleContinue, isPending} = useSelectSolution({groupId, runId});
   const [isEditing, _setIsEditing] = useState(false);
   const [instructions, setInstructions] = useState('');
@@ -483,6 +482,8 @@ function AutofixSolutionDisplay({
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const iconFixRef = useRef<HTMLDivElement>(null);
+
+  const changesDisabled = repos.every(repo => repo.is_readable === false);
 
   const handleAddInstruction = () => {
     if (instructions.trim()) {
@@ -668,12 +669,10 @@ export function AutofixSolution(props: AutofixSolutionProps) {
     );
   }
 
-  const changesDisabled = props.repos.every(repo => repo.is_readable === false);
-
   return (
     <AnimatePresence initial={props.isSolutionFirstAppearance}>
       <AnimationWrapper key="card" {...cardAnimationProps}>
-        <AutofixSolutionDisplay {...props} changesDisabled={changesDisabled} />
+        <AutofixSolutionDisplay {...props} />
       </AnimationWrapper>
     </AnimatePresence>
   );

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -483,7 +483,8 @@ function AutofixSolutionDisplay({
   const containerRef = useRef<HTMLDivElement>(null);
   const iconFixRef = useRef<HTMLDivElement>(null);
 
-  const changesDisabled = repos.every(repo => repo.is_readable === false);
+  const hasNoRepos = repos.length === 0;
+  const cantReadRepos = repos.every(repo => repo.is_readable === false);
 
   const handleAddInstruction = () => {
     if (instructions.trim()) {
@@ -577,16 +578,20 @@ function AutofixSolutionDisplay({
             <ButtonBar merged>
               <Button
                 title={
-                  changesDisabled
+                  hasNoRepos
                     ? t(
-                        'You need to set up the GitHub integration for Autofix to write code for you.'
+                        'You need to set up the GitHub integration and configure repository access for Autofix to write code for you.'
                       )
-                    : undefined
+                    : cantReadRepos
+                      ? t(
+                          "We can't access any of your repos. Check your GitHub integration and configure repository access for Autofix to write code for you."
+                        )
+                      : undefined
                 }
                 size="sm"
                 priority={solutionSelected ? 'default' : 'primary'}
                 busy={isPending}
-                disabled={changesDisabled}
+                disabled={hasNoRepos || cantReadRepos}
                 onClick={() => {
                   handleContinue({
                     mode: 'fix',

--- a/static/app/components/events/autofix/autofixSteps.spec.tsx
+++ b/static/app/components/events/autofix/autofixSteps.spec.tsx
@@ -49,7 +49,10 @@ describe('AutofixSteps', () => {
           index: 1,
         }),
       ],
-      repositories: [],
+      request: {
+        repos: [],
+      },
+      codebases: {},
       created_at: '2023-01-01T00:00:00Z',
       run_id: '1',
       status: AutofixStatus.PROCESSING,

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -14,7 +14,6 @@ import {
   type AutofixData,
   type AutofixFeedback,
   type AutofixProgressItem,
-  type AutofixRepository,
   AutofixStatus,
   type AutofixStep,
   AutofixStepType,
@@ -35,7 +34,6 @@ interface StepProps {
   hasErroredStepBefore: boolean;
   hasStepAbove: boolean;
   hasStepBelow: boolean;
-  repos: AutofixRepository[];
   runId: string;
   step: AutofixStep;
   feedback?: AutofixFeedback;
@@ -63,7 +61,6 @@ export function Step({
   step,
   groupId,
   runId,
-  repos,
   hasStepBelow,
   hasStepAbove,
   hasErroredStepBefore,
@@ -105,7 +102,6 @@ export function Step({
                   rootCauseSelection={step.selection}
                   terminationReason={step.termination_reason}
                   agentCommentThread={step.agent_comment_thread ?? undefined}
-                  repos={repos}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}
                   feedback={feedback}
@@ -120,7 +116,6 @@ export function Step({
                   description={step.description}
                   solutionSelected={step.solution_selected}
                   customSolution={step.custom_solution}
-                  repos={repos}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}
                   agentCommentThread={step.agent_comment_thread ?? undefined}
@@ -149,7 +144,6 @@ export function Step({
 
 export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
   const steps = data.steps;
-  const repos = data.repositories;
   const isMountedRef = useRef<boolean>(false);
 
   useEffect(() => {
@@ -227,7 +221,6 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               hasStepAbove
               groupId={groupId}
               runId={runId}
-              repos={repos}
               hasErroredStepBefore={previousStepErrored}
               shouldCollapseByDefault={
                 step.type === AutofixStepType.DEFAULT &&

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -53,17 +53,6 @@ export type AutofixUpdateEndpointResponse = {
   status?: 'success' | 'error';
 };
 
-export type AutofixRepository = {
-  default_branch: string;
-  external_id: string;
-  integration_id: string;
-  name: string;
-  provider: string;
-  url: string;
-  is_readable?: boolean;
-  is_writeable?: boolean;
-};
-
 export type CodebaseState = {
   is_readable: boolean | null;
   is_writeable: boolean | null;
@@ -73,7 +62,9 @@ export type CodebaseState = {
 export type AutofixData = {
   codebases: Record<string, CodebaseState>;
   created_at: string;
-  repositories: AutofixRepository[];
+  request: {
+    repos: SeerRepoDefinition[];
+  };
   run_id: string;
   status: AutofixStatus;
   actor_ids?: number[];

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -64,7 +64,14 @@ export type AutofixRepository = {
   is_writeable?: boolean;
 };
 
+export type CodebaseState = {
+  is_readable: boolean | null;
+  is_writeable: boolean | null;
+  repo_external_id: string | null;
+};
+
 export type AutofixData = {
+  codebases: Record<string, CodebaseState>;
   created_at: string;
   repositories: AutofixRepository[];
   run_id: string;

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {
   type AutofixData,
@@ -123,6 +123,24 @@ const isPolling = (
       AutofixStatus.NEED_MORE_INFORMATION,
     ].includes(autofixData.status)
   );
+};
+
+export const useAutofixRepos = (groupId: string) => {
+  const {data} = useAutofixData({groupId});
+
+  return useMemo(() => {
+    const repos = data?.request?.repos ?? [];
+    const codebases = data?.codebases ?? {};
+
+    return {
+      repos: repos.map(repo => ({
+        ...repo,
+        is_readable: codebases[repo.external_id]?.is_readable,
+        is_writeable: codebases[repo.external_id]?.is_writeable,
+      })),
+      codebases,
+    };
+  }, [data]);
 };
 
 export const useAutofixData = ({groupId}: {groupId: string}) => {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -49,7 +49,10 @@ const makeInitialAutofixData = (): AutofixResponse => ({
       },
     ],
     created_at: new Date().toISOString(),
-    repositories: [],
+    request: {
+      repos: [],
+    },
+    codebases: {},
   },
 });
 

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -42,7 +42,10 @@ describe('useCopyIssueDetails', () => {
   // Create a mock AutofixData with steps that includes root cause and solution steps
   const mockAutofixData: AutofixData = {
     created_at: '2023-01-01T00:00:00Z',
-    repositories: [],
+    request: {
+      repos: [],
+    },
+    codebases: {},
     run_id: '123',
     status: AutofixStatus.COMPLETED,
     steps: [

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -82,17 +82,23 @@ describe('SeerDrawer', () => {
 
   const mockAutofixWithUnreadableNonGithubRepos = AutofixDataFixture({
     steps: [AutofixStepFixture()],
-    repositories: [
-      {
-        name: 'org/gitlab-repo',
-        provider: 'gitlab',
-        integration_id: '123',
-        default_branch: 'main',
-        external_id: 'repo-123',
-        url: 'https://gitlab.com/org/gitlab-repo',
+    request: {
+      repos: [
+        {
+          name: 'org/gitlab-repo',
+          provider: 'gitlab',
+          owner: 'org',
+          external_id: 'repo-123',
+        },
+      ],
+    },
+    codebases: {
+      'repo-123': {
+        repo_external_id: 'repo-123',
         is_readable: false,
+        is_writeable: false,
       },
-    ],
+    },
   });
 
   beforeEach(() => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -40,32 +40,44 @@ describe('SeerDrawer', () => {
   // Create autofix data with various repository configurations for testing notices
   const mockAutofixWithReadableRepos = AutofixDataFixture({
     steps: [AutofixStepFixture()],
-    repositories: [
-      {
-        name: 'org/repo',
-        provider: 'github',
-        integration_id: '123',
-        default_branch: 'main',
-        external_id: 'repo-123',
-        url: 'https://github.com/org/repo',
+    request: {
+      repos: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+        },
+      ],
+    },
+    codebases: {
+      'repo-123': {
+        repo_external_id: 'repo-123',
         is_readable: true,
+        is_writeable: true,
       },
-    ],
+    },
   });
 
   const mockAutofixWithUnreadableGithubRepos = AutofixDataFixture({
     steps: [AutofixStepFixture()],
-    repositories: [
-      {
-        name: 'org/repo',
-        provider: 'github',
-        integration_id: '123',
-        default_branch: 'main',
-        external_id: 'repo-123',
-        url: 'https://github.com/org/repo',
+    request: {
+      repos: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+        },
+      ],
+    },
+    codebases: {
+      'repo-123': {
+        repo_external_id: 'repo-123',
         is_readable: false,
+        is_writeable: false,
       },
-    ],
+    },
   });
 
   const mockAutofixWithUnreadableNonGithubRepos = AutofixDataFixture({

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -239,8 +239,8 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         ) : (
           <Fragment>
             <SeerNotices
+              groupId={group.id}
               hasGithubIntegration={aiConfig.hasGithubIntegration}
-              autofixRepositories={autofixData?.repositories ?? []}
             />
             {aiConfig.hasSummary && (
               <StyledCard>

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -1,40 +1,47 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import type {AutofixRepository} from 'sentry/components/events/autofix/types';
+import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import {SeerNotices} from 'sentry/views/issueDetails/streamline/sidebar/seerNotices';
+
+jest.mock('sentry/components/events/autofix/useAutofix');
 
 describe('SeerNotices', function () {
   // Helper function to create repository objects
-  const createRepository = (
-    overrides: Partial<AutofixRepository> = {}
-  ): AutofixRepository => ({
-    default_branch: 'main',
+  const createRepository = (overrides = {}) => ({
     external_id: 'repo-123',
-    integration_id: '123',
     name: 'org/repo',
+    owner: 'org',
     provider: 'github',
-    url: 'https://github.com/org/repo',
+    provider_raw: 'github',
     is_readable: true,
+    is_writeable: true,
     ...overrides,
+  });
+
+  beforeEach(() => {
+    // Reset mock before each test
+    jest.mocked(useAutofixRepos).mockReset();
   });
 
   it('renders nothing when all repositories are readable', function () {
     const repositories = [createRepository(), createRepository({name: 'org/repo2'})];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    const {container} = render(
-      <SeerNotices autofixRepositories={repositories} hasGithubIntegration />
-    );
+    const {container} = render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders GitHub integration setup card when hasGithubIntegration is false', function () {
-    render(
-      <SeerNotices
-        autofixRepositories={[createRepository()]}
-        hasGithubIntegration={false}
-      />
-    );
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: [createRepository()],
+      codebases: {},
+    });
+
+    render(<SeerNotices groupId="123" hasGithubIntegration={false} />);
 
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
 
@@ -58,21 +65,28 @@ describe('SeerNotices', function () {
 
   it('renders warning for a single unreadable GitHub repository', function () {
     const repositories = [createRepository({is_readable: false})];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(screen.getByText(/Autofix can't access the/)).toBeInTheDocument();
     expect(screen.getByText('org/repo')).toBeInTheDocument();
     expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-    expect(screen.getByText(/code mappings/)).toBeInTheDocument();
   });
 
   it('renders warning for a single unreadable non-GitHub repository', function () {
     const repositories = [
       createRepository({is_readable: false, provider: 'gitlab', name: 'org/gitlab-repo'}),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(screen.getByText(/Autofix can't access the/)).toBeInTheDocument();
     expect(screen.getByText('org/gitlab-repo')).toBeInTheDocument();
@@ -86,8 +100,12 @@ describe('SeerNotices', function () {
       createRepository({is_readable: false, name: 'org/repo1'}),
       createRepository({is_readable: false, name: 'org/repo2'}),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(
       screen.getByText(/Autofix can't access these repositories:/)
@@ -95,7 +113,6 @@ describe('SeerNotices', function () {
     expect(screen.getByText('org/repo1, org/repo2')).toBeInTheDocument();
     expect(screen.getByText(/For best performance, enable the/)).toBeInTheDocument();
     expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-    expect(screen.getByText(/code mappings/)).toBeInTheDocument();
   });
 
   it('renders warning for multiple unreadable repositories (all non-GitHub)', function () {
@@ -111,8 +128,12 @@ describe('SeerNotices', function () {
         name: 'org/bitbucket-repo2',
       }),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(
       screen.getByText(/Autofix can't access these repositories:/)
@@ -128,8 +149,12 @@ describe('SeerNotices', function () {
       createRepository({is_readable: false, name: 'org/github-repo'}),
       createRepository({is_readable: false, provider: 'gitlab', name: 'org/gitlab-repo'}),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     expect(
       screen.getByText(/Autofix can't access these repositories:/)
@@ -137,7 +162,6 @@ describe('SeerNotices', function () {
     expect(screen.getByText('org/github-repo, org/gitlab-repo')).toBeInTheDocument();
     expect(screen.getByText(/For best performance, enable the/)).toBeInTheDocument();
     expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-    expect(screen.getByText(/code mappings/)).toBeInTheDocument();
     expect(
       screen.getByText(/Autofix currently only supports GitHub repositories/)
     ).toBeInTheDocument();
@@ -148,10 +172,12 @@ describe('SeerNotices', function () {
       createRepository({is_readable: false, name: 'org/repo1'}),
       createRepository({is_readable: false, name: 'org/repo2'}),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(
-      <SeerNotices autofixRepositories={repositories} hasGithubIntegration={false} />
-    );
+    render(<SeerNotices groupId="123" hasGithubIntegration={false} />);
 
     // GitHub setup card
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
@@ -164,23 +190,19 @@ describe('SeerNotices', function () {
     expect(screen.getByText('org/repo1, org/repo2')).toBeInTheDocument();
   });
 
-  it('renders correct integration links based on integration_id', function () {
-    const repositories = [
-      createRepository({is_readable: false, integration_id: '456', name: 'org/repo1'}),
-    ];
+  it('renders GitHub integration link correctly', function () {
+    const repositories = [createRepository({is_readable: false, name: 'org/repo1'})];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(<SeerNotices autofixRepositories={repositories} hasGithubIntegration />);
+    render(<SeerNotices groupId="123" hasGithubIntegration />);
 
     const integrationLink = screen.getByText('GitHub integration');
     expect(integrationLink).toHaveAttribute(
       'href',
-      '/settings/org-slug/integrations/github/456'
-    );
-
-    const codeMappingsLink = screen.getByText('code mappings');
-    expect(codeMappingsLink).toHaveAttribute(
-      'href',
-      '/settings/org-slug/integrations/github/456/?tab=codeMappings'
+      '/settings/org-slug/integrations/github/'
     );
   });
 
@@ -189,10 +211,12 @@ describe('SeerNotices', function () {
       createRepository({is_readable: false, name: 'org/repo1'}),
       createRepository({is_readable: false, name: 'org/repo2'}),
     ];
+    jest.mocked(useAutofixRepos).mockReturnValue({
+      repos: repositories,
+      codebases: {},
+    });
 
-    render(
-      <SeerNotices autofixRepositories={repositories} hasGithubIntegration={false} />
-    );
+    render(<SeerNotices groupId="123" hasGithubIntegration={false} />);
 
     // Should have both the GitHub setup card and the unreadable repos warning
     const setupCard = screen.getByText('Set Up the GitHub Integration').closest('div');

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -5,14 +5,14 @@ import onboardingInstall from 'sentry-images/spot/onboarding-install.svg';
 
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button';
-import type {AutofixRepository} from 'sentry/components/events/autofix/types';
+import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface SeerNoticesProps {
-  autofixRepositories: AutofixRepository[];
+  groupId: string;
   hasGithubIntegration?: boolean;
 }
 
@@ -55,17 +55,11 @@ function GithubIntegrationSetupCard() {
   );
 }
 
-export function SeerNotices({
-  autofixRepositories,
-  hasGithubIntegration,
-}: SeerNoticesProps) {
+export function SeerNotices({groupId, hasGithubIntegration}: SeerNoticesProps) {
   const organization = useOrganization();
-  const unreadableRepos = autofixRepositories.filter(repo => repo.is_readable === false);
+  const {repos} = useAutofixRepos(groupId);
+  const unreadableRepos = repos.filter(repo => repo.is_readable === false);
   const notices: React.JSX.Element[] = [];
-
-  const integrationId = autofixRepositories.find(repo =>
-    repo.provider.includes('github')
-  )?.integration_id;
 
   if (!hasGithubIntegration) {
     notices.push(<GithubIntegrationSetupCard key="github-setup" />);
@@ -86,22 +80,13 @@ export function SeerNotices({
           <Fragment>
             {' '}
             {tct(
-              'For best performance, enable the [integrationLink:GitHub integration] and its [codeMappingsLink:code mappings].',
+              'For best performance, enable the [integrationLink:GitHub integration].',
               {
                 integrationLink: (
                   <ExternalLink
-                    href={
-                      integrationId
-                        ? `/settings/${organization.slug}/integrations/github/${integrationId}/`
-                        : `/settings/${organization.slug}/integrations/github/`
-                    }
+                    href={`/settings/${organization.slug}/integrations/github/`}
                   />
                 ),
-                codeMappingsLink: integrationId ? (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/${integrationId}/?tab=codeMappings`}
-                  />
-                ) : null,
               }
             )}
           </Fragment>
@@ -120,17 +105,12 @@ export function SeerNotices({
       <Alert type="warning" showIcon key="single-repo">
         {unreadableRepo.provider.includes('github')
           ? tct(
-              "Autofix can't access the [repo] repository, make sure the [integrationLink:GitHub integration] and its [codeMappingsLink:code mappings] are correctly set up.",
+              "Autofix can't access the [repo] repository, make sure the [integrationLink:GitHub integration] is correctly set up.",
               {
                 repo: <b>{unreadableRepo.name}</b>,
                 integrationLink: (
                   <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/${unreadableRepo.integration_id}`}
-                  />
-                ),
-                codeMappingsLink: (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/${unreadableRepo.integration_id}/?tab=codeMappings`}
+                    href={`/settings/${organization.slug}/integrations/github/`}
                   />
                 ),
               }

--- a/tests/js/fixtures/autofixData.ts
+++ b/tests/js/fixtures/autofixData.ts
@@ -7,7 +7,10 @@ export function AutofixDataFixture(params: Partial<AutofixData>): AutofixData {
     completed_at: '',
     created_at: '',
     steps: [],
-    repositories: [],
+    request: {
+      repos: [],
+    },
+    codebases: {},
     ...params,
   };
 }


### PR DESCRIPTION
Fixes all uses of repository access to use a new `useAutofixRepos` hook that uses the codebases and repos list from the autofix state instead of using code mappings

also removes references to code mappings in set up instructions and notices!

![CleanShot 2025-04-02 at 10 55 51@2x](https://github.com/user-attachments/assets/099d64a1-0aec-4ec0-ad5e-b3bb2f849505)
