### PR TITLE
fix(explore): Filter empty string from the groupby in Multi Query mode

### DIFF
--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -292,7 +292,10 @@ export function generateExploreCompareRoute({
   const url = getCompareBaseUrl(organization);
   const compareQuery: WritableExploreQueryParts = {
     chartType,
-    groupBys: mode === Mode.AGGREGATE ? groupBys : [],
+    // Filter out empty strings which are used to indicate no grouping
+    // in Trace Explorer. The same assumption does not exist for the
+    // comparison view.
+    groupBys: mode === Mode.AGGREGATE ? groupBys?.filter(Boolean) : [],
     query,
     sortBys,
     yAxes,


### PR DESCRIPTION
The main explore page uses the empty string to represent "None" as a selection for the grouping. If the URL does not contain `groupBy=`, then the view will assume it's in a default state and apply a default grouping. This needs to be filtered out otherwise it thinks we're doing a TopN query

Alternatively, we could make the behaviour between Explore and MultiQuery Mode the same, but I think that might be more effort and this is a quick fix for the meantime.