### PR TITLE
fix(query-builder): Fix issue where menu stays open after selecting a filter from the empty menu

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -372,6 +372,15 @@ describe('SearchQueryBuilder', function () {
       );
     });
 
+    it('can add a new filter key by clicking an option in the menu', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.click(screen.getByRole('option', {name: 'age'}));
+
+      expect(await screen.findByRole('row', {name: 'age:-24h'})).toBeInTheDocument();
+    });
+
     describe('recent filter keys', function () {
       beforeEach(() => {
         MockApiClient.addMockResponse({

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -357,6 +357,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     items,
     autoFocus,
     inputValue: filterValue,
+    selectedKey: null,
     onSelectionChange,
     allowsCustomValue: true,
     disabledKeys,


### PR DESCRIPTION
![CleanShot 2025-03-27 at 16 04 28@2x](https://github.com/user-attachments/assets/64799e53-3a6c-4ab4-9f33-758e3989986e)


After a long investigation, the fix was very tiny. After debugging the react aria code, I found that it was immediately reopening the filter key menu due to the selected key changing (which in turn changed the input value state, which caused the menu to reopen). Something with the React 19 upgrade must have changed the behavior somehow. Either way, controlling the selected key prevents the menu from reopening.