### PR TITLE
fix(schema-hints): Add colour to tag badges in drawer

### DIFF
--- a/static/app/views/explore/components/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHintsDrawer.tsx
@@ -102,8 +102,9 @@ function SchemaHintsDrawer({
     (hint: Tag) => {
       const filterQuery = new MutableSearch(currentQuery);
       if (
-        filterQuery.getFilterKeys().includes(hint.key) ||
-        filterQuery.getFilterKeys().includes(`!${hint.key}`)
+        filterQuery
+          .getFilterKeys()
+          .some(key => key === hint.key || key === `!${hint.key}`)
       ) {
         // remove hint and/or negated hint if it exists
         filterQuery.removeFilter(hint.key);

--- a/static/app/views/explore/components/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHintsDrawer.tsx
@@ -136,11 +136,13 @@ function SchemaHintsDrawer({
     const hintFieldDefinition = getFieldDefinition(hint.key, 'span', hint.kind);
 
     const hintType =
-      hintFieldDefinition?.valueType === FieldValueType.BOOLEAN
-        ? t('boolean')
-        : hint.kind === FieldKind.MEASUREMENT
-          ? t('number')
-          : t('string');
+      hintFieldDefinition?.valueType === FieldValueType.BOOLEAN ? (
+        <Badge type="default">{t('boolean')}</Badge>
+      ) : hint.kind === FieldKind.MEASUREMENT ? (
+        <Badge type="success">{t('number')}</Badge>
+      ) : (
+        <Badge type="highlight">{t('string')}</Badge>
+      );
 
     return (
       <div ref={virtualizer.measureElement} data-index={index}>
@@ -153,7 +155,7 @@ function SchemaHintsDrawer({
             <Tooltip title={prettifyTagKey(hint.key)} showOnlyOnOverflow skipWrapper>
               <CheckboxLabel>{prettifyTagKey(hint.key)}</CheckboxLabel>
             </Tooltip>
-            <Badge>{hintType}</Badge>
+            {hintType}
           </CheckboxLabelContainer>
         </StyledMultipleCheckboxItem>
       </div>


### PR DESCRIPTION
Addressing [this bug](https://www.notion.so/sentry/can-we-give-String-and-number-pills-different-colours-1c08b10e4b5d80f0bdb3f77d264e67de?pvs=4) from the bug bash. Made the badge colours the same as the tags in the sort by dropdown. 

<img width="349" alt="image" src="https://github.com/user-attachments/assets/65d92e29-456c-4bcc-972b-50aec7000c2a" />

