### PR TITLE
feat(seer): update autofix analytics

### DIFF
--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -259,6 +259,7 @@ function AutofixSummary({
                         {card.insight && (
                           <div
                             onClick={e => {
+                              // Stop propagation if the click is directly on a link
                               if ((e.target as HTMLElement).tagName === 'A') {
                                 e.stopPropagation();
                               }

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -21,8 +21,10 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import marked from 'sentry/utils/marked';
 import testableTransition from 'sentry/utils/testableTransition';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useOpenSeerDrawer} from 'sentry/views/issueDetails/streamline/sidebar/seerDrawer';
 
 const pulseAnimation = {
@@ -106,6 +108,7 @@ export function GroupSummaryWithAutofix({
   if (rootCauseDescription) {
     return (
       <AutofixSummary
+        group={group}
         rootCauseDescription={rootCauseDescription}
         solutionDescription={solutionDescription}
         solutionIsLoading={solutionIsLoading}
@@ -122,6 +125,7 @@ export function GroupSummaryWithAutofix({
 }
 
 function AutofixSummary({
+  group,
   rootCauseDescription,
   solutionDescription,
   solutionIsLoading,
@@ -133,6 +137,7 @@ function AutofixSummary({
 }: {
   codeChangesDescription: string | null;
   codeChangesIsLoading: boolean;
+  group: Group;
   openSeerDrawer: () => void;
   rootCauseCopyText: string | null;
   rootCauseDescription: string | null;
@@ -140,6 +145,8 @@ function AutofixSummary({
   solutionDescription: string | null;
   solutionIsLoading: boolean;
 }) {
+  const organization = useOrganization();
+
   const insightCards: InsightCardObject[] = [
     {
       id: 'root_cause_description',
@@ -180,6 +187,33 @@ function AutofixSummary({
       : []),
   ];
 
+  const handleCardClick = (cardId: string, originalOnClick?: () => void) => {
+    let eventKey: string | null = null;
+
+    switch (cardId) {
+      case 'root_cause_description':
+        eventKey = 'autofix.summary_root_cause_clicked';
+        break;
+      case 'solution_description':
+        eventKey = 'autofix.summary_solution_clicked';
+        break;
+      case 'code_changes':
+        eventKey = 'autofix.summary_code_changes_clicked';
+        break;
+      default:
+        break;
+    }
+
+    if (eventKey) {
+      trackAnalytics(eventKey, {
+        organization,
+        group_id: group.id,
+      });
+    }
+
+    originalOnClick?.();
+  };
+
   return (
     <div data-testid="autofix-summary">
       <Content>
@@ -192,7 +226,7 @@ function AutofixSummary({
             return (
               <InsightCardButton
                 key={card.id}
-                onClick={card.onClick}
+                onClick={() => handleCardClick(card.id, card.onClick)}
                 role="button"
                 initial="initial"
                 animate={card.isLoading ? 'animate' : 'initial'}
@@ -225,7 +259,6 @@ function AutofixSummary({
                         {card.insight && (
                           <div
                             onClick={e => {
-                              // Stop propagation if the click is directly on a link
                               if ((e.target as HTMLElement).tagName === 'A') {
                                 e.stopPropagation();
                               }

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -194,7 +194,11 @@ export function SeerSectionCtaButton({
       onClick={handleOpenDrawer}
       analyticsEventKey="issue_details.seer_opened"
       analyticsEventName="Issue Details: Seer Opened"
-      analyticsParams={{has_streamlined_ui: hasStreamlinedUI}}
+      analyticsParams={{
+        has_streamlined_ui: hasStreamlinedUI,
+        autofix_exists: Boolean(autofixData?.steps?.length),
+        autofix_step_type: lastStep?.type ?? null,
+      }}
     >
       {getButtonText()}
       <ChevronContainer>


### PR DESCRIPTION
track whether or not there is an active run when the user opens the autofix flyout - this will be important for tracking DAU/MAU once more folks are using automation, as the analytics event for triggering a run will become less reliable once it is auto-running. 