### PR TITLE
fix(taskworker) Align signatures with celery.Task.apply_async

### DIFF
--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from collections.abc import Callable
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
 from uuid import uuid4
 
 import orjson
@@ -81,14 +81,16 @@ class Task(Generic[P, R]):
         The provided parameters will be JSON encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka
         """
-        self.apply_async(*args, **kwargs)
+        self.apply_async(args, kwargs)
 
-    def apply_async(self, *args: P.args, **kwargs: P.kwargs) -> None:
+    def apply_async(self, args: Any, kwargs: Any) -> None:
         """
         Schedule a task to run later with a set of arguments.
 
         The provided parameters will be JSON encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka
+
+        Prefer using `delay()` instead of `apply_async()`.
         """
         if settings.TASK_WORKER_ALWAYS_EAGER:
             self._func(*args, **kwargs)

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -63,7 +63,7 @@ def test_delay_taskrunner_immediate_mode(task_namespace: TaskNamespace) -> None:
     # This emulates the behavior we have with celery.
     with TaskRunner():
         task.delay("arg", org_id=1)
-        task.apply_async("arg2", org_id=2)
+        task.apply_async(args=["arg2"], kwargs={"org_id": 2})
 
     assert len(calls) == 2
     assert calls[0] == {"args": ("arg",), "kwargs": {"org_id": 1}}


### PR DESCRIPTION
The celery implementation of `apply_async` has an `args` and `kwargs` parameter that don't use `*` or `**`. Aligning taskworker.Task with this interface will ease shifting work off of celery and onto taskworker.