### PR TITLE
:recycle: ref(messaging): refactor `get_title_link`

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -55,6 +55,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         rule_id = None
         if self.rules:
             rule_id = self.rules[0].id
+            rule_environment_id = self.rules[0].environment_id
 
         embeds = [
             DiscordMessageEmbed(
@@ -68,6 +69,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
                     self.notification,
                     ExternalProviders.DISCORD,
                     rule_id,
+                    rule_environment_id,
                     notification_uuid=notification_uuid,
                 ),
                 color=LEVEL_TO_COLOR[get_color(event_for_tags, self.notification, self.group)],

--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -53,6 +53,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         )
         obj: Group | GroupEvent = self.event if self.event is not None else self.group
         rule_id = None
+        rule_environment_id = None
         if self.rules:
             rule_id = self.rules[0].id
             rule_environment_id = self.rules[0].environment_id

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -10,6 +10,7 @@ from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
@@ -93,19 +94,26 @@ def build_attachment_title(obj: Group | Event | GroupEvent) -> str:
     return title
 
 
-def get_title_link(
-    group: Group,
-    event: Event | GroupEvent | None,
-    link_to_event: bool,
-    issue_details: bool,
-    notification: BaseNotification | None,
-    provider: ExternalProviders = ExternalProviders.SLACK,
-    rule_id: int | None = None,
-    notification_uuid: str | None = None,
-) -> str:
-    other_params = {}
-    # add in rule id if we have it
-    if rule_id:
+def fetch_environment_name(rule_env: int) -> str | None:
+    try:
+        env = Environment.objects.get(id=rule_env)
+    except Environment.DoesNotExist:
+        return None
+    else:
+        return env.name
+
+
+def get_rule_environment_param(
+    rule_id: int, rule_environment_id: int | None, organization: Organization
+) -> dict[str, str]:
+    params = {}
+    if features.has("organizations:workflow-engine-trigger-actions", organization):
+        if (
+            rule_environment_id is not None
+            and (environment_name := fetch_environment_name(rule_environment_id)) is not None
+        ):
+            params["environment"] = environment_name
+    else:
         try:
             rule = Rule.objects.get(id=rule_id)
         except Rule.DoesNotExist:
@@ -113,16 +121,33 @@ def get_title_link(
         else:
             rule_env = rule.environment_id
 
-        if rule_env is not None:
-            try:
-                env = Environment.objects.get(id=rule_env)
-            except Environment.DoesNotExist:
-                pass
-            else:
-                other_params["environment"] = env.name
+        if (
+            rule_env is not None
+            and (environment_name := fetch_environment_name(rule_env)) is not None
+        ):
+            params["environment"] = environment_name
+    return params
 
-        other_params["alert_rule_id"] = str(rule_id)
+
+def get_title_link(
+    group: Group,
+    event: Event | GroupEvent | None,
+    link_to_event: bool,
+    issue_details: bool,
+    notification: BaseNotification | None,
+    provider: ExternalProviders,
+    rule_id: int | None = None,
+    rule_environment_id: int | None = None,
+    notification_uuid: str | None = None,
+) -> str:
+    other_params = {}
+    # add in rule id if we have it
+    if rule_id:
+        other_params.update(
+            get_rule_environment_param(rule_id, rule_environment_id, group.organization)
+        )
         # hard code for issue alerts
+        other_params["alert_rule_id"] = str(rule_id)
         other_params["alert_type"] = "issue"
 
     if event and link_to_event:
@@ -151,6 +176,19 @@ def get_title_link(
         )
 
     return url
+
+
+def get_title_link_workflow_engine_ui(
+    group: Group,
+    event: Event | GroupEvent | None,
+    link_to_event: bool,
+    issue_details: bool,
+    notification: BaseNotification | None,
+    provider: ExternalProviders,
+    rule_id: int | None = None,
+    notification_uuid: str | None = None,
+) -> str:
+    raise NotImplementedError("Link building for workflow engine UI is not implemented")
 
 
 def build_attachment_text(group: Group, event: Event | GroupEvent | None = None) -> Any | None:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -627,6 +627,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             has_action = False
 
         rule_id = None
+        rule_environment_id = None
         if self.rules:
             rule_id = self.rules[0].id
             rule_environment_id = self.rules[0].environment_id

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -458,6 +458,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         event_or_group: Event | GroupEvent | Group,
         has_action: bool,
         rule_id: int | None = None,
+        rule_environment_id: int | None = None,
         notification_uuid: str | None = None,
     ) -> SlackBlock:
         title_link = get_title_link(
@@ -468,6 +469,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             self.notification,
             ExternalProviders.SLACK,
             rule_id,
+            rule_environment_id,
             notification_uuid=notification_uuid,
         )
         # Use summary headline if available, otherwise use default title
@@ -627,6 +629,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         rule_id = None
         if self.rules:
             rule_id = self.rules[0].id
+            rule_environment_id = self.rules[0].environment_id
 
         # build up actions text
         if self.actions and self.identity and not action_text:
@@ -634,7 +637,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             action_text = get_action_text(self.actions, self.identity)
             has_action = True
 
-        blocks = [self.get_title_block(event_or_group, has_action, rule_id, notification_uuid)]
+        blocks = [
+            self.get_title_block(
+                event_or_group, has_action, rule_id, rule_environment_id, notification_uuid
+            )
+        ]
 
         if culprit_block := self.get_culprit_block(event_or_group):
             blocks.append(culprit_block)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -556,7 +556,7 @@ class Factories:
         action_data=None,
         allow_no_action_data=False,
         condition_data=None,
-        name="",
+        name="Test Alert",
         action_match="all",
         filter_match="all",
         **kwargs,

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -96,7 +96,7 @@ class DummyNotificationWithMoreFields(DummyNotification):
     def get_title_link(self, *args):
         from sentry.integrations.messaging.message_builder import get_title_link
 
-        return get_title_link(self.group, None, False, True, self)
+        return get_title_link(self.group, None, False, True, self, ExternalProviders.SLACK)
 
 
 TEST_ISSUE_OCCURRENCE = IssueOccurrence(

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -316,6 +316,7 @@ class TestInit(RuleTestCase):
         # Create a rule with a numeric ID for the test
         rule = self.get_rule(data=self.action_data)
         rule.id = self.action.id
+        rule.environment_id = None
 
         results = list(rule.after(event=self.event))
         assert len(results) == 1
@@ -353,6 +354,7 @@ class TestInit(RuleTestCase):
 
         rule = self.get_rule(data=self.action_data)
         rule.id = self.action.id
+        rule.environment_id = None
         results = list(rule.after(event=self.event))
         assert len(results) == 1
 
@@ -405,6 +407,7 @@ class TestInit(RuleTestCase):
 
         rule = self.get_rule(data=self.action_data)
         rule.id = self.action.id
+        rule.environment_id = None
         results = list(rule.after(event=event))
         assert len(results) == 1
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -96,7 +96,7 @@ def build_test_message_blocks(
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
     if rule:
-        title_link += "&alert_rule_id=2&alert_type=issue"
+        title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
 
     title_text = f":red_circle: <{title_link}|*{formatted_title}*>"
 


### PR DESCRIPTION
i refactored `get_title_link` so its methods are decomposed.

i also pass in `rule_environment_id` inside because we don't want to do lookups for rules inside this method eventually. currently this is gated behind aci, but eventually we can delete the non-ff'ed portion