### PR TITLE
:wrench: chore: finish up sentry app config and cleanup

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -28,8 +28,11 @@ class WorkflowEngineActionSerializer(Serializer):
         target_identifier = obj.config.get("target_identifier")
         target_display = obj.config.get("target_display")
 
-        sentry_app_id = obj.data.get("sentry_app_id")
-        sentry_app_config = obj.data.get("sentry_app_config")
+        sentry_app_id = None
+        sentry_app_config = None
+        if obj.type == Action.Type.SENTRY_APP.value:
+            sentry_app_id = int(obj.config.get("target_identifier"))
+            sentry_app_config = obj.data.get("settings")
 
         result = {
             "id": str(aarta.alert_rule_trigger_action.id),

--- a/src/sentry/workflow_engine/handlers/action/notification/common.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/common.py
@@ -1,24 +1,5 @@
 from sentry.notifications.models.notificationaction import ActionTarget
 
-# TODO(iamrajjoshi): This should be removed once I define the config schemas for each action type
-GENERIC_ACTION_CONFIG_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "The configuration schema for Notification Actions",
-    "type": "object",
-    "properties": {
-        "target_identifier": {
-            "type": ["string", "null"],
-        },
-        "target_display": {
-            "type": ["string", "null"],
-        },
-        "target_type": {
-            "type": ["integer", "null"],
-            "enum": [*ActionTarget] + [None],
-        },
-    },
-}
-
 MESSAGING_ACTION_CONFIG_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "The configuration schema for a Messaging Action",
@@ -59,33 +40,5 @@ ONCALL_ACTION_CONFIG_SCHEMA = {
         },
     },
     "required": ["target_identifier", "target_type"],
-    "additionalProperties": False,
-}
-
-EMAIL_ACTION_CONFIG_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "The configuration schema for an email Action",
-    "type": "object",
-    "properties": {
-        "target_identifier": {"type": ["string", "null"]},
-        "target_display": {"type": ["null"]},
-        "target_type": {
-            "type": ["integer"],
-            "enum": [*ActionTarget],
-        },
-    },
-    "required": ["target_type"],
-    "additionalProperties": False,
-}
-
-EMAIL_ACTION_DATA_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "fallthroughType": {
-            "type": "string",
-            "description": "The fallthrough type for issue owners email notifications",
-        },
-    },
     "additionalProperties": False,
 }

--- a/src/sentry/workflow_engine/handlers/action/notification/email_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/email_handler.py
@@ -1,8 +1,5 @@
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
-from sentry.workflow_engine.handlers.action.notification.common import (
-    EMAIL_ACTION_CONFIG_SCHEMA,
-    EMAIL_ACTION_DATA_SCHEMA,
-)
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
@@ -10,8 +7,33 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 @action_handler_registry.register(Action.Type.EMAIL)
 class EmailActionHandler(ActionHandler):
-    config_schema = EMAIL_ACTION_CONFIG_SCHEMA
-    data_schema = EMAIL_ACTION_DATA_SCHEMA
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for an email Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {"type": ["string", "null"]},
+            "target_display": {"type": ["null"]},
+            "target_type": {
+                "type": ["integer"],
+                "enum": [*ActionTarget],
+            },
+        },
+        "required": ["target_type"],
+        "additionalProperties": False,
+    }
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "fallthroughType": {
+                "type": "string",
+                "description": "The fallthrough type for issue owners email notifications",
+            },
+        },
+        "additionalProperties": False,
+    }
+
     group = ActionHandler.Group.NOTIFICATION
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/action/notification/plugin_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/plugin_handler.py
@@ -1,5 +1,4 @@
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
-from sentry.workflow_engine.handlers.action.notification.common import GENERIC_ACTION_CONFIG_SCHEMA
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
@@ -9,7 +8,23 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 class PluginActionHandler(ActionHandler):
     group = ActionHandler.Group.OTHER
 
-    config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for Plugin Actions",
+        "type": "object",
+        "properties": {
+            "target_identifier": {
+                "type": ["string", "null"],
+            },
+            "target_display": {
+                "type": ["string", "null"],
+            },
+            "target_type": {
+                "type": ["integer", "null"],
+                "enum": [None],
+            },
+        },
+    }
     data_schema = {}
 
     @staticmethod

