### PR TITLE
fix(tour): Prevent interactions with page during tour

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -543,7 +543,6 @@ const BlurWindow = styled('div')`
   inset: 0;
   z-index: ${p => p.theme.zIndex.tour.blur};
   user-select: none;
-  pointer-events: none;
   backdrop-filter: blur(3px);
 `;
 


### PR DESCRIPTION
This removes the `pointer-events: none` style on the tour blur window. This fixes an issue where the user was able to click on buttons under the blurred area of the page.

@leeandher LMK if I'm missing something or if allowing interactions was intended!