### PR TITLE
chore(flags): rm audit log flag references from code

### DIFF
--- a/src/sentry/flags/endpoints/hooks.py
+++ b/src/sentry/flags/endpoints/hooks.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -21,11 +20,6 @@ class OrganizationFlagsHooksEndpoint(OrganizationEndpoint):
     publish_status = {"POST": ApiPublishStatus.PRIVATE}
 
     def post(self, request: Request, organization: Organization, provider: str) -> Response:
-        if not features.has(
-            "organizations:feature-flag-audit-log", organization, actor=request.user
-        ):
-            return Response("Not enabled.", status=404)
-
         try:
             provider_cls = get_provider(organization.id, provider, request.headers)
             if provider_cls is None:

--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -68,11 +67,6 @@ class OrganizationFlagsWebHookSigningSecretsEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has(
-            "organizations:feature-flag-audit-log", organization, actor=request.user
-        ):
-            return Response("Not enabled.", status=404)
-
         return self.paginate(
             request=request,
             queryset=FlagWebHookSigningSecretModel.objects.filter(organization_id=organization.id),
@@ -84,11 +78,6 @@ class OrganizationFlagsWebHookSigningSecretsEndpoint(OrganizationEndpoint):
         )
 
     def post(self, request: Request, organization: Organization) -> Response:
-        if not features.has(
-            "organizations:feature-flag-audit-log", organization, actor=request.user
-        ):
-            return Response("Not enabled.", status=404)
-
         validator = FlagWebhookSigningSecretValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
@@ -136,11 +125,6 @@ class OrganizationFlagsWebHookSigningSecretEndpoint(OrganizationEndpoint):
     def delete(
         self, request: Request, organization: Organization, signing_secret_id: str
     ) -> Response:
-        if not features.has(
-            "organizations:feature-flag-audit-log", organization, actor=request.user
-        ):
-            return Response("Not enabled.", status=404)
-
         try:
             model = FlagWebHookSigningSecretModel.objects.filter(
                 organization_id=organization.id

--- a/tests/sentry/flags/endpoints/test_hooks.py
+++ b/tests/sentry/flags/endpoints/test_hooks.py
@@ -24,7 +24,7 @@ class OrganizationFlagsHooksEndpointTestCase(APITestCase):
 
     @property
     def features(self):
-        return {"organizations:feature-flag-audit-log": True}
+        return {}
 
     def test_generic_post_create(self, mock_incr):
         request_data = {
@@ -195,12 +195,6 @@ class OrganizationFlagsHooksEndpointTestCase(APITestCase):
             response = self.client.post(url, {})
             assert response.status_code == 404
             assert call("feature_flags.audit_log_event_posted") not in mock_incr.call_args_list
-
-    def test_post_disabled(self, mock_incr):
-        response = self.client.post(self.url, data={})
-        assert response.status_code == 404
-        assert response.content == b'"Not enabled."'
-        assert call("feature_flags.audit_log_event_posted") not in mock_incr.call_args_list
 
     def test_post_missing_signature(self, mock_incr):
         with self.feature(self.features):

--- a/tests/sentry/flags/endpoints/test_secrets.py
+++ b/tests/sentry/flags/endpoints/test_secrets.py
@@ -20,7 +20,7 @@ class OrganizationFlagsWebHookSigningSecretsEndpointTestCase(APITestCase):
 
     @property
     def features(self):
-        return {"organizations:feature-flag-audit-log": True}
+        return {}
 
     def test_browse(self):
         org = self.create_organization()
@@ -48,10 +48,6 @@ class OrganizationFlagsWebHookSigningSecretsEndpointTestCase(APITestCase):
                     }
                 ]
             }
-
-    def test_browse_disabled(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 404
 
     def test_post_launchdarkly(self):
         with self.feature(self.features):
@@ -103,10 +99,6 @@ class OrganizationFlagsWebHookSigningSecretsEndpointTestCase(APITestCase):
         models = FlagWebHookSigningSecretModel.objects.filter(provider="statsig").all()
         assert len(models) == 1
         assert models[0].secret == "webhook-Xk9pL8NQaR5Ym2cx7vHnWtBj4M3f6qyZdC12mnspk8"
-
-    def test_post_disabled(self):
-        response = self.client.post(self.url, data={})
-        assert response.status_code == 404, response.content
 
     def test_post_invalid_provider(self):
         with self.feature(self.features):
@@ -282,16 +274,12 @@ class OrganizationFlagsWebHookSigningSecretEndpointTestCase(APITestCase):
 
     @property
     def features(self):
-        return {"organizations:feature-flag-audit-log": True}
+        return {}
 
     def test_delete(self):
         with self.feature(self.features):
             response = self.client.delete(self.url)
             assert response.status_code == 204
-
-    def test_delete_disabled(self):
-        response = self.client.delete(self.url)
-        assert response.status_code == 404
 
     def test_delete_other_organization(self):
         """Attempt to delete a secret outside your organization."""


### PR DESCRIPTION
it's been rolled out to everyone for a while, so let's clean up this flag

- options removal PR: https://github.com/getsentry/sentry-options-automator/pull/3426
- unregister PR: https://github.com/getsentry/sentry/pull/88347