### PR TITLE
fix(autofix): Several UI fixes

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -777,6 +777,7 @@ const DiffContent = styled('div')<{lineType: DiffLineType}>`
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
+  overflow: visible;
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
@@ -809,6 +810,7 @@ const ButtonGroup = styled('div')`
   top: 0;
   right: ${space(0.25)};
   display: flex;
+  z-index: 1;
 `;
 
 const ActionButton = styled(Button)<{isHovered: boolean}>`

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -510,7 +510,7 @@ function DiffHunkContent({
               </ButtonGroup>
             )}
             {editingGroup === index && (
-              <EditOverlay ref={overlayRef}>
+              <EditOverlay ref={overlayRef} data-ignore-autofix-highlight="true">
                 <OverlayHeader>
                   <OverlayTitle
                     dangerouslySetInnerHTML={{

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -329,8 +329,8 @@ function getOptimalPosition(referenceRect: DOMRect, popupRect: DOMRect) {
   if (top + popupRect.height > viewportHeight) {
     top = viewportHeight - popupRect.height;
   }
-  if (top < 0) {
-    top = 0;
+  if (top < 42) {
+    top = 42;
   }
 
   return {left, top};

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -315,7 +315,6 @@ const StyledButton = styled(Button)`
   height: 24px;
   width: 24px;
   margin-right: 0;
-  z-index: 2;
 `;
 
 const SeerIconContainer = styled('div')`

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -825,6 +825,7 @@ const InstructionsInputWrapper = styled('form')`
 
 const InstructionsInput = styled(Input)`
   flex-grow: 1;
+  padding-right: ${space(4)};
 
   &::placeholder {
     color: ${p => p.theme.subText};

--- a/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
+++ b/static/app/components/events/autofix/preferences/autofixPreferenceDropdown.tsx
@@ -163,6 +163,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
         }
 
         const newIds = [...prevSelectedIds, repoId];
+        setSearchQuery('');
         setTimeout(() => savePreferencesToServer(newIds), 500);
         return newIds;
       });
@@ -171,7 +172,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
         restoreScrollPosition(scrollPosition);
       }, 0);
     },
-    [saveScrollPosition, restoreScrollPosition, savePreferencesToServer]
+    [saveScrollPosition, restoreScrollPosition, savePreferencesToServer, setSearchQuery]
   );
 
   const removeRepository = useCallback(
@@ -249,7 +250,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
     }, [repositories, selectedRepoIds, searchQuery, showAddRepositories]);
 
   const sectionTitle = showAddRepositories
-    ? t('Add repositories')
+    ? t('Add Repositories')
     : selectedRepoIds.length === 0
       ? t('No Repositories Selected')
       : selectedRepoIds.length === 1
@@ -312,8 +313,8 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
       <Button
         {...triggerProps}
         size="xs"
-        title={t('Autofix Settings')}
-        aria-label={t('Autofix Settings')}
+        title={t('Project Settings for Autofix')}
+        aria-label={t('Project Settings for Autofix')}
         icon={<IconSettings />}
       />
 
@@ -332,11 +333,13 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
             <div {...keyboardProps}>
               <ContentContainer ref={contentRef} className="scrollable-content">
                 <ContentHeader>
-                  <ContentTitle>{t('Autofix Settings')}</ContentTitle>
+                  <ContentTitle>
+                    {t('Configure Autofix for %s', project.name.toUpperCase())}
+                  </ContentTitle>
                 </ContentHeader>
                 {showSaveNotice && (
                   <SaveNotice>
-                    <IconInfo size="sm" color="warningText" />
+                    <IconInfo size="md" />
                     {t(
                       'Changes will apply to the next run. Hit "Start Over" then start a new run for Autofix to use your changes.'
                     )}
@@ -348,7 +351,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
                     {!showAddRepositories && (
                       <QuestionTooltip
                         title={t(
-                          'Below are the repositories that Autofix will work on. Autofix will only be able to see code and make PRs to the repositories that you select here.'
+                          'Below are the repositories that Autofix will work on. Autofix will only be able to see code from and make PRs to the repositories that you select here.'
                         )}
                         size="sm"
                       />
@@ -374,7 +377,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
                     }
                     onClick={toggleAddRepositoriesView}
                   >
-                    {showAddRepositories ? t('Back to selected') : t('Add repositories')}
+                    {showAddRepositories ? t('Back to Selected') : t('Add Repos')}
                   </AddReposButton>
                 </SectionHeader>
                 {showAddRepositories && (
@@ -388,6 +391,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
                         type="text"
                         placeholder={t('Search repositories...')}
                         value={searchQuery}
+                        autoFocus
                         onChange={handleSearchChange}
                       />
                     </InputGroup>
@@ -395,7 +399,7 @@ function AutofixPreferenceDropdown({project}: {project: Project}) {
                 )}
                 {isFetchingRepositories || isLoadingPreferences ? (
                   <LoadingContainer>
-                    <StyledLoadingIndicator size={48} />
+                    <StyledLoadingIndicator size={36} />
                     <LoadingMessage>
                       {t('Loading all your messy repositories...')}
                     </LoadingMessage>
@@ -577,9 +581,9 @@ const SaveNotice = styled('div')`
   gap: ${space(1)};
   padding: ${space(1.5)};
   margin-bottom: ${space(1.5)};
-  background-color: ${p => p.theme.yellow100};
-  border: 1px solid ${p => p.theme.yellow200};
+  background-color: ${p => p.theme.alert.warning.backgroundLight};
+  border: 1px solid ${p => p.theme.alert.warning.border};
   border-radius: ${p => p.theme.borderRadius};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.alert.warning.color};
 `;

--- a/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
+++ b/static/app/components/events/autofix/preferences/components/SelectedRepoItem.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
+import {TextArea} from 'sentry/components/core/textarea';
 import type {RepoSettings} from 'sentry/components/events/autofix/types';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconChevron as IconExpandToggle, IconClose, IconCommit} from 'sentry/icons';
@@ -18,7 +19,7 @@ interface Props {
 }
 
 export function SelectedRepoItem({repo, onRemove, settings, onSettingsChange}: Props) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [isEditingBranch, setIsEditingBranch] = useState(false);
   const [branchInputValue, setBranchInputValue] = useState(settings.branch);
   const [instructionsValue, setInstructionsValue] = useState(settings.instructions);
@@ -182,6 +183,8 @@ const SelectedRepoContainer = styled('div')`
   width: 100%;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  box-shadow: ${p => p.theme.dropShadowLight};
+  overflow: hidden;
 `;
 
 const SelectedRepoHeader = styled('div')`
@@ -278,7 +281,7 @@ const FormActions = styled('div')`
   padding-top: ${space(2)};
 `;
 
-const StyledTextArea = styled('textarea')`
+const StyledTextArea = styled(TextArea)`
   width: 100%;
   padding: ${space(1)};
   border: 1px solid ${p => p.theme.border};

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -11,12 +11,20 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement | nul
   const isClickInPopup = (target: HTMLElement) =>
     target.closest('[data-popup="autofix-highlight"]');
 
+  const shouldIgnoreElement = (target: HTMLElement) =>
+    target.closest('[data-ignore-autofix-highlight="true"]');
+
   const handleClick = useCallback(
     (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
       // If clicking in popup, do nothing
       if (isClickInPopup(target)) {
+        return;
+      }
+
+      // If clicking in an ignored element, do nothing
+      if (shouldIgnoreElement(target)) {
         return;
       }
 

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -35,22 +35,23 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement | nul
         return;
       }
 
-      // Get the text content of the clicked element
+      // Get the text content of the clicked element or its container
       const clickedText = target.textContent?.trim() || '';
       if (!clickedText) {
         setSelection(null);
         return;
       }
 
-      // Clear selection if clicking the same text
-      if (selection?.referenceElement === target) {
+      // Clear selection if clicking within the same container while already selected
+      if (selection?.referenceElement === containerRef.current) {
         setSelection(null);
         return;
       }
 
+      // Use the containerRef as the reference element for positioning
       setSelection({
         selectedText: clickedText,
-        referenceElement: target,
+        referenceElement: containerRef.current,
       });
     },
     [containerRef, selection]


### PR DESCRIPTION
- Fix overlap of plus icon and input text in Solution input
- Remove comment popup from diff editor
- Fix output stream input chevron clipping through settings panel
- Cleanup the preference dropdown styling and reword for clarity
- Fix popup positioning not lining up with some text content (I had to compromise here; the popup will line up with the container around the text, not the text itself, but at least it's not completely bugged anymore)
- Fix diff edit/reject buttons being cut off