### PR TITLE
feat(ourlogs): Enable the sentry logger integration for sentry

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.65
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.7
-sentry-sdk[http2]>=2.24.1
+sentry-sdk[http2]>=2.25.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -192,7 +192,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.65
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.24.1
+sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.65
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.24.1
+sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -527,6 +527,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Extract logs from python loggers within sentry itself
+# 1.0 = extract all warning-level logs
+register(
+    "ourlogs.sentry-emit-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Extract logs from breadcrumbs only for a random fraction of sent breadcrumbs.
 #
 # NOTE: Any value below 1.0 will break the product. Do not override in production.


### PR DESCRIPTION
This enables the new `logging` integration within Sentry itself, gated behind a rollout flag `ourlogs.sentry-emit-rollout`