### PR TITLE
fix(stats): asterisk css

### DIFF
--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -31,7 +31,7 @@ function ScoreCard({
   isEstimate,
 }: ScoreCardProps) {
   const value = score ?? '\u2014';
-  const displayScore = isEstimate ? `~${value}` : value;
+  const displayScore = isEstimate && value !== '0' ? `~${value}` : value;
 
   return (
     <ScorePanel className={className}>
@@ -135,7 +135,7 @@ const Asterisk = styled('div')`
   width: 10pt;
   height: 10pt;
   position: relative;
-  top: -10px;
+  top: -10pt;
   margin-left: ${space(0.25)};
 `;
 


### PR DESCRIPTION
align asterisk with the top of the numbers and avoid ~ for 0

<img width="318" alt="Screenshot 2025-03-28 at 2 00 04 PM" src="https://github.com/user-attachments/assets/5eefb964-6854-4a7f-b1a7-301be3444e54" />
