### PR TITLE
fix(spans-metrics): has filter not working with `column_remapping` alias

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -775,7 +775,7 @@ class MetricsQueryBuilder(BaseQueryBuilder):
             return self.resolve_metric_index(value)
 
     def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        name = search_filter.key.name
+        name = self.column_remapping.get(search_filter.key.name, search_filter.key.name)
         operator = search_filter.operator
         value = search_filter.value.value
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -2332,7 +2332,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         response = self.do_request(
             {
                 "field": ["sentry.normalized_description", "avg(span.self_time)"],
-                "query": "",
+                "query": "has:sentry.normalized_description",
                 "orderby": ["-avg(span.self_time)"],
                 "project": self.project.id,
                 "dataset": "spansMetrics",


### PR DESCRIPTION
I noticed after this PR https://github.com/getsentry/sentry/pull/88447
The `has` filter doesn't work for `column_remapping` in spans metrics. This PR fixes that issue