### PR TITLE
fix(explore): Top event pluralization

### DIFF
--- a/static/app/views/explore/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.tsx
@@ -51,8 +51,8 @@ function confidenceMessage({sampleCount, confidence, topEvents}: Props) {
 
   if (confidence === 'low') {
     if (isTopN) {
-      return tct('Sample count for top [topEvents] groups: [sampleCount]', {
-        topEvents,
+      return tct('Sample count for top [groupText]: [sampleCount]', {
+        groupText: topEvents > 1 ? tct('[topEvents] groups', {topEvents}) : t('group'),
         sampleCount: lowAccuracySampleCount,
       });
     }


### PR DESCRIPTION
- Updates text so we don't say `top 1 groups`

<img width="205" alt="image" src="https://github.com/user-attachments/assets/d445a71a-e8fb-48ec-901d-85ff3ca6964e" />
<img width="233" alt="image" src="https://github.com/user-attachments/assets/9ef26db1-d913-4bbe-b1af-cc51d55efc2d" />
