### PR TITLE
:wrench: chore(sentry apps): remove sentry_app  auto disable

### DIFF
--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -8,7 +8,7 @@ from slack_sdk.web import SlackResponse
 
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
-from sentry.integrations.base import disable_integration, is_response_error, is_response_success
+from sentry.integrations.base import is_response_error, is_response_success
 from sentry.integrations.models import Integration
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.integrations.services.integration import integration_service
@@ -63,7 +63,14 @@ def record_response_for_disabling_integration(response: SlackResponse, integrati
         if is_response_error(response):
             buffer.record_error()
     if buffer.is_integration_broken():
-        disable_integration(buffer, redis_key, integration_id)
+        # disable_integration(buffer, redis_key, integration_id)
+        logger.info(
+            "integration.should_disable",
+            extra={
+                "integration_id": integration_id,
+                "broken_range_day_counts": buffer._get_broken_range_from_buffer(),
+            },
+        )
 
 
 def wrapper(method: FunctionType):

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -63,6 +63,7 @@ def record_response_for_disabling_integration(response: SlackResponse, integrati
         if is_response_error(response):
             buffer.record_error()
     if buffer.is_integration_broken():
+        # TODO(ecosystem): We should delete this feature of fix it
         # disable_integration(buffer, redis_key, integration_id)
         logger.info(
             "integration.should_disable",

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -422,6 +422,7 @@ class BaseApiClient:
             if is_response_error(response):
                 buffer.record_error()
         if buffer.is_integration_broken():
+            # TODO(ecosystem): We should delete this feature of fix it
             # disable_integration(buffer, redis_key, self.integration_id)
             self.logger.info(
                 "integration.should_disable",
@@ -441,6 +442,7 @@ class BaseApiClient:
         else:
             buffer.record_error()
         if buffer.is_integration_broken():
+            # TODO(ecosystem): We should delete this feature of fix it
             # disable_integration(buffer, redis_key, self.integration_id)
             self.logger.info(
                 "integration.should_disable",

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1368,6 +1368,7 @@ class TestWebhookRequests(TestCase):
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", side_effect=Timeout)
     @override_settings(BROKEN_TIMEOUT_THRESHOLD=3)
+    @pytest.mark.skip(reason="Feature is temporarily disabled")
     def test_timeout_disable(self, safe_urlopen):
         """
         Test that the integration is disabled after BROKEN_TIMEOUT_THRESHOLD number of timeouts
@@ -1412,6 +1413,7 @@ class TestWebhookRequests(TestCase):
     @patch(
         "sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockFailureResponseInstance
     )
+    @pytest.mark.skip(reason="Feature is temporarily disabled")
     def test_slow_should_disable(self, safe_urlopen):
         """
         Tests that the integration is broken after 7 days of errors and disabled


### PR DESCRIPTION
This feature is buggy and doesn't use the organization_service to fetch an org.

from previous change to disable other parts of this feature
> We've seen two reported cases where this is not behaving as expected. 

Here, i disable the feature and add logging incase we want to investigate this apps in the future

continues https://github.com/getsentry/sentry/pull/73295

fixes https://sentry.sentry.io/issues/6383663640/