### PR TITLE
ref: fix test pollution caused by slack.test_utils leaking responses mock

### DIFF
--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import orjson
 import pytest
-import responses
 from slack_sdk.web.slack_response import SlackResponse
 
 from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
@@ -22,9 +21,6 @@ pytestmark = [requires_snuba]
 
 class GetChannelIdTest(TestCase):
     def setUp(self):
-        self.resp = responses.mock
-        self.resp.__enter__()
-
         self.integration = install_slack(self.event.project.organization)
 
         self.response_json = {


### PR DESCRIPTION
fixes this test pollution:

```console
$ pytest tests/sentry/integrations/slack/test_utils.py::GetChannelIdTest::test_rate_limiting_sdk_client $(tail -1 testlist2)
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/sentry/integrations/slack/test_utils.py .                          [ 50%]
tests/sentry/integrations/test_metric_alerts.py E                        [100%]

==================================== ERRORS ====================================
_ ERROR at setup of IncidentAttachmentInfoTestForCrashRateAlerts.test_with_incident_trigger_sessions _
src/sentry/testutils/pytest/fixtures.py:350: in reset_snuba
    assert all(
src/sentry/testutils/pytest/fixtures.py:350: in <genexpr>
    assert all(
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/concurrent/futures/_base.py:619: in result_iterator
    yield _result_or_cancel(fs.pop())
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/concurrent/futures/_base.py:317: in _result_or_cancel
    return fut.result(timeout)
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/concurrent/futures/_base.py:456: in result
    return self.__get_result()
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/concurrent/futures/_base.py:401: in __get_result
    raise self._exception
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/concurrent/futures/thread.py:59: in run
    result = self.fn(*self.args, **self.kwargs)
src/sentry/testutils/pytest/fixtures.py:330: in inner
    return requests.post(settings.SENTRY_SNUBA + endpoint)
.venv/lib/python3.13/site-packages/requests/api.py:115: in post
    return request("post", url, data=data, json=json, **kwargs)
.venv/lib/python3.13/site-packages/requests/api.py:59: in request
    return session.request(method=method, url=url, **kwargs)
.venv/lib/python3.13/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
.venv/lib/python3.13/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
.venv/lib/python3.13/site-packages/responses/__init__.py:1104: in unbound_on_send
    return self._on_request(adapter, request, *a, **kwargs)
.venv/lib/python3.13/site-packages/responses/__init__.py:1046: in _on_request
    raise response
E   requests.exceptions.ConnectionError: Connection refused by Responses - the call doesn't match any registered mock.
E   
E   Request: 
E   - POST http://127.0.0.1:1218/tests/events_analytics_platform/drop
E   
E   Available matches:
=========================== short test summary info ============================
ERROR tests/sentry/integrations/test_metric_alerts.py::IncidentAttachmentInfoTestForCrashRateAlerts::test_with_incident_trigger_sessions - requests.exceptions.ConnectionError: Connection refused by Responses - the ...
========================== 1 passed, 1 error in 5.50s ==========================
```

<!-- Describe your PR here. -->