### PR TITLE
fix(tour): Dismissing modal should prevent modal from showing again

### DIFF
--- a/static/app/components/nav/tour/tour.tsx
+++ b/static/app/components/nav/tour/tour.tsx
@@ -252,6 +252,16 @@ export function useTourModal() {
         ),
         {
           modalCss: navTourModalCss,
+
+          // If user closes modal through other means, also prevent the modal from being shown again.
+          onClose: reason => {
+            if (reason) {
+              mutateAssistant({
+                guide: STACKED_NAVIGATION_TOUR_GUIDE_KEY,
+                status: 'dismissed',
+              });
+            }
+          },
         }
       );
     }

--- a/static/app/components/nav/tour/tour.tsx
+++ b/static/app/components/nav/tour/tour.tsx
@@ -12,7 +12,7 @@ import {
   TourGuide,
 } from 'sentry/components/tours/components';
 import type {TourContextType} from 'sentry/components/tours/tourContext';
-import {useAssistant} from 'sentry/components/tours/useAssistant';
+import {useAssistant, useMutateAssistant} from 'sentry/components/tours/useAssistant';
 import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -223,10 +223,11 @@ export function StackedNavigationTourReminder({children}: {children: React.React
 // Displays the introductory tour modal when a user is entering the experience for the first time.
 export function useTourModal() {
   const hasOpenedTourModal = useRef(false);
-  const {startTour, endTour} = useStackedNavigationTour();
+  const {startTour} = useStackedNavigationTour();
   const {data: assistantData} = useAssistant({
     notifyOnChangeProps: ['data'],
   });
+  const {mutate: mutateAssistant} = useMutateAssistant();
 
   const shouldShowTourModal =
     assistantData?.find(item => item.guide === STACKED_NAVIGATION_TOUR_GUIDE_KEY)
@@ -239,7 +240,13 @@ export function useTourModal() {
         props => (
           <NavTourModal
             closeModal={props.closeModal}
-            handleDismissTour={endTour}
+            handleDismissTour={() => {
+              mutateAssistant({
+                guide: STACKED_NAVIGATION_TOUR_GUIDE_KEY,
+                status: 'dismissed',
+              });
+              props.closeModal();
+            }}
             handleStartTour={startTour}
           />
         ),
@@ -248,5 +255,5 @@ export function useTourModal() {
         }
       );
     }
-  }, [shouldShowTourModal, endTour, startTour]);
+  }, [shouldShowTourModal, startTour, mutateAssistant]);
 }

--- a/static/app/components/nav/tour/tour.tsx
+++ b/static/app/components/nav/tour/tour.tsx
@@ -223,7 +223,7 @@ export function StackedNavigationTourReminder({children}: {children: React.React
 // Displays the introductory tour modal when a user is entering the experience for the first time.
 export function useTourModal() {
   const hasOpenedTourModal = useRef(false);
-  const {startTour} = useStackedNavigationTour();
+  const {startTour, endTour} = useStackedNavigationTour();
   const {data: assistantData} = useAssistant({
     notifyOnChangeProps: ['data'],
   });
@@ -245,6 +245,7 @@ export function useTourModal() {
                 guide: STACKED_NAVIGATION_TOUR_GUIDE_KEY,
                 status: 'dismissed',
               });
+              endTour();
               props.closeModal();
             }}
             handleStartTour={startTour}
@@ -260,10 +261,11 @@ export function useTourModal() {
                 guide: STACKED_NAVIGATION_TOUR_GUIDE_KEY,
                 status: 'dismissed',
               });
+              endTour();
             }
           },
         }
       );
     }
-  }, [shouldShowTourModal, startTour, mutateAssistant]);
+  }, [shouldShowTourModal, startTour, mutateAssistant, endTour]);
 }


### PR DESCRIPTION
Dismissing the modal should call the API so it doesn't show up again, but I was only calling endTour() which does not do that.