### PR TITLE
feat(react19): `<Context>` as a provider

### DIFF
--- a/static/app/actionCreators/onboardingTasks.spec.tsx
+++ b/static/app/actionCreators/onboardingTasks.spec.tsx
@@ -36,11 +36,11 @@ describe('actionCreators/onboardingTasks', function () {
 
       const {result} = renderHook(() => useUpdateOnboardingTasks(), {
         wrapper: ({children}) => (
-          <OrganizationContext.Provider value={organization}>
+          <OrganizationContext value={organization}>
             <QueryClientProvider client={makeTestQueryClient()}>
               {children}
             </QueryClientProvider>
-          </OrganizationContext.Provider>
+          </OrganizationContext>
         ),
       });
 

--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -19,9 +19,9 @@ describe('Feature', function () {
 
   function WrappedFeature(props: React.ComponentProps<typeof Feature>) {
     return (
-      <ProjectContext.Provider value={project}>
+      <ProjectContext value={project}>
         <Feature {...props} />
-      </ProjectContext.Provider>
+      </ProjectContext>
     );
   }
 

--- a/static/app/components/acl/useRole.spec.tsx
+++ b/static/app/components/acl/useRole.spec.tsx
@@ -11,11 +11,7 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 function createWrapper(organization: Organization) {
   return function ({children}: {children: React.ReactNode}) {
-    return (
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
-    );
+    return <OrganizationContext value={organization}>{children}</OrganizationContext>;
   };
 }
 

--- a/static/app/components/analyticsArea.tsx
+++ b/static/app/components/analyticsArea.tsx
@@ -52,7 +52,5 @@ export default function AnalyticsArea({
   const parentArea = useAnalyticsArea();
   const area = overrideParent || !parentArea ? name : `${parentArea}.${name}`;
 
-  return (
-    <AnalyticsAreaContext.Provider value={area}>{children}</AnalyticsAreaContext.Provider>
-  );
+  return <AnalyticsAreaContext value={area}>{children}</AnalyticsAreaContext>;
 }

--- a/static/app/components/arithmeticBuilder/index.tsx
+++ b/static/app/components/arithmeticBuilder/index.tsx
@@ -46,7 +46,7 @@ export function ArithmeticBuilder({
 
   return (
     <PanelProvider>
-      <ArithmeticBuilderContext.Provider value={contextValue}>
+      <ArithmeticBuilderContext value={contextValue}>
         <Wrapper
           className={className}
           aria-disabled={disabled}
@@ -55,7 +55,7 @@ export function ArithmeticBuilder({
         >
           <TokenGrid tokens={state.expression.tokens} />
         </Wrapper>
-      </ArithmeticBuilderContext.Provider>
+      </ArithmeticBuilderContext>
     </PanelProvider>
   );
 }

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -38,7 +38,7 @@ function Tokens(props: TokensProp) {
   );
 
   return (
-    <ArithmeticBuilderContext.Provider
+    <ArithmeticBuilderContext
       value={{
         dispatch: wrappedDispatch,
         focusOverride: state.focusOverride,
@@ -47,7 +47,7 @@ function Tokens(props: TokensProp) {
       }}
     >
       <TokenGrid tokens={state.expression.tokens} />
-    </ArithmeticBuilderContext.Provider>
+    </ArithmeticBuilderContext>
   );
 }
 

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -505,7 +505,7 @@ export function Control({
 
   const theme = useTheme();
   return (
-    <SelectContext.Provider value={contextValue}>
+    <SelectContext value={contextValue}>
       <ControlWrap {...wrapperProps}>
         {trigger ? (
           trigger(mergeProps(triggerKeyboardProps, overlayTriggerProps), overlayIsOpen)
@@ -580,7 +580,7 @@ export function Control({
           </StyledOverlay>
         </StyledPositionWrapper>
       </ControlWrap>
-    </SelectContext.Provider>
+    </SelectContext>
   );
 }
 

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -346,7 +346,7 @@ function List<Value extends SelectKey>({
   return (
     <Fragment>
       {grid ? (
-        <SelectFilterContext.Provider value={hiddenOptions}>
+        <SelectFilterContext value={hiddenOptions}>
           <GridList
             {...props}
             id={listId}
@@ -354,7 +354,7 @@ function List<Value extends SelectKey>({
             sizeLimitMessage={sizeLimitMessage}
             keyDownHandler={keyDownHandler}
           />
-        </SelectFilterContext.Provider>
+        </SelectFilterContext>
       ) : (
         <ListBox
           {...props}
@@ -369,7 +369,6 @@ function List<Value extends SelectKey>({
           keyDownHandler={keyDownHandler}
         />
       )}
-
       {multiple &&
         sections.map(
           section =>

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -72,11 +72,11 @@ export function InputGroup({children, ...props}: React.HTMLAttributes<HTMLDivEle
   );
 
   return (
-    <InputGroupContext.Provider value={contextValue}>
+    <InputGroupContext value={contextValue}>
       <InputGroupWrap disabled={inputProps.disabled} {...props}>
         {children}
       </InputGroupWrap>
-    </InputGroupContext.Provider>
+    </InputGroupContext>
   );
 }
 

--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -131,7 +131,7 @@ class Form<
     const nonFieldErrors = this.state.errors?.non_field_errors;
 
     return (
-      <FormContext.Provider value={this.getContext()}>
+      <FormContext value={this.getContext()}>
         <StyledForm
           onSubmit={this.onSubmit}
           className={this.props.className}
@@ -181,7 +181,7 @@ class Form<
             {this.props.extraButton}
           </div>
         </StyledForm>
-      </FormContext.Provider>
+      </FormContext>
     );
   }
 }

--- a/static/app/components/devtoolbar/components/analyticsProvider.tsx
+++ b/static/app/components/devtoolbar/components/analyticsProvider.tsx
@@ -16,10 +16,10 @@ export default function AnalyticsProvider({
 }) {
   const {eventKey, eventName} = useContext(AnalyticsContext);
   return (
-    <AnalyticsContext.Provider
+    <AnalyticsContext
       value={{eventName: eventName + ' ' + nameVal, eventKey: eventKey + '.' + keyVal}}
     >
       {children}
-    </AnalyticsContext.Provider>
+    </AnalyticsContext>
   );
 }

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsContext.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsContext.tsx
@@ -61,11 +61,9 @@ export function FeatureFlagsContextProvider({children}: {children: ReactNode}) {
   }, [featureFlags]);
 
   return (
-    <FeatureFlagContext.Provider
-      value={{isDirty, featureFlagMap, setOverride, clearOverrides}}
-    >
+    <FeatureFlagContext value={{isDirty, featureFlagMap, setOverride, clearOverrides}}>
       {children}
-    </FeatureFlagContext.Provider>
+    </FeatureFlagContext>
   );
 }
 

--- a/static/app/components/devtoolbar/hooks/useConfiguration.tsx
+++ b/static/app/components/devtoolbar/hooks/useConfiguration.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext} from 'react';
 
 import type {Configuration} from '../types';
 
-const context = createContext<Configuration>({
+const Context = createContext<Configuration>({
   apiPrefix: '',
   environment: ['production'],
   featureFlags: {},
@@ -20,9 +20,9 @@ export function ConfigurationContextProvider({
   children: React.ReactNode;
   config: Configuration;
 }) {
-  return <context.Provider value={config}>{children}</context.Provider>;
+  return <Context value={config}>{children}</Context>;
 }
 
 export default function useConfiguration() {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
+++ b/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
@@ -11,7 +11,7 @@ type State = {
     | 'replay';
 };
 
-const context = createContext<{
+const Context = createContext<{
   setActivePanel: (activePanel: State['activePanel']) => void;
   state: State;
 }>({
@@ -33,9 +33,9 @@ export function ToolbarRouterContextProvider({children}: {children: React.ReactN
     [setState]
   );
 
-  return <context.Provider value={{setActivePanel, state}}>{children}</context.Provider>;
+  return <Context value={{setActivePanel, state}}>{children}</Context>;
 }
 
 export default function useToolbarRoute() {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/components/devtoolbar/hooks/useVisibility.tsx
+++ b/static/app/components/devtoolbar/hooks/useVisibility.tsx
@@ -10,9 +10,7 @@ const VisibilityContext = createContext<[State, Dispatch<SetStateAction<State>>]
 
 export function VisibilityContextProvider({children}: {children: ReactNode}) {
   const state = useState<State>('visible');
-  return (
-    <VisibilityContext.Provider value={state}>{children}</VisibilityContext.Provider>
-  );
+  return <VisibilityContext value={state}>{children}</VisibilityContext>;
 }
 
 export default function useVisibility() {

--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -9,11 +9,11 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 function WrapperComponent(props: any) {
   return (
-    <OrganizationContext.Provider value={props.organization}>
+    <OrganizationContext value={props.organization}>
       <MEPSettingProvider>
         <TransactionsList {...props} />
       </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -240,7 +240,7 @@ function DropdownMenuList({
   return (
     <FocusScope restoreFocus autoFocus>
       <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayPositionProps}>
-        <DropdownMenuContext.Provider value={contextValue}>
+        <DropdownMenuContext value={contextValue}>
           <StyledOverlay>
             {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
             <DropdownMenuListWrap
@@ -256,7 +256,7 @@ function DropdownMenuList({
             </DropdownMenuListWrap>
             {menuFooter}
           </StyledOverlay>
-        </DropdownMenuContext.Provider>
+        </DropdownMenuContext>
       </PositionWrapper>
     </FocusScope>
   );

--- a/static/app/components/events/interfaces/spans/context.tsx
+++ b/static/app/components/events/interfaces/spans/context.tsx
@@ -14,10 +14,6 @@ export type SpanEntryContextChildrenProps = {
   ) => LocationDescriptor | undefined;
 };
 
-const SpanEntryContext = createContext<SpanEntryContextChildrenProps>({
+export const SpanEntryContext = createContext<SpanEntryContextChildrenProps>({
   getViewChildTransactionTarget: () => undefined,
 });
-
-export const Provider = SpanEntryContext.Provider;
-
-export const Consumer = SpanEntryContext.Consumer;

--- a/static/app/components/events/interfaces/spans/cursorGuideHandler.tsx
+++ b/static/app/components/events/interfaces/spans/cursorGuideHandler.tsx
@@ -110,9 +110,9 @@ export class Provider extends Component<PropType, StateType> {
     };
 
     return (
-      <CursorGuideManagerContext.Provider value={childrenProps}>
+      <CursorGuideManagerContext value={childrenProps}>
         {this.props.children}
-      </CursorGuideManagerContext.Provider>
+      </CursorGuideManagerContext>
     );
   }
 }

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -243,9 +243,9 @@ export class Provider extends Component<PropType, StateType> {
     // to the respective divider components.
 
     return (
-      <DividerManagerContext.Provider value={childrenProps}>
+      <DividerManagerContext value={childrenProps}>
         {this.props.children}
-      </DividerManagerContext.Provider>
+      </DividerManagerContext>
     );
   }
 }

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -51,7 +51,7 @@ import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerforma
 
 import {OpsDot} from '../../opsBreakdown';
 
-import * as SpanEntryContext from './context';
+import {SpanEntryContext} from './context';
 import {GapSpanDetails} from './gapSpanDetails';
 import InlineDocs from './inlineDocs';
 import {SpanProfileDetails} from './spanProfileDetails';

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -534,9 +534,9 @@ export class Provider extends Component<Props, State> {
     };
 
     return (
-      <ScrollbarManagerContext.Provider value={childrenProps}>
+      <ScrollbarManagerContext value={childrenProps}>
         {this.props.children}
-      </ScrollbarManagerContext.Provider>
+      </ScrollbarManagerContext>
     );
   }
 }

--- a/static/app/components/events/interfaces/spans/spanContext.tsx
+++ b/static/app/components/events/interfaces/spans/spanContext.tsx
@@ -55,11 +55,7 @@ export class Provider extends Component<Props> {
       isSpanExpanded: this.isSpanExpanded,
     };
 
-    return (
-      <SpanContext.Provider value={childrenProps}>
-        {this.props.children}
-      </SpanContext.Provider>
-    );
+    return <SpanContext value={childrenProps}>{this.props.children}</SpanContext>;
   }
 }
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -52,7 +52,7 @@ import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerforma
 
 import {OpsDot} from '../../opsBreakdown';
 
-import * as SpanEntryContext from './context';
+import {SpanEntryContext} from './context';
 import {GapSpanDetails} from './gapSpanDetails';
 import InlineDocs from './inlineDocs';
 import {SpanProfileDetails} from './spanProfileDetails';

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -294,9 +294,9 @@ describe('TraceView', () => {
       render(
         <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
           {results => (
-            <QuickTraceContext.Provider value={results}>
+            <QuickTraceContext value={results}>
               <TraceView organization={organization} waterfallModel={waterfallModel} />
-            </QuickTraceContext.Provider>
+            </QuickTraceContext>
           )}
         </QuickTraceQuery>
       );
@@ -424,9 +424,9 @@ describe('TraceView', () => {
       render(
         <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
           {results => (
-            <QuickTraceContext.Provider value={results}>
+            <QuickTraceContext value={results}>
               <TraceView organization={organization} waterfallModel={waterfallModel} />
-            </QuickTraceContext.Provider>
+            </QuickTraceContext>
           )}
         </QuickTraceQuery>
       );

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -449,9 +449,9 @@ export function TraceEventDataSection({
         )
       }
     >
-      <TraceEventDataSectionContext.Provider value={childProps}>
+      <TraceEventDataSectionContext value={childProps}>
         {children(childProps)}
-      </TraceEventDataSectionContext.Provider>
+      </TraceEventDataSectionContext>
     </SectionComponent>
   );
 }

--- a/static/app/components/forms/controls/multipleCheckbox.tsx
+++ b/static/app/components/forms/controls/multipleCheckbox.tsx
@@ -71,9 +71,9 @@ function MultipleCheckbox<T extends string | number>({
   );
 
   return (
-    <MultipleCheckboxContext.Provider value={contextValue}>
+    <MultipleCheckboxContext value={contextValue}>
       <MultipleCheckboxWrapper className={className}>{children}</MultipleCheckboxWrapper>
-    </MultipleCheckboxContext.Provider>
+    </MultipleCheckboxContext>
   );
 }
 

--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -231,7 +231,7 @@ function Form({
   const shouldShowFooter = typeof hideFooter === 'undefined' ? !saveOnBlur : !hideFooter;
 
   return (
-    <FormContext.Provider value={contextData}>
+    <FormContext value={contextData}>
       <form
         onSubmit={handleSubmit}
         className={className ?? 'form-stacked'}
@@ -284,7 +284,7 @@ function Form({
           </StyledFooter>
         )}
       </form>
-    </FormContext.Provider>
+    </FormContext>
   );
 }
 

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -57,9 +57,9 @@ export function DrawerPanel({
           For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
           when it's button is pressed.
         */}
-        <DrawerContentContext.Provider value={{onClose, ariaLabel}}>
+        <DrawerContentContext value={{onClose, ariaLabel}}>
           {children}
-        </DrawerContentContext.Provider>
+        </DrawerContentContext>
       </DrawerSlidePanel>
     </DrawerContainer>
   );

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -175,7 +175,7 @@ export function GlobalDrawer({children}: any) {
     : null;
 
   return (
-    <DrawerContext.Provider value={{closeDrawer, isDrawerOpen, openDrawer}}>
+    <DrawerContext value={{closeDrawer, isDrawerOpen, openDrawer}}>
       <ErrorBoundary mini message={t('There was a problem rendering the drawer.')}>
         <AnimatePresence>
           {isDrawerOpen && (
@@ -193,7 +193,7 @@ export function GlobalDrawer({children}: any) {
         </AnimatePresence>
       </ErrorBoundary>
       {children}
-    </DrawerContext.Provider>
+    </DrawerContext>
   );
 }
 

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -224,7 +224,7 @@ function GlobalModal({onClose}: Props) {
         style={{pointerEvents: visible ? 'auto' : 'none'}}
         onClick={backdrop ? clickClose : undefined}
       >
-        <TooltipContext.Provider
+        <TooltipContext
           value={{
             // To ensure tooltips within the modal remain interactive (e.g., clickable or selectable),
             // they need to be rendered inside the modal's DOM node.
@@ -250,7 +250,7 @@ function GlobalModal({onClose}: Props) {
               </Modal>
             )}
           </AnimatePresence>
-        </TooltipContext.Provider>
+        </TooltipContext>
       </Container>
     </Fragment>,
     portal

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -206,9 +206,9 @@ export function GuidedSteps({className, children, onStepChange}: GuidedStepsProp
   const value = useGuidedStepsContentValue({onStepChange});
 
   return (
-    <GuidedStepsContext.Provider value={value}>
+    <GuidedStepsContext value={value}>
       <StepsWrapper className={className}>{children}</StepsWrapper>
-    </GuidedStepsContext.Provider>
+    </GuidedStepsContext>
   );
 }
 

--- a/static/app/components/modals/insightChartModal.tsx
+++ b/static/app/components/modals/insightChartModal.tsx
@@ -21,9 +21,9 @@ export default function InsightChartModal({Header, title, children}: Props) {
           <h3>{title}</h3>
         </Header>
 
-        <ChartRenderingContext.Provider value={{height: 300, isFullscreen: true}}>
+        <ChartRenderingContext value={{height: 300, isFullscreen: true}}>
           {children}
-        </ChartRenderingContext.Provider>
+        </ChartRenderingContext>
       </Container>
     </Fragment>
   );

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -88,7 +88,7 @@ function InviteMembersModal({
           isOverMemberLimit: isOverMemberLimit,
         }) => {
           return (
-            <InviteMembersContext.Provider
+            <InviteMembersContext
               value={{
                 willInvite,
                 invites,
@@ -121,7 +121,7 @@ function InviteMembersModal({
               <Footer>
                 <InviteMembersFooter canSend={canSend} />
               </Footer>
-            </InviteMembersContext.Provider>
+            </InviteMembersContext>
           );
         }}
       </InviteModalHook>

--- a/static/app/components/modals/inviteMembersModal/inviteMembersFooter.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersFooter.spec.tsx
@@ -12,11 +12,9 @@ import InviteMembersFooter from 'sentry/components/modals/inviteMembersModal/inv
 describe('InviteRowControlNew', function () {
   const renderComponent = (props: any) => {
     render(
-      <InviteMembersContext.Provider
-        value={{...defaultInviteProps, ...props, willInvite: true}}
-      >
+      <InviteMembersContext value={{...defaultInviteProps, ...props, willInvite: true}}>
         <InviteMembersFooter canSend />
-      </InviteMembersContext.Provider>,
+      </InviteMembersContext>,
       {organization: OrganizationFixture()}
     );
   };

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.spec.tsx
@@ -35,7 +35,7 @@ describe('InviteRowControlNew', function () {
   };
 
   const getComponent = (props: InviteMembersContextValue) => (
-    <InviteMembersContext.Provider value={props}>
+    <InviteMembersContext value={props}>
       <InviteRowControlNew
         roleDisabledUnallowed={false}
         roleOptions={[
@@ -55,7 +55,7 @@ describe('InviteRowControlNew', function () {
           },
         ]}
       />
-    </InviteMembersContext.Provider>
+    </InviteMembersContext>
   );
 
   beforeEach(function () {

--- a/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
@@ -62,11 +62,11 @@ export function AuthTokenGeneratorProvider({
   });
 
   return (
-    <AuthTokenGeneratorContext.Provider
+    <AuthTokenGeneratorContext
       value={{authToken, isLoading: isPending, generateAuthToken}}
     >
       {children}
-    </AuthTokenGeneratorContext.Provider>
+    </AuthTokenGeneratorContext>
   );
 }
 

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -47,11 +47,7 @@ export function OnboardingContextProvider({children, value}: ProviderProps) {
     [onboarding, setOnboarding, removeOnboarding]
   );
 
-  return (
-    <OnboardingContext.Provider value={contextValue}>
-      {children}
-    </OnboardingContext.Provider>
-  );
+  return <OnboardingContext value={contextValue}>{children}</OnboardingContext>;
 }
 
 /**

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -208,9 +208,9 @@ class UnwrappedProvider extends Component<Props> {
     };
 
     return (
-      <TeamKeyTransactionsManagerContext.Provider value={childrenProps}>
+      <TeamKeyTransactionsManagerContext value={childrenProps}>
         {this.props.children}
-      </TeamKeyTransactionsManagerContext.Provider>
+      </TeamKeyTransactionsManagerContext>
     );
   }
 }

--- a/static/app/components/replays/diff/diffCompareContext.tsx
+++ b/static/app/components/replays/diff/diffCompareContext.tsx
@@ -22,7 +22,7 @@ type ContextType = {
   setRightOffsetMs: Dispatch<SetStateAction<number>>;
 };
 
-const context = createContext<ContextType>({
+const Context = createContext<ContextType>({
   frameOrEvent: {} as Event,
   replay: ReplayReader.factory({
     attachments: [],
@@ -39,7 +39,7 @@ const context = createContext<ContextType>({
 });
 
 export function useDiffCompareContext() {
-  return useContext(context);
+  return useContext(Context);
 }
 
 interface Props {
@@ -65,7 +65,7 @@ export function DiffCompareContextProvider({
   const rightTimestampMs = startTimestampMs + rightOffsetMs;
 
   return (
-    <context.Provider
+    <Context
       value={{
         frameOrEvent,
         leftOffsetMs,
@@ -78,6 +78,6 @@ export function DiffCompareContextProvider({
       }}
     >
       {children}
-    </context.Provider>
+    </Context>
   );
 }

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -591,7 +591,7 @@ export function Provider({
 
   return (
     <ReplayCurrentTimeContextProvider>
-      <ReplayPlayerContext.Provider
+      <ReplayPlayerContext
         value={{
           analyticsContext,
           clearAllHighlights,
@@ -615,7 +615,7 @@ export function Provider({
         }}
       >
         {children}
-      </ReplayPlayerContext.Provider>
+      </ReplayPlayerContext>
     </ReplayCurrentTimeContextProvider>
   );
 }

--- a/static/app/components/replays/replayGroupContext.tsx
+++ b/static/app/components/replays/replayGroupContext.tsx
@@ -18,9 +18,7 @@ const ReplayGroupContext = createContext<BreadcrumbCustomizationContextType>({})
 export function ReplayGroupContextProvider({children, groupId, eventId}: Props) {
   const value = useMemo(() => ({groupId, eventId}), [groupId, eventId]);
 
-  return (
-    <ReplayGroupContext.Provider value={value}>{children}</ReplayGroupContext.Provider>
-  );
+  return <ReplayGroupContext value={value}>{children}</ReplayGroupContext>;
 }
 
 export const useReplayGroupContext = () => useContext(ReplayGroupContext);

--- a/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
@@ -118,9 +118,5 @@ const KeyboardSelectionContext = createContext<KeyboardSelectionData>({
 export function KeyboardSelection({children}: {children: ReactNode}) {
   const state = useKeyboardSelectionState();
 
-  return (
-    <KeyboardSelectionContext.Provider value={state}>
-      {children}
-    </KeyboardSelectionContext.Provider>
-  );
+  return <KeyboardSelectionContext value={state}>{children}</KeyboardSelectionContext>;
 }

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -304,7 +304,7 @@ export function SearchQueryBuilder({
   ]);
 
   return (
-    <SearchQueryBuilderContext.Provider value={contextValue}>
+    <SearchQueryBuilderContext value={contextValue}>
       <Wrapper
         className={className}
         onBlur={() =>
@@ -329,7 +329,7 @@ export function SearchQueryBuilder({
           )}
         </PanelProvider>
       </Wrapper>
-    </SearchQueryBuilderContext.Provider>
+    </SearchQueryBuilderContext>
   );
 }
 

--- a/static/app/components/sentryDocumentTitle.tsx
+++ b/static/app/components/sentryDocumentTitle.tsx
@@ -84,11 +84,7 @@ function SentryDocumentTitle({
     };
   }, [parentTitle]);
 
-  return (
-    <DocumentTitleContext.Provider value={documentTitle}>
-      {children}
-    </DocumentTitleContext.Provider>
-  );
+  return <DocumentTitleContext value={documentTitle}>{children}</DocumentTitleContext>;
 }
 
 export default SentryDocumentTitle;

--- a/static/app/components/sidebar/expandedContextProvider.tsx
+++ b/static/app/components/sidebar/expandedContextProvider.tsx
@@ -24,10 +24,8 @@ export function ExpandedContextProvider(props: any) {
   const shouldAccordionFloat = horizontal || !!preferences.collapsed;
 
   return (
-    <ExpandedContext.Provider
-      value={{expandedItemId, setExpandedItemId, shouldAccordionFloat}}
-    >
+    <ExpandedContext value={{expandedItemId, setExpandedItemId, shouldAccordionFloat}}>
       {props.children}
-    </ExpandedContext.Provider>
+    </ExpandedContext>
   );
 }

--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -152,7 +152,7 @@ function SplitPanel(props: SplitPanelProps) {
     const {left: a, right: b} = props;
 
     return (
-      <SplitPanelContext.Provider value={contextValue}>
+      <SplitPanelContext value={contextValue}>
         <SplitPanelContainer
           className={isHeld ? 'disable-iframe-pointer' : undefined}
           orientation="columns"
@@ -167,13 +167,13 @@ function SplitPanel(props: SplitPanelProps) {
           />
           <Panel>{b}</Panel>
         </SplitPanelContainer>
-      </SplitPanelContext.Provider>
+      </SplitPanelContext>
     );
   }
 
   const {top: a, bottom: b} = props;
   return (
-    <SplitPanelContext.Provider value={contextValue}>
+    <SplitPanelContext value={contextValue}>
       <SplitPanelContainer
         orientation="rows"
         size={sizePct}
@@ -188,7 +188,7 @@ function SplitPanel(props: SplitPanelProps) {
         />
         <Panel>{b}</Panel>
       </SplitPanelContainer>
-    </SplitPanelContext.Provider>
+    </SplitPanelContext>
   );
 }
 

--- a/static/app/components/structuredEventData/useExpandedState.tsx
+++ b/static/app/components/structuredEventData/useExpandedState.tsx
@@ -5,7 +5,7 @@ import {uniq} from 'sentry/utils/array/uniq';
 
 type State = 'expanded' | 'collapsed';
 
-const context = createContext<{
+const Context = createContext<{
   collapse: (path: string) => void;
   expand: (path: string) => void;
   expandedPaths: string[];
@@ -49,11 +49,11 @@ export function ExpandedStateContextProvider({
     [collapse, expand]
   );
 
-  return <context.Provider value={value}>{children}</context.Provider>;
+  return <Context value={value}>{children}</Context>;
 }
 
 export default function useExpandedState({path}: {path: string}) {
-  const {collapse, expand, expandedPaths} = useContext(context);
+  const {collapse, expand, expandedPaths} = useContext(Context);
   const isExpanded = expandedPaths.includes(path);
   return useMemo(
     () => ({

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -63,7 +63,7 @@ export function TabStateProvider<T extends string | number>({
   const [tabListState, setTabListState] = useState<TabListState<any>>();
 
   return (
-    <TabsContext.Provider
+    <TabsContext
       value={{
         rootProps: {...props, orientation: 'horizontal'},
         tabListState,
@@ -71,7 +71,7 @@ export function TabStateProvider<T extends string | number>({
       }}
     >
       {children}
-    </TabsContext.Provider>
+    </TabsContext>
   );
 }
 

--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -32,7 +32,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <div>Child Content</div>
         </TourContextProvider>
@@ -50,7 +50,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <div>Child Content</div>
         </TourContextProvider>
@@ -61,7 +61,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
           omitBlur
         >
           <div>Child Content</div>
@@ -89,7 +89,7 @@ describe('Tour Components', () => {
           tourKey={tourKey}
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <div>Child Content</div>
         </TourContextProvider>
@@ -110,7 +110,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             id={TestTour.NAME}
@@ -135,7 +135,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             id={TestTour.NAME}
@@ -162,7 +162,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             id={TestTour.NAME}
@@ -196,7 +196,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             id={TestTour.EMAIL}
@@ -226,7 +226,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             id={TestTour.PASSWORD}
@@ -255,7 +255,7 @@ describe('Tour Components', () => {
         <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             tourContext={TestTourContext}
@@ -306,7 +306,7 @@ describe('Tour Components', () => {
           tourKey={tourKey}
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
-          tourContext={TestTourContext}
+          TourContext={TestTourContext}
         >
           <TourElement<TestTour>
             tourContext={TestTourContext}

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -30,6 +30,10 @@ import useOverlay, {type UseOverlayProps} from 'sentry/utils/useOverlay';
 
 export interface TourContextProviderProps<T extends TourEnumType> {
   /**
+   * The React context (from React.createContext) containing the provider for the tour.
+   */
+  TourContext: React.Context<TourContextType<T> | null>;
+  /**
    * The children of the tour context provider.
    * All children of this component will be blurred when the tour is active.
    * Only the active tour element and overlay will be discernible.
@@ -43,10 +47,6 @@ export interface TourContextProviderProps<T extends TourEnumType> {
    * The ordered list of Step IDs
    */
   orderedStepIds: TourState<T>['orderedStepIds'];
-  /**
-   * The React context (from React.createContext) containing the provider for the tour.
-   */
-  tourContext: React.Context<TourContextType<T> | null>;
   /**
    * Whether to omit the blurring window.
    */
@@ -77,7 +77,7 @@ export function TourContextProvider<T extends TourEnumType>({
   children,
   isCompleted,
   tourKey,
-  tourContext,
+  TourContext,
   omitBlur,
   orderedStepIds,
   onEndTour,
@@ -148,10 +148,10 @@ export function TourContextProvider<T extends TourEnumType>({
   }, [isTourActive, mutate, tourKey]);
 
   return (
-    <tourContext.Provider value={tourContextValue}>
+    <TourContext value={tourContextValue}>
       {isTourActive && !omitBlur && <BlurWindow data-test-id="tour-blur-window" />}
       {children}
-    </tourContext.Provider>
+    </TourContext>
   );
 }
 

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -332,7 +332,7 @@ function TourProvider({
         <TourContextProvider<MyTour>
           isCompleted={false}
           orderedStepIds={ORDERED_MY_TOUR}
-          tourContext={MyTourContext}
+          TourContext={MyTourContext}
           {...tourProviderProps}
         >
           <Flex gap={space(2)} align="center">

--- a/static/app/components/workflowEngine/gridCell/index.spec.tsx
+++ b/static/app/components/workflowEngine/gridCell/index.spec.tsx
@@ -18,9 +18,9 @@ describe('Action Cell Component', function () {
   it('renders tooltip', async function () {
     const container = document.createElement('div');
     render(
-      <TooltipContext.Provider value={{container}}>
+      <TooltipContext value={{container}}>
         <ActionCell actions={['slack', 'discord', 'email']} />
-      </TooltipContext.Provider>
+      </TooltipContext>
     );
 
     const span = screen.getByText('Slack, Discord, Email');

--- a/static/app/components/workflowEngine/layout/actions.tsx
+++ b/static/app/components/workflowEngine/layout/actions.tsx
@@ -12,7 +12,7 @@ export function ActionsProvider({
   actions: React.ReactNode;
   children: React.ReactNode;
 }) {
-  return <ActionContext.Provider value={actions}>{children}</ActionContext.Provider>;
+  return <ActionContext value={actions}>{children}</ActionContext>;
 }
 
 /**

--- a/static/app/components/workflowEngine/layout/breadcrumbs.tsx
+++ b/static/app/components/workflowEngine/layout/breadcrumbs.tsx
@@ -20,9 +20,9 @@ export function BreadcrumbsProvider({
 }) {
   const context = useContext(BreadcrumbsContext);
   return (
-    <BreadcrumbsContext.Provider value={{crumbs: [...context.crumbs, crumb]}}>
+    <BreadcrumbsContext value={{crumbs: [...context.crumbs, crumb]}}>
       {children}
-    </BreadcrumbsContext.Provider>
+    </BreadcrumbsContext>
   );
 }
 

--- a/static/app/icons/useIconDefaults.tsx
+++ b/static/app/icons/useIconDefaults.tsx
@@ -8,9 +8,7 @@ const IconDefaultsContext = createContext<SVGIconProps>({});
  * Use this context provider to set default values for icons.
  */
 function IconDefaultsProvider({children, ...props}: SVGIconProps) {
-  return (
-    <IconDefaultsContext.Provider value={props}>{children}</IconDefaultsContext.Provider>
-  );
+  return <IconDefaultsContext value={props}>{children}</IconDefaultsContext>;
 }
 
 /**

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -94,8 +94,8 @@ export function CustomMeasurementsProvider({
   }, [selection, api, organization]);
 
   return (
-    <CustomMeasurementsContext.Provider value={state}>
+    <CustomMeasurementsContext value={state}>
       {typeof children === 'function' ? children(state) : children}
-    </CustomMeasurementsContext.Provider>
+    </CustomMeasurementsContext>
   );
 }

--- a/static/app/utils/performance/contexts/genericQueryBatcher.tsx
+++ b/static/app/utils/performance/contexts/genericQueryBatcher.tsx
@@ -267,13 +267,13 @@ export function QueryBatchNode(props: {
   };
 
   return (
-    <BatchNodeContext.Provider
+    <BatchNodeContext
       value={{
         id,
         batchProperty,
       }}
     >
       {children({queryBatching})}
-    </BatchNodeContext.Provider>
+    </BatchNodeContext>
   );
 }

--- a/static/app/utils/performance/contexts/operationBreakdownFilter.tsx
+++ b/static/app/utils/performance/contexts/operationBreakdownFilter.tsx
@@ -19,14 +19,14 @@ export function OpBreakdownFilterProvider({
 }) {
   const [opBreakdownFilter, setOpBreakdownFilter] = useState(filter);
   return (
-    <OpBreakdownFilterContext.Provider
+    <OpBreakdownFilterContext
       value={{
         opBreakdownFilter: opBreakdownFilter ?? SpanOperationBreakdownFilter.NONE,
         setOpBreakdownFilter,
       }}
     >
       {children}
-    </OpBreakdownFilterContext.Provider>
+    </OpBreakdownFilterContext>
   );
 }
 

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -26,7 +26,7 @@ type PageAlertSetter = (
   options?: Pick<PageAlertOptions, 'dismissId'>
 ) => void;
 
-const pageErrorContext = createContext<{
+const PageErrorContext = createContext<{
   setPageError: PageAlertSetter;
   setPageInfo: PageAlertSetter;
   setPageMuted: PageAlertSetter;
@@ -66,7 +66,7 @@ export function PageAlertProvider({children}: {children: React.ReactNode}) {
   }, []);
 
   return (
-    <pageErrorContext.Provider
+    <PageErrorContext
       value={{
         pageAlert,
         setPageInfo,
@@ -77,12 +77,12 @@ export function PageAlertProvider({children}: {children: React.ReactNode}) {
       }}
     >
       {children}
-    </pageErrorContext.Provider>
+    </PageErrorContext>
   );
 }
 
 export function PageAlert() {
-  const {pageAlert} = useContext(pageErrorContext);
+  const {pageAlert} = useContext(PageErrorContext);
   const [dismissedAlerts, setDismissedAlerts] = useLocalStorageState<number[]>(
     localStorageKey,
     []
@@ -120,4 +120,4 @@ export function PageAlert() {
   );
 }
 
-export const usePageAlert = () => useContext(pageErrorContext);
+export const usePageAlert = () => useContext(PageErrorContext);

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -79,10 +79,10 @@ export function FlamegraphStateProvider(
   }, [state, nextState, previousState]);
 
   return (
-    <FlamegraphStateValueContext.Provider value={flamegraphContextValue}>
-      <FlamegraphStateDispatchContext.Provider value={dispatch}>
+    <FlamegraphStateValueContext value={flamegraphContextValue}>
+      <FlamegraphStateDispatchContext value={dispatch}>
         {props.children}
-      </FlamegraphStateDispatchContext.Provider>
-    </FlamegraphStateValueContext.Provider>
+      </FlamegraphStateDispatchContext>
+    </FlamegraphStateValueContext>
   );
 }

--- a/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
@@ -59,11 +59,11 @@ function FlamegraphThemeProvider(
   }, [mutation, colorMode, theme]);
 
   return (
-    <FlamegraphThemeMutationContext.Provider value={addModifier}>
-      <FlamegraphThemeContext.Provider value={activeFlamegraphTheme}>
+    <FlamegraphThemeMutationContext value={addModifier}>
+      <FlamegraphThemeContext value={activeFlamegraphTheme}>
         {props.children}
-      </FlamegraphThemeContext.Provider>
-    </FlamegraphThemeMutationContext.Provider>
+      </FlamegraphThemeContext>
+    </FlamegraphThemeMutationContext>
   );
 }
 

--- a/static/app/utils/profiling/hooks/useHasProfileChunks.spec.tsx
+++ b/static/app/utils/profiling/hooks/useHasProfileChunks.spec.tsx
@@ -12,9 +12,9 @@ function createWrapper() {
   return function Wrapper({children}: any) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={OrganizationFixture()}>
+        <OrganizationContext value={OrganizationFixture()}>
           {children}
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
@@ -14,9 +14,7 @@ const {organization} = initializeOrg();
 function TestContext({children}: {children?: ReactNode}) {
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
     </QueryClientProvider>
   );
 }
@@ -32,9 +30,9 @@ describe('useProfileEvents', function () {
     function TestContextUsingTransactions({children}: {children?: ReactNode}) {
       return (
         <QueryClientProvider client={makeTestQueryClient()}>
-          <OrganizationContext.Provider value={organizationUsingTransactions}>
+          <OrganizationContext value={organizationUsingTransactions}>
             {children}
-          </OrganizationContext.Provider>
+          </OrganizationContext>
         </QueryClientProvider>
       );
     }

--- a/static/app/utils/profiling/hooks/useProfileEventsStats.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEventsStats.spec.tsx
@@ -12,9 +12,7 @@ const {organization} = initializeOrg();
 function TestContext({children}: {children?: ReactNode}) {
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
     </QueryClientProvider>
   );
 }
@@ -169,9 +167,9 @@ describe('useProfileEvents', function () {
     function TestContextUsingTransactions({children}: {children?: ReactNode}) {
       return (
         <QueryClientProvider client={makeTestQueryClient()}>
-          <OrganizationContext.Provider value={organizationUsingTransactions}>
+          <OrganizationContext value={organizationUsingTransactions}>
             {children}
-          </OrganizationContext.Provider>
+          </OrganizationContext>
         </QueryClientProvider>
       );
     }

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
@@ -13,9 +13,7 @@ function TestContext({children}: {children: React.ReactNode}) {
 
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
     </QueryClientProvider>
   );
 }

--- a/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
@@ -13,9 +13,7 @@ function TestContext({children}: {children: React.ReactNode}) {
 
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
     </QueryClientProvider>
   );
 }

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -88,9 +88,9 @@ function ReleasesProvider({
   }, [skipLoad, api, organization.slug, JSON.stringify(selection), searchTerm]);
 
   return (
-    <ReleasesContext.Provider value={{releases, loading, onSearch: handleSearch}}>
+    <ReleasesContext value={{releases, loading, onSearch: handleSearch}}>
       {children}
-    </ReleasesContext.Provider>
+    </ReleasesContext>
   );
 }
 

--- a/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
+++ b/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
@@ -12,9 +12,7 @@ jest.mock('sentry/utils/replays/hooks/useReplayData', () => ({
 const {organization, project} = initializeOrg();
 
 const wrapper = ({children}: {children?: React.ReactNode}) => (
-  <OrganizationContext.Provider value={organization}>
-    {children}
-  </OrganizationContext.Provider>
+  <OrganizationContext value={organization}>{children}</OrganizationContext>
 );
 
 describe('useLoadReplayReader', () => {

--- a/static/app/utils/replays/hooks/useTimelineScale.tsx
+++ b/static/app/utils/replays/hooks/useTimelineScale.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext, useState} from 'react';
 
-const context = createContext<[scale: number, setScale: (scale: number) => void]>([
+const Context = createContext<[scale: number, setScale: (scale: number) => void]>([
   1,
   (_scale: number) => {},
 ]);
@@ -8,9 +8,9 @@ const context = createContext<[scale: number, setScale: (scale: number) => void]
 export function TimelineScaleContextProvider({children}: {children: React.ReactNode}) {
   const state = useState(1);
 
-  return <context.Provider value={state}>{children}</context.Provider>;
+  return <Context value={state}>{children}</Context>;
 }
 
 export default function useTimelineScale() {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/utils/replays/playback/providers/replayPlayerPluginsContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerPluginsContext.tsx
@@ -5,7 +5,7 @@ import {CanvasReplayerPlugin} from 'sentry/components/replays/canvasReplayerPlug
 import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
-const context = createContext<(events: eventWithTime[]) => ReplayPlugin[]>(() => []);
+const Context = createContext<(events: eventWithTime[]) => ReplayPlugin[]>(() => []);
 
 export function ReplayPlayerPluginsContextProvider({
   children,
@@ -21,11 +21,11 @@ export function ReplayPlayerPluginsContextProvider({
     [organization]
   );
 
-  return <context.Provider value={getter}>{children}</context.Provider>;
+  return <Context value={getter}>{children}</Context>;
 }
 
 export function useReplayPlayerPlugins() {
-  return useContext(context);
+  return useContext(Context);
 }
 
 function getPlugins(_organization: Organization, events: eventWithTime[]) {

--- a/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
@@ -13,11 +13,11 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 function makeWrapper(organization: Organization) {
   return function ({children}: {children?: ReactNode}) {
     return (
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <ReplayPlayerPluginsContextProvider>
           {children}
         </ReplayPlayerPluginsContextProvider>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
   };
 }
@@ -43,9 +43,7 @@ describe('replayPlayerPluginsContext', () => {
 
     const {result} = renderHook(useReplayPlayerPlugins, {
       wrapper: ({children}: {children?: ReactNode}) => (
-        <OrganizationContext.Provider value={mockOrganization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={mockOrganization}>{children}</OrganizationContext>
       ),
     });
 

--- a/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
@@ -69,13 +69,11 @@ export function ReplayPlayerStateContextProvider({children}: {children: ReactNod
   );
 
   return (
-    <StateContext.Provider value={state}>
-      <DispatchContext.Provider value={dispatch}>
-        <UserActionContext.Provider value={handleUserAction}>
-          {children}
-        </UserActionContext.Provider>
-      </DispatchContext.Provider>
-    </StateContext.Provider>
+    <StateContext value={state}>
+      <DispatchContext value={dispatch}>
+        <UserActionContext value={handleUserAction}>{children}</UserActionContext>
+      </DispatchContext>
+    </StateContext>
   );
 }
 

--- a/static/app/utils/replays/playback/providers/replayPreferencesContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPreferencesContext.tsx
@@ -34,9 +34,7 @@ export function ReplayPreferencesContextProvider({
     [prefsStrategy]
   );
 
-  return (
-    <StateContext.Provider value={[state, setPrefs]}>{children}</StateContext.Provider>
-  );
+  return <StateContext value={[state, setPrefs]}>{children}</StateContext>;
 }
 
 export function useReplayPrefs() {

--- a/static/app/utils/replays/playback/providers/replayReaderProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayReaderProvider.tsx
@@ -8,7 +8,7 @@ interface Props {
   replay: ReplayReader;
 }
 
-const context = createContext<ReplayReader>(
+const Context = createContext<ReplayReader>(
   ReplayReader.factory({
     attachments: [],
     errors: [],
@@ -18,9 +18,9 @@ const context = createContext<ReplayReader>(
 );
 
 export function ReplayReaderProvider({children, replay}: Props) {
-  return <context.Provider value={replay}>{children}</context.Provider>;
+  return <Context value={replay}>{children}</Context>;
 }
 
 export function useReplayReader() {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
+++ b/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
@@ -3,14 +3,14 @@ import {createContext, useContext, useState} from 'react';
 
 type ContextType = [undefined | number, Dispatch<SetStateAction<number | undefined>>];
 
-const context = createContext<ContextType>([undefined, () => {}]);
+const Context = createContext<ContextType>([undefined, () => {}]);
 
 export function ReplayCurrentTimeContextProvider({children}: {children: ReactNode}) {
   const state = useState<undefined | number>(undefined);
 
-  return <context.Provider value={state}>{children}</context.Provider>;
+  return <Context value={state}>{children}</Context>;
 }
 
 export default function useCurrentHoverTime() {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/utils/routeAnalytics/useDisableRouteAnalytics.spec.tsx
+++ b/static/app/utils/routeAnalytics/useDisableRouteAnalytics.spec.tsx
@@ -22,7 +22,7 @@ describe('useDisableRouteAnalytics', function () {
       return <div>hi</div>;
     }
     const getComponent = ({previousUrl = ''}: {previousUrl?: string} = {}) => (
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           ...otherFns,
           setDisableRouteAnalytics,
@@ -30,7 +30,7 @@ describe('useDisableRouteAnalytics', function () {
         }}
       >
         <TestComponent />
-      </RouteAnalyticsContext.Provider>
+      </RouteAnalyticsContext>
     );
     const {rerender} = render(getComponent({}));
     expect(setDisableRouteAnalytics).toHaveBeenCalledWith(true);
@@ -48,7 +48,7 @@ describe('useDisableRouteAnalytics', function () {
       return <div>hi</div>;
     }
     const getComponent = ({disabled}: {disabled: boolean}) => (
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           ...otherFns,
           setDisableRouteAnalytics,
@@ -56,7 +56,7 @@ describe('useDisableRouteAnalytics', function () {
         }}
       >
         <TestComponent disabled={disabled} />
-      </RouteAnalyticsContext.Provider>
+      </RouteAnalyticsContext>
     );
     const {rerender} = render(getComponent({disabled: true}));
     expect(setDisableRouteAnalytics).toHaveBeenCalledWith(true);

--- a/static/app/utils/routeAnalytics/useRouteAnalyticsEventNames.spec.tsx
+++ b/static/app/utils/routeAnalytics/useRouteAnalyticsEventNames.spec.tsx
@@ -17,7 +17,7 @@ describe('useRouteAnalyticsEventNames', function () {
       eventName: string,
       extraContext?: Record<string, any>
     ) => (
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           setDisableRouteAnalytics: jest.fn(),
           setRouteAnalyticsParams: jest.fn(),
@@ -28,7 +28,7 @@ describe('useRouteAnalyticsEventNames', function () {
         }}
       >
         <TestComponent {...{eventKey, eventName}} />
-      </RouteAnalyticsContext.Provider>
+      </RouteAnalyticsContext>
     );
     const {rerender} = render(getComponent('a', 'b'));
     expect(setEventNames).toHaveBeenCalledWith('a', 'b');

--- a/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.spec.tsx
+++ b/static/app/utils/routeAnalytics/useRouteAnalyticsHookSetup.spec.tsx
@@ -17,7 +17,7 @@ describe('useRouteAnalyticsHookSetup', function () {
     const {organization} = initializeOrg();
     const setOrganization = jest.fn();
     render(
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           setOrganization,
           setDisableRouteAnalytics: jest.fn(),
@@ -26,10 +26,10 @@ describe('useRouteAnalyticsHookSetup', function () {
           previousUrl: '',
         }}
       >
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext value={organization}>
           <TestComponent />
-        </OrganizationContext.Provider>
-      </RouteAnalyticsContext.Provider>
+        </OrganizationContext>
+      </RouteAnalyticsContext>
     );
     expect(
       HookStore.getCallback('react-hook:route-activated', 'setOrganization')

--- a/static/app/utils/routeAnalytics/useRouteAnalyticsParams.spec.tsx
+++ b/static/app/utils/routeAnalytics/useRouteAnalyticsParams.spec.tsx
@@ -13,7 +13,7 @@ describe('useRouteAnalyticsParams', function () {
   it('calls setRouteAnalyticsParams', function () {
     const setRouteAnalyticsParams = jest.fn();
     const getComponent = (extraContext?: Record<string, any>) => (
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           setRouteAnalyticsParams,
           setOrganization: jest.fn(),
@@ -24,7 +24,7 @@ describe('useRouteAnalyticsParams', function () {
         }}
       >
         <TestComponent />
-      </RouteAnalyticsContext.Provider>
+      </RouteAnalyticsContext>
     );
 
     const {rerender} = render(getComponent());

--- a/static/app/utils/routeAnalytics/withRouteAnalytics.spec.tsx
+++ b/static/app/utils/routeAnalytics/withRouteAnalytics.spec.tsx
@@ -19,7 +19,7 @@ describe('withRouteAnalytics', function () {
   it('passes context to children as props', function () {
     const setRouteAnalyticsParams = jest.fn();
     render(
-      <RouteAnalyticsContext.Provider
+      <RouteAnalyticsContext
         value={{
           setRouteAnalyticsParams,
           setDisableRouteAnalytics: jest.fn(),
@@ -29,7 +29,7 @@ describe('withRouteAnalytics', function () {
         }}
       >
         <WrappedComponent />
-      </RouteAnalyticsContext.Provider>
+      </RouteAnalyticsContext>
     );
     expect(setRouteAnalyticsParams).toHaveBeenCalledWith({foo: 'bar'});
   });

--- a/static/app/utils/useFeedbackForm.tsx
+++ b/static/app/utils/useFeedbackForm.tsx
@@ -117,8 +117,6 @@ export function GlobalFeedbackForm({children}: {children: ReactNode}) {
   const openForm = useOpenForm();
 
   return (
-    <GlobalFeedbackFormContext.Provider value={openForm}>
-      {children}
-    </GlobalFeedbackFormContext.Provider>
+    <GlobalFeedbackFormContext value={openForm}>{children}</GlobalFeedbackFormContext>
   );
 }

--- a/static/app/utils/useLocation.spec.tsx
+++ b/static/app/utils/useLocation.spec.tsx
@@ -26,9 +26,9 @@ describe('useLocation', () => {
     };
 
     render(
-      <TestRouteContext.Provider value={routeContext}>
+      <TestRouteContext value={routeContext}>
         <HomePage />
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
 
     expect(location.pathname).toBe('/mock-pathname/');

--- a/static/app/utils/useNavigate.spec.tsx
+++ b/static/app/utils/useNavigate.spec.tsx
@@ -32,9 +32,9 @@ describe('useNavigate', () => {
     };
 
     render(
-      <TestRouteContext.Provider value={routeContext}>
+      <TestRouteContext value={routeContext}>
         <HomePage />
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
 
     expect(typeof navigate).toBe('function');
@@ -64,9 +64,9 @@ describe('useNavigate', () => {
     };
 
     render(
-      <TestRouteContext.Provider value={routeContext}>
+      <TestRouteContext value={routeContext}>
         <HomePage />
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
 
     expect(routeContext.router.push).toHaveBeenCalledWith({

--- a/static/app/utils/useParams.spec.tsx
+++ b/static/app/utils/useParams.spec.tsx
@@ -43,9 +43,9 @@ describe('useParams', () => {
       };
 
       render(
-        <TestRouteContext.Provider value={routeContext}>
+        <TestRouteContext value={routeContext}>
           <HomePage />
-        </TestRouteContext.Provider>
+        </TestRouteContext>
       );
 
       expect(params).toEqual({});
@@ -68,9 +68,9 @@ describe('useParams', () => {
       };
 
       render(
-        <TestRouteContext.Provider value={routeContext}>
+        <TestRouteContext value={routeContext}>
           <HomePage />
-        </TestRouteContext.Provider>
+        </TestRouteContext>
       );
       expect(params).toEqual({slug: 'sentry'});
     });
@@ -105,9 +105,9 @@ describe('useParams', () => {
       };
 
       render(
-        <TestRouteContext.Provider value={routeContext}>
+        <TestRouteContext value={routeContext}>
           <Component />
-        </TestRouteContext.Provider>
+        </TestRouteContext>
       );
 
       expect(
@@ -143,9 +143,9 @@ describe('useParams', () => {
       };
 
       render(
-        <TestRouteContext.Provider value={routeContext}>
+        <TestRouteContext value={routeContext}>
           <Component />
-        </TestRouteContext.Provider>
+        </TestRouteContext>
       );
 
       expect(

--- a/static/app/utils/useProjects.spec.tsx
+++ b/static/app/utils/useProjects.spec.tsx
@@ -10,9 +10,7 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const org = OrganizationFixture();
 function TestContext({children}: {children?: ReactNode}) {
-  return (
-    <OrganizationContext.Provider value={org}>{children}</OrganizationContext.Provider>
-  );
+  return <OrganizationContext value={org}>{children}</OrganizationContext>;
 }
 
 describe('useProjects', function () {

--- a/static/app/utils/useRouter.spec.tsx
+++ b/static/app/utils/useRouter.spec.tsx
@@ -23,9 +23,9 @@ describe('useRouter', () => {
     };
 
     render(
-      <TestRouteContext.Provider value={routeContext}>
+      <TestRouteContext value={routeContext}>
         <HomePage />
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
     expect(actualRouter).toEqual(routeContext.router);
   });

--- a/static/app/utils/useRoutes.spec.tsx
+++ b/static/app/utils/useRoutes.spec.tsx
@@ -28,9 +28,9 @@ describe('useRoutes', () => {
     };
 
     render(
-      <TestRouteContext.Provider value={routeContext}>
+      <TestRouteContext value={routeContext}>
         <HomePage />
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
     expect(routes).toHaveLength(1);
     expect(routes[0]).toEqual({path: '/', component: HomePage});

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -111,7 +111,7 @@ describe('withDomainRedirect', function () {
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     const {container} = render(
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <WrappedComponent
           router={router}
           location={router.location}
@@ -120,7 +120,7 @@ describe('withDomainRedirect', function () {
           routeParams={router.params}
           route={{}}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router}
     );
 
@@ -146,7 +146,7 @@ describe('withDomainRedirect', function () {
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     const {container} = render(
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <WrappedComponent
           router={router}
           location={router.location}
@@ -155,7 +155,7 @@ describe('withDomainRedirect', function () {
           routeParams={router.params}
           route={{}}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router}
     );
 
@@ -186,7 +186,7 @@ describe('withDomainRedirect', function () {
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     const {container} = render(
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <WrappedComponent
           router={router}
           location={router.location}
@@ -195,7 +195,7 @@ describe('withDomainRedirect', function () {
           routeParams={router.params}
           route={{}}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router}
     );
 
@@ -230,7 +230,7 @@ describe('withDomainRedirect', function () {
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     render(
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <WrappedComponent
           router={router}
           location={router.location}
@@ -239,7 +239,7 @@ describe('withDomainRedirect', function () {
           routeParams={router.params}
           route={{}}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router}
     );
 
@@ -271,7 +271,7 @@ describe('withDomainRedirect', function () {
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     render(
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <WrappedComponent
           router={router}
           location={router.location}
@@ -280,7 +280,7 @@ describe('withDomainRedirect', function () {
           routeParams={router.params}
           route={{}}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router}
     );
 

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
@@ -20,7 +20,7 @@ describe('AddIntegrationRow', function () {
   });
 
   const getComponent = () => (
-    <IntegrationContext.Provider
+    <IntegrationContext
       value={{
         provider,
         type: 'first_party',
@@ -33,7 +33,7 @@ describe('AddIntegrationRow', function () {
       }}
     >
       <AddIntegrationRow onClick={jest.fn()} />
-    </IntegrationContext.Provider>
+    </IntegrationContext>
   );
 
   it('renders', async () => {

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
@@ -38,7 +38,7 @@ function MessagingIntegrationModal({
         <IntegrationsWrapper>
           {providers.map(provider => {
             return (
-              <IntegrationContext.Provider
+              <IntegrationContext
                 key={provider.key}
                 value={{
                   provider,
@@ -53,7 +53,7 @@ function MessagingIntegrationModal({
                 }}
               >
                 <AddIntegrationRow onClick={closeModal} />
-              </IntegrationContext.Provider>
+              </IntegrationContext>
             );
           })}
         </IntegrationsWrapper>

--- a/static/app/views/app/asyncSDKIntegrationProvider.tsx
+++ b/static/app/views/app/asyncSDKIntegrationProvider.tsx
@@ -10,7 +10,7 @@ type Context = {
   state: State;
 };
 
-const context = createContext<Context>({
+const Context = createContext<Context>({
   setState: () => {},
   state: {},
 });
@@ -21,9 +21,9 @@ export function AsyncSDKIntegrationContextProvider({
   children: React.ReactNode;
 }) {
   const [state, setState] = useState<State>({});
-  return <context.Provider value={{setState, state}}>{children}</context.Provider>;
+  return <Context value={{setState, state}}>{children}</Context>;
 }
 
 export default function useAsyncSDKIntegrationStore(): Context {
-  return useContext(context);
+  return useContext(Context);
 }

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -273,7 +273,7 @@ describe('Dashboards > Dashboard', () => {
     const mockHandleUpdateWidgetList = jest.fn();
 
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
+      <OrganizationContext value={initialData.organization}>
         <MEPSettingProvider forceTransactions={false}>
           <Dashboard
             theme={ThemeFixture()}
@@ -291,7 +291,7 @@ describe('Dashboards > Dashboard', () => {
             widgetLegendState={widgetLegendState}
           />
         </MEPSettingProvider>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
 
     await userEvent.hover(screen.getByLabelText('Widget warnings'));
@@ -328,7 +328,7 @@ describe('Dashboards > Dashboard', () => {
     };
 
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
+      <OrganizationContext value={initialData.organization}>
         <MEPSettingProvider forceTransactions={false}>
           <Dashboard
             theme={ThemeFixture()}
@@ -346,7 +346,7 @@ describe('Dashboards > Dashboard', () => {
             widgetLegendState={widgetLegendState}
           />
         </MEPSettingProvider>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
 
     await userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -381,7 +381,7 @@ describe('Dashboards > Dashboard', () => {
 
     const mount = (dashboard: DashboardDetails, mockedOrg = initialData.organization) => {
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <MEPSettingProvider forceTransactions={false}>
             <Dashboard
               theme={ThemeFixture()}
@@ -398,7 +398,7 @@ describe('Dashboards > Dashboard', () => {
               widgetLegendState={widgetLegendState}
             />
           </MEPSettingProvider>
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       );
     };
 
@@ -443,7 +443,7 @@ describe('Dashboards > Dashboard', () => {
       isPreview = false,
     }: any) => {
       const getDashboardComponent = () => (
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <MEPSettingProvider forceTransactions={false}>
             <Dashboard
               theme={ThemeFixture()}
@@ -463,7 +463,7 @@ describe('Dashboards > Dashboard', () => {
               widgetLegendState={widgetLegendState}
             />
           </MEPSettingProvider>
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       );
       const {rerender} = render(getDashboardComponent());
       return {rerender: () => rerender(getDashboardComponent())};

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -213,7 +213,7 @@ describe('Dashboards > Detail', function () {
       });
 
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: 'default-overview'}}
@@ -222,7 +222,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
 
@@ -459,7 +459,7 @@ describe('Dashboards > Detail', function () {
         body: DashboardFixture([widgets[0]!], {id: '1', title: 'Custom Errors'}),
       });
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: '1'}}
@@ -468,7 +468,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
 
@@ -522,7 +522,7 @@ describe('Dashboards > Detail', function () {
       });
 
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: '1'}}
@@ -531,7 +531,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
 
@@ -554,7 +554,7 @@ describe('Dashboards > Detail', function () {
         params: {orgId: 'org-slug', dashboardId: '1'},
       });
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: '1'}}
@@ -563,7 +563,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
 
@@ -594,7 +594,7 @@ describe('Dashboards > Detail', function () {
       });
 
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: '1'}}
@@ -603,7 +603,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
@@ -619,7 +619,7 @@ describe('Dashboards > Detail', function () {
       types.MAX_WIDGETS = 1;
 
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard
             {...RouteComponentPropsFixture()}
             params={{orgId: 'org-slug', dashboardId: '1'}}
@@ -628,7 +628,7 @@ describe('Dashboards > Detail', function () {
           >
             {null}
           </ViewEditDashboard>
-        </OrganizationContext.Provider>,
+        </OrganizationContext>,
         {router}
       );
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1344,7 +1344,7 @@ class DashboardDetail extends Component<Props, State> {
                                 }}
                               />
 
-                              <WidgetViewerContext.Provider value={{seriesData, setData}}>
+                              <WidgetViewerContext value={{seriesData, setData}}>
                                 <Fragment>
                                   <Dashboard
                                     theme={this.props.theme}
@@ -1386,7 +1386,7 @@ class DashboardDetail extends Component<Props, State> {
                                     onSave={this.handleSaveWidget}
                                   />
                                 </Fragment>
-                              </WidgetViewerContext.Provider>
+                              </WidgetViewerContext>
                             </MEPSettingProvider>
                           )}
                         </MetricsDataSwitcher>

--- a/static/app/views/dashboards/indexedEventsSelectionAlert.spec.tsx
+++ b/static/app/views/dashboards/indexedEventsSelectionAlert.spec.tsx
@@ -16,11 +16,9 @@ describe('IndexedEventsSelectionAlert', () => {
   it('Shows warning if falling through to indexed events', async () => {
     render(
       <MEPSettingProvider forceTransactions>
-        <DashboardsMEPContext.Provider
-          value={{isMetricsData: false, setIsMetricsData: () => {}}}
-        >
+        <DashboardsMEPContext value={{isMetricsData: false, setIsMetricsData: () => {}}}>
           <IndexedEventsSelectionAlert widget={widget} />
-        </DashboardsMEPContext.Provider>
+        </DashboardsMEPContext>
       </MEPSettingProvider>
     );
 
@@ -30,11 +28,9 @@ describe('IndexedEventsSelectionAlert', () => {
   it('Does not show warning if using metrics successfully', () => {
     render(
       <MEPSettingProvider>
-        <DashboardsMEPContext.Provider
-          value={{isMetricsData: true, setIsMetricsData: () => {}}}
-        >
+        <DashboardsMEPContext value={{isMetricsData: true, setIsMetricsData: () => {}}}>
           <IndexedEventsSelectionAlert widget={widget} />
-        </DashboardsMEPContext.Provider>
+        </DashboardsMEPContext>
       </MEPSettingProvider>
     );
 

--- a/static/app/views/dashboards/releasesSelectControl.spec.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.spec.tsx
@@ -14,7 +14,7 @@ function renderReleasesSelect({
   onSearch?: (searchTerm: string) => void;
 }) {
   render(
-    <ReleasesContext.Provider
+    <ReleasesContext
       value={{
         releases: [
           ReleaseFixture({
@@ -41,7 +41,7 @@ function renderReleasesSelect({
         selectedReleases={[]}
         handleChangeFilter={handleChangeFilter}
       />
-    </ReleasesContext.Provider>
+    </ReleasesContext>
   );
 }
 
@@ -124,7 +124,7 @@ describe('Dashboards > ReleasesSelectControl', function () {
 
   it('includes Latest Release(s) even if no matching releases', async function () {
     render(
-      <ReleasesContext.Provider
+      <ReleasesContext
         value={{
           releases: [],
           loading: false,
@@ -132,7 +132,7 @@ describe('Dashboards > ReleasesSelectControl', function () {
         }}
       >
         <ReleasesSelectControl selectedReleases={[]} handleChangeFilter={jest.fn()} />
-      </ReleasesContext.Provider>
+      </ReleasesContext>
     );
 
     expect(screen.getByText('All Releases')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
@@ -69,9 +69,7 @@ export function UrlParamBatchProvider({children}: {children: React.ReactNode}) {
   }, [updateURL]);
 
   return (
-    <BatchContext.Provider value={{batchUrlParamUpdates, flushUpdates}}>
-      {children}
-    </BatchContext.Provider>
+    <BatchContext value={{batchUrlParamUpdates, flushUpdates}}>{children}</BatchContext>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/contexts/widgetBuilderContext.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/widgetBuilderContext.tsx
@@ -19,9 +19,7 @@ interface WidgetBuilderProviderProps {
 function WidgetBuilderStateProvider({children}: WidgetBuilderProviderProps) {
   const widgetBuilderState = useWidgetBuilderState();
   return (
-    <WidgetBuilderContext.Provider value={widgetBuilderState}>
-      {children}
-    </WidgetBuilderContext.Provider>
+    <WidgetBuilderContext value={widgetBuilderState}>{children}</WidgetBuilderContext>
   );
 }
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -755,7 +755,7 @@ describe('Dashboards > WidgetQueries', function () {
     const children = jest.fn(() => <div />);
 
     renderWithProviders(
-      <DashboardsMEPContext.Provider
+      <DashboardsMEPContext
         value={{
           isMetricsData: undefined,
           setIsMetricsData: setIsMetricsMock,
@@ -772,7 +772,7 @@ describe('Dashboards > WidgetQueries', function () {
         >
           {children}
         </WidgetQueries>
-      </DashboardsMEPContext.Provider>
+      </DashboardsMEPContext>
     );
 
     expect(mock).toHaveBeenCalledWith(
@@ -801,7 +801,7 @@ describe('Dashboards > WidgetQueries', function () {
     const children = jest.fn(() => <div />);
 
     renderWithProviders(
-      <DashboardsMEPContext.Provider
+      <DashboardsMEPContext
         value={{
           isMetricsData: undefined,
           setIsMetricsData: setIsMetricsMock,
@@ -818,7 +818,7 @@ describe('Dashboards > WidgetQueries', function () {
         >
           {children}
         </WidgetQueries>
-      </DashboardsMEPContext.Provider>
+      </DashboardsMEPContext>
     );
 
     expect(mock).toHaveBeenCalledWith(

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -12,7 +12,7 @@ import EventCustomPerformanceMetrics from 'sentry/components/events/eventCustomP
 import {BorderlessEventEntries} from 'sentry/components/events/eventEntries';
 import EventMessage from 'sentry/components/events/eventMessage';
 import EventVitals from 'sentry/components/events/eventVitals';
-import * as SpanEntryContext from 'sentry/components/events/interfaces/spans/context';
+import {SpanEntryContext} from 'sentry/components/events/interfaces/spans/context';
 import FileSize from 'sentry/components/fileSize';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
@@ -201,7 +201,7 @@ function EventDetailsContent(props: Props) {
               <Projects orgId={organization.slug} slugs={[projectId]}>
                 {({projects, initiallyLoaded}) =>
                   initiallyLoaded ? (
-                    <SpanEntryContext.Provider
+                    <SpanEntryContext
                       value={{
                         getViewChildTransactionTarget: childTransactionProps => {
                           const childTransactionLink = eventDetailsRoute({
@@ -216,7 +216,7 @@ function EventDetailsContent(props: Props) {
                         },
                       }}
                     >
-                      <QuickTraceContext.Provider value={results}>
+                      <QuickTraceContext value={results}>
                         {hasProfilingFeature ? (
                           <ProfilesProvider
                             orgSlug={organization.slug}
@@ -250,8 +250,8 @@ function EventDetailsContent(props: Props) {
                             showTagSummary={false}
                           />
                         )}
-                      </QuickTraceContext.Provider>
-                    </SpanEntryContext.Provider>
+                      </QuickTraceContext>
+                    </SpanEntryContext>
                   ) : (
                     <LoadingIndicator />
                   )

--- a/static/app/views/discover/landing.spec.tsx
+++ b/static/app/views/discover/landing.spec.tsx
@@ -83,9 +83,9 @@ describe('Discover > Landing', function () {
     const org = OrganizationFixture({features});
 
     render(
-      <OrganizationContext.Provider value={org}>
+      <OrganizationContext value={org}>
         <DiscoverLanding />
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
 
     const expectedSorts = [
@@ -112,9 +112,9 @@ describe('Discover > Landing', function () {
     const org = OrganizationFixture({features});
 
     render(
-      <OrganizationContext.Provider value={org}>
+      <OrganizationContext value={org}>
         <DiscoverLanding />
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
 
     expect(await screen.findByText('Discover')).toHaveAttribute(

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -94,7 +94,7 @@ export function LogsPageParamsProvider({
   const cursor = getLogCursorFromLocation(location);
 
   return (
-    <LogsPageParamsContext.Provider
+    <LogsPageParamsContext
       value={{
         fields,
         search,
@@ -107,7 +107,7 @@ export function LogsPageParamsProvider({
       }}
     >
       {children}
-    </LogsPageParamsContext.Provider>
+    </LogsPageParamsContext>
   );
 }
 

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -136,9 +136,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
     };
   }, [location, organization]);
 
-  return (
-    <PageParamsContext.Provider value={pageParams}>{children}</PageParamsContext.Provider>
-  );
+  return <PageParamsContext value={pageParams}>{children}</PageParamsContext>;
 }
 
 export function useExplorePageParams(): ReadablePageParams {

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -80,9 +80,7 @@ export function SpanTagsProvider({children, dataset, enabled}: SpanTagsProviderP
     };
   }, [allNumberTags, allStringTags, numberTagsLoading, stringTagsLoading]);
 
-  return (
-    <SpanTagsContext.Provider value={tagsResult}>{children}</SpanTagsContext.Provider>
-  );
+  return <SpanTagsContext value={tagsResult}>{children}</SpanTagsContext>;
 }
 
 export function useSpanTags(type?: 'number' | 'string') {

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -94,9 +94,9 @@ export function TraceItemAttributeProvider({
   ]);
 
   return (
-    <TraceItemAttributeContext.Provider value={attributesResult}>
+    <TraceItemAttributeContext value={attributesResult}>
       {children}
-    </TraceItemAttributeContext.Provider>
+    </TraceItemAttributeContext>
   );
 }
 

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -44,9 +44,7 @@ function createWrapper(org: Organization) {
     const queryClient = makeTestQueryClient();
     return (
       <QueryClientProvider client={queryClient}>
-        <OrganizationContext.Provider value={org}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={org}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -21,13 +21,13 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext value={organization}>
           <PageParamsProvider>
             <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
               {children}
             </SpanTagsProvider>
           </PageParamsProvider>
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -21,9 +21,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.spec.tsx
@@ -21,9 +21,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useTraceSpans.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceSpans.spec.tsx
@@ -38,9 +38,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useTraces.spec.tsx
+++ b/static/app/views/explore/hooks/useTraces.spec.tsx
@@ -36,9 +36,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -20,13 +20,13 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext value={organization}>
           <PageParamsProvider>
             <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
               {children}
             </SpanTagsProvider>
           </PageParamsProvider>
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -26,9 +26,7 @@ jest.mock('sentry/utils/usePageFilters');
 function Wrapper({children}: {children?: ReactNode}) {
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={OrganizationFixture()}>
-        {children}
-      </OrganizationContext.Provider>
+      <OrganizationContext value={OrganizationFixture()}>{children}</OrganizationContext>
     </QueryClientProvider>
   );
 }

--- a/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
@@ -21,9 +21,7 @@ describe('useSpanMetricsSeries', () => {
   function Wrapper({children}: {children?: ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   }

--- a/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
@@ -21,9 +21,7 @@ describe('useSpanMetricsTopNSeries', () => {
   function Wrapper({children}: {children?: ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   }

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -19,9 +19,7 @@ describe('useSpanSamples', () => {
   function Wrapper({children}: {children?: ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   }

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -824,7 +824,7 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
       tourKey={ISSUE_DETAILS_TOUR_GUIDE_KEY}
       isCompleted={isIssueDetailsTourCompleted}
       orderedStepIds={ORDERED_ISSUE_DETAILS_TOUR}
-      tourContext={IssueDetailsTourContext}
+      TourContext={IssueDetailsTourContext}
     >
       <GroupDetailsContent
         {...props}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -215,7 +215,6 @@ export function EventDetailsContent({
           organization={organization}
         />
       ) : null}
-
       {!hasStreamlinedUI && group.issueCategory === IssueCategory.UPTIME && (
         <UptimeDataSection event={event} project={project} group={group} />
       )}
@@ -233,7 +232,6 @@ export function EventDetailsContent({
           project={project}
         />
       )}
-
       <EventEvidence event={event} group={group} project={project} />
       {defined(eventEntries[EntryType.MESSAGE]) && (
         <EntryErrorBoundary type={EntryType.MESSAGE}>
@@ -317,9 +315,9 @@ export function EventDetailsContent({
         >
           {results => {
             return (
-              <QuickTraceContext.Provider value={results}>
+              <QuickTraceContext value={results}>
                 <AnrRootCause event={event} organization={organization} />
-              </QuickTraceContext.Provider>
+              </QuickTraceContext>
             );
           }}
         </QuickTraceQuery>

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -46,7 +46,7 @@ export function GroupDetailsLayout({
   const hasFilterBar = issueTypeConfig.header.filterBar.enabled;
 
   return (
-    <IssueDetailsContext.Provider value={{...issueDetails, dispatch}}>
+    <IssueDetailsContext value={{...issueDetails, dispatch}}>
       <StreamlinedGroupHeader
         group={group}
         event={event ?? null}
@@ -92,7 +92,7 @@ export function GroupDetailsLayout({
           <StreamlinedSidebar group={group} event={event} project={project} />
         ) : null}
       </StyledLayoutBody>
-    </IssueDetailsContext.Provider>
+    </IssueDetailsContext>
   );
 }
 

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
@@ -31,9 +31,9 @@ describe('DetectorSection', () => {
     const detectorDetails = getDetectorDetails({event, organization, project});
 
     const {container} = render(
-      <IssueDetailsContext.Provider value={{...issueDetailsContext, detectorDetails}}>
+      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
         <DetectorSection group={group} project={project} />
-      </IssueDetailsContext.Provider>
+      </IssueDetailsContext>
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -53,9 +53,9 @@ describe('DetectorSection', () => {
     const detectorDetails = getDetectorDetails({event, organization, project});
 
     render(
-      <IssueDetailsContext.Provider value={{...issueDetailsContext, detectorDetails}}>
+      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
         <DetectorSection group={group} project={project} />
-      </IssueDetailsContext.Provider>
+      </IssueDetailsContext>
     );
 
     expect(screen.getByText('Metric Alert Detector')).toBeInTheDocument();
@@ -87,9 +87,9 @@ describe('DetectorSection', () => {
     const detectorDetails = getDetectorDetails({event, organization, project});
 
     render(
-      <IssueDetailsContext.Provider value={{...issueDetailsContext, detectorDetails}}>
+      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
         <DetectorSection group={group} project={project} />
-      </IssueDetailsContext.Provider>
+      </IssueDetailsContext>
     );
 
     expect(screen.getByText('Cron Monitor')).toBeInTheDocument();
@@ -122,9 +122,9 @@ describe('DetectorSection', () => {
     const detectorDetails = getDetectorDetails({event, organization, project});
 
     render(
-      <IssueDetailsContext.Provider value={{...issueDetailsContext, detectorDetails}}>
+      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
         <DetectorSection group={group} project={project} />
-      </IssueDetailsContext.Provider>
+      </IssueDetailsContext>
     );
 
     expect(screen.getByText('Uptime Monitor')).toBeInTheDocument();

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -672,7 +672,7 @@ export function IssueViewsStateProvider({
   }, [setOnNewViewsSaved, handleNewViewsSaved]);
 
   return (
-    <IssueViewsContext.Provider
+    <IssueViewsContext
       value={{
         rootProps: {...restProps, orientation: 'horizontal'},
         tabListState,
@@ -683,7 +683,7 @@ export function IssueViewsStateProvider({
       }}
     >
       {children}
-    </IssueViewsContext.Provider>
+    </IssueViewsContext>
   );
 }
 

--- a/static/app/views/issueList/utils/newTabContext.tsx
+++ b/static/app/views/issueList/utils/newTabContext.tsx
@@ -31,7 +31,7 @@ export function NewTabContextProvider({children}: {children: React.ReactNode}) {
   >(() => () => {});
 
   return (
-    <NewTabContext.Provider
+    <NewTabContext
       value={{
         newViewActive,
         setNewViewActive,
@@ -40,6 +40,6 @@ export function NewTabContextProvider({children}: {children: React.ReactNode}) {
       }}
     >
       {children}
-    </NewTabContext.Provider>
+    </NewTabContext>
   );
 }

--- a/static/app/views/lastKnownRouteContextProvider.tsx
+++ b/static/app/views/lastKnownRouteContextProvider.tsx
@@ -32,9 +32,5 @@ export default function LastKnownRouteContextProvider({children}: Props) {
 
   const lastKnownRoute = getRouteStringFromRoutes(prevRoute.current);
 
-  return (
-    <LastKnownRouteContext.Provider value={lastKnownRoute}>
-      {children}
-    </LastKnownRouteContext.Provider>
-  );
+  return <LastKnownRouteContext value={lastKnownRoute}>{children}</LastKnownRouteContext>;
 }

--- a/static/app/views/nav/context.tsx
+++ b/static/app/views/nav/context.tsx
@@ -93,5 +93,5 @@ export function NavContextProvider({children}: {children: React.ReactNode}) {
     ]
   );
 
-  return <NavContext.Provider value={value}>{children}</NavContext.Provider>;
+  return <NavContext value={value}>{children}</NavContext>;
 }

--- a/static/app/views/nav/tour/tour.tsx
+++ b/static/app/views/nav/tour/tour.tsx
@@ -181,7 +181,7 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
       tourKey={STACKED_NAVIGATION_TOUR_GUIDE_KEY}
       isCompleted={isStackedNavigationTourCompleted}
       orderedStepIds={ORDERED_STACKED_NAVIGATION_TOUR}
-      tourContext={StackedNavigationTourContext}
+      TourContext={StackedNavigationTourContext}
       onStartTour={onStartTour}
       onEndTour={onEndTour}
       onStepChange={onStepChange}

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -167,10 +167,8 @@ export function OrganizationContextProvider({children}: Props) {
   }, [orgSlug]);
 
   return (
-    <OrganizationLoaderContext.Provider value={{bootstrapIsPending}}>
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
-    </OrganizationLoaderContext.Provider>
+    <OrganizationLoaderContext value={{bootstrapIsPending}}>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
+    </OrganizationLoaderContext>
   );
 }

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -36,7 +36,7 @@ function WrappedComponent({data, withStaticFilters = false}: any) {
 
   return (
     <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={data.organization}>
+      <OrganizationContext value={data.organization}>
         <MetricsCardinalityProvider
           location={data.router.location}
           organization={data.organization}
@@ -55,7 +55,7 @@ function WrappedComponent({data, withStaticFilters = false}: any) {
             withStaticFilters={withStaticFilters}
           />
         </MetricsCardinalityProvider>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     </QueryClientProvider>
   );
 }

--- a/static/app/views/performance/landing/queryBatcher.spec.tsx
+++ b/static/app/views/performance/landing/queryBatcher.spec.tsx
@@ -30,7 +30,7 @@ const BASIC_QUERY_PARAMS = {
 
 function WrappedComponent({data, ...rest}: any) {
   return (
-    <OrganizationContext.Provider value={data.organization}>
+    <OrganizationContext value={data.organization}>
       <MEPSettingProvider>
         <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
           <WidgetContainer
@@ -47,7 +47,7 @@ function WrappedComponent({data, ...rest}: any) {
           />
         </PerformanceDisplayProvider>
       </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/views/performance/landing/samplingModal.spec.tsx
+++ b/static/app/views/performance/landing/samplingModal.spec.tsx
@@ -23,7 +23,7 @@ function WrappedComponent({data}: any) {
   const eventView = EventView.fromLocation(data.router.location);
 
   return (
-    <OrganizationContext.Provider value={data.organization}>
+    <OrganizationContext value={data.organization}>
       <MEPSettingProvider>
         <SamplingModal
           Header={stubEl}
@@ -38,7 +38,7 @@ function WrappedComponent({data}: any) {
           isMEPEnabled={data.isMEPEnabled}
         />
       </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -27,7 +27,7 @@ const initializeData = (query = {}, rest: InitializeDataSettings = {}) => {
 
 function WrappedComponent({data, withStaticFilters = false, ...rest}: any) {
   return (
-    <OrganizationContext.Provider value={data.organization}>
+    <OrganizationContext value={data.organization}>
       <MetricsCardinalityProvider
         location={data.router.location}
         organization={data.organization}
@@ -53,7 +53,7 @@ function WrappedComponent({data, withStaticFilters = false, ...rest}: any) {
           </PerformanceDisplayProvider>
         </MEPSettingProvider>
       </MetricsCardinalityProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -6,7 +6,7 @@ import omit from 'lodash/omit';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {LinkButton} from 'sentry/components/core/button';
 import DiscoverButton from 'sentry/components/discoverButton';
-import * as SpanEntryContext from 'sentry/components/events/interfaces/spans/context';
+import {SpanEntryContext} from 'sentry/components/events/interfaces/spans/context';
 import {
   getTraceDateTimeRange,
   scrollToSpan,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -435,7 +435,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
         </TabsLayout>
       </TabsHeightContainer>
       {isDrawerMinimized ? null : (
-        <DrawerContainerRefContext.Provider value={contentContainerRef}>
+        <DrawerContainerRefContext value={contentContainerRef}>
           <Content
             ref={contentContainerRef}
             layout={traceState.preferences.layout}
@@ -474,7 +474,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
               ) : null}
             </ContentWrapper>
           </Content>
-        </DrawerContainerRefContext.Provider>
+        </DrawerContainerRefContext>
       )}
     </PanelWrapper>
   );

--- a/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
@@ -109,12 +109,12 @@ export function TraceStateProvider(props: TraceStateProviderProps): React.ReactN
   }, [traceState.preferences, props.preferencesStorageKey]);
 
   return (
-    <TraceStateContext.Provider value={traceState}>
-      <TraceStateDispatchContext.Provider value={traceDispatch}>
-        <TraceStateEmitterContext.Provider value={traceStateEmitter}>
+    <TraceStateContext value={traceState}>
+      <TraceStateDispatchContext value={traceDispatch}>
+        <TraceStateEmitterContext value={traceStateEmitter}>
           {props.children}
-        </TraceStateEmitterContext.Provider>
-      </TraceStateDispatchContext.Provider>
-    </TraceStateContext.Provider>
+        </TraceStateEmitterContext>
+      </TraceStateDispatchContext>
+    </TraceStateContext>
   );
 }

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -33,7 +33,7 @@ const initializeData = (settings = {}, features: string[] = []) => {
 
 function WrappedComponent({data, ...rest}: any) {
   return (
-    <OrganizationContext.Provider value={data.organization}>
+    <OrganizationContext value={data.organization}>
       <MEPSettingProvider>
         <Table
           organization={data.organization}
@@ -44,7 +44,7 @@ function WrappedComponent({data, ...rest}: any) {
           {...rest}
         />
       </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -13,7 +13,7 @@ import {BorderlessEventEntries} from 'sentry/components/events/eventEntries';
 import EventMetadata from 'sentry/components/events/eventMetadata';
 import EventVitals from 'sentry/components/events/eventVitals';
 import getUrlFromEvent from 'sentry/components/events/interfaces/request/getUrlFromEvent';
-import * as SpanEntryContext from 'sentry/components/events/interfaces/spans/context';
+import {SpanEntryContext} from 'sentry/components/events/interfaces/spans/context';
 import RootSpanStatus from 'sentry/components/events/rootSpanStatus';
 import FileSize from 'sentry/components/fileSize';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -215,7 +215,7 @@ function EventDetailsContent(props: Props) {
                   <Layout.Main fullWidth={!isSidebarVisible}>
                     <Projects orgId={organization.slug} slugs={[projectId]}>
                       {({projects: _projects}) => (
-                        <SpanEntryContext.Provider
+                        <SpanEntryContext
                           value={{
                             getViewChildTransactionTarget: childTransactionProps => {
                               return getTransactionDetailsUrl(
@@ -227,7 +227,7 @@ function EventDetailsContent(props: Props) {
                             },
                           }}
                         >
-                          <QuickTraceContext.Provider value={results}>
+                          <QuickTraceContext value={results}>
                             {hasProfilingFeature ? (
                               <ProfilesProvider
                                 orgSlug={organization.slug}
@@ -263,8 +263,8 @@ function EventDetailsContent(props: Props) {
                                 showTagSummary={false}
                               />
                             )}
-                          </QuickTraceContext.Provider>
-                        </SpanEntryContext.Provider>
+                          </QuickTraceContext>
+                        </SpanEntryContext>
                       )}
                     </Projects>
                   </Layout.Main>

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -193,7 +193,7 @@ describe('Performance Transaction Events Content', function () {
 
   it('basic rendering', async function () {
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
+      <OrganizationContext value={initialData.organization}>
         <EventsPageContent
           eventView={eventView}
           organization={initialData.organization}
@@ -207,7 +207,7 @@ describe('Performance Transaction Events Content', function () {
           projectId="123"
           projects={[]}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router: initialData.router}
     );
 
@@ -233,7 +233,7 @@ describe('Performance Transaction Events Content', function () {
 
   it('rendering with webvital selected', async function () {
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
+      <OrganizationContext value={initialData.organization}>
         <EventsPageContent
           eventView={eventView}
           organization={initialData.organization}
@@ -248,7 +248,7 @@ describe('Performance Transaction Events Content', function () {
           projectId="123"
           projects={[]}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router: initialData.router}
     );
 
@@ -279,7 +279,7 @@ describe('Performance Transaction Events Content', function () {
       initialData.router.location
     );
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
+      <OrganizationContext value={initialData.organization}>
         <EventsPageContent
           eventView={_eventView}
           organization={initialData.organization}
@@ -294,7 +294,7 @@ describe('Performance Transaction Events Content', function () {
           projectId="1"
           projects={[ProjectFixture({id: '1', platform: 'python'})]}
         />
-      </OrganizationContext.Provider>,
+      </OrganizationContext>,
       {router: initialData.router}
     );
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext.tsx
@@ -84,7 +84,7 @@ export function PerformanceAtScaleContextProvider({children}: ProviderProps) {
   ]);
 
   return (
-    <PerformanceAtScaleContext.Provider
+    <PerformanceAtScaleContext
       value={{
         metricsSeriesDataEmpty,
         setMetricsSeriesDataEmpty,
@@ -93,6 +93,6 @@ export function PerformanceAtScaleContextProvider({children}: ProviderProps) {
       }}
     >
       {children}
-    </PerformanceAtScaleContext.Provider>
+    </PerformanceAtScaleContext>
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
@@ -57,7 +57,7 @@ describe('SuspectSpans', function () {
     it('renders basic UI elements', async function () {
       const initialData = initializeData();
       render(
-        <OrganizationContext.Provider value={initialData.organization}>
+        <OrganizationContext value={initialData.organization}>
           <MEPSettingProvider>
             <SuspectSpans
               organization={initialData.organization}
@@ -68,7 +68,7 @@ describe('SuspectSpans', function () {
               totals={{'count()': 1}}
             />
           </MEPSettingProvider>
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       );
 
       expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
@@ -19,11 +19,11 @@ const mockUseLocation = jest.mocked(useLocation);
 
 function WrapperComponent(props: React.ComponentProps<typeof TagExplorer>) {
   return (
-    <OrganizationContext.Provider value={props.organization}>
+    <OrganizationContext value={props.organization}>
       <MEPSettingProvider>
         <TagExplorer {...props} />
       </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/app/views/profiling/continuousProfileProvider.tsx
+++ b/static/app/views/profiling/continuousProfileProvider.tsx
@@ -66,7 +66,7 @@ export default function ProfileAndTransactionProvider(
       profile={profile}
       setProfile={setProfile}
     >
-      <ProfileTransactionContext.Provider value={profileTransaction}>
+      <ProfileTransactionContext value={profileTransaction}>
         <ContinuousProfileHeader
           projectId={projectSlug}
           transaction={
@@ -74,7 +74,7 @@ export default function ProfileAndTransactionProvider(
           }
         />
         {props.children}
-      </ProfileTransactionContext.Provider>
+      </ProfileTransactionContext>
     </ContinuousProfileProvider>
   );
 }

--- a/static/app/views/profiling/flamegraphProvider.tsx
+++ b/static/app/views/profiling/flamegraphProvider.tsx
@@ -60,9 +60,5 @@ export function FlamegraphProvider(props: FlamegraphProviderProps) {
     return newFlamegraph;
   }, [sorting, threadId, view, profileGroup]);
 
-  return (
-    <FlamegraphContext.Provider value={flamegraph}>
-      {props.children}
-    </FlamegraphContext.Provider>
-  );
+  return <FlamegraphContext value={flamegraph}>{props.children}</FlamegraphContext>;
 }

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -57,9 +57,5 @@ export function ProfileGroupProvider(props: ProfileGroupProviderProps) {
     }
   }, [props.input, props.traceID, props.type, props.frameFilter]);
 
-  return (
-    <ProfileGroupContext.Provider value={profileGroup}>
-      {props.children}
-    </ProfileGroupContext.Provider>
-  );
+  return <ProfileGroupContext value={profileGroup}>{props.children}</ProfileGroupContext>;
 }

--- a/static/app/views/profiling/profilesProvider.tsx
+++ b/static/app/views/profiling/profilesProvider.tsx
@@ -159,7 +159,7 @@ export function TransactionProfileProvider({
     };
   }, [api, orgSlug, projectSlug, profileId, setProfile]);
 
-  return <ProfileContext.Provider value={profile}>{children}</ProfileContext.Provider>;
+  return <ProfileContext value={profile}>{children}</ProfileContext>;
 }
 
 export interface ContinuousProfileQueryParams {
@@ -225,5 +225,5 @@ export function ContinuousProfileProvider({
     return () => api.clear();
   }, [api, profileMeta, orgSlug, projectSlug, projects, setProfile]);
 
-  return <ProfileContext.Provider value={profile}>{children}</ProfileContext.Provider>;
+  return <ProfileContext value={profile}>{children}</ProfileContext>;
 }

--- a/static/app/views/profiling/transactionProfileProvider.tsx
+++ b/static/app/views/profiling/transactionProfileProvider.tsx
@@ -50,7 +50,7 @@ export default function ProfileAndTransactionProvider(
       profile={profile}
       setProfile={setProfile}
     >
-      <ProfileTransactionContext.Provider value={profileTransaction}>
+      <ProfileTransactionContext value={profileTransaction}>
         <ProfileHeader
           eventId={params.eventId!}
           projectId={projectSlug}
@@ -59,7 +59,7 @@ export default function ProfileAndTransactionProvider(
           }
         />
         {props.children}
-      </ProfileTransactionContext.Provider>
+      </ProfileTransactionContext>
     </TransactionProfileProvider>
   );
 }

--- a/static/app/views/projects/gettingStartedWithProjectContext.tsx
+++ b/static/app/views/projects/gettingStartedWithProjectContext.tsx
@@ -44,13 +44,13 @@ export function GettingStartedWithProjectContextProvider({
   );
 
   return (
-    <GettingStartedWithProjectContext.Provider
+    <GettingStartedWithProjectContext
       value={{
         project: sessionStorage.project,
         setProject: handleSetProject,
       }}
     >
       {children}
-    </GettingStartedWithProjectContext.Provider>
+    </GettingStartedWithProjectContext>
   );
 }

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -239,9 +239,9 @@ class ProjectContextProvider extends Component<Props, State> {
 
     if (!error && project) {
       return (
-        <ProjectContext.Provider value={project}>
+        <ProjectContext value={project}>
           {typeof children === 'function' ? children({project}) : children}
-        </ProjectContext.Provider>
+        </ProjectContext>
       );
     }
 

--- a/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
@@ -22,7 +22,7 @@ describe('Commits', () => {
 
   function renderComponent() {
     return render(
-      <ReleaseContext.Provider
+      <ReleaseContext
         value={{
           release,
           project,
@@ -34,7 +34,7 @@ describe('Commits', () => {
         }}
       >
         <Commits />
-      </ReleaseContext.Provider>,
+      </ReleaseContext>,
       {router}
     );
   }
@@ -161,7 +161,7 @@ describe('Commits', () => {
       ],
     });
     render(
-      <ReleaseContext.Provider
+      <ReleaseContext
         value={{
           release,
           project,
@@ -173,7 +173,7 @@ describe('Commits', () => {
         }}
       >
         <Commits />
-      </ReleaseContext.Provider>,
+      </ReleaseContext>,
       {router: newRouterContext}
     );
     expect(await screen.findByRole('button')).toHaveTextContent(otherRepo.name);

--- a/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
@@ -36,7 +36,7 @@ describe('FilesChanged', () => {
 
   function renderComponent() {
     return render(
-      <ReleaseContext.Provider
+      <ReleaseContext
         value={{
           release,
           project,
@@ -48,7 +48,7 @@ describe('FilesChanged', () => {
         }}
       >
         <FilesChanged />
-      </ReleaseContext.Provider>,
+      </ReleaseContext>,
       {router}
     );
   }

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -229,7 +229,7 @@ class ReleasesDetail extends DeprecatedAsyncView<Props, State> {
             releaseMeta={releaseMeta}
             refetchData={this.fetchData}
           />
-          <ReleaseContext.Provider
+          <ReleaseContext
             value={{
               release,
               project,
@@ -242,7 +242,7 @@ class ReleasesDetail extends DeprecatedAsyncView<Props, State> {
             }}
           >
             {this.props.children}
-          </ReleaseContext.Provider>
+          </ReleaseContext>
         </NoProjectMessage>
       </Layout.Page>
     );

--- a/static/app/views/replays/detail/trace/replayTransactionContext.tsx
+++ b/static/app/views/replays/detail/trace/replayTransactionContext.tsx
@@ -249,9 +249,22 @@ function ReplayTransactionContext({children, replayRecord}: Options) {
         const pageLinks = listResp?.getResponseHeader('Link') ?? null;
         cursor = parseLinkHeader(pageLinks)?.next!;
         const indexComplete = !cursor.results;
-        setState(prev => ({...prev, indexComplete}) as InternalState);
+        setState(
+          prev =>
+            ({
+              ...prev,
+              indexComplete,
+            }) as InternalState
+        );
       } catch (indexError) {
-        setState(prev => ({...prev, indexError, indexComplete: true}) as InternalState);
+        setState(
+          prev =>
+            ({
+              ...prev,
+              indexError,
+              indexComplete: true,
+            }) as InternalState
+        );
         cursor = {cursor: '', results: false, href: ''} as ParsedHeader;
       }
     }
@@ -260,7 +273,7 @@ function ReplayTransactionContext({children, replayRecord}: Options) {
   const externalState = useMemo(() => internalToExternalState(state), [state]);
 
   return (
-    <TxnContext.Provider
+    <TxnContext
       value={{
         eventView: listEventView,
         fetchTransactionData,
@@ -268,7 +281,7 @@ function ReplayTransactionContext({children, replayRecord}: Options) {
       }}
     >
       {children}
-    </TxnContext.Provider>
+    </TxnContext>
   );
 }
 

--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -72,9 +72,5 @@ export default function RouteAnalyticsContextProvider({children}: Props) {
     ]
   );
 
-  return (
-    <RouteAnalyticsContext.Provider value={memoizedValue}>
-      {children}
-    </RouteAnalyticsContext.Provider>
-  );
+  return <RouteAnalyticsContext value={memoizedValue}>{children}</RouteAnalyticsContext>;
 }

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -216,7 +216,7 @@ function SentryAppExternalInstallationContent({params, ...props}: Props) {
         sentryApp={sentryApp}
       />
       {organization && (
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext value={organization}>
           <SentryAppDetailsModal
             sentryApp={sentryApp}
             organization={organization}
@@ -224,7 +224,7 @@ function SentryAppExternalInstallationContent({params, ...props}: Props) {
             closeModal={onClose}
             isInstalled={disableInstall()}
           />
-        </OrganizationContext.Provider>
+        </OrganizationContext>
       )}
     </div>
   );

--- a/static/app/views/settings/components/settingsBreadcrumb/context.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/context.tsx
@@ -80,7 +80,7 @@ function BreadcrumbProvider({children}: ProviderProps) {
     setExplicitTitle,
   };
 
-  return <BreadcrumbContext.Provider value={ctx}>{children}</BreadcrumbContext.Provider>;
+  return <BreadcrumbContext value={ctx}>{children}</BreadcrumbContext>;
 }
 
 /**

--- a/static/app/views/settings/dynamicSampling/utils/formContext.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/formContext.tsx
@@ -211,7 +211,7 @@ export const createForm = <
     children: React.ReactNode;
     formState: FormState<FormFields, FieldErrors>;
   }) {
-    return <FormContext.Provider value={formState}>{children}</FormContext.Provider>;
+    return <FormContext value={formState}>{children}</FormContext>;
   }
 
   const useFormField = <K extends keyof FormFields>(name: K) => {

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -24,7 +24,7 @@ describe('AddIntegrationButton', function () {
   });
 
   const getComponent = () => (
-    <IntegrationContext.Provider
+    <IntegrationContext
       value={{
         provider,
         type: 'first_party',
@@ -43,7 +43,7 @@ describe('AddIntegrationButton', function () {
         externalInstallText={externalInstallText}
         buttonProps={null}
       />
-    </IntegrationContext.Provider>
+    </IntegrationContext>
   );
 
   it('Opens the setup dialog on click', async function () {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -281,7 +281,7 @@ export default function IntegrationDetailedView() {
       }
 
       return (
-        <IntegrationContext.Provider
+        <IntegrationContext
           value={{
             provider,
             type: integrationType,
@@ -307,7 +307,7 @@ export default function IntegrationDetailedView() {
             }}
             buttonProps={buttonProps}
           />
-        </IntegrationContext.Provider>
+        </IntegrationContext>
       );
     },
     [

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -74,7 +74,7 @@ function SharedGroupDetails({params}: Props) {
 
   return (
     <SentryDocumentTitle noSuffix title={group?.title ?? 'Sentry'}>
-      <OrganizationContext.Provider value={org}>
+      <OrganizationContext value={org}>
         <div className="app">
           <div className="pattern-bg" />
           <div className="container">
@@ -105,7 +105,7 @@ function SharedGroupDetails({params}: Props) {
             </div>
           </div>
         </div>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/traces/hooks/useTraceSpans.spec.tsx
+++ b/static/app/views/traces/hooks/useTraceSpans.spec.tsx
@@ -36,9 +36,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/traces/hooks/useTraces.spec.tsx
+++ b/static/app/views/traces/hooks/useTraces.spec.tsx
@@ -35,9 +35,7 @@ function createWrapper(organization: Organization) {
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext.Provider value={organization}>
-          {children}
-        </OrganizationContext.Provider>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/gsAdmin/components/am2CompatibilityCheckModal.tsx
+++ b/static/gsAdmin/components/am2CompatibilityCheckModal.tsx
@@ -402,9 +402,9 @@ const modalCss = css`
 export const triggerAM2CompatibilityCheck = ({organization}: Props) => {
   return openModal(
     () => (
-      <OrganizationContext.Provider value={organization}>
+      <OrganizationContext value={organization}>
         <AM2CompatibilityCheckModal />
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     ),
     {
       modalCss,

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -779,9 +779,9 @@ class CustomerDetails extends DeprecatedAsyncComponent<Props, State> {
             {
               visible: !!data.pendingChanges,
               content: (
-                <OrganizationContext.Provider value={organization}>
+                <OrganizationContext value={organization}>
                   <PendingChanges subscription={data} />
-                </OrganizationContext.Provider>
+                </OrganizationContext>
               ),
             },
             {

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -198,9 +198,9 @@ const TrialInfo = styled('div')<{status?: string}>`
 // wraps the component to add the organization context
 function MemberInviteModalCustomizationWrapper(props: MemberInviteProps) {
   return (
-    <OrganizationContext.Provider value={props.organization}>
+    <OrganizationContext value={props.organization}>
       <MemberInviteModalCustomization {...props} />
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/gsApp/components/promotionModal.tsx
+++ b/static/gsApp/components/promotionModal.tsx
@@ -195,9 +195,9 @@ const PromotionModal = withPromotions(
 function PromotionModalWrapper(props: Omit<PromotionModalProps, 'promotionData'>) {
   // provide org context so we can use withPromotions
   return (
-    <OrganizationContext.Provider value={props.organization}>
+    <OrganizationContext value={props.organization}>
       <PromotionModal {...props} />
-    </OrganizationContext.Provider>
+    </OrganizationContext>
   );
 }
 

--- a/static/gsApp/hooks/useButtonTracking.spec.tsx
+++ b/static/gsApp/hooks/useButtonTracking.spec.tsx
@@ -34,9 +34,9 @@ describe('buttonTracking', function () {
   };
 
   const wrapper = ({children}: ButtonProps) => (
-    <OrganizationContext.Provider value={organization}>
-      <TestRouteContext.Provider value={router}>{children}</TestRouteContext.Provider>
-    </OrganizationContext.Provider>
+    <OrganizationContext value={organization}>
+      <TestRouteContext value={router}>{children}</TestRouteContext>
+    </OrganizationContext>
   );
 
   afterEach(function () {

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -147,15 +147,15 @@ function makeAllTheProviders(options: ProviderOptions) {
 
   return function ({children}: {children?: React.ReactNode}) {
     const content = (
-      <OrganizationContext.Provider value={optionalOrganization}>
+      <OrganizationContext value={optionalOrganization}>
         <GlobalDrawer>{children}</GlobalDrawer>
-      </OrganizationContext.Provider>
+      </OrganizationContext>
     );
 
     const wrappedContent = options.disableRouterMocks ? (
       content
     ) : (
-      <TestRouteContext.Provider
+      <TestRouteContext
         value={{
           router,
           location: router.location,
@@ -165,7 +165,7 @@ function makeAllTheProviders(options: ProviderOptions) {
       >
         {/* ProvideAriaRouter may not be necessary in tests but matches routes.tsx */}
         <ProvideAriaRouter>{content}</ProvideAriaRouter>
-      </TestRouteContext.Provider>
+      </TestRouteContext>
     );
 
     if (!options.disableRouterMocks) {


### PR DESCRIPTION
React 19 opened up the ability to remove .Provider https://react.dev/blog/2024/12/05/react-19#context-as-a-provider which makes more sense with useContext (instead of .Consumer) and go to definition in editor works a bit better.

Had to rename a few to start with an uppercase character

```console
npx codemod@latest react/19/remove-context-provider
```
