### PR TITLE
fix(DDM): removes problematic option queries

### DIFF
--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -1,10 +1,8 @@
 from typing import Any
 
-from sentry import options
 from sentry.metrics.base import MetricsBackend, Tags
 from sentry.metrics.dummy import DummyMetricsBackend
 from sentry.metrics.minimetrics import MiniMetricsMetricsBackend
-from sentry.options import UnknownOption
 from sentry.utils.imports import import_string
 
 __all__ = ["CompositeExperimentalMetricsBackend"]
@@ -35,11 +33,10 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
 
     @staticmethod
     def _minimetrics_sample_rate() -> float:
-        try:
-            # We want to control the sample rate of minimetrics independently of the primary backend's sample rate.
-            return options.get("delightful_metrics.minimetrics_sample_rate")
-        except UnknownOption:
-            return 0.0
+        # Previously bound to options.get("delightful_metrics.minimetrics_sample_rate")
+        # but this option check was resulting in excessive cache misses somehow.
+
+        return 0.0
 
     def incr(
         self,

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -36,7 +36,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         # Previously bound to options.get("delightful_metrics.minimetrics_sample_rate")
         # but this option check was resulting in excessive cache misses somehow.
 
-        return 0.0
+        return 1.0
 
     def incr(
         self,


### PR DESCRIPTION
Removes option query for minimetrics sample rate due to excessive options queries.

For some reason, this option check is resulting in cache misses in our control silo and needs to be removed.
