### PR TITLE
ref(ourlogs): Use item_type in TraceItemDetails hook

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,7 +1,6 @@
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 
-import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   type ApiQueryKey,
   fetchDataQuery,
@@ -11,6 +10,7 @@ import {
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
 import {
   getRetryDelay,
   shouldRetryHandler,
@@ -18,17 +18,7 @@ import {
 
 const DEFAULT_HOVER_TIMEOUT = 200;
 
-/**
- * ProjectTraceItemDetailsEndpoint currently only supports ourlogs dataset
- * TODO: Add SPANS_EAP once the backend supports it.
- */
-type EAPDataset = DiscoverDatasets.OURLOGS;
-
 export interface UseTraceItemDetailsProps {
-  /**
-   * Trace items are only supported by EAP.
-   */
-  dataset: EAPDataset;
   /**
    * Every trace item belongs to a project.
    */
@@ -46,6 +36,10 @@ export interface UseTraceItemDetailsProps {
    * The trace item ID representing an EAP trace item.
    */
   traceItemId: string;
+  /**
+   * The trace item type supported by the endpoint, currently only supports LOGS.
+   */
+  traceItemType: TraceItemDataset;
   /**
    * Alias for `enabled` in react-query.
    */
@@ -65,9 +59,9 @@ type TraceItemDetailsUrlParams = {
 };
 
 type TraceItemDetailsQueryParams = {
-  dataset: EAPDataset;
   referrer: string;
   traceId: string;
+  traceItemType: TraceItemDataset;
 };
 
 export type TraceItemResponseAttribute =
@@ -93,7 +87,7 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
 
   const queryParams: TraceItemDetailsQueryParams = {
     referrer: props.referrer,
-    dataset: props.dataset,
+    traceItemType: props.traceItemType,
     traceId: props.traceId,
   };
 
@@ -125,7 +119,7 @@ function traceItemDetailsQueryKey({
   urlParams: TraceItemDetailsUrlParams;
 }): ApiQueryKey {
   const query: Record<string, string | string[]> = {
-    dataset: queryParams.dataset,
+    item_type: queryParams.traceItemType,
     referrer: queryParams.referrer,
     trace_id: queryParams.traceId,
   };
@@ -140,7 +134,7 @@ export function usePrefetchTraceItemDetailsOnHover({
   traceItemId,
   projectId,
   traceId,
-  dataset,
+  traceItemType,
   referrer,
   hoverPrefetchDisabled,
   sharedHoverTimeoutRef,
@@ -173,7 +167,7 @@ export function usePrefetchTraceItemDetailsOnHover({
               traceItemId,
             },
             queryParams: {
-              dataset,
+              traceItemType,
               referrer,
               traceId,
             },

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -1,5 +1,4 @@
 import type EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   useLogsBaseSearch,
   useLogsCursor,
@@ -13,6 +12,7 @@ import {
   useTraceItemDetails,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {AlwaysPresentLogFields} from 'sentry/views/explore/logs/constants';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOurlogs} from 'sentry/views/insights/common/queries/useDiscover';
 
 export interface OurLogsTableResult {
@@ -60,7 +60,7 @@ export function useExploreLogsTableRow(props: {
     traceItemId: String(props.logId),
     projectId: props.projectId,
     traceId: props.traceId,
-    dataset: DiscoverDatasets.OURLOGS,
+    traceItemType: TraceItemDataset.LOGS,
     referrer: 'api.explore.log-item-details',
   });
 }
@@ -82,7 +82,7 @@ export function usePrefetchLogTableRowOnHover({
     traceItemId: String(logId),
     projectId,
     traceId,
-    dataset: DiscoverDatasets.OURLOGS,
+    traceItemType: TraceItemDataset.LOGS,
     hoverPrefetchDisabled,
     sharedHoverTimeoutRef,
     referrer: 'api.explore.log-item-details',


### PR DESCRIPTION
### Summary
The backend supports trace item type instead of 'dataset' now, and should use it moving forward.


