### PR TITLE
feat(org member invite): OrganizationMemberInviteDetails GET endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -16,9 +16,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
-from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.endpoints.organization_member.index import OrganizationMemberRequestSerializer
-from sentry.api.endpoints.organization_member.utils import ROLE_CHOICES
+from sentry.api.endpoints.organization_member.utils import ROLE_CHOICES, RelaxedMemberPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberWithRolesSerializer
 from sentry.apidocs.constants import (
@@ -72,22 +71,6 @@ Configures the team role of the member. The two roles are:
 }
 ```
 """
-
-
-class RelaxedMemberPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["member:read", "member:write", "member:admin"],
-        "POST": ["member:write", "member:admin"],
-        "PUT": ["member:invite", "member:write", "member:admin"],
-        # DELETE checks for role comparison as you can either remove a member
-        # with a lower access role, or yourself, without having the req. scope
-        "DELETE": ["member:read", "member:write", "member:admin"],
-    }
-
-    # Allow deletions to happen for disabled members so they can remove themselves
-    # allowing other methods should be fine as well even if we don't strictly need to allow them
-    def is_member_disabled_from_limit(self, request: Request, organization):
-        return False
 
 
 @extend_schema(tags=["Organizations"])

--- a/src/sentry/api/endpoints/organization_member/utils.py
+++ b/src/sentry/api/endpoints/organization_member/utils.py
@@ -1,4 +1,7 @@
 from rest_framework import serializers
+from rest_framework.request import Request
+
+from sentry.api.bases.organization import OrganizationPermission
 
 ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
 
@@ -33,3 +36,19 @@ ROLE_CHOICES = [
 
 class MemberConflictValidationError(serializers.ValidationError):
     pass
+
+
+class RelaxedMemberPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read", "member:write", "member:admin"],
+        "POST": ["member:write", "member:admin"],
+        "PUT": ["member:invite", "member:write", "member:admin"],
+        # DELETE checks for role comparison as you can either remove a member
+        # with a lower access role, or yourself, without having the req. scope
+        "DELETE": ["member:read", "member:write", "member:admin"],
+    }
+
+    # Allow deletions to happen for disabled members so they can remove themselves
+    # allowing other methods should be fine as well even if we don't strictly need to allow them
+    def is_member_disabled_from_limit(self, request: Request, organization):
+        return False

--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -5,6 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_member.utils import RelaxedMemberPermission
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
 from sentry.models.organizationmemberinvite import OrganizationMemberInvite
@@ -18,6 +21,24 @@ class OrganizationMemberIndexDetailsEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (RelaxedMemberPermission,)
+
+    def convert_args(
+        self,
+        request: Request,
+        member_invite_id: str,
+        organization_id_or_slug: str | int | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        args, kwargs = super().convert_args(request, organization_id_or_slug, *args, **kwargs)
+
+        try:
+            kwargs["invited_member"] = OrganizationMemberInvite.objects.filter(
+                id=int(member_invite_id)
+            )
+        except OrganizationMemberInvite.DoesNotExist:
+            raise ResourceDoesNotExist
+        return args, kwargs
 
     def get(
         self,

--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_member.utils import RelaxedMemberPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -13,6 +14,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 
 
+@region_silo_endpoint
 class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -1,0 +1,40 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.endpoints.organization_member.utils import RelaxedMemberPermission
+from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
+from sentry.models.organizationmemberinvite import OrganizationMemberInvite
+
+
+class OrganizationMemberIndexDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ENTERPRISE
+    permission_classes = (RelaxedMemberPermission,)
+
+    def get(
+        self,
+        request: Request,
+        invited_member: OrganizationMemberInvite,
+    ) -> Response:
+        """
+        Retrieve an invited organization member's details.
+        """
+        return Response(serialize(invited_member, request.user))
+
+    def put(
+        self, request: Request, organization: Organization, invited_member: OrganizationMemberInvite
+    ) -> Response:
+        raise NotImplementedError
+
+    def delete(
+        self, request: Request, organization: Organization, invited_member: OrganizationMemberInvite
+    ) -> Response:
+        raise NotImplementedError

--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -13,7 +13,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 
 
-class OrganizationMemberIndexDetailsEndpoint(OrganizationEndpoint):
+class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
         "GET": ApiPublishStatus.EXPERIMENTAL,
@@ -33,7 +33,7 @@ class OrganizationMemberIndexDetailsEndpoint(OrganizationEndpoint):
         args, kwargs = super().convert_args(request, organization_id_or_slug, *args, **kwargs)
 
         try:
-            kwargs["invited_member"] = OrganizationMemberInvite.objects.filter(
+            kwargs["invited_member"] = OrganizationMemberInvite.objects.get(
                 id=int(member_invite_id)
             )
         except OrganizationMemberInvite.DoesNotExist:
@@ -43,6 +43,7 @@ class OrganizationMemberIndexDetailsEndpoint(OrganizationEndpoint):
     def get(
         self,
         request: Request,
+        organization: Organization,
         invited_member: OrganizationMemberInvite,
     ) -> Response:
         """

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -16,6 +16,9 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
     OrganizationEventsRootCauseAnalysisEndpoint,
 )
 from sentry.api.endpoints.organization_fork import OrganizationForkEndpoint
+from sentry.api.endpoints.organization_member_invite.details import (
+    OrganizationMemberInviteDetailsEndpoint,
+)
 from sentry.api.endpoints.organization_member_invite.index import (
     OrganizationMemberInviteIndexEndpoint,
 )
@@ -1699,6 +1702,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/invited-members/$",
         OrganizationMemberInviteIndexEndpoint.as_view(),
         name="sentry-api-0-organization-member-invite-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/invited-members/(?P<member_invite_id>[^\/]+)/$",
+        OrganizationMemberInviteDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-member-invite-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/external-users/$",

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-# from sentry.api.serializers.models.organization_member.response import _OrganizationMemberFlags
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope

--- a/tests/sentry/api/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_details.py
@@ -32,4 +32,4 @@ class GetOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         assert response.data["inviteStatus"] == "requested_to_be_invited"
 
     def test_get_by_garbage(self):
-        self.get_error_response(self.organization.slug, "trash", status_code=404)
+        self.get_error_response(self.organization.slug, "-1", status_code=404)

--- a/tests/sentry/api/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_details.py
@@ -1,0 +1,35 @@
+from sentry.models.organizationmemberinvite import InviteStatus
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationMemberInviteTestBase(APITestCase):
+    endpoint = "sentry-api-0-organization-member-invite-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+
+class GetOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
+    def test_simple(self):
+        invited_member = self.create_member_invite(
+            organization=self.organization, email="matcha@latte.com"
+        )
+        response = self.get_success_response(self.organization.slug, invited_member.id)
+        assert response.data["id"] == str(invited_member.id)
+        assert response.data["email"] == "matcha@latte.com"
+
+    def test_invite_request(self):
+        # users can also hit this endpoint to view pending invite requests
+        invited_member = self.create_member_invite(
+            organization=self.organization,
+            email="matcha@latte.com",
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+        response = self.get_success_response(self.organization.slug, invited_member.id)
+        assert response.data["id"] == str(invited_member.id)
+        assert response.data["email"] == "matcha@latte.com"
+        assert response.data["inviteStatus"] == "requested_to_be_invited"
+
+    def test_get_by_garbage(self):
+        self.get_error_response(self.organization.slug, "trash", status_code=404)

--- a/tests/sentry/api/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_details.py
@@ -1,5 +1,6 @@
 from sentry.models.organizationmemberinvite import InviteStatus
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 
 
 class OrganizationMemberInviteTestBase(APITestCase):
@@ -10,6 +11,7 @@ class OrganizationMemberInviteTestBase(APITestCase):
         self.login_as(self.user)
 
 
+@apply_feature_flag_on_cls("organizations:new-organization-member-invite")
 class GetOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
     def test_simple(self):
         invited_member = self.create_member_invite(


### PR DESCRIPTION
The `OrganizationMemberDetails` endpoint also adds lists of serialized team roles and organization roles to the GET response. Talked with @leedongwei: it is not clear why this is necessary, so we decided not to add these fields to the new endpoint. 

In particular, `allowed_roles = get_allowed_org_roles(request, organization, member)` gets the roles that the _member_ would be allowed to assign when inviting a user to the organization. This only really makes sense when `member` is the requesting user themself, which isn't possible for an invited organization member.