### PR TITLE
fix(taskworker) Rework task usage of retry()

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -15,7 +15,8 @@ from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.fileblobindex import FileBlobIndex
 from sentry.models.files.utils import DEFAULT_BLOB_SIZE, MAX_FILE_SIZE, AssembleChecksumMismatch
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry_task
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.retry import NoRetriesRemainingError, retry_task
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
 from sentry.utils.sdk import capture_exception
@@ -161,7 +162,7 @@ def assemble_download(
 
             try:
                 retry_task()
-            except MaxRetriesExceededError:
+            except (MaxRetriesExceededError, NoRetriesRemainingError):
                 metrics.incr(
                     "dataexport.end",
                     tags={"success": False, "error": str(error)},

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from celery import Task, current_task
 from django.urls import reverse
 from requests.exceptions import RequestException
 
@@ -42,7 +41,7 @@ from sentry.sentry_apps.services.app.service import (
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task, retry, retry_task
 from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -242,7 +241,6 @@ def _process_resource_change(
     action: str,
     sender: str,
     instance_id: int,
-    retryer: Task | None = None,
     **kwargs: Any,
 ) -> None:
 
@@ -276,10 +274,6 @@ def _process_resource_change(
                 project_id=project_id, group_id=group_id, event_id=str(instance_id), data=nodedata
             )
 
-        # By default, use Celery's `current_task` but allow a value to be passed for the
-        # bound Task.
-        retryer = retryer or current_task
-
         # We may run into a race condition where this task executes before the
         # transaction that creates the Group has committed.
         if not issubclass(model, Event):
@@ -288,7 +282,7 @@ def _process_resource_change(
             except model.DoesNotExist as e:
                 # Explicitly requeue the task, so we don't report this to Sentry until
                 # we hit the max number of retries.
-                return retryer.retry(exc=e)
+                return retry_task(e)
 
         org = None
 
@@ -320,15 +314,13 @@ def _process_resource_change(
 
 
 @instrumented_task(
-    "sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound", bind=True, **TASK_OPTIONS
+    "sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound", **TASK_OPTIONS
 )
 @retry_decorator
 def process_resource_change_bound(
-    self: Task, action: str, sender: str, instance_id: int, **kwargs: Any
+    action: str, sender: str, instance_id: int, **kwargs: Any
 ) -> None:
-    _process_resource_change(
-        action=action, sender=sender, instance_id=instance_id, retryer=self, **kwargs
-    )
+    _process_resource_change(action=action, sender=sender, instance_id=instance_id, **kwargs)
 
 
 @instrumented_task(

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -41,7 +41,8 @@ from sentry.sentry_apps.services.app.service import (
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry, retry_task
+from sentry.tasks.base import instrumented_task, retry
+from sentry.taskworker.retry import retry_task
 from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable
 from datetime import datetime
 from typing import Any, ParamSpec, TypeVar
 
-from celery import Task, current_task
+from celery import Task
 from django.conf import settings
 from django.db.models import Model
 from kombu import Producer
@@ -16,7 +16,7 @@ from sentry import options
 from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.taskworker.config import TaskworkerConfig
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import retry_task
 from sentry.taskworker.task import Task as TaskworkerTask
 from sentry.utils import metrics
 from sentry.utils.memory import track_memory_usage
@@ -256,18 +256,6 @@ def retry(
         return wrapped
 
     return inner
-
-
-def retry_task(exc: Exception | None = None):
-    """
-    Shim function to bridge between celery retry API
-    and Taskworker retry API.
-    """
-    celery_retry = getattr(current_task, "retry", None)
-    if celery_retry:
-        current_task.retry(exc=exc)
-    else:
-        raise RetryError()
 
 
 def track_group_async_operation(function):

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -25,8 +25,9 @@ from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task, retry_task
+from sentry.tasks.base import instrumented_task
 from sentry.tasks.groupowner import process_suspect_commits
+from sentry.taskworker.retry import NoRetriesRemainingError, retry_task
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.sdk import set_current_event_project
@@ -234,7 +235,7 @@ def process_commit_context(
             )
     except UnableToAcquireLock:
         pass
-    except MaxRetriesExceededError:
+    except (MaxRetriesExceededError, NoRetriesRemainingError):
         metrics.incr("tasks.process_commit_context.max_retries_exceeded")
         logger.info(
             "process_commit_context.max_retries_exceeded",

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -44,7 +44,9 @@ def retry_task(exc: Exception | None = None) -> None:
     """
     Helper for triggering retry errors.
     If all retries have been consumed, this will raise a
-    MaxAttemptsExceededError.
+    sentry.taskworker.retry.NoRetriesRemaining or
+    celery.exceptions.MaxAttemptsExceeded depending on how
+    the task is operated.
 
     During task conversion, this function will shim
     between celery's retry API and Taskworker retry API.

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from multiprocessing.context import TimeoutError
 
+from celery.exceptions import Retry as CeleryRetry
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
@@ -55,6 +56,10 @@ class Retry:
 
         # Explicit RetryError with attempts left.
         if isinstance(exc, RetryError):
+            return True
+
+        # Handle celery retry exceptions
+        if isinstance(exc, CeleryRetry):
             return True
 
         # No retries for types on the ignore list

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -12,6 +12,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 )
 
 from sentry.taskworker.state import current_task as taskworker_current_task
+from sentry.utils import metrics
 
 
 class RetryError(Exception):
@@ -57,6 +58,7 @@ def retry_task(exc: Exception | None = None) -> None:
     else:
         current = taskworker_current_task()
         if current and not current.retries_remaining:
+            metrics.incr("taskworker.retry.no_retries_remaining")
             raise NoRetriesRemainingError()
         raise RetryError()
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -46,8 +46,8 @@ def retry_task(exc: Exception | None = None) -> None:
     If all retries have been consumed, this will raise a
     MaxAttemptsExceededError.
 
-    During task conversion, this function will shims
-    between celery's retry AP and Taskworker retry API.
+    During task conversion, this function will shim
+    between celery's retry API and Taskworker retry API.
     """
     celery_retry = getattr(current_task, "retry", None)
     if celery_retry:

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from enum import Enum
 from multiprocessing.context import TimeoutError
 
-from celery.exceptions import Retry as CeleryRetry
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
@@ -56,10 +55,6 @@ class Retry:
 
         # Explicit RetryError with attempts left.
         if isinstance(exc, RetryError):
-            return True
-
-        # Handle celery retry exceptions
-        if isinstance(exc, CeleryRetry):
             return True
 
         # No retries for types on the ignore list

--- a/src/sentry/taskworker/state.py
+++ b/src/sentry/taskworker/state.py
@@ -1,0 +1,40 @@
+import dataclasses
+import threading
+
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
+
+_current_state = threading.local()
+
+
+@dataclasses.dataclass
+class CurrentTaskState:
+    id: str
+    namespace: str
+    taskname: str
+    attempt: int
+    retries_remaining: bool
+
+
+def current_task() -> CurrentTaskState | None:
+    if not hasattr(_current_state, "state"):
+        _current_state.state = None
+
+    return _current_state.state
+
+
+def set_current_task(activation: TaskActivation) -> None:
+    retry_state = activation.retry_state
+    state = CurrentTaskState(
+        id=activation.id,
+        namespace=activation.namespace,
+        taskname=activation.taskname,
+        attempt=activation.retry_state.attempts,
+        # We subtract one, as attempts starts at 0, but `max_attempts`
+        # starts at 1.
+        retries_remaining=(retry_state.attempts < (retry_state.max_attempts - 1)),
+    )
+    _current_state.state = state
+
+
+def clear_current_task() -> None:
+    _current_state.state = None

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -4,7 +4,9 @@ import logging
 from time import sleep
 
 from sentry.taskworker.registry import taskregistry
-from sentry.taskworker.retry import LastAction, Retry, RetryError
+from sentry.taskworker.retry import LastAction, NoRetriesRemainingError, Retry, RetryError
+from sentry.taskworker.retry import retry_task as retry_task_helper
+from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,17 @@ def say_hello(name: str) -> None:
 )
 def retry_deadletter() -> None:
     raise RetryError
+
+
+@exampletasks.register(
+    name="examples.retry_state", retry=Retry(times=2, times_exceeded=LastAction.Deadletter)
+)
+def retry_state() -> None:
+    try:
+        retry_task_helper()
+    except NoRetriesRemainingError:
+        redis = redis_clusters.get("default")
+        redis.set("no-retries-remaining", 1)
 
 
 @exampletasks.register(

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -4,7 +4,6 @@ from unittest.mock import ANY, patch
 
 import pytest
 import responses
-from celery import Task
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
@@ -556,16 +555,6 @@ class TestProcessResourceChange(TestCase):
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=1
         )
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps._process_resource_change")
-    def test_process_resource_change_bound_passes_retry_object(self, process, safe_urlopen):
-        group = self.create_group(project=self.project)
-
-        process_resource_change_bound("created", "Group", group.id)
-
-        ((_, kwargs),) = process.call_args_list
-        task = kwargs["retryer"]
-        assert isinstance(task, Task)
 
     @with_feature("organizations:integrations-event-hooks")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -86,7 +86,7 @@ def test_exclude_exception_retry(capture_exception):
     assert capture_exception.call_count == 0
 
 
-@patch("sentry.tasks.base.current_task")
+@patch("sentry.taskworker.retry.current_task")
 @patch("sentry.tasks.base.capture_exception")
 def test_retry_on(capture_exception, current_task):
 

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -2,7 +2,6 @@ import datetime
 
 import pytest
 import sentry_sdk
-from celery.exceptions import Retry as CeleryRetry
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
@@ -82,9 +81,6 @@ def test_should_retry(task_namespace: TaskNamespace) -> None:
         retry=retry,
     )
     err = RetryError("try again plz")
-    assert task.should_retry(state, err)
-
-    err = CeleryRetry()
     assert task.should_retry(state, err)
 
     state.attempts = 3

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 import sentry_sdk
+from celery.exceptions import Retry as CeleryRetry
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
@@ -81,6 +82,9 @@ def test_should_retry(task_namespace: TaskNamespace) -> None:
         retry=retry,
     )
     err = RetryError("try again plz")
+    assert task.should_retry(state, err)
+
+    err = CeleryRetry()
     assert task.should_retry(state, err)
 
     state.attempts = 3


### PR DESCRIPTION
We use `celery.Task.retry()` in a few places. In order to be able to move these tasks to taskbroker, we need to use a shim function that uses celery's `current_task.retry()` proxy, or raises a taskworker exception. 

I still need to implement a replacement for `celery.exceptions.MaxRetriesExceededError` and will do that in a subsequent pull request.

Part of #88089