### PR TITLE
feat(shared-views): Create `GET` `group-search-view/starred` endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -186,6 +186,7 @@ from sentry.issues.endpoints import (
     OrganizationGroupIndexStatsEndpoint,
     OrganizationGroupSearchViewDetailsEndpoint,
     OrganizationGroupSearchViewsEndpoint,
+    OrganizationGroupSearchViewsStarredEndpoint,
     OrganizationGroupSearchViewStarredEndpoint,
     OrganizationGroupSearchViewVisitEndpoint,
     OrganizationIssuesCountEndpoint,
@@ -1786,6 +1787,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/$",
         OrganizationGroupSearchViewsEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-views",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/starred/$",
+        OrganizationGroupSearchViewsStarredEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-views-starred",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/$",

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -19,6 +19,7 @@ from .organization_group_search_view_details import OrganizationGroupSearchViewD
 from .organization_group_search_view_starred import OrganizationGroupSearchViewStarredEndpoint
 from .organization_group_search_view_visit import OrganizationGroupSearchViewVisitEndpoint
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
+from .organization_group_search_views_starred import OrganizationGroupSearchViewsStarredEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
 from .organization_searches import OrganizationSearchesEndpoint
@@ -56,7 +57,7 @@ __all__ = (
     "OrganizationGroupSearchViewDetailsEndpoint",
     "OrganizationGroupSearchViewStarredEndpoint",
     "OrganizationGroupSearchViewVisitEndpoint",
-    "OrganizationGroupSearchViewStarredEndpoint",
+    "OrganizationGroupSearchViewsStarredEndpoint",
     "OrganizationIssuesCountEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -23,33 +23,14 @@ from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidator,
     GroupSearchViewValidatorResponse,
 )
-from sentry.models.groupsearchview import (
-    DEFAULT_TIME_FILTER,
-    GroupSearchView,
-    GroupSearchViewVisibility,
-)
+from sentry.issues.endpoints.organization_group_search_views_starred import DEFAULT_VIEWS
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.savedsearch import SortOptions
 from sentry.models.team import Team
 from sentry.users.models.user import User
-
-DEFAULT_VIEWS: list[GroupSearchViewValidatorResponse] = [
-    {
-        "name": "Prioritized",
-        "query": "is:unresolved issue.priority:[high, medium]",
-        "querySort": SortOptions.DATE.value,
-        "position": 0,
-        "isAllProjects": False,
-        "environments": [],
-        "projects": [],
-        "timeFilters": DEFAULT_TIME_FILTER,
-        "dateCreated": None,
-        "dateUpdated": None,
-    }
-]
 
 
 class MemberPermission(OrganizationPermission):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -23,8 +23,7 @@ from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidator,
     GroupSearchViewValidatorResponse,
 )
-from sentry.issues.endpoints.organization_group_search_views_starred import DEFAULT_VIEWS
-from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchview import DEFAULT_VIEWS, GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -11,29 +11,12 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewStarredSerializer
-from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
-from sentry.models.groupsearchview import DEFAULT_TIME_FILTER
+from sentry.models.groupsearchview import DEFAULT_VIEWS
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.savedsearch import SortOptions
 from sentry.models.team import Team
 from sentry.users.models.user import User
-
-DEFAULT_VIEWS: list[GroupSearchViewValidatorResponse] = [
-    {
-        "name": "Prioritized",
-        "query": "is:unresolved issue.priority:[high, medium]",
-        "querySort": SortOptions.DATE.value,
-        "position": 0,
-        "isAllProjects": False,
-        "environments": [],
-        "projects": [],
-        "timeFilters": DEFAULT_TIME_FILTER,
-        "dateCreated": None,
-        "dateUpdated": None,
-    }
-]
 
 
 class MemberPermission(OrganizationPermission):

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -1,0 +1,109 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.paginator import SequencePaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.groupsearchview import GroupSearchViewStarredSerializer
+from sentry.issues.endpoints.organization_group_search_view_details import (
+    GroupSearchViewValidatorResponse,
+)
+from sentry.issues.endpoints.organization_group_search_views import (
+    MemberPermission,
+    pick_default_project,
+)
+from sentry.models.groupsearchview import DEFAULT_TIME_FILTER
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.organization import Organization
+from sentry.models.savedsearch import SortOptions
+
+DEFAULT_VIEWS: list[GroupSearchViewValidatorResponse] = [
+    {
+        "name": "Prioritized",
+        "query": "is:unresolved issue.priority:[high, medium]",
+        "querySort": SortOptions.DATE.value,
+        "position": 0,
+        "isAllProjects": False,
+        "environments": [],
+        "projects": [],
+        "timeFilters": DEFAULT_TIME_FILTER,
+        "dateCreated": None,
+        "dateUpdated": None,
+    }
+]
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Retrieve a list of starred views for the current organization member.
+        """
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        has_global_views = features.has("organizations:global-views", organization)
+
+        default_project = None
+        if not has_global_views:
+            default_project = pick_default_project(organization, request.user)
+            if default_project is None:
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"detail": "You do not have access to any projects."},
+                )
+
+        starred_views = GroupSearchViewStarred.objects.filter(
+            organization=organization, user_id=request.user.id
+        )
+
+        # TODO(msun): Remove when tabbed views are deprecated
+        if not starred_views.exists():
+            return self.paginate(
+                request=request,
+                paginator=SequencePaginator(
+                    [
+                        (
+                            idx,
+                            {
+                                **view,
+                                "projects": (
+                                    []
+                                    if has_global_views
+                                    else [pick_default_project(organization, request.user)]
+                                ),
+                            },
+                        )
+                        for idx, view in enumerate(DEFAULT_VIEWS)
+                    ]
+                ),
+                on_results=lambda results: serialize(results, request.user),
+            )
+
+        return self.paginate(
+            request=request,
+            queryset=starred_views,
+            order_by="position",
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                serializer=GroupSearchViewStarredSerializer(
+                    has_global_views=has_global_views,
+                    default_project=default_project,
+                    organization=organization,
+                ),
+            ),
+        )

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -6,17 +6,12 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewStarredSerializer
-from sentry.issues.endpoints.organization_group_search_view_details import (
-    GroupSearchViewValidatorResponse,
-)
-from sentry.issues.endpoints.organization_group_search_views import (
-    MemberPermission,
-    pick_default_project,
-)
+from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
+from sentry.issues.endpoints.organization_group_search_views import pick_default_project
 from sentry.models.groupsearchview import DEFAULT_TIME_FILTER
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
@@ -36,6 +31,12 @@ DEFAULT_VIEWS: list[GroupSearchViewValidatorResponse] = [
         "dateUpdated": None,
     }
 ]
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read", "member:write"],
+    }
 
 
 @region_silo_endpoint

--- a/src/sentry/models/groupsearchview.py
+++ b/src/sentry/models/groupsearchview.py
@@ -14,6 +14,21 @@ from sentry.models.savedsearch import SortOptions
 
 DEFAULT_TIME_FILTER = {"period": "14d"}
 
+DEFAULT_VIEWS = [
+    {
+        "name": "Prioritized",
+        "query": "is:unresolved issue.priority:[high, medium]",
+        "querySort": SortOptions.DATE.value,
+        "position": 0,
+        "isAllProjects": False,
+        "environments": [],
+        "projects": [],
+        "timeFilters": DEFAULT_TIME_FILTER,
+        "dateCreated": None,
+        "dateUpdated": None,
+    }
+]
+
 
 @region_silo_model
 class GroupSearchViewProject(DefaultFieldsModel):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -5,8 +5,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
-from sentry.issues.endpoints.organization_group_search_views import DEFAULT_VIEWS
-from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchview import DEFAULT_VIEWS, GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.testutils.cases import APITestCase, TransactionTestCase

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationGroupSearchViewsStarredEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-views-starred"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+
+    def create_view(self, **kwargs):
+        default_data = {
+            "organization": self.org,
+            "user_id": self.user.id,
+            "name": "Test View",
+            "query": "is:unresolved",
+            "query_sort": "date",
+            "is_all_projects": True,
+            "environments": [],
+            "time_filters": {"start": None, "end": None, "period": "14d"},
+        }
+        return GroupSearchView.objects.create(**{**default_data, **kwargs})
+
+    def test_simple(self):
+        view1 = self.create_view(name="View 1")
+        self.create_view(name="View 2")
+        view3 = self.create_view(name="View 3")
+
+        # Star view1 and view3 (skipping view2)
+        GroupSearchViewStarred.objects.insert_starred_view(
+            organization=self.org, user_id=self.user.id, view=view1, position=0
+        )
+        GroupSearchViewStarred.objects.insert_starred_view(
+            organization=self.org, user_id=self.user.id, view=view3, position=1
+        )
+
+        url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.org.slug})
+        with self.feature(
+            {"organizations:issue-stream-custom-views": True, "organizations:global-views": True}
+        ):
+            response = self.client.get(url)
+
+        assert response.status_code == 200
+        result = response.data
+        assert len(result) == 2
+        assert result[0]["name"] == "View 1"
+        assert result[0]["position"] == 0
+        assert result[1]["name"] == "View 3"
+        assert result[1]["position"] == 1
+
+    def test_feature_flag_required(self):
+        url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.org.slug})
+        response = self.client.get(url)
+        assert response.status_code == 404


### PR DESCRIPTION
This PR creates the `GET` `group-search-views/starred` endpoint, which returns the user's starred views. 

This logic is directly copied over from the `GET` `/group-search-views/` endpoint, and is intended to replace it in certain instances. 

I still need to refactor the frontend to switch over to this new endpoint before I can remove this logic from the old endpoint. 