### PR TITLE
fix(sentry apps): Fix redirect behavior for external install

### DIFF
--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -63,9 +63,9 @@ export default function SentryAppDetailsModal(props: Props) {
 
   const installMutation = useMutation({
     mutationFn: onInstall,
-    onSettled: () => {
-      // we want to make sure install finishes before we close the modal
-      // and we should close the modal if there is an error as well
+    onError: () => {
+      // We are only calling the closeModal (onClose) modal function on error because currently the onInstall already calls onClose
+      // TODO(christinarlong): Verify that the redirect behavior of external-install is the same if we onSuccess
       closeModal();
     },
   });

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -151,7 +151,7 @@ function SentryAppExternalInstallationContent({params, ...props}: Props) {
     [isInstalled, selectedOrgSlug, sentryApp]
   );
 
-  const onInstall = useCallback(async (): Promise<any | undefined> => {
+  const onInstall = useCallback(async (): Promise<undefined | void> => {
     if (!organization || !sentryApp) {
       return undefined;
     }


### PR DESCRIPTION
Expo raised an issue where they observed that when they tried to install their sentry app via 
`https://<org_slug>.sentry.io/sentry-apps/<app_slug>/external-install/ `, the page would redirect to `/settings/integrations/ `instead of the `sentryApp`'s `redirectUrl`.

The latter is the intended behavior as seen [here](https://github.com/getsentry/sentry/blob/d4374c8b5d7edb4d25e27e8d381f42d4a86dd256/static/app/views/sentryAppExternalInstallation/index.tsx#L154-L192) . Where we should be redirecting to the `redirectUrl` if it exists. Other wise we call [`onClose`](https://github.com/getsentry/sentry/blob/d4374c8b5d7edb4d25e27e8d381f42d4a86dd256/static/app/views/sentryAppExternalInstallation/index.tsx#L138-L142) to redirect to`/settings/integrations/`. 

We found out that in the[ FC refactor](https://github.com/getsentry/sentry/pull/88125/files#diff-4e8e3678a46d33ecba708ba2192b89aded6f0a2262c204a0ea093689fcb75531R64-R73) for `sentryAppDetails` modal we switched to using `useMutation` for the installation flow. It seems like our [onInstall](https://github.com/getsentry/sentry/blob/d4374c8b5d7edb4d25e27e8d381f42d4a86dd256/static/app/views/sentryAppExternalInstallation/index.tsx#L189) function's redirect(`window.location.assign`) was getting overwritten by the `closeModal`'s ([onClose](https://github.com/getsentry/sentry/blob/d4374c8b5d7edb4d25e27e8d381f42d4a86dd256/static/app/views/sentryAppExternalInstallation/index.tsx#L138-L142)) redirect.

[`onSettled`](https://tanstack.com/query/latest/docs/framework/react/reference/useMutation) is called no matter the result of the mutation function so we're changing to `onError` since the [onInstall](https://github.com/getsentry/sentry/blob/d4374c8b5d7edb4d25e27e8d381f42d4a86dd256/static/app/views/sentryAppExternalInstallation/index.tsx#L191) function will take care of the closing alternatively.
