### PR TITLE
chore(ui): Update eslint to react 19, ignore .artrifacts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -155,7 +155,7 @@ export default typescript.config([
     settings: {
       react: {
         version: '19.0.0',
-        defaultVersion: '19',
+        defaultVersion: '19.0',
       },
       'import/parsers': {'@typescript-eslint/parser': ['.ts', '.tsx']},
       'import/resolver': {typescript: {}},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -154,8 +154,8 @@ export default typescript.config([
     },
     settings: {
       react: {
-        version: '18.2.0',
-        defaultVersion: '18.2',
+        version: '19.0.0',
+        defaultVersion: '19',
       },
       'import/parsers': {'@typescript-eslint/parser': ['.ts', '.tsx']},
       'import/resolver': {typescript: {}},
@@ -192,6 +192,7 @@ export default typescript.config([
     'src/sentry/static/sentry/js/**/*',
     'src/sentry/templates/sentry/**/*',
     'stylelint.config.js',
+    '.artifacts/**/*',
   ]),
   /**
    * Rules are grouped by plugin. If you want to override a specific rule inside


### PR DESCRIPTION
.artifacts includes coverage js files sometimes if run locally.