### PR TITLE
ref(types): improve types of exported fields with satisfies

### DIFF
--- a/static/app/data/forms/accountNotificationSettings.tsx
+++ b/static/app/data/forms/accountNotificationSettings.tsx
@@ -4,7 +4,7 @@ import {t} from 'sentry/locale';
 // Export route to make these forms searchable by label/help
 export const route = '/settings/account/notifications/';
 
-export const fields: {[key: string]: Field} = {
+export const fields = {
   personalActivityNotifications: {
     name: 'personalActivityNotifications',
     type: 'boolean',
@@ -17,4 +17,4 @@ export const fields: {[key: string]: Field} = {
     label: t("Claim Unassigned Issues I've Resolved"),
     help: t("You'll receive notifications about any changes that happen afterwards."),
   },
-};
+} satisfies Record<string, Field>;

--- a/static/app/data/forms/projectAlerts.tsx
+++ b/static/app/data/forms/projectAlerts.tsx
@@ -9,7 +9,7 @@ const formatMinutes = (value: number | '') => {
   return tn('%s minute', '%s minutes', value);
 };
 
-export const fields: {[key: string]: Field} = {
+export const fields = {
   subjectTemplate: {
     name: 'subjectTemplate',
     type: 'string',
@@ -43,4 +43,4 @@ export const fields: {[key: string]: Field} = {
     help: t('Notifications will be delivered at least this often.'),
     formatLabel: formatMinutes,
   },
-};
+} satisfies Record<string, Field>;

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -48,7 +48,7 @@ const StyledPlatformIcon = styled(PlatformIcon)`
   margin-right: ${space(1)};
 `;
 
-export const fields: Record<string, Field> = {
+export const fields = {
   name: {
     name: 'name',
     type: 'string',
@@ -182,4 +182,4 @@ export const fields: Record<string, Field> = {
     label: t('Verify TLS/SSL'),
     help: t('Outbound requests will verify TLS (sometimes known as SSL) connections'),
   },
-};
+} satisfies Record<string, Field>;

--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -9,7 +9,7 @@ import {space} from 'sentry/styles/space';
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/issue-grouping/';
 
-export const fields: Record<string, Field> = {
+export const fields = {
   fingerprintingRules: {
     name: 'fingerprintingRules',
     type: 'string',
@@ -97,7 +97,7 @@ stack.function:mylibrary_* +app`}
     validate: () => [],
     visible: true,
   },
-};
+} satisfies Record<string, Field>;
 
 const RuleDescription = styled('div')`
   margin-bottom: ${space(1)};

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -151,13 +151,13 @@ function ProjectAlertSettings({canEditRule, params}: ProjectAlertSettingsProps) 
             <JsonForm
               disabled={!canEditRule}
               title={t('Email Settings')}
-              fields={[fields.subjectTemplate!]}
+              fields={[fields.subjectTemplate]}
             />
 
             <JsonForm
               title={t('Digests')}
               disabled={!canEditRule}
-              fields={[fields.digestsMinDelay!, fields.digestsMaxDelay!]}
+              fields={[fields.digestsMinDelay, fields.digestsMaxDelay]}
               renderHeader={() => (
                 <PanelAlert type="info">
                   {t(

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -320,12 +320,12 @@ class ProjectGeneralSettings extends DeprecatedAsyncComponent<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
-            fields={[fields.name!, projectIdField, fields.platform!]}
+            fields={[fields.name, projectIdField, fields.platform]}
           />
           <JsonForm
             {...jsonFormProps}
             title={t('Email')}
-            fields={[fields.subjectPrefix!]}
+            fields={[fields.subjectPrefix]}
           />
         </Form>
         <Hook
@@ -336,18 +336,18 @@ class ProjectGeneralSettings extends DeprecatedAsyncComponent<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Event Settings')}
-            fields={[fields.resolveAge!]}
+            fields={[fields.resolveAge]}
           />
 
           <JsonForm
             {...jsonFormProps}
             title={t('Client Security')}
             fields={[
-              fields.allowedDomains!,
-              fields.scrapeJavaScript!,
-              fields.securityToken!,
-              fields.securityTokenHeader!,
-              fields.verifySSL!,
+              fields.allowedDomains,
+              fields.scrapeJavaScript,
+              fields.securityToken,
+              fields.securityTokenHeader,
+              fields.verifySSL,
             ]}
             renderHeader={() => (
               <PanelAlert type="info">

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -92,13 +92,13 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
         <JsonForm
           {...jsonFormProps}
           title={t('Fingerprint Rules')}
-          fields={[fields.fingerprintingRules!]}
+          fields={[fields.fingerprintingRules]}
         />
 
         <JsonForm
           {...jsonFormProps}
           title={t('Stack Trace Rules')}
-          fields={[fields.groupingEnhancements!]}
+          fields={[fields.groupingEnhancements]}
         />
       </Form>
     </SentryDocumentTitle>


### PR DESCRIPTION
satisfies makes sure we adhere to a certain structure (in this case, Record<string, Field>), but it will still infer the type from what we have actually defined.

In this case, this means that it won't be a Record with an index signature, but it will rather know about the names of the defined fields. That makes sure we can access fields without doing a non-null assertion (!)