### PR TITLE
fix(dashboards): Ensure a limit is set for all widgets in a dashboard

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -6,12 +6,15 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {PageFilters} from 'sentry/types/core';
-import type {
-  DashboardDetails,
-  DashboardListItem,
-  Widget,
+import {defined} from 'sentry/utils';
+import {
+  type DashboardDetails,
+  type DashboardListItem,
+  DisplayType,
+  type Widget,
 } from 'sentry/views/dashboards/types';
 import {flattenErrors} from 'sentry/views/dashboards/utils';
+import {getResultsLimit} from 'sentry/views/dashboards/widgetBuilder/utils';
 
 export function fetchDashboards(api: Client, orgSlug: string) {
   const promise: Promise<DashboardListItem[]> = api.requestPromise(
@@ -51,7 +54,7 @@ export function createDashboard(
       method: 'POST',
       data: {
         title,
-        widgets: widgets.map(widget => omit(widget, ['tempId'])),
+        widgets: widgets.map(widget => omit(widget, ['tempId'])).map(_enforceWidgetLimit),
         duplicate,
         projects,
         environment,
@@ -162,7 +165,7 @@ export function updateDashboard(
     dashboard;
   const data = {
     title,
-    widgets: widgets.map(widget => omit(widget, ['tempId'])),
+    widgets: widgets.map(widget => omit(widget, ['tempId'])).map(_enforceWidgetLimit),
     projects,
     environment,
     period,
@@ -288,4 +291,30 @@ export function validateWidget(
   const widgetQuery = validateWidgetRequest(orgId, widget, selection);
   const promise: Promise<undefined> = api.requestPromise(widgetQuery[0], widgetQuery[1]);
   return promise;
+}
+
+/**
+ * Enforces a limit on the widget if it is a chart and has a grouping
+ *
+ * This ensures that widgets from previously created dashboards will have
+ * a limit applied properly when editing old dashboards that did not have
+ * this validation in place.
+ */
+function _enforceWidgetLimit(widget: Widget) {
+  if (
+    widget.displayType === DisplayType.TABLE ||
+    widget.displayType === DisplayType.BIG_NUMBER
+  ) {
+    return widget;
+  }
+
+  const hasColumns = widget.queries.some(query => query.columns.length > 0);
+  if (hasColumns && !defined(widget.limit)) {
+    return {
+      ...widget,
+      limit: getResultsLimit(widget.queries.length, widget.queries[0]!.aggregates.length),
+    };
+  }
+
+  return widget;
 }

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -343,6 +343,7 @@ function useWidgetBuilderState(): {
           setQuery([config.defaultWidgetQuery.conditions]);
           setLegendAlias([]);
           setSelectedAggregate(undefined);
+          setLimit(undefined);
           break;
         }
         case BuilderStateAction.SET_FIELDS: {


### PR DESCRIPTION
When we make an update request, there are old dashboards that were created before
the limit validation was applied, but we would default to `TOP_N` (i.e. `5`) on the frontend.

This enforces that, for the case where validation is necessary (i.e. a chart widget that has a grouping), we will always assign a limit. The limit is defined as the minimum between `TOP_N`, our default, and the maximum value. We do this because we want the number of series to remain the same prior to enforcing a limit, but if the widget has conditions which make the default limit _too high_ then we will use the lesser value.