### PR TITLE
chore(flags): rm feature-flag-ui references from code

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -144,8 +144,6 @@ export function getOrganizationNavigationConfiguration({
               }}
             />
           ),
-          show: ({organization}) =>
-            !!organization && organization.features.includes('feature-flag-ui'),
         },
         {
           path: `${organizationSettingsPathPrefix}/stats/`,

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -180,8 +180,6 @@ export function getUserOrgNavigationConfiguration({
           title: t('Feature Flags'),
           description: t('Set up feature flag integrations'),
           badge: () => 'beta',
-          show: ({organization}) =>
-            !!organization && organization.features.includes('feature-flag-ui'),
         },
       ],
     },


### PR DESCRIPTION
it's been rolled out to everyone for a while, so let's clean up this flag

- options removal PR: https://github.com/getsentry/sentry-options-automator/pull/3425
- unregister PR: https://github.com/getsentry/sentry/pull/88345