### PR TITLE
fix(autofix): Remove animations when navigating, handle comment popup overlap

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -39,6 +39,7 @@ type AutofixChangesProps = {
   runId: string;
   step: AutofixChangesStep;
   agentCommentThread?: CommentThread;
+  isChangesFirstAppearance?: boolean;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 };
@@ -426,6 +427,7 @@ export function AutofixChanges({
   previousDefaultStepIndex,
   previousInsightCount,
   agentCommentThread,
+  isChangesFirstAppearance,
 }: AutofixChangesProps) {
   const {data} = useAutofixData({groupId});
   const [isBusy, setIsBusy] = useState(false);
@@ -469,7 +471,7 @@ export function AutofixChanges({
     step.changes.every(change => change.branch_name);
 
   return (
-    <AnimatePresence initial>
+    <AnimatePresence initial={isChangesFirstAppearance}>
       <AnimationWrapper key="card" {...cardAnimationProps}>
         <ChangesContainer>
           <ClippedBox clipHeight={408}>

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -121,7 +121,8 @@ function AutofixHighlightPopupContent({
   stepIndex,
   retainInsightCardIndex,
   isAgentComment,
-}: Props) {
+  isFocused,
+}: Props & {isFocused?: boolean}) {
   const {mutate: submitComment} = useCommentThread({groupId, runId});
   const {mutate: closeCommentThread} = useCloseCommentThread({groupId, runId});
 
@@ -253,7 +254,7 @@ function AutofixHighlightPopupContent({
   };
 
   return (
-    <Container onClick={handleContainerClick}>
+    <Container onClick={handleContainerClick} isFocused={isFocused}>
       <Header>
         <SelectedText>{truncatedText && <span>"{truncatedText}"</span>}</SelectedText>
         {allMessages.length > 0 && (
@@ -419,9 +420,9 @@ function AutofixHighlightPopup(props: Props) {
       onBlur={handleBlur}
       tabIndex={-1}
     >
-      <Arrow />
-      <ScaleContainer>
-        <AutofixHighlightPopupContent {...props} />
+      <ScaleContainer isFocused={isFocused}>
+        <Arrow />
+        <AutofixHighlightPopupContent {...props} isFocused={isFocused} />
       </ScaleContainer>
     </Wrapper>,
     document.body
@@ -442,23 +443,28 @@ const Wrapper = styled(motion.div)<
   will-change: transform;
 `;
 
-const ScaleContainer = styled(motion.div)`
+const ScaleContainer = styled(motion.div)<{isFocused?: boolean}>`
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  transform-origin: top left;
+  transform-origin: top right;
   padding-left: ${space(2)};
+  transform: scale(${p => (p.isFocused ? 1 : 0.9)});
+  transition: transform 200ms ease;
 `;
 
-const Container = styled(motion.div)<React.HTMLAttributes<HTMLDivElement>>`
+const Container = styled(motion.div)<
+  React.HTMLAttributes<HTMLDivElement> & {isFocused?: boolean}
+>`
   position: relative;
   width: 100%;
   border-radius: ${p => p.theme.borderRadius};
   background: ${p => p.theme.background};
   border: 1px dashed ${p => p.theme.border};
   overflow: hidden;
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+  box-shadow: ${p => (p.isFocused ? p.theme.dropShadowHeavy : p.theme.dropShadowLight)};
+  transition: box-shadow 200ms ease;
 
   &:before {
     content: '';
@@ -539,6 +545,7 @@ const Arrow = styled('div')`
   top: 20px;
   right: -6px;
   transform: rotate(135deg);
+  z-index: 1;
 `;
 
 const MessagesContainer = styled('div')`

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
+import {AnimatePresence, motion} from 'framer-motion';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
@@ -14,7 +14,6 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import marked, {singleLineRenderer} from 'sentry/utils/marked';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
-import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
@@ -61,27 +60,6 @@ export function ExpandableInsightContext({
   );
 }
 
-const animationProps: AnimationProps = {
-  exit: {opacity: 0, height: 0, scale: 0.8, y: -20},
-  initial: {opacity: 0, height: 0, scale: 0.8},
-  animate: {opacity: 1, height: 'auto', scale: 1},
-  transition: testableTransition({
-    duration: 1.0,
-    height: {
-      type: 'spring',
-      bounce: 0.2,
-    },
-    scale: {
-      type: 'spring',
-      bounce: 0.2,
-    },
-    y: {
-      type: 'tween',
-      ease: 'easeOut',
-    },
-  }),
-};
-
 interface AutofixInsightCardProps {
   groupId: string;
   hasCardAbove: boolean;
@@ -91,6 +69,7 @@ interface AutofixInsightCardProps {
   insightCount: number;
   runId: string;
   stepIndex: number;
+  isNewInsight?: boolean;
 }
 
 function AutofixInsightCard({
@@ -102,6 +81,7 @@ function AutofixInsightCard({
   groupId,
   runId,
   insightCount,
+  isNewInsight,
 }: AutofixInsightCardProps) {
   const isLastInsightInStep = index === insightCount - 1;
   const headerRef = useRef<HTMLDivElement>(null);
@@ -166,8 +146,8 @@ function AutofixInsightCard({
           />
         )}
       </AnimatePresence>
-      <AnimatePresence initial>
-        <AnimationWrapper key="content" {...animationProps}>
+      <AnimatePresence initial={isNewInsight}>
+        <AnimationWrapper key="content">
           {hasCardAbove && (
             <ChainLink
               stepIndex={stepIndex}
@@ -176,7 +156,7 @@ function AutofixInsightCard({
               insightCount={insightCount}
             />
           )}
-          <InsightContainer>
+          <InsightContainer data-new-insight={isNewInsight ? 'true' : 'false'}>
             {isEditing ? (
               <EditContainer>
                 <form onSubmit={handleSubmit}>
@@ -356,6 +336,18 @@ function AutofixInsightCards({
   shouldCollapseByDefault,
 }: AutofixInsightCardsProps) {
   const [isCollapsed, setIsCollapsed] = useState(!!shouldCollapseByDefault);
+  const previousInsightsRef = useRef<AutofixInsight[]>([]);
+  const [newInsightIndices, setNewInsightIndices] = useState<number[]>([]);
+
+  // Compare current insights with previous insights to determine which ones are new
+  useEffect(() => {
+    if (insights.length === previousInsightsRef.current.length + 1) {
+      setNewInsightIndices([insights.length - 1]);
+    } else {
+      setNewInsightIndices([]);
+    }
+    previousInsightsRef.current = [...insights];
+  }, [insights]);
 
   useEffect(() => {
     setIsCollapsed(!!shouldCollapseByDefault);
@@ -398,6 +390,7 @@ function AutofixInsightCards({
                       groupId={groupId}
                       runId={runId}
                       insightCount={validInsightCount}
+                      isNewInsight={newInsightIndices.includes(index)}
                     />
                   ) : null
                 )}
@@ -576,16 +569,24 @@ const InsightsContainer = styled('div')`
 const InsightContainer = styled(motion.div)`
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
-  animation: fadeFromActive 1.2s ease-out;
 
-  @keyframes fadeFromActive {
-    from {
-      background-color: ${p => p.theme.active};
-      border-color: ${p => p.theme.active};
-    }
-    to {
-      background-color: ${p => p.theme.background};
-      border-color: ${p => p.theme.innerBorder};
+  &[data-new-insight='true'] {
+    animation: fadeFromActive 0.8s ease-in-out;
+    @keyframes fadeFromActive {
+      from {
+        background-color: ${p => p.theme.active};
+        border-color: ${p => p.theme.active};
+        scale: 0.8;
+        height: 0;
+        opacity: 0;
+      }
+      to {
+        background-color: ${p => p.theme.background};
+        border-color: ${p => p.theme.innerBorder};
+        scale: 1;
+        height: auto;
+        opacity: 1;
+      }
     }
   }
 `;
@@ -688,16 +689,15 @@ const ContextBody = styled('div')`
 const AnimationWrapper = styled(motion.div)`
   transform-origin: top center;
 
-  &.new-insight {
+  &[data-new-insight='true'] {
     animation: textFadeFromActive 1.2s ease-out;
-  }
-
-  @keyframes textFadeFromActive {
-    from {
-      color: ${p => p.theme.white};
-    }
-    to {
-      color: inherit;
+    @keyframes textFadeFromActive {
+      from {
+        color: ${p => p.theme.white};
+      }
+      to {
+        color: inherit;
+      }
     }
   }
 `;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -43,6 +43,7 @@ type AutofixRootCauseProps = {
   runId: string;
   agentCommentThread?: CommentThread;
   feedback?: AutofixFeedback;
+  isRootCauseFirstAppearance?: boolean;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
   terminationReason?: string;
@@ -424,7 +425,7 @@ function AutofixRootCauseDisplay({
 export function AutofixRootCause(props: AutofixRootCauseProps) {
   if (props.causes.length === 0) {
     return (
-      <AnimatePresence initial>
+      <AnimatePresence initial={props.isRootCauseFirstAppearance}>
         <AnimationWrapper key="card" {...cardAnimationProps}>
           <NoCausesPadding>
             <Alert.Container>
@@ -439,7 +440,7 @@ export function AutofixRootCause(props: AutofixRootCauseProps) {
   }
 
   return (
-    <AnimatePresence initial>
+    <AnimatePresence initial={props.isRootCauseFirstAppearance}>
       <AnimationWrapper key="card" {...cardAnimationProps}>
         <AutofixRootCauseDisplay {...props} />
       </AnimationWrapper>

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -118,6 +118,7 @@ type AutofixSolutionProps = {
   customSolution?: string;
   description?: string;
   feedback?: AutofixFeedback;
+  isSolutionFirstAppearance?: boolean;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 };
@@ -647,7 +648,7 @@ function AutofixSolutionDisplay({
 export function AutofixSolution(props: AutofixSolutionProps) {
   if (props.solution.length === 0) {
     return (
-      <AnimatePresence initial>
+      <AnimatePresence initial={props.isSolutionFirstAppearance}>
         <AnimationWrapper key="card" {...cardAnimationProps}>
           <NoSolutionPadding>
             <Alert type="warning">{t('No solution found.')}</Alert>
@@ -660,7 +661,7 @@ export function AutofixSolution(props: AutofixSolutionProps) {
   const changesDisabled = props.repos.every(repo => repo.is_readable === false);
 
   return (
-    <AnimatePresence initial>
+    <AnimatePresence initial={props.isSolutionFirstAppearance}>
       <AnimationWrapper key="card" {...cardAnimationProps}>
         <AutofixSolutionDisplay {...props} changesDisabled={changesDisabled} />
       </AnimationWrapper>

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -248,13 +248,18 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               feedback={data.feedback}
               isRootCauseFirstAppearance={
                 step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS &&
-                isRootCauseFirstAppearance
+                isRootCauseFirstAppearance &&
+                !(isSolutionFirstAppearance || isChangesFirstAppearance)
               }
               isSolutionFirstAppearance={
-                step.type === AutofixStepType.SOLUTION && isSolutionFirstAppearance
+                step.type === AutofixStepType.SOLUTION &&
+                isSolutionFirstAppearance &&
+                !(isRootCauseFirstAppearance || isChangesFirstAppearance)
               }
               isChangesFirstAppearance={
-                step.type === AutofixStepType.CHANGES && isChangesFirstAppearance
+                step.type === AutofixStepType.CHANGES &&
+                isChangesFirstAppearance &&
+                !(isRootCauseFirstAppearance || isSolutionFirstAppearance)
               }
             />
           </div>

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useRef} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
@@ -150,9 +150,14 @@ export function Step({
 export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
   const steps = data.steps;
   const repos = data.repositories;
-  const previousRootCauseRef = useRef<boolean>(false);
-  const previousSolutionRef = useRef<boolean>(false);
-  const previousChangesRef = useRef<boolean>(false);
+  const isMountedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   if (!steps?.length) {
     return null;
@@ -179,19 +184,7 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
     replaceHeadersWithBold(logs.at(-1)?.message ?? '') ??
     '';
 
-  const hasRootCauseStep = steps.some(
-    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
-  );
-  const hasSolutionStep = steps.some(step => step.type === AutofixStepType.SOLUTION);
-  const hasChangesStep = steps.some(step => step.type === AutofixStepType.CHANGES);
-
-  const isRootCauseFirstAppearance = hasRootCauseStep && !previousRootCauseRef.current;
-  const isSolutionFirstAppearance = hasSolutionStep && !previousSolutionRef.current;
-  const isChangesFirstAppearance = hasChangesStep && !previousChangesRef.current;
-
-  previousRootCauseRef.current = hasRootCauseStep;
-  previousSolutionRef.current = hasSolutionStep;
-  previousChangesRef.current = hasChangesStep;
+  const isInitialMount = !isMountedRef.current;
 
   return (
     <StepsContainer>
@@ -247,19 +240,13 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               previousInsightCount={previousInsightCount}
               feedback={data.feedback}
               isRootCauseFirstAppearance={
-                step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS &&
-                isRootCauseFirstAppearance &&
-                !(isSolutionFirstAppearance || isChangesFirstAppearance)
+                step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && !isInitialMount
               }
               isSolutionFirstAppearance={
-                step.type === AutofixStepType.SOLUTION &&
-                isSolutionFirstAppearance &&
-                !(isRootCauseFirstAppearance || isChangesFirstAppearance)
+                step.type === AutofixStepType.SOLUTION && !isInitialMount
               }
               isChangesFirstAppearance={
-                step.type === AutofixStepType.CHANGES &&
-                isChangesFirstAppearance &&
-                !(isRootCauseFirstAppearance || isSolutionFirstAppearance)
+                step.type === AutofixStepType.CHANGES && !isInitialMount
               }
             />
           </div>


### PR DESCRIPTION
Remove animations when opening drawer and expanding insight section. Also increase clarity of which comment thread is focused when there are multiple.