### PR TITLE
feat(explore): Disable other series in explore by default

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -297,6 +297,10 @@ export function ExploreCharts({
                       stack: 'all',
                     });
                   })}
+                  legendSelection={{
+                    // disable the 'Other' series by default since its large values can cause the other lines to be insignificant
+                    Other: false,
+                  }}
                 />
               }
               Footer={


### PR DESCRIPTION
The `Other` series can often dominate the chart so disable it by default.

Fixes EXP-41