### PR TITLE
fix(ui): fix TextArea styling by importing inputStyles directly

### DIFF
--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -10,6 +10,9 @@ export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>,
     InputStylesProps {}
 
+export const inputStyles = (p: InputStylesProps & {theme: Theme}) =>
+  p.theme.isChonk ? chonkInputStyles(p as any) : legacyInputStyles(p);
+
 /**
  * Basic input component.
  *
@@ -36,7 +39,7 @@ export const Input = styled(
   }) => <input {...props} ref={ref} size={nativeSize} />,
   {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
 )`
-  ${p => (p.theme.isChonk ? chonkInputStyles(p as any) : inputStyles(p))}
+  ${inputStyles};
 `;
 
 export interface InputStylesProps {
@@ -47,7 +50,7 @@ export interface InputStylesProps {
   type?: React.HTMLInputTypeAttribute;
 }
 
-const inputStyles = (p: InputStylesProps & {theme: Theme}) => css`
+const legacyInputStyles = (p: InputStylesProps & {theme: Theme}) => css`
   display: block;
   width: 100%;
   color: ${p.theme.formText};

--- a/static/app/components/core/textarea/index.tsx
+++ b/static/app/components/core/textarea/index.tsx
@@ -2,7 +2,8 @@ import TextareaAutosize, {type TextareaAutosizeProps} from 'react-textarea-autos
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
-import {Input, type InputStylesProps} from 'sentry/components/core/input';
+import type {InputStylesProps} from 'sentry/components/core/input';
+import {inputStyles} from 'sentry/components/core/input';
 import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
@@ -46,9 +47,10 @@ function TextAreaControl({
 
 TextAreaControl.displayName = 'TextAreaControl';
 
-const StyledTextArea = styled(Input.withComponent(TextAreaControl), {
+const StyledTextArea = styled(TextAreaControl, {
   shouldForwardProp: (p: string) => ['autosize', 'maxRows'].includes(p) || isPropValid(p),
 })`
+  ${inputStyles};
   line-height: ${p => p.theme.text.lineHeightBody};
   /** Allow react-textarea-autosize to freely control height based on props. */
   ${p =>
@@ -57,7 +59,7 @@ const StyledTextArea = styled(Input.withComponent(TextAreaControl), {
       height: unset;
       min-height: unset;
     `}
-` as unknown as typeof TextAreaControl;
+`;
 
 export const TextArea = withChonk(
   StyledTextArea,


### PR DESCRIPTION
`Input.withComponent(TextAreaControl)` is removing props, because it uses the default `shouldForwardProp`, which means `autosize` is always missing.