### PR TITLE
feat(checkout): show starting PAYG prices

### DIFF
--- a/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
@@ -177,7 +177,7 @@ describe('PlanSelect', function () {
     expect(screen.getByText(warningText)).toBeInTheDocument();
   });
 
-  it('renders with correct default prices', async function () {
+  it('renders with correct default prices and errors on-demand pricing', async function () {
     render(
       <AMCheckout
         {...RouteComponentPropsFixture()}
@@ -194,6 +194,41 @@ describe('PlanSelect', function () {
 
     expect(teamPlan).toHaveTextContent('$29/mo');
     expect(businessPlan).toHaveTextContent('$89/mo');
+
+    expect(teamPlan).toHaveTextContent('$0.000377 / error');
+    expect(teamPlan).not.toHaveTextContent(/\/ span/);
+    expect(businessPlan).toHaveTextContent('$0.001157 / error');
+    expect(businessPlan).not.toHaveTextContent(/\/ span/);
+  });
+
+  it('renders with correct default prices and errors and spans on-demand pricing', async function () {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+      />,
+      {organization}
+    );
+
+    const teamPlan = await screen.findByLabelText('Team');
+    const businessPlan = screen.getByLabelText('Business');
+
+    expect(teamPlan).toHaveTextContent('$29/mo');
+    expect(businessPlan).toHaveTextContent('$89/mo');
+
+    // NOTE: prices on fixtures are not necessarily correct, just for testing
+    expect(teamPlan).toHaveTextContent('$0.000362 / error');
+    expect(teamPlan).toHaveTextContent('$0.000002 / span');
+    expect(businessPlan).toHaveTextContent('$0.001113 / error');
+    expect(businessPlan).toHaveTextContent('$0.000004 / span');
   });
 
   it('renders with default plan selected', async function () {

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -20,7 +20,11 @@ import {
 import {isBizPlanFamily} from 'getsentry/utils/billing';
 import MoreFeaturesLink from 'getsentry/views/amCheckout/moreFeaturesLink';
 import type {PlanContent} from 'getsentry/views/amCheckout/steps/planSelect';
-import {formatPrice, getShortInterval} from 'getsentry/views/amCheckout/utils';
+import {
+  displayUnitPrice,
+  formatPrice,
+  getShortInterval,
+} from 'getsentry/views/amCheckout/utils';
 
 type UpdateData = {
   plan: string;
@@ -80,6 +84,12 @@ function PlanSelectRow({
 
   const describeId = `plan-details-${plan.id}`;
   const hasFeatures = !!Object.keys(features || {}).length;
+  const errorsStartingPrice = plan.planCategories.errors
+    ? plan.planCategories.errors[1]?.onDemandPrice
+    : null;
+  const spansStartingPrice = plan.planCategories.spans
+    ? plan.planCategories.spans[1]?.onDemandPrice
+    : null;
 
   return (
     <PlanOption isSelected={isSelected} data-test-id={plan.id}>
@@ -170,6 +180,12 @@ function PlanSelectRow({
               <Amount>{price}</Amount>
               <BillingInterval>{`/${billingInterval}`}</BillingInterval>
             </Price>
+            {errorsStartingPrice && (
+              <EventPriceTag>{`${displayUnitPrice({cents: errorsStartingPrice})} / error`}</EventPriceTag>
+            )}
+            {spansStartingPrice && (
+              <EventPriceTag>{`${displayUnitPrice({cents: spansStartingPrice})} / span`}</EventPriceTag>
+            )}
             {discountInfo && (
               <DiscountWrapper>
                 <OriginalTotal>{`$${formatPrice({
@@ -341,4 +357,10 @@ const DiscountWrapper = styled('div')`
 const PercentOff = styled('span')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const EventPriceTag = styled(Tag)`
+  display: flex;
+  align-items: center;
+  line-height: normal;
 `;

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -117,187 +117,224 @@ const AM2_PLANS: Record<string, Plan> = {
           events: 50000,
           unitPrice: 0.089,
           price: 0,
+          onDemandPrice: 0.1157
         },
         {
           events: 100000,
-          unitPrice: 0.05,
+          unitPrice: 0.089,
           price: 4500,
+          onDemandPrice: 0.1157
         },
         {
           events: 200000,
           unitPrice: 0.05,
           price: 9500,
+          onDemandPrice: 0.065
         },
         {
           events: 300000,
           unitPrice: 0.05,
           price: 14500,
+          onDemandPrice: 0.065
         },
         {
           events: 400000,
           unitPrice: 0.05,
           price: 19500,
+          onDemandPrice: 0.065
         },
         {
           events: 500000,
-          unitPrice: 0.03,
+          unitPrice: 0.05,
           price: 24500,
+          onDemandPrice: 0.065
         },
         {
           events: 1000000,
           unitPrice: 0.03,
           price: 39500,
+          onDemandPrice: 0.039
         },
         {
           events: 1500000,
           unitPrice: 0.03,
           price: 54500,
+          onDemandPrice: 0.039
         },
         {
           events: 2000000,
           unitPrice: 0.03,
           price: 69500,
+          onDemandPrice: 0.039
         },
         {
           events: 3000000,
           unitPrice: 0.03,
           price: 99500,
+          onDemandPrice: 0.039
         },
         {
           events: 4000000,
           unitPrice: 0.03,
           price: 129500,
+          onDemandPrice: 0.039
         },
         {
           events: 5000000,
           unitPrice: 0.03,
           price: 159500,
+          onDemandPrice: 0.039
         },
         {
           events: 6000000,
           unitPrice: 0.03,
           price: 189500,
+          onDemandPrice: 0.039
         },
         {
           events: 7000000,
           unitPrice: 0.03,
           price: 219500,
+          onDemandPrice: 0.039
         },
         {
           events: 8000000,
           unitPrice: 0.03,
           price: 249500,
+          onDemandPrice: 0.039
         },
         {
           events: 9000000,
           unitPrice: 0.03,
           price: 279500,
+          onDemandPrice: 0.039
         },
         {
           events: 10000000,
-          unitPrice: 0.0251,
+          unitPrice: 0.03,
           price: 309500,
+          onDemandPrice: 0.039
         },
         {
           events: 11000000,
           unitPrice: 0.0251,
           price: 334500,
+          onDemandPrice: 0.03263
         },
         {
           events: 12000000,
           unitPrice: 0.0251,
           price: 359500,
+          onDemandPrice: 0.03263
         },
         {
           events: 13000000,
           unitPrice: 0.0251,
           price: 384500,
+          onDemandPrice: 0.03263
         },
         {
           events: 14000000,
           unitPrice: 0.0251,
           price: 409500,
+          onDemandPrice: 0.03263
         },
         {
           events: 15000000,
           unitPrice: 0.0251,
           price: 434500,
+          onDemandPrice: 0.03263
         },
         {
           events: 16000000,
           unitPrice: 0.0251,
           price: 459500,
+          onDemandPrice: 0.03263
         },
         {
           events: 17000000,
           unitPrice: 0.0251,
           price: 484500,
+          onDemandPrice: 0.03263
         },
         {
           events: 18000000,
           unitPrice: 0.0251,
           price: 509500,
+          onDemandPrice: 0.03263
         },
         {
           events: 19000000,
           unitPrice: 0.0251,
           price: 534500,
+          onDemandPrice: 0.03263
         },
         {
           events: 20000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0251,
           price: 559500,
+          onDemandPrice: 0.03263
         },
         {
           events: 21000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0144,
           price: 573900,
+          onDemandPrice: 0.01872
         },
         {
           events: 22000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0144,
           price: 588300,
+          onDemandPrice: 0.01872
         },
         {
           events: 23000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0144,
           price: 602700,
+          onDemandPrice: 0.01872
         },
         {
           events: 24000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0144,
           price: 617100,
+          onDemandPrice: 0.01872
         },
         {
           events: 25000000,
-          unitPrice: 0.0132,
+          unitPrice: 0.0144,
           price: 631500,
+          onDemandPrice: 0.01872
         },
         {
           events: 30000000,
+          unitPrice: 0.0144,
           price: 703500,
-          unitPrice: 0.0132,
+          onDemandPrice: 0.01872
         },
         {
           events: 35000000,
+          unitPrice: 0.0144,
           price: 775500,
-          unitPrice: 0.0132,
+          onDemandPrice: 0.01872
         },
         {
           events: 40000000,
+          unitPrice: 0.0144,
           price: 847500,
-          unitPrice: 0.0132,
+          onDemandPrice: 0.01872
         },
         {
           events: 45000000,
+          unitPrice: 0.0144,
           price: 919500,
-          unitPrice: 0.0132,
+          onDemandPrice: 0.01872
         },
         {
           events: 50000000,
+          unitPrice: 0.0144,
           price: 991500,
-          unitPrice: 0.0132,
-        },
+          onDemandPrice: 0.01872
+        }
       ],
       transactions: [
         {
@@ -879,193 +916,228 @@ const AM2_PLANS: Record<string, Plan> = {
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
-      errors: [
-        {
-          events: 50000,
-          unitPrice: 0.029,
-          price: 0,
-        },
-        {
-          events: 100000,
-          unitPrice: 0.0175,
-          price: 1500,
-        },
-        {
-          events: 200000,
-          unitPrice: 0.0175,
-          price: 3200,
-        },
-        {
-          events: 300000,
-          unitPrice: 0.0175,
-          price: 5000,
-        },
-        {
-          events: 400000,
-          unitPrice: 0.0175,
-          price: 6700,
-        },
-        {
-          events: 500000,
-          unitPrice: 0.015,
-          price: 8500,
-        },
-        {
-          events: 1000000,
-          unitPrice: 0.015,
-          price: 16000,
-        },
-        {
-          events: 1500000,
-          unitPrice: 0.015,
-          price: 23500,
-        },
-        {
-          events: 2000000,
-          unitPrice: 0.015,
-          price: 31000,
-        },
-        {
-          events: 3000000,
-          unitPrice: 0.015,
-          price: 46000,
-        },
-        {
-          events: 4000000,
-          unitPrice: 0.015,
-          price: 61000,
-        },
-        {
-          events: 5000000,
-          unitPrice: 0.015,
-          price: 76000,
-        },
-        {
-          events: 6000000,
-          unitPrice: 0.015,
-          price: 91000,
-        },
-        {
-          events: 7000000,
-          unitPrice: 0.015,
-          price: 106000,
-        },
-        {
-          events: 8000000,
-          unitPrice: 0.015,
-          price: 121000,
-        },
-        {
-          events: 9000000,
-          unitPrice: 0.015,
-          price: 136000,
-        },
-        {
-          events: 10000000,
-          unitPrice: 0.013,
-          price: 151000,
-        },
-        {
-          events: 11000000,
-          unitPrice: 0.013,
-          price: 164000,
-        },
-        {
-          events: 12000000,
-          unitPrice: 0.013,
-          price: 177000,
-        },
-        {
-          events: 13000000,
-          unitPrice: 0.013,
-          price: 190000,
-        },
-        {
-          events: 14000000,
-          unitPrice: 0.013,
-          price: 203000,
-        },
-        {
-          events: 15000000,
-          unitPrice: 0.013,
-          price: 216000,
-        },
-        {
-          events: 16000000,
-          price: 229000,
-          unitPrice: 0.013,
-        },
-        {
-          events: 17000000,
-          price: 242000,
-          unitPrice: 0.013,
-        },
-        {
-          events: 18000000,
-          price: 255000,
-          unitPrice: 0.013,
-        },
-        {
-          events: 19000000,
-          price: 268000,
-          unitPrice: 0.013,
-        },
-        {
-          events: 20000000,
-          price: 281000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 21000000,
-          price: 293000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 22000000,
-          price: 305000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 23000000,
-          price: 317000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 24000000,
-          price: 329000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 25000000,
-          price: 341000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 30000000,
-          price: 401000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 35000000,
-          price: 461000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 40000000,
-          price: 521000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 45000000,
-          price: 581000,
-          unitPrice: 0.011,
-        },
-        {
-          events: 50000000,
-          price: 641000,
-          unitPrice: 0.011,
-        },
-      ],
+      errors: [{
+        events: 50000,
+        unitPrice: 0.029,
+        price: 0,
+        onDemandPrice: 0.0377
+      },
+      {
+        events: 100000,
+        unitPrice: 0.029,
+        price: 1500,
+        onDemandPrice: 0.0377
+      },
+      {
+        events: 200000,
+        unitPrice: 0.0175,
+        price: 3200,
+        onDemandPrice: 0.02275
+      },
+      {
+        events: 300000,
+        unitPrice: 0.0175,
+        price: 5000,
+        onDemandPrice: 0.02275
+      },
+      {
+        events: 400000,
+        unitPrice: 0.0175,
+        price: 6700,
+        onDemandPrice: 0.02275
+      },
+      {
+        events: 500000,
+        unitPrice: 0.0175,
+        price: 8500,
+        onDemandPrice: 0.02275
+      },
+      {
+        events: 1000000,
+        unitPrice: 0.015,
+        price: 16000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 1500000,
+        unitPrice: 0.015,
+        price: 23500,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 2000000,
+        unitPrice: 0.015,
+        price: 31000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 3000000,
+        unitPrice: 0.015,
+        price: 46000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 4000000,
+        unitPrice: 0.015,
+        price: 61000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 5000000,
+        unitPrice: 0.015,
+        price: 76000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 6000000,
+        unitPrice: 0.015,
+        price: 91000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 7000000,
+        unitPrice: 0.015,
+        price: 106000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 8000000,
+        unitPrice: 0.015,
+        price: 121000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 9000000,
+        unitPrice: 0.015,
+        price: 136000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 10000000,
+        unitPrice: 0.015,
+        price: 151000,
+        onDemandPrice: 0.0195
+      },
+      {
+        events: 11000000,
+        unitPrice: 0.013,
+        price: 164000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 12000000,
+        unitPrice: 0.013,
+        price: 177000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 13000000,
+        unitPrice: 0.013,
+        price: 190000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 14000000,
+        unitPrice: 0.013,
+        price: 203000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 15000000,
+        unitPrice: 0.013,
+        price: 216000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 16000000,
+        unitPrice: 0.013,
+        price: 229000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 17000000,
+        unitPrice: 0.013,
+        price: 242000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 18000000,
+        unitPrice: 0.013,
+        price: 255000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 19000000,
+        unitPrice: 0.013,
+        price: 268000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 20000000,
+        unitPrice: 0.013,
+        price: 281000,
+        onDemandPrice: 0.0169
+      },
+      {
+        events: 21000000,
+        unitPrice: 0.012,
+        price: 293000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 22000000,
+        unitPrice: 0.012,
+        price: 305000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 23000000,
+        unitPrice: 0.012,
+        price: 317000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 24000000,
+        unitPrice: 0.012,
+        price: 329000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 25000000,
+        unitPrice: 0.012,
+        price: 341000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 30000000,
+        unitPrice: 0.012,
+        price: 401000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 35000000,
+        unitPrice: 0.012,
+        price: 461000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 40000000,
+        unitPrice: 0.012,
+        price: 521000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 45000000,
+        unitPrice: 0.012,
+        price: 581000,
+        onDemandPrice: 0.0156
+      },
+      {
+        events: 50000000,
+        unitPrice: 0.012,
+        price: 641000,
+        onDemandPrice: 0.0156
+      }],
       transactions: [
         {
           events: 100000,


### PR DESCRIPTION
![Screenshot 2025-04-01 at 4 03 58 PM](https://github.com/user-attachments/assets/38e0bc64-e195-478f-9d15-ae562e7a9e14)

Adds starting spans and errors per-unit pricing to the plan select step.