### PR TITLE
chore(aci): delayed workflow logs round 3

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -534,9 +534,11 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
         condition_group_results = get_condition_group_results(condition_groups, project)
 
     if features.has("organizations:workflow-engine-process-workflows", project.organization):
-        serialized_results = {
-            str(query): count_dict for query, count_dict in condition_group_results.items()
-        }
+        serialized_results = (
+            {str(query): count_dict for query, count_dict in condition_group_results.items()}
+            if condition_group_results
+            else None
+        )
         logger.info(
             "delayed_processing.condition_group_results",
             extra={

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -275,7 +275,7 @@ def get_groups_to_fire(
         workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
 
         for group_id in dcg_to_groups[dcg.id]:
-            conditions_to_evaluate = []
+            conditions_to_evaluate: tuple[DataCondition, list[int]] = []
             for condition in slow_conditions:
                 unique_queries = generate_unique_queries(condition, workflow_env)
                 query_values = [
@@ -517,9 +517,12 @@ def process_delayed_workflows(
     )
     condition_group_results = get_condition_group_results(condition_groups)
 
+    serialized_results = {
+        str(query): count_dict for query, count_dict in condition_group_results.items()
+    }
     logger.info(
         "delayed_workflow.condition_group_results",
-        extra={"results": condition_group_results},
+        extra={"condition_group_results": serialized_results},
     )
 
     # Evaluate DCGs

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -275,7 +275,7 @@ def get_groups_to_fire(
         workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
 
         for group_id in dcg_to_groups[dcg.id]:
-            conditions_to_evaluate: tuple[DataCondition, list[int]] = []
+            conditions_to_evaluate: list[tuple[DataCondition, list[int]]] = []
             for condition in slow_conditions:
                 unique_queries = generate_unique_queries(condition, workflow_env)
                 query_values = [


### PR DESCRIPTION
`condition_group_results` is always {} in GCP, try to explicitly serialize it here so we can see what the results are. Also emit the results from existing delayed processing under a FF to compare with workflow engine.