### PR TITLE
feat(ourlogs): Add project AbuseQuota for logs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1333,6 +1333,12 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "project-abuse-quota.log-limit",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 
 register(

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -477,6 +477,12 @@ class Quota(Service):
                 categories=[DataCategory.SPAN_INDEXED],
                 scope=QuotaScope.PROJECT,
             ),
+            AbuseQuota(
+                id="pal",
+                option="project-abuse-quota.log-limit",
+                categories=[DataCategory.LOG_ITEM],
+                scope=QuotaScope.PROJECT,
+            ),
         ]
 
         abuse_quotas.extend(build_metric_abuse_quotas())

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -120,6 +120,7 @@ class RedisQuotaTest(TestCase):
         self.organization.update_option("project-abuse-quota.session-limit", 602)
         self.organization.update_option("organization-abuse-quota.metric-bucket-limit", 603)
         self.organization.update_option("project-abuse-quota.span-limit", 605)
+        self.organization.update_option("project-abuse-quota.log-limit", 606)
 
         metric_abuse_limit_by_id = dict()
         for i, mabq in enumerate(build_metric_abuse_quotas()):
@@ -168,6 +169,14 @@ class RedisQuotaTest(TestCase):
         assert quotas[5].limit == 6050
         assert quotas[5].window == 10
         assert quotas[5].reason_code == "project_abuse_limit"
+
+        assert quotas[6].id == "pal"
+        assert quotas[6].scope == QuotaScope.PROJECT
+        assert quotas[6].scope_id is None
+        assert quotas[6].categories == {DataCategory.LOG_ITEM}
+        assert quotas[6].limit == 6060
+        assert quotas[6].window == 10
+        assert quotas[6].reason_code == "project_abuse_limit"
 
         expected_quotas: dict[tuple[QuotaScope, UseCaseID | None], str] = dict()
         for scope, prefix in [


### PR DESCRIPTION
### Summary
This adds an AbuseQuota for logs (specifically for log items, which is the count of logs), which will be set to match spans for now as we know we can hand that limit safely in EAP.

