### PR TITLE
ref(js): Remove withLatestContext from SettingsIndex

### DIFF
--- a/static/app/views/settings/settingsIndex.spec.tsx
+++ b/static/app/views/settings/settingsIndex.spec.tsx
@@ -1,11 +1,8 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import * as OrgActions from 'sentry/actionCreators/organizations';
 import ConfigStore from 'sentry/stores/configStore';
-import type {Organization} from 'sentry/types/organization';
 import SettingsIndex from 'sentry/views/settings/settingsIndex';
 
 import {BreadcrumbProvider} from './components/settingsBreadcrumb/context';
@@ -23,19 +20,9 @@ describe('SettingsIndex', function () {
   it('renders', function () {
     render(
       <BreadcrumbProvider>
-        <SettingsIndex {...props} organization={OrganizationFixture()} />
+        <SettingsIndex {...props} />
       </BreadcrumbProvider>
     );
-  });
-
-  it('has loading when there is no organization', function () {
-    render(
-      <BreadcrumbProvider>
-        <SettingsIndex {...props} organization={null} />
-      </BreadcrumbProvider>
-    );
-
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('has different links for self-hosted users', function () {
@@ -43,7 +30,7 @@ describe('SettingsIndex', function () {
 
     render(
       <BreadcrumbProvider>
-        <SettingsIndex {...props} organization={OrganizationFixture()} />
+        <SettingsIndex {...props} />
       </BreadcrumbProvider>
     );
 
@@ -51,64 +38,5 @@ describe('SettingsIndex', function () {
 
     expect(formLink).toBeInTheDocument();
     expect(formLink).toHaveAttribute('href', 'https://forum.sentry.io/');
-  });
-
-  describe('Fetch org details for Sidebar', function () {
-    const organization = {
-      id: '44',
-      name: 'Org Index',
-      slug: 'org-index',
-      features: [],
-    } as unknown as Organization;
-
-    const spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
-    let orgApi: jest.Mock;
-
-    beforeEach(function () {
-      ConfigStore.set('isSelfHosted', false);
-      MockApiClient.clearMockResponses();
-      orgApi = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/`,
-      });
-    });
-
-    it('fetches org details for SidebarDropdown', async function () {
-      const {rerender} = render(
-        <BreadcrumbProvider>
-          <SettingsIndex {...props} params={{}} organization={null} />
-        </BreadcrumbProvider>
-      );
-
-      // org from index endpoint, no `access` info
-      rerender(
-        <BreadcrumbProvider>
-          <SettingsIndex {...props} organization={organization} />
-        </BreadcrumbProvider>
-      );
-
-      await waitFor(() => expect(orgApi).toHaveBeenCalledTimes(1));
-      expect(spy).toHaveBeenCalledWith(expect.anything(), organization.slug, {
-        setActive: true,
-        loadProjects: true,
-      });
-    });
-
-    it('does not fetch org details for SidebarDropdown', function () {
-      const {rerender} = render(
-        <BreadcrumbProvider>
-          <SettingsIndex {...props} params={{}} organization={null} />
-        </BreadcrumbProvider>
-      );
-
-      // org already has details
-      rerender(
-        <BreadcrumbProvider>
-          <SettingsIndex {...props} organization={OrganizationFixture()} />
-        </BreadcrumbProvider>
-      );
-
-      expect(spy).not.toHaveBeenCalledWith();
-      expect(orgApi).not.toHaveBeenCalled();
-    });
   });
 });

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -1,15 +1,12 @@
-import {useEffect} from 'react';
 import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
 import {OrganizationAvatar} from 'sentry/components/core/avatar/organizationAvatar';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import ExternalLink from 'sentry/components/links/externalLink';
 import type {LinkProps} from 'sentry/components/links/link';
 import Link from 'sentry/components/links/link';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {prefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -21,12 +18,10 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-import withLatestContext from 'sentry/utils/withLatestContext';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
 const LINKS = {
@@ -44,25 +39,12 @@ const LINKS = {
 
 const HOME_ICON_SIZE = 56;
 
-interface SettingsIndexProps extends RouteComponentProps {
-  organization: Organization;
-}
+interface SettingsIndexProps extends RouteComponentProps {}
 
-function SettingsIndex({organization, ...props}: SettingsIndexProps) {
-  const api = useApi();
-
-  useEffect(() => {
-    // if there is no org in context, SidebarDropdown uses an org from `withLatestContext`
-    // (which queries the org index endpoint instead of org details)
-    // and does not have `access` info
-    if (organization && typeof organization.access === 'undefined') {
-      fetchOrganizationDetails(api, organization.slug, {
-        setActive: true,
-        loadProjects: true,
-      });
-    }
-  }, [api, organization]);
-
+function SettingsIndex(props: SettingsIndexProps) {
+  // Organization may be null on settings index if the user is not part of any
+  // organization
+  const organization = useOrganization({allowNull: true});
   const user = useUser();
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
@@ -77,7 +59,7 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
   // For the new navigation, we are removing this page. The default base route should
   // be the organization settings page.
   // When GAing, this page should be removed and the redirect should be moved to routes.tsx.
-  if (prefersStackedNav()) {
+  if (organization && prefersStackedNav()) {
     return (
       <Redirect
         to={normalizeUrl(
@@ -119,7 +101,6 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
 
   const orgSettings = (
     <GridPanel>
-      {!organization && <LoadingIndicator overlay hideSpinner />}
       <HomePanelHeader>
         <HomeLinkIcon to={organizationSettingsUrl}>
           {organization ? (
@@ -276,7 +257,7 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
   );
 }
 
-export default withLatestContext(SettingsIndex);
+export default SettingsIndex;
 
 const GridLayout = styled('div')`
   display: grid;


### PR DESCRIPTION
This page will be removed in the near future. But for now there's no
need for this to use withLatestContext