### PR TITLE
dev: upgrade stripe to V4

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -203,7 +203,7 @@ sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
 sqlparse==0.5.0
 statsd==3.3.0
-stripe==3.1.0
+stripe==4.2.0
 structlog==22.1.0
 symbolic==12.14.1
 tiktoken==0.8.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -140,7 +140,7 @@ snuba-sdk==3.0.43
 soupsieve==2.3.2.post1
 sqlparse==0.5.0
 statsd==3.3.0
-stripe==3.1.0
+stripe==4.2.0
 structlog==22.1.0
 symbolic==12.14.1
 tiktoken==0.8.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -11,4 +11,4 @@ iso3166
 pycountry==17.5.14
 pyvat==1.3.15
 reportlab==4.2.5
-stripe==3.1.0
+stripe==4.2.0

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -290,7 +290,7 @@ class MonitorValidator(CamelSnakeSerializer):
         # a seat, otherwise fail with the reason it cannot.
         #
         # XXX: This check will ONLY be performed when a monitor is provided via
-        #      context. It is the callers responsabiliy to ensure that a
+        #      context. It is the caller's responsibility to ensure that a
         #      monitor is provided in context for this to be validated.
         if status == ObjectStatus.ACTIVE and monitor:
             result = quotas.backend.check_assign_monitor_seat(monitor)


### PR DESCRIPTION
This PR aims to upgrade our stripe version from v3.1.0 to v4.2.0

[Notion](https://www.notion.so/sentry/Upgrading-Stripe-from-v3-to-latest-1c88b10e4b5d80adbf87f574c2929d27)

[Migration Guide](https://github.com/stripe/stripe-python/wiki/Migration-guide-for-v4#%EF%B8%8F-changed)

[Changelog](https://github.com/stripe/stripe-python/releases?page=19)

No breaking changes, the one reference we're using to refund over here is already using the "suggested" pattern
- https://github.com/getsentry/getsentry/blob/63d9ee266d5e23ea3fd0dbf8407ae6f101296cb6/getsentry/utils/billing.py#L166

We also weren't using the Charge.dispute methods as far as I could see, or the Card.Details() API


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
