### PR TITLE
ref: avoid registering / unregistering fly oauth provider

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -1,8 +1,6 @@
 from django.urls import reverse
 
-from sentry import auth
 from sentry.auth.partnership_configs import ChannelName
-from sentry.auth.providers.fly.provider import FlyOAuth2Provider, NonPartnerFlyOAuth2Provider
 from sentry.testutils.cases import APITestCase, PermissionTestCase
 
 
@@ -28,11 +26,6 @@ class OrganizationAuthProviders(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-        auth.register(FlyOAuth2Provider)
-        self.addCleanup(auth.unregister, FlyOAuth2Provider)
-
-        auth.register(NonPartnerFlyOAuth2Provider)
-        self.addCleanup(auth.unregister, NonPartnerFlyOAuth2Provider)
 
     def test_get_list_of_auth_providers(self):
         with self.feature("organizations:sso-basic"):

--- a/tests/sentry/auth/providers/fly/test_provider.py
+++ b/tests/sentry/auth/providers/fly/test_provider.py
@@ -11,13 +11,13 @@ from sentry.testutils.silo import control_silo_test
 @control_silo_test
 class FlyOAuth2ProviderTest(TestCase):
     def setUp(self):
-        self.auth_provider: AuthProvider = AuthProvider.objects.create(
+        self.auth_provider = AuthProvider.objects.create(
             provider=ChannelName.FLY_IO.value, organization_id=self.organization.id
         )
         super().setUp()
 
     def test_refresh_identity_without_refresh_token(self):
-        auth_identity: AuthIdentity = AuthIdentity.objects.create(
+        auth_identity = AuthIdentity.objects.create(
             auth_provider=self.auth_provider, user=self.user, data={"access_token": "access_token"}
         )
 
@@ -81,6 +81,6 @@ class FlyOAuth2ProviderTest(TestCase):
 @control_silo_test
 class NonPartnerFlyOAuth2ProviderTest(FlyOAuth2ProviderTest):
     def setUp(self):
-        self.auth_provider: AuthProvider = AuthProvider.objects.create(
+        self.auth_provider = AuthProvider.objects.create(
             provider=ChannelName.FLY_NON_PARTNER.value, organization_id=self.organization.id
         )

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -5,7 +5,7 @@ from django.core import mail
 from django.db import models
 from django.urls import reverse
 
-from sentry import audit_log, auth
+from sentry import audit_log
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.providers.dummy import (
@@ -13,7 +13,6 @@ from sentry.auth.providers.dummy import (
     DummySAML2Provider,
     dummy_provider_config,
 )
-from sentry.auth.providers.fly.provider import FlyOAuth2Provider
 from sentry.auth.providers.saml2.generic.provider import GenericSAML2Provider
 from sentry.auth.providers.saml2.provider import Attributes
 from sentry.models.auditlogentry import AuditLogEntry
@@ -170,10 +169,6 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
             assert not getattr(member.flags, "sso:invalid")
 
     def create_org_and_auth_provider(self, provider_name="dummy"):
-        if provider_name == "fly":
-            auth.register(FlyOAuth2Provider)
-            self.addCleanup(auth.unregister, FlyOAuth2Provider)
-
         self.user.update(is_managed=True)
         with assume_test_silo_mode(SiloMode.REGION):
             organization = self.create_organization(name="foo", owner=self.user)


### PR DESCRIPTION
it is always registered so when the test re-registers and then un-registers it breaks other tests!

<!-- Describe your PR here. -->