### PR TITLE
feat(span-metrics): alias `sentry.normalized_description` to `span.description`

### DIFF
--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -29,6 +29,7 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
         # text search use case so that it searches the `span.description`
         # when the user performs a free text search
         "message": "span.description",
+        "sentry.normalized_description": "span.description",
     }
 
     @property

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -29,6 +29,8 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
         # text search use case so that it searches the `span.description`
         # when the user performs a free text search
         "message": "span.description",
+        # This is to assist in the eap migration,
+        # span.description in span metrics is sentry.normalized_description in eap
         "sentry.normalized_description": "span.description",
     }
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -2310,6 +2310,46 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["dataset"] == "spansMetrics"
         assert meta["fields"]["trace_error_rate()"] == "percentage"
 
+    def test_normalized_description(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "http", "span.description": "f"},
+        )
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "db", "span.description": "e"},
+        )
+        self.store_span_metric(
+            5,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "db", "span.description": "e"},
+        )
+        response = self.do_request(
+            {
+                "field": ["sentry.normalized_description", "avg(span.self_time)"],
+                "query": "",
+                "orderby": ["-avg(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 2
+        assert data[0]["avg(span.self_time)"] == 4.0
+        assert data[0]["sentry.normalized_description"] == "e"
+        assert data[1]["avg(span.self_time)"] == 1.0
+        assert data[1]["sentry.normalized_description"] == "f"
+        meta = response.data["meta"]
+        assert meta["fields"]["sentry.normalized_description"] == "string"
+        assert meta["dataset"] == "spansMetrics"
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
EAP has the fields
1. `sentry.normalized_description` for the parameterized description.
2. `span.description` for the full description.

Span metrics has
1. `span.description` for the parameterized description.

Span indexed has
1. `span.description` for the full description

Therefore once we migrate to the eap dataset, we can't use `span.description` to retrieve the parameterized description, before we were able to because it lived on a different dataset.
To make the migration to EAP easier, we can create an alias from `sentry.normalized_description` to `span.description` in `spansMetrics`, and update the frontend to query for `sentry.normalized_description` when `dataset=spansMetrics`