### PR TITLE
ref(replay): rm issue details replay cta from backend platforms

### DIFF
--- a/static/app/utils/event/useEventCanShowReplayUpsell.tsx
+++ b/static/app/utils/event/useEventCanShowReplayUpsell.tsx
@@ -56,10 +56,14 @@ export default function useEventCanShowReplayUpsell({
     ? getConfigForIssueType(group, group?.project).pages.replays.enabled
     : true;
 
+  // Only show the upsell if the issue & project supports replays,
+  // the org has never sent replays, and
+  // the project platform is not a backend platform.
   const canShowUpsell =
     groupHasReplays &&
     projectCanUpsellReplay(project) &&
-    (!hasOrgSentReplays || replayBackendPlatforms.includes(upsellPlatform));
+    !hasOrgSentReplays &&
+    !replayBackendPlatforms.includes(upsellPlatform);
 
   return {
     canShowUpsell,

--- a/static/app/utils/event/useEventCanShowReplayUpsell.tsx
+++ b/static/app/utils/event/useEventCanShowReplayUpsell.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 
-import {replayBackendPlatforms} from 'sentry/data/platformCategories';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {PlatformKey} from 'sentry/types/project';
@@ -60,10 +59,7 @@ export default function useEventCanShowReplayUpsell({
   // the org has never sent replays, and
   // the project platform is not a backend platform.
   const canShowUpsell =
-    groupHasReplays &&
-    projectCanUpsellReplay(project) &&
-    !hasOrgSentReplays &&
-    !replayBackendPlatforms.includes(upsellPlatform);
+    groupHasReplays && projectCanUpsellReplay(project) && !hasOrgSentReplays;
 
   return {
     canShowUpsell,

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -1,4 +1,8 @@
-import {backend, replayPlatforms} from 'sentry/data/platformCategories';
+import {
+  backend,
+  replayBackendPlatforms,
+  replayPlatforms,
+} from 'sentry/data/platformCategories';
 import type {Organization} from 'sentry/types/organization';
 import type {MinimalProject} from 'sentry/types/project';
 
@@ -34,7 +38,10 @@ export function projectCanUpsellReplay(project: undefined | MinimalProject) {
   if (!project || !project.platform) {
     return false;
   }
-  return replayPlatforms.includes(project.platform);
+  return (
+    replayPlatforms.includes(project.platform) &&
+    !replayBackendPlatforms.includes(project.platform)
+  );
 }
 
 export default projectSupportsReplay;


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/88323

before:
<img width="876" alt="SCR-20250331-jfxt" src="https://github.com/user-attachments/assets/9777c996-fcf4-45dc-95bc-1bc9fdf69aa5" />


after:
<img width="1020" alt="SCR-20250331-jgtj" src="https://github.com/user-attachments/assets/ba6f795e-4486-4a58-91c6-a45ca55f1001" />
