### PR TITLE
fix(tours): Avoid conflicting guides on issue details

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -33,6 +33,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export interface BreadcrumbsDataSectionProps {
   event: Event;
@@ -47,6 +48,7 @@ export default function BreadcrumbsDataSection({
   project,
   initialCollapse,
 }: BreadcrumbsDataSectionProps) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const {closeDrawer, isDrawerOpen, openDrawer} = useDrawer();
@@ -157,7 +159,7 @@ export default function BreadcrumbsDataSection({
       key="breadcrumbs"
       type={SectionKey.BREADCRUMBS}
       title={
-        <GuideAnchor target="breadcrumbs" position="top">
+        <GuideAnchor target="breadcrumbs" position="top" disabled={hasStreamlinedUI}>
           {t('Breadcrumbs')}
         </GuideAnchor>
       }

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -21,6 +21,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import type {CommonSidebarProps} from './types';
@@ -40,6 +41,7 @@ export function OnboardingStatus({
   const {mutate: mutateUserOptions} = useMutateUserOptions();
   const {activateSidebar} = useOnboardingSidebar();
   const organization = useOrganization();
+  const hasStreamlinedUI = useHasStreamlinedUI();
   const {shouldAccordionFloat} = useContext(ExpandedContext);
   const [quickStartCompleted, setQuickStartCompleted] = useLocalStorageState(
     `quick-start:${organization.slug}:completed`,
@@ -138,7 +140,7 @@ export function OnboardingStatus({
   }
 
   return (
-    <GuideAnchor target="onboarding_sidebar" position="right">
+    <GuideAnchor target="onboarding_sidebar" position="right" disabled={hasStreamlinedUI}>
       <Container
         role="button"
         aria-label={label}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -248,7 +248,8 @@ export function EventDetailsContent({
               !(
                 defined(eventEntries[EntryType.EXCEPTION]) ||
                 defined(eventEntries[EntryType.STACKTRACE]) ||
-                defined(eventEntries[EntryType.THREADS])
+                defined(eventEntries[EntryType.THREADS]) ||
+                hasStreamlinedUI
               )
             }
             // Prevent the container span from shrinking the content

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Flex} from 'sentry/components/container/flex';
 import {LinkButton} from 'sentry/components/core/button';
@@ -156,9 +155,7 @@ export default function StreamlinedGroupHeader({
           {issueTypeConfig.eventAndUserCounts.enabled && (
             <Fragment>
               <StatCount value={eventCount} aria-label={t('Event count')} />
-              <GuideAnchor target="issue_header_stats">
-                <StatCount value={userCount} aria-label={t('User count')} />
-              </GuideAnchor>
+              <StatCount value={userCount} aria-label={t('User count')} />
             </Fragment>
           )}
           <Flex gap={space(1)} align="center">
@@ -212,16 +209,14 @@ export default function StreamlinedGroupHeader({
               {t('Priority')}
               <GroupPriority group={group} />
             </Workflow>
-            <GuideAnchor target="issue_sidebar_owners" position="left">
-              <Workflow>
-                {t('Assignee')}
-                <GroupHeaderAssigneeSelector
-                  group={group}
-                  project={project}
-                  event={event}
-                />
-              </Workflow>
-            </GuideAnchor>
+            <Workflow>
+              {t('Assignee')}
+              <GroupHeaderAssigneeSelector
+                group={group}
+                project={project}
+                event={event}
+              />
+            </Workflow>
           </WorkflowActions>
         </ActionBar>
       </TourElement>

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import * as SidebarSection from 'sentry/components/sidebarSection';
@@ -63,9 +62,7 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       position={isBottomSidebar ? 'top' : 'left-start'}
     >
       <Side>
-        <GuideAnchor target="issue_sidebar_releases" position="left">
-          <FirstLastSeenSection group={group} />
-        </GuideAnchor>
+        <FirstLastSeenSection group={group} />
         <StyledBreak />
         {((organization.features.includes('gen-ai-features') &&
           issueTypeConfig.issueSummary.enabled &&


### PR DESCRIPTION
The legacy tour overlapped with the new one in a few places. This PR addresses that:

1. If a new component is used on the streamline UI, delete the GuideAnchor
2. If they use the same component, disable the GuideAnchor with the streamline UI flag

I went and did this for all the guide anchors in the current issue tour, found here https://github.com/getsentry/sentry/blob/master/static/app/components/assistant/getGuidesContent.tsx#L17