### PR TITLE
fix(explore): Update search bar query on filter deletion

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -35,6 +35,7 @@ interface SpanSearchQueryBuilderProps {
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
   projects?: PageFilters['projects'];
+  updateOnFilterDelete?: boolean;
 }
 
 export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
@@ -67,6 +68,7 @@ export function SpanSearchQueryBuilder({
   onBlur,
   placeholder,
   projects,
+  updateOnFilterDelete,
 }: SpanSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -148,6 +150,7 @@ export function SpanSearchQueryBuilder({
       disallowUnsupportedFilters
       recentSearches={SavedSearchType.SPAN}
       showUnsubmittedIndicator
+      updateOnFilterDelete={updateOnFilterDelete}
     />
   );
 }
@@ -172,6 +175,7 @@ export function EAPSpanSearchQueryBuilder({
   supportedAggregates = [],
   projects,
   portalTarget,
+  updateOnFilterDelete,
 }: EAPSpanSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -250,6 +254,7 @@ export function EAPSpanSearchQueryBuilder({
       recentSearches={SavedSearchType.SPAN}
       showUnsubmittedIndicator
       portalTarget={portalTarget}
+      updateOnFilterDelete={updateOnFilterDelete}
     />
   );
 }

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -124,6 +124,10 @@ export interface SearchQueryBuilderProps {
    * to the left of the clear button.
    */
   trailingItems?: React.ReactNode;
+  /**
+   * When true, the filter will be updated when a filter's delete button is clicked.
+   */
+  updateOnFilterDelete?: boolean;
 }
 
 function SearchIndicator({
@@ -208,6 +212,7 @@ export function SearchQueryBuilder({
   trailingItems,
   getFilterTokenWarning,
   portalTarget,
+  updateOnFilterDelete,
 }: SearchQueryBuilderProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -322,7 +327,11 @@ export function SearchQueryBuilder({
           {!parsedQuery || queryInterface === QueryInterfaceType.TEXT ? (
             <PlainTextQueryInput label={label} />
           ) : (
-            <TokenizedQueryGrid label={label} actionBarWidth={actionBarWidth} />
+            <TokenizedQueryGrid
+              label={label}
+              actionBarWidth={actionBarWidth}
+              updateOnFilterDelete={updateOnFilterDelete}
+            />
           )}
           {size !== 'small' && (
             <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -24,12 +24,14 @@ import {space} from 'sentry/styles/space';
 interface TokenizedQueryGridProps {
   actionBarWidth: number;
   label?: string;
+  updateOnFilterDelete?: boolean;
 }
 
 interface GridProps extends AriaGridListOptions<ParseResultToken> {
   actionBarWidth: number;
   children: CollectionChildren<ParseResultToken>;
   items: ParseResultToken[];
+  updateOnFilterDelete?: boolean;
 }
 
 function useApplyFocusOverride(state: ListState<ParseResultToken>) {
@@ -95,6 +97,7 @@ function Grid(props: GridProps) {
                 token={token}
                 item={item}
                 state={state}
+                updateOnFilterDelete={props.updateOnFilterDelete}
               />
             );
           case Token.FREE_TEXT:
@@ -134,7 +137,11 @@ function Grid(props: GridProps) {
   );
 }
 
-export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridProps) {
+export function TokenizedQueryGrid({
+  label,
+  actionBarWidth,
+  updateOnFilterDelete,
+}: TokenizedQueryGridProps) {
   const {parsedQuery} = useSearchQueryBuilder();
 
   // Shouldn't ever get here since we will render the plain text input instead
@@ -149,6 +156,7 @@ export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridPr
         items={parsedQuery}
         selectionMode="multiple"
         actionBarWidth={actionBarWidth}
+        updateOnFilterDelete={updateOnFilterDelete}
       >
         {item => (
           <Item key={makeTokenKey(item, parsedQuery)}>

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -218,6 +218,7 @@ export function SpansTabContentImpl({
             initialQuery={query}
             onSearch={setQuery}
             searchSource="explore"
+            updateOnFilterDelete
           />
         ) : (
           <EAPSpanSearchQueryBuilder
@@ -244,6 +245,7 @@ export function SpansTabContentImpl({
             }
             numberTags={numberTags}
             stringTags={stringTags}
+            updateOnFilterDelete
           />
         )}
       </TopSection>


### PR DESCRIPTION
When a filter on the search bar is deleted, the query in the url wouldn't update unless the query was "submitted" (you hit enter). I've added an optional prop to indicate if you want to update the query with filter deletion. Side note: i know that the search bar doesn't submit in a bunch of other configurations but that's something the Issues team is supposed to take care of.

Addresses [this bug](https://www.notion.so/sentry/Getting-rid-of-fields-from-the-search-bar-doesn-t-update-url-1c08b10e4b5d8058b1afc7d83f532be7?pvs=4)
