### PR TITLE
fix(migrations): Allow `CreateExtension` operations in migrations.

### DIFF
--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from django.contrib.contenttypes.management import RenameContentType
+from django.contrib.postgres.operations import CreateExtension
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.migration import Migration
 from django.db.migrations.operations import AlterField, SeparateDatabaseAndState
@@ -75,7 +76,14 @@ class SentryMigrationExecutor(MigrationExecutor):
             failed_ops = []
             for operation in operations:
                 if isinstance(
-                    operation, (FieldOperation, ModelOperation, RenameContentType, IndexOperation)
+                    operation,
+                    (
+                        FieldOperation,
+                        ModelOperation,
+                        RenameContentType,
+                        IndexOperation,
+                        CreateExtension,
+                    ),
                 ):
                     continue
                 elif isinstance(operation, SeparateDatabaseAndState):

--- a/tests/sentry/new_migrations/monkey/test_executor.py
+++ b/tests/sentry/new_migrations/monkey/test_executor.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.postgres.operations import BtreeGistExtension
 from django.db import migrations, models
 
 from sentry.new_migrations.monkey.executor import (
@@ -162,6 +163,12 @@ class SentryMigrationExecutorTest(TestCase):
             operations = [
                 migrations.RunSQL("TEST SQL"),
             ]
+
+        SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="auth"))
+
+    def test_check_db_routing_extensions(self):
+        class TestMigration(migrations.Migration):
+            operations = [BtreeGistExtension()]
 
         SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="auth"))
 


### PR DESCRIPTION
These fail due to not being included in `_check_db_routing`, just adding them here.

<!-- Describe your PR here. -->