### PR TITLE
feat(explore): Convert sample and aggregate table queries to progressive loading

### DIFF
--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -13,7 +13,7 @@ import {
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {
   QUERY_MODE,
-  type SpanRPCQueryExtras,
+  type SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useProgressiveQuery} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
@@ -22,7 +22,7 @@ interface UseExploreAggregatesTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
-  queryExtras?: SpanRPCQueryExtras;
+  queryExtras?: SpansRPCQueryExtras;
 }
 
 export interface AggregatesTableResult {

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -11,12 +11,18 @@ import {
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {
+  QUERY_MODE,
+  type SpanRPCQueryExtras,
+} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {useProgressiveQuery} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreAggregatesTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
+  queryExtras?: SpanRPCQueryExtras;
 }
 
 export interface AggregatesTableResult {
@@ -29,6 +35,19 @@ export function useExploreAggregatesTable({
   enabled,
   limit,
   query,
+}: UseExploreAggregatesTableOptions) {
+  return useProgressiveQuery<typeof useExploreAggregatesTableImp>({
+    queryHookImplementation: useExploreAggregatesTableImp,
+    queryHookArgs: {enabled, limit, query},
+    queryMode: QUERY_MODE.SERIAL,
+  });
+}
+
+function useExploreAggregatesTableImp({
+  enabled,
+  limit,
+  query,
+  queryExtras,
 }: UseExploreAggregatesTableOptions): AggregatesTableResult {
   const {selection} = usePageFilters();
 
@@ -89,6 +108,7 @@ export function useExploreAggregatesTable({
     limit,
     referrer: 'api.explore.spans-aggregates-table',
     trackResponseAnalytics: false,
+    queryExtras,
   });
 
   return useMemo(() => {

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -32,7 +32,7 @@ export function useExploreSpansTable({
   enabled,
   limit,
   query,
-}: UseExploreSpansTableOptions): SpansTableResult {
+}: UseExploreSpansTableOptions) {
   return useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
     queryHookArgs: {enabled, limit, query},

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -9,12 +9,18 @@ import {
   useExploreFields,
   useExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
+import {
+  QUERY_MODE,
+  type SpanRPCQueryExtras,
+  useProgressiveQuery,
+} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreSpansTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
+  queryExtras?: SpanRPCQueryExtras;
 }
 
 export interface SpansTableResult {
@@ -26,6 +32,19 @@ export function useExploreSpansTable({
   enabled,
   limit,
   query,
+}: UseExploreSpansTableOptions): SpansTableResult {
+  return useProgressiveQuery<typeof useExploreSpansTableImp>({
+    queryHookImplementation: useExploreSpansTableImp,
+    queryHookArgs: {enabled, limit, query},
+    queryMode: QUERY_MODE.SERIAL,
+  });
+}
+
+function useExploreSpansTableImp({
+  enabled,
+  limit,
+  query,
+  queryExtras,
 }: UseExploreSpansTableOptions): SpansTableResult {
   const {selection} = usePageFilters();
 
@@ -76,6 +95,7 @@ export function useExploreSpansTable({
     referrer: 'api.explore.spans-samples-table',
     allowAggregateConditions: false,
     trackResponseAnalytics: false,
+    queryExtras,
   });
 
   return useMemo(() => {

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -11,7 +11,7 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {
   QUERY_MODE,
-  type SpanRPCQueryExtras,
+  type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
@@ -20,7 +20,7 @@ interface UseExploreSpansTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
-  queryExtras?: SpanRPCQueryExtras;
+  queryExtras?: SpansRPCQueryExtras;
 }
 
 export interface SpansTableResult {

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -16,7 +16,7 @@ import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBy
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
   QUERY_MODE,
-  type SpanRPCQueryExtras,
+  type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
@@ -25,7 +25,7 @@ import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSorte
 interface UseExploreTimeseriesOptions {
   enabled: boolean;
   query: string;
-  queryExtras?: SpanRPCQueryExtras;
+  queryExtras?: SpansRPCQueryExtras;
 }
 
 interface UseExploreTimeseriesResults {

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -16,7 +16,7 @@ import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBy
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
   QUERY_MODE,
-  type SamplingMode,
+  type SpanRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
@@ -25,9 +25,7 @@ import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSorte
 interface UseExploreTimeseriesOptions {
   enabled: boolean;
   query: string;
-  queryExtras?: {
-    samplingMode?: SamplingMode;
-  };
+  queryExtras?: SpanRPCQueryExtras;
 }
 
 interface UseExploreTimeseriesResults {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -20,7 +20,7 @@ const HIGH_SAMPLING_MODE_QUERY_EXTRAS = {
 
 export type QueryMode = (typeof QUERY_MODE)[keyof typeof QUERY_MODE];
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
-export type SpanRPCQueryExtras = {
+export type SpansRPCQueryExtras = {
   samplingMode?: SamplingMode;
 };
 

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -20,6 +20,9 @@ const HIGH_SAMPLING_MODE_QUERY_EXTRAS = {
 
 export type QueryMode = (typeof QUERY_MODE)[keyof typeof QUERY_MODE];
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
+export type SpanRPCQueryExtras = {
+  samplingMode?: SamplingMode;
+};
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {
   queryHookArgs: Parameters<TQueryFn>[0];

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -9,7 +9,7 @@ import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBy
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
   QUERY_MODE,
-  type SpanRPCQueryExtras,
+  type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
@@ -21,7 +21,7 @@ import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSorte
 interface UseMultiQueryTimeseriesOptions {
   enabled: boolean;
   index: number;
-  queryExtras?: SpanRPCQueryExtras;
+  queryExtras?: SpansRPCQueryExtras;
 }
 
 export interface UseMultiQueryTimeseriesResults {

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -9,7 +9,7 @@ import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBy
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
   QUERY_MODE,
-  type SamplingMode,
+  type SpanRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
@@ -21,9 +21,7 @@ import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSorte
 interface UseMultiQueryTimeseriesOptions {
   enabled: boolean;
   index: number;
-  queryExtras?: {
-    samplingMode?: SamplingMode;
-  };
+  queryExtras?: SpanRPCQueryExtras;
 }
 
 export interface UseMultiQueryTimeseriesResults {

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -182,6 +182,14 @@ export function SpansTabContentImpl({
         ? spansTableResult.result.isPending
         : tracesTableResult.result.isPending;
 
+  const tableIsProgressivelyLoading =
+    organization.features.includes('visibility-explore-progressive-loading') &&
+    (queryType === 'samples'
+      ? spansTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+      : queryType === 'aggregate'
+        ? aggregatesTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+        : false);
+
   return (
     <Body
       withToolbar={expanded}
@@ -276,6 +284,7 @@ export function SpansTabContentImpl({
             confidences={confidences}
             samplesTab={samplesTab}
             setSamplesTab={setSamplesTab}
+            isProgressivelyLoading={tableIsProgressivelyLoading}
           />
           <Toggle>
             <StyledButton

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -20,6 +20,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 import {
   Table,
   TableBody,
@@ -46,9 +47,13 @@ import {FieldRenderer} from './fieldRenderer';
 
 interface AggregatesTableProps {
   aggregatesTableResult: AggregatesTableResult;
+  isProgressivelyLoading: boolean;
 }
 
-export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
+export function AggregatesTable({
+  aggregatesTableResult,
+  isProgressivelyLoading,
+}: AggregatesTableProps) {
   const location = useLocation();
   const {projects} = useProjects();
 
@@ -84,7 +89,9 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
         <TableHead>
           <TableRow>
             <TableHeadCell isFirst={false}>
-              <TableHeadCellContent />
+              <TableHeadCellContent>
+                {getProgressiveLoadingIndicator(isProgressivelyLoading)}
+              </TableHeadCellContent>
             </TableHeadCell>
             {fields.map((field, i) => {
               // Hide column names before alignment is determined

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -26,13 +26,13 @@ import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface BaseExploreTablesProps {
   confidences: Confidence[];
+  isProgressivelyLoading: boolean;
   samplesTab: Tab;
   setSamplesTab: (tab: Tab) => void;
 }
 
 interface ExploreTablesProps extends BaseExploreTablesProps {
   aggregatesTableResult: AggregatesTableResult;
-  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
 }
@@ -50,7 +50,6 @@ export function ExploreTables(props: ExploreTablesProps) {
 
 interface AggregatesExploreTablesProps extends BaseExploreTablesProps {
   aggregatesTableResult: AggregatesTableResult;
-  isProgressivelyLoading: boolean;
 }
 
 function ExploreAggregatesTable(props: AggregatesExploreTablesProps) {
@@ -58,7 +57,6 @@ function ExploreAggregatesTable(props: AggregatesExploreTablesProps) {
 }
 
 interface SamplesExploreTablesProps extends BaseExploreTablesProps {
-  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
 }

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -32,6 +32,7 @@ interface BaseExploreTablesProps {
 
 interface ExploreTablesProps extends BaseExploreTablesProps {
   aggregatesTableResult: AggregatesTableResult;
+  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
 }
@@ -49,6 +50,7 @@ export function ExploreTables(props: ExploreTablesProps) {
 
 interface AggregatesExploreTablesProps extends BaseExploreTablesProps {
   aggregatesTableResult: AggregatesTableResult;
+  isProgressivelyLoading: boolean;
 }
 
 function ExploreAggregatesTable(props: AggregatesExploreTablesProps) {
@@ -56,6 +58,7 @@ function ExploreAggregatesTable(props: AggregatesExploreTablesProps) {
 }
 
 interface SamplesExploreTablesProps extends BaseExploreTablesProps {
+  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
 }

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -10,6 +10,7 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {fieldAlignment, prettifyTagKey} from 'sentry/utils/discover/fields';
+import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 import {
   Table,
   TableBody,
@@ -32,10 +33,11 @@ import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansT
 import {FieldRenderer} from './fieldRenderer';
 
 interface SpansTableProps {
+  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
 }
 
-export function SpansTable({spansTableResult}: SpansTableProps) {
+export function SpansTable({spansTableResult, isProgressivelyLoading}: SpansTableProps) {
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();
   const setSortBys = useSetExploreSortBys();
@@ -91,6 +93,7 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
                     <Tooltip showOnlyOnOverflow title={label}>
                       {label}
                     </Tooltip>
+                    {i === 0 && getProgressiveLoadingIndicator(isProgressivelyLoading)}
                     {defined(direction) && (
                       <IconArrow
                         size="xs"

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -13,7 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {
   SamplingMode,
-  SpanRPCQueryExtras,
+  SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
   getRetryDelay,
@@ -40,7 +40,7 @@ export function useSpansQuery<T = any[]>({
   eventView?: EventView;
   initialData?: T;
   limit?: number;
-  queryExtras?: SpanRPCQueryExtras;
+  queryExtras?: SpansRPCQueryExtras;
   referrer?: string;
   trackResponseAnalytics?: boolean;
 }) {


### PR DESCRIPTION
Refactors the `useExploreAggregatesTable`, `useExploreSpansTable`, and related components to support progressive loading and improve query handling. I've added a reusable type for the query extras we can use for spans, updated the table hooks to use the `useProgressiveLoading` hook, and added some UI loaders to indicate that we're still fetching more data.

