### PR TITLE
:wrench: chore(integrations): start consolidating provider enum

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -4,7 +4,7 @@ import abc
 import logging
 import sys
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from enum import Enum, StrEnum
+from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn, NotRequired, TypedDict
 
@@ -20,6 +20,7 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.team import Team
 from sentry.organizations.services.organization import (
     RpcOrganization,
@@ -96,7 +97,7 @@ class IntegrationMetadata(NamedTuple):
         return metadata
 
 
-class IntegrationFeatures(Enum):
+class IntegrationFeatures(StrEnum):
     """
     IntegrationFeatures are used for marking supported features on an
     integration. Features are marked on the IntegrationProvider itself, as well
@@ -133,22 +134,6 @@ class IntegrationDomain(StrEnum):
     SOURCE_CODE_MANAGEMENT = "source_code_management"
     ON_CALL_SCHEDULING = "on_call_scheduling"
     IDENTITY = "identity"  # for identity pipelines
-
-
-class IntegrationProviderSlug(StrEnum):
-    SLACK = "slack"
-    DISCORD = "discord"
-    MSTEAMS = "msteams"
-    JIRA = "jira"
-    JIRA_SERVER = "jira_server"
-    AZURE_DEVOPS = "vsts"
-    GITHUB = "github"
-    GITHUB_ENTERPRISE = "github_enterprise"
-    GITLAB = "gitlab"
-    BITBUCKET = "bitbucket"
-    BITBUCKET_SERVER = "bitbucket_server"
-    PAGERDUTY = "pagerduty"
-    OPSGENIE = "opsgenie"
 
 
 INTEGRATION_TYPE_TO_PROVIDER = {

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Generic, TypeVar
 
 from sentry.hybridcloud.rpc import ValueEqualityEnum
@@ -27,17 +27,33 @@ class ExternalProviders(ValueEqualityEnum):
         return EXTERNAL_PROVIDERS.get(ExternalProviders(self.value), "")
 
 
-class ExternalProviderEnum(Enum):
-    EMAIL = "email"
+class IntegrationProviderSlug(StrEnum):
     SLACK = "slack"
-    MSTEAMS = "msteams"
-    PAGERDUTY = "pagerduty"
     DISCORD = "discord"
-    OPSGENIE = "opsgenie"
+    MSTEAMS = "msteams"
+    JIRA = "jira"
+    JIRA_SERVER = "jira_server"
+    AZURE_DEVOPS = "vsts"
     GITHUB = "github"
     GITHUB_ENTERPRISE = "github_enterprise"
     GITLAB = "gitlab"
+    BITBUCKET = "bitbucket"
+    BITBUCKET_SERVER = "bitbucket_server"
+    PAGERDUTY = "pagerduty"
+    OPSGENIE = "opsgenie"
+
+
+class ExternalProviderEnum(StrEnum):
+    EMAIL = "email"
     CUSTOM = "custom_scm"
+    SLACK = IntegrationProviderSlug.SLACK
+    MSTEAMS = IntegrationProviderSlug.MSTEAMS
+    PAGERDUTY = IntegrationProviderSlug.PAGERDUTY
+    DISCORD = IntegrationProviderSlug.DISCORD
+    OPSGENIE = IntegrationProviderSlug.OPSGENIE
+    GITHUB = IntegrationProviderSlug.GITHUB
+    GITHUB_ENTERPRISE = IntegrationProviderSlug.GITHUB_ENTERPRISE
+    GITLAB = IntegrationProviderSlug.GITLAB
 
 
 EXTERNAL_PROVIDERS_REVERSE = {


### PR DESCRIPTION
first part of consolidating all the provider enums

Here I convert enums to `StrEnum` since it easier to use and u don't have to remember to do `.value` during comparisons.

I also build `ExternalProviderEnum` from `IntegrationProviderSlug`. 

After this, we can start consolidation of the enums

closes https://linear.app/getsentry/issue/ECO-378/have-externalproviderenum-use-integrationproviderslug