### PR TITLE
fix(ourlogs): Cleanup UI after aliasing changes

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -39,7 +39,6 @@ interface SchemaHintsListProps extends SchemaHintsPageParams {
   numberTags: TagCollection;
   stringTags: TagCollection;
   supportedAggregates: AggregationKey[];
-  filterKeySections?: FilterKeySection[];
   isLoading?: boolean;
   source?: SchemaHintsSources;
 }

--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -1,3 +1,4 @@
+import type {TagCollection} from 'sentry/types/group';
 import {FieldKey} from 'sentry/utils/fields';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -24,6 +25,7 @@ const COMMON_HINT_KEYS = [
 const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.BODY,
   OurLogKnownFieldKey.SEVERITY_TEXT,
+  OurLogKnownFieldKey.SEVERITY_NUMBER,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.PROJECT_ID,
   OurLogKnownFieldKey.PARENT_SPAN_ID,
@@ -43,6 +45,18 @@ const SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE = [
   ...new Set([...FRONTEND_HINT_KEYS, ...MOBILE_HINT_KEYS, ...COMMON_HINT_KEYS]),
 ];
 
+const SCHEMA_HINTS_HIDDEN_KEYS_LOGS = [
+  OurLogKnownFieldKey.SEVERITY_NUMBER, // Severity number is a detail saved by the OTel protocol, and may not be required. 'level' is a mandatory field on the new 'log' ItemType schema.
+  OurLogKnownFieldKey.SENTRY_PROJECT_ID, // Public alias since int<->string alias reversing is broken. Should be removed in the future.
+  OurLogKnownFieldKey.ITEM_TYPE, // This is a detail internal to the trace items table.
+  OurLogKnownFieldKey.ID, // This is a detail internal to the trace items table.
+];
+
+// Unlike ORDER_KEYS, hidden keys are completely omitted from the schema hints list.
+export const SCHEMA_HINTS_HIDDEN_KEYS: string[] = [
+  ...new Set([...SCHEMA_HINTS_HIDDEN_KEYS_LOGS]),
+];
+
 export enum SchemaHintsSources {
   EXPLORE = 'explore',
   LOGS = 'logs',
@@ -54,4 +68,14 @@ export const getSchemaHintsListOrder = (source: SchemaHintsSources) => {
   }
 
   return SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE;
+};
+
+export const removeHiddenKeys = (tagCollection: TagCollection): TagCollection => {
+  const result: TagCollection = {};
+  for (const key in tagCollection) {
+    if (key && !SCHEMA_HINTS_HIDDEN_KEYS.includes(key) && tagCollection[key]) {
+      result[key] = tagCollection[key];
+    }
+  }
+  return result;
 };

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -52,10 +52,8 @@ export interface UseTraceItemDetailsProps {
   enabled?: boolean;
 }
 
-export type TraceItemAttributes = Record<string, TraceItemResponseAttribute>;
-
 interface TraceItemDetailsResponse {
-  attributes: TraceItemAttributes;
+  attributes: TraceItemResponseAttribute[];
   itemId: string;
   timestamp: string;
 }

--- a/static/app/views/explore/logs/logFieldsTree.spec.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.spec.tsx
@@ -1,0 +1,82 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {LogFieldsTree} from 'sentry/views/explore/logs/logFieldsTree';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+jest.mock('sentry/utils/useLocation');
+const mockedUsedLocation = jest.mocked(useLocation);
+
+function ProviderWrapper({children}: {children?: React.ReactNode}) {
+  return (
+    <QueryClientProvider client={makeTestQueryClient()}>
+      <LogsPageParamsProvider analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}>
+        {children}
+      </LogsPageParamsProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('logFieldsTree', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(function () {
+    mockedUsedLocation.mockReturnValue(LocationFixture());
+  });
+
+  it('when rendering sentry.project_id, it should be aliased to project_id when rendering and when using the cell action', () => {
+    const attributes: TraceItemResponseAttribute[] = [
+      {
+        type: 'str',
+        value: '123',
+        name: OurLogKnownFieldKey.SENTRY_PROJECT_ID,
+      } as TraceItemResponseAttribute,
+      {
+        type: 'str',
+        value: '456',
+        name: OurLogKnownFieldKey.SEVERITY_NUMBER,
+      } as TraceItemResponseAttribute,
+    ];
+
+    render(
+      <ProviderWrapper>
+        <LogFieldsTree
+          attributes={attributes}
+          renderExtra={{
+            highlightTerms: [],
+            logColors: {
+              background: '#fff',
+              backgroundLight: '#f8f8f8',
+              border: '#ccc',
+              borderHover: '#999',
+              color: '#000',
+            },
+            useFullSeverityText: false,
+            renderSeverityCircle: false,
+            wrapBody: false,
+            organization,
+            location: LocationFixture(),
+          }}
+        />
+      </ProviderWrapper>
+    );
+
+    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText('456')).toBeInTheDocument();
+
+    expect(screen.getByTestId('tree-key-project.id')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-key-project.id')).toHaveTextContent('project_id');
+    expect(screen.getByTestId('tree-key-log.severity_number')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-key-log.severity_number')).toHaveTextContent(
+      'severity_number'
+    );
+  });
+});

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -21,16 +21,17 @@ import {
   useSetLogsFields,
   useSetLogsSearch,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
-import type {TraceItemAttributes} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import type {
   LogAttributesRendererMap,
   RendererExtra,
 } from 'sentry/views/explore/logs/fieldRenderers';
 import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {
+  adjustAliases,
   adjustLogTraceID,
   getLogAttributeItem,
-  removeSentryPrefix,
+  removePrefixes,
 } from 'sentry/views/explore/logs/utils';
 
 const MAX_TREE_DEPTH = 4;
@@ -66,14 +67,12 @@ interface LogAttributeFieldRender {
 }
 
 interface LogFieldsTreeProps extends LogAttributeFieldRender {
-  attributes: TraceItemAttributes;
+  attributes: TraceItemResponseAttribute[];
   hiddenAttributes?: OurLogFieldKey[];
 }
 
-interface LogFieldsTreeColumnsProps extends LogAttributeFieldRender {
-  attributes: TraceItemAttributes;
+interface LogFieldsTreeColumnsProps extends LogFieldsTreeProps {
   columnCount: number;
-  hiddenAttributes?: OurLogFieldKey[];
 }
 
 interface LogFieldsTreeRowConfig {
@@ -208,10 +207,8 @@ function LogFieldsTreeColumns({
     }
 
     // Convert attributes record to the format expected by addToAttributeTree
-    const visibleAttributes = (
-      Array.isArray(attributes) ? attributes : Object.keys(attributes)
-    )
-      .map(key => getAttribute(attributes, key, hiddenAttributes))
+    const visibleAttributes = attributes
+      .map(key => getAttribute(key, hiddenAttributes))
       .filter(defined);
 
     // Create the AttributeTree data structure using all the given attributes
@@ -331,7 +328,11 @@ function LogFieldsTreeRow({
           </Fragment>
         )}
         <TreeSearchKey aria-hidden>{originalAttribute.attribute_key}</TreeSearchKey>
-        <TreeKey hasErrors={hasErrors} title={originalAttribute.attribute_key}>
+        <TreeKey
+          hasErrors={hasErrors}
+          title={originalAttribute.attribute_key}
+          data-test-id={`tree-key-${content.originalAttribute?.original_attribute_key}`}
+        >
           {attributeKey}
         </TreeKey>
       </TreeKeyTrunk>
@@ -516,42 +517,6 @@ function LogFieldsTreeValue({
  * Filters out hidden attributes, replaces sentry. prefixed keys, and simplifies the value
  */
 function getAttribute(
-  attributes: TraceItemAttributes,
-  attributeKey: string | Record<string, any>,
-  hiddenAttributes: OurLogFieldKey[]
-): Attribute | undefined {
-  if (typeof attributeKey === 'object') {
-    return getAttributeFromObject(attributes, attributeKey, hiddenAttributes);
-  }
-
-  // Filter out hidden attributes
-  if (hiddenAttributes.includes(attributeKey)) {
-    return undefined;
-  }
-
-  const attribute = attributes[attributeKey];
-  if (!attribute) {
-    return undefined;
-  }
-
-  // Replace the key name with the new key name
-  const newKeyName = removeSentryPrefix(attributeKey);
-
-  const attributeValue =
-    attribute.type === 'bool' ? String(attribute.value) : attribute.value;
-  if (!defined(attributeValue)) {
-    return undefined;
-  }
-
-  return {
-    attribute_key: newKeyName,
-    attribute_value: attributeValue,
-    original_attribute_key: attributeKey,
-  };
-}
-
-function getAttributeFromObject(
-  _: TraceItemAttributes,
   attribute: Record<string, any>,
   hiddenAttributes: OurLogFieldKey[]
 ): Attribute | undefined {
@@ -562,7 +527,7 @@ function getAttributeFromObject(
   }
 
   // Replace the key name with the new key name
-  const newKeyName = removeSentryPrefix(attributeKey);
+  const newKeyName = removePrefixes(attributeKey);
 
   const attributeValue =
     attribute.type === 'bool' ? String(attribute.value) : attribute.value;
@@ -573,7 +538,7 @@ function getAttributeFromObject(
   return {
     attribute_key: newKeyName,
     attribute_value: attributeValue,
-    original_attribute_key: attributeKey,
+    original_attribute_key: adjustAliases(attributeKey),
   };
 }
 

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -118,7 +118,7 @@ export function LogsTable({
             </LogTableRow>
           </TableHead>
         ) : null}
-        <LogTableBody>
+        <LogTableBody showHeader={showHeader}>
           {isPending && (
             <TableStatus>
               <LoadingIndicator />

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -8,13 +8,19 @@ import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {FieldValueType} from 'sentry/utils/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
+import type {TableColumn} from 'sentry/views/discover/table/types';
 import {TableRow} from 'sentry/views/explore/components/table';
 import {
   useLogsAnalyticsPageSource,
   useLogsFields,
+  useLogsSearch,
+  useSetLogsSearch,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {HiddenLogDetailFields} from 'sentry/views/explore/logs/constants';
 import {
@@ -53,6 +59,8 @@ type LogsRowProps = {
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
 };
 
+export const ALLOWED_CELL_ACTIONS: Actions[] = [Actions.ADD, Actions.EXCLUDE];
+
 export function LogRowContent({
   dataRow,
   highlightTerms,
@@ -62,6 +70,9 @@ export function LogRowContent({
   const location = useLocation();
   const organization = useOrganization();
   const fields = useLogsFields();
+  const search = useLogsSearch();
+  const setLogsSearch = useSetLogsSearch();
+
   const analyticsPageSource = useLogsAnalyticsPageSource();
   const [expanded, setExpanded] = useState<boolean>(false);
   const onClickExpand = useCallback(() => {
@@ -72,6 +83,22 @@ export function LogRowContent({
       organization,
     });
   }, [dataRow, organization, analyticsPageSource]);
+  const addSearchFilter = useCallback(
+    ({
+      key,
+      value,
+      negated,
+    }: {
+      key: string;
+      value: string | number | boolean;
+      negated?: boolean;
+    }) => {
+      const newSearch = search.copy();
+      newSearch.addFilterValue(`${negated ? '!' : ''}${key}`, String(value));
+      setLogsSearch(newSearch);
+    },
+    [setLogsSearch, search]
+  );
   const theme = useTheme();
 
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
@@ -133,13 +160,51 @@ export function LogRowContent({
             );
           }
 
+          const discoverColumn: TableColumn<keyof TableDataRow> = {
+            column: {
+              field,
+              kind: 'field',
+            },
+            name: field,
+            key: field,
+            isSortable: true,
+            type: FieldValueType.STRING,
+          };
+
           return (
             <LogTableBodyCell key={field}>
-              <LogFieldRenderer
-                item={getLogRowItem(field, dataRow, meta)}
-                meta={meta}
-                extra={rendererExtra}
-              />
+              <CellAction
+                column={discoverColumn}
+                dataRow={dataRow as unknown as TableDataRow}
+                handleCellAction={(actions, cellValue) => {
+                  switch (actions) {
+                    case Actions.ADD:
+                      addSearchFilter({
+                        key: field,
+                        value: cellValue,
+                      });
+                      break;
+                    case Actions.EXCLUDE:
+                      addSearchFilter({
+                        key: field,
+                        value: cellValue,
+                        negated: true,
+                      });
+                      break;
+                    default:
+                      break;
+                  }
+                }}
+                allowActions={
+                  field === OurLogKnownFieldKey.BODY ? ALLOWED_CELL_ACTIONS : []
+                }
+              >
+                <LogFieldRenderer
+                  item={getLogRowItem(field, dataRow, meta)}
+                  meta={meta}
+                  extra={rendererExtra}
+                />
+              </CellAction>
             </LogTableBodyCell>
           );
         })}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -64,9 +64,14 @@ export const LogTableBodyCell = styled(TableBodyCell)`
   }
 `;
 
-export const LogTableBody = styled(TableBody)`
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
+export const LogTableBody = styled(TableBody)<{showHeader?: boolean}>`
+  ${p =>
+    p.showHeader
+      ? ''
+      : `
+    padding-top: ${space(1)};
+    padding-bottom: ${space(1)};
+    `}
 `;
 
 export const LogDetailTableBodyCell = styled(TableBodyCell)`

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -10,17 +10,22 @@ import type {
 type OurLogCustomFieldKey = string; // We could brand this for nominal types.
 
 // This enum is used to represent known fields or attributes in the logs response.
+// Should always map to the public alias from the backend (.../search/eap/ourlogs/attributes.py)
 export enum OurLogKnownFieldKey {
-  TRACE_ID = 'sentry.trace_id',
+  TRACE_ID = 'trace',
+  // From the EAP dataset directly not using a column alias.
   ID = 'sentry.item_id',
-  BODY = 'sentry.body',
-  SEVERITY_NUMBER = 'sentry.severity_number',
-  SEVERITY_TEXT = 'sentry.severity_text',
-  ORGANIZATION_ID = 'sentry.organization_id',
-  PROJECT_ID = 'project_id',
+  // Also aliased to 'message'
+  BODY = 'log.body',
+  SEVERITY_NUMBER = 'log.severity_number',
+  SEVERITY_TEXT = 'log.severity_text',
+  ORGANIZATION_ID = 'organization.id',
+  PROJECT_ID = 'project.id',
+  SPAN_ID = 'span_id',
   SENTRY_PROJECT_ID = 'sentry.project_id',
   PARENT_SPAN_ID = 'sentry.trace.parent_span_id',
   TIMESTAMP = 'timestamp',
+  // From the EAP dataset directly not using a column alias, should be hidden.
   ITEM_TYPE = 'sentry.item_type',
 }
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -131,12 +131,21 @@ export function logsFieldAlignment(...args: Parameters<typeof fieldAlignment>) {
   return fieldAlignment(...args);
 }
 
-export function removeSentryPrefix(key: string) {
-  return key.replace('sentry.', '');
+export function removePrefixes(key: string) {
+  return key.replace('log.', '').replace('sentry.', '');
+}
+
+export function adjustAliases(key: string) {
+  switch (key) {
+    case OurLogKnownFieldKey.SENTRY_PROJECT_ID:
+      return OurLogKnownFieldKey.PROJECT_ID; // Public alias since int<->string alias reversing is broken. Should be removed in the future.
+    default:
+      return key;
+  }
 }
 
 export function getTableHeaderLabel(field: OurLogFieldKey) {
-  return LogAttributesHumanLabel[field] ?? removeSentryPrefix(field);
+  return LogAttributesHumanLabel[field] ?? removePrefixes(field);
 }
 
 export function isLogAttributeUnit(unit: string | null): unit is LogAttributeUnits {


### PR DESCRIPTION
### Summary

General cleanup after aliasing and other backend changes. Also adds a simple aliasing test for LogsFieldTree since we're doing a bunch of logic aside from rendering, we'll have to add a few more tests before we cleanup the field tree though.

This also does some other cleanup:
- Fully switch trace-items response type over from 'object' to 'array' since the backend has been out for a while
- Fixes the log. aliases
- Makes schema hints also be able to hide certain keys (some known fields of logs are internal and we don't want to expose them)
- Adds a cell action for the body column on table (only body for now, the fieldrenderers need to be re-arranged before we do it for all of them, and they need tests first)
- Fixes aliasing on sentry.project.id -> project_id since the backend fix will take a bit.

