### PR TITLE
feat(dashboards): Add support for "score" value type

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -145,6 +145,7 @@ export enum FieldValueType {
   SIZE = 'size',
   RATE = 'rate',
   PERCENT_CHANGE = 'percent_change',
+  SCORE = 'score',
 }
 
 export enum WebVital {

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -11,6 +11,7 @@ export const PLOTTABLE_TIME_SERIES_VALUE_TYPES = [
   'percentage',
   'size',
   'rate',
+  'score',
 ] as const;
 
 export const MIN_WIDTH = 110;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -14,6 +14,7 @@ type AttributeValueType =
   | 'string'
   | 'size'
   | 'rate'
+  | 'score'
   | null;
 
 type AttributeValueUnit = DataUnit | null;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
@@ -1,0 +1,207 @@
+import {TimeSeries} from '../../common/types';
+
+export const sampleScoreTimeSeries: TimeSeries = {
+  field: 'performance_score(measurements.score.lcp)',
+  meta: {
+    type: 'score',
+    unit: null,
+  },
+  data: [
+    {
+      value: 16,
+      timestamp: '2024-10-24T15:00:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T15:30:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T16:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-24T16:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-24T17:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-24T17:30:00-04:00',
+    },
+    {
+      value: 15,
+      timestamp: '2024-10-24T18:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-24T18:30:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T19:00:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T19:30:00-04:00',
+    },
+    {
+      value: 15,
+      timestamp: '2024-10-24T20:00:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T20:30:00-04:00',
+    },
+    {
+      value: 15,
+      timestamp: '2024-10-24T21:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-24T21:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-24T22:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-24T22:30:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-24T23:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-24T23:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T00:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T00:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T01:00:00-04:00',
+    },
+    {
+      value: 20,
+      timestamp: '2024-10-25T01:30:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T02:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T02:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T03:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T03:30:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T04:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T04:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T05:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T05:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T06:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T06:30:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T07:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T07:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T08:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T08:30:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T09:00:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T09:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T10:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T10:30:00-04:00',
+    },
+    {
+      value: 19,
+      timestamp: '2024-10-25T11:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T11:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T12:00:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T12:30:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T13:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T13:30:00-04:00',
+    },
+    {
+      value: 16,
+      timestamp: '2024-10-25T14:00:00-04:00',
+    },
+    {
+      value: 17,
+      timestamp: '2024-10-25T14:30:00-04:00',
+    },
+    {
+      value: 18,
+      timestamp: '2024-10-25T15:00:00-04:00',
+    },
+  ],
+};

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
@@ -64,4 +64,13 @@ describe('formatTooltipValue', () => {
       expect(formatTooltipValue(value, 'rate', unit)).toEqual(formattedValue);
     });
   });
+
+  describe('score', () => {
+    it.each([
+      [0, undefined, '0'],
+      [17.231, undefined, '17'],
+    ])('Formats %s as %s', (value, unit, formattedValue) => {
+      expect(formatTooltipValue(value, 'score', unit)).toEqual(formattedValue);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
@@ -48,6 +48,9 @@ export function formatTooltipValue(
       // This way, named rate functions like `epm()` will be shows in per minute
       // units
       return formatRate(value, unit as RateUnit);
+    case 'score':
+      // Scores are always integers, no half-marks.
+      return value.toFixed(0);
     default:
       return value.toString();
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -17,6 +17,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import type {LegendSelection, Release, TimeSeries, TimeSeriesMeta} from '../common/types';
 
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
+import {sampleScoreTimeSeries} from './fixtures/sampleScoreTimeSeries';
 import {sampleThroughputTimeSeries} from './fixtures/sampleThroughputTimeSeries';
 import {spanSamplesWithDurations} from './fixtures/spanSamplesWithDurations';
 import {Area} from './plottables/area';
@@ -214,6 +215,49 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
 />
           `}
         </CodeSnippet>
+      </Fragment>
+    );
+  });
+
+  story('Data Types', () => {
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="TimeSeriesWidgetVisualization" /> can plot most, but not all data
+          types that come back from our time series endpoints. The supported data types
+          are:
+          <ul>
+            <li>
+              <code>number</code>
+            </li>
+            <li>
+              <code>integer</code>
+            </li>
+            <li>
+              <code>duration</code>
+            </li>
+            <li>
+              <code>percentage</code>
+            </li>
+            <li>
+              <code>size</code>
+            </li>
+            <li>
+              <code>rate</code>
+            </li>
+            <li>
+              <code>score</code>
+            </li>
+          </ul>
+        </p>
+        <p>
+          Each of those types has specific behavior in its axes range, axis value
+          formatting, tooltip formatting, unit scaling, and so on. For example, the{' '}
+          <code>score</code> type always uses the 0-100 Y axis range.
+        </p>
+        <MediumWidget>
+          <TimeSeriesWidgetVisualization plottables={[new Area(sampleScoreTimeSeries)]} />
+        </MediumWidget>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
@@ -50,6 +50,12 @@ export function TimeSeriesWidgetYAxis(
           return 0.001;
         }
 
+        // "Score" axes are _always_ from 0 to 100. Otherwise it's unclear how much
+        // opportunity there is to improve them.
+        if (yAxisFieldType === 'score') {
+          return 100;
+        }
+
         return null;
       },
     },


### PR DESCRIPTION
A new value type! A "score" is a special kind of integer. It only ranges from 0 to 100, and it has no units. Soon, the backend will return this type for functions like `performance_score`, but for now just frontend support is helpful. The "score" type:

- always rounded to nearest integer in the tooltip formatter
- always 0-100 on the Y axis

**e.g.,**
<img width="442" alt="Screenshot 2025-03-31 at 11 20 47 AM" src="https://github.com/user-attachments/assets/3c018bee-3292-4c9d-a61c-e075a7b5d4c5" />


Contributes to [DAIN-111: Replace Web Vitals "Score Breakdown" chart with `TimeSeriesWidgetVisualization`](https://linear.app/getsentry/issue/DAIN-111/replace-web-vitals-score-breakdown-chart-with)