### PR TITLE
chore(billing): Use budgetTerm

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
@@ -161,9 +161,7 @@ function PerformanceQuotaExceededWarning(props: ErrorOnlyWarningsProps) {
 
   const title = tct("You've exceeded your [billingType]", {
     billingType: subscription?.onDemandBudgets?.enabled
-      ? ['am1', 'am2'].includes(subscription.planTier)
-        ? t('on-demand budget')
-        : t('pay-as-you-go budget')
+      ? subscription.planDetails.budgetTerm
       : t('quota'),
   });
 

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
@@ -17,6 +17,7 @@ type Subscription = {
       };
   planDetails: {
     billingInterval: 'monthly' | 'annual';
+    budgetTerm: 'pay-as-you-go' | 'on-demand';
   };
   planTier: string;
   onDemandBudgets?: {

--- a/static/gsAdmin/components/customers/pendingChanges.spec.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.spec.tsx
@@ -200,7 +200,7 @@ describe('PendingChanges', function () {
       'The following changes will take effect on Feb 16, 2022'
     );
     expect(container).toHaveTextContent(
-      'On-demand budget — shared on-demand of $100 → per-category on-demand (errors at $3, transactions at $2, and attachments at $1)'
+      'On-demand budget — shared on-demand budget of $100 → per-category on-demand budget (errors at $3, transactions at $2, and attachments at $1)'
     );
   });
 
@@ -245,7 +245,7 @@ describe('PendingChanges', function () {
     );
     expect(container).toHaveTextContent('Plan changes — Developer → Team (Enterprise)');
     expect(container).toHaveTextContent(
-      'On-demand budget — shared on-demand of $100 → per-category on-demand (errors at $3, transactions at $2, and attachments at $1)'
+      'On-demand budget — shared on-demand budget of $100 → per-category on-demand budget (errors at $3, transactions at $2, and attachments at $1)'
     );
     expect(screen.getAllByText(/The following changes will take effect on/)).toHaveLength(
       1

--- a/static/gsAdmin/components/customers/pendingChanges.spec.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.spec.tsx
@@ -169,6 +169,7 @@ describe('PendingChanges', function () {
           contractInterval: 'annual',
           billingInterval: 'annual',
           onDemandCategories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
         onDemandBudgets: {
           enabled: true,
@@ -218,6 +219,7 @@ describe('PendingChanges', function () {
           contractInterval: 'annual',
           billingInterval: 'annual',
           onDemandCategories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
         onDemandBudgets: {
           enabled: true,

--- a/static/gsAdmin/components/customers/pendingChanges.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.tsx
@@ -300,13 +300,11 @@ function getOnDemandChanges(subscription: Subscription) {
     if (!isOnDemandBudgetsEqual(pendingOnDemandBudgets, currentOnDemandBudgets)) {
       const current = formatOnDemandBudget(
         subscription.planDetails,
-        subscription.planTier,
         currentOnDemandBudgets,
         subscription.planDetails.onDemandCategories
       );
       const change = formatOnDemandBudget(
         pendingChanges.planDetails,
-        subscription.planTier,
         pendingOnDemandBudgets,
         pendingChanges.planDetails.onDemandCategories
       );

--- a/static/gsApp/__fixtures__/plan.tsx
+++ b/static/gsApp/__fixtures__/plan.tsx
@@ -13,7 +13,7 @@ export function PlanFixture(fields: Partial<Plan>): Plan {
     description: '',
     features: [],
     hasOnDemandModes: false,
-    id: 'am2_f',
+    id: 'am3_f',
     isTestPlan: false,
     maxMembers: 1,
     name: 'Developer',
@@ -45,6 +45,7 @@ export function PlanFixture(fields: Partial<Plan>): Plan {
     trialPlan: null,
     userSelectable: true,
     categoryDisplayNames: {},
+    budgetTerm: 'pay-as-you-go',
     ...fields,
   };
 }

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -9,7 +9,10 @@ import withApi from 'sentry/utils/withApi';
 import {sendAddEventsRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
 import StartTrialButton from 'getsentry/components/startTrialButton';
 import type {Subscription} from 'getsentry/types';
-import {getBestActionToIncreaseEventLimits} from 'getsentry/utils/billing';
+import {
+  displayBudgetName,
+  getBestActionToIncreaseEventLimits,
+} from 'getsentry/utils/billing';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
@@ -107,7 +110,7 @@ function AddEventsCTA(props: Props) {
         <Button to={subscriptionUrl} onClick={() => manageOnDemand()} {...commonProps}>
           {tct('[action] [budgetTerm]', {
             action: subscription.onDemandBudgets?.enabled ? 'Increase' : 'Setup',
-            budgetTerm: subscription.planDetails.budgetTerm,
+            budgetTerm: displayBudgetName(subscription.planDetails, {title: true}),
           })}
         </Button>
       );

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -2,13 +2,13 @@ import {useState} from 'react';
 
 import type {Client} from 'sentry/api';
 import {Button, type ButtonProps} from 'sentry/components/core/button';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import withApi from 'sentry/utils/withApi';
 
 import {sendAddEventsRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
 import StartTrialButton from 'getsentry/components/startTrialButton';
-import {PlanTier, type Subscription} from 'getsentry/types';
+import type {Subscription} from 'getsentry/types';
 import {getBestActionToIncreaseEventLimits} from 'getsentry/utils/billing';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
@@ -101,21 +101,14 @@ function AddEventsCTA(props: Props) {
   const checkoutUrl = `/settings/${organization.slug}/billing/checkout/?referrer=${referrer}`;
   const subscriptionUrl = `/settings/${organization.slug}/billing/overview/`;
 
-  // Make an exception for when only crons has an overage to change the language to be more fitting
-  const strictlyCronsOverage =
-    eventTypes?.length === 1 && eventTypes[0] === 'monitorSeat';
-
   switch (action) {
     case 'add_events':
       return (
         <Button to={subscriptionUrl} onClick={() => manageOnDemand()} {...commonProps}>
-          {subscription.planTier === PlanTier.AM3
-            ? subscription?.onDemandBudgets?.enabled
-              ? t('Increase Pay-as-you-go')
-              : t('Setup Pay-as-you-go')
-            : strictlyCronsOverage
-              ? t('Update Plan')
-              : t('Increase Reserved Limits')}
+          {tct('[action] [budgetTerm]', {
+            action: subscription.onDemandBudgets?.enabled ? 'Increase' : 'Setup',
+            budgetTerm: subscription.planDetails.budgetTerm,
+          })}
         </Button>
       );
     case 'request_add_events':

--- a/static/gsApp/components/crons/cronsBillingBanner.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.tsx
@@ -12,12 +12,7 @@ import {
 } from 'getsentry/components/crons/cronsBannerUpgradeCTA';
 import withSubscription from 'getsentry/components/withSubscription';
 import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
-import {
-  type BillingConfig,
-  type MonitorCountResponse,
-  PlanTier,
-  type Subscription,
-} from 'getsentry/types';
+import type {BillingConfig, MonitorCountResponse, Subscription} from 'getsentry/types';
 import {getTrialDaysLeft} from 'getsentry/utils/billing';
 
 interface Props {
@@ -116,8 +111,7 @@ function TrialEndingBanner({
   trialDaysLeft,
   subscription,
 }: TrialEndingBannerProps & {subscription: Subscription}) {
-  const budgetType =
-    subscription.planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand';
+  const budgetType = subscription.planDetails.budgetTerm;
   return (
     <TrialBanner hasBillingAccess={hasBillingAccess}>
       {hasBillingAccess
@@ -172,8 +166,7 @@ function InsufficentOnDemandMonitorsDisabledBanner({
   hasBillingAccess,
   subscription,
 }: BannerProps & {subscription: Subscription}) {
-  const budgetType =
-    subscription.planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand';
+  const budgetType = subscription.planDetails.budgetTerm;
   return (
     <Alert.Container>
       <NoBorderRadiusAlert

--- a/static/gsApp/components/cronsOnDemandStepWarning.tsx
+++ b/static/gsApp/components/cronsOnDemandStepWarning.tsx
@@ -5,12 +5,7 @@ import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
-import {
-  type MonitorCountResponse,
-  type Plan,
-  PlanTier,
-  type Subscription,
-} from 'getsentry/types';
+import type {MonitorCountResponse, Plan, Subscription} from 'getsentry/types';
 
 interface Props {
   activePlan: Plan;
@@ -55,8 +50,7 @@ export function CronsOnDemandStepWarning({
           "These changes will take effect at the start of your next billing cycle. Heads up that you're currently using $[currentUsageDollars] of Cron Monitors. These monitors will be turned off at the start of your next billing cycle unless you increase your [budgetType] budget.",
           {
             currentUsageDollars: currentUsage / 100,
-            budgetType:
-              subscription.planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand',
+            budgetType: subscription.planDetails.budgetTerm,
           }
         )}
       </Alert>

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -312,9 +312,7 @@ describe('GSBanner', function () {
       )
     ).toBeInTheDocument();
 
-    expect(
-      screen.getByRole('button', {name: /increase reserved limits/i})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /setup on-demand/i})).toBeInTheDocument();
   });
 
   it('shows add quota button for paid plans without active product trial', async function () {
@@ -350,7 +348,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
     ).toBeInTheDocument();
   });
 
@@ -387,7 +385,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup pay-as-you-go/i})
     ).not.toBeInTheDocument();
   });
 
@@ -511,7 +509,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup on-demand/i})
     ).toBeInTheDocument();
   });
 
@@ -549,7 +547,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
     ).toBeInTheDocument();
   });
 
@@ -585,7 +583,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup pay-as-you-go/i})
     ).not.toBeInTheDocument();
   });
 
@@ -607,7 +605,7 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup on-demand/i})
     ).not.toBeInTheDocument();
   });
 
@@ -694,7 +692,7 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup on-demand/i})
     ).not.toBeInTheDocument();
   });
 
@@ -722,7 +720,7 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup on-demand/i})
     ).not.toBeInTheDocument();
   });
 
@@ -1870,7 +1868,9 @@ describe('GSBanner', function () {
       )
     ).toBeInTheDocument();
 
-    expect(await screen.findByRole('button', {name: 'Update Plan'})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Setup On-Demand'})
+    ).toBeInTheDocument();
   });
 
   it('shows specific banner text just for uptime overages', async function () {
@@ -1900,7 +1900,7 @@ describe('GSBanner', function () {
     ).toBeInTheDocument();
 
     expect(
-      await screen.findByRole('button', {name: 'Increase Reserved Limits'})
+      await screen.findByRole('button', {name: 'Setup On-Demand'})
     ).toBeInTheDocument();
   });
 
@@ -2003,7 +2003,7 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup on-demand/i})
     ).not.toBeInTheDocument();
   });
 
@@ -2029,7 +2029,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup on-demand/i})
     ).toBeInTheDocument();
   });
 
@@ -2051,7 +2051,7 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(
-      screen.queryByRole('button', {name: /increase reserved limits/i})
+      screen.queryByRole('button', {name: /setup on-demand/i})
     ).not.toBeInTheDocument();
   });
 
@@ -2132,7 +2132,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
     ).toBeInTheDocument();
   });
 
@@ -2160,7 +2160,7 @@ describe('GSBanner', function () {
     render(<GSBanner organization={organization} />, {organization});
 
     expect(
-      await screen.findByRole('button', {name: /increase reserved limits/i})
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
     ).toBeInTheDocument();
   });
 });

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -247,15 +247,12 @@ function NoticeModal({
           )
         : t('To ensure uninterrupted service, upgrade your subscription.');
     } else {
-      if (subscription.planTier === PlanTier.AM3) {
-        subText = t(
-          `To ensure uninterrupted service, upgrade your subscription or increase your pay-as-you-go spend limit.`
-        );
-      } else {
-        subText = t(
-          `To ensure uninterrupted service, upgrade your subscription or increase your on-demand spend limit.`
-        );
-      }
+      subText = tct(
+        `To ensure uninterrupted service, upgrade your subscription or increase your [budgetTerm] spend limit.`,
+        {
+          budgetTerm: subscription.planDetails.budgetTerm,
+        }
+      );
     }
   }
 
@@ -1151,8 +1148,7 @@ class GSBanner extends Component<Props, State> {
           {
             monitorTitle:
               eventTypes[0] === 'monitorSeat' ? 'Cron Monitors' : 'Uptime Monitors',
-            budgetType:
-              subscription.planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand',
+            budgetType: subscription.planDetails.budgetTerm,
           }
         );
       } else {

--- a/static/gsApp/components/performance/quotaExceededAlert.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.tsx
@@ -84,21 +84,14 @@ function useQuotaExceededAlertMessage(
 
   if (!formattedDateRange) {
     return subscription?.onDemandBudgets?.enabled
-      ? ['am1', 'am2'].includes(subscription.planTier)
-        ? tct(
-            'You’ve exceeded your on-demand budget during this date range and results will be skewed. We can’t collect more spans until [subscriptionRenewalDate]. If you need more, [billingPageLink:increase your on-demand budget].',
-            {
-              periodRenewalDate,
-              billingPageLink,
-            }
-          )
-        : tct(
-            'You’ve exceeded your pay-as-you-go budget during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. If you need more, [billingPageLink:increase your pay-as-you-go budget].',
-            {
-              periodRenewalDate,
-              billingPageLink,
-            }
-          )
+      ? tct(
+          'You’ve exceeded your [budgetType] budget during this date range and results will be skewed. We can’t collect more spans until [subscriptionRenewalDate]. If you need more, [billingPageLink:increase your [budgetType] budget].',
+          {
+            budgetType: subscription.planDetails.budgetTerm,
+            periodRenewalDate,
+            billingPageLink,
+          }
+        )
       : tct(
           'You’ve exceeded your reserved volumes during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. If you need more, [billingPageLink:increase your reserved volumes].',
           {
@@ -110,49 +103,30 @@ function useQuotaExceededAlertMessage(
 
   const {period} = selection.datetime;
   return subscription?.onDemandBudgets?.enabled
-    ? ['am1', 'am2'].includes(subscription.planTier)
-      ? tct(
-          'You’ve exceeded your on-demand budget during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. [rest]',
-          {
-            periodRenewalDate,
-            rest: period
-              ? tct(
-                  'If you need more, [billingPageLink: increase your on-demand budget] or adjust your date range prior to [formattedDateRange].',
-                  {
-                    billingPageLink,
-                    formattedDateRange,
-                  }
-                )
-              : tct(
-                  'If you need more, [billingPageLink: increase your on-demand budget] or adjust your date range before or after [formattedDateRange].',
-                  {
-                    billingPageLink,
-                    formattedDateRange,
-                  }
-                ),
-          }
-        )
-      : tct(
-          'You’ve exceeded your pay-as-you-go budget during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. [rest]',
-          {
-            periodRenewalDate,
-            rest: period
-              ? tct(
-                  'If you need more, [billingPageLink: increase your pay-as-you-go budget] or adjust your date range prior to [formattedDateRange].',
-                  {
-                    billingPageLink,
-                    formattedDateRange,
-                  }
-                )
-              : tct(
-                  'If you need more, [billingPageLink: increase your pay-as-you-go budget] or adjust your date range before or after [formattedDateRange].',
-                  {
-                    billingPageLink,
-                    formattedDateRange,
-                  }
-                ),
-          }
-        )
+    ? tct(
+        'You’ve exceeded your [budgetType] budget during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. [rest]',
+        {
+          budgetType: subscription.planDetails.budgetTerm,
+          periodRenewalDate,
+          rest: period
+            ? tct(
+                'If you need more, [billingPageLink: increase your [budgetType] budget] or adjust your date range prior to [formattedDateRange].',
+                {
+                  billingPageLink,
+                  budgetType: subscription.planDetails.budgetTerm,
+                  formattedDateRange,
+                }
+              )
+            : tct(
+                'If you need more, [billingPageLink: increase your [budgetType] budget] or adjust your date range before or after [formattedDateRange].',
+                {
+                  billingPageLink,
+                  budgetType: subscription.planDetails.budgetTerm,
+                  formattedDateRange,
+                }
+              ),
+        }
+      )
     : tct(
         'You’ve exceeded your reserved volumes during this date range and results will be skewed. We can’t collect more spans until [periodRenewalDate]. [rest]',
         {

--- a/static/gsApp/hooks/orgStatsBanner.spec.tsx
+++ b/static/gsApp/hooks/orgStatsBanner.spec.tsx
@@ -47,7 +47,7 @@ describe('OrgStatsBanner', function () {
     SubscriptionStore.set(organization.slug, subscription);
 
     wrapper = render(<OrgStatsBanner organization={organization} />);
-    expect(screen.getByText('Increase Reserved Limits')).toBeInTheDocument();
+    expect(screen.getByText('Setup On-Demand')).toBeInTheDocument();
     expect(screen.getByText('Increase your Reserved Quotas')).toBeInTheDocument();
   });
 

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -87,6 +87,7 @@ export type Plan = {
   availableCategories: string[];
   basePrice: number;
   billingInterval: 'monthly' | 'annual';
+  budgetTerm: 'pay-as-you-go' | 'on-demand';
   /**
    * Data categories on the plan (errors, transactions, etc.)
    */
@@ -95,8 +96,8 @@ export type Plan = {
   contractInterval: 'monthly' | 'annual';
   description: string;
   features: string[];
-  hasOnDemandModes: boolean;
 
+  hasOnDemandModes: boolean;
   id: string;
   isTestPlan: boolean;
   maxMembers: number | null;
@@ -107,8 +108,8 @@ export type Plan = {
     [categoryKey in DataCategories]?: EventBucket[];
   };
   price: number;
-  reservedMinimum: number;
 
+  reservedMinimum: number;
   retentionDays: number;
   totalPrice: number;
   trialPlan: string | null;

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -340,6 +340,20 @@ export function hasJustStartedPlanTrial(subscription: Subscription) {
   return subscription.isTrial && subscription.isTrialStarted;
 }
 
+export const displayBudgetName = (
+  plan?: Plan | null,
+  options: {title?: boolean} = {}
+) => {
+  const budgetTerm = plan?.budgetTerm ?? 'on-demand';
+  if (options.title) {
+    if (budgetTerm === 'on-demand') {
+      return 'On-Demand';
+    }
+    return titleCase(budgetTerm);
+  }
+  return budgetTerm;
+};
+
 export const displayPlanName = (plan?: Plan | null) => {
   return isAmEnterprisePlan(plan?.id) ? 'Enterprise' : (plan?.name ?? '[unavailable]');
 };

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -342,16 +342,27 @@ export function hasJustStartedPlanTrial(subscription: Subscription) {
 
 export const displayBudgetName = (
   plan?: Plan | null,
-  options: {title?: boolean} = {}
+  options: {
+    pluralOndemand?: boolean;
+    title?: boolean;
+    withBudget?: boolean;
+  } = {}
 ) => {
   const budgetTerm = plan?.budgetTerm ?? 'on-demand';
+  const text = `${budgetTerm}${options.withBudget ? ' budget' : ''}`;
   if (options.title) {
     if (budgetTerm === 'on-demand') {
+      if (options.withBudget) {
+        if (options.pluralOndemand) {
+          return 'On-Demand Budgets';
+        }
+        return 'On-Demand Budget';
+      }
       return 'On-Demand';
     }
-    return titleCase(budgetTerm);
+    return titleCase(text);
   }
-  return budgetTerm;
+  return text;
 };
 
 export const displayPlanName = (plan?: Plan | null) => {

--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
@@ -224,10 +224,11 @@ function ReviewAndConfirmHeader({
   let subText;
   if (subscription.isSelfServePartner) {
     subText = tct(
-      'These changes will apply [applyDate], and you will be billed by [partnerName] monthly for any recurring subscription fees and incurred pay-as-you-go fees.',
+      'These changes will apply [applyDate], and you will be billed by [partnerName] monthly for any recurring subscription fees and incurred [budgetType] fees.',
       {
         applyDate: effectiveNow ? 'immediately' : 'on the date above',
         partnerName: subscription.partner?.partnership.displayName,
+        budgetType: subscription.planDetails.budgetTerm,
       }
     );
   } else {

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -32,8 +32,12 @@ class OnDemandBudgets extends Component<Props> {
     const {subscription} = this.props;
     return (
       <Label>
-        {tct('[budgetType] Budget', {
-          budgetType: displayBudgetName(subscription.planDetails, {title: true}),
+        {tct('[budgetType]', {
+          budgetType: displayBudgetName(subscription.planDetails, {
+            title: true,
+            withBudget: true,
+            pluralOndemand: true,
+          }),
         })}
         <Tooltip
           title={t(
@@ -85,12 +89,11 @@ class OnDemandBudgets extends Component<Props> {
 
     const budgetTerm = subscription.planDetails.budgetTerm;
     const budgetString =
-      budgetTerm === 'pay-as-you-go' ? 'a pay-as-you-go' : 'an on-demand';
+      budgetTerm === 'pay-as-you-go' ? 'a pay-as-you-go budget' : 'on-demand budgets';
 
-    const label = tct(
-      "To set [budgetType] budget, you'll need a valid credit card on file.",
-      {budgetType: budgetString}
-    );
+    const label = tct("To set [budgetType], you'll need a valid credit card on file.", {
+      budgetType: budgetString,
+    });
     const action = (
       <div>
         <Button

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -15,9 +15,9 @@ import {openEditCreditCard} from 'getsentry/actionCreators/modal';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import type {Subscription} from 'getsentry/types';
 import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import {getPlanCategoryName, listDisplayNames} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
-import titleCase from 'getsentry/utils/titleCase';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
 type Props = {
@@ -33,7 +33,7 @@ class OnDemandBudgets extends Component<Props> {
     return (
       <Label>
         {tct('[budgetType] Budget', {
-          budgetType: titleCase(subscription.planDetails.budgetTerm),
+          budgetType: displayBudgetName(subscription.planDetails, {title: true}),
         })}
         <Tooltip
           title={t(
@@ -42,7 +42,7 @@ class OnDemandBudgets extends Component<Props> {
             subscription.planDetails.budgetTerm === 'pay-as-you-go'
               ? 'Pay-as-you-go allows'
               : 'On-Demand budgets allow',
-            titleCase(subscription.planDetails.budgetTerm)
+            displayBudgetName(subscription.planDetails, {title: true})
           )}
           skipWrapper
         >
@@ -68,7 +68,7 @@ class OnDemandBudgets extends Component<Props> {
       <FieldGroup
         label={this.renderLabel()}
         help={tct('[budgetType] is not supported for your account.', {
-          budgetType: titleCase(subscription.planDetails.budgetTerm),
+          budgetType: displayBudgetName(subscription.planDetails, {title: true}),
         })}
       >
         <div>
@@ -180,7 +180,7 @@ class OnDemandBudgets extends Component<Props> {
             }}
           >
             {tct('Set Up [budgetType]', {
-              budgetType: titleCase(subscription.planDetails.budgetTerm),
+              budgetType: displayBudgetName(subscription.planDetails, {title: true}),
             })}
           </Button>
         </InlineButtonGroup>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -9,7 +9,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {Tooltip} from 'sentry/components/tooltip';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -19,6 +19,7 @@ import {CronsOnDemandStepWarning} from 'getsentry/components/cronsOnDemandStepWa
 import type {OnDemandBudgets, Plan, Subscription} from 'getsentry/types';
 import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
 import {getPlanCategoryName, listDisplayNames} from 'getsentry/utils/dataCategory';
+import titleCase from 'getsentry/utils/titleCase';
 
 function coerceValue(value: number): number {
   return value / 100;
@@ -46,10 +47,9 @@ type Props = {
 class OnDemandBudgetEdit extends Component<Props> {
   onDemandUnsupportedCopy = () => {
     const {subscription} = this.props;
-    return t(
-      '%s is not supported for your account.',
-      subscription.planTier === PlanTier.AM3 ? 'Pay-as-you-go' : 'On-demand'
-    );
+    return tct('[budgetType] is not supported for your account.', {
+      budgetType: titleCase(subscription.planDetails.budgetTerm),
+    });
   };
   renderInputFields = (displayBudgetMode: OnDemandBudgetMode) => {
     const {
@@ -80,7 +80,7 @@ class OnDemandBudgetEdit extends Component<Props> {
                 <OnDemandInput
                   disabled={!onDemandSupported}
                   aria-label={
-                    subscription.planTier === PlanTier.AM3
+                    subscription.planDetails.budgetTerm === 'pay-as-you-go'
                       ? t('Pay-as-you-go max budget')
                       : t('Shared max budget')
                   }
@@ -192,7 +192,7 @@ class OnDemandBudgetEdit extends Component<Props> {
       categories: activePlan.onDemandCategories,
     });
 
-    if (subscription.planTier === PlanTier.AM3) {
+    if (subscription.planDetails.budgetTerm === 'pay-as-you-go') {
       return (
         <PaygBody>
           <BudgetDetails>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -18,8 +18,8 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {CronsOnDemandStepWarning} from 'getsentry/components/cronsOnDemandStepWarning';
 import type {OnDemandBudgets, Plan, Subscription} from 'getsentry/types';
 import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import {getPlanCategoryName, listDisplayNames} from 'getsentry/utils/dataCategory';
-import titleCase from 'getsentry/utils/titleCase';
 
 function coerceValue(value: number): number {
   return value / 100;
@@ -48,7 +48,7 @@ class OnDemandBudgetEdit extends Component<Props> {
   onDemandUnsupportedCopy = () => {
     const {subscription} = this.props;
     return tct('[budgetType] is not supported for your account.', {
-      budgetType: titleCase(subscription.planDetails.budgetTerm),
+      budgetType: displayBudgetName(subscription.planDetails, {title: true}),
     });
   };
   renderInputFields = (displayBudgetMode: OnDemandBudgetMode) => {

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
@@ -16,6 +16,7 @@ import withApi from 'sentry/utils/withApi';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import type {OnDemandBudgets, Subscription} from 'getsentry/types';
 import {OnDemandBudgetMode} from 'getsentry/types';
+import {displayBudgetName} from 'getsentry/utils/billing';
 
 import OnDemandBudgetEdit from './onDemandBudgetEdit';
 import {
@@ -312,7 +313,7 @@ class OnDemandBudgetEditModal extends Component<Props, State> {
           <h4>
             {tct('[action] [budgetType] Budget', {
               action: onDemandBudgets.enabled ? t('Edit') : t('Set Up'),
-              budgetType: subscription.planDetails.budgetTerm,
+              budgetType: displayBudgetName(subscription.planDetails, {title: true}),
             })}
           </h4>
         </Header>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
@@ -311,9 +311,13 @@ class OnDemandBudgetEditModal extends Component<Props, State> {
       <Fragment>
         <Header closeButton>
           <h4>
-            {tct('[action] [budgetType] Budget', {
+            {tct('[action] [budgetType]', {
               action: onDemandBudgets.enabled ? t('Edit') : t('Set Up'),
-              budgetType: displayBudgetName(subscription.planDetails, {title: true}),
+              budgetType: displayBudgetName(subscription.planDetails, {
+                title: true,
+                withBudget: true,
+                pluralOndemand: true,
+              }),
             })}
           </h4>
         </Header>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEditModal.tsx
@@ -8,14 +8,14 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import withApi from 'sentry/utils/withApi';
 
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import type {OnDemandBudgets, Subscription} from 'getsentry/types';
-import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {OnDemandBudgetMode} from 'getsentry/types';
 
 import OnDemandBudgetEdit from './onDemandBudgetEdit';
 import {
@@ -132,7 +132,7 @@ class OnDemandBudgetEditModal extends Component<Props, State> {
 
     if (exceedsInvoicedBudgetLimit(subscription, newOnDemandBudget)) {
       const message =
-        subscription.planTier === PlanTier.AM3
+        subscription.planDetails.budgetTerm === 'pay-as-you-go'
           ? PAYG_BUDGET_EXCEEDS_INVOICED_LIMIT
           : ONDEMAND_BUDGET_EXCEEDS_INVOICED_LIMIT;
       this.setState({
@@ -178,14 +178,15 @@ class OnDemandBudgetEditModal extends Component<Props, State> {
       return true;
     } catch (response) {
       const updateError =
-        (response?.responseJSON ?? subscription.planTier === PlanTier.AM3)
+        (response?.responseJSON ??
+        subscription.planDetails.budgetTerm === 'pay-as-you-go')
           ? PAYG_BUDGET_SAVE_ERROR
           : ONDEMAND_BUDGET_SAVE_ERROR;
       this.setState({
         updateError,
       });
       addErrorMessage(
-        subscription.planTier === PlanTier.AM3
+        subscription.planDetails.budgetTerm === 'pay-as-you-go'
           ? PAYG_BUDGET_SAVE_ERROR
           : ONDEMAND_BUDGET_SAVE_ERROR
       );
@@ -309,13 +310,10 @@ class OnDemandBudgetEditModal extends Component<Props, State> {
       <Fragment>
         <Header closeButton>
           <h4>
-            {subscription.planTier === PlanTier.AM3
-              ? onDemandBudgets.enabled
-                ? t('Edit Pay-as-you-go Budget')
-                : t('Set Up pay-as-you-go')
-              : onDemandBudgets.enabled
-                ? t('Edit On-Demand Budgets')
-                : t('Set Up On-Demand')}
+            {tct('[action] [budgetType] Budget', {
+              action: onDemandBudgets.enabled ? t('Edit') : t('Set Up'),
+              budgetType: subscription.planDetails.budgetTerm,
+            })}
           </h4>
         </Header>
         <OffsetBody>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -98,7 +98,7 @@ describe('OnDemandBudgets', () => {
 
     expect(
       screen.getByText(
-        `To use on-demand budgets, you'll need a valid credit card on file.`
+        `To set an on-demand budget, you'll need a valid credit card on file.`
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Add Credit Card')).toBeInTheDocument();

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -98,7 +98,7 @@ describe('OnDemandBudgets', () => {
 
     expect(
       screen.getByText(
-        `To set an on-demand budget, you'll need a valid credit card on file.`
+        `To set on-demand budgets, you'll need a valid credit card on file.`
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Add Credit Card')).toBeInTheDocument();

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -13,6 +13,7 @@ import type {
   SubscriptionOnDemandBudgets,
 } from 'getsentry/types';
 import {BillingType, OnDemandBudgetMode} from 'getsentry/types';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
@@ -129,10 +130,15 @@ export function formatOnDemandBudget(
   ]
 ): React.ReactNode {
   if (budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    return `per-category ${plan.budgetTerm} (${listBudgets({plan, categories, budget})})`;
+    return `per-category ${displayBudgetName(plan, {
+      withBudget: true,
+      pluralOndemand: true,
+    })} (${listBudgets({plan, categories, budget})})`;
   }
 
-  return `shared ${plan.budgetTerm} of ${formatCurrency(budget.sharedMaxBudget ?? 0)}`;
+  return `shared ${displayBudgetName(plan, {
+    withBudget: true,
+  })} of ${formatCurrency(budget.sharedMaxBudget ?? 0)}`;
 }
 
 export function hasOnDemandBudgetsFeature(

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -12,7 +12,7 @@ import type {
   Subscription,
   SubscriptionOnDemandBudgets,
 } from 'getsentry/types';
-import {BillingType, OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {BillingType, OnDemandBudgetMode} from 'getsentry/types';
 import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
@@ -116,7 +116,6 @@ function listBudgets({plan, categories, budget}: DisplayNameProps) {
 
 export function formatOnDemandBudget(
   plan: Plan,
-  planTier: string,
   budget: OnDemandBudgets,
   categories: string[] = [
     'errors',
@@ -129,12 +128,11 @@ export function formatOnDemandBudget(
     'profileDurationUI',
   ]
 ): React.ReactNode {
-  const budgetType = planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'on-demand';
   if (budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    return `per-category ${budgetType} (${listBudgets({plan, categories, budget})})`;
+    return `per-category ${plan.budgetTerm} (${listBudgets({plan, categories, budget})})`;
   }
 
-  return `shared ${budgetType} of ${formatCurrency(budget.sharedMaxBudget ?? 0)}`;
+  return `shared ${plan.budgetTerm} of ${formatCurrency(budget.sharedMaxBudget ?? 0)}`;
 }
 
 export function hasOnDemandBudgetsFeature(

--- a/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
+++ b/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
@@ -12,7 +12,7 @@ import {space} from 'sentry/styles/space';
 import {DataCategory} from 'sentry/types/core';
 
 import type {Subscription} from 'getsentry/types';
-import titleCase from 'getsentry/utils/titleCase';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import {displayPrice} from 'getsentry/views/amCheckout/utils';
 
 import {Card, HalvedGrid} from './components/styles';
@@ -86,7 +86,7 @@ function RootAllocationCard({
                   {
                     odLink: (
                       <ExternalLink href="https://docs.sentry.io/product/accounts/pricing/#on-demand-capacity">
-                        {titleCase(subscription.planDetails.budgetTerm)}
+                        {displayBudgetName(subscription.planDetails, {title: true})}
                       </ExternalLink>
                     ),
                   }

--- a/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
+++ b/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
@@ -11,7 +11,8 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategory} from 'sentry/types/core';
 
-import {PlanTier, type Subscription} from 'getsentry/types';
+import type {Subscription} from 'getsentry/types';
+import titleCase from 'getsentry/utils/titleCase';
 import {displayPrice} from 'getsentry/views/amCheckout/utils';
 
 import {Card, HalvedGrid} from './components/styles';
@@ -85,9 +86,7 @@ function RootAllocationCard({
                   {
                     odLink: (
                       <ExternalLink href="https://docs.sentry.io/product/accounts/pricing/#on-demand-capacity">
-                        {subscription.planTier === PlanTier.AM3
-                          ? 'Pay-as-you-go'
-                          : 'On-Demand'}
+                        {titleCase(subscription.planDetails.budgetTerm)}
                       </ExternalLink>
                     ),
                   }

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
@@ -10,9 +10,9 @@ import type {Organization} from 'sentry/types/organization';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 
 import {PlanTier, type Subscription} from 'getsentry/types';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {roundUpToNearestDollar} from 'getsentry/utils/roundUpToNearestDollar';
-import titleCase from 'getsentry/utils/titleCase';
 import {
   getTotalBudget,
   hasOnDemandBudgetsFeature,
@@ -107,12 +107,12 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
             <SummaryTitleWrapper>
               <SummaryTitle>
                 {tct('[budgetType] Spent', {
-                  budgetType: titleCase(subscription.planDetails.budgetTerm),
+                  budgetType: displayBudgetName(subscription.planDetails, {title: true}),
                 })}
               </SummaryTitle>
               <Tooltip
                 title={tct('[budgetType] budget consumed', {
-                  budgetType: titleCase(subscription.planDetails.budgetTerm),
+                  budgetType: displayBudgetName(subscription.planDetails, {title: true}),
                 })}
                 skipWrapper
               >
@@ -203,7 +203,9 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
           <LegendContainer>
             <LegendDot style={{backgroundColor: COLORS.ondemand}} />
             <div>
-              <LegendTitle>{titleCase(subscription.planDetails.budgetTerm)}</LegendTitle>
+              <LegendTitle>
+                {displayBudgetName(subscription.planDetails, {title: true})}
+              </LegendTitle>
               <LegendPrice>
                 {formatCurrency(onDemandTotalSpent)} of{' '}
                 {formatCurrency(onDemandTotalBudget)}

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
@@ -111,8 +111,11 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
                 })}
               </SummaryTitle>
               <Tooltip
-                title={tct('[budgetType] budget consumed', {
-                  budgetType: displayBudgetName(subscription.planDetails, {title: true}),
+                title={tct('[budgetType] consumed', {
+                  budgetType: displayBudgetName(subscription.planDetails, {
+                    title: true,
+                    withBudget: true,
+                  }),
                 })}
                 skipWrapper
               >

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
@@ -4,7 +4,7 @@ import color from 'color';
 import {Tooltip} from 'sentry/components/tooltip';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconInfo} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -12,6 +12,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {PlanTier, type Subscription} from 'getsentry/types';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {roundUpToNearestDollar} from 'getsentry/utils/roundUpToNearestDollar';
+import titleCase from 'getsentry/utils/titleCase';
 import {
   getTotalBudget,
   hasOnDemandBudgetsFeature,
@@ -105,16 +106,14 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
           <SummaryWrapper>
             <SummaryTitleWrapper>
               <SummaryTitle>
-                {subscription.planTier === PlanTier.AM3
-                  ? t('Pay-as-you-go Spent')
-                  : t('On-Demand Spent')}
+                {tct('[budgetType] Spent', {
+                  budgetType: titleCase(subscription.planDetails.budgetTerm),
+                })}
               </SummaryTitle>
               <Tooltip
-                title={
-                  subscription.planTier === PlanTier.AM3
-                    ? t('Pay-as-you-go budget consumed')
-                    : t('On-Demand budget consumed')
-                }
+                title={tct('[budgetType] budget consumed', {
+                  budgetType: titleCase(subscription.planDetails.budgetTerm),
+                })}
                 skipWrapper
               >
                 <IconInfo size="xs" />
@@ -204,11 +203,7 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
           <LegendContainer>
             <LegendDot style={{backgroundColor: COLORS.ondemand}} />
             <div>
-              <LegendTitle>
-                {subscription.planTier === PlanTier.AM3
-                  ? t('Pay-as-you-go')
-                  : t('On-Demand')}
-              </LegendTitle>
+              <LegendTitle>{titleCase(subscription.planDetails.budgetTerm)}</LegendTitle>
               <LegendPrice>
                 {formatCurrency(onDemandTotalSpent)} of{' '}
                 {formatCurrency(onDemandTotalBudget)}

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -26,7 +26,8 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import withSubscription from 'getsentry/components/withSubscription';
-import {PlanTier, type Subscription} from 'getsentry/types';
+import type {Subscription} from 'getsentry/types';
+import titleCase from 'getsentry/utils/titleCase';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 
 import SubscriptionHeader from './subscriptionHeader';
@@ -149,16 +150,10 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
           />
           {onDemandEnabled && (
             <GenericConsumptionGroup
-              label={
-                subscription.planTier === PlanTier.AM3
-                  ? t('Pay-as-you-go Consumption')
-                  : t('On-Demand Consumption')
-              }
+              label={t('%s Consumption', titleCase(subscription.planDetails.budgetTerm))}
               help={t(
                 "Receive notifications when your organization's usage exceeds a threshold (%% of monthly %s budget)",
-                subscription.planTier === PlanTier.AM3
-                  ? t('Pay-as-you-go')
-                  : t('On-Demand')
+                titleCase(subscription.planDetails.budgetTerm)
               )}
               thresholds={notificationThresholds.perProductOndemandPercent}
               removeThreshold={indexToRemove => {

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -155,8 +155,11 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
                 displayBudgetName(subscription.planDetails, {title: true})
               )}
               help={t(
-                "Receive notifications when your organization's usage exceeds a threshold (%% of monthly %s budget)",
-                displayBudgetName(subscription.planDetails, {title: true})
+                "Receive notifications when your organization's usage exceeds a threshold (%% of monthly %s)",
+                displayBudgetName(subscription.planDetails, {
+                  title: true,
+                  withBudget: true,
+                })
               )}
               thresholds={notificationThresholds.perProductOndemandPercent}
               removeThreshold={indexToRemove => {

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -27,7 +27,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import withSubscription from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import titleCase from 'getsentry/utils/titleCase';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 
 import SubscriptionHeader from './subscriptionHeader';
@@ -150,10 +150,13 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
           />
           {onDemandEnabled && (
             <GenericConsumptionGroup
-              label={t('%s Consumption', titleCase(subscription.planDetails.budgetTerm))}
+              label={t(
+                '%s Consumption',
+                displayBudgetName(subscription.planDetails, {title: true})
+              )}
               help={t(
                 "Receive notifications when your organization's usage exceeds a threshold (%% of monthly %s budget)",
-                titleCase(subscription.planDetails.budgetTerm)
+                displayBudgetName(subscription.planDetails, {title: true})
               )}
               thresholds={notificationThresholds.perProductOndemandPercent}
               removeThreshold={indexToRemove => {

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
@@ -177,7 +177,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('45');
 
@@ -310,7 +310,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('0.76');
 
@@ -421,7 +421,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
     expect(screen.getByTestId('per-category-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Errors budget'})).toHaveValue('10');
     expect(screen.getByRole('textbox', {name: 'Transactions budget'})).toHaveValue('20');
@@ -525,7 +525,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('42');
 
@@ -622,7 +622,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
     expect(screen.getByTestId('per-category-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Errors budget'})).toHaveValue('10');
     expect(screen.getByRole('textbox', {name: 'Transactions budget'})).toHaveValue('20');

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
@@ -177,7 +177,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('45');
 
@@ -310,7 +310,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('0.76');
 
@@ -421,7 +421,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
     expect(screen.getByTestId('per-category-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Errors budget'})).toHaveValue('10');
     expect(screen.getByRole('textbox', {name: 'Transactions budget'})).toHaveValue('20');
@@ -525,7 +525,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
     expect(screen.getByTestId('shared-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Shared max budget'})).toHaveValue('42');
 
@@ -622,7 +622,7 @@ describe('edit on-demand budget', () => {
 
     await userEvent.click(screen.getByText('Edit'));
 
-    expect(await screen.findByText('Edit On-Demand Budget')).toBeInTheDocument();
+    expect(await screen.findByText('Edit On-Demand Budgets')).toBeInTheDocument();
     expect(screen.getByTestId('per-category-budget-radio')).toBeChecked();
     expect(screen.getByRole('textbox', {name: 'Errors budget'})).toHaveValue('10');
     expect(screen.getByRole('textbox', {name: 'Transactions budget'})).toHaveValue('20');

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
@@ -15,6 +15,7 @@ import useApi from 'sentry/utils/useApi';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {PlanTier, type Subscription} from 'getsentry/types/index';
 import {isTrialPlan} from 'getsentry/utils/billing';
+import titleCase from 'getsentry/utils/titleCase';
 import OnDemandBudgets from 'getsentry/views/onDemandBudgets';
 import {EditOnDemandButton} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 import {hasOnDemandBudgetsFeature} from 'getsentry/views/onDemandBudgets/utils';
@@ -54,12 +55,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
       },
       success: data => {
         SubscriptionStore.set(data.slug, data);
-        addSuccessMessage(
-          t(
-            '%s max spend updated',
-            subscription.planTier === PlanTier.AM3 ? 'pay-as-you-go' : 'On-Demand'
-          )
-        );
+        addSuccessMessage(t('%s max spend updated', subscription.planDetails.budgetTerm));
       },
     });
   }
@@ -83,7 +79,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
         }
       >
         <PanelTitleWrapper>
-          {subscription.planTier === PlanTier.AM3
+          {subscription.planDetails.budgetTerm === 'pay-as-you-go'
             ? t('Pay-as-you-go Budget')
             : t('On-Demand Budgets')}{' '}
           <QuestionTooltip
@@ -92,10 +88,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
               `[budgetType] allows you to pay for additional data beyond your subscription's
 									reserved quotas. [budgetType] is billed monthly at the end of each usage period. [link:Learn more]`,
               {
-                budgetType:
-                  subscription.planTier === PlanTier.AM3
-                    ? t('Pay-as-you-go')
-                    : t('On-Demand'),
+                budgetType: titleCase(subscription.planDetails.budgetTerm),
                 link: (
                   <ExternalLink
                     href={

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
@@ -14,8 +14,7 @@ import useApi from 'sentry/utils/useApi';
 
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {PlanTier, type Subscription} from 'getsentry/types/index';
-import {isTrialPlan} from 'getsentry/utils/billing';
-import titleCase from 'getsentry/utils/titleCase';
+import {displayBudgetName, isTrialPlan} from 'getsentry/utils/billing';
 import OnDemandBudgets from 'getsentry/views/onDemandBudgets';
 import {EditOnDemandButton} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 import {hasOnDemandBudgetsFeature} from 'getsentry/views/onDemandBudgets/utils';
@@ -88,7 +87,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
               `[budgetType] allows you to pay for additional data beyond your subscription's
 									reserved quotas. [budgetType] is billed monthly at the end of each usage period. [link:Learn more]`,
               {
-                budgetType: titleCase(subscription.planDetails.budgetTerm),
+                budgetType: displayBudgetName(subscription.planDetails, {title: true}),
                 link: (
                   <ExternalLink
                     href={

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
@@ -78,9 +78,11 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
         }
       >
         <PanelTitleWrapper>
-          {subscription.planDetails.budgetTerm === 'pay-as-you-go'
-            ? t('Pay-as-you-go Budget')
-            : t('On-Demand Budgets')}{' '}
+          {displayBudgetName(subscription.planDetails, {
+            title: true,
+            withBudget: true,
+            pluralOndemand: true,
+          })}{' '}
           <QuestionTooltip
             size="sm"
             title={tct(

--- a/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
@@ -246,7 +246,7 @@ describe('Subscription > PendingChanges', function () {
 
     expect(
       getItemWithText(
-        'On-Demand budget change from shared on-demand of $50 to shared on-demand of $10'
+        'On-Demand budget change from shared on-demand budget of $50 to shared on-demand budget of $10'
       )
     ).toBeInTheDocument();
   });
@@ -299,7 +299,7 @@ describe('Subscription > PendingChanges', function () {
 
     expect(
       getItemWithText(
-        'On-Demand budget change from shared on-demand of $50 to per-category on-demand (errors at $10, transactions at $20, and attachments at $30)'
+        'On-Demand budget change from shared on-demand budget of $50 to per-category on-demand budget (errors at $10, transactions at $20, and attachments at $30)'
       )
     ).toBeInTheDocument();
   });
@@ -408,7 +408,7 @@ describe('Subscription > PendingChanges', function () {
     render(<PendingChanges organization={organization} subscription={sub} />);
     expect(
       screen.getByText(
-        'Pay-as-you-go budget change from per-category on-demand (errors at $10, performance units at $0, replays at $0, attachments at $0, cron monitors at $0, continuous profile hours at $0, UI profile hours at $0, and uptime monitors at $0) to shared pay-as-you-go of $50'
+        'Pay-as-you-go budget change from per-category on-demand budget (errors at $10, performance units at $0, replays at $0, attachments at $0, cron monitors at $0, continuous profile hours at $0, UI profile hours at $0, and uptime monitors at $0) to shared pay-as-you-go budget of $50'
       )
     ).toBeInTheDocument();
   });

--- a/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
@@ -45,6 +45,7 @@ describe('Subscription > PendingChanges', function () {
         planDetails: PlanFixture({
           name: 'Team',
           contractInterval: MONTHLY,
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -59,7 +60,7 @@ describe('Subscription > PendingChanges', function () {
     expect(screen.queryByText('Billing period')).not.toBeInTheDocument();
     expect(getItemWithText('Contract period change to monthly')).toBeInTheDocument();
     expect(getItemWithText('Reserved errors change to 100,000')).toBeInTheDocument();
-    expect(getItemWithText('On-demand spend change from $100 to $0')).toBeInTheDocument();
+    expect(getItemWithText('On-Demand spend change from $100 to $0')).toBeInTheDocument();
 
     expect(screen.getAllByRole('listitem')).toHaveLength(4);
   });
@@ -83,6 +84,7 @@ describe('Subscription > PendingChanges', function () {
           billingInterval: MONTHLY,
           contractInterval: MONTHLY,
           categories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -100,7 +102,7 @@ describe('Subscription > PendingChanges', function () {
     ).toBeInTheDocument();
     expect(getItemWithText('Reserved attachments change to 50 GB')).toBeInTheDocument();
     expect(
-      getItemWithText('On-demand spend change from $100 to $50')
+      getItemWithText('On-Demand spend change from $100 to $50')
     ).toBeInTheDocument();
 
     expect(screen.getAllByRole('listitem')).toHaveLength(7);
@@ -125,6 +127,7 @@ describe('Subscription > PendingChanges', function () {
           billingInterval: MONTHLY,
           contractInterval: MONTHLY,
           categories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -142,7 +145,7 @@ describe('Subscription > PendingChanges', function () {
     ).toBeInTheDocument();
     expect(getItemWithText('Reserved attachments change to 50 GB')).toBeInTheDocument();
     expect(
-      getItemWithText('On-demand spend change from $100 to $50')
+      getItemWithText('On-Demand spend change from $100 to $50')
     ).toBeInTheDocument();
 
     expect(screen.getAllByRole('listitem')).toHaveLength(7);
@@ -174,6 +177,7 @@ describe('Subscription > PendingChanges', function () {
           billingInterval: MONTHLY,
           contractInterval: MONTHLY,
           categories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -190,7 +194,7 @@ describe('Subscription > PendingChanges', function () {
     ).toBeInTheDocument();
     expect(getItemWithText('Reserved attachments change to 50 GB')).toBeInTheDocument();
     expect(
-      getItemWithText('On-demand spend change from $100 to $50')
+      getItemWithText('On-Demand spend change from $100 to $50')
     ).toBeInTheDocument();
 
     expect(screen.getAllByRole('listitem')).toHaveLength(6);
@@ -233,6 +237,7 @@ describe('Subscription > PendingChanges', function () {
           billingInterval: MONTHLY,
           contractInterval: MONTHLY,
           categories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -241,7 +246,7 @@ describe('Subscription > PendingChanges', function () {
 
     expect(
       getItemWithText(
-        'On-demand budget change from shared on-demand of $50 to shared on-demand of $10'
+        'On-Demand budget change from shared on-demand of $50 to shared on-demand of $10'
       )
     ).toBeInTheDocument();
   });
@@ -285,6 +290,7 @@ describe('Subscription > PendingChanges', function () {
           contractInterval: MONTHLY,
           categories: ['errors', 'transactions', 'attachments'],
           onDemandCategories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -293,7 +299,7 @@ describe('Subscription > PendingChanges', function () {
 
     expect(
       getItemWithText(
-        'On-demand budget change from shared on-demand of $50 to per-category on-demand (errors at $10, transactions at $20, and attachments at $30)'
+        'On-Demand budget change from shared on-demand of $50 to per-category on-demand (errors at $10, transactions at $20, and attachments at $30)'
       )
     ).toBeInTheDocument();
   });
@@ -316,6 +322,7 @@ describe('Subscription > PendingChanges', function () {
           categories: ['errors', 'transactions', 'attachments'],
           billingInterval: ANNUAL,
           contractInterval: ANNUAL,
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -344,6 +351,7 @@ describe('Subscription > PendingChanges', function () {
           categories: ['errors', 'transactions', 'attachments'],
           billingInterval: ANNUAL,
           contractInterval: ANNUAL,
+          budgetTerm: 'on-demand',
         }),
       }),
     });
@@ -352,7 +360,7 @@ describe('Subscription > PendingChanges', function () {
 
     expect(screen.getByText('Mar 1, 2021')).toBeInTheDocument();
     expect(
-      getItemWithText('On-demand spend change from $100 to $50')
+      getItemWithText('On-Demand spend change from $100 to $50')
     ).toBeInTheDocument();
 
     expect(screen.getByText('Feb 1, 2021')).toBeInTheDocument();
@@ -421,6 +429,7 @@ describe('Subscription > PendingChanges', function () {
           name: 'Team',
           contractInterval: ANNUAL,
           categories: ['errors', 'transactions', 'attachments'],
+          budgetTerm: 'on-demand',
         }),
       }),
     });

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -13,6 +13,7 @@ import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {PendingOnDemandBudgets, Subscription} from 'getsentry/types';
 import {
+  displayBudgetName,
   formatReservedWithUnits,
   hasPerformance,
   isAm3DsPlan,
@@ -22,7 +23,6 @@ import {
   getReservedBudgetDisplayName,
 } from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
-import titleCase from 'getsentry/utils/titleCase';
 import {
   formatOnDemandBudget,
   hasOnDemandBudgetsFeature,
@@ -106,7 +106,7 @@ class PendingChanges extends Component<Props> {
         this.getNestedValue<number>(subscription, 'onDemandMaxSpend') ?? 0;
       results.push(
         tct('[budgetType] spend change from [currentAmount] to [newAmount]', {
-          budgetType: titleCase(subscription.planDetails.budgetTerm),
+          budgetType: displayBudgetName(subscription.planDetails, {title: true}),
           newAmount: formatCurrency(nextOnDemandMaxSpend),
           currentAmount: formatCurrency(currentOnDemandMaxSpend),
         })

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -83,7 +83,9 @@ class PendingChanges extends Component<Props> {
             tct(
               '[budgetType] budget change from [currentOnDemandBudgets] to [nextOnDemandBudgets]',
               {
-                budgetType: displayBudgetName(pendingChanges.planDetails, {title: true}),
+                budgetType: displayBudgetName(pendingChanges.planDetails, {
+                  title: true,
+                }),
                 currentOnDemandBudgets: formatOnDemandBudget(
                   subscription.planDetails,
                   currentOnDemandBudgets,

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -83,14 +83,14 @@ class PendingChanges extends Component<Props> {
             tct(
               '[budgetType] budget change from [currentOnDemandBudgets] to [nextOnDemandBudgets]',
               {
-                budgetType: subscription.planDetails.budgetTerm,
+                budgetType: displayBudgetName(pendingChanges.planDetails, {title: true}),
                 currentOnDemandBudgets: formatOnDemandBudget(
                   subscription.planDetails,
                   currentOnDemandBudgets,
                   subscription.planDetails.onDemandCategories
                 ),
                 nextOnDemandBudgets: formatOnDemandBudget(
-                  subscription.planDetails,
+                  pendingChanges.planDetails,
                   nextOnDemandBudgets,
                   pendingChanges.planDetails.onDemandCategories
                 ),

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -11,10 +11,9 @@ import type {Organization} from 'sentry/types/organization';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
-import {type PendingOnDemandBudgets, PlanTier, type Subscription} from 'getsentry/types';
+import type {PendingOnDemandBudgets, Subscription} from 'getsentry/types';
 import {
   formatReservedWithUnits,
-  getAmPlanTier,
   hasPerformance,
   isAm3DsPlan,
 } from 'getsentry/utils/billing';
@@ -23,6 +22,7 @@ import {
   getReservedBudgetDisplayName,
 } from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
+import titleCase from 'getsentry/utils/titleCase';
 import {
   formatOnDemandBudget,
   hasOnDemandBudgetsFeature,
@@ -77,23 +77,20 @@ class PendingChanges extends Component<Props> {
       if (nextOnDemandBudgets) {
         const pendingOnDemandBudgets = parseOnDemandBudgets(nextOnDemandBudgets);
         const currentOnDemandBudgets = parseOnDemandBudgetsFromSubscription(subscription);
-        const planTier = getAmPlanTier(pendingChanges.plan);
 
         if (!isOnDemandBudgetsEqual(pendingOnDemandBudgets, currentOnDemandBudgets)) {
           results.push(
             tct(
               '[budgetType] budget change from [currentOnDemandBudgets] to [nextOnDemandBudgets]',
               {
-                budgetType: planTier === PlanTier.AM3 ? 'Pay-as-you-go' : 'On-demand',
+                budgetType: subscription.planDetails.budgetTerm,
                 currentOnDemandBudgets: formatOnDemandBudget(
                   subscription.planDetails,
-                  subscription.planTier,
                   currentOnDemandBudgets,
                   subscription.planDetails.onDemandCategories
                 ),
                 nextOnDemandBudgets: formatOnDemandBudget(
                   subscription.planDetails,
-                  planTier?.toString() || subscription.planTier,
                   nextOnDemandBudgets,
                   pendingChanges.planDetails.onDemandCategories
                 ),
@@ -109,8 +106,7 @@ class PendingChanges extends Component<Props> {
         this.getNestedValue<number>(subscription, 'onDemandMaxSpend') ?? 0;
       results.push(
         tct('[budgetType] spend change from [currentAmount] to [newAmount]', {
-          budgetType:
-            subscription.planTier === PlanTier.AM3 ? 'Pay-as-you-go' : 'On-demand',
+          budgetType: titleCase(subscription.planDetails.budgetTerm),
           newAmount: formatCurrency(nextOnDemandMaxSpend),
           currentAmount: formatCurrency(currentOnDemandMaxSpend),
         })

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -38,15 +38,14 @@ import {
 } from 'sentry/views/organizationStats/usageChart/utils';
 
 import {GIGABYTE} from 'getsentry/constants';
-import {
-  type BillingMetricHistory,
-  type BillingStat,
-  type BillingStats,
-  type CustomerUsage,
-  type Plan,
-  PlanTier,
-  type ReservedBudgetForCategory,
-  type Subscription,
+import type {
+  BillingMetricHistory,
+  BillingStat,
+  BillingStats,
+  CustomerUsage,
+  Plan,
+  ReservedBudgetForCategory,
+  Subscription,
 } from 'getsentry/types';
 import {formatReservedWithUnits, isUnlimitedReserved} from 'getsentry/utils/billing';
 import {getPlanCategoryName, hasCategoryFeature} from 'getsentry/utils/dataCategory';
@@ -690,8 +689,7 @@ function ReservedUsageChart({
                 color: CHART_PALETTE[5][0],
               }),
               barSeries({
-                name:
-                  subscription.planTier === PlanTier.AM3 ? 'Pay-as-you-go' : 'On-Demand',
+                name: titleCase(subscription.planDetails.budgetTerm),
                 data: chartData.onDemand,
                 barMinHeight: 1,
                 stack: 'usage',

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -47,10 +47,13 @@ import type {
   ReservedBudgetForCategory,
   Subscription,
 } from 'getsentry/types';
-import {formatReservedWithUnits, isUnlimitedReserved} from 'getsentry/utils/billing';
+import {
+  displayBudgetName,
+  formatReservedWithUnits,
+  isUnlimitedReserved,
+} from 'getsentry/utils/billing';
 import {getPlanCategoryName, hasCategoryFeature} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
-import titleCase from 'getsentry/utils/titleCase';
 import {
   calculateCategoryOnDemandUsage,
   calculateCategoryPrepaidUsage,
@@ -689,7 +692,7 @@ function ReservedUsageChart({
                 color: CHART_PALETTE[5][0],
               }),
               barSeries({
-                name: titleCase(subscription.planDetails.budgetTerm),
+                name: displayBudgetName(subscription.planDetails, {title: true}),
                 data: chartData.onDemand,
                 barMinHeight: 1,
                 stack: 'usage',
@@ -731,13 +734,12 @@ function ReservedUsageChart({
             ? t('Current Usage Period')
             : t(
                 'Estimated %s Spend This Period',
-                titleCase(
-                  getPlanCategoryName({
-                    plan: subscription.planDetails,
-                    category,
-                    hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
-                  })
-                )
+                getPlanCategoryName({
+                  plan: subscription.planDetails,
+                  category,
+                  hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+                  title: true,
+                })
               )}
         </Title>
       }

--- a/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
@@ -200,7 +200,7 @@ describe('Subscription > UsageAlert', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/errors and attachments capacity/))
     ).toBeInTheDocument();
-    expect(screen.getByLabelText('Increase Reserved Limits')).toBeInTheDocument();
+    expect(screen.getByText('Setup On-Demand')).toBeInTheDocument();
 
     expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -30,7 +30,7 @@ import type {
   Plan,
   Subscription,
 } from 'getsentry/types';
-import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {OnDemandBudgetMode} from 'getsentry/types';
 import {
   formatReservedWithUnits,
   formatUsageWithUnits,
@@ -190,7 +190,7 @@ function UsageHistoryRow({history, subscription}: RowProps) {
         <thead>
           <tr>
             <th>
-              {subscription.planTier === PlanTier.AM3
+              {subscription.planDetails.budgetTerm === 'pay-as-you-go'
                 ? t('Pay-as-you-go Spend')
                 : history.onDemandBudgetMode === OnDemandBudgetMode.PER_CATEGORY
                   ? t('On-Demand Spend (Per-Category)')

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -741,9 +741,7 @@ function UsageTotals({
                   {isDisplayingSpend ? (
                     <div>
                       <LegendTitle>
-                        {subscription.planTier === PlanTier.AM3
-                          ? t('Pay-as-you-go')
-                          : t('On-Demand')}
+                        {titleCase(subscription.planDetails.budgetTerm)}
                       </LegendTitle>
                       <LegendPrice>
                         {formatCurrency(onDemandCategorySpend)} of{' '}
@@ -759,9 +757,7 @@ function UsageTotals({
                   ) : (
                     <div>
                       <LegendTitle>
-                        {subscription.planTier === PlanTier.AM3
-                          ? t('Pay-as-you-go')
-                          : t('On-Demand')}
+                        {titleCase(subscription.planDetails.budgetTerm)}
                       </LegendTitle>
                       <LegendPrice>
                         {formatUsageWithUnits(onDemandUsage, category, usageOptions)}
@@ -786,9 +782,7 @@ function UsageTotals({
                   {showOnDemand && (
                     <Fragment>
                       {formatCurrency(onDemandCategorySpend)}{' '}
-                      {subscription.planTier === PlanTier.AM3
-                        ? t('Pay-as-you-go')
-                        : t('On-Demand')}
+                      {titleCase(subscription.planDetails.budgetTerm)}
                     </Fragment>
                   )}
                 </TotalSpendLabel>

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -26,6 +26,7 @@ import {
 } from 'getsentry/types';
 import {
   addBillingStatTotals,
+  displayBudgetName,
   formatReservedWithUnits,
   formatUsageWithUnits,
   getActiveProductTrial,
@@ -741,7 +742,7 @@ function UsageTotals({
                   {isDisplayingSpend ? (
                     <div>
                       <LegendTitle>
-                        {titleCase(subscription.planDetails.budgetTerm)}
+                        {displayBudgetName(subscription.planDetails, {title: true})}
                       </LegendTitle>
                       <LegendPrice>
                         {formatCurrency(onDemandCategorySpend)} of{' '}
@@ -757,7 +758,7 @@ function UsageTotals({
                   ) : (
                     <div>
                       <LegendTitle>
-                        {titleCase(subscription.planDetails.budgetTerm)}
+                        {displayBudgetName(subscription.planDetails, {title: true})}
                       </LegendTitle>
                       <LegendPrice>
                         {formatUsageWithUnits(onDemandUsage, category, usageOptions)}
@@ -782,7 +783,7 @@ function UsageTotals({
                   {showOnDemand && (
                     <Fragment>
                       {formatCurrency(onDemandCategorySpend)}{' '}
-                      {titleCase(subscription.planDetails.budgetTerm)}
+                      {displayBudgetName(subscription.planDetails, {title: true})}
                     </Fragment>
                   )}
                 </TotalSpendLabel>

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -75,6 +75,8 @@ const AM1_TRIAL_FEATURES = AM1_BUSINESS_FEATURES.filter(
   feature => feature !== 'sso-saml2' && feature !== 'baa'
 );
 
+const BUDGET_TERM = 'on-demand';
+
 const AM1_PLANS: Record<string, Plan> = {
   am1_f: {
     allowAdditionalReservedEvents: false,
@@ -145,6 +147,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_FREE_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_t: {
     allowAdditionalReservedEvents: false,
@@ -215,6 +218,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_TRIAL_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_team: {
     allowAdditionalReservedEvents: false,
@@ -795,6 +799,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_TEAM_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_team_auf: {
     allowAdditionalReservedEvents: false,
@@ -1375,6 +1380,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_TEAM_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_business: {
     allowAdditionalReservedEvents: false,
@@ -1955,6 +1961,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_BUSINESS_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_business_auf: {
     allowAdditionalReservedEvents: false,
@@ -2535,6 +2542,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     features: AM1_BUSINESS_FEATURES,
+    budgetTerm: BUDGET_TERM,
   },
   am1_business_ent: {
     id: 'am1_business_ent',
@@ -2612,6 +2620,7 @@ const AM1_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    budgetTerm: BUDGET_TERM,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -81,6 +81,8 @@ const AM2_TRIAL_FEATURES = AM2_BUSINESS_FEATURES.filter(
   feature => feature !== 'sso-saml2' && feature !== 'baa'
 );
 
+const BUDGET_TERM = 'on-demand';
+
 // TODO: Update with correct pricing and structure
 const AM2_PLANS: Record<string, Plan> = {
   am2_business: {
@@ -762,6 +764,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    budgetTerm: BUDGET_TERM,
   },
   am2_f: {
     id: 'am2_f',
@@ -847,6 +850,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    budgetTerm: BUDGET_TERM,
   },
   am2_team: {
     id: 'am2_team',
@@ -1527,6 +1531,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    budgetTerm: BUDGET_TERM,
   },
   am2_t: {
     id: 'am2_t',
@@ -1612,6 +1617,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    budgetTerm: BUDGET_TERM,
   },
   am2_team_auf: {
     id: 'am2_team_auf',
@@ -1639,6 +1645,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -2319,6 +2326,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -3010,6 +3018,7 @@ const AM2_PLANS: Record<string, Plan> = {
       profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
+    budgetTerm: BUDGET_TERM,
   },
   am2_sponsored_team_auf: {
     id: 'am2_sponsored_team_auf',
@@ -3047,6 +3056,7 @@ const AM2_PLANS: Record<string, Plan> = {
       profileDurationUI: [{events: 0, unitPrice: 0, price: 0}],
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
+    budgetTerm: BUDGET_TERM,
   },
   am2_business_bundle: {
     id: 'am2_business_bundle',
@@ -3069,6 +3079,7 @@ const AM2_PLANS: Record<string, Plan> = {
     reservedMinimum: 500000,
     allowAdditionalReservedEvents: false,
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
+    budgetTerm: BUDGET_TERM,
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
@@ -3564,6 +3575,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -4104,6 +4116,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -4659,6 +4672,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -4744,6 +4758,7 @@ const AM2_PLANS: Record<string, Plan> = {
     availableCategories: AM2_CATEGORIES,
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -101,6 +101,8 @@ const AM3_DS_FEATURES = [
   'dynamic-sampling-custom',
 ];
 
+const BUDGET_TERM = 'pay-as-you-go';
+
 const AM3_PLANS: Record<string, Plan> = {
   am3_business: {
     id: 'am3_business',
@@ -127,6 +129,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -838,6 +841,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1333,6 +1337,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1426,6 +1431,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1519,6 +1525,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_DS_CATEGORIES,
     onDemandCategories: AM3_DS_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1620,6 +1627,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_DS_CATEGORIES,
     onDemandCategories: AM3_DS_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1721,6 +1729,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1814,6 +1823,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -1907,6 +1917,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_DS_CATEGORIES,
     onDemandCategories: AM3_DS_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -2008,6 +2019,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -2503,6 +2515,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {
@@ -2998,6 +3011,7 @@ const AM3_PLANS: Record<string, Plan> = {
     availableCategories: AM3_CATEGORIES,
     onDemandCategories: AM3_CATEGORIES,
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     planCategories: {
       errors: [
         {

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -1,5 +1,7 @@
 import type {Plan} from 'getsentry/types';
 
+const BUDGET_TERM = 'on-demand';
+
 const MM1_CATEGORY_DISPLAY_NAMES = {
   errors: {singular: 'error', plural: 'errors'},
 };
@@ -47,6 +49,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'relay',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   e1_auf: {
     isTestPlan: false,
@@ -89,6 +92,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'relay',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   f1: {
     isTestPlan: false,
@@ -123,6 +127,7 @@ const MM1_PLANS: Record<string, Plan> = {
     onDemandEventPrice: 0,
     retentionDays: 30,
     features: [],
+    budgetTerm: BUDGET_TERM,
   },
   l1: {
     isTestPlan: false,
@@ -167,6 +172,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   l1_ac: {
     isTestPlan: false,
@@ -211,6 +217,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   l1_auf: {
     isTestPlan: false,
@@ -255,6 +262,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   m1: {
     isTestPlan: false,
@@ -296,6 +304,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   m1_ac: {
     isTestPlan: false,
@@ -337,6 +346,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   m1_auf: {
     isTestPlan: false,
@@ -378,6 +388,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-sync',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   s1: {
     isTestPlan: false,
@@ -417,6 +428,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-basic',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
   s1_ac: {
     isTestPlan: false,
@@ -456,6 +468,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'integrations-issue-basic',
       'extended-data-retention',
     ],
+    budgetTerm: BUDGET_TERM,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -6,6 +6,7 @@ const MM2_CATEGORY_DISPLAY_NAMES = {
   errors: {singular: 'error', plural: 'errors'},
 };
 
+const BUDGET_TERM = 'on-demand';
 const MM2_PLANS: Record<string, Plan> = {
   mm2_a_100k: {
     isTestPlan: false,
@@ -18,6 +19,7 @@ const MM2_PLANS: Record<string, Plan> = {
     categories: ['errors'],
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
+    budgetTerm: BUDGET_TERM,
     hasOnDemandModes: false,
     trialPlan: null,
     maxMembers: null,
@@ -73,6 +75,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: null,
     maxMembers: null,
     planCategories: {
@@ -127,6 +130,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: null,
     maxMembers: null,
     planCategories: {
@@ -181,6 +185,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: null,
     maxMembers: null,
     planCategories: {
@@ -235,6 +240,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: null,
     maxMembers: null,
     planCategories: {
@@ -289,6 +295,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: null,
     maxMembers: null,
     planCategories: {
@@ -343,6 +350,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -386,6 +394,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -429,6 +438,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -472,6 +482,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -516,6 +527,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -559,6 +571,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'mm2_a',
     maxMembers: null,
     planCategories: {
@@ -602,6 +615,7 @@ const MM2_PLANS: Record<string, Plan> = {
     checkoutCategories: ['errors'],
     onDemandCategories: ['errors'],
     hasOnDemandModes: false,
+    budgetTerm: BUDGET_TERM,
     trialPlan: 'am1_t',
     maxMembers: 1,
     planCategories: {
@@ -684,7 +698,8 @@ const MM2_PLANS: Record<string, Plan> = {
         ]
     },
     categoryDisplayNames: MM2_CATEGORY_DISPLAY_NAMES,
-},
+    budgetTerm: BUDGET_TERM,
+  },
 };
 
 export default MM2_PLANS;


### PR DESCRIPTION
Follow up to https://github.com/getsentry/getsentry/pull/17051

This also updates over quota banner copy to be consistent across tiers (if over quota and user has billing perms, the CTA pushes them to setup/increase PAYG/OD). Prior to this PR, legacy customers would see the copy "Increase Reserved Limits" or "Update Plan" which should've taken them to checkout when it actually mistakenly took them to subscription settings with the open OD modal.