### PR TITLE
fix(project-create): Tweak placement threshold

### DIFF
--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -424,6 +424,7 @@ function CreateProject() {
                     placeholder={t('Select a Team')}
                     onChange={(choice: any) => setTeam(choice.value)}
                     teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+                    minMenuHeight={240}
                   />
                 </TeamSelectInput>
               </div>


### PR DESCRIPTION
Display team selector menu above the trigger if there is not enough room for at least 6 items to be visible.