### PR TITLE
feat(explore): Add suggested query for top server calls

### DIFF
--- a/static/app/views/explore/toolbar/toolbarSuggestedQueries.tsx
+++ b/static/app/views/explore/toolbar/toolbarSuggestedQueries.tsx
@@ -238,6 +238,22 @@ function getSuggestedQueries(platforms: PlatformCategory[], maxQueries = 5) {
         {chartType: ChartType.LINE, yAxes: ['p90(span.duration)']},
       ],
     },
+    {
+      title: t('Top Server Calls'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:http.server',
+      sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
+      visualizes: [{chartType: ChartType.BAR, yAxes: ['count(span.duration)']}],
+    },
   ];
 
   const mobileQueries: SuggestedQuery[] = [


### PR DESCRIPTION
This adds a suggested query for visualizing the most common server calls.

Fixes EXP-39