### PR TITLE
fix(nav): Fix nav on dashboard details page

### DIFF
--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -1,25 +1,4 @@
-import {t} from 'sentry/locale';
-import {PrimaryNavGroup} from 'sentry/views/nav/types';
-
 export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
-
-export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
-  [PrimaryNavGroup.ISSUES]: t('Issues'),
-  [PrimaryNavGroup.EXPLORE]: t('Explore'),
-  [PrimaryNavGroup.DASHBOARDS]: t('Dashboards'),
-  [PrimaryNavGroup.INSIGHTS]: t('Insights'),
-  [PrimaryNavGroup.SETTINGS]: t('Settings'),
-  [PrimaryNavGroup.PIPELINE]: t('Pipeline'),
-};
-
-export const PRIMARY_NAV_GROUP_PATHS = {
-  [PrimaryNavGroup.ISSUES]: 'issues' as const,
-  [PrimaryNavGroup.EXPLORE]: 'explore' as const,
-  [PrimaryNavGroup.DASHBOARDS]: 'dashboards' as const,
-  [PrimaryNavGroup.INSIGHTS]: 'insights' as const,
-  [PrimaryNavGroup.SETTINGS]: 'settings' as const,
-  [PrimaryNavGroup.PIPELINE]: 'pipeline' as const,
-} satisfies Record<PrimaryNavGroup, string>;
 
 export const PRIMARY_SIDEBAR_WIDTH = 66;
 export const SECONDARY_SIDEBAR_WIDTH = 190;

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -298,7 +298,7 @@ const NavLinkLabel = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 

--- a/static/app/views/nav/primary/config.tsx
+++ b/static/app/views/nav/primary/config.tsx
@@ -1,0 +1,39 @@
+import {t} from 'sentry/locale';
+import {PrimaryNavGroup} from 'sentry/views/nav/types';
+
+type PrimaryNavGroupConfig = Record<
+  PrimaryNavGroup,
+  {
+    basePaths: string[];
+    label: string;
+  }
+>;
+
+export const PRIMARY_NAV_GROUP_CONFIG: PrimaryNavGroupConfig = {
+  [PrimaryNavGroup.ISSUES]: {
+    basePaths: ['issues'],
+    label: t('Issues'),
+  },
+  [PrimaryNavGroup.EXPLORE]: {
+    basePaths: ['explore'],
+    label: t('Explore'),
+  },
+  [PrimaryNavGroup.DASHBOARDS]: {
+    // XXX: Dashboard uses the singular `dashboard` path for details pages
+    // but the plural `dashboards` path for the list of dashboards.
+    basePaths: ['dashboards', 'dashboard'],
+    label: t('Dashboards'),
+  },
+  [PrimaryNavGroup.INSIGHTS]: {
+    basePaths: ['insights'],
+    label: t('Insights'),
+  },
+  [PrimaryNavGroup.SETTINGS]: {
+    basePaths: ['settings'],
+    label: t('Settings'),
+  },
+  [PrimaryNavGroup.PIPELINE]: {
+    basePaths: ['pipeline'],
+    label: t('Pipeline'),
+  },
+};

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -14,9 +14,9 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import {SeparatorItem, SidebarLink} from 'sentry/views/nav/primary/components';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {PrimaryNavigationHelp} from 'sentry/views/nav/primary/help';
 import {PrimaryNavigationOnboarding} from 'sentry/views/nav/primary/onboarding';
 import {PrimaryNavigationServiceIncidents} from 'sentry/views/nav/primary/serviceIncidents';
@@ -57,7 +57,7 @@ export function PrimaryNavigationItems() {
           <SidebarLink
             to={`/${prefix}/issues/`}
             analyticsKey="issues"
-            label={NAV_GROUP_LABELS[PrimaryNavGroup.ISSUES]}
+            label={PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.ISSUES].label}
           >
             <IconIssues />
           </SidebarLink>
@@ -76,7 +76,7 @@ export function PrimaryNavigationItems() {
             }
             activeTo={`/${prefix}/explore`}
             analyticsKey="explore"
-            label={NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
+            label={PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.EXPLORE].label}
           >
             <IconSearch />
           </SidebarLink>
@@ -98,7 +98,7 @@ export function PrimaryNavigationItems() {
               analyticsKey="dashboards"
               label={
                 layout === NavLayout.MOBILE
-                  ? NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]
+                  ? PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.DASHBOARDS].label
                   : t('Dash')
               }
             >
@@ -117,7 +117,7 @@ export function PrimaryNavigationItems() {
               to={`/${prefix}/insights/frontend/`}
               activeTo={`/${prefix}/insights`}
               analyticsKey="insights"
-              label={NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
+              label={PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.INSIGHTS].label}
             >
               <IconGraph type="area" />
             </SidebarLink>
@@ -135,7 +135,7 @@ export function PrimaryNavigationItems() {
             to={`/${prefix}/settings/${organization.slug}/`}
             activeTo={`/${prefix}/settings/`}
             analyticsKey="settings"
-            label={NAV_GROUP_LABELS[PrimaryNavGroup.SETTINGS]}
+            label={PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.SETTINGS].label}
           >
             <IconSettings />
           </SidebarLink>

--- a/static/app/views/nav/secondary/secondaryMobile.tsx
+++ b/static/app/views/nav/secondary/secondaryMobile.tsx
@@ -4,8 +4,8 @@ import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {useActiveNavGroup} from 'sentry/views/nav/useActiveNavGroup';
 
 type Props = {
@@ -26,7 +26,9 @@ export function SecondaryMobile({handleClickBack}: Props) {
           size="xs"
           borderless
         />
-        <HeaderLabel>{activeGroup ? NAV_GROUP_LABELS[activeGroup] : ''}</HeaderLabel>
+        <HeaderLabel>
+          {activeGroup ? PRIMARY_NAV_GROUP_CONFIG[activeGroup].label : ''}
+        </HeaderLabel>
       </GroupHeader>
       <ContentWrapper ref={setSecondaryNavEl} />
     </SecondaryMobileWrapper>

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
@@ -27,7 +27,7 @@ export function DashboardsSecondaryNav() {
   return (
     <SecondaryNav>
       <SecondaryNav.Header>
-        {NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.DASHBOARDS].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section>

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -1,7 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
@@ -12,7 +12,7 @@ export function ExploreSecondaryNav() {
   return (
     <SecondaryNav>
       <SecondaryNav.Header>
-        {NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.EXPLORE].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section>

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -26,7 +26,7 @@ import {
   MOBILE_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
@@ -75,7 +75,7 @@ export function InsightsSecondaryNav() {
   return (
     <SecondaryNav>
       <SecondaryNav.Header>
-        {NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.INSIGHTS].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section>

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -7,9 +7,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewNavItems} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
 import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
+import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function IssuesSecondaryNav() {
   const organization = useOrganization();
@@ -35,7 +37,9 @@ export function IssuesSecondaryNav() {
 
   return (
     <SecondaryNav>
-      <SecondaryNav.Header>{t('Issues')}</SecondaryNav.Header>
+      <SecondaryNav.Header>
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.ISSUES].label}
+      </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section>
           <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="issues_feed">

--- a/static/app/views/nav/secondary/sections/pipeline/pipelineSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/pipeline/pipelineSecondaryNav.tsx
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 import {makePipelinePathname} from 'sentry/views/pipeline/pathnames';
@@ -20,7 +20,7 @@ function PipelineSecondaryNav() {
   return (
     <SecondaryNav>
       <SecondaryNav.Header>
-        {NAV_GROUP_LABELS[PrimaryNavGroup.PIPELINE]}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.PIPELINE].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section>

--- a/static/app/views/nav/useActiveNavGroup.spec.tsx
+++ b/static/app/views/nav/useActiveNavGroup.spec.tsx
@@ -31,7 +31,8 @@ describe('useActiveNavGroup', function () {
     it.each([
       [PrimaryNavGroup.ISSUES, '/issues/foo/'],
       [PrimaryNavGroup.EXPLORE, '/explore/foo/'],
-      [PrimaryNavGroup.DASHBOARDS, '/dashboards/foo/'],
+      [PrimaryNavGroup.DASHBOARDS, '/dashboards/'],
+      [PrimaryNavGroup.DASHBOARDS, '/dashboard/foo/'],
       [PrimaryNavGroup.INSIGHTS, '/insights/foo/'],
       [PrimaryNavGroup.SETTINGS, '/settings/foo/'],
       [PrimaryNavGroup.PIPELINE, '/pipeline/foo/'],
@@ -53,7 +54,8 @@ describe('useActiveNavGroup', function () {
     it.each([
       [PrimaryNavGroup.ISSUES, '/organizations/org-slug/issues/foo/'],
       [PrimaryNavGroup.EXPLORE, '/organizations/org-slug/explore/foo/'],
-      [PrimaryNavGroup.DASHBOARDS, '/organizations/org-slug/dashboards/foo/'],
+      [PrimaryNavGroup.DASHBOARDS, '/organizations/org-slug/dashboards/'],
+      [PrimaryNavGroup.DASHBOARDS, '/organizations/org-slug/dashboard/foo/'],
       [PrimaryNavGroup.INSIGHTS, '/organizations/org-slug/insights/foo/'],
       [PrimaryNavGroup.SETTINGS, '/organizations/org-slug/settings/foo/'],
       [PrimaryNavGroup.PIPELINE, '/organizations/org-slug/pipeline/foo/'],

--- a/static/app/views/nav/useActiveNavGroup.tsx
+++ b/static/app/views/nav/useActiveNavGroup.tsx
@@ -1,13 +1,12 @@
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
-import {unreachable} from 'sentry/utils/unreachable';
 import {useLocation} from 'sentry/utils/useLocation';
-import {PRIMARY_NAV_GROUP_PATHS} from 'sentry/views/nav/constants';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 const CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX = /^\/([^\/]+)/;
 const NON_CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX = /^\/organizations\/[^\/]+\/([^\/]+)/;
 
-const getPrimaryRoutePath = (path: string) => {
+const getPrimaryRoutePath = (path: string): string | undefined => {
   if (USING_CUSTOMER_DOMAIN) {
     return path.match(CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX)?.[1];
   }
@@ -18,29 +17,17 @@ const getPrimaryRoutePath = (path: string) => {
 export function useActiveNavGroup(): PrimaryNavGroup {
   const location = useLocation();
 
-  const primaryPath = getPrimaryRoutePath(location.pathname) as
-    | (typeof PRIMARY_NAV_GROUP_PATHS)[keyof typeof PRIMARY_NAV_GROUP_PATHS]
-    | undefined;
+  const primaryPath = getPrimaryRoutePath(location.pathname);
 
   if (!primaryPath) {
     return PrimaryNavGroup.ISSUES;
   }
 
-  switch (primaryPath) {
-    case PRIMARY_NAV_GROUP_PATHS.issues:
-      return PrimaryNavGroup.ISSUES;
-    case PRIMARY_NAV_GROUP_PATHS.explore:
-      return PrimaryNavGroup.EXPLORE;
-    case PRIMARY_NAV_GROUP_PATHS.dashboards:
-      return PrimaryNavGroup.DASHBOARDS;
-    case PRIMARY_NAV_GROUP_PATHS.insights:
-      return PrimaryNavGroup.INSIGHTS;
-    case PRIMARY_NAV_GROUP_PATHS.settings:
-      return PrimaryNavGroup.SETTINGS;
-    case PRIMARY_NAV_GROUP_PATHS.pipeline:
-      return PrimaryNavGroup.PIPELINE;
-    default:
-      unreachable(primaryPath);
-      return PrimaryNavGroup.ISSUES;
+  for (const [navGroup, config] of Object.entries(PRIMARY_NAV_GROUP_CONFIG)) {
+    if (config.basePaths.includes(primaryPath)) {
+      return navGroup as PrimaryNavGroup;
+    }
   }
+
+  return PrimaryNavGroup.ISSUES;
 }

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {space} from 'sentry/styles/space';
-import {NAV_GROUP_LABELS} from 'sentry/views/nav/constants';
 import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 import SettingsNavigationGroup from 'sentry/views/settings/components/settingsNavigationGroup';
@@ -45,7 +45,7 @@ function SettingsSecondaryNavigation({
   return (
     <SecondaryNav>
       <SecondaryNav.Header>
-        {NAV_GROUP_LABELS[PrimaryNavGroup.SETTINGS]}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.SETTINGS].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         {navWithHooks.map(config => (


### PR DESCRIPTION
The dashboard routes are a bit weird because they use `/dashboards/` for the list and `/dashboard/` for the details pages. The new `useActiveNavGroup()` hook was not handling this correctly.

While fixing this I merged the route and label configs into a single object (`PRIMARY_NAV_GROUP_CONFIG`).