### PR TITLE
feat(profiling): Add feature flag to monitor latest profiling sdk

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -287,6 +287,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program
     manager.add("organizations:profiling-beta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Enables monitoring for latest profiling sdk used
+    manager.add("organizations:profiling-sdks", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enables production profiling in sentry browser application
     manager.add("organizations:profiling-browser", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables separate differential flamegraph page


### PR DESCRIPTION
In order to monitor if a project is using an outdated profiling sdk, this feature flag will be used to track the latest profiling sdk used by a project.