### PR TITLE
feat(trace-eap-waterfall): Adding persistent toggle for trace format

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -20,7 +20,7 @@ import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/trace
 import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
 import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
-import {SwitchToNonEAPTraceButton} from 'sentry/views/performance/newTraceDetails/traceHeader';
+import {ToggleTraceFormatButton} from 'sentry/views/performance/newTraceDetails/traceHeader';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
   loadTraceViewPreferences,
@@ -175,7 +175,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
       title={t('Trace Preview')}
       actions={
         <ButtonBar gap={1}>
-          <SwitchToNonEAPTraceButton location={location} organization={organization} />
+          <ToggleTraceFormatButton location={location} organization={organization} />
           <LinkButton
             size="xs"
             to={getTraceLinkForIssue(traceTarget)}

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
@@ -2,6 +2,8 @@ import type {EventTransaction} from 'sentry/types/event';
 import {isTraceSplitResult} from 'sentry/utils/performance/quickTrace/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import {TRACE_FORMAT_PREFERENCE_KEY} from 'sentry/views/performance/newTraceDetails/traceHeader';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
 export function useTraceRootEvent(trace: TraceTree.Trace | null) {
@@ -11,6 +13,10 @@ export function useTraceRootEvent(trace: TraceTree.Trace | null) {
       : trace[0]
     : null;
   const organization = useOrganization();
+  const [traceFormat] = useSyncedLocalStorageState(
+    TRACE_FORMAT_PREFERENCE_KEY,
+    'non-eap'
+  );
 
   return useApiQuery<EventTransaction>(
     [
@@ -23,7 +29,8 @@ export function useTraceRootEvent(trace: TraceTree.Trace | null) {
     ],
     {
       staleTime: 0,
-      enabled: !!trace && !!root?.project_slug && !!root?.event_id,
+      enabled:
+        !!trace && !!root?.project_slug && !!root?.event_id && traceFormat === 'non-eap',
     }
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
@@ -13,7 +13,7 @@ export function useTraceRootEvent(trace: TraceTree.Trace | null) {
       : trace[0]
     : null;
   const organization = useOrganization();
-  const [traceFormat] = useSyncedLocalStorageState(
+  const [storedTraceFormat] = useSyncedLocalStorageState(
     TRACE_FORMAT_PREFERENCE_KEY,
     'non-eap'
   );
@@ -30,7 +30,10 @@ export function useTraceRootEvent(trace: TraceTree.Trace | null) {
     {
       staleTime: 0,
       enabled:
-        !!trace && !!root?.project_slug && !!root?.event_id && traceFormat === 'non-eap',
+        !!trace &&
+        !!root?.project_slug &&
+        !!root?.event_id &&
+        storedTraceFormat === 'non-eap',
     }
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -23,7 +23,7 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {ProjectsRenderer} from 'sentry/views/explore/tables/tracesTable/fieldRenderers';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
@@ -73,33 +73,29 @@ function FeedbackButton() {
   ) : null;
 }
 
-export function SwitchToNonEAPTraceButton({
-  location,
+export const TRACE_FORMAT_PREFERENCE_KEY = 'trace_format_preference';
+
+export function ToggleTraceFormatButton({
   organization,
 }: {
   location: Location;
   organization: Organization;
 }) {
-  const navigate = useNavigate();
-  const switchToNonEAPTrace = useCallback(() => {
-    navigate({
-      ...location,
-      query: {
-        ...location.query,
-        trace_format: 'non-eap',
-      },
-    });
-  }, [location, navigate]);
+  const [traceFormat, setTraceFormat] = useSyncedLocalStorageState(
+    TRACE_FORMAT_PREFERENCE_KEY,
+    'non-eap'
+  );
 
   return (
-    <Feature organization={organization} features="visibility-explore-admin">
+    <Feature organization={organization} features="trace-spans-format">
       <Button
-        disabled={location.query.trace_format === 'non-eap'}
         size="xs"
-        aria-label="non-eap-trace-btn"
-        onClick={switchToNonEAPTrace}
+        aria-label="toggle-trace-format-btn"
+        onClick={() => {
+          setTraceFormat(traceFormat === 'eap' ? 'non-eap' : 'eap');
+        }}
       >
-        {t('Switch to Non-EAP Trace')}
+        {traceFormat === 'eap' ? t('Switch to Non-EAP Trace') : t('Switch to EAP Trace')}
       </Button>
     </Feature>
   );
@@ -123,7 +119,7 @@ function PlaceHolder({organization}: {organization: Organization}) {
             )}
           />
           <ButtonBar gap={1}>
-            <SwitchToNonEAPTraceButton location={location} organization={organization} />
+            <ToggleTraceFormatButton location={location} organization={organization} />
             <FeedbackButton />
           </ButtonBar>
         </HeaderRow>
@@ -308,7 +304,7 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             )}
           />
           <ButtonBar gap={1}>
-            <SwitchToNonEAPTraceButton
+            <ToggleTraceFormatButton
               location={location}
               organization={props.organization}
             />

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -81,7 +81,7 @@ export function ToggleTraceFormatButton({
   location: Location;
   organization: Organization;
 }) {
-  const [traceFormat, setTraceFormat] = useSyncedLocalStorageState(
+  const [storedTraceFormat, setStoredTraceFormat] = useSyncedLocalStorageState(
     TRACE_FORMAT_PREFERENCE_KEY,
     'non-eap'
   );
@@ -92,10 +92,12 @@ export function ToggleTraceFormatButton({
         size="xs"
         aria-label="toggle-trace-format-btn"
         onClick={() => {
-          setTraceFormat(traceFormat === 'eap' ? 'non-eap' : 'eap');
+          setStoredTraceFormat(storedTraceFormat === 'eap' ? 'non-eap' : 'eap');
         }}
       >
-        {traceFormat === 'eap' ? t('Switch to Non-EAP Trace') : t('Switch to EAP Trace')}
+        {storedTraceFormat === 'eap'
+          ? t('Switch to Non-EAP Trace')
+          : t('Switch to EAP Trace')}
       </Button>
     </Feature>
   );


### PR DESCRIPTION
Initially it's set to `NON-EAP`.

<img width="1259" alt="Screenshot 2025-03-31 at 5 18 42 PM" src="https://github.com/user-attachments/assets/4685518d-8aa0-4419-a527-74de5fef8a1c" />
