### PR TITLE
feat(pipeline) Add pipeline page

### DIFF
--- a/static/app/views/pipeline/index.spec.tsx
+++ b/static/app/views/pipeline/index.spec.tsx
@@ -1,0 +1,39 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PipelinePage from 'sentry/views/pipeline';
+
+const COVERAGE_FEATURE = ['codecov-ui'];
+
+describe('PipelinePage', () => {
+  describe('when the user has access to the feature', () => {
+    it('renders the passed children', () => {
+      render(
+        <PipelinePage>
+          <p>Test content</p>
+        </PipelinePage>,
+        {
+          organization: OrganizationFixture({features: COVERAGE_FEATURE}),
+        }
+      );
+
+      const testContent = screen.getByText('Test content');
+      expect(testContent).toBeInTheDocument();
+    });
+  });
+
+  describe('when the user does not have access to the feature', () => {
+    it('renders the NoAccess component', () => {
+      render(
+        <PipelinePage>
+          <p>Test content</p>
+        </PipelinePage>,
+        {organization: OrganizationFixture({features: []})}
+      );
+
+      const noAccessText = screen.getByText("You don't have access to this feature");
+      expect(noAccessText).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/pipeline/index.tsx
+++ b/static/app/views/pipeline/index.tsx
@@ -1,0 +1,25 @@
+import Feature from 'sentry/components/acl/feature';
+import {NoAccess} from 'sentry/components/noAccess';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import useOrganization from 'sentry/utils/useOrganization';
+import PipelineSecondaryNav from 'sentry/views/pipeline/navigation';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function PipelinePage({children}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['codecov-ui']}
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <NoProjectMessage organization={organization}>
+        <PipelineSecondaryNav>{children}</PipelineSecondaryNav>
+      </NoProjectMessage>
+    </Feature>
+  );
+}


### PR DESCRIPTION
This PR sets up the wrapping page that will be rendered on the upcoming `/pipeline` route.
