### PR TITLE
:wrench: chore(aci): add workflow_id to WorkflowEventData

### DIFF
--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -40,6 +40,7 @@ class WorkflowEventData:
     group_state: GroupState | None = None
     has_reappeared: bool | None = None
     has_escalated: bool | None = None
+    workflow_id: int | None = None
     workflow_env: Environment | None = None
 
 


### PR DESCRIPTION
notification actions need `workflow_id` to lookup the corresponding `rule_id` so we can build links correctly. to do that, we will pass `workflow_id` in the `WorkflowEventData`

EDIT: we will wire everything up in a future pr