### PR TITLE
chore(flags): unregister feature-flag-ui flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -337,8 +337,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:dev-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable feature flag audit log (to show flag series)
     manager.add("organizations:feature-flag-audit-log", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable feature flag settings page
-    manager.add("organizations:feature-flag-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature flag CTA on issue details page
     manager.add("organizations:feature-flag-cta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature flag search autocomplete


### PR DESCRIPTION
it's been rolled out to everyone for a while, so let's clean up this flag

- options removal PR: https://github.com/getsentry/sentry-options-automator/pull/3425
- frontend removal PR: https://github.com/getsentry/sentry/pull/88353