### PR TITLE
DI-612: print flaky pytest errors to log (v2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,6 +405,7 @@ module = [
     "sentry.testutils.helpers.task_runner",
     "sentry.testutils.helpers.usage_accountant",
     "sentry.testutils.pytest.json_report_reruns",
+    "sentry.testutils.pytest.show_flaky_failures",
     "sentry.testutils.skips",
     "sentry.toolbar.utils.*",
     "sentry.types.*",

--- a/src/sentry/testutils/pytest/__init__.py
+++ b/src/sentry/testutils/pytest/__init__.py
@@ -9,4 +9,5 @@ pytest_plugins = [
     "sentry.testutils.pytest.metrics",
     "sentry.testutils.pytest.stale_database_reads",
     "sentry.testutils.pytest.json_report_reruns",
+    "sentry.testutils.pytest.show_flaky_failures",
 ]

--- a/src/sentry/testutils/pytest/show_flaky_failures.py
+++ b/src/sentry/testutils/pytest/show_flaky_failures.py
@@ -1,0 +1,49 @@
+from _pytest.reports import BaseReport
+from _pytest.terminal import TerminalReporter
+
+
+# see also: TerminalReporter.print_teardown_sections
+def print_section(terminalreporter: TerminalReporter, secname: str, content: str) -> None:
+    terminalreporter.write_sep("-", secname)
+    if content[-1:] == "\n":
+        content = content[:-1]
+    terminalreporter.line(content)
+
+
+# see also: TerminalReporter._handle_teardown_sections
+def _handle_teardown_sections(terminalreporter: TerminalReporter, nodeid: str) -> None:
+    reports = terminalreporter.getreports("")
+    for report in reports:
+        if report.when == "teardown" and report.nodeid == nodeid:
+            for secname, content in report.sections:
+                if "teardown" in secname:
+                    print_section(terminalreporter, secname, content)
+                    return
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter,
+) -> None:
+    """lightly customized, from terminalreporter.summary_failures_combined"""
+    flakes: list[BaseReport] = terminalreporter.getreports("rerun")
+    if not flakes:
+        return
+
+    header_done = False
+
+    # "hard" failures are already reported, elsewhere
+    test_seen: set[str] = set()
+    for flake in flakes:
+        # we only care to see the _first_ flaky failure in the log
+        if flake.nodeid in test_seen:
+            continue
+        else:
+            test_seen.add(flake.nodeid)
+
+        if not header_done:
+            terminalreporter.write_sep("=", "FLAKES (original error)")
+            header_done = True
+
+        terminalreporter.write_sep("_", flake.head_line, red=True, bold=True)
+        terminalreporter._outrep_summary(flake)
+        _handle_teardown_sections(terminalreporter, flake.nodeid)


### PR DESCRIPTION
Example results:

```
import pytest

counter = 0


@pytest.fixture
def noisy_fixture():
    print("noisy_fixture (before):", counter)
    yield
    print("noisy_fixture (after):", counter)


@pytest.fixture
def noisy_fixture2():
    print("noisy_fixture2 (before):", counter)
    yield
    print("noisy_fixture2 (after):", counter)


@pytest.mark.usefixtures("noisy_fixture", "noisy_fixture2")
def test_flaky():
    global counter
    counter += 1

    print(str(counter) * 79)
    try:
        assert counter == 3
    except:
        raise
```

"soft" flake:

```
$ export 'PYTEST_ADDOPTS=--reruns=2 --durations=10 --fail-slow=60s'
$ python -m pytest -vvvvvvv ./tests/flaky_test.py --json-report --json-report-file=.artifacts/pytest.acceptance.2025-04-01T18:00:27.920480000-0500.json --json-report-omit=log
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.3.5, pluggy-1.5.0 -- /Users/buck/repo/getsentry/sentry/.venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.13.1', 'Platform': 'macOS-15.2-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '8.3.5', 'pluggy': '1.5.0'}, 'Plugins': {'fail-slow': '0.3.0', 'time-machine': '2.16.0', 'json-report': '1.5.0', 'metadata': '3.1.1', 'xdist': '3.0.2', 'django': '4.9.0', 'pytest_sentry': '0.3.0', 'anyio': '3.7.1', 'rerunfailures': '15.0', 'cov': '4.0.0'}}
django: version: 5.1.7
rootdir: /Users/buck/repo/getsentry/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collecting ... collected 1 item

tests/flaky_test.py::test_flaky RERUN                                    [100%]
tests/flaky_test.py::test_flaky RERUN                                    [100%]
tests/flaky_test.py::test_flaky PASSED                                   [100%]

--------------------------------- JSON report ----------------------------------
report saved to: .artifacts/pytest.acceptance.2025-04-01T18:00:27.920480000-0500.json
=========================== FLAKES (original error) ============================
__________________________________ test_flaky __________________________________
tests/flaky_test.py:27: in test_flaky
    assert counter == 3
E   assert 1 == 3
---------------------------- Captured stdout setup -----------------------------
noisy_fixture (before): 0
noisy_fixture2 (before): 0
----------------------------- Captured stdout call -----------------------------
1111111111111111111111111111111111111111111111111111111111111111111111111111111
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 1
noisy_fixture (after): 1
============================= slowest 10 durations =============================
0.02s setup    tests/flaky_test.py::test_flaky
0.01s setup    tests/flaky_test.py::test_flaky
0.01s setup    tests/flaky_test.py::test_flaky
0.01s teardown tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
```

"hard" failure:

```
$ export 'PYTEST_ADDOPTS=--reruns=2 --durations=10 --fail-slow=60s'
$ python -m pytest -vvvvvvv ./tests/flaky_test.py --json-report --json-report-file=.artifacts/pytest.acceptance.2025-04-01T18:00:27.920480000-0500.json --json-report-omit=log
$    ./demo.sh |& tee demo.log
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0 -- /Users/buck/repo/getsentry/sentry/.venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.13.1', 'Platform': 'macOS-15.2-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '8.1.2', 'pluggy': '1.5.0'}, 'Plugins': {'fail-slow': '0.3.0', 'time-machine': '2.16.0', 'json-report': '1.5.0', 'metadata': '3.1.1', 'xdist': '3.0.2', 'django': '4.9.0', 'pytest_sentry': '0.3.0', 'anyio': '3.7.1', 'rerunfailures': '15.0', 'cov': '4.0.0'}}
django: version: 5.1.7
rootdir: /Users/buck/repo/getsentry/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collecting ... collected 1 item

tests/flaky_test.py::test_flaky RERUN                                    [100%]
tests/flaky_test.py::test_flaky RERUN                                    [100%]
tests/flaky_test.py::test_flaky FAILED                                   [100%]

=================================== FAILURES ===================================
__________________________________ test_flaky __________________________________
tests/flaky_test.py:27: in test_flaky
    assert counter == 99
E   assert 3 == 99
---------------------------- Captured stdout setup -----------------------------
noisy_fixture (before): 0
noisy_fixture2 (before): 0
----------------------------- Captured stdout call -----------------------------
1111111111111111111111111111111111111111111111111111111111111111111111111111111
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 1
noisy_fixture (after): 1
---------------------------- Captured stdout setup -----------------------------
noisy_fixture (before): 1
noisy_fixture2 (before): 1
----------------------------- Captured stdout call -----------------------------
2222222222222222222222222222222222222222222222222222222222222222222222222222222
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 2
noisy_fixture (after): 2
---------------------------- Captured stdout setup -----------------------------
noisy_fixture (before): 2
noisy_fixture2 (before): 2
----------------------------- Captured stdout call -----------------------------
3333333333333333333333333333333333333333333333333333333333333333333333333333333
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 1
noisy_fixture (after): 1
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 2
noisy_fixture (after): 2
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 3
noisy_fixture (after): 3
--------------------------------- JSON report ----------------------------------
report saved to: .artifacts/pytest.acceptance.2025-04-02T11:12:05.263683000-0500.json
=========================== FLAKES (original error) ============================
__________________________________ test_flaky __________________________________
tests/flaky_test.py:27: in test_flaky
    assert counter == 99
E   assert 1 == 99
---------------------------- Captured stdout setup -----------------------------
noisy_fixture (before): 0
noisy_fixture2 (before): 0
----------------------------- Captured stdout call -----------------------------
1111111111111111111111111111111111111111111111111111111111111111111111111111111
--------------------------- Captured stdout teardown ---------------------------
noisy_fixture2 (after): 1
noisy_fixture (after): 1
============================= slowest 10 durations =============================
0.02s setup    tests/flaky_test.py::test_flaky
0.01s setup    tests/flaky_test.py::test_flaky
0.01s setup    tests/flaky_test.py::test_flaky
0.01s teardown tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
0.00s call     tests/flaky_test.py::test_flaky
=========================== short test summary info ============================
FAILED tests/flaky_test.py::test_flaky - assert 3 == 99
========================== 1 failed, 2 rerun in 0.23s ==========================
duration: 4.482 seconds

```