### PR TITLE
draft - (feat)add-wizard-binaries-for-JS

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -16,8 +16,8 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
-import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -142,7 +142,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                code: getWizardInstallSnippet({
+                code: getWizardSnippet({
                   platform: 'android',
                   params,
                 }),

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -1,5 +1,5 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import List from 'sentry/components/list/';
+import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
@@ -14,8 +14,8 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {appleFeedbackOnboarding} from 'sentry/gettingStartedDocs/apple/macos';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
-import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -197,7 +197,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                code: getWizardInstallSnippet({
+                code: getWizardSnippet({
                   platform: 'ios',
                   params,
                 }),

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -17,8 +17,8 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
-import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -172,7 +172,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                code: getWizardInstallSnippet({
+                code: getWizardSnippet({
                   platform: 'flutter',
                   params,
                 }),

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -29,13 +29,9 @@ import {
 import {featureFlagOnboarding} from 'sentry/gettingStartedDocs/javascript/javascript';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 
 type Params = DocsParams;
-
-const getInstallSnippet = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-  return `npx @sentry/wizard@latest -i nextjs ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
-};
 
 const getInstallConfig = (params: Params) => {
   return [
@@ -48,8 +44,10 @@ const getInstallConfig = (params: Params) => {
           ),
         }
       ),
-      language: 'bash',
-      code: getInstallSnippet(params),
+      code: getWizardSnippet({
+        platform: 'nextjs',
+        params,
+      }),
     },
   ];
 };
@@ -301,7 +299,8 @@ const performanceOnboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: getInstallSnippet(params),
+          code:
+            getInstallConfig(params)?.[0]?.code ?? 'npx @sentry/wizard@latest -i nextjs',
         },
       ],
     },

--- a/static/app/gettingStartedDocs/javascript/nuxt.tsx
+++ b/static/app/gettingStartedDocs/javascript/nuxt.tsx
@@ -28,12 +28,11 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {featureFlagOnboarding} from 'sentry/gettingStartedDocs/javascript/javascript';
 import {t, tct, tctCode} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 
 type Params = DocsParams;
 
-const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-
+const getConfigStep = (params: Params) => {
   return [
     {
       type: StepType.INSTALL,
@@ -47,8 +46,10 @@ const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
       ),
       configurations: [
         {
-          language: 'bash',
-          code: `npx @sentry/wizard@latest -i nuxt ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
+          code: getWizardSnippet({
+            platform: 'nuxt',
+            params,
+          }),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -132,6 +132,12 @@ const getInstallConfig = () => [
         language: 'bash',
         code: 'yarn add @sentry/react',
       },
+      {
+        label: 'pnpm',
+        value: 'pnpm',
+        language: 'bash',
+        code: 'pnpm add @sentry/react',
+      },
     ],
   },
 ];
@@ -141,9 +147,12 @@ const onboarding: OnboardingConfig = {
     <Fragment>
       <MaybeBrowserProfilingBetaWarning {...params} />
       <p>
-        {tct('In this quick guide you’ll use [strong:npm] or [strong:yarn] to set up:', {
-          strong: <strong />,
-        })}
+        {tct(
+          "In this quick guide you'll use [strong:npm], [strong:yarn], or [strong:pnpm] to set up:",
+          {
+            strong: <strong />,
+          }
+        )}
       </p>
     </Fragment>
   ),
@@ -151,7 +160,7 @@ const onboarding: OnboardingConfig = {
     {
       type: StepType.INSTALL,
       description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm] or [code:yarn]:',
+        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
         {code: <code />}
       ),
       configurations: getInstallConfig(),

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -27,12 +27,11 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {featureFlagOnboarding} from 'sentry/gettingStartedDocs/javascript/javascript';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 
 type Params = DocsParams;
 
-const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-
+const getConfigStep = (params: Params) => {
   return [
     {
       description: tct(
@@ -43,8 +42,10 @@ const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
           ),
         }
       ),
-      language: 'bash',
-      code: `npx @sentry/wizard@latest -i remix ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
+      code: getWizardSnippet({
+        platform: 'remix',
+        params,
+      }),
     },
   ];
 };

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -27,12 +27,11 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {featureFlagOnboarding} from 'sentry/gettingStartedDocs/javascript/javascript';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 
 type Params = DocsParams;
 
-const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-
+const getConfigStep = (params: Params) => {
   return [
     {
       type: StepType.INSTALL,
@@ -46,8 +45,10 @@ const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
       ),
       configurations: [
         {
-          language: 'bash',
-          code: `npx @sentry/wizard@latest -i sveltekit ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
+          code: getWizardSnippet({
+            platform: 'sveltekit',
+            params,
+          }),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -19,6 +19,7 @@ import {
   getReplayVerifyStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
+import {getWizardSnippet} from 'sentry/utils/gettingStartedDocs/cliSdkWizard';
 import {getInstallConfig} from 'sentry/utils/gettingStartedDocs/reactNative';
 
 export enum InstallationMode {
@@ -137,14 +138,10 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                code: [
-                  {
-                    label: 'npx',
-                    value: 'npx',
-                    language: 'bash',
-                    code: `npx @sentry/wizard@latest -i reactNative ${params.isSelfHosted ? '' : '--saas'} --org ${params.organization.slug} --project ${params.projectSlug}`,
-                  },
-                ],
+                code: getWizardSnippet({
+                  platform: 'reactNative',
+                  params,
+                }),
               },
               {
                 description: (

--- a/static/app/utils/gettingStartedDocs/cliSdkWizard.spec.tsx
+++ b/static/app/utils/gettingStartedDocs/cliSdkWizard.spec.tsx
@@ -1,0 +1,99 @@
+import {getWizardSnippet} from './cliSdkWizard';
+
+// Mock the getPackageVersion function
+jest.mock('./getPackageVersion', () => ({
+  getPackageVersion: jest.fn(() => '4.2.1'),
+}));
+
+describe('cliSdkWizard', function () {
+  // Create a complete DocsParams mock
+  const mockParams = {
+    api: {},
+    dsn: {
+      public: 'https://example.com',
+      secret: 'secret',
+      projectId: '123',
+    },
+    isFeedbackSelected: false,
+    isPerformanceSelected: false,
+    isProfilingSelected: false,
+    isReplaySelected: false,
+    isSelfHosted: false,
+    organization: {
+      slug: 'test-org',
+    },
+    project: {
+      slug: 'test-project',
+    },
+    projectSlug: 'test-project',
+  } as any; // Cast to any to avoid needing to fully implement DocsParams
+
+  it('generates wizard snippets for JavaScript frameworks', function () {
+    const snippets = getWizardSnippet({
+      platform: 'nextjs',
+      params: mockParams,
+    });
+
+    // Should not include brew for JavaScript frameworks
+    const brewSnippet = snippets.find(snippet => snippet.label === 'brew');
+    expect(brewSnippet).toBeUndefined();
+
+    // Verify the npx snippet
+    const npxSnippet = snippets.find(snippet => snippet.label === 'npx');
+    expect(npxSnippet?.code).toContain(
+      'npx @sentry/wizard@latest -i nextjs --saas --org test-org --project test-project'
+    );
+  });
+
+  it('generates wizard snippets for mobile platforms with brew option', function () {
+    const mobilePlatforms = ['ios', 'android', 'flutter', 'reactNative'];
+
+    mobilePlatforms.forEach(platform => {
+      const snippets = getWizardSnippet({
+        platform,
+        params: mockParams,
+      });
+
+      // Should include brew for mobile platforms
+      const brewSnippet = snippets.find(snippet => snippet.label === 'brew');
+      expect(brewSnippet).toBeDefined();
+      expect(brewSnippet?.code).toContain(`sentry-wizard -i ${platform} --saas`);
+
+      // Verify the npx snippet
+      const npxSnippet = snippets.find(snippet => snippet.label === 'npx');
+      expect(npxSnippet?.code).toContain(
+        `npx @sentry/wizard@latest -i ${platform} --saas`
+      );
+    });
+  });
+
+  it('handles self-hosted environments correctly', function () {
+    const selfHostedParams = {
+      ...mockParams,
+      isSelfHosted: true,
+    };
+
+    const snippets = getWizardSnippet({
+      platform: 'nextjs',
+      params: selfHostedParams,
+    });
+
+    // Should not include the --saas flag
+    const npxSnippet = snippets.find(snippet => snippet.label === 'npx');
+    expect(npxSnippet?.code).not.toContain('--saas');
+    expect(npxSnippet?.code).toContain(
+      'npx @sentry/wizard@latest -i nextjs  --org test-org --project test-project'
+    );
+  });
+
+  it('uses the provided SDK version from the release registry', function () {
+    const snippets = getWizardSnippet({
+      platform: 'nextjs',
+      params: mockParams,
+    });
+
+    // Verify the macOS Intel snippet uses the version from the registry
+    const macosSnippet = snippets.find(snippet => snippet.label === 'macOS (Intel/x64)');
+    expect(macosSnippet?.code).toContain('v4.2.1');
+  });
+});

--- a/static/app/utils/gettingStartedDocs/cliSdkWizard.ts
+++ b/static/app/utils/gettingStartedDocs/cliSdkWizard.ts
@@ -1,33 +1,74 @@
+import type * as React from 'react';
+
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
-export function getWizardInstallSnippet({
+export type PlatformType =
+  // JS Frameworks
+  | 'nextjs'
+  | 'nuxt'
+  | 'sveltekit'
+  | 'remix'
+  // Mobile Platforms
+  | 'ios'
+  | 'android'
+  | 'flutter'
+  | 'reactNative'
+  // Other
+  | 'source-maps'
+  | string;
+
+// Default version to use if sourcePackageRegistries is not available
+const DEFAULT_VERSION = '4.0.1';
+
+/**
+ * Generate wizard installation snippets for any platform
+ */
+export function getWizardSnippet({
   platform,
   params,
 }: {
   params: DocsParams;
-  platform: 'ios' | 'android' | 'flutter' | 'reactNative';
+  platform: PlatformType;
 }) {
   const {isSelfHosted, organization, projectSlug} = params;
   const urlParam = isSelfHosted ? '' : '--saas';
   const platformWithFlags = `${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
 
-  // Get version from registry if available, or use fallback
-  const version = getPackageVersion(params, 'sentry.wizard', '4.0.1');
+  // Use the default version directly if sourcePackageRegistries is missing or incomplete
+  let version = DEFAULT_VERSION;
+
+  // Only try to get the version from registry if we have a complete sourcePackageRegistries object
+  if (
+    params.sourcePackageRegistries &&
+    typeof params.sourcePackageRegistries.isLoading !== 'undefined' &&
+    (params.sourcePackageRegistries.isLoading === false ||
+      params.sourcePackageRegistries.data)
+  ) {
+    version = getPackageVersion(params, 'sentry.wizard', DEFAULT_VERSION);
+  }
 
   return [
-    {
-      label: 'brew',
-      value: 'brew',
-      language: 'bash',
-      code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ${platformWithFlags}`,
-    },
     {
       label: 'npx',
       value: 'npx',
       language: 'bash',
       code: `npx @sentry/wizard@latest -i ${platformWithFlags}`,
     },
+    // Include brew for mobile platforms
+    ...(platform === 'ios' ||
+    platform === 'android' ||
+    platform === 'flutter' ||
+    platform === 'reactNative'
+      ? [
+          {
+            label: 'brew',
+            value: 'brew',
+            language: 'bash',
+            code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ${platformWithFlags}`,
+          },
+        ]
+      : []),
     {
       label: 'macOS (Intel/x64)',
       value: 'macos-x64',
@@ -73,4 +114,27 @@ Invoke-WebRequest $downloadUrl -OutFile sentry-wizard.exe
 ./sentry-wizard.exe -i ${platformWithFlags}`,
     },
   ];
+}
+
+/**
+ * Create a common install configuration for docs
+ */
+export function getWizardConfig(
+  params: DocsParams,
+  platform: PlatformType,
+  options?: {
+    description?: React.ReactNode;
+    onCopy?: () => void;
+    onSelectAndCopy?: () => void;
+  }
+) {
+  return {
+    description: options?.description || '',
+    code: getWizardSnippet({
+      platform,
+      params,
+    }),
+    onCopy: options?.onCopy,
+    onSelectAndCopy: options?.onSelectAndCopy,
+  };
 }

--- a/static/app/utils/gettingStartedDocs/getPackageVersion.ts
+++ b/static/app/utils/gettingStartedDocs/getPackageVersion.ts
@@ -2,7 +2,18 @@ import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import {t} from 'sentry/locale';
 
 export function getPackageVersion(params: DocsParams, name: string, fallback: string) {
-  return params.sourcePackageRegistries.isLoading
-    ? t('loading\u2026')
-    : (params.sourcePackageRegistries.data?.[name]?.version ?? fallback);
+  // Completely defensive check for the entire chain of properties
+  if (!params?.sourcePackageRegistries) {
+    return fallback;
+  }
+
+  if (params.sourcePackageRegistries.isLoading) {
+    return t('loading\u2026');
+  }
+
+  if (!params.sourcePackageRegistries.data) {
+    return fallback;
+  }
+
+  return params.sourcePackageRegistries.data[name]?.version ?? fallback;
 }


### PR DESCRIPTION
- abstracts all logic for creating wizard snippet into one place `cliSdkWizard.ts`
  - there is a `sourcemapsWizard.tsx` which uses all the logic populate the changes whereever the source maps wizard is used
  - all wizards should respect arguments for saas, and org and proiect slugs
- updates all JS metra framework wizard and source maps wizards snippets to have the alternative OS executables
- some hacks to get rid of some errors, around package versions which could be reviewed/removed

Additionally this includes changes to add install by pnpm. This is non-controversial and should probably be added regardless

<img width="830" alt="image" src="https://github.com/user-attachments/assets/0cbb3b97-b9f9-4236-ac12-2764222d9098" />
