### PR TITLE
fix(nav): Improve sizing of primary link click targets

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -260,7 +260,8 @@ export const NavLink = styled(Link, {
   ${p =>
     !p.isMobile &&
     css`
-      padding-top: ${space(0.5)};
+      width: 56px;
+      padding-top: ${space(0.75)};
       padding-bottom: ${space(1.5)};
 
       &:hover {


### PR DESCRIPTION
Tiny fix, just improving the sizing of the links so that they are easier to click. This also makes the tour highlights look better.

Before:

![CleanShot 2025-03-31 at 13 12 07](https://github.com/user-attachments/assets/8f187c07-1567-4b1f-aee3-28e0f46f7b52)

After:

![CleanShot 2025-03-31 at 13 21 21](https://github.com/user-attachments/assets/8a2be3b7-905c-48cb-90fe-58edf51e9cd5)

