### PR TITLE
fix(billing): Add profile duration categories to on-demand parser

### DIFF
--- a/static/gsApp/views/onDemandBudgets/utils.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.spec.tsx
@@ -153,6 +153,8 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
         attachmentsBudget: 300,
         monitorSeatsBudget: 400,
         replaysBudget: 0,
+        profileDurationBudget: 0,
+        profileDurationUIBudget: 0,
         budgets: {
           errors: 100,
           transactions: 200,
@@ -160,6 +162,8 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
           replays: 0,
           monitorSeats: 400,
           uptime: 500,
+          profileDuration: 0,
+          profileDurationUI: 0,
         },
         attachmentSpendUsed: 0,
         errorSpendUsed: 0,
@@ -171,6 +175,8 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
           replays: 0,
           monitorSeats: 0,
           uptime: 0,
+          profileDuration: 0,
+          profileDurationUI: 0,
         },
       },
     });
@@ -188,6 +194,8 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
       monitorSeatsBudget: 400,
       uptimeBudget: 500,
       replaysBudget: 0,
+      profileDurationBudget: 0,
+      profileDurationUIBudget: 0,
       budgets: {
         errors: 100,
         transactions: 200,
@@ -195,6 +203,8 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
         replays: 0,
         monitorSeats: 400,
         uptime: 500,
+        profileDuration: 0,
+        profileDurationUI: 0,
       },
     });
   });

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -46,6 +46,8 @@ export function parseOnDemandBudgets(
       replaysBudget: onDemandBudgets.budgets.replays ?? 0,
       monitorSeatsBudget: onDemandBudgets.budgets.monitorSeats ?? 0,
       uptimeBudget: onDemandBudgets.budgets.uptime ?? 0,
+      profileDurationBudget: onDemandBudgets.budgets.profileDuration ?? 0,
+      profileDurationUIBudget: onDemandBudgets.budgets.profileDurationUI ?? 0,
       budgets: {
         errors: onDemandBudgets.budgets.errors,
         transactions: onDemandBudgets.budgets.transactions,
@@ -53,6 +55,8 @@ export function parseOnDemandBudgets(
         replays: onDemandBudgets.budgets.replays,
         monitorSeats: onDemandBudgets.budgets.monitorSeats,
         uptime: onDemandBudgets.budgets.uptime,
+        profileDuration: onDemandBudgets.budgets.profileDuration,
+        profileDurationUI: onDemandBudgets.budgets.profileDurationUI,
       },
     };
   }
@@ -70,13 +74,17 @@ export function getTotalBudget(onDemandBudgets: OnDemandBudgets): number {
     const replaysBudget = onDemandBudgets.budgets.replays ?? 0;
     const monitorSeatsBudget = onDemandBudgets.budgets.monitorSeats ?? 0;
     const uptimeBudget = onDemandBudgets.budgets.uptime ?? 0;
+    const profileDurationBudget = onDemandBudgets.budgets.profileDuration ?? 0;
+    const profileDurationUIBudget = onDemandBudgets.budgets.profileDurationUI ?? 0;
     return (
       errorsBudget +
       transactionsBudget +
       attachmentsBudget +
       replaysBudget +
       monitorSeatsBudget +
-      uptimeBudget
+      uptimeBudget +
+      profileDurationBudget +
+      profileDurationUIBudget
     );
   }
 
@@ -117,6 +125,8 @@ export function formatOnDemandBudget(
     'replays',
     'monitorSeats',
     'uptime',
+    'profileDuration',
+    'profileDurationUI',
   ]
 ): React.ReactNode {
   const budgetType = planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand';


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/17041

Adds profile duration categories to the per-category on-demand parser. This should fix the on-demand value persistence when using the edit modal or the checkout flow.