### PR TITLE
chore(HC): Re-adds logging with a low sample rate for cache hits/misses on options

### DIFF
--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -9,6 +9,7 @@ from typing import Any
 from django.conf import settings
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils import timezone
+from sentry_sdk.integrations.logging import ignore_logger
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.options.manager import UpdateChannel
@@ -16,7 +17,12 @@ from sentry.options.manager import UpdateChannel
 CACHE_FETCH_ERR = "Unable to fetch option cache for %s"
 CACHE_UPDATE_ERR = "Unable to update option cache for %s"
 
-logger = logging.getLogger("sentry")
+OPTIONS_LOGGER_NAME = "sentry.options_store"
+
+logger = logging.getLogger(OPTIONS_LOGGER_NAME)
+# Our SDK logging integration will create a circular dependency due to its
+# reliance on options, so we need to ignore it.
+ignore_logger(OPTIONS_LOGGER_NAME)
 
 
 @dataclasses.dataclass

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -104,8 +104,8 @@ class OptionsStore:
             return result
 
         if should_log:
-            # Log 1% of our cache misses for option retrieval to help triage
-            # excessive queries against the store.
+            # Log some percentage of our cache misses for option retrieval to
+            # help triage excessive queries against the store.
             logger.info(
                 "sentry_options_store.cache_miss",
                 extra={"key": key.name, "cache_configured": self.cache is not None},


### PR DESCRIPTION
Re-adds logging with a very low sample rate to gauge how well we're caching our options.
