### PR TITLE
theme: remove tour theme imports

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -21,8 +21,6 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-// eslint-disable-next-line no-restricted-imports -- @TODO(jonasbadalic): Remove theme import
-import {darkTheme, lightTheme} from 'sentry/utils/theme';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -255,12 +253,12 @@ function TourElementContent<T extends TourEnumType>({
     () => (
       <ButtonBar gap={1}>
         {hasPreviousStep && (
-          <TextTourAction size="xs" onClick={() => previousStep()}>
+          <TextTourAction size="xs" onClick={previousStep}>
             {t('Previous')}
           </TextTourAction>
         )}
         {hasNextStep ? (
-          <TourAction size="xs" onClick={() => nextStep()}>
+          <TourAction size="xs" onClick={nextStep}>
             {t('Next')}
           </TourAction>
         ) : (
@@ -408,9 +406,7 @@ export function TourGuide({
                       strokeWidth: 0,
                       className: css`
                         path.fill {
-                          fill: ${prefersDarkMode
-                            ? darkTheme.purple300
-                            : darkTheme.surface400};
+                          fill: ${theme.tour.background};
                         }
                         path.stroke {
                           stroke: transparent;
@@ -427,7 +423,7 @@ export function TourGuide({
                               onClick={e => {
                                 handleDismiss(e);
                               }}
-                              icon={<IconClose style={{color: darkTheme.textColor}} />}
+                              icon={<IconClose style={{color: theme.textColor}} />}
                               aria-label={t('Close')}
                               borderless
                               size="sm"
@@ -458,13 +454,13 @@ function scrollToElement(element: HTMLDivElement | null) {
 const TourBody = styled('div')<{prefersDarkMode: boolean}>`
   display: flex;
   flex-direction: column;
-  background: ${p => (p.prefersDarkMode ? darkTheme.purple300 : darkTheme.surface400)};
+  background: ${p => p.theme.tour.background};
   padding: ${space(1.5)} ${space(2)};
-  color: ${darkTheme.textColor};
+  color: ${p => p.theme.tour.text};
   border-radius: ${p => p.theme.borderRadius};
   width: 360px;
   a {
-    color: ${darkTheme.textColor};
+    color: ${p => p.theme.tour.text};
     text-decoration: underline;
   }
 `;
@@ -486,14 +482,14 @@ const TopRow = styled('div')`
   grid-template-columns: 1fr 15px;
   align-items: start;
   height: 18px;
-  color: ${lightTheme.white};
+  color: ${p => p.theme.white};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightBold};
   opacity: 0.6;
 `;
 
 const TitleRow = styled('div')`
-  color: ${darkTheme.headingColor};
+  color: ${p => p.theme.tour.header};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: ${p => p.theme.fontWeightBold};
   line-height: 1.4;
@@ -501,7 +497,7 @@ const TitleRow = styled('div')`
 `;
 
 const DescriptionRow = styled('div')`
-  color: ${darkTheme.textColor};
+  color: ${p => p.theme.tour.text};
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightNormal};
   line-height: 1.4;
@@ -517,12 +513,13 @@ const ActionRow = styled('div')`
 
 export const TourAction = styled(Button)`
   border: 0;
-  background: ${lightTheme.white};
-  color: ${lightTheme.headingColor};
+  background: ${p => p.theme.white};
+  color: ${p => p.theme.tour.next};
+
   &:hover,
   &:active,
   &:focus {
-    color: ${lightTheme.headingColor};
+    color: ${p => p.theme.tour.next};
   }
 `;
 
@@ -530,11 +527,11 @@ export const TextTourAction = styled(Button)`
   border: 0;
   box-shadow: none;
   background: transparent;
-  color: ${lightTheme.white};
+  color: ${p => p.theme.tour.previous};
   &:hover,
   &:active,
   &:focus {
-    color: ${lightTheme.white};
+    color: ${p => p.theme.tour.previous};
   }
 `;
 
@@ -560,8 +557,7 @@ const TourTriggerWrapper = styled('div')<{prefersDarkMode: boolean}>`
       z-index: ${p => p.theme.zIndex.tour.element + 1};
       inset: 0;
       border-radius: ${p => p.theme.borderRadius};
-      box-shadow: inset 0 0 0 3px
-        ${p => (p.prefersDarkMode ? darkTheme.purple300 : darkTheme.surface400)};
+      box-shadow: inset 0 0 0 3px ${p => p.theme.tour.background};
     }
   }
 `;

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -362,8 +362,8 @@ export function TourGuide({
 }: TourGuideProps) {
   const config = useLegacyStore(ConfigStore);
   const prefersDarkMode = config.theme === 'dark';
-
   const theme = useTheme();
+
   const isStepCountVisible = defined(stepCount) && defined(stepTotal) && stepTotal !== 1;
   const isDismissVisible = defined(handleDismiss);
   const isTopRowVisible = isStepCountVisible || isDismissVisible;
@@ -420,10 +420,8 @@ export function TourGuide({
                           <div>{countText}</div>
                           {isDismissVisible && (
                             <TourCloseButton
-                              onClick={e => {
-                                handleDismiss(e);
-                              }}
-                              icon={<IconClose style={{color: theme.textColor}} />}
+                              onClick={handleDismiss}
+                              icon={<IconClose />}
                               aria-label={t('Close')}
                               borderless
                               size="sm"
@@ -470,6 +468,10 @@ const TourCloseButton = styled(Button)`
   padding: 0;
   height: 14px;
   min-height: 14px;
+  color: ${p => p.theme.tour.close};
+  &:hover {
+    color: ${p => p.theme.tour.close};
+  }
 `;
 
 const TourOverlay = styled(Overlay)`
@@ -482,7 +484,7 @@ const TopRow = styled('div')`
   grid-template-columns: 1fr 15px;
   align-items: start;
   height: 18px;
-  color: ${p => p.theme.white};
+  color: ${p => p.theme.tour.close};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightBold};
   opacity: 0.6;

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1050,6 +1050,14 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
   tag: generateTagTheme(chonkLightColorMapping),
   level: generateLevelTheme(chonkLightColorMapping),
 
+  tour: {
+    background: darkColors.surface400,
+    header: darkColors.white,
+    text: darkAliases.subText,
+    next: lightAliases.textColor,
+    previous: 'inherit',
+  },
+
   chart: {
     colors: CHART_PALETTE,
     getColorPalette,
@@ -1111,6 +1119,14 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
   button: generateButtonTheme(chonkDarkColorMapping, darkAliases),
   tag: generateTagTheme(chonkDarkColorMapping),
   level: generateLevelTheme(chonkDarkColorMapping),
+
+  tour: {
+    background: darkColors.blue400,
+    header: darkColors.white,
+    text: darkAliases.subText,
+    next: lightAliases.textColor,
+    previous: 'inherit',
+  },
 
   chart: {
     colors: CHART_PALETTE,

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1054,8 +1054,9 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
     background: darkColors.surface400,
     header: darkColors.white,
     text: darkAliases.subText,
-    next: lightAliases.textColor,
-    previous: 'inherit',
+    next: '',
+    previous: '',
+    close: lightColors.white,
   },
 
   chart: {
@@ -1123,9 +1124,10 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
   tour: {
     background: darkColors.blue400,
     header: darkColors.white,
-    text: darkAliases.subText,
-    next: lightAliases.textColor,
-    previous: 'inherit',
+    text: darkColors.white,
+    next: '',
+    previous: '',
+    close: lightColors.white,
   },
 
   chart: {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1315,9 +1315,10 @@ export const lightTheme = {
   tour: {
     background: darkColors.surface400,
     header: darkColors.white,
-    text: lightColors.white,
+    text: darkAliases.textColor,
     next: lightAliases.textColor,
     previous: darkColors.white,
+    close: lightColors.white,
   },
   chart: {
     colors: CHART_PALETTE,
@@ -1371,9 +1372,10 @@ export const darkTheme: typeof lightTheme = {
   tour: {
     background: darkColors.purple300,
     header: darkColors.white,
-    text: darkColors.white,
+    text: darkAliases.textColor,
     next: lightAliases.textColor,
     previous: darkColors.white,
+    close: lightColors.white,
   },
   chart: {
     colors: CHART_PALETTE,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1312,6 +1312,13 @@ export const lightTheme = {
   level: generateLevelTheme(lightColors),
   stacktraceActiveBackground: lightColors.gray500,
   stacktraceActiveText: lightColors.white,
+  tour: {
+    background: darkColors.surface400,
+    header: darkColors.white,
+    text: lightColors.white,
+    next: lightAliases.textColor,
+    previous: darkColors.white,
+  },
   chart: {
     colors: CHART_PALETTE,
     getColorPalette,
@@ -1361,6 +1368,13 @@ export const darkTheme: typeof lightTheme = {
   ),
   stacktraceActiveBackground: darkColors.gray200,
   stacktraceActiveText: darkColors.white,
+  tour: {
+    background: darkColors.purple300,
+    header: darkColors.white,
+    text: darkColors.white,
+    next: lightAliases.textColor,
+    previous: darkColors.white,
+  },
   chart: {
     colors: CHART_PALETTE,
     getColorPalette: getChartColorPalette,

--- a/static/app/views/issueDetails/issueDetailsTourModal.tsx
+++ b/static/app/views/issueDetails/issueDetailsTourModal.tsx
@@ -9,8 +9,6 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
-// eslint-disable-next-line no-restricted-imports -- @TODO(jonasbadalic): Remove theme import
-import {darkTheme} from 'sentry/utils/theme';
 
 interface IssueDetailsTourModalProps {
   handleDismissTour: () => void;
@@ -23,6 +21,7 @@ export function IssueDetailsTourModal({
 }: IssueDetailsTourModalProps) {
   const config = useLegacyStore(ConfigStore);
   const prefersDarkMode = config.theme === 'dark';
+
   return (
     <TourContainer prefersDarkMode={prefersDarkMode}>
       <ImageContainer prefersDarkMode={prefersDarkMode} />
@@ -71,7 +70,7 @@ const TourContainer = styled('div')<{prefersDarkMode: boolean}>`
     margin: -${space(4)};
   }
   border-radius: ${p => p.theme.borderRadius};
-  background: ${p => (p.prefersDarkMode ? darkTheme.purple300 : darkTheme.surface400)};
+  background: ${p => p.theme.tour.background};
   overflow: hidden;
 `;
 
@@ -80,14 +79,14 @@ const TextContainer = styled('div')`
 `;
 
 const Header = styled('div')<{prefersDarkMode: boolean}>`
-  color: ${p => (p.prefersDarkMode ? p.theme.white : darkTheme.headingColor)};
+  color: ${p => p.theme.tour.header};
   font-size: ${p => p.theme.headerFontSize};
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 const Description = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.white};
+  color: ${p => p.theme.tour.text};
   opacity: 0.8;
 `;
 

--- a/static/app/views/nav/tour/tourModal.tsx
+++ b/static/app/views/nav/tour/tourModal.tsx
@@ -8,8 +8,6 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
-// eslint-disable-next-line no-restricted-imports -- @TODO(jonasbadalic): Remove theme import
-import {darkTheme} from 'sentry/utils/theme';
 
 interface NavTourModalProps {
   closeModal: () => void;
@@ -82,7 +80,7 @@ const TourContainer = styled('div')<{prefersDarkMode: boolean}>`
     margin: -${space(4)};
   }
   border-radius: ${p => p.theme.borderRadius};
-  background: ${p => (p.prefersDarkMode ? darkTheme.purple300 : darkTheme.surface400)};
+  background: ${p => p.theme.tour.background};
   overflow: hidden;
 `;
 
@@ -91,7 +89,7 @@ const TextContainer = styled('div')`
 `;
 
 const Header = styled('div')<{prefersDarkMode: boolean}>`
-  color: ${p => (p.prefersDarkMode ? p.theme.white : darkTheme.headingColor)};
+  color: ${p => p.theme.tour.header};
   font-size: ${p => p.theme.headerFontSize};
   font-weight: ${p => p.theme.fontWeightBold};
 `;


### PR DESCRIPTION
Update tours to no longer import theme directly. Chonk black on purple buttons look a bit odd, but we can fix that separately cc @Jesse-Box 

https://github.com/user-attachments/assets/c2fc958b-cf48-4c53-bc8c-47a4477e513d


