### PR TITLE
feat(autofix): File edit insights

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -28,6 +28,7 @@ type AutofixDiffProps = {
   editable: boolean;
   groupId: string;
   runId: string;
+  isExpandable?: boolean;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
   repoId?: string;
@@ -583,10 +584,12 @@ function FileDiff({
   editable,
   previousDefaultStepIndex,
   previousInsightCount,
+  isExpandable,
 }: {
   editable: boolean;
   file: FilePatch;
   groupId: string;
+  isExpandable: boolean;
   runId: string;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
@@ -599,22 +602,27 @@ function FileDiff({
 
   return (
     <FileDiffWrapper>
-      <FileHeader onClick={() => setIsExpanded(value => !value)}>
-        <InteractionStateLayer />
+      <FileHeader
+        isExpandable={isExpandable}
+        onClick={() => (isExpandable ? setIsExpanded(value => !value) : undefined)}
+      >
+        {isExpandable && <InteractionStateLayer />}
         <FileAddedRemoved>
           <FileAdded>+{file.added}</FileAdded>
           <FileRemoved>-{file.removed}</FileRemoved>
         </FileAddedRemoved>
         <FileName title={file.path}>{file.path}</FileName>
-        <Button
-          icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
-          aria-label={t('Toggle file diff')}
-          aria-expanded={isExpanded}
-          size="zero"
-          borderless
-        />
+        {isExpandable && (
+          <Button
+            icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
+            aria-label={t('Toggle file diff')}
+            aria-expanded={isExpanded}
+            size="zero"
+            borderless
+          />
+        )}
       </FileHeader>
-      {selection && (
+      {selection && previousDefaultStepIndex !== undefined && (
         <AutofixHighlightPopup
           selectedText={selection.selectedText}
           referenceElement={selection.referenceElement}
@@ -659,6 +667,7 @@ export function AutofixDiff({
   editable,
   previousDefaultStepIndex,
   previousInsightCount,
+  isExpandable = true,
 }: AutofixDiffProps) {
   if (!diff || !diff.length) {
     return null;
@@ -676,6 +685,7 @@ export function AutofixDiff({
           editable={editable}
           previousDefaultStepIndex={previousDefaultStepIndex}
           previousInsightCount={previousInsightCount}
+          isExpandable={isExpandable}
         />
       ))}
     </DiffsColumn>
@@ -696,9 +706,10 @@ const FileDiffWrapper = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
+  background-color: ${p => p.theme.background};
 `;
 
-const FileHeader = styled('div')`
+const FileHeader = styled('div')<{isExpandable?: boolean}>`
   position: relative;
   display: grid;
   align-items: center;
@@ -706,7 +717,7 @@ const FileHeader = styled('div')`
   gap: ${space(2)};
   background-color: ${p => p.theme.backgroundSecondary};
   padding: ${space(1)} ${space(2)};
-  cursor: pointer;
+  cursor: ${p => (p.isExpandable ? 'pointer' : 'default')};
 `;
 
 const FileAddedRemoved = styled('div')`

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -5,14 +5,12 @@ import {type Change, diffWords} from 'diff';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import {TextArea} from 'sentry/components/core/textarea';
-import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
 import {
   type DiffLine,
   DiffLineType,
   type FilePatch,
 } from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
-import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {DIFF_COLORS} from 'sentry/components/splitDiff';
 import {IconChevron, IconClose, IconDelete, IconEdit} from 'sentry/icons';
@@ -582,8 +580,6 @@ function FileDiff({
   runId,
   repoId,
   editable,
-  previousDefaultStepIndex,
-  previousInsightCount,
   isExpandable,
 }: {
   editable: boolean;
@@ -598,7 +594,7 @@ function FileDiff({
   const [isExpanded, setIsExpanded] = useState(true);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const selection = useTextSelection(containerRef);
+  // const selection = useTextSelection(containerRef);
 
   return (
     <FileDiffWrapper>
@@ -622,7 +618,7 @@ function FileDiff({
           />
         )}
       </FileHeader>
-      {selection && previousDefaultStepIndex !== undefined && (
+      {/* {selection && (
         <AutofixHighlightPopup
           selectedText={selection.selectedText}
           referenceElement={selection.referenceElement}
@@ -635,7 +631,7 @@ function FileDiff({
               : -1
           }
         />
-      )}
+      )} */}
       {isExpanded && (
         <DiffContainer ref={containerRef}>
           {file.hunks.map(({section_header, source_start, lines}, index) => {

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -6,6 +6,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
+import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRootCause';
 import type {AutofixInsight} from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
@@ -203,6 +204,7 @@ function AutofixInsightCard({
                     __html: singleLineRenderer(insight.insight),
                   }}
                 />
+
                 <RightSection>
                   {!isUserMessage && (
                     <Button
@@ -243,16 +245,28 @@ function AutofixInsightCard({
                   }}
                 >
                   <ContextBody>
-                    <p
-                      ref={justificationRef}
-                      dangerouslySetInnerHTML={{
-                        __html: marked(
-                          replaceHeadersWithBold(
-                            insight.justification || t('No details here.')
-                          )
-                        ),
-                      }}
-                    />
+                    {insight.justification || !insight.change_diff ? (
+                      <p
+                        ref={justificationRef}
+                        dangerouslySetInnerHTML={{
+                          __html: marked(
+                            replaceHeadersWithBold(
+                              insight.justification || t('No details here.')
+                            )
+                          ),
+                        }}
+                      />
+                    ) : (
+                      <DiffContainer>
+                        <AutofixDiff
+                          diff={insight.change_diff}
+                          groupId={groupId}
+                          runId={runId}
+                          editable={false}
+                          isExpandable={false}
+                        />
+                      </DiffContainer>
+                    )}
                   </ContextBody>
                 </motion.div>
               )}
@@ -765,6 +779,10 @@ const AddButton = styled(Button)`
     color: ${p => p.theme.pink400};
   }
   margin-right: ${space(1)};
+`;
+
+const DiffContainer = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 
 export default AutofixInsightCards;

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -131,6 +131,8 @@ export type CodeSnippetContext = {
 export type AutofixInsight = {
   insight: string;
   justification: string;
+  change_diff?: FilePatch[];
+  type?: 'insight' | 'file_change';
 };
 
 export interface AutofixDefaultStep extends BaseStep {


### PR DESCRIPTION
During the coding step, Autofix will now output insights for file edits and changes. This shows diffs in file edit insights.

![CleanShot 2025-03-31 at 15 23 48](https://github.com/user-attachments/assets/b0e618a5-999c-41e8-a089-fe80c763cf24)
