### PR TITLE
fix(spans): Avoid back pressure in the segments consumer

### DIFF
--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -44,6 +44,7 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         self.input_block_size = input_block_size
         self.output_block_size = output_block_size
         self.skip_produce = skip_produce
+        self.num_processes = num_processes
         self.pool = MultiprocessingPool(num_processes)
 
         topic_definition = get_topic_definition(Topic.SNUBA_SPANS)
@@ -66,7 +67,7 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
             # finished by the multi processing pool. We size the produce buffer
             # so that it can accommodate batches from all subprocesses at the
             # sime time, assuming some upper bound of spans per segment.
-            max_buffer_size = self.max_batch_size * self.pool.pool.num_processes * SPANS_PER_SEG_P95
+            max_buffer_size = self.max_batch_size * self.num_processes * SPANS_PER_SEG_P95
 
             produce_step = Produce(
                 producer=self.producer,

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -19,6 +19,14 @@ from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_to
 
 logger = logging.getLogger(__name__)
 
+# An amortized ceiling of spans per segment used to compute the size of the
+# produce buffer. If that buffer fills up, the consumer exercises backpressure.
+# We use the 95th percentile, since the average is much lower and equalizes over
+# the batches.
+#
+# NOTE: The true maximum is 1000 at the time of writing.
+SPANS_PER_SEG_P95 = 350
+
 
 class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(
@@ -53,10 +61,18 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         produce_step: ProcessingStrategy[FilteredPayload | KafkaPayload]
 
         if not self.skip_produce:
+            # Due to the unfold step that precedes the producer, this pipeline
+            # writes large bursts of spans at once when a batch of segments is
+            # finished by the multi processing pool. We size the produce buffer
+            # so that it can accommodate batches from all subprocesses at the
+            # sime time, assuming some upper bound of spans per segment.
+            max_buffer_size = self.max_batch_size * self.pool.pool.num_processes * SPANS_PER_SEG_P95
+
             produce_step = Produce(
                 producer=self.producer,
                 topic=self.output_topic,
                 next_step=commit_step,
+                max_buffer_size=max_buffer_size,
             )
         else:
             produce_step = commit_step


### PR DESCRIPTION
In multi processing mode, the segments consumer continuously triggered
backpressure. This is because we batch segments in the multiprocessing
step. When a batch of segments is flushed by a process, the pipeline
unfolds the spans, which immediately exhausts the produce buffer.

For example, at a batch size of 100 with 4 processes and assuming an
average of 40 spans per segment, we write up to 16k spans if all
processes finish around the same time. This already exceeds the default
buffer size of 10k.

To avoid manual tuning, we've run long-term tests and determined that
the p95 spans per segment is at 350. We use this along with the number
of processes and the batch size to compute a safer upper bound for the
produce buffer. The consumer is primarily CPU and I/O bound, so we can
afford the additional memory usage.