### PR TITLE
:wrench: chore(integration slos): fix gitlab `check_file` slos

### DIFF
--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -23,7 +23,13 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
-from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiRateLimitedError
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiHostError,
+    ApiRateLimitedError,
+    ApiRetryError,
+)
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
@@ -188,7 +194,8 @@ class GitlabRefreshAuthTest(GitLabClientTest):
         assert responses.calls[0].response.status_code == 404
 
     @responses.activate
-    def test_get_stacktrace_link(self):
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_get_stacktrace_link(self, mock_record):
         path = "/src/file.py"
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
@@ -202,13 +209,48 @@ class GitlabRefreshAuthTest(GitLabClientTest):
             source_url
             == "https://example.gitlab.com/example-repo/blob/537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3/src/file.py"
         )
+        assert (
+            len(mock_record.mock_calls) == 4
+        )  # get_stacktrace_link calls check_file, which also has metrics
+        start1, start2, halt1, halt2 = mock_record.mock_calls
+        assert start1.args[0] == EventLifecycleOutcome.STARTED
+        assert start2.args[0] == EventLifecycleOutcome.STARTED  # check_file
+        assert halt1.args[0] == EventLifecycleOutcome.SUCCESS  # check_file
+        assert halt2.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.gitlab.client.GitLabApiClient.check_file",
+        side_effect=ApiRetryError(text="retry error"),
+    )
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_get_stacktrace_link_retry_error(self, mock_record, mock_check_file):
+        path = "/src/file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+        responses.add(
+            responses.HEAD,
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
+            json={"text": 200},
+        )
+
+        source_url = self.installation.get_stacktrace_link(self.repo, path, "master", None)
+        assert source_url is None
+        assert (
+            len(mock_record.mock_calls) == 4
+        )  # get_stacktrace_link calls check_file, which also has metrics
+        start1, start2, halt1, halt2 = mock_record.mock_calls
+        assert start1.args[0] == EventLifecycleOutcome.STARTED
+        assert start2.args[0] == EventLifecycleOutcome.STARTED  # check_file
+        assert halt1.args[0] == EventLifecycleOutcome.HALTED  # check_file
+        assert halt2.args[0] == EventLifecycleOutcome.SUCCESS
 
     @mock.patch(
         "sentry.integrations.gitlab.integration.GitlabIntegration.check_file",
         return_value=GITLAB_CODEOWNERS["html_url"],
     )
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
-    def test_get_codeowner_file(self, mock_check_file):
+    def test_get_codeowner_file(self, mock_record, mock_check_file):
         self.config = self.create_code_mapping(
             repo=self.repo,
             project=self.project,
@@ -223,6 +265,12 @@ class GitlabRefreshAuthTest(GitLabClientTest):
         )
 
         assert result == GITLAB_CODEOWNERS
+
+        assert (
+            len(mock_record.mock_calls) == 2
+        )  # check_file is mocked in this test, so there will be no metrics logged for it
+        assert mock_record.mock_calls[0].args[0] == EventLifecycleOutcome.STARTED
+        assert mock_record.mock_calls[1].args[0] == EventLifecycleOutcome.SUCCESS
 
     @responses.activate
     def test_get_commit(self):


### PR DESCRIPTION
similar to the fix made for `get_blame_for_files`, we record halts for `check_file` as well for the same `ApiRetryError`

i also added slo tests for gitlab since they were missing

relates to https://github.com/getsentry/sentry/pull/87785

closes: https://linear.app/getsentry/issue/ECO-369/fix-gitlab-slos