### PR TITLE
feat(global drawer): Make flyout resizable, reusing existing hook

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -321,8 +321,21 @@ function getOptimalPosition(referenceRect: DOMRect, popupRect: DOMRect) {
   const viewportHeight = window.innerHeight;
   const viewportWidth = window.innerWidth;
 
-  // Fixed position from the right edge of the viewport
-  const left = viewportWidth / 2 - popupRect.width + 8;
+  // Find the drawer element to get its actual width
+  const drawerElement = document.querySelector('.drawer-panel');
+  const drawerWidth = drawerElement
+    ? drawerElement.getBoundingClientRect().width
+    : viewportWidth * 0.5;
+
+  // Calculate initial position to the left of the drawer
+  let left = viewportWidth - drawerWidth - popupRect.width - 8;
+
+  // Ensure the popup is not cut off on the left side
+  const minLeftMargin = 8;
+  if (left < minLeftMargin) {
+    left = minLeftMargin;
+  }
+
   let top = referenceRect.top;
 
   // Ensure the popup stays within the viewport vertically
@@ -346,6 +359,7 @@ function AutofixHighlightPopup(props: Props) {
     left: 0,
     top: 0,
   });
+  const [width, setWidth] = useState<number | undefined>(undefined);
   const [isFocused, setIsFocused] = useState(false);
 
   useLayoutEffect(() => {
@@ -356,9 +370,22 @@ function AutofixHighlightPopup(props: Props) {
     const updatePosition = () => {
       const referenceRect = referenceElement.getBoundingClientRect();
       const popupRect = popupRef.current!.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+
+      // Find the drawer element to get its actual width
+      const drawerElement = document.querySelector('.drawer-panel');
+      const drawerWidth = drawerElement
+        ? drawerElement.getBoundingClientRect().width
+        : viewportWidth * 0.5;
+
+      // Calculate available width for the popup
+      const availableWidth = viewportWidth - drawerWidth - 16; // 8px padding on each side
+      const defaultWidth = 300;
+      const newWidth = Math.min(defaultWidth, Math.max(200, availableWidth));
 
       startTransition(() => {
         setPosition(getOptimalPosition(referenceRect, popupRect));
+        setWidth(newWidth);
       });
     };
 
@@ -413,6 +440,7 @@ function AutofixHighlightPopup(props: Props) {
       style={{
         left: `${position.left}px`,
         top: `${position.top}px`,
+        width: width ? `${width}px` : '300px',
       }}
       isFocused={isFocused}
       onFocus={handleFocus}
@@ -437,7 +465,8 @@ const Wrapper = styled(motion.div)<
   align-items: flex-start;
   margin-right: ${space(1)};
   gap: ${space(1)};
-  width: 300px;
+  max-width: 300px;
+  min-width: 200px;
   position: fixed;
   will-change: transform;
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -92,6 +92,7 @@ export default function BreadcrumbsDataSection({
         ),
         {
           ariaLabel: 'breadcrumb drawer',
+          drawerKey: `breadcrumbs-drawer`,
           // We prevent a click on the 'View All' button from closing the drawer so that
           // we don't reopen it immediately, and instead let the button handle this itself.
           shouldCloseOnInteractOutside: element => {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -186,6 +186,7 @@ export function EventFeatureFlagList({
         ),
         {
           ariaLabel: t('Feature flags drawer'),
+          drawerKey: 'feature-flags-drawer',
           // We prevent a click on the 'View All' button from closing the drawer so that
           // we don't reopen it immediately, and instead let the button handle this itself.
           shouldCloseOnInteractOutside: element => {

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -145,13 +145,14 @@ export function DrawerPanel({
         }}
         transitionProps={transitionProps}
         panelWidth={`${persistedWidthPercent}%`}
-        className="drawer-panel"
+        className={`drawer-panel${isHeld ? ' resizing' : ''}`}
       >
         {drawerKey && (
           <ResizeHandle
             onMouseDown={onMouseDown}
             isResizing={isHeld}
             isAtMinWidth={persistedWidthPercent <= MIN_WIDTH_PERCENT}
+            isAtMaxWidth={persistedWidthPercent >= MAX_WIDTH_PERCENT}
           />
         )}
         <DrawerContentContext.Provider value={{onClose, ariaLabel}}>
@@ -276,6 +277,7 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
 
 const ResizeHandle = styled('div')<{
   isResizing: boolean;
+  isAtMaxWidth?: boolean;
   isAtMinWidth?: boolean;
 }>`
   position: absolute;
@@ -286,6 +288,9 @@ const ResizeHandle = styled('div')<{
   cursor: ${p => {
     if (p.isAtMinWidth) {
       return 'w-resize';
+    }
+    if (p.isAtMaxWidth) {
+      return 'e-resize';
     }
     return 'ew-resize';
   }};

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -249,6 +249,29 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
   border-left: 1px solid ${p => p.theme.border};
   position: relative;
   pointer-events: auto;
+
+  &.resizing {
+    /* Hide scrollbars during resize */
+    overflow: hidden !important;
+
+    /* Hide scrollbars in Firefox */
+    scrollbar-width: none;
+
+    /* Hide scrollbars in WebKit browsers */
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Apply to all scrollable children */
+    * {
+      overflow: hidden !important;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
 `;
 
 const ResizeHandle = styled('div')<{

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -33,6 +33,10 @@ export interface DrawerOptions {
    */
   closeOnOutsideClick?: boolean;
   /**
+   * Key to identify the drawer and enable persistence of the drawer width
+   */
+  drawerKey?: string;
+  /**
    * Custom width for the drawer
    */
   drawerWidth?: string;
@@ -186,6 +190,7 @@ export function GlobalDrawer({children}: any) {
               headerContent={currentDrawerConfig?.options?.headerContent ?? null}
               transitionProps={currentDrawerConfig?.options?.transitionProps}
               drawerWidth={currentDrawerConfig?.options?.drawerWidth}
+              drawerKey={currentDrawerConfig?.options?.drawerKey}
             >
               {renderedChild}
             </DrawerComponents.DrawerPanel>

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -18,6 +18,10 @@ export interface UseResizableDrawerOptions {
    */
   onResize: (size: number, userEvent: boolean) => void;
   /**
+   * The maximum size the container may be dragged to
+   */
+  max?: number;
+  /**
    * The local storage key used to persist the size of the container
    */
   sizeStorageKey?: string;
@@ -100,10 +104,14 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
           Math.max(options.min, sizeRef.current + positionDelta * (isInverted ? -1 : 1))
         );
 
-        updateSize(newSize, true);
+        // Apply max constraint if provided
+        const constrainedSize =
+          options.max === undefined ? newSize : Math.min(newSize, options.max);
+
+        updateSize(constrainedSize, true);
       });
     },
-    [options.direction, options.min, updateSize]
+    [options.direction, options.min, options.max, updateSize]
   );
 
   const onMouseUp = useCallback(() => {

--- a/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
@@ -28,6 +28,7 @@ export function useGroupTagsDrawer({
       ),
       {
         ariaLabel: t('Tags Drawer'),
+        drawerKey: 'distribution-drawer',
         onClose: () => {
           navigate(
             {

--- a/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
@@ -23,6 +23,7 @@ export function useIssueActivityDrawer({group, project}: UseIssueActivityDrawerP
   const openIssueActivityDrawer = useCallback(() => {
     openDrawer(() => <ActivityDrawer group={group} project={project} />, {
       ariaLabel: t('Issue Activity'),
+      drawerKey: 'issue-activity-drawer',
       shouldCloseOnInteractOutside: () => false,
       onClose: () => {
         navigate(

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -282,6 +282,7 @@ export const useOpenSeerDrawer = (
 
     openDrawer(() => <SeerDrawer group={group} project={project} event={event} />, {
       ariaLabel: t('Seer drawer'),
+      drawerKey: 'seer-autofix-drawer',
       shouldCloseOnInteractOutside: element => {
         const viewAllButton = buttonRef?.current;
 


### PR DESCRIPTION
Uses existing resizing hook, with custom logic to persist settings and save size as a percentage of viewport width. 