### PR TITLE
feat(taskworker) Make deletions tasks taskworker compatible

### DIFF
--- a/src/sentry/deletions/tasks/__init__.py
+++ b/src/sentry/deletions/tasks/__init__.py
@@ -1,0 +1,13 @@
+from sentry.taskworker.registry import taskregistry
+
+deletiontasks = taskregistry.create_namespace(
+    "deletions",
+    # Deletions can take several minutes, so we have a long processing deadline.
+    processing_deadline_duration=60 * 3,
+)
+
+deletioncontroltasks = taskregistry.create_namespace(
+    "deletions.control",
+    # Deletions can take several minutes, so we have a long processing deadline.
+    processing_deadline_duration=60 * 3,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3152,3 +3152,13 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "taskworker.deletions.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "taskworker.deletions.control.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
- Remove countdown - this behavior isn't provided by taskworker yet, and we don't really need it for celery either.
- Switch to delay() as it is simpler.
- Add namespaces for deletions, and rollout options.

Refs #88091
