### PR TITLE
feat(aci): available actions endpoint

### DIFF
--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -228,28 +228,6 @@ class NotifyEventServiceAction(EventAction):
 
         return results
 
-    def get_plugins_for_organization(self) -> Sequence[PluginService]:
-        """
-        Gets all plugins for an organization, not just for a specific project.
-        This method returns a deduplicated list of plugins that are enabled for any project in the organization.
-        """
-        from sentry.models.project import Project
-        from sentry.plugins.bases.notify import NotificationPlugin
-
-        organization_projects = Project.objects.filter(organization_id=self.project.organization_id)
-
-        plugin_map = {}
-
-        for project in organization_projects:
-            for plugin in plugins.for_project(project, version=1):
-                if not isinstance(plugin, NotificationPlugin):
-                    continue
-
-                if plugin.slug not in plugin_map:
-                    plugin_map[plugin.slug] = PluginService(plugin)
-
-        return list(plugin_map.values())
-
     def get_services(self) -> Sequence[Any]:
         return [*self.get_plugins(), *self.get_sentry_app_services()]
 

--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -110,7 +110,7 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
                         )
                     )
 
-            # add all other actions
+            # add all other action types (EMAIL, PLUGIN, etc.)
             else:
                 actions.append(
                     serialize(

--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -1,0 +1,132 @@
+from collections import defaultdict
+
+from drf_spectacular.utils import extend_schema
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import RpcIntegration, integration_service
+from sentry.models.organization import Organization
+from sentry.sentry_apps.services.app import app_service
+from sentry.workflow_engine.endpoints.serializers import (
+    ActionHandlerSerializer,
+    ActionHandlerSerializerResponse,
+)
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.registry import action_handler_registry
+
+
+def get_available_action_integrations_for_org(organization: Organization) -> list[RpcIntegration]:
+    """
+    Returns a list of integrations that the organization has installed. Integrations are
+    filtered by the list of registered providers.
+    :param organization:
+    """
+
+    providers = [
+        handler.provider_slug
+        for handler in action_handler_registry.registrations.values()
+        if hasattr(handler, "provider_slug")
+    ]
+    return integration_service.get_integrations(
+        status=ObjectStatus.ACTIVE,
+        org_integration_status=ObjectStatus.ACTIVE,
+        organization_id=organization.id,
+        providers=providers,
+    )
+
+
+@region_silo_endpoint
+class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    @extend_schema(
+        operation_id="Fetch Available Actions",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
+        responses={
+            201: inline_sentry_response_serializer(
+                "ListAvailableActionResponse", list[ActionHandlerSerializerResponse]
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request, organization):
+        """
+        Returns a list of available actions for a given org
+        """
+        provider_integrations: dict[str, list[RpcIntegration]] = defaultdict(list)
+        for integration in get_available_action_integrations_for_org(organization):
+            provider_integrations[integration.provider].append(integration)
+
+        sentry_app_component_contexts = app_service.get_installation_component_contexts(
+            filter={"organization_id": organization.id},
+            component_type="alert-rule-action",
+            include_contexts_without_component=True,
+        )
+
+        actions = []
+        for action_type, handler in action_handler_registry.registrations.items():
+            # add integration actions
+            if hasattr(handler, "provider_slug"):
+                integrations = provider_integrations.get(handler.provider_slug, [])
+                actions.append(
+                    serialize(
+                        handler,
+                        request.user,
+                        ActionHandlerSerializer(),
+                        action_type=action_type,
+                        integrations=integrations,
+                    )
+                )
+
+            # add alertable sentry app actions
+            elif action_type == Action.Type.SENTRY_APP:
+                for context in sentry_app_component_contexts:
+                    if context.installation.sentry_app.is_alertable:
+                        actions.append(
+                            serialize(
+                                handler,
+                                request.user,
+                                ActionHandlerSerializer(),
+                                action_type=action_type,
+                                sentry_app_context=context,
+                            )
+                        )
+
+            # TODO(mia): handle adding webhoook actions
+            elif action_type == Action.Type.WEBHOOK:
+                continue
+
+            # add all other actions
+            else:
+                actions.append(
+                    serialize(
+                        handler, request.user, ActionHandlerSerializer(), action_type=action_type
+                    )
+                )
+
+        return self.paginate(
+            request=request,
+            queryset=actions,
+            paginator_cls=OffsetPaginator,
+        )

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -86,7 +86,7 @@ class ActionHandlerSerializer(Serializer):
         }
 
         integrations = kwargs.get("integrations")
-        if integrations is not None:
+        if integrations:
             result["integrations"] = [
                 {"id": str(integration.id), "name": integration.name}
                 for integration in integrations

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -44,7 +44,7 @@ class ActionSerializer(Serializer):
 class SentryAppContext(TypedDict):
     id: str
     name: str
-    installationUuid: str
+    installationId: str
     status: int
     settings: NotRequired[dict[str, Any]]
 
@@ -53,9 +53,9 @@ class ActionHandlerSerializerResponse(TypedDict):
     type: str
     handlerGroup: str
     configSchema: dict
-    dataSchema: NotRequired[dict]
+    dataSchema: dict
     sentryApp: NotRequired[SentryAppContext]
-    installations: NotRequired[list]
+    integrations: NotRequired[list]
 
 
 @register(ActionHandler)
@@ -88,7 +88,7 @@ class ActionHandlerSerializer(Serializer):
         sentry_app_context = kwargs.get("sentry_app_context")
         if sentry_app_context:
             installation = sentry_app_context.installation
-            sentry_app = {
+            sentry_app: SentryAppContext = {
                 "id": str(installation.sentry_app.id),
                 "name": installation.sentry_app.name,
                 "installationId": str(installation.id),

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,5 +1,6 @@
 from django.urls import re_path
 
+from .organization_available_action_index import OrganizationAvailableActionIndexEndpoint
 from .organization_data_condition_index import OrganizationDataConditionIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
 from .organization_detector_workflow_index import OrganizationDetectorWorkflowIndexEndpoint
@@ -49,7 +50,7 @@ organization_urlpatterns = [
         name="sentry-api-0-organization-data-condition-index",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/detector_types/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/detector-types/$",
         OrganizationDetectorTypeIndexEndpoint.as_view(),
         name="sentry-api-0-organization-detector-type-index",
     ),
@@ -57,5 +58,10 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^\/]+)/detector-workflow/$",
         OrganizationDetectorWorkflowIndexEndpoint.as_view(),
         name="sentry-api-0-organization-detector-workflow-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/available-actions/$",
+        OrganizationAvailableActionIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-available-action-index",
     ),
 ]

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -116,6 +116,8 @@ def get_notification_plugins_for_org(organization: Organization) -> list[PluginS
     """
 
     projects = Project.objects.filter(organization_id=organization.id)
+
+    # Need to use a map to deduplicate plugins by slug because the same plugin can be enabled for multiple projects
     plugin_map = {}
 
     for project in projects:

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -125,7 +125,6 @@ def get_notification_plugins_for_org(organization: Organization) -> list[PluginS
             if not isinstance(plugin, NotificationPlugin):
                 continue
 
-            if plugin.slug not in plugin_map:
-                plugin_map[plugin.slug] = PluginService(plugin)
+            plugin_map[plugin.slug] = PluginService(plugin)
 
     return list(plugin_map.values())

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -109,7 +109,7 @@ def get_available_action_integrations_for_org(organization: Organization) -> lis
     )
 
 
-def get_notification_plugins_for_org(organization: Organization) -> list[RpcIntegration]:
+def get_notification_plugins_for_org(organization: Organization) -> list[PluginService]:
     """
     Get all plugins for an organization.
     This method returns a deduplicated list of plugins that are enabled for any project in the organization.

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -1,0 +1,267 @@
+from dataclasses import dataclass
+from unittest.mock import ANY, patch
+
+from sentry.constants import SentryAppStatus
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.registry import Registry
+from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
+from sentry.workflow_engine.handlers.action.notification.common import (
+    GENERIC_ACTION_CONFIG_SCHEMA,
+    MESSAGING_ACTION_CONFIG_SCHEMA,
+    NOTES_SCHEMA,
+    TAGS_SCHEMA,
+)
+from sentry.workflow_engine.models.action import Action
+from sentry.workflow_engine.types import ActionHandler, DataConditionHandler
+
+MOCK_DATA_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "description": "Mock schema for action data blob",
+    "properties": {
+        "tags": TAGS_SCHEMA,
+        "notes": NOTES_SCHEMA,
+    },
+    "additionalProperties": False,
+}
+
+
+@region_silo_test
+class OrganizationAvailableActionAPITestCase(APITestCase):
+    endpoint = "sentry-api-0-organization-available-action-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.registry = Registry[DataConditionHandler](enable_reverse_lookup=False)
+        self.registry_patcher = patch(
+            "sentry.workflow_engine.endpoints.organization_available_action_index.action_handler_registry",
+            new=self.registry,
+        )
+        self.registry_patcher.start()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.registry_patcher.stop()
+
+    def test_simple(self):
+        @self.registry.register(Action.Type.EMAIL)
+        @dataclass(frozen=True)
+        class EmailActionHandler(ActionHandler):
+            group = ActionHandler.Group.NOTIFICATION
+            config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+            data_schema = {}
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 1
+        assert response.data == [
+            {
+                "type": Action.Type.EMAIL,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": GENERIC_ACTION_CONFIG_SCHEMA,
+                "dataSchema": {},
+            }
+        ]
+
+    def test_integrations(self):
+        @self.registry.register(Action.Type.MSTEAMS)
+        @dataclass(frozen=True)
+        class MSTeamsActionHandler(IntegrationActionHandler):
+            group = ActionHandler.Group.NOTIFICATION
+            provider_slug = "msteams"
+            config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
+            data_schema = MOCK_DATA_SCHEMA
+
+        @self.registry.register(Action.Type.SLACK)
+        @dataclass(frozen=True)
+        class SlackActionHandler(IntegrationActionHandler):
+            group = ActionHandler.Group.NOTIFICATION
+            provider_slug = "slack"
+            config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
+            data_schema = MOCK_DATA_SCHEMA
+
+        token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            name="My Slack Integration",
+            provider="slack",
+            metadata={"access_token": token, "installation_type": "born_as_bot"},
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 2
+        assert sorted(response.data, key=lambda x: x["type"]) == [
+            {
+                "type": Action.Type.MSTEAMS,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": MESSAGING_ACTION_CONFIG_SCHEMA,
+                "dataSchema": MOCK_DATA_SCHEMA,
+                "integrations": [],
+            },
+            {
+                "type": Action.Type.SLACK,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": MESSAGING_ACTION_CONFIG_SCHEMA,
+                "dataSchema": MOCK_DATA_SCHEMA,
+                "integrations": [{"id": str(self.integration.id), "name": self.integration.name}],
+            },
+        ]
+
+    def test_sentry_apps(self):
+        @self.registry.register(Action.Type.SENTRY_APP)
+        @dataclass(frozen=True)
+        class SentryAppActionHandler(ActionHandler):
+            group = ActionHandler.Group.OTHER
+            config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+            data_schema = {}
+
+        self.sentry_app = self.create_sentry_app(
+            name="Moo Deng's Fire Sentry App",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+            is_alertable=True,
+        )
+        self.sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization
+        )
+
+        self.no_component_sentry_app = self.create_sentry_app(
+            name="Poppy's Fire Sentry App",
+            organization=self.organization,
+            is_alertable=True,
+        )
+        self.no_component_sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.no_component_sentry_app.slug, organization=self.organization
+        )
+
+        # should not return sentry apps that are not installed
+        self.create_sentry_app(
+            name="Bad Sentry App",
+            organization=self.organization,
+            is_alertable=True,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 2
+        assert sorted(response.data, key=lambda x: x["sentryApp"]["id"]) == [
+            {
+                "type": Action.Type.SENTRY_APP,
+                "handlerGroup": ActionHandler.Group.OTHER.value,
+                "configSchema": GENERIC_ACTION_CONFIG_SCHEMA,
+                "dataSchema": {},
+                "sentryApp": {
+                    "id": str(self.sentry_app.id),
+                    "name": self.sentry_app.name,
+                    "installationId": str(self.sentry_app_installation.id),
+                    "status": SentryAppStatus.as_str(self.sentry_app.status),
+                    "settings": ANY,
+                },
+            },
+            {
+                "type": Action.Type.SENTRY_APP,
+                "handlerGroup": ActionHandler.Group.OTHER.value,
+                "configSchema": GENERIC_ACTION_CONFIG_SCHEMA,
+                "dataSchema": {},
+                "sentryApp": {
+                    "id": str(self.no_component_sentry_app.id),
+                    "name": self.no_component_sentry_app.name,
+                    "installationId": str(self.no_component_sentry_app_installation.id),
+                    "status": SentryAppStatus.as_str(self.no_component_sentry_app.status),
+                },
+            },
+        ]
+
+    def test_multiple_action_types(self):
+        @self.registry.register(Action.Type.EMAIL)
+        @dataclass(frozen=True)
+        class EmailActionHandler(ActionHandler):
+            group = ActionHandler.Group.NOTIFICATION
+            config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+            data_schema = {}
+
+        @self.registry.register(Action.Type.SENTRY_APP)
+        @dataclass(frozen=True)
+        class SentryAppActionHandler(ActionHandler):
+            group = ActionHandler.Group.OTHER
+            config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+            data_schema = {}
+
+        self.sentry_app = self.create_sentry_app(
+            name="Moo Deng's Fire Sentry App",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+            is_alertable=True,
+        )
+        self.sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization
+        )
+
+        @self.registry.register(Action.Type.SLACK)
+        @dataclass(frozen=True)
+        class SlackActionHandler(IntegrationActionHandler):
+            group = ActionHandler.Group.NOTIFICATION
+            provider_slug = "slack"
+            config_schema = MESSAGING_ACTION_CONFIG_SCHEMA
+            data_schema = MOCK_DATA_SCHEMA
+
+        token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            name="My Slack Integration",
+            provider="slack",
+            metadata={"access_token": token, "installation_type": "born_as_bot"},
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 3
+        assert sorted(response.data, key=lambda x: x["type"]) == [
+            {
+                "type": Action.Type.EMAIL,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": GENERIC_ACTION_CONFIG_SCHEMA,
+                "dataSchema": {},
+            },
+            {
+                "type": Action.Type.SENTRY_APP,
+                "handlerGroup": ActionHandler.Group.OTHER.value,
+                "configSchema": GENERIC_ACTION_CONFIG_SCHEMA,
+                "dataSchema": {},
+                "sentryApp": {
+                    "id": str(self.sentry_app.id),
+                    "name": self.sentry_app.name,
+                    "installationId": str(self.sentry_app_installation.id),
+                    "status": SentryAppStatus.as_str(self.sentry_app.status),
+                    "settings": ANY,
+                },
+            },
+            {
+                "type": Action.Type.SLACK,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": MESSAGING_ACTION_CONFIG_SCHEMA,
+                "dataSchema": MOCK_DATA_SCHEMA,
+                "integrations": [{"id": str(self.integration.id), "name": self.integration.name}],
+            },
+        ]


### PR DESCRIPTION
adding new endpoint that returns all available actions

all actions will have:
```
{
    type: str
    handlerGroup: str
    configSchema: dict
    dataSchema: dict
}
```

for integration actions, actions will contain a list of all installations (ids and names) for that integration provider:
```
    installations: list[(id, name)]
```

for sentry app actions, actions will contain:
```
    sentryApp: {
        id: str
        name: str
        installationId: str
        status: int
        settings: dict  // this represents the settings component, if the sentry app has one
    }
```

for the webhook action, action will contain a list of all plugin services (slugs and names):
```
    services: list[(slug, name)]
```

actions are sorted by `handlerGroup`, then `type` (with the exception of the email action which should always be first), then `name` for sentry app actions

this currently does not return any webhook (plugin) actions