### PR TITLE
integration: add back capitalized link

### DIFF
--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import Access from 'sentry/components/acl/access';
@@ -101,13 +100,20 @@ function IntegrationTabs({
       <Tabs value={activeTab} onChange={onTabChange}>
         <TabList>
           {tabs.map(tab => (
-            <TabList.Item key={tab}>{capitalize(renderTab(tab))}</TabList.Item>
+            <TabList.Item key={tab}>
+              <Capitalized>{renderTab(tab)}</Capitalized>
+            </TabList.Item>
           ))}
         </TabList>
       </Tabs>
     </TabsContainer>
   );
 }
+
+// Requires CSS transform because of how the tab rendering works
+const Capitalized = styled('div')`
+  text-transform: capitalize;
+`;
 
 const TabsContainer = styled('div')`
   margin-top: ${space(2)};

--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
+import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import Access from 'sentry/components/acl/access';
@@ -100,7 +101,7 @@ function IntegrationTabs({
       <Tabs value={activeTab} onChange={onTabChange}>
         <TabList>
           {tabs.map(tab => (
-            <TabList.Item key={tab}>{renderTab(tab)}</TabList.Item>
+            <TabList.Item key={tab}>{capitalize(renderTab(tab))}</TabList.Item>
           ))}
         </TabList>
       </Tabs>


### PR DESCRIPTION
This used to render the label under `CapitalizedLink` component that had `text-transform: capitalize` style applied to it.

![CleanShot 2025-04-01 at 17 45 18@2x](https://github.com/user-attachments/assets/c5b1ca92-749a-4430-afd1-679ee23a9ef6)
