### PR TITLE
ref(releases): two big charts on mobile session health tab

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -128,36 +128,36 @@ function ViewSpecificCharts({
     case MOBILE_LANDING_SUB_PATH:
       return (
         <Fragment>
-          <ModuleLayout.Third>
+          <ModuleLayout.Half>
             <CrashFreeSessionsChart />
-          </ModuleLayout.Third>
-          <ModuleLayout.Third>
-            <NewAndResolvedIssueChart type="issue" />
-          </ModuleLayout.Third>
+          </ModuleLayout.Half>
+          <ModuleLayout.Half>
+            <ReleaseSessionPercentageChart />
+          </ModuleLayout.Half>
+
           <ModuleLayout.Third>
             <ReleaseNewIssuesChart />
           </ModuleLayout.Third>
-
           <ModuleLayout.Third>
             <ReleaseSessionCountChart />
           </ModuleLayout.Third>
           <ModuleLayout.Third>
             <SessionHealthCountChart />
           </ModuleLayout.Third>
+
           <ModuleLayout.Third>
             <UserHealthCountChart />
           </ModuleLayout.Third>
-
           <ModuleLayout.Third>
-            <ReleaseSessionPercentageChart />
+            <NewAndResolvedIssueChart type="issue" />
           </ModuleLayout.Third>
           <ModuleLayout.Third>
             <SessionHealthRateChart />
           </ModuleLayout.Third>
+
           <ModuleLayout.Third>
             <UserHealthRateChart />
           </ModuleLayout.Third>
-
           <ModuleLayout.Third>
             <NewAndResolvedIssueChart type="feedback" />
           </ModuleLayout.Third>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/88155

<img width="1241" alt="SCR-20250328-kfli" src="https://github.com/user-attachments/assets/1e8231c4-a111-489e-bc6d-68a3b1de8914" />
