### PR TITLE
fix(taskworker) Make shared secret a list

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1386,12 +1386,13 @@ BGTASKS = {
 
 # Shared secrets used to sign RPC requests to taskbrokers
 # The first secret is used for signing.
-TASKWORKER_SHARED_SECRET: list[str] | None = env(
-    "TASKWORKER_SHARED_SECRET", default=None, type=env_types.List
-)
+# Environment variable is expected to be a JSON encoded list
+TASKWORKER_SHARED_SECRET = os.getenv("TASKWORKER_SHARED_SECRET")
 
 TASKWORKER_ROUTER: str = "sentry.taskworker.router.DefaultRouter"
-TASKWORKER_ROUTES: dict[str, str] = env("TASKWORKER_ROUTES", default={}, type=env_types.Dict)
+
+# Expected to be a JSON encoded dictionary of namespace:topic
+TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 
 # The list of modules that workers will import after starting up
 # Like celery, taskworkers need to import task modules to make tasks

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1381,8 +1381,9 @@ BGTASKS = {
 }
 
 # Taskworker settings #
-# Shared secret used to sign RPC requests to taskbrokers
-TASKWORKER_SHARED_SECRET: str | None = None
+# Shared secrets used to sign RPC requests to taskbrokers
+# The first secret is used for signing.
+TASKWORKER_SHARED_SECRET: list[str] | None = None
 
 # The list of modules that workers will import after starting up
 # Like celery, taskworkers need to import task modules to make tasks

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -405,12 +405,13 @@ def taskbroker_send_tasks(
     kafka_topic: str,
     namespace: str,
 ) -> None:
-    from sentry.conf.server import KAFKA_CLUSTERS, TASKWORKER_ROUTES
+    from sentry import options
+    from sentry.conf.server import KAFKA_CLUSTERS
     from sentry.utils.imports import import_string
 
     KAFKA_CLUSTERS["default"]["common"]["bootstrap.servers"] = bootstrap_servers
     if kafka_topic and namespace:
-        TASKWORKER_ROUTES[namespace] = kafka_topic
+        options.set("taskworker.route.overrides", {namespace: kafka_topic})
 
     try:
         func = import_string(task_function_path)

--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -55,8 +55,8 @@ else:
 
 
 class RequestSignatureInterceptor(InterceptorBase):
-    def __init__(self, shared_secret: str):
-        self._secret = shared_secret.encode("utf-8")
+    def __init__(self, shared_secret: list[str]):
+        self._secret = shared_secret[0].encode("utf-8")
 
     def intercept_unary_unary(
         self,

--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -19,7 +19,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2_grpc import ConsumerServiceStub
 
 from sentry import options
 from sentry.taskworker.constants import DEFAULT_REBALANCE_AFTER
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 logger = logging.getLogger("sentry.taskworker.client")
 
@@ -117,9 +117,8 @@ class TaskworkerClient:
         logger.info("Connecting to %s with options %s", host, self._grpc_options)
         channel = grpc.insecure_channel(host, options=self._grpc_options)
         if settings.TASKWORKER_SHARED_SECRET:
-            channel = grpc.intercept_channel(
-                channel, RequestSignatureInterceptor(settings.TASKWORKER_SHARED_SECRET)
-            )
+            secrets = json.loads(settings.TASKWORKER_SHARED_SECRET)
+            channel = grpc.intercept_channel(channel, RequestSignatureInterceptor(secrets))
         return ConsumerServiceStub(channel)
 
     def _get_all_hosts(self, pattern: str, num_brokers: int) -> list[str]:

--- a/src/sentry/taskworker/router.py
+++ b/src/sentry/taskworker/router.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Protocol
 
 from django.conf import settings
@@ -17,18 +16,17 @@ class DefaultRouter:
 
     _route_map: dict[str, str]
 
-    @cached_property
-    def _routes(self) -> dict[str, str]:
+    def __init__(self) -> None:
         try:
             routes = json.loads(settings.TASKWORKER_ROUTES)
         except Exception:
             routes = {}
-        return routes
+        self._route_map = routes
 
     def route_namespace(self, name: str) -> Topic:
         overrides = options.get("taskworker.route.overrides")
         if name in overrides:
             return Topic(overrides[name])
-        if name in self._routes:
-            return Topic(self._routes[name])
+        if name in self._route_map:
+            return Topic(self._route_map[name])
         return Topic.TASKWORKER

--- a/src/sentry/taskworker/router.py
+++ b/src/sentry/taskworker/router.py
@@ -1,9 +1,11 @@
+from functools import cached_property
 from typing import Protocol
 
 from django.conf import settings
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic
+from sentry.utils import json
 
 
 class TaskRouter(Protocol):
@@ -13,10 +15,20 @@ class TaskRouter(Protocol):
 class DefaultRouter:
     """Router that uses django settings and options to select topics at runtime"""
 
+    _route_map: dict[str, str]
+
+    @cached_property
+    def _routes(self) -> dict[str, str]:
+        try:
+            routes = json.loads(settings.TASKWORKER_ROUTES)
+        except Exception:
+            routes = {}
+        return routes
+
     def route_namespace(self, name: str) -> Topic:
         overrides = options.get("taskworker.route.overrides")
         if name in overrides:
             return Topic(overrides[name])
-        if name in settings.TASKWORKER_ROUTES:
-            return Topic(settings.TASKWORKER_ROUTES[name])
+        if name in self._routes:
+            return Topic(self._routes[name])
         return Topic.TASKWORKER

--- a/src/sentry/taskworker/router.py
+++ b/src/sentry/taskworker/router.py
@@ -1,6 +1,7 @@
 from typing import Protocol
 
 from django.conf import settings
+from sentry_sdk import capture_exception
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic
@@ -17,10 +18,12 @@ class DefaultRouter:
     _route_map: dict[str, str]
 
     def __init__(self) -> None:
-        try:
-            routes = json.loads(settings.TASKWORKER_ROUTES)
-        except Exception:
-            routes = {}
+        routes = {}
+        if settings.TASKWORKER_ROUTES:
+            try:
+                routes = json.loads(settings.TASKWORKER_ROUTES)
+            except Exception as err:
+                capture_exception(err)
         self._route_map = routes
 
     def route_namespace(self, name: str) -> Topic:

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -131,7 +131,7 @@ def test_get_task_ok():
 
 
 @django_db_all
-@override_settings(TASKWORKER_SHARED_SECRET=["a long secret value", "notused"])
+@override_settings(TASKWORKER_SHARED_SECRET='["a long secret value","notused"]')
 def test_get_task_with_interceptor():
     channel = MockChannel()
     channel.add_response(

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -131,7 +131,7 @@ def test_get_task_ok():
 
 
 @django_db_all
-@override_settings(TASKWORKER_SHARED_SECRET="a long secret value")
+@override_settings(TASKWORKER_SHARED_SECRET=["a long secret value", "notused"])
 def test_get_task_with_interceptor():
     channel = MockChannel()
     channel.add_response(

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -282,11 +282,7 @@ def test_registry_create_namespace_simple() -> None:
 
 @pytest.mark.django_db
 def test_registry_create_namespace_route_setting() -> None:
-    routes = {
-        "profiling": "profiles",
-        "lol": "nope",
-    }
-    with override_settings(TASKWORKER_ROUTES=routes):
+    with override_settings(TASKWORKER_ROUTES='{"profiling":"profiles", "lol":"nope"}'):
         registry = TaskRegistry()
 
         # namespaces without routes resolve to the default topic.


### PR DESCRIPTION
To simplify config management this value should be a list, as it will align with the types used in brokers.