### PR TITLE
chore(issue summary): Update Slack alert design

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -504,24 +504,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         parts = []
 
-        if whats_wrong := self.issue_summary.get("whatsWrong"):
-            parts.append(
-                ISSUE_SUMMARY_TO_EMOJI.get("whatsWrong", "*What's Wrong:*")
-                + " "
-                + escape_slack_markdown_asterisks(whats_wrong)
-            )
-        if trace := self.issue_summary.get("trace"):
-            parts.append(
-                ISSUE_SUMMARY_TO_EMOJI.get("trace", "*In the Trace:*")
-                + " "
-                + escape_slack_markdown_asterisks(trace)
-            )
         if possible_cause := self.issue_summary.get("possibleCause"):
-            parts.append(
-                ISSUE_SUMMARY_TO_EMOJI.get("possibleCause", "*Possible Cause:*")
-                + " "
-                + escape_slack_markdown_asterisks(possible_cause)
-            )
+            parts.append(escape_slack_markdown_asterisks(possible_cause))
 
         if not parts:
             return None
@@ -641,7 +625,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # Use issue summary if available, otherwise use the default text
         if summary_text := self.get_issue_summary_text():
+            original_title = build_attachment_title(event_or_group)
+            original_message = text.lstrip(" ")
+
+            blocks.append(self.get_divider())
+            blocks.append(
+                self.get_text_block(f"*{original_title}*: `{original_message}`", small=True)
+            )
             blocks.append(self.get_text_block(summary_text, small=True))
+            blocks.append(self.get_divider())
         else:
             text = text.lstrip(" ")
             # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -574,7 +574,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 footer_text = footer_text[:-4]  # chop off the empty space
 
             if self.issue_summary:
-                footer_text += f"    {ISSUE_SUMMARY_TO_EMOJI.get('seer')} Revealed by Seer"
+                footer_text += f"    {ISSUE_SUMMARY_TO_EMOJI.get('seer')} Powered by Seer"
 
             return self.get_context_block(text=footer_text)
         else:

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -39,8 +39,5 @@ ACTIONED_CATEGORY_TO_EMOJI = {
 }
 
 ISSUE_SUMMARY_TO_EMOJI = {
-    "whatsWrong": ":skull:",
-    "trace": ":link:",
-    "possibleCause": ":dart:",
     "seer": ":eye:",
 }

--- a/src/sentry/integrations/slack/utils/escape.py
+++ b/src/sentry/integrations/slack/utils/escape.py
@@ -33,9 +33,9 @@ def escape_slack_markdown_text(txt: str | None) -> str:
 
 def escape_slack_markdown_asterisks(txt: str | None) -> str:
     """
-    Removes pairs of double asterisks with pairs of single asterisks.
+    Removes pairs of double asterisks.
     """
     if not txt:
         return ""
 
-    return re.sub(r"\*\*(.*?)\*\*", r"*\1*", txt)
+    return re.sub(r"\*\*(.*?)\*\*", r"\1", txt)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -879,19 +879,16 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
             # Verify that the AI title is used
             assert "Custom AI Title" in blocks["blocks"][0]["text"]["text"]
+
             # Verify that the original title is not present
             assert "IntegrationError" not in blocks["blocks"][0]["text"]["text"]
 
             # Verify that the AI content is used in the context block
-            content_block = blocks["blocks"][1]["elements"][0]["text"]
-            assert ":skull:" in content_block
-            assert "This is what's wrong with the issue" in content_block
-            assert ":link:" in content_block
-            assert "This is trace information" in content_block
-            assert ":dart:" in content_block
+            content_block = blocks["blocks"][2]["elements"][0]["text"]
+            assert "Identity not found" in content_block
+
+            content_block = blocks["blocks"][3]["elements"][0]["text"]
             assert "This is a possible cause" in content_block
-            # Check that the original text is not present
-            assert "Identity not found" not in content_block
 
     @override_options({"alerts.issue_summary_timeout": 5})
     def test_build_group_block_with_ai_summary_without_feature_flag(self):


### PR DESCRIPTION
Redesigns the alert to look like this:
![Screenshot 2025-04-01 at 2 08 09 PM](https://github.com/user-attachments/assets/f72c1762-6562-4c26-b9f6-b961b8802817)

(once again this all behind a feature flag, just for the Seer project)

