### PR TITLE
feat(auto_source_config): Do not process categorized frames

### DIFF
--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -22,13 +22,18 @@ def get_frames_to_process(data: NodeData | dict[str, Any], platform: str) -> lis
             if frame is None:
                 continue
 
-            if platform_config.creates_in_app_stack_trace_rules():
+            # We do not process frames that have already been categorized
+            if platform_config.creates_in_app_stack_trace_rules() and _check_not_categorized(frame):
                 frames_to_process.append(frame)
 
             elif frame.get("in_app") and frame.get("filename"):
                 frames_to_process.append(frame)
 
     return list(frames_to_process)
+
+
+def _check_not_categorized(frame: dict[str, Any]) -> bool:
+    return frame.get("data", {}).get("category") is None
 
 
 def get_stacktraces(data: NodeData | dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -84,7 +84,7 @@ class BaseDeriveCodeMappings(TestCase):
         self,
         *,  # Force keyword arguments
         repo_trees: Mapping[str, Sequence[str]],
-        frames: Sequence[Mapping[str, str | bool]],
+        frames: Sequence[Mapping[str, str | bool | Any]],
         platform: str,
         expected_new_code_mappings: Sequence[ExpectedCodeMapping] | None = None,
         expected_new_in_app_stack_trace_rules: list[str] | None = None,
@@ -185,8 +185,9 @@ class BaseDeriveCodeMappings(TestCase):
         in_app: bool | None = True,
         module: str | None = None,
         abs_path: str | None = None,
-    ) -> dict[str, str | bool]:
-        frame: dict[str, str | bool] = {}
+        category: str | None = None,
+    ) -> dict[str, str | bool | Any]:
+        frame: dict[str, str | bool | Any] = {}
         if filename:
             frame["filename"] = filename
         if module:
@@ -195,6 +196,8 @@ class BaseDeriveCodeMappings(TestCase):
             frame["abs_path"] = abs_path
         if in_app and in_app is not None:
             frame["in_app"] = in_app
+        if category:
+            frame["data"] = {"category": category}
         return frame
 
     def code_mapping(
@@ -784,3 +787,31 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
         # The enhancements now contain the automatic rule (+app) and the developer's rule (-app)
         assert event.data["grouping_config"]["enhancements"] != first_enhancements_base64_string
         assert event.data["grouping_config"]["enhancements"] != second_enhancements_hash
+
+    def test_categorized_frames_are_not_processed(self) -> None:
+        # Even though the file is in the repo, it's not processed because it's categorized as internals
+        repo_trees = {REPO1: ["src/android/app/Activity.java"]}
+        frame = self.frame(module="android.app.Activity", abs_path="Activity.java", in_app=False)
+        with (
+            patch(f"{CLIENT}.get_tree", side_effect=create_mock_get_tree(repo_trees)),
+            patch(f"{CLIENT}.get_remaining_api_requests", return_value=500),
+            patch(
+                f"{REPO_TREES_INTEGRATION}._populate_repositories",
+                return_value=mock_populate_repositories(),
+            ),
+        ):
+            event = self.create_event([frame], self.platform)
+            dry_run_code_mappings, in_app_stack_trace_rules = process_event(
+                self.project.id, event.group_id, event.event_id
+            )
+            assert dry_run_code_mappings == []
+            assert in_app_stack_trace_rules == []
+
+            # If we remove the category, it will be processed
+            with patch(f"{CODE_ROOT}.stacktraces._check_not_categorized", return_value=True):
+                event = self.create_event([frame], self.platform)
+                dry_run_code_mappings, in_app_stack_trace_rules = process_event(
+                    self.project.id, event.group_id, event.event_id
+                )
+                assert dry_run_code_mappings != []
+                assert in_app_stack_trace_rules != []

--- a/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
+++ b/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
@@ -71,6 +71,20 @@ BASIC_FRAME = {"in_app": True, "filename": "foo"}
             ],
             id="python_paths",
         ),
+        pytest.param(
+            [
+                # This frame is excluded because it has already been categorized
+                {"module": "android.app", "in_app": False, "data": {"category": "foo"}},
+                {"module": "com.example.foo", "in_app": False, "data": {}},
+                {"module": "com.example.bar", "in_app": False},
+            ],
+            "java",
+            [
+                {"module": "com.example.foo", "in_app": False, "data": {}},
+                {"module": "com.example.bar", "in_app": False},
+            ],
+            id="java_module_with_category",
+        ),
     ],
 )
 def test_get_frames_to_process(


### PR DESCRIPTION
A developer may clone an Android sample app, thus, we can end up creating a code mapping and stack trace rule for it.

This change prevents attempting to create code mappings and stack trace rules for frames we have already categorized with our internal rules.

In other words, only non-categorized frames will be attempted.