### PR TITLE
chore: Update empty transaction table copy

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -239,7 +239,11 @@ function TransactionsTable(props: Props) {
       <PanelTable
         data-test-id="transactions-table"
         isEmpty={!hasResults}
-        emptyMessage={t('No transactions found')}
+        emptyMessage={
+          eventView.query
+            ? t('No transactions found for this filter.')
+            : t('No transactions found.')
+        }
         headers={renderHeader()}
         isLoading={isLoading}
         disablePadding


### PR DESCRIPTION
Empty table with the message "No transactions found" is a bit confusing when the table says there are 6 transactions for this release. The filter for "Failed transactions" is much smaller than the "Not found" text. This updates the text to indicate there is a filter being applied. 
![Screenshot 2025-03-31 at 11 30 46 AM](https://github.com/user-attachments/assets/d56af99e-2e2a-4b8d-b19d-0a5e48ed4c68)
