### PR TITLE
fix(ui): pass `theme` to preview_component

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -286,7 +286,9 @@ function RegressionEvidence({event, issueType}: SpanEvidenceKeyValueListProps) {
   return data ? <PresortedKeyValueList data={data} /> : null;
 }
 
-const PREVIEW_COMPONENTS = {
+const PREVIEW_COMPONENTS: Partial<
+  Record<IssueType, (p: SpanEvidenceKeyValueListProps) => React.ReactElement | null>
+> = {
   [IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES]: NPlusOneDBQueriesSpanEvidence,
   [IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS]: NPlusOneAPICallsSpanEvidence,
   [IssueType.PERFORMANCE_SLOW_DB_QUERY]: SlowDBQueryEvidence,
@@ -340,17 +342,20 @@ export function SpanEvidenceKeyValueList({
     );
   }
 
-  const Component = (PREVIEW_COMPONENTS as any)[issueType] ?? DefaultSpanEvidence;
+  const Component = PREVIEW_COMPONENTS[issueType] ?? DefaultSpanEvidence;
 
   return (
     <ClippedBox clipHeight={300}>
       <Component
+        theme={theme}
         event={event}
         issueType={issueType}
         organization={organization}
         location={location}
         projectSlug={projectSlug}
-        {...spanInfo}
+        parentSpan={spanInfo?.parentSpan ?? null}
+        offendingSpans={spanInfo?.offendingSpans ?? []}
+        causeSpans={spanInfo?.causeSpans ?? []}
       />
     </ClippedBox>
   );


### PR DESCRIPTION
fixes Sentry issue: JAVASCRIPT-2Z0E

regression from:

- https://github.com/getsentry/sentry/pull/88206

since `PREVIEW_COMPONENTS` wasn’t typed correctly, the resulting `Component` was just `any`. That means we didn’t get a type error when `theme` wasn’t passed.

I fixed the typings, which showed some other potential issues as well, and now passing the `theme` as a prop is required.

@JonasBa FYI. Given the low trust in types (too many `any`s), it might be better to convert some of these utils to hooks and have them call `useTheme` directly rather than having them functions that get the theme as a prop if we only intend to call them from components.