### PR TITLE
ref: avoid mutating os.environ as init cli side-effect

### DIFF
--- a/src/sentry/runner/commands/init.py
+++ b/src/sentry/runner/commands/init.py
@@ -45,10 +45,7 @@ def init(dev: bool, no_clobber: bool, directory: str) -> None:
     "Initialize new configuration directory."
     from sentry.runner.settings import discover_configs
 
-    if directory is not None:
-        os.environ["SENTRY_CONF"] = directory
-
-    directory, py, yaml = discover_configs()
+    directory, py, yaml = discover_configs(directory=directory)
 
     # In this case, the config is pointing directly to a file, so we
     # must maintain old behavior, and just abort

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -24,17 +24,20 @@ def get_sentry_conf() -> str:
             return "~/.sentry"
 
 
-def discover_configs() -> tuple[str, str, str | None]:
+def discover_configs(directory: str | None = None) -> tuple[str, str, str | None]:
     """
     Discover the locations of three configuration components:
      * Config directory (~/.sentry)
      * Optional python config file (~/.sentry/sentry.conf.py)
      * Optional yaml config (~/.sentry/config.yml)
     """
-    try:
-        config = os.environ["SENTRY_CONF"]
-    except KeyError:
-        config = "~/.sentry"
+    if directory is not None:
+        config = directory
+    else:
+        try:
+            config = os.environ["SENTRY_CONF"]
+        except KeyError:
+            config = "~/.sentry"
 
     config = os.path.expanduser(config)
 


### PR DESCRIPTION
fixes this test pollution:

```console
$ pytest tests/sentry/runner/commands/test_init.py::InitTest::test_simple $(tail -1 testlist2)
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/sentry/runner/commands/test_init.py .                              [ 50%]
tests/sentry/test_wsgi.py F                                              [100%]

=================================== FAILURES ===================================
________________________________ test_wsgi_init ________________________________
tests/sentry/test_wsgi.py:25: in test_wsgi_init
    subprocess.check_call(
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/subprocess.py:419: in check_call
    raise CalledProcessError(retcode, cmd)
E   subprocess.CalledProcessError: Command '['/Users/asottile/workspace/sentry/.venv/bin/python3', '-c', '\nimport sys\nassert "sentry.conf.urls" not in sys.modules\n\nimport sentry.wsgi\nassert "sentry.conf.urls" in sys.modules\n\nimport django.urls.resolvers\nfrom django.conf import settings\nresolver = django.urls.resolvers.get_resolver()\nassert resolver._populated is True\nfor lang, _ in settings.LANGUAGES:\n    assert lang in resolver._reverse_dict\n']' returned non-zero exit status 1.
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "<string>", line 5, in <module>
    import sentry.wsgi
  File "/Users/asottile/workspace/sentry/src/sentry/wsgi.py", line 16, in <module>
    configure()
    ~~~~~~~~~^^
  File "/Users/asottile/workspace/sentry/src/sentry/runner/__init__.py", line 33, in configure
    _configure(ctx, py, yaml, skip_service_validation)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/runner/settings.py", line 101, in configure
    raise ValueError("Configuration file does not exist at '%s'" % click.format_filename(yaml))
ValueError: Configuration file does not exist at 'config/config.yml'
=========================== short test summary info ============================
FAILED tests/sentry/test_wsgi.py::test_wsgi_init - subprocess.CalledProcessError: Command '['/Users/asottile/workspace/sentry/...
========================= 1 failed, 1 passed in 4.53s ==========================
```

<!-- Describe your PR here. -->