### PR TITLE
feat(ui): Add copy DSN action to command pallete

### DIFF
--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -101,7 +101,7 @@ if (NODE_ENV === 'development' && window?.__initialData?.isSelfHosted === false)
 
 function createCopyDSNAction(params: {orgId?: string; projectId?: string}) {
   return {
-    title: t('Copy Project DSN to Clipboard'),
+    title: t('Copy Project (%s) DSN to Clipboard', params.projectId),
     description: t('Copies the Project DSN to the clipboard.'),
     isHidden: () => !params.orgId || !params.projectId, // visible if both orgId and projectId are present
     requiresSuperuser: false,

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -11,7 +11,6 @@ import type {ProjectKey} from 'sentry/types/project';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {createFuzzySearch} from 'sentry/utils/fuzzySearch';
 import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
-import type {Params} from 'sentry/utils/useParams';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
 
@@ -100,7 +99,7 @@ if (NODE_ENV === 'development' && window?.__initialData?.isSelfHosted === false)
   });
 }
 
-function createCopyDSNAction(params: Params) {
+function createCopyDSNAction(params: {orgId?: string; projectId?: string}) {
   return {
     title: t('Copy Project DSN to Clipboard'),
     description: t('Copies the Project DSN to the clipboard.'),

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -41,6 +41,8 @@ type ParamKeys =
   | 'viewId'
   | 'widgetIndex';
 
+export type Params = Partial<Record<ParamKeys, string | undefined>>;
+
 /**
  * Get params from the current route. Param availability depends on the current route.
  *
@@ -49,7 +51,7 @@ type ParamKeys =
  * const params = useParams<{projectId: string}>();
  * ```
  */
-export function useParams<P extends Partial<Record<ParamKeys, string | undefined>>>(): P {
+export function useParams<P extends Params>(): P {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const testRouteContext = useTestRouteContext();

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -41,7 +41,7 @@ type ParamKeys =
   | 'viewId'
   | 'widgetIndex';
 
-export type Params = Partial<Record<ParamKeys, string | undefined>>;
+type Params = Partial<Record<ParamKeys, string | undefined>>;
 
 /**
  * Get params from the current route. Param availability depends on the current route.

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -41,8 +41,6 @@ type ParamKeys =
   | 'viewId'
   | 'widgetIndex';
 
-type Params = Partial<Record<ParamKeys, string | undefined>>;
-
 /**
  * Get params from the current route. Param availability depends on the current route.
  *
@@ -51,7 +49,7 @@ type Params = Partial<Record<ParamKeys, string | undefined>>;
  * const params = useParams<{projectId: string}>();
  * ```
  */
-export function useParams<P extends Params>(): P {
+export function useParams<P extends Partial<Record<ParamKeys, string | undefined>>>(): P {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const testRouteContext = useTestRouteContext();


### PR DESCRIPTION
Clean start after a mistake in https://github.com/getsentry/sentry/pull/88076/

Adds new action to CMD+K command palette - "Copy Project DSN".

This action is only visible if the user is on the project site (project is in the route), and we get this information from the context.

<img width="646" alt="image" src="https://github.com/user-attachments/assets/bf1d5b31-b12d-4622-a817-ef44fe2637ba" />


Closes https://github.com/getsentry/sentry/issues/87701