### PR TITLE
fix(taskworker) Remove usage of Task.signature() and Task.s()

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1161,14 +1161,14 @@ def _trigger_incident_triggers(incident: Incident) -> None:
         for action in actions:
             for project in incident.projects.all():
                 transaction.on_commit(
-                    handle_trigger_action.s(
+                    lambda: handle_trigger_action.delay(
                         action_id=action.id,
                         incident_id=incident.id,
                         project_id=project.id,
                         method="resolve",
                         new_status=IncidentStatus.CLOSED.value,
-                    ).delay,
-                    router.db_for_write(AlertRuleTrigger),
+                    ),
+                    using=router.db_for_write(AlertRuleTrigger),
                 )
 
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1161,13 +1161,13 @@ def _trigger_incident_triggers(incident: Incident) -> None:
         for action in actions:
             for project in incident.projects.all():
                 transaction.on_commit(
-                    lambda: handle_trigger_action.delay(
+                    handle_trigger_action.s(
                         action_id=action.id,
                         incident_id=incident.id,
                         project_id=project.id,
                         method="resolve",
                         new_status=IncidentStatus.CLOSED.value,
-                    ),
+                    ).delay,
                     using=router.db_for_write(AlertRuleTrigger),
                 )
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -787,14 +787,14 @@ class SubscriptionProcessor:
         # Schedule the actions to be fired
         for action in actions_to_fire:
             transaction.on_commit(
-                lambda: handle_trigger_action.delay(
+                handle_trigger_action.s(
                     action_id=action.id,
                     incident_id=incident.id,
                     project_id=self.subscription.project_id,
                     method=method,
                     new_status=new_status,
                     metric_value=metric_value,
-                ),
+                ).delay,
                 using=router.db_for_write(AlertRule),
             )
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -787,15 +787,15 @@ class SubscriptionProcessor:
         # Schedule the actions to be fired
         for action in actions_to_fire:
             transaction.on_commit(
-                handle_trigger_action.s(
+                lambda: handle_trigger_action.delay(
                     action_id=action.id,
                     incident_id=incident.id,
                     project_id=self.subscription.project_id,
                     method=method,
                     new_status=new_status,
                     metric_value=metric_value,
-                ).delay,
-                router.db_for_write(AlertRule),
+                ),
+                using=router.db_for_write(AlertRule),
             )
 
         if features.has("organizations:metric-issue-poc", self.alert_rule.organization):

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -15,7 +15,7 @@ def process_message(message: Message[KafkaPayload]) -> None:
     sampled = is_sampled(message.payload.headers)
 
     if sampled or options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
-        process_profile_task.s(payload=message.payload.value, sampled=sampled).apply_async()
+        process_profile_task.delay(payload=message.payload.value, sampled=sampled)
 
 
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -60,7 +60,7 @@ def test_bad_config():
         process_one_message(consumer_type="profiles", topic="profiles", payload=PROFILES_MSG)
 
 
-@patch("sentry.profiles.consumers.process.factory.process_profile_task.s")
+@patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
 @override_options(
     {
         "backpressure.checking.enabled": True,
@@ -133,7 +133,7 @@ def test_backpressure_healthy_events(preprocess_event):
     preprocess_event.assert_called_once()
 
 
-@patch("sentry.profiles.consumers.process.factory.process_profile_task.s")
+@patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
 @override_options(
     {
         "backpressure.checking.enabled": False,

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -20,7 +20,7 @@ class TestProcessProfileConsumerStrategy(TestCase):
     def processing_factory():
         return ProcessProfileStrategyFactory()
 
-    @patch("sentry.profiles.consumers.process.factory.process_profile_task.s")
+    @patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
     def test_basic_profile_to_celery(self, process_profile_task):
         processing_strategy = self.processing_factory().create_with_partitions(
             commit=Mock(), partitions=None


### PR DESCRIPTION
Remove usage of these celery features where we don't need to be using them.

Refs #88088