### PR TITLE
feat(dashboards): Add `onHighlight` support to plottables

### DIFF
--- a/static/app/utils/number/rangeMap.tsx
+++ b/static/app/utils/number/rangeMap.tsx
@@ -49,10 +49,14 @@ export class RangeMap<T> {
     this.ranges = sortedRanges;
   }
 
-  get(value: number) {
+  getRange(value: number): Range<T> | undefined {
     return this.ranges.find(r => {
       return value >= r.min && value < r.max;
-    })?.value;
+    });
+  }
+
+  get(value: number): T | undefined {
+    return this.getRange(value)?.value;
   }
 
   get min() {

--- a/static/app/utils/tabularData/shiftTabularDataToNow.tsx
+++ b/static/app/utils/tabularData/shiftTabularDataToNow.tsx
@@ -1,0 +1,25 @@
+import type {TabularData} from 'sentry/views/dashboards/widgets/common/types';
+
+export function shiftTabularDataToNow(tabularData: TabularData): TabularData {
+  const currentTimestamp = Date.now();
+
+  const lastDatum = tabularData.data.at(-1);
+  if (!lastDatum) {
+    return tabularData;
+  }
+
+  if (!tabularData.data.every(datum => !!datum.timestamp)) {
+    return tabularData;
+  }
+
+  const lastTimeStampInData = new Date(lastDatum.timestamp!).getTime();
+  const diff = currentTimestamp - lastTimeStampInData;
+
+  return {
+    ...tabularData,
+    data: tabularData.data.map(datum => ({
+      ...datum,
+      timestamp: new Date(new Date(datum.timestamp!).getTime() + diff).toISOString(),
+    })),
+  };
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -1,27 +1,67 @@
+import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
 
 import LineSeries from 'sentry/components/charts/series/lineSeries';
+import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 import {splitSeriesIntoCompleteAndIncomplete} from 'sentry/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete';
 import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 
+import type {TimeSeries} from '../../common/types';
+
 import {
   ContinuousTimeSeries,
+  type ContinuousTimeSeriesConfig,
   type ContinuousTimeSeriesPlottingOptions,
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
 
+const {error} = Sentry.logger;
+
 export class Area extends ContinuousTimeSeries implements Plottable {
+  #completeTimeSeries?: TimeSeries;
+  #incompleteTimeSeries?: TimeSeries;
+
+  constructor(timeSeries: TimeSeries, config?: ContinuousTimeSeriesConfig) {
+    super(timeSeries, config);
+
+    const [completeTimeSeries, incompleteTimeSeries] =
+      splitSeriesIntoCompleteAndIncomplete(timeSeries, config?.delay ?? 0);
+
+    this.#completeTimeSeries = completeTimeSeries;
+    this.#incompleteTimeSeries = incompleteTimeSeries;
+  }
+
   constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
     return new Area(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
   }
+
+  onHighlight(dataIndex: number): void {
+    const {config = {}} = this;
+    // The incomplete series prepends the final data point from the complete
+    // series. This causes off-by-one errors with `seriesDataIndex`, since the
+    // complete series has one more data points than we'd expect. Account for
+    // this by reconstructing the data points from the split series
+    const mergedData = [
+      ...(this.#completeTimeSeries?.data ?? []),
+      ...(this.#incompleteTimeSeries?.data ?? []),
+    ];
+
+    const datum = mergedData.at(dataIndex);
+
+    if (!datum) {
+      error('`Area` plottable `onHighlight` out-of-range error', {
+        seriesDataIndex: dataIndex,
+      });
+      return;
+    }
+
+    config.onHighlight?.(datum);
+  }
+
   toSeries(plottingOptions: ContinuousTimeSeriesPlottingOptions): LineSeriesOption[] {
     const {config = {}} = this;
 
     const color = plottingOptions.color ?? config.color ?? undefined;
-    const scaledSeries = this.scaleToUnit(plottingOptions.unit);
-
-    const [completeTimeSeries, incompleteTimeSeries] =
-      splitSeriesIntoCompleteAndIncomplete(scaledSeries, config.delay ?? 0);
 
     const plottableSeries: LineSeriesOption[] = [];
 
@@ -32,7 +72,7 @@ export class Area extends ContinuousTimeSeries implements Plottable {
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
     };
 
-    if (completeTimeSeries) {
+    if (this.#completeTimeSeries) {
       plottableSeries.push(
         LineSeries({
           ...commonOptions,
@@ -41,17 +81,23 @@ export class Area extends ContinuousTimeSeries implements Plottable {
             color,
             opacity: 1.0,
           },
-          data: completeTimeSeries.data.map(timeSeriesItemToEChartsDataPoint),
+          data: scaleTimeSeriesData(
+            this.#completeTimeSeries,
+            plottingOptions.unit
+          ).data.map(timeSeriesItemToEChartsDataPoint),
         })
       );
     }
 
-    if (incompleteTimeSeries) {
+    if (this.#incompleteTimeSeries) {
       plottableSeries.push(
         LineSeries({
           ...commonOptions,
           stack: 'incomplete',
-          data: incompleteTimeSeries.data.map(timeSeriesItemToEChartsDataPoint),
+          data: scaleTimeSeriesData(
+            this.#incompleteTimeSeries,
+            plottingOptions.unit
+          ).data.map(timeSeriesItemToEChartsDataPoint),
           lineStyle: {
             type: 'dotted',
           },

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -22,6 +22,10 @@ export type ContinuousTimeSeriesConfig = {
    * Data delay, in seconds. Data older than N seconds will be visually deemphasized.
    */
   delay?: number;
+  /**
+   * Callback for ECharts' `onHighlight`. Called with the data point that corresponds to the highlighted point in the chart
+   */
+  onHighlight?: (datum: Readonly<TimeSeries['data'][number]>) => void;
 };
 
 export type ContinuousTimeSeriesPlottingOptions = {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -1,27 +1,67 @@
+import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
 
 import LineSeries from 'sentry/components/charts/series/lineSeries';
+import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 import {splitSeriesIntoCompleteAndIncomplete} from 'sentry/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete';
 import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 
+import type {TimeSeries} from '../../common/types';
+
 import {
   ContinuousTimeSeries,
+  type ContinuousTimeSeriesConfig,
   type ContinuousTimeSeriesPlottingOptions,
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
 
+const {error} = Sentry.logger;
+
 export class Line extends ContinuousTimeSeries implements Plottable {
+  #completeTimeSeries?: TimeSeries;
+  #incompleteTimeSeries?: TimeSeries;
+
+  constructor(timeSeries: TimeSeries, config?: ContinuousTimeSeriesConfig) {
+    super(timeSeries, config);
+
+    const [completeTimeSeries, incompleteTimeSeries] =
+      splitSeriesIntoCompleteAndIncomplete(timeSeries, config?.delay ?? 0);
+
+    this.#completeTimeSeries = completeTimeSeries;
+    this.#incompleteTimeSeries = incompleteTimeSeries;
+  }
+
   constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
     return new Line(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
   }
+
+  onHighlight(seriesDataIndex: number): void {
+    const {config = {}} = this;
+    // The incomplete series prepends the final data point from the complete
+    // series. This causes off-by-one errors with `seriesDataIndex`, since the
+    // complete series has one more data points than we'd expect. Account for
+    // this by reconstructing the data points from the split series
+    const mergedData = [
+      ...(this.#completeTimeSeries?.data ?? []),
+      ...(this.#incompleteTimeSeries?.data ?? []),
+    ];
+
+    const datum = mergedData.at(seriesDataIndex);
+
+    if (!datum) {
+      error('`Line` plottable `onHighlight` out-of-range error', {
+        seriesDataIndex,
+      });
+      return;
+    }
+
+    config.onHighlight?.(datum);
+  }
+
   toSeries(plottingOptions: ContinuousTimeSeriesPlottingOptions) {
     const {config = {}} = this;
 
     const color = plottingOptions.color ?? config.color ?? undefined;
-    const scaledSeries = this.scaleToUnit(plottingOptions.unit);
-
-    const [completeTimeSeries, incompleteTimeSeries] =
-      splitSeriesIntoCompleteAndIncomplete(scaledSeries, config.delay ?? 0);
 
     const plottableSeries: LineSeriesOption[] = [];
 
@@ -32,20 +72,26 @@ export class Line extends ContinuousTimeSeries implements Plottable {
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
     };
 
-    if (completeTimeSeries) {
+    if (this.#completeTimeSeries) {
       plottableSeries.push(
         LineSeries({
           ...commonOptions,
-          data: completeTimeSeries.data.map(timeSeriesItemToEChartsDataPoint),
+          data: scaleTimeSeriesData(
+            this.#completeTimeSeries,
+            plottingOptions.unit
+          ).data.map(timeSeriesItemToEChartsDataPoint),
         })
       );
     }
 
-    if (incompleteTimeSeries) {
+    if (this.#incompleteTimeSeries) {
       plottableSeries.push(
         LineSeries({
           ...commonOptions,
-          data: incompleteTimeSeries.data.map(timeSeriesItemToEChartsDataPoint),
+          data: scaleTimeSeriesData(
+            this.#incompleteTimeSeries,
+            plottingOptions.unit
+          ).data.map(timeSeriesItemToEChartsDataPoint),
           lineStyle: {
             type: 'dotted',
           },

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -48,4 +48,8 @@ export interface Plottable {
    * Optional label for this plottable, if it appears in the legend and in tooltips.
    */
   label?: string;
+  /**
+   * `TimeSeriesWidgetVisualization` will call this function if the user highlights (via mouse, or imperatively) a point on a series that originated from this plottable.
+   */
+  onHighlight?: (dataIndex: number) => void;
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -428,6 +428,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
   });
 
   story('Samples', () => {
+    const [sampleId, setSampleId] = useState<string>();
+
     const timeSeriesPlottable = useMemo(() => {
       return new Bars(shiftTimeSeriesToNow(sampleDurationTimeSeries), {
         delay: 1800,
@@ -440,6 +442,9 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         attributeName: 'p99(span.duration)',
         baselineValue: 175,
         baselineLabel: 'Average',
+        onHighlight: row => {
+          setSampleId(row.id);
+        },
       });
     }, []);
 
@@ -451,6 +456,13 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           below, we plot a set of span duration samples on top of an aggregate series of
           the 99th percentile of those durations. Samples that are faster than a baseline
           are green, samples that are slower are red.
+        </p>
+
+        <p>
+          <code>Samples</code> supports the <code>onHighlight</code> configuration option.
+          It's a callback, called whenever a sample is highlighted by bringing the X axis
+          cursor near its timestamp. e.g., here's the sample ID of the most recent
+          highlighted sample: {sampleId}
         </p>
 
         <MediumWidget>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
@@ -11,6 +11,7 @@ import storyBook from 'sentry/stories/storyBook';
 import type {DateString} from 'sentry/types/core';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {shiftTabularDataToNow} from 'sentry/utils/tabularData/shiftTabularDataToNow';
 import {shiftTimeSeriesToNow} from 'sentry/utils/timeSeries/shiftTimeSeriesToNow';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 
@@ -427,6 +428,21 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
   });
 
   story('Samples', () => {
+    const timeSeriesPlottable = useMemo(() => {
+      return new Bars(shiftTimeSeriesToNow(sampleDurationTimeSeries), {
+        delay: 1800,
+      });
+    }, []);
+
+    const samplesPlottable = useMemo(() => {
+      return new Samples(shiftTabularDataToNow(spanSamplesWithDurations), {
+        alias: 'Span Samples',
+        attributeName: 'p99(span.duration)',
+        baselineValue: 175,
+        baselineLabel: 'Average',
+      });
+    }, []);
+
     return (
       <Fragment>
         <p>
@@ -439,15 +455,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
 
         <MediumWidget>
           <TimeSeriesWidgetVisualization
-            plottables={[
-              new Line(sampleDurationTimeSeries),
-              new Samples(spanSamplesWithDurations, {
-                alias: 'Span Samples',
-                attributeName: 'p99(span.duration)',
-                baselineValue: 175,
-                baselineLabel: 'Average',
-              }),
-            ]}
+            plottables={[timeSeriesPlottable, samplesPlottable]}
           />
         </MediumWidget>
       </Fragment>


### PR DESCRIPTION
All plottables can have an `onHighlight` configuration option. If passed, it'll call the callback with the original data point that is responsible for that plotted point. Mapping from series highlights to original data is a little complicated, so I added a bunch of line annotations for how it works.

Closes [DAIN-123: Add an `onHighlight` support to `Plottable` objects](https://linear.app/getsentry/issue/DAIN-123/add-an-onhighlight-support-to-plottable-objects)

## Functional Changes

`Area` and `Line` plottables now split the dataset into complete and incomplete at instantiation time, not at render time. This makes it possible to then do a reverse lookup, and figure out the split when highlighting.

`onHighlight` callback in all plottables accepts an offset index, which they can use the look up the corresponding data.

`TimeSeriesWidgetVisualization` correctly calculates a `dataIndex` and an offset and passes it to any `Plottable` that is involved in a `"highlight"` event