### PR TITLE
fix(issues): Fix drawers not opening on first click

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
@@ -667,7 +660,7 @@ function GroupDetailsContent({
 
   const hasStreamlinedUI = useHasStreamlinedUI();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!hasStreamlinedUI || isDrawerOpen) {
       return;
     }

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -42,14 +42,13 @@ export enum DrawerTab {
 }
 
 function useDrawerTab({enabled}: {enabled: boolean}) {
-  const {getParamValue: getTabParam, setParamValue: setTabParam} = useUrlParams('tab');
-  const [tab, setTab] = useState<DrawerTab>(() =>
-    getTabParam() === DrawerTab.FEATURE_FLAGS ? DrawerTab.FEATURE_FLAGS : DrawerTab.TAGS
+  const {getParamValue: getTabParam, setParamValue: setTabParam} = useUrlParams(
+    'tab',
+    DrawerTab.TAGS
   );
 
   const setTabCallback = useCallback(
     (newTab: DrawerTab) => {
-      setTab(newTab);
       setTabParam(newTab);
     },
     [setTabParam]
@@ -58,7 +57,7 @@ function useDrawerTab({enabled}: {enabled: boolean}) {
   if (!enabled) {
     return {tab: DrawerTab.TAGS, setTab: (_tab: string) => {}};
   }
-  return {tab, setTab: setTabCallback};
+  return {tab: enabled ? getTabParam() : DrawerTab.TAGS, setTab: setTabCallback};
 }
 
 function getHeaderTitle(

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
@@ -43,20 +43,22 @@ export enum DrawerTab {
 
 function useDrawerTab({enabled}: {enabled: boolean}) {
   const {getParamValue: getTabParam, setParamValue: setTabParam} = useUrlParams('tab');
-  const [tab, setTab] = useState<DrawerTab>(
+  const [tab, setTab] = useState<DrawerTab>(() =>
     getTabParam() === DrawerTab.FEATURE_FLAGS ? DrawerTab.FEATURE_FLAGS : DrawerTab.TAGS
   );
 
-  useEffect(() => {
-    if (enabled) {
-      setTabParam(tab);
-    }
-  }, [tab, setTabParam, enabled]);
+  const setTabCallback = useCallback(
+    (newTab: DrawerTab) => {
+      setTab(newTab);
+      setTabParam(newTab);
+    },
+    [setTabParam]
+  );
 
   if (!enabled) {
     return {tab: DrawerTab.TAGS, setTab: (_tab: string) => {}};
   }
-  return {tab, setTab};
+  return {tab, setTab: setTabCallback};
 }
 
 function getHeaderTitle(

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -57,7 +57,10 @@ function useDrawerTab({enabled}: {enabled: boolean}) {
   if (!enabled) {
     return {tab: DrawerTab.TAGS, setTab: (_tab: string) => {}};
   }
-  return {tab: enabled ? getTabParam() : DrawerTab.TAGS, setTab: setTabCallback};
+  return {
+    tab: enabled ? (getTabParam() as DrawerTab) : DrawerTab.TAGS,
+    setTab: setTabCallback,
+  };
 }
 
 function getHeaderTitle(

--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
@@ -47,19 +47,12 @@ function useDrawerTab({enabled}: {enabled: boolean}) {
     DrawerTab.TAGS
   );
 
-  const setTabCallback = useCallback(
-    (newTab: DrawerTab) => {
-      setTabParam(newTab);
-    },
-    [setTabParam]
-  );
-
   if (!enabled) {
     return {tab: DrawerTab.TAGS, setTab: (_tab: string) => {}};
   }
   return {
     tab: enabled ? (getTabParam() as DrawerTab) : DrawerTab.TAGS,
-    setTab: setTabCallback,
+    setTab: setTabParam,
   };
 }
 


### PR DESCRIPTION
Revert useLayoutEffect for opening the drawer. I thought it might help with reducing the number of rerenders but it kinda just breaks it. 

Remove feature flags hook that updates query on open which is more rerenders. Use query params with a default.
