### PR TITLE
fix(global drawer): Disable drawer resizing on small screens

### DIFF
--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -58,14 +58,20 @@ export function DrawerPanel({
 }: DrawerPanelProps & {
   ref?: React.Ref<HTMLDivElement>;
 }) {
-  const {panelRef, resizeHandleRef, handleResizeStart, persistedWidthPercent} =
-    useDrawerResizing({
-      drawerKey,
-      drawerWidth,
-    });
+  const {
+    panelRef,
+    resizeHandleRef,
+    handleResizeStart,
+    persistedWidthPercent,
+    isSmallScreen,
+  } = useDrawerResizing({
+    drawerKey,
+    drawerWidth,
+  });
 
   // Calculate actual drawer width in pixels
-  const actualDrawerWidth = (window.innerWidth * persistedWidthPercent) / 100;
+  const actualDrawerWidth =
+    (window.innerWidth * (isSmallScreen ? 100 : persistedWidthPercent)) / 100;
 
   return (
     <DrawerContainer>
@@ -76,10 +82,10 @@ export function DrawerPanel({
           collapsed={false}
           ref={mergeRefs(panelRef, ref)}
           transitionProps={transitionProps}
-          panelWidth="var(--drawer-width)" // Initial width only
+          panelWidth={isSmallScreen ? '100%' : 'var(--drawer-width)'}
           className="drawer-panel"
         >
-          {drawerKey && (
+          {drawerKey && !isSmallScreen && (
             <ResizeHandle
               ref={resizeHandleRef}
               onMouseDown={handleResizeStart}

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -1,4 +1,5 @@
 import {createContext, Fragment, useContext} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 import type {AnimationProps} from 'framer-motion';
@@ -9,6 +10,7 @@ import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useMedia from 'sentry/utils/useMedia';
 
 import {
   DEFAULT_WIDTH_PERCENT,
@@ -58,16 +60,13 @@ export function DrawerPanel({
 }: DrawerPanelProps & {
   ref?: React.Ref<HTMLDivElement>;
 }) {
-  const {
-    panelRef,
-    resizeHandleRef,
-    handleResizeStart,
-    persistedWidthPercent,
-    isSmallScreen,
-  } = useDrawerResizing({
-    drawerKey,
-    drawerWidth,
-  });
+  const {panelRef, resizeHandleRef, handleResizeStart, persistedWidthPercent} =
+    useDrawerResizing({
+      drawerKey,
+      drawerWidth,
+    });
+  const theme = useTheme();
+  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
 
   // Calculate actual drawer width in pixels
   const actualDrawerWidth =

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -1,5 +1,4 @@
 import {createContext, Fragment, useContext} from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 import type {AnimationProps} from 'framer-motion';
@@ -10,7 +9,6 @@ import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import useMedia from 'sentry/utils/useMedia';
 
 import {
   DEFAULT_WIDTH_PERCENT,
@@ -60,17 +58,15 @@ export function DrawerPanel({
 }: DrawerPanelProps & {
   ref?: React.Ref<HTMLDivElement>;
 }) {
-  const {panelRef, resizeHandleRef, handleResizeStart, persistedWidthPercent} =
+  const {panelRef, resizeHandleRef, handleResizeStart, persistedWidthPercent, enabled} =
     useDrawerResizing({
       drawerKey,
       drawerWidth,
     });
-  const theme = useTheme();
-  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
 
   // Calculate actual drawer width in pixels
   const actualDrawerWidth =
-    (window.innerWidth * (isSmallScreen ? 100 : persistedWidthPercent)) / 100;
+    (window.innerWidth * (enabled ? persistedWidthPercent : 100)) / 100;
 
   return (
     <DrawerContainer>
@@ -81,10 +77,10 @@ export function DrawerPanel({
           collapsed={false}
           ref={mergeRefs(panelRef, ref)}
           transitionProps={transitionProps}
-          panelWidth={isSmallScreen ? '100%' : 'var(--drawer-width)'}
+          panelWidth="var(--drawer-width)" // Initial width only
           className="drawer-panel"
         >
-          {drawerKey && !isSmallScreen && (
+          {drawerKey && enabled && (
             <ResizeHandle
               ref={resizeHandleRef}
               onMouseDown={handleResizeStart}

--- a/static/app/components/globalDrawer/useDrawerResizing.tsx
+++ b/static/app/components/globalDrawer/useDrawerResizing.tsx
@@ -18,6 +18,7 @@ interface UseDrawerResizingOptions {
 }
 
 interface UseDrawerResizingResult {
+  enabled: boolean;
   handleResizeStart: (e: React.MouseEvent) => void;
   panelRef: React.RefObject<HTMLDivElement>;
   persistedWidthPercent: number;
@@ -172,6 +173,7 @@ export function useDrawerResizing({
     resizeHandleRef,
     handleResizeStart,
     persistedWidthPercent,
+    enabled: !isSmallScreen && !!drawerKey,
   };
 }
 

--- a/static/app/components/globalDrawer/useDrawerResizing.tsx
+++ b/static/app/components/globalDrawer/useDrawerResizing.tsx
@@ -1,5 +1,7 @@
 import {useCallback, useLayoutEffect, useRef} from 'react';
+import {useTheme} from '@emotion/react';
 
+import useMedia from 'sentry/utils/useMedia';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
 const MIN_WIDTH_PERCENT = 30;
@@ -17,6 +19,7 @@ interface UseDrawerResizingOptions {
 
 interface UseDrawerResizingResult {
   handleResizeStart: (e: React.MouseEvent) => void;
+  isSmallScreen: boolean;
   panelRef: React.RefObject<HTMLDivElement>;
   persistedWidthPercent: number;
   resizeHandleRef: React.RefObject<HTMLDivElement>;
@@ -26,6 +29,8 @@ export function useDrawerResizing({
   drawerKey,
   drawerWidth,
 }: UseDrawerResizingOptions): UseDrawerResizingResult {
+  const theme = useTheme();
+  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
   const resizeHandleRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
   const panelRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
   const rafIdRef = useRef<number | null>(null);
@@ -65,11 +70,24 @@ export function useDrawerResizing({
     );
 
   useLayoutEffect(() => {
-    panelRef.current?.style.setProperty('--drawer-width', `${persistedWidthPercent}%`);
-  }, [persistedWidthPercent]);
+    if (isSmallScreen) {
+      panelRef.current?.style.setProperty('--drawer-width', '100%');
+      panelRef.current?.style.setProperty('--drawer-min-width', '100%');
+      panelRef.current?.style.setProperty('--drawer-max-width', '100%');
+    } else {
+      panelRef.current?.style.setProperty('--drawer-width', `${persistedWidthPercent}%`);
+      panelRef.current?.style.setProperty('--drawer-min-width', `${MIN_WIDTH_PERCENT}%`);
+      panelRef.current?.style.setProperty('--drawer-max-width', `${MAX_WIDTH_PERCENT}%`);
+    }
+  }, [persistedWidthPercent, isSmallScreen]);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
+      // Don't allow resizing on small screens
+      if (isSmallScreen) {
+        return;
+      }
+
       e.preventDefault();
 
       const handle = resizeHandleRef.current;
@@ -139,7 +157,7 @@ export function useDrawerResizing({
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
     },
-    [setPersistedWidthPercent]
+    [setPersistedWidthPercent, isSmallScreen]
   );
 
   useLayoutEffect(() => {
@@ -155,6 +173,7 @@ export function useDrawerResizing({
     resizeHandleRef,
     handleResizeStart,
     persistedWidthPercent,
+    isSmallScreen,
   };
 }
 

--- a/static/app/components/globalDrawer/useDrawerResizing.tsx
+++ b/static/app/components/globalDrawer/useDrawerResizing.tsx
@@ -19,7 +19,6 @@ interface UseDrawerResizingOptions {
 
 interface UseDrawerResizingResult {
   handleResizeStart: (e: React.MouseEvent) => void;
-  isSmallScreen: boolean;
   panelRef: React.RefObject<HTMLDivElement>;
   persistedWidthPercent: number;
   resizeHandleRef: React.RefObject<HTMLDivElement>;
@@ -173,7 +172,6 @@ export function useDrawerResizing({
     resizeHandleRef,
     handleResizeStart,
     persistedWidthPercent,
-    isSmallScreen,
   };
 }
 


### PR DESCRIPTION
Disables drawer resizing on small screens so that the drawer can take the full width.

<img width="630" alt="Screenshot 2025-04-01 at 2 59 34 PM" src="https://github.com/user-attachments/assets/d217d823-72f9-42fe-ae16-98ae88bd2343" />
