### PR TITLE
fix(dashboards): Add limit suggestion to validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from enum import Enum
+from math import floor
 from typing import TypedDict
 
 import sentry_sdk
@@ -490,7 +491,23 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             and data.get("limit") is None
             and has_columns
         ):
-            raise serializers.ValidationError({"limit": "limit is required."})
+            defaultLimit = 5
+            maxLimit = 10
+            numQueries = len(data.get("queries", []))
+            numYAxes = len(data.get("queries", [])[0].get("aggregates", []))
+            limit = defaultLimit
+
+            if numQueries == 0 or numYAxes == 0:
+                limit = defaultLimit
+            else:
+                limit = floor(maxLimit / (numQueries * numYAxes))
+
+            sentry_sdk.capture_message(
+                f"Dashboard Widget limit was not set. Suggested maximum limit is {limit}."
+            )
+            raise serializers.ValidationError(
+                {"limit": f"limit is required. the maximum limit is ${limit}."}
+            )
         # Validate widget thresholds
         thresholds = data.get("thresholds")
         if thresholds:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -506,7 +506,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 f"Dashboard Widget limit was not set. Suggested maximum limit is {limit}."
             )
             raise serializers.ValidationError(
-                {"limit": f"limit is required. the maximum limit is ${limit}."}
+                {"limit": f"limit is required. The maximum limit is ${limit}."}
             )
         # Validate widget thresholds
         thresholds = data.get("thresholds")

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1276,3 +1276,57 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
 
         assert response.status_code == 200, response.data
+
+    def test_has_correct_limit_suggestion_with_muiltiple_aggregates_on_creation(self):
+        data = {
+            "title": "Test Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": ["count()", "epm()", "equation|count()*epm()"],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 400, response.data == {
+            "limit": "limit is required. the maximum limit is 3."
+        }
+
+    def test_has_correct_limit_suggestion_with_no_aggregates_on_creation(self):
+        data = {
+            "title": "Test Query",
+            "widgetType": "discover",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "columns": ["transaction"],
+                    "fields": [],
+                    "aggregates": [],
+                    "orderby": "-transaction",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 400, response.data == {
+            "limit": "limit is required. the maximum limit is 5."
+        }

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1301,7 +1301,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
 
         assert response.status_code == 400, response.data == {
-            "limit": "limit is required. the maximum limit is 3."
+            "limit": "limit is required. The maximum limit is 3."
         }
 
     def test_has_correct_limit_suggestion_with_no_aggregates_on_creation(self):
@@ -1328,5 +1328,5 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
 
         assert response.status_code == 400, response.data == {
-            "limit": "limit is required. the maximum limit is 5."
+            "limit": "limit is required. The maximum limit is 5."
         }


### PR DESCRIPTION
The SE team was hitting the limit validation errors when importing dashboards from JSON. To ease their confusion, I've added a max limit suggestion to the error message. I've also added Sentry messaging to be able to track when this error is being raised.