### PR TITLE
fix(nav): Fix project settings routes in new navigation

### DIFF
--- a/static/app/views/nav/secondary/sections/settings/settingsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/settings/settingsSecondaryNav.tsx
@@ -1,8 +1,18 @@
+import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import OrganizationSettingsNavigation from 'sentry/views/settings/organization/organizationSettingsNavigation';
+import ProjectSettingsNavigation from 'sentry/views/settings/project/projectSettingsNavigation';
 
 export function SettingsSecondaryNav() {
   const organization = useOrganization();
+  const params = useParams();
 
-  return <OrganizationSettingsNavigation organization={organization} />;
+  const isProjectSettings = defined(params.projectId);
+
+  return isProjectSettings ? (
+    <ProjectSettingsNavigation organization={organization} />
+  ) : (
+    <OrganizationSettingsNavigation organization={organization} />
+  );
 }

--- a/static/app/views/nav/useActiveNavGroup.spec.tsx
+++ b/static/app/views/nav/useActiveNavGroup.spec.tsx
@@ -27,31 +27,48 @@ describe('useActiveNavGroup', function () {
     return <div>{activeNavGroup}</div>;
   }
 
-  it('correctly matches when using customer domain', async function () {
-    render(<TestComponent />, {
-      disableRouterMocks: true,
-      initialRouterConfig: {
-        location: {
-          pathname: '/explore/traces/trace/123/',
+  describe('customer domain', function () {
+    it.each([
+      [PrimaryNavGroup.ISSUES, '/issues/foo/'],
+      [PrimaryNavGroup.EXPLORE, '/explore/foo/'],
+      [PrimaryNavGroup.DASHBOARDS, '/dashboards/foo/'],
+      [PrimaryNavGroup.INSIGHTS, '/insights/foo/'],
+      [PrimaryNavGroup.SETTINGS, '/settings/foo/'],
+      [PrimaryNavGroup.PIPELINE, '/pipeline/foo/'],
+    ])('correctly matches %s nav group', async function (navGroup, path) {
+      render(<TestComponent />, {
+        disableRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: path,
+          },
         },
-      },
-    });
+      });
 
-    expect(await screen.findByText(PrimaryNavGroup.EXPLORE)).toBeInTheDocument();
+      expect(await screen.findByText(navGroup)).toBeInTheDocument();
+    });
   });
 
-  it('correctly matches when not using customer domain', async function () {
-    mockUsingCustomerDomain.mockReturnValue(false);
-
-    render(<TestComponent />, {
-      disableRouterMocks: true,
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/explore/traces/trace/123/',
+  describe('non-customer domain', function () {
+    it.each([
+      [PrimaryNavGroup.ISSUES, '/organizations/org-slug/issues/foo/'],
+      [PrimaryNavGroup.EXPLORE, '/organizations/org-slug/explore/foo/'],
+      [PrimaryNavGroup.DASHBOARDS, '/organizations/org-slug/dashboards/foo/'],
+      [PrimaryNavGroup.INSIGHTS, '/organizations/org-slug/insights/foo/'],
+      [PrimaryNavGroup.SETTINGS, '/organizations/org-slug/settings/foo/'],
+      [PrimaryNavGroup.PIPELINE, '/organizations/org-slug/pipeline/foo/'],
+    ])('correctly matches %s nav group', async function (navGroup, path) {
+      mockUsingCustomerDomain.mockReturnValue(false);
+      render(<TestComponent />, {
+        disableRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: path,
+          },
         },
-      },
-    });
+      });
 
-    expect(await screen.findByText(PrimaryNavGroup.EXPLORE)).toBeInTheDocument();
+      expect(await screen.findByText(navGroup)).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/nav/useActiveNavGroup.tsx
+++ b/static/app/views/nav/useActiveNavGroup.tsx
@@ -1,7 +1,6 @@
-import {useLocation} from 'react-router-dom';
-
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import {unreachable} from 'sentry/utils/unreachable';
+import {useLocation} from 'sentry/utils/useLocation';
 import {PRIMARY_NAV_GROUP_PATHS} from 'sentry/views/nav/constants';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -1,3 +1,5 @@
+import {useParams} from 'react-router-dom';
+
 import {trackAnalytics} from 'sentry/utils/analytics';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -6,6 +8,7 @@ import type {NavigationGroupProps} from 'sentry/views/settings/types';
 
 function SettingsNavigationGroup(props: NavigationGroupProps) {
   const {organization, project, name, items} = props;
+  const params = useParams();
 
   const navLinks = items.map(({path, title, index, show, badge, id, recordAnalytics}) => {
     if (typeof show === 'function' && !show(props)) {
@@ -15,10 +18,7 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
       return null;
     }
     const badgeResult = typeof badge === 'function' ? badge(props) : null;
-    const to = replaceRouterParams(path, {
-      ...(organization ? {orgId: organization.slug} : {}),
-      ...(project ? {projectId: project.slug} : {}),
-    });
+    const to = replaceRouterParams(path, {...params, orgId: organization?.slug});
 
     const handleClick = () => {
       // only call the analytics event if the URL is changing

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -1,7 +1,6 @@
-import {useParams} from 'react-router-dom';
-
 import {trackAnalytics} from 'sentry/utils/analytics';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+import {useParams} from 'sentry/utils/useParams';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import SettingsNavItem from 'sentry/views/settings/components/settingsNavItem';
 import type {NavigationGroupProps} from 'sentry/views/settings/types';

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, isValidElement} from 'react';
+import {cloneElement, isValidElement} from 'react';
 
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
@@ -31,25 +31,16 @@ function InnerProjectSettingsLayout({
   const organization = useOrganization();
   const prefersStackedNav = usePrefersStackedNav();
 
-  if (prefersStackedNav) {
-    return (
-      <Fragment>
-        <ProjectSettingsNavigation organization={organization} />
-        <SettingsLayout params={params} routes={routes} {...props}>
-          {children && isValidElement(children)
-            ? cloneElement<any>(children, {organization, project})
-            : children}
-        </SettingsLayout>
-      </Fragment>
-    );
-  }
-
   return (
     <SettingsLayout
       params={params}
       routes={routes}
       {...props}
-      renderNavigation={() => <ProjectSettingsNavigation organization={organization} />}
+      renderNavigation={
+        prefersStackedNav
+          ? undefined
+          : () => <ProjectSettingsNavigation organization={organization} />
+      }
     >
       {children && isValidElement(children)
         ? cloneElement<any>(children, {organization, project})


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/88368 caused an issue with project settings routes, where double navs were being rendered because I forgot to relocate the nav rendering on the settings route. This relocates that from the settings layout to SecondarySettingsNav and updates some tests.