### PR TITLE
🔧 chore(aci): switch to enum for notification action handler `provider_slug`

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/azure_devops_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/azure_devops_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import TicketingActionHandler
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -7,4 +8,4 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.AZURE_DEVOPS)
 class AzureDevopsActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
-    provider_slug = "azure_devops"
+    provider_slug = IntegrationProviderSlug.AZURE_DEVOPS

--- a/src/sentry/workflow_engine/handlers/action/notification/discord_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/discord_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
@@ -10,7 +11,7 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 @action_handler_registry.register(Action.Type.DISCORD)
 class DiscordActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
-    provider_slug = "discord"
+    provider_slug = IntegrationProviderSlug.DISCORD
 
     # Main difference between the discord and slack action config schemas is that the target_display is possibly null
     config_schema = {

--- a/src/sentry/workflow_engine/handlers/action/notification/github_enterprise_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/github_enterprise_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import TicketingActionHandler
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -7,4 +8,4 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.GITHUB_ENTERPRISE)
 class GithubEnterpriseActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
-    provider_slug = "github_enterprise"
+    provider_slug = IntegrationProviderSlug.GITHUB_ENTERPRISE

--- a/src/sentry/workflow_engine/handlers/action/notification/github_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/github_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import TicketingActionHandler
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -7,4 +8,4 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.GITHUB)
 class GithubActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
-    provider_slug = "github"
+    provider_slug = IntegrationProviderSlug.GITHUB

--- a/src/sentry/workflow_engine/handlers/action/notification/jira_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/jira_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import TicketingActionHandler
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -7,4 +8,4 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.JIRA)
 class JiraActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
-    provider_slug = "jira"
+    provider_slug = IntegrationProviderSlug.JIRA

--- a/src/sentry/workflow_engine/handlers/action/notification/jira_server_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/jira_server_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import TicketingActionHandler
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
@@ -7,4 +8,4 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.JIRA_SERVER)
 class JiraServerActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
-    provider_slug = "jira_server"
+    provider_slug = IntegrationProviderSlug.JIRA_SERVER

--- a/src/sentry/workflow_engine/handlers/action/notification/msteams_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/msteams_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import (
@@ -11,7 +12,7 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 @action_handler_registry.register(Action.Type.MSTEAMS)
 class MSTeamsActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
-    provider_slug = "msteams"
+    provider_slug = IntegrationProviderSlug.MSTEAMS
 
     config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
 

--- a/src/sentry/workflow_engine/handlers/action/notification/opsgenie_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/opsgenie_handler.py
@@ -1,4 +1,5 @@
 from sentry.integrations.opsgenie.utils import OPSGENIE_CUSTOM_PRIORITIES
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import ONCALL_ACTION_CONFIG_SCHEMA
 from sentry.workflow_engine.models import Action
@@ -9,7 +10,7 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.OPSGENIE)
 class OpsgenieActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
-    provider_slug = "opsgenie"
+    provider_slug = IntegrationProviderSlug.OPSGENIE
 
     config_schema = ONCALL_ACTION_CONFIG_SCHEMA
     data_schema = {

--- a/src/sentry/workflow_engine/handlers/action/notification/pagerduty_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/pagerduty_handler.py
@@ -1,4 +1,5 @@
 from sentry.integrations.pagerduty.client import PagerdutySeverity
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import ONCALL_ACTION_CONFIG_SCHEMA
 from sentry.workflow_engine.models import Action
@@ -9,7 +10,7 @@ from sentry.workflow_engine.types import ActionHandler
 @action_handler_registry.register(Action.Type.PAGERDUTY)
 class PagerdutyActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
-    provider_slug = "pagerduty"
+    provider_slug = IntegrationProviderSlug.PAGERDUTY
 
     config_schema = ONCALL_ACTION_CONFIG_SCHEMA
     data_schema = {

--- a/src/sentry/workflow_engine/handlers/action/notification/slack_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/slack_handler.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import (
@@ -13,7 +14,7 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 @action_handler_registry.register(Action.Type.SLACK)
 class SlackActionHandler(IntegrationActionHandler):
     group = ActionHandler.Group.NOTIFICATION
-    provider_slug = "slack"
+    provider_slug = IntegrationProviderSlug.SLACK
 
     config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
 


### PR DESCRIPTION
builds on https://github.com/getsentry/sentry/pull/88273

removing the `str` usage for a `StrEnum`