### PR TITLE
ref(releases): two big charts on frontend session health tab

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -96,26 +96,26 @@ function ViewSpecificCharts({
     case FRONTEND_LANDING_SUB_PATH:
       return (
         <Fragment>
-          <ModuleLayout.Third>
+          <ModuleLayout.Half>
             <ErrorFreeSessionsChart />
-          </ModuleLayout.Third>
-          <ModuleLayout.Third>
-            <SessionHealthCountChart />
-          </ModuleLayout.Third>
+          </ModuleLayout.Half>
+          <ModuleLayout.Half>
+            <UserHealthRateChart />
+          </ModuleLayout.Half>
+
           <ModuleLayout.Third>
             <UserHealthCountChart />
           </ModuleLayout.Third>
-
           <ModuleLayout.Third>
             <NewAndResolvedIssueChart type="issue" />
           </ModuleLayout.Third>
           <ModuleLayout.Third>
             <SessionHealthRateChart />
           </ModuleLayout.Third>
-          <ModuleLayout.Third>
-            <UserHealthRateChart />
-          </ModuleLayout.Third>
 
+          <ModuleLayout.Third>
+            <SessionHealthCountChart />
+          </ModuleLayout.Third>
           <ModuleLayout.Third>
             <NewAndResolvedIssueChart type="feedback" />
           </ModuleLayout.Third>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/88238

<img width="1255" alt="SCR-20250328-kkdc" src="https://github.com/user-attachments/assets/91f5e51e-76bf-4a09-a9fd-6e6ec9a80b73" />
