### PR TITLE
fix(schema-hints): Add border to schema hints drawer search bar

### DIFF
--- a/static/app/views/explore/components/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHintsDrawer.tsx
@@ -223,6 +223,7 @@ export const useSchemaHintsOnLargeScreen = () => {
 
 const SchemaHintsHeader = styled('h4')`
   margin: 0;
+  flex-shrink: 0;
 `;
 
 const StyledDrawerBody = styled(DrawerBody)`
@@ -234,6 +235,7 @@ const HeaderContainer = styled('div')`
   justify-content: space-between;
   align-items: center;
   margin-bottom: ${space(2)};
+  gap: ${space(1.5)};
 `;
 
 const CheckboxLabelContainer = styled('div')`
@@ -307,7 +309,6 @@ const VirtualOffset = styled('div')<{offset: number}>`
 `;
 
 const SearchInput = styled(InputGroup.Input)`
-  border: 0;
   box-shadow: unset;
   color: inherit;
 `;


### PR DESCRIPTION
Addresses [this bug](https://www.notion.so/sentry/Search-bar-in-Filter-Attributes-drawer-should-be-highlighted-as-default-1c08b10e4b5d801a93b7d5b7e76dbfef?pvs=4) and [this](https://www.notion.so/sentry/Filter-Attributes-in-one-line-1c08b10e4b5d8045b435fbe369b5b430?pvs=4). It has a border now yay

![image](https://github.com/user-attachments/assets/47473da5-7ec1-4833-bfb7-198284458437)

