### PR TITLE
fix(issue-list): Fix the issue list header label from first seen -> last seen

### DIFF
--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -31,14 +31,14 @@ function GroupListHeader({
         <Fragment>
           <NarrowIssueWrapper hideDivider>{t('Issue')}</NarrowIssueWrapper>
           {withColumns.includes('lastSeen') && (
-            <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
+            <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
               {t('Last Seen')}
-            </FirstSeenWrapper>
+            </LastSeenWrapper>
           )}
           {withColumns.includes('firstSeen') && (
-            <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
+            <AgeWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
               {t('Age')}
-            </LastSeenWrapper>
+            </AgeWrapper>
           )}
           {withColumns.includes('lastTriggered') && (
             <NarrowLastTriggeredLabel align="right">
@@ -128,11 +128,11 @@ const NarrowIssueWrapper = styled(GroupListHeaderLabel)`
   padding-left: ${space(2)};
 `;
 
-const FirstSeenWrapper = styled(GroupListHeaderLabel)`
+const LastSeenWrapper = styled(GroupListHeaderLabel)`
   width: 80px;
 `;
 
-const LastSeenWrapper = styled(GroupListHeaderLabel)`
+const AgeWrapper = styled(GroupListHeaderLabel)`
   width: 50px;
 `;
 

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -30,13 +30,13 @@ function GroupListHeader({
       {hasNewLayout ? (
         <Fragment>
           <NarrowIssueWrapper hideDivider>{t('Issue')}</NarrowIssueWrapper>
-          {withColumns.includes('firstSeen') && (
-            <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
-              {t('First Seen')}
+          {withColumns.includes('lastSeen') && (
+            <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
+              {t('Last Seen')}
             </FirstSeenWrapper>
           )}
-          {withColumns.includes('lastSeen') && (
-            <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
+          {withColumns.includes('firstSeen') && (
+            <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
               {t('Age')}
             </LastSeenWrapper>
           )}


### PR DESCRIPTION
For issue list components (outside of the issue stream), the header was mistakenly labeling last seen as first seen. Now fixed:

![CleanShot 2025-04-01 at 11 40 43](https://github.com/user-attachments/assets/6f3cf792-906a-4396-b580-5bb0dde00874)
