### PR TITLE
feat(ourlogs): Add a per-project enable flag for log extraction

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -498,6 +498,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:jira-per-project-statuses", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Relay extracting logs from breadcrumbs for a project.
     manager.add("projects:ourlogs-breadcrumb-extraction", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable our logs product on a per project basis, only set in the case particular projects need to be opted out. Use organization:ourlogs-ingestion otherwise.
+    manager.add("projects:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -69,6 +69,7 @@ EXPOSABLE_FEATURES = [
     "organizations:ourlogs-ingestion",
     "organizations:view-hierarchy-scrubbing",
     "projects:ourlogs-breadcrumb-extraction",
+    "projects:ourlogs-ingestion",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
### Summary
We had one for breadcrumb extraction but we also need one for the based log extraction in relay in case of trouble with particular projects.
