### PR TITLE
fix(issues) - Correct error handler to catch Postgres timeouts

### DIFF
--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -2,7 +2,6 @@ import datetime
 import unittest
 from unittest.mock import MagicMock, patch
 
-import psycopg2
 import pytest
 from django.db import OperationalError
 from django.utils import timezone
@@ -202,8 +201,6 @@ class HandleQueryErrorsTest(APITestCase):
 
     def test_handle_postgres_timeout(self):
         class TimeoutError(OperationalError):
-            pgcode = psycopg2.errorcodes.QUERY_CANCELED
-
             def __str__(self):
                 return "canceling statement due to statement timeout"
 
@@ -228,8 +225,6 @@ class HandleQueryErrorsTest(APITestCase):
 
     def test_handle_postgres_user_cancel(self):
         class UserCancelError(OperationalError):
-            pgcode = psycopg2.errorcodes.QUERY_CANCELED
-
             def __str__(self):
                 return "canceling statement due to user request"
 
@@ -244,7 +239,6 @@ class HandleQueryErrorsTest(APITestCase):
     @patch("sentry.api.utils.ParseError")
     def test_handle_other_operational_error(self, mock_parse_error):
         class OtherError(OperationalError):
-            # No pgcode attribute
             pass
 
         try:

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4,7 +4,6 @@ from time import sleep
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import uuid4
 
-import psycopg2
 from django.db import OperationalError
 from django.urls import reverse
 from django.utils import timezone
@@ -4066,14 +4065,10 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         only when it's a statement timeout, and remains a 500 for user cancellation"""
 
         class TimeoutError(OperationalError):
-            pgcode = psycopg2.errorcodes.QUERY_CANCELED
-
             def __str__(self):
                 return "canceling statement due to statement timeout"
 
         class UserCancelError(OperationalError):
-            pgcode = psycopg2.errorcodes.QUERY_CANCELED
-
             def __str__(self):
                 return "canceling statement due to user request"
 


### PR DESCRIPTION
Following up on #88158, it seems the timeouts were not getting caught and so I relaxed the condition to not check for pgcode and only check for the message.

This is not an ideal solution but it will hopefully get the job done with minimal risk of catching wrong errors here. With some more effort into reproducing the issue locally we could perhaps get to the bottom of this and understand exactly how to categorize this error correctly, but I think this has taken enough attention from us for now.