### PR TITLE
fix(dashboard): Validation when columns undefined

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -411,7 +411,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         if data.get("queries"):
             # Check each query to see if they have an issue or discover error depending on the type of the widget
             for query in data.get("queries"):
-                if len(query.get("columns")) > 0:
+                if len(query.get("columns", [])) > 0:
                     has_columns = True
                 if (
                     data.get("widget_type") == DashboardWidgetTypes.ISSUE

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -2641,6 +2641,33 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert widget.discover_widget_split is None
         assert widget.dataset_source == DatasetSourcesTypes.UNKNOWN.value
 
+    def test_dashboard_widget_missing_columns_can_successfully_save(self):
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "title": "Issue Widget",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ISSUE),
+                    "queries": [
+                        {
+                            "name": "Errors",
+                            "fields": ["issue", "title"],
+                            "aggregates": [],
+                            "conditions": "",
+                            "orderby": "",
+                        }
+                    ],
+                }
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+        assert response.data["widgets"][0]["queries"][0]["columns"] == []
+        assert response.data["widgets"][0]["queries"][0]["fields"] == ["issue", "title"]
+        assert response.data["widgets"][0]["widgetType"] == "issue"
+
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):
     widget_type = DashboardWidgetTypes.DISCOVER


### PR DESCRIPTION
If columns isn't defined, this shouldn't error out

Fixes SENTRY-3R8A