### PR TITLE
fix(nav): Adjust primary nav item label text styles

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -298,8 +298,8 @@ const NavLinkLabel = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: ${p => p.theme.fontSizeExtraSmall};
-  margin-top: ${space(0.25)};
+  font-size: 10px;
+  font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 export const NavButton = styled('button', {


### PR DESCRIPTION
Bolder, smaller, less spacing from icon

Before and after:

![CleanShot 2025-04-01 at 08 34 16@2x](https://github.com/user-attachments/assets/f0f92125-d488-44a6-9ba3-82fde6b0ceb0)![CleanShot 2025-04-01 at 08 33 19@2x](https://github.com/user-attachments/assets/b8a4586a-e923-4323-964c-98f04ae0d7c8)


