### PR TITLE
feat(sentryapps): add RPC method to get all installation component contents

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -165,11 +165,15 @@ class RuleSerializer(Serializer):
                     rpc_component = install_context.component
                     rpc_app = rpc_install.sentry_app
 
-                    component = prepare_ui_component(
-                        rpc_install,
-                        rpc_component,
-                        self.project_slug,
-                        action.get("settings"),
+                    component = (
+                        prepare_ui_component(
+                            rpc_install,
+                            rpc_component,
+                            self.project_slug,
+                            action.get("settings"),
+                        )
+                        if rpc_component
+                        else None
                     )
                     if component is None:
                         errors.append({"detail": f"Could not fetch details from {rpc_app.name}"})

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -151,11 +151,15 @@ class AlertRuleSerializer(Serializer):
 
                     action["sentryAppInstallationUuid"] = rpc_install.uuid
 
-                    component = prepare_ui_component(
-                        rpc_install,
-                        rpc_component,
-                        None,
-                        action.get("settings"),
+                    component = (
+                        prepare_ui_component(
+                            rpc_install,
+                            rpc_component,
+                            None,
+                            action.get("settings"),
+                        )
+                        if rpc_component
+                        else None
                     )
                     if component is None:
                         errors.append({"detail": f"Could not fetch details from {rpc_app.name}"})

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -176,7 +176,7 @@ class DatabaseBackedAppService(AppService):
         *,
         filter: SentryAppInstallationFilterArgs,
         component_type: str,
-        include_contexts_without_component: bool,
+        include_contexts_without_component: bool = False,
     ) -> list[RpcSentryAppComponentContext]:
         install_query = self._FQ.query_many(filter=filter)
         app_ids = install_query.select_related("sentry_app", "sentry_app__application").values_list(

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -176,7 +176,7 @@ class DatabaseBackedAppService(AppService):
         *,
         filter: SentryAppInstallationFilterArgs,
         component_type: str,
-        include_contexts_with_component: bool = True,
+        include_contexts_without_component: bool,
     ) -> list[RpcSentryAppComponentContext]:
         install_query = self._FQ.query_many(filter=filter)
         app_ids = install_query.select_related("sentry_app", "sentry_app__application").values_list(
@@ -189,11 +189,11 @@ class DatabaseBackedAppService(AppService):
         output = []
 
         for component in component_query:
-            component_map[component.sentry_app.id] = component
+            component_map[component.sentry_app_id] = component
 
         for install in install_query:
             install_component = component_map.get(install.sentry_app_id)
-            if include_contexts_with_component or install_component:
+            if include_contexts_without_component or install_component:
                 context_item = RpcSentryAppComponentContext(
                     installation=serialize_sentry_app_installation(
                         installation=install, app=install.sentry_app

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -179,9 +179,8 @@ class DatabaseBackedAppService(AppService):
         include_contexts_without_component: bool = False,
     ) -> list[RpcSentryAppComponentContext]:
         install_query = self._FQ.query_many(filter=filter)
-        app_ids = install_query.select_related("sentry_app", "sentry_app__application").values_list(
-            "sentry_app_id", flat=True
-        )
+        app_ids = install_query.values_list("sentry_app_id", flat=True)
+
         component_query = SentryAppComponent.objects.filter(
             type=component_type, sentry_app_id__in=list(app_ids)
         )

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -94,7 +94,7 @@ class RpcSentryAppComponent(RpcModel):
 
 class RpcSentryAppComponentContext(RpcModel):
     installation: RpcSentryAppInstallation
-    component: RpcSentryAppComponent
+    component: RpcSentryAppComponent | None = None
 
 
 class RpcAlertRuleActionResult(RpcModel):

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -164,6 +164,17 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_installation_component_contexts(
+        self,
+        *,
+        filter: SentryAppInstallationFilterArgs,
+        component_type: str,
+        include_contexts_with_component: bool = True,
+    ) -> list[RpcSentryAppComponentContext]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def trigger_sentry_app_action_creators(
         self, *, fields: list[Mapping[str, Any]], install_uuid: str | None
     ) -> RpcAlertRuleActionResult:

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -169,7 +169,7 @@ class AppService(RpcService):
         *,
         filter: SentryAppInstallationFilterArgs,
         component_type: str,
-        include_contexts_with_component: bool = True,
+        include_contexts_without_component: bool,
     ) -> list[RpcSentryAppComponentContext]:
         pass
 

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -178,6 +178,7 @@ def test_get_installation_component_contexts() -> None:
     result = app_service.get_installation_component_contexts(
         filter={"uuids": [install.uuid]},
         component_type="alert-rule-trigger",
+        include_contexts_without_component=False,
     )
     assert len(result) == 1
     row = result[0]

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -89,6 +89,7 @@ def test_get_component_contexts() -> None:
     for row in result:
         assert row.installation.id in {install.id, install_other.id}
         assert row.installation.sentry_app.slug == app.slug
+        assert row.component
         assert row.component.sentry_app_id == app.id
         assert row.component.app_schema
 
@@ -100,8 +101,118 @@ def test_get_component_contexts() -> None:
     row = result[0]
     assert row.installation.id == install.id
     assert row.installation.sentry_app.slug == app.slug
+    assert row.component
     assert row.component.sentry_app_id == app.id
     assert row.component.app_schema
+
+
+@django_db_all(transaction=True)
+@all_silo_test
+def test_get_installation_component_contexts() -> None:
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    other_org = Factories.create_organization(owner=user)
+    app = Factories.create_sentry_app(
+        name="demo-app",
+        user=user,
+        published=True,
+        schema={
+            "elements": [
+                {
+                    "type": "alert-rule-trigger",
+                    "title": "go beep",
+                    "settings": {
+                        "type": "alert-rule-settings",
+                        "uri": "https://example.com/search/",
+                    },
+                },
+            ]
+        },
+    )
+    install = Factories.create_sentry_app_installation(
+        organization=org,
+        slug=app.slug,
+    )
+    install_other = Factories.create_sentry_app_installation(
+        organization=other_org,
+        slug=app.slug,
+    )
+
+    no_component_app = Factories.create_sentry_app(
+        name="no-component",
+        user=user,
+        published=True,
+    )
+    no_component_install = Factories.create_sentry_app_installation(
+        organization=org,
+        slug=no_component_app.slug,
+    )
+    no_component_install_other = Factories.create_sentry_app_installation(
+        organization=other_org,
+        slug=no_component_app.slug,
+    )
+
+    # wrong component type
+    result = app_service.get_installation_component_contexts(
+        filter={"app_ids": [app.id]}, component_type="derp", include_contexts_with_component=False
+    )
+    assert len(result) == 0
+
+    # filter by app_id gets all installs for app
+    result = app_service.get_installation_component_contexts(
+        filter={"app_ids": [app.id]},
+        component_type="alert-rule-trigger",
+        include_contexts_with_component=False,
+    )
+    assert len(result) == 2
+    for row in result:
+        assert row.installation.id in {install.id, install_other.id}
+        assert row.installation.sentry_app.slug == app.slug
+        assert row.component
+        assert row.component.sentry_app_id == app.id
+        assert row.component.app_schema
+
+    # filter by install_uuid gets only one
+    result = app_service.get_installation_component_contexts(
+        filter={"uuids": [install.uuid]},
+        component_type="alert-rule-trigger",
+        include_contexts_with_component=False,
+    )
+    assert len(result) == 1
+    row = result[0]
+    assert row.installation.id == install.id
+    assert row.installation.sentry_app.slug == app.slug
+    assert row.component
+    assert row.component.sentry_app_id == app.id
+    assert row.component.app_schema
+
+    # filter by org_id and include app without component
+    result = app_service.get_installation_component_contexts(
+        filter={"organization_id": org.id},
+        component_type="alert-rule-trigger",
+        include_contexts_with_component=True,
+    )
+    assert len(result) == 2
+    for row in result:
+        assert row.installation.organization_id == org.id
+        if row.installation.sentry_app.slug == app.slug:
+            assert row.component
+            assert row.component.sentry_app_id == app.id
+            assert row.component.app_schema
+        else:
+            assert row.component is None
+
+    # filter by app_id on app without component
+    result = app_service.get_installation_component_contexts(
+        filter={"app_ids": [no_component_app.id]},
+        component_type="alert-rule-trigger",
+        include_contexts_with_component=True,
+    )
+    assert len(result) == 2
+    for row in result:
+        assert row.installation.id in {no_component_install.id, no_component_install_other.id}
+        assert row.installation.sentry_app.slug == no_component_app.slug
+        assert row.component is None
 
 
 @django_db_all(transaction=True)

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -154,7 +154,9 @@ def test_get_installation_component_contexts() -> None:
 
     # wrong component type
     result = app_service.get_installation_component_contexts(
-        filter={"app_ids": [app.id]}, component_type="derp", include_contexts_with_component=False
+        filter={"app_ids": [app.id, no_component_app.id]},
+        component_type="derp",
+        include_contexts_without_component=False,
     )
     assert len(result) == 0
 
@@ -162,7 +164,7 @@ def test_get_installation_component_contexts() -> None:
     result = app_service.get_installation_component_contexts(
         filter={"app_ids": [app.id]},
         component_type="alert-rule-trigger",
-        include_contexts_with_component=False,
+        include_contexts_without_component=False,
     )
     assert len(result) == 2
     for row in result:
@@ -176,7 +178,6 @@ def test_get_installation_component_contexts() -> None:
     result = app_service.get_installation_component_contexts(
         filter={"uuids": [install.uuid]},
         component_type="alert-rule-trigger",
-        include_contexts_with_component=False,
     )
     assert len(result) == 1
     row = result[0]
@@ -190,7 +191,7 @@ def test_get_installation_component_contexts() -> None:
     result = app_service.get_installation_component_contexts(
         filter={"organization_id": org.id},
         component_type="alert-rule-trigger",
-        include_contexts_with_component=True,
+        include_contexts_without_component=True,
     )
     assert len(result) == 2
     for row in result:
@@ -206,7 +207,7 @@ def test_get_installation_component_contexts() -> None:
     result = app_service.get_installation_component_contexts(
         filter={"app_ids": [no_component_app.id]},
         component_type="alert-rule-trigger",
-        include_contexts_with_component=True,
+        include_contexts_without_component=True,
     )
     assert len(result) == 2
     for row in result:


### PR DESCRIPTION
Adding new `get_installation_component_contexts` RPC method which will eventually replace `get_component_contexts`.

We need this new RPC method in order to return Sentry Apps that do not have a component. This new method takes an optional flag (`include_contexts_with_component`) which can be turned off to filter out Sentry Apps without a component.