### PR TITLE
chore(sentry app): Add logging for when we cant find a service hook

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -113,7 +113,7 @@ class EventLifecycle:
         """
         self._extra[name] = value
 
-    def add_extras(self, extras: Mapping[str, int | str]) -> None:
+    def add_extras(self, extras: Mapping[str, Any]) -> None:
         """Add multiple values to logged "extra" data."""
         self._extra.update(extras)
 

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -560,14 +560,14 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
                 organization_id=installation.organization_id, actor_id=installation.id
             )
         except ServiceHook.DoesNotExist:
+            lifecycle.add_extra("events", installation.sentry_app.events)
             lifecycle.add_extras(
                 {
                     "installation_uuid": installation.uuid,
                     "installation_id": installation.id,
                     "organization": installation.organization_id,
                     "sentry_app": installation.sentry_app.id,
-                    "events": installation.sentry_app.events,
-                    "webhook_url": installation.sentry_app.webhook_url,
+                    "webhook_url": installation.sentry_app.webhook_url or "",
                 }
             )
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SERVICEHOOK)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -567,6 +567,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
                     "installation_id": installation.id,
                     "organization": installation.organization_id,
                     "sentry_app": installation.sentry_app.id,
+                    "events": installation.sentry_app.events,
                     "webhook_url": installation.sentry_app.webhook_url or "",
                 }
             )


### PR DESCRIPTION
For [this ticket](https://linear.app/getsentry/issue/ECO-366/review-sentry-app-send-resource-change-webhook-alert)
Current hypothesis:
1. Potentially really old installations that existed prior to servicehooks existing ??? so need to be backfilled
2. We're not updating servicehooks correctly for another reason. I believe prior we weren't updating `ServiceHooks` because of region issues but US `ServiceHook` creation should've still worked. 

Note: The path to even get to this point means that the sentry app installation should be alerting to this event. So I need more info to aggregate with. BigQuery shows me the installations that are missing `ServiceHooks` but I want to filter more to `installations` that are running into this error I think.