### PR TITLE
fix(billing): Fix overage banner for profile hours

### DIFF
--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -992,7 +992,6 @@ class GSBanner extends Component<Props, State> {
           clicked_event: eventType,
         });
       };
-      // @ts-expect-error TS(2339): Property 'profileDuration' does not exist on type ... Remove this comment to see the full error message
       return {
         error: (
           <ExternalLink
@@ -1085,20 +1084,32 @@ class GSBanner extends Component<Props, State> {
             })}
           </ExternalLink>
         ),
-        // TODO(continuous profiling): Uncomment when we have a continuous profile doc link
-        // profile: (
-        //   <ExternalLink
-        //     key="profiles"
-        //     href={getDocsLinkForEventType(DataCategoryExact.PROFILE)}
-        //     onClick={onClick}
-        //   >
-        //     {getSingularCategoryName({
-        //       plan,
-        //       category: DataCategory.PROFILES,
-        //       capitalize: false,
-        //     })}
-        //   </ExternalLink>
-        // ),
+        profileDuration: (
+          <ExternalLink
+            key="profiles"
+            href={getDocsLinkForEventType(DataCategoryExact.PROFILE_DURATION)}
+            onClick={onClick}
+          >
+            {getSingularCategoryName({
+              plan,
+              category: DataCategory.PROFILE_DURATION,
+              capitalize: false,
+            })}
+          </ExternalLink>
+        ),
+        profileDurationUI: (
+          <ExternalLink
+            key="profiles-ui"
+            href={getDocsLinkForEventType(DataCategoryExact.PROFILE_DURATION_UI)}
+            onClick={onClick}
+          >
+            {getSingularCategoryName({
+              plan,
+              category: DataCategory.PROFILE_DURATION_UI,
+              capitalize: false,
+            })}
+          </ExternalLink>
+        ),
       }[eventType]!;
     };
 


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/17049

<img width="2095" alt="Screenshot 2025-03-28 at 8 20 52 PM" src="https://github.com/user-attachments/assets/b5915a8c-c503-4836-a8f3-a56fc7cc467c" />


Fix the overage banner.