### PR TITLE
fix(nav): Fix traces link to go to /explore/ when new nav is enabled

### DIFF
--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -53,7 +53,7 @@ function getBaseTraceUrl(
         ? getPerformanceBaseUrl(organization.slug, view, true)
         : source && source in routesMap
           ? routesMap[source]
-          : 'traces'
+          : routesMap.traces
     }`
   );
 }


### PR DESCRIPTION
Using the route map here should return `traces` with the old nav and `explore/traces` with the new nav.

Bad link found here: https://sentry.sentry.io/issues/6337892209/events/3789d081a9934144a5c29328e124ac95/