### PR TITLE
:wrench: chore(aci): loosen sentry app config schema

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -698,12 +698,14 @@ class SentryAppFormConfigDataBlob(DataBlob):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SentryAppFormConfigDataBlob:
-        if not isinstance(data.get("name"), str) or not isinstance(data.get("value"), str):
+        if not isinstance(data.get("name"), str) or not isinstance(
+            data.get("value"), (str, type(None))
+        ):
             raise ValueError("Sentry app config must contain name and value keys")
         return cls(name=data["name"], value=data["value"], label=data.get("label"))
 
     name: str = ""
-    value: str = ""
+    value: str | None = ""
     label: str | None = None
 
 


### PR DESCRIPTION
when @mifu67  ran dry runs for the metric alert migration - we found that we saved a couple sentry_config `value` keys as `None`, when they shouldn't be. the hunch is that it is because the user unset a form value at some point in time, and instead of removing the key, we set it to be None.

wrote a test to verify