### PR TITLE
fix(ui): Add height back to page filter bar styling

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -16,6 +16,7 @@ const pageFilterBarStyles = (p: {theme: Theme; condensed?: boolean}) => css`
   display: flex;
   position: relative;
   border-radius: ${p.theme.borderRadius};
+  height: ${p.theme.form.md.height};
 
   ${p.condensed &&
   css`


### PR DESCRIPTION
The height property was removed from the `PageFilterBar` styling making the container automatically select a height. It was causing this issue on a couple of the explore pages: 

<img width="820" alt="image" src="https://github.com/user-attachments/assets/8485159a-6fd8-4fef-86ff-1ea46c10c654" />

