### PR TITLE
:wrench: chore(aci): consolidate trigger action flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -480,8 +480,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable notification action for workflow_engine (see: alerts create issues)
-    manager.add("organizations:workflow-engine-notification-action", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new workflow_engine UI (see: alerts create issues)
     manager.add("organizations:workflow-engine-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -465,9 +465,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         key = f"slack:{integration.id}:{channel}"
 
         metrics.incr("notifications.sent", instance="slack.notification", skip_internal=False)
-        if features.has(
-            "organizations:workflow-engine-notification-action", self.project.organization
-        ):
+        if features.has("organizations:workflow-engine-trigger-actions", self.project.organization):
             yield self.future(send_notification_noa, key=key)
         else:
             yield self.future(send_notification, key=key)

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -234,7 +234,7 @@ class SlackService:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)
                 if features.has(
-                    "organizations:workflow-engine-notification-action",
+                    "organizations:workflow-engine-trigger-actions",
                     group.organization,
                 ):
                     parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(
@@ -249,7 +249,7 @@ class SlackService:
                     )
             else:
                 if features.has(
-                    "organizations:workflow-engine-notification-action",
+                    "organizations:workflow-engine-trigger-actions",
                     group.organization,
                 ):
                     parent_notifications = self._notification_action_repository.get_all_parent_notification_messages_by_filters(

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -428,7 +428,7 @@ def send_incident_alert_notification(
         notification_uuid=notification_uuid,
     )
 
-    if features.has("organizations:workflow-engine-notification-action", organization):
+    if features.has("organizations:workflow-engine-trigger-actions", organization):
         return _handle_workflow_engine_notification(
             organization=organization,
             notification_context=notification_context,

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -302,7 +302,7 @@ class TestInit(RuleTestCase):
             SLACK_DATADOG_METRIC, sample_rate=1.0, tags={"ok": False, "status": 200}
         )
 
-    @with_feature("organizations:workflow-engine-notification-action")
+    @with_feature("organizations:workflow-engine-trigger-actions")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
@@ -340,7 +340,7 @@ class TestInit(RuleTestCase):
         assert send_notification_start.args[0] == EventLifecycleOutcome.STARTED
         assert send_notification_success.args[0] == EventLifecycleOutcome.SUCCESS
 
-    @with_feature("organizations:workflow-engine-notification-action")
+    @with_feature("organizations:workflow-engine-trigger-actions")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
@@ -376,7 +376,7 @@ class TestInit(RuleTestCase):
         assert send_notification_start.args[0] == EventLifecycleOutcome.STARTED
         assert send_notification_success.args[0] == EventLifecycleOutcome.SUCCESS
 
-    @with_feature("organizations:workflow-engine-notification-action")
+    @with_feature("organizations:workflow-engine-trigger-actions")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -344,7 +344,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
             self.service.notify_all_threads_for_activity(activity=self.activity)
             mock_notify.assert_called_once()
 
-    @with_feature("organizations:workflow-engine-notification-action")
+    @with_feature("organizations:workflow-engine-trigger-actions")
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch(
         "sentry.integrations.slack.service.SlackService._send_notification_to_slack_channel"
@@ -385,7 +385,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
 
     @with_feature(
         {
-            "organizations:workflow-engine-notification-action": True,
+            "organizations:workflow-engine-trigger-actions": True,
             "organizations:slack-threads-refactor-uptime": True,
         }
     )


### PR DESCRIPTION
milestone 2 and milestone 4 both introduces flags to represent when we called `action.trigger`.

here, i replace the flag milestone 2 created with the flag milestone 4 created to make things simpler.