### PR TITLE
ref: cleanup forwardedRef

### DIFF
--- a/static/app/components/charts/areaChart.tsx
+++ b/static/app/components/charts/areaChart.tsx
@@ -1,6 +1,6 @@
 import type {LineSeriesOption} from 'echarts';
 
-import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
+import type {Series} from 'sentry/types/echarts';
 
 import AreaSeries from './series/areaSeries';
 import type {BaseChartProps} from './baseChart';
@@ -46,19 +46,10 @@ export function transformToAreaSeries({
   );
 }
 
-export function AreaChart({
-  ref,
-  series,
-  stacked,
-  colors,
-  ...props
-}: AreaChartProps & {
-  ref?: React.Ref<ReactEchartsRef>;
-}) {
+export function AreaChart({series, stacked, colors, ...props}: AreaChartProps) {
   return (
     <BaseChart
       {...props}
-      ref={ref}
       data-test-id="area-chart"
       colors={colors}
       series={transformToAreaSeries({series, stacked, colors})}

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -49,7 +49,6 @@ import type {
   EChartMouseOverHandler,
   EChartRenderedHandler,
   EChartRestoreHandler,
-  ReactEchartsRef,
   Series,
 } from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
@@ -178,10 +177,6 @@ export interface BaseChartProps {
    */
   end?: Date;
   /**
-   * Forwarded Ref
-   */
-  forwardedRef?: React.Ref<ReactEchartsCore>;
-  /**
    * Graphic options
    */
   graphic?: EChartsOption['graphic'];
@@ -245,6 +240,7 @@ export interface BaseChartProps {
    * Display previous period as a LineSeries
    */
   previousPeriod?: Series[];
+  ref?: React.Ref<ReactEchartsCore>;
   /**
    * Use `canvas` when dealing with large datasets
    * See: https://ecomfe.github.io/echarts-doc/public/en/tutorial.html#Render%20by%20Canvas%20or%20SVG
@@ -337,7 +333,7 @@ const DEFAULT_ADDITIONAL_SERIES: LineSeriesOption[] = [];
 const DEFAULT_Y_AXIS = {};
 const DEFAULT_X_AXIS = {};
 
-function BaseChartUnwrapped({
+function BaseChart({
   brush,
   colors,
   grid,
@@ -363,7 +359,7 @@ function BaseChartUnwrapped({
   xAxes,
 
   style,
-  forwardedRef,
+  ref,
 
   onClick,
   onLegendSelectChanged,
@@ -676,7 +672,7 @@ function BaseChartUnwrapped({
     <ChartContainer autoHeightResize={autoHeightResize} data-test-id={dataTestId}>
       {isTooltipPortalled && <Global styles={getPortalledTooltipStyles({theme})} />}
       <ReactEchartsCore
-        ref={forwardedRef}
+        ref={ref}
         echarts={echarts}
         notMerge={notMerge}
         lazyUpdate={lazyUpdate}
@@ -852,16 +848,5 @@ const getPortalledTooltipStyles = (p: {theme: Theme}) => css`
     ${getTooltipStyles(p)};
   }
 `;
-
-function BaseChart({
-  ref,
-  ...props
-}: BaseChartProps & {
-  ref?: React.Ref<ReactEchartsRef>;
-}) {
-  return <BaseChartUnwrapped forwardedRef={ref} {...props} />;
-}
-
-BaseChart.displayName = 'forwardRef(BaseChart)';
 
 export default BaseChart;

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -68,6 +68,7 @@ interface ListBoxProps
    * Used to determine whether to render the list box items or not
    */
   overlayIsOpen?: boolean;
+  ref?: React.Ref<HTMLUListElement>;
   /**
    * When false, hides option details.
    */
@@ -99,7 +100,7 @@ const EMPTY_SET = new Set<never>();
  * the `grid` prop on CompactSelect to true).
  */
 export function ListBox({
-  ref: forwardedRef,
+  ref,
   listState,
   size = 'md',
   shouldFocusWrap = true,
@@ -114,10 +115,8 @@ export function ListBox({
   showSectionHeaders = true,
   showDetails = true,
   ...props
-}: ListBoxProps & {
-  ref?: React.Ref<HTMLUListElement>;
-}) {
-  const ref = useRef<HTMLUListElement>(null);
+}: ListBoxProps) {
+  const listElementRef = useRef<HTMLUListElement>(null);
   const {listBoxProps, labelProps} = useListBox(
     {
       ...props,
@@ -127,7 +126,7 @@ export function ListBox({
       shouldSelectOnPressUp: true,
     },
     listState,
-    ref
+    listElementRef
   );
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
@@ -157,7 +156,7 @@ export function ListBox({
       <ListWrap
         {...mergeProps(listBoxProps, props)}
         onKeyDown={onKeyDown}
-        ref={mergeRefs(ref, forwardedRef)}
+        ref={mergeRefs(listElementRef, ref)}
       >
         {overlayIsOpen &&
           listItems.map(item => {

--- a/static/app/components/core/input/numberDragInput.tsx
+++ b/static/app/components/core/input/numberDragInput.tsx
@@ -149,15 +149,7 @@ const VerySmallIconArrow = styled(IconArrow)`
   height: 8px;
 `;
 
-// forwardRef is required so that skipWrapper can be applied by the tooltip
-const TrailingItemsContainer = styled(
-  ({
-    ref,
-    ...props
-  }: React.HTMLAttributes<HTMLDivElement> & {
-    ref?: React.Ref<HTMLDivElement>;
-  }) => <div {...props} ref={ref} />
-)<{
+const TrailingItemsContainer = styled('div')<{
   layout: 'vertical' | 'horizontal';
 }>`
   display: flex;

--- a/static/app/components/deprecatedforms/selectAsyncField.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.tsx
@@ -10,7 +10,7 @@ import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
 export interface SelectAsyncFieldProps
   extends SelectFieldProps,
-    Omit<SelectAsyncControlProps, 'value' | 'forwardedRef' | 'onQuery' | 'onResults'> {
+    Omit<SelectAsyncControlProps, 'value' | 'onQuery' | 'onResults'> {
   onQuery?: SelectAsyncControlProps['onQuery'];
   onResults?: SelectAsyncControlProps['onResults'];
 }

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -24,6 +24,7 @@ interface DropdownBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
    * If true, the menu will be visually detached from actor.
    */
   detached?: boolean;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The width of the menu
    */
@@ -64,14 +65,8 @@ const getMenuBorderRadius = ({
 };
 
 const DropdownBubble = styled(
-  ({
-    ref: forwardedRef,
-    children,
-    ...props
-  }: DropdownBubbleProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  }) => (
-    <div ref={forwardedRef} {...props}>
+  ({children, ...props}: DropdownBubbleProps) => (
+    <div {...props}>
       <PanelProvider>{children}</PanelProvider>
     </div>
   ),

--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -17,7 +17,7 @@ export interface DropdownButtonProps extends Omit<ButtonProps, 'type' | 'prefix'
   /**
    * Forward a ref to the button's root
    */
-  ref?: React.ForwardedRef<HTMLButtonElement>;
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Should a chevron icon be shown?
    */

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -114,10 +114,10 @@ function DropdownMenuItem({
   onClose,
   showDivider,
   renderAs = 'li',
-  ref: forwardedRef,
+  ref,
   ...props
 }: DropdownMenuItemProps) {
-  const ref = useRef<HTMLLIElement | null>(null);
+  const listElementRef = useRef<HTMLLIElement | null>(null);
   const isDisabled = state.disabledKeys.has(node.key);
   const isFocused = state.selectionManager.focusedKey === node.key;
   const {key, onAction, to, label, isSubmenu, trailingItems, externalHref, ...itemProps} =
@@ -178,7 +178,7 @@ function DropdownMenuItem({
             ctrlKey: e.ctrlKey,
             metaKey: e.metaKey,
           });
-          ref.current
+          listElementRef.current
             ?.querySelector(`${MenuListItemInnerWrap}`)
             ?.dispatchEvent(mouseEvent);
           return;
@@ -212,7 +212,7 @@ function DropdownMenuItem({
       isDisabled,
     },
     state,
-    ref
+    listElementRef
   );
 
   // Merged menu item props, class names are combined, event handlers chained,
@@ -233,7 +233,7 @@ function DropdownMenuItem({
 
   return (
     <MenuListItem
-      ref={mergeRefs(ref, forwardedRef)}
+      ref={mergeRefs(listElementRef, ref)}
       as={renderAs}
       data-test-id={key}
       label={itemLabel}

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -34,10 +34,7 @@ export interface LinkProps
    * Indicator if the link should be disabled
    */
   disabled?: boolean;
-  /**
-   * Forwarded ref
-   */
-  forwardedRef?: React.Ref<HTMLAnchorElement>;
+  ref?: React.Ref<HTMLAnchorElement>;
   replace?: ReactRouterLinkProps['replace'];
   state?: ReactRouterLinkProps['state'];
 }
@@ -46,28 +43,19 @@ export interface LinkProps
  * A context-aware version of Link (from react-router) that falls
  * back to <a> if there is no router present
  */
-function BaseLink({disabled, to, forwardedRef, ...props}: LinkProps): React.ReactElement {
+function BaseLink({disabled, to, ...props}: LinkProps): React.ReactElement {
   const location = useLocation();
   to = normalizeUrl(to, location);
 
   if (!disabled && location) {
-    return (
-      <RouterLink to={locationDescriptorToTo(to)} ref={forwardedRef as any} {...props} />
-    );
+    return <RouterLink to={locationDescriptorToTo(to)} {...props} />;
   }
 
-  return <a href={typeof to === 'string' ? to : ''} ref={forwardedRef} {...props} />;
+  return <a href={typeof to === 'string' ? to : ''} {...props} />;
 }
 
 // Re-assign to Link to make auto-importing smarter
-const Link = styled(
-  ({
-    ref,
-    ...props
-  }: Omit<LinkProps, 'forwardedRef'> & {
-    ref?: React.Ref<HTMLAnchorElement>;
-  }) => <BaseLink forwardedRef={ref} {...props} />
-)`
+const Link = styled(BaseLink)`
   ${linkStyles}
 `;
 

--- a/static/app/components/organizations/environmentPageFilter/trigger.tsx
+++ b/static/app/components/organizations/environmentPageFilter/trigger.tsx
@@ -22,7 +22,6 @@ export function EnvironmentPageFilterTrigger({
   environments,
   ready,
   desynced,
-  ref: forwardedRef,
   ...props
 }: EnvironmentPageFilterTriggerProps) {
   const isAllEnvironmentsSelected =
@@ -42,11 +41,7 @@ export function EnvironmentPageFilterTrigger({
   const remainingCount = isAllEnvironmentsSelected ? 0 : value.length - envsToShow.length;
 
   return (
-    <DropdownButton
-      {...props}
-      ref={forwardedRef}
-      data-test-id="page-filter-environment-selector"
-    >
+    <DropdownButton {...props} data-test-id="page-filter-environment-selector">
       <TriggerLabelWrap>
         <TriggerLabel>{ready ? label : t('Loading\u2026')}</TriggerLabel>
         {desynced && <DesyncedFilterIndicator role="presentation" />}

--- a/static/app/components/organizations/projectPageFilter/trigger.tsx
+++ b/static/app/components/organizations/projectPageFilter/trigger.tsx
@@ -26,7 +26,6 @@ export function ProjectPageFilterTrigger({
   nonMemberProjects,
   ready,
   desynced,
-  ref: forwardedRef,
   ...props
 }: ProjectPageFilterTriggerProps) {
   const isMemberProjectsSelected = memberProjects.every(p =>
@@ -75,7 +74,6 @@ export function ProjectPageFilterTrigger({
   return (
     <DropdownButton
       {...props}
-      ref={forwardedRef}
       data-test-id="page-filter-project-selector"
       icon={
         ready &&

--- a/static/app/components/panels/panel.tsx
+++ b/static/app/components/panels/panel.tsx
@@ -7,17 +7,12 @@ import PanelProvider from 'sentry/utils/panelProvider';
 interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {
   dashedBorder?: boolean;
   'data-test-id'?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 const Panel = styled(
-  ({
-    ref: forwardedRef,
-    children,
-    ...props
-  }: PanelProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  }) => (
-    <div ref={forwardedRef} {...props}>
+  ({children, ...props}: PanelProps) => (
+    <div {...props}>
       <PanelProvider>{children}</PanelProvider>
     </div>
   ),

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabProps} from '@react-aria/tabs';
@@ -58,46 +57,44 @@ export interface BaseTabProps {
    * `variant='filled'` since other variants do not have a border
    */
   borderStyle?: 'solid' | 'dashed';
+  ref?: React.Ref<HTMLLIElement>;
   to?: string;
   variant?: 'flat' | 'filled' | 'floating';
 }
 
-export function BaseTab({
-  ref: forwardedRef,
-  ...props
-}: BaseTabProps & {
-  ref?: React.Ref<HTMLLIElement>;
-}) {
-  const {
-    to,
-    orientation,
-    overflowing,
-    tabProps,
-    hidden,
-    isSelected,
-    variant = 'flat',
-    borderStyle = 'solid',
-    as = 'li',
-  } = props;
-
-  const ref = useObjectRef(forwardedRef);
-  const InnerWrap = useCallback(
-    ({children}: any) =>
-      to ? (
-        <TabLink
-          to={to}
-          onMouseDown={handleLinkClick}
-          onPointerDown={handleLinkClick}
-          orientation={orientation}
-          tabIndex={-1}
-        >
-          {children}
-        </TabLink>
-      ) : (
-        <TabInnerWrap orientation={orientation}>{children}</TabInnerWrap>
-      ),
-    [to, orientation]
+function InnerWrap({
+  children,
+  to,
+  orientation,
+}: Pick<BaseTabProps, 'children' | 'to' | 'orientation'>) {
+  return to ? (
+    <TabLink
+      to={to}
+      onMouseDown={handleLinkClick}
+      onPointerDown={handleLinkClick}
+      orientation={orientation}
+      tabIndex={-1}
+    >
+      {children}
+    </TabLink>
+  ) : (
+    <TabInnerWrap orientation={orientation}>{children}</TabInnerWrap>
   );
+}
+
+export function BaseTab({
+  to,
+  children,
+  ref,
+  orientation,
+  overflowing,
+  tabProps,
+  hidden,
+  isSelected,
+  variant = 'flat',
+  borderStyle = 'solid',
+  as = 'li',
+}: BaseTabProps) {
   if (variant === 'filled') {
     return (
       <FilledTabWrap
@@ -112,7 +109,7 @@ export function BaseTab({
           <VariantStyledInteractionStateLayer hasSelectedBackground={false} />
         )}
         <FilledFocusLayer />
-        {props.children}
+        {children}
       </FilledTabWrap>
     );
   }
@@ -128,7 +125,7 @@ export function BaseTab({
       >
         <VariantStyledInteractionStateLayer hasSelectedBackground={false} />
         <VariantFocusLayer />
-        {props.children}
+        {children}
       </FloatingTabWrap>
     );
   }
@@ -142,13 +139,13 @@ export function BaseTab({
       ref={ref}
       as={as}
     >
-      <InnerWrap>
+      <InnerWrap to={to} orientation={orientation}>
         <StyledInteractionStateLayer
           orientation={orientation}
           higherOpacity={isSelected}
         />
         <FocusLayer orientation={orientation} />
-        {props.children}
+        {children}
         <TabSelectionIndicator orientation={orientation} selected={isSelected} />
       </InnerWrap>
     </TabWrap>
@@ -161,7 +158,7 @@ export function BaseTab({
  * usage in tabs.stories.js
  */
 export function Tab({
-  ref: forwardedRef,
+  ref,
   item,
   state,
   orientation,
@@ -172,14 +169,14 @@ export function Tab({
 }: TabProps & {
   ref?: React.Ref<HTMLLIElement>;
 }) {
-  const ref = useObjectRef(forwardedRef);
+  const objectRef = useObjectRef(ref);
 
   const {
     key,
     rendered,
     props: {to, hidden},
   } = item;
-  const {tabProps, isSelected} = useTab({key, isDisabled: hidden}, state, ref);
+  const {tabProps, isSelected} = useTab({key, isDisabled: hidden}, state, objectRef);
 
   return (
     <BaseTab
@@ -189,7 +186,7 @@ export function Tab({
       hidden={hidden}
       orientation={orientation}
       overflowing={overflowing}
-      ref={ref}
+      ref={objectRef}
       borderStyle={borderStyle}
       variant={variant}
       as={as}

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -429,7 +429,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
         showTimeInTooltip
         minutesThresholdToDisplaySeconds={minutesThresholdToDisplaySeconds}
         period={DEFAULT_STATS_PERIOD || period}
-        forwardedRef={this.handleRef}
+        ref={this.handleRef}
         grid={CHART_GRID}
         {...chartOptions}
         graphic={Graphic({

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
@@ -18,10 +18,10 @@ export interface QueryFieldProps {
   canDelete?: boolean;
   canDrag?: boolean;
   fieldValidationError?: ReactNode;
-  forwardRef?: React.Ref<HTMLDivElement>;
   isDragging?: boolean;
   listeners?: DraggableSyntheticListeners;
   onDelete?: () => void;
+  ref?: React.Ref<HTMLDivElement>;
   style?: React.CSSProperties;
 }
 
@@ -30,7 +30,7 @@ export function QueryField({
   onChange,
   fieldOptions,
   value,
-  forwardRef,
+  ref,
   listeners,
   attributes,
   canDelete,
@@ -40,7 +40,7 @@ export function QueryField({
   isDragging,
 }: QueryFieldProps) {
   return (
-    <QueryFieldWrapper ref={forwardRef} style={style}>
+    <QueryFieldWrapper ref={ref} style={style}>
       {isDragging ? null : (
         <Fragment>
           {canDrag && (

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/sortableQueryField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/sortableQueryField.tsx
@@ -35,7 +35,7 @@ export function SortableQueryField({dragId, ...props}: SortableItemProps) {
 
   return (
     <QueryField
-      forwardRef={setNodeRef}
+      ref={setNodeRef}
       listeners={listeners}
       attributes={attributes}
       isDragging={isDragging}

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -486,7 +486,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       },
     };
 
-    const forwardedRef = this.props.chartGroup ? this.handleRef : undefined;
+    const ref = this.props.chartGroup ? this.handleRef : undefined;
 
     // Excluding Other uses a slightly altered regex to match the Other series name
     // because the series names are formatted with widget IDs to avoid conflicts
@@ -541,7 +541,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                             legend,
                             series: [...series, ...(modifiedReleaseSeriesResults ?? [])],
                             onLegendSelectChanged,
-                            forwardedRef,
+                            ref,
                           }),
                           fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                         })}

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -83,7 +83,6 @@ type Props = {
   disableXAxis?: boolean;
   durationUnit?: number;
   error?: Error | null;
-  forwardedRef?: RefObject<ReactEchartsRef>;
   grid?: AreaChartProps['grid'];
   height?: number;
   hideYAxis?: boolean;
@@ -104,6 +103,7 @@ type Props = {
   onMouseOver?: EChartMouseOverHandler;
   previousData?: Series[];
   rateUnit?: RateUnit;
+  ref?: RefObject<ReactEchartsRef>;
   scatterPlot?: Series[];
   showLegend?: boolean;
   stacked?: boolean;
@@ -135,7 +135,7 @@ function Chart({
   onMouseOver,
   onMouseOut,
   onHighlight,
-  forwardedRef,
+  ref,
   chartGroup,
   tooltipFormatterOptions = {},
   error,
@@ -155,7 +155,7 @@ function Chart({
   const isLegendVisible = renderingContext?.isFullscreen ?? showLegend;
 
   const defaultRef = useRef<ReactEchartsRef>(null);
-  const chartRef = forwardedRef || defaultRef;
+  const chartRef = ref || defaultRef;
 
   const echartsInstance = chartRef?.current?.getEchartsInstance?.();
   if (echartsInstance && !echartsInstance.group) {
@@ -500,7 +500,7 @@ function Chart({
 
     return (
       <AreaChart
-        forwardedRef={chartRef}
+        ref={chartRef}
         height={height}
         {...zoomRenderProps}
         series={[...series, ...incompleteSeries, ...(releaseSeries ?? [])]}

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -57,6 +57,7 @@ export interface FoldSectionProps {
    * Disable the ability for the user to collapse the section
    */
   preventCollapse?: boolean;
+  ref?: React.Ref<HTMLElement>;
   style?: CSSProperties;
 }
 
@@ -77,7 +78,7 @@ function useOptionalLocalStorageState(
 }
 
 export function FoldSection({
-  ref: forwardedRef,
+  ref,
   children,
   title,
   actions,
@@ -86,9 +87,7 @@ export function FoldSection({
   initialCollapse = false,
   preventCollapse = false,
   disableCollapsePersistence = false,
-}: FoldSectionProps & {
-  ref?: React.Ref<HTMLElement>;
-}) {
+}: FoldSectionProps) {
   const organization = useOrganization();
   const {sectionData, navScrollMargin, dispatch} = useIssueDetails();
 
@@ -166,7 +165,7 @@ export function FoldSection({
   return (
     <Fragment>
       <Section
-        ref={mergeRefs(forwardedRef, scrollToSection)}
+        ref={mergeRefs(ref, scrollToSection)}
         id={sectionKey}
         scrollMargin={navScrollMargin ?? 0}
         role="region"

--- a/static/app/views/releases/drawer/foldSection.tsx
+++ b/static/app/views/releases/drawer/foldSection.tsx
@@ -32,6 +32,7 @@ export interface FoldSectionProps {
    * Disable the ability for the user to collapse the section
    */
   preventCollapse?: boolean;
+  ref?: React.Ref<HTMLElement>;
   style?: CSSProperties;
 }
 
@@ -41,7 +42,7 @@ export interface FoldSectionProps {
  * analytics.
  */
 export function FoldSection({
-  ref: forwardedRef,
+  ref,
   children,
   title,
   sectionKey,
@@ -50,9 +51,7 @@ export function FoldSection({
   navScrollMargin = 0,
   initialCollapse = false,
   preventCollapse = false,
-}: FoldSectionProps & {
-  ref?: React.Ref<HTMLElement>;
-}) {
+}: FoldSectionProps) {
   const hasAttemptedScroll = useRef(false);
   const [isCollapsed, setIsCollapsed] = useState(initialCollapse);
 
@@ -99,7 +98,7 @@ export function FoldSection({
   return (
     <Fragment>
       <Section
-        ref={mergeRefs(forwardedRef, scrollToSection)}
+        ref={mergeRefs(ref, scrollToSection)}
         id={sectionKey}
         scrollMargin={navScrollMargin ?? 0}
         role="region"


### PR DESCRIPTION
we've had a couple of places where we have leftovers from the automatic migration that renames props unnecessarily from `ref` to `forwardRef` or `forwardedRef`; this PR cleans this up
