### PR TITLE
chore(flags): rm autocomplete flag references in code

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -236,10 +236,6 @@ export function fetchFeatureFlagValues({
   search?: string;
   sort?: '-last_seen' | '-count';
 }): Promise<TagValue[]> {
-  if (!organization.features.includes('feature-flag-autocomplete')) {
-    return Promise.resolve([]);
-  }
-
   // Search syntax may wrap with flags[] or flags[""], but this endpoint doesn't support it.
   const strippedKey = tagKey.replace(/^flags\[(?:"?)(.*?)(?:"?)\]$/, '$1');
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -58,6 +58,11 @@ describe('NewWidgetBuiler', function () {
     });
 
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboard/1/',
       body: [],
     });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -43,6 +43,11 @@ describe('WidgetBuilderSlideout', () => {
       method: 'POST',
       statusCode: 200,
     });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -164,9 +164,7 @@ function ResultsSearchQueryBuilder(props: Props) {
     () => normalizeDateTimeParams(selection.datetime),
     [selection.datetime]
   );
-  const includeFeatureFlags =
-    (!dataset || dataset === DiscoverDatasets.ERRORS) &&
-    organization.features.includes('feature-flag-autocomplete');
+  const includeFeatureFlags = !dataset || dataset === DiscoverDatasets.ERRORS;
 
   const tags = useTags();
   const filteredTags = useMemo(() => {

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -24,10 +24,7 @@ import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 import {useIssueListFilterKeys} from 'sentry/views/issueList/utils/useIssueListFilterKeys';
 
-const getFilterKeySections = (
-  tags: TagCollection,
-  organization: Organization
-): FilterKeySection[] => {
+const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
   const allTags: Tag[] = Object.values(tags).filter(
     tag => !EXCLUDED_TAGS.includes(tag.key)
   );
@@ -72,10 +69,7 @@ const getFilterKeySections = (
     },
   ];
 
-  if (
-    organization.features.includes('feature-flag-autocomplete') &&
-    eventFeatureFlags.length > 0
-  ) {
+  if (eventFeatureFlags.length > 0) {
     sections.push({
       value: FieldKind.FEATURE_FLAG,
       label: t('Flags'), // Keeping this short so the tabs stay on 1 line.
@@ -168,8 +162,8 @@ function IssueListSearchBar({
   );
 
   const filterKeySections = useMemo(() => {
-    return getFilterKeySections(filterKeys, organization);
-  }, [filterKeys, organization]);
+    return getFilterKeySections(filterKeys);
+  }, [filterKeys]);
 
   return (
     <SearchQueryBuilder

--- a/static/app/views/issueList/utils/useIssueListFilterKeys.tsx
+++ b/static/app/views/issueList/utils/useIssueListFilterKeys.tsx
@@ -6,15 +6,12 @@ import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags'
 export function useIssueListFilterKeys() {
   const organization = useOrganization();
   const {selection: pageFilters} = usePageFilters();
-  const hasFeatureFlagSearch = organization.features.includes(
-    'feature-flag-autocomplete'
-  );
 
   const {tags: issueTags} = useFetchIssueTags({
     org: organization,
     projectIds: pageFilters.projects.map(id => id.toString()),
     keepPreviousData: true,
-    includeFeatureFlags: hasFeatureFlagSearch,
+    includeFeatureFlags: true,
     start: pageFilters.datetime.start
       ? getUtcDateString(pageFilters.datetime.start)
       : undefined,


### PR DESCRIPTION
it's been rolled out to everyone for a while, so let's clean up this flag

- options removal PR: https://github.com/getsentry/sentry-options-automator/pull/3427
- unregister PR: https://github.com/getsentry/sentry/pull/88344