### PR TITLE
fix(billing): Gifted profile hour subtext

### DIFF
--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -139,6 +139,13 @@ export function formatReservedWithUnits(
   },
   isReservedBudget = false
 ): string {
+  if (
+    dataCategory === DataCategory.PROFILE_DURATION ||
+    dataCategory === DataCategory.PROFILE_DURATION_UI
+  ) {
+    const hours = reservedQuantity ? reservedQuantity / 3_600_000 : 0;
+    return `${hours}`;
+  }
   if (isReservedBudget) {
     return displayPriceWithCents({cents: reservedQuantity ?? 0});
   }

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -139,13 +139,6 @@ export function formatReservedWithUnits(
   },
   isReservedBudget = false
 ): string {
-  if (
-    dataCategory === DataCategory.PROFILE_DURATION ||
-    dataCategory === DataCategory.PROFILE_DURATION_UI
-  ) {
-    const hours = reservedQuantity ? reservedQuantity / 3_600_000 : 0;
-    return `${hours}`;
-  }
   if (isReservedBudget) {
     return displayPriceWithCents({cents: reservedQuantity ?? 0});
   }

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -1007,7 +1007,7 @@ describe('Subscription > UsageTotals', function () {
         category="profileDuration"
         totals={UsageTotalFixture({accepted: 15 * MILLISECONDS_IN_HOUR})}
         reservedUnits={null}
-        freeUnits={3_600_000}
+        freeUnits={50}
         prepaidUnits={150}
         subscription={subscription}
         organization={organization}
@@ -1015,7 +1015,7 @@ describe('Subscription > UsageTotals', function () {
       />
     );
 
-    expect(screen.getByTestId('gifted-profileDuration')).toHaveTextContent('1 Gifted');
+    expect(screen.getByTestId('gifted-profileDuration')).toHaveTextContent('50 Gifted');
     expect(screen.getByTestId('gifted-profileDuration')).not.toHaveTextContent(
       '0 Reserved'
     );
@@ -1027,7 +1027,7 @@ describe('Subscription > UsageTotals', function () {
         category="profileDurationUI"
         totals={UsageTotalFixture({accepted: 15 * MILLISECONDS_IN_HOUR})}
         reservedUnits={null}
-        freeUnits={7_200_000}
+        freeUnits={50}
         prepaidUnits={150}
         subscription={subscription}
         organization={organization}
@@ -1035,7 +1035,7 @@ describe('Subscription > UsageTotals', function () {
       />
     );
 
-    expect(screen.getByTestId('gifted-profileDurationUI')).toHaveTextContent('2 Gifted');
+    expect(screen.getByTestId('gifted-profileDurationUI')).toHaveTextContent('50 Gifted');
     expect(screen.getByTestId('gifted-profileDurationUI')).not.toHaveTextContent(
       '0 Reserved'
     );

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -1007,7 +1007,7 @@ describe('Subscription > UsageTotals', function () {
         category="profileDuration"
         totals={UsageTotalFixture({accepted: 15 * MILLISECONDS_IN_HOUR})}
         reservedUnits={null}
-        freeUnits={50}
+        freeUnits={3_600_000}
         prepaidUnits={150}
         subscription={subscription}
         organization={organization}
@@ -1015,7 +1015,7 @@ describe('Subscription > UsageTotals', function () {
       />
     );
 
-    expect(screen.getByTestId('gifted-profileDuration')).toHaveTextContent('50 Gifted');
+    expect(screen.getByTestId('gifted-profileDuration')).toHaveTextContent('1 Gifted');
     expect(screen.getByTestId('gifted-profileDuration')).not.toHaveTextContent(
       '0 Reserved'
     );
@@ -1027,7 +1027,7 @@ describe('Subscription > UsageTotals', function () {
         category="profileDurationUI"
         totals={UsageTotalFixture({accepted: 15 * MILLISECONDS_IN_HOUR})}
         reservedUnits={null}
-        freeUnits={50}
+        freeUnits={7_200_000}
         prepaidUnits={150}
         subscription={subscription}
         organization={organization}
@@ -1035,7 +1035,7 @@ describe('Subscription > UsageTotals', function () {
       />
     );
 
-    expect(screen.getByTestId('gifted-profileDurationUI')).toHaveTextContent('50 Gifted');
+    expect(screen.getByTestId('gifted-profileDurationUI')).toHaveTextContent('2 Gifted');
     expect(screen.getByTestId('gifted-profileDurationUI')).not.toHaveTextContent(
       '0 Reserved'
     );

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -1016,6 +1016,9 @@ describe('Subscription > UsageTotals', function () {
     );
 
     expect(screen.getByTestId('gifted-profileDuration')).toHaveTextContent('50 Gifted');
+    expect(screen.getByTestId('gifted-profileDuration')).not.toHaveTextContent(
+      '0 Reserved'
+    );
   });
 
   it('renders gifted hours for profile duration ui when gifted present', function () {
@@ -1033,6 +1036,9 @@ describe('Subscription > UsageTotals', function () {
     );
 
     expect(screen.getByTestId('gifted-profileDurationUI')).toHaveTextContent('50 Gifted');
+    expect(screen.getByTestId('gifted-profileDurationUI')).not.toHaveTextContent(
+      '0 Reserved'
+    );
   });
 });
 

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -400,15 +400,24 @@ function UsageTotals({
       reservedInfo = tct('[reservedInfo] (True Forward)', {reservedInfo});
     }
     if (displayGifts) {
-      reservedInfo = tct('[reservedInfo] + [giftedAmount] Gifted', {
-        reservedInfo,
-        giftedAmount: formatReservedWithUnits(
-          free,
-          category,
-          reservedOptions,
-          hasReservedBudget
-        ),
-      });
+      reservedInfo = hasReservedQuota
+        ? tct('[reservedInfo] + [giftedAmount] Gifted', {
+            reservedInfo,
+            giftedAmount: formatReservedWithUnits(
+              free,
+              category,
+              reservedOptions,
+              hasReservedBudget
+            ),
+          })
+        : tct('[giftedAmount] Gifted', {
+            giftedAmount: formatReservedWithUnits(
+              free,
+              category,
+              reservedOptions,
+              hasReservedBudget
+            ),
+          });
     }
     return reservedInfo;
   }


### PR DESCRIPTION
Closes: https://github.com/getsentry/getsentry/issues/17065

Removes the "0 Reserved" from the Profile Hour subtext when displaying the org's gifted units.

### Before

![Screenshot 2025-03-31 at 7 02 38 PM](https://github.com/user-attachments/assets/fa660d17-e136-4339-be8b-37ecb3d71ebd)

### After

<img width="406" alt="Screenshot 2025-04-01 at 9 20 47 AM" src="https://github.com/user-attachments/assets/9404e362-31e0-4e40-bc6a-52fcd457ec42" />

