### PR TITLE
chore(HC): Adds logging with a low sample rate for cache misses on options

### DIFF
--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -94,6 +94,14 @@ class OptionsStore:
         if result is not None:
             return result
 
+        if random() < 0.01:
+            # Log 1% of our cache misses for option retrieval to help triage
+            # excessive queries against the store.
+            logger.info(
+                "sentry_options_store.cache_miss",
+                extra={"key": key.name, "ttl": key.ttl, "grace": key.grace},
+            )
+
         result = self.get_store(key, silent=silent)
         if result is not None:
             return result


### PR DESCRIPTION
Adds logging with a 1% sample rate to cache misses in our options store. This PR replaces #88360 for now.