--- a/src/sentry/workflow_engine/handlers/action/notification/sentry_app_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/sentry_app_handler.py
@@ -1,16 +1,42 @@
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
-from sentry.workflow_engine.handlers.action.notification.common import GENERIC_ACTION_CONFIG_SCHEMA
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @action_handler_registry.register(Action.Type.SENTRY_APP)
 class SentryAppActionHandler(ActionHandler):
     group = ActionHandler.Group.OTHER
 
-    config_schema = GENERIC_ACTION_CONFIG_SCHEMA
-    data_schema = {}
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Sentry App Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {"type": ["string"]},
+            "target_display": {"type": ["string", "null"]},
+            "target_type": {
+                "type": ["integer"],
+                "enum": [ActionTarget.SENTRY_APP.value],
+            },
+            "sentry_app_identifier": {
+                "type": ["string"],
+                "enum": [*SentryAppIdentifier],
+            },
+        },
+        "required": ["target_type", "target_identifier", "sentry_app_identifier"],
+        "additionalProperties": False,
+    }
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "settings": {"type": ["array", "object"]},
+        },
+        "additionalProperties": False,
+    }
 
     @staticmethod
     def execute(

--- a/src/sentry/workflow_engine/handlers/action/notification/webhook_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/webhook_handler.py
@@ -1,5 +1,4 @@
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
-from sentry.workflow_engine.handlers.action.notification.common import GENERIC_ACTION_CONFIG_SCHEMA
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
@@ -9,7 +8,23 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 class WebhookActionHandler(ActionHandler):
     group = ActionHandler.Group.OTHER
 
-    config_schema = GENERIC_ACTION_CONFIG_SCHEMA
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for Webhook Actions",
+        "type": "object",
+        "properties": {
+            "target_identifier": {
+                "type": ["string"],
+            },
+            "target_display": {
+                "type": ["null"],
+            },
+            "target_type": {
+                "type": ["integer", "null"],
+                "enum": [None],
+            },
+        },
+    }
     data_schema = {}
 
     @staticmethod

--- a/tests/sentry/incidents/serializers/test_workflow_engine_action.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_action.py
@@ -10,6 +10,7 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @freeze_time("2018-12-11 03:21:34")
@@ -77,10 +78,10 @@ class TestActionSerializer(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": str(sentry_app.id),
                 "target_display": sentry_app.name,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
             data={
-                "sentry_app_config": self.sentry_app_trigger_action.sentry_app_config,
-                "sentry_app_id": sentry_app.id,
+                "settings": self.sentry_app_trigger_action.sentry_app_config,
             },
         )
         ActionAlertRuleTriggerAction.objects.create(
@@ -96,7 +97,7 @@ class TestActionSerializer(TestCase):
         assert serialized_action["targetType"] == "sentry_app"
         assert serialized_action["targetIdentifier"] == sentry_app.id
         assert serialized_action["sentryAppId"] == sentry_app.id
-        assert serialized_action["settings"] == self.sentry_app_action.data["sentry_app_config"]
+        assert serialized_action["settings"] == self.sentry_app_action.data["settings"]
 
         serialized_alert_rule_trigger_action = serialize(
             self.sentry_app_trigger_action, self.user, AlertRuleTriggerActionSerializer()

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -598,6 +598,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": target_id,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
         blob = self.handler.build_rule_action_blob(action, self.organization.id)
@@ -618,6 +619,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": target_id,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
@@ -644,6 +646,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": self.sentry_app_installation.uuid,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
         blob = self.handler.build_rule_action_blob(action, self.organization.id)
@@ -664,6 +667,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": self.sentry_app_installation2.uuid,
                 "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
@@ -684,7 +688,11 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
 
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
-            config={"target_identifier": target_id},
+            config={
+                "target_identifier": target_id,
+                "target_type": ActionTarget.SENTRY_APP.value,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+            },
         )
 
         # sentry app with no settings
@@ -699,7 +707,11 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
 
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
-            config={"target_identifier": target_id},
+            config={
+                "target_identifier": target_id,
+                "target_type": ActionTarget.SENTRY_APP.value,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+            },
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
 


### PR DESCRIPTION
i realized we were using the generic schema in a couple places, so removed it and made it specific to the actions that were still using it.

i also moved email action stuff from common to its own file
