### PR TITLE
feat(grouping-settings): Show super user the derived grouping enhancements information

### DIFF
--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -97,6 +97,34 @@ stack.function:mylibrary_* +app`}
     validate: () => [],
     visible: true,
   },
+  derivedGroupingEnhancements: {
+    name: 'derivedGroupingEnhancements',
+    type: 'string',
+    label: 'Derived Grouping Enhancements (staff only)',
+    hideLabel: true,
+    placeholder: '',
+    multiline: true,
+    monospace: true,
+    autosize: true,
+    inline: false,
+    maxRows: 20,
+    saveOnBlur: false,
+    saveMessageAlertType: 'info',
+    saveMessage: '',
+    formatMessageValue: false,
+    help: () => (
+      <Fragment>
+        <RuleDescription>
+          These rules are automatically derived for some languages for customers that have
+          the GitHub integration and the language has been marked to derive in-app rules.
+          These rules are not editable but they can be negated by adding their own rules
+          in the Stack Trace Rules section.
+        </RuleDescription>
+      </Fragment>
+    ),
+    validate: () => [],
+    visible: true,
+  },
 } satisfies Record<string, Field>;
 
 const RuleDescription = styled('div')`

--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -100,7 +100,7 @@ stack.function:mylibrary_* +app`}
   derivedGroupingEnhancements: {
     name: 'derivedGroupingEnhancements',
     type: 'string',
-    label: 'Derived Grouping Enhancements (staff only)',
+    label: 'Derived Grouping Enhancements (super user only)',
     hideLabel: true,
     placeholder: '',
     multiline: true,

--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -113,14 +113,12 @@ stack.function:mylibrary_* +app`}
     saveMessage: '',
     formatMessageValue: false,
     help: () => (
-      <Fragment>
         <RuleDescription>
           These rules are automatically derived for some languages for customers that have
           the GitHub integration and the language has been marked to derive in-app rules.
           These rules are not editable but they can be negated by adding their own rules
           in the Stack Trace Rules section.
         </RuleDescription>
-      </Fragment>
     ),
     validate: () => [],
     visible: true,

--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -113,12 +113,12 @@ stack.function:mylibrary_* +app`}
     saveMessage: '',
     formatMessageValue: false,
     help: () => (
-        <RuleDescription>
-          These rules are automatically derived for some languages for customers that have
-          the GitHub integration and the language has been marked to derive in-app rules.
-          These rules are not editable but they can be negated by adding their own rules
-          in the Stack Trace Rules section.
-        </RuleDescription>
+      <RuleDescription>
+        These rules are automatically derived for some languages for customers that have
+        the GitHub integration and the language has been marked to derive in-app rules.
+        These rules are not editable but they can be negated by adding their own rules in
+        the Stack Trace Rules section.
+      </RuleDescription>
     ),
     validate: () => [],
     visible: true,

--- a/static/app/views/settings/projectIssueGrouping/index.spec.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.spec.tsx
@@ -1,11 +1,14 @@
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import ProjectIssueGrouping from 'sentry/views/settings/projectIssueGrouping';
+
+jest.mock('sentry/utils/isActiveSuperuser', () => ({
+  isActiveSuperuser: jest.fn(),
+}));
 
 describe('projectIssueGrouping', () => {
   const {organization, projects} = initializeOrg();
@@ -72,12 +75,11 @@ describe('projectIssueGrouping', () => {
     expect(await screen.findByText('Issue Grouping')).toBeInTheDocument();
     expect(screen.queryByText(/Derived Grouping Enhancements/)).not.toBeInTheDocument();
 
-    // Re-render with a superuser
-    ConfigStore.set('user', UserFixture({isSuperuser: true, isStaff: true}));
-    const orgWithSuperUser = {...organization, user: {isSuperuser: true}};
+    // Re-render for superuser
+    jest.mocked(isActiveSuperuser).mockReturnValue(true);
     rerender(
       <ProjectIssueGrouping
-        organization={orgWithSuperUser}
+        organization={organization}
         project={project}
         {...RouteComponentPropsFixture()}
       />

--- a/static/app/views/settings/projectIssueGrouping/index.spec.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.spec.tsx
@@ -1,8 +1,10 @@
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import ProjectIssueGrouping from 'sentry/views/settings/projectIssueGrouping';
 
 describe('projectIssueGrouping', () => {
@@ -48,5 +50,40 @@ describe('projectIssueGrouping', () => {
     expect(
       await screen.findByText('Failed to load grouping configs')
     ).toBeInTheDocument();
+  });
+
+  it('shows derived grouping enhancements only for superusers', async () => {
+    // Mock the API response
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/grouping-configs/`,
+      body: [],
+    });
+
+    // First render with a non-superuser
+    const {rerender} = render(
+      <ProjectIssueGrouping
+        organization={organization}
+        project={project}
+        {...RouteComponentPropsFixture()}
+      />
+    );
+
+    // Verify the section is not visible for non-superuser
+    expect(await screen.findByText('Issue Grouping')).toBeInTheDocument();
+    expect(screen.queryByText(/Derived Grouping Enhancements/)).not.toBeInTheDocument();
+
+    // Re-render with a superuser
+    ConfigStore.set('user', UserFixture({isSuperuser: true, isStaff: true}));
+    const orgWithSuperUser = {...organization, user: {isSuperuser: true}};
+    rerender(
+      <ProjectIssueGrouping
+        organization={orgWithSuperUser}
+        project={project}
+        {...RouteComponentPropsFixture()}
+      />
+    );
+
+    // Verify the section is visible for superuser
+    expect(screen.getByText(/Derived Grouping Enhancements/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -100,6 +100,12 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
           title={t('Stack Trace Rules')}
           fields={[fields.groupingEnhancements]}
         />
+
+        <JsonForm
+          {...jsonFormProps}
+          title={t('Derived Grouping Enhancements')}
+          fields={[fields.derivedGroupingEnhancements!]}
+        />
       </Form>
     </SentryDocumentTitle>
   );

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -12,6 +12,7 @@ import type {EventGroupingConfig} from 'sentry/types/event';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -50,6 +51,7 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
   const endpoint = `/projects/${organization.slug}/${project.slug}/`;
 
   const access = new Set(organization.access.concat(project.access));
+  const activeSuperUser = isActiveSuperuser();
   const hasAccess = hasEveryAccess(['project:write'], {organization, project});
 
   const jsonFormProps = {
@@ -101,11 +103,13 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
           fields={[fields.groupingEnhancements]}
         />
 
-        <JsonForm
-          {...jsonFormProps}
-          title={t('Derived Grouping Enhancements')}
-          fields={[fields.derivedGroupingEnhancements!]}
-        />
+        {activeSuperUser && (
+          <JsonForm
+            {...jsonFormProps}
+            title={t('Derived Grouping Enhancements')}
+            fields={[fields.derivedGroupingEnhancements!]}
+          />
+        )}
       </Form>
     </SentryDocumentTitle>
   );


### PR DESCRIPTION
This will help if we need to debug automatically derived in-app stack trace rules.
This will only show when the user is signed in as a superuser.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/eca8e2ea-4f7c-4fe6-9217-93bbc9259e3b" />
