### PR TITLE
ref(issue-stream): Remove other references to issue-stream-table-layout

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -7,7 +7,7 @@ import bannerStar from 'sentry-images/spot/banner-star.svg';
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
 import {Chevron} from 'sentry/components/chevron';
-import {Tag, type TagProps} from 'sentry/components/core/badge/tag';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -36,7 +36,6 @@ type GroupPriorityBadgeProps = {
   priority: PriorityLevel;
   children?: React.ReactNode;
   showLabel?: boolean;
-  variant?: 'default' | 'signal';
 };
 
 const PRIORITY_KEY_TO_LABEL: Record<PriorityLevel, string> = {
@@ -46,18 +45,6 @@ const PRIORITY_KEY_TO_LABEL: Record<PriorityLevel, string> = {
 };
 
 const PRIORITY_OPTIONS = [PriorityLevel.HIGH, PriorityLevel.MEDIUM, PriorityLevel.LOW];
-
-function getTagTypeForPriority(priority: string): TagProps['type'] {
-  switch (priority) {
-    case PriorityLevel.HIGH:
-      return 'error';
-    case PriorityLevel.MEDIUM:
-      return 'warning';
-    case PriorityLevel.LOW:
-    default:
-      return 'default';
-  }
-}
 
 function useLastEditedBy({
   groupId,
@@ -88,20 +75,13 @@ function useLastEditedBy({
 
 export function makeGroupPriorityDropdownOptions({
   onChange,
-  hasIssueStreamTableLayout,
 }: {
-  hasIssueStreamTableLayout: boolean;
   onChange: (value: PriorityLevel) => void;
 }) {
   return PRIORITY_OPTIONS.map(priority => ({
     textValue: PRIORITY_KEY_TO_LABEL[priority],
     key: priority,
-    label: (
-      <GroupPriorityBadge
-        variant={hasIssueStreamTableLayout ? 'signal' : 'default'}
-        priority={priority}
-      />
-    ),
+    label: <GroupPriorityBadge priority={priority} />,
     onAction: () => onChange(priority),
   }));
 }
@@ -109,7 +89,6 @@ export function makeGroupPriorityDropdownOptions({
 export function GroupPriorityBadge({
   priority,
   showLabel = true,
-  variant = 'default',
   children,
 }: GroupPriorityBadgeProps) {
   const bars =
@@ -117,10 +96,7 @@ export function GroupPriorityBadge({
   const label = PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown');
 
   return (
-    <StyledTag
-      type={variant === 'signal' ? 'default' : getTagTypeForPriority(priority)}
-      icon={variant === 'signal' && <IconCellSignal bars={bars} />}
-    >
+    <StyledTag type="default" icon={<IconCellSignal bars={bars} />}>
       {showLabel ? label : <VisuallyHidden>{label}</VisuallyHidden>}
       {children}
     </StyledTag>
@@ -209,14 +185,9 @@ export function GroupPriorityDropdown({
   onChange,
   lastEditedBy,
 }: GroupPriorityDropdownProps) {
-  const organization = useOrganization();
-  const hasIssueStreamTableLayout = organization.features.includes(
-    'issue-stream-table-layout'
-  );
-
   const options: MenuItemProps[] = useMemo(
-    () => makeGroupPriorityDropdownOptions({onChange, hasIssueStreamTableLayout}),
-    [onChange, hasIssueStreamTableLayout]
+    () => makeGroupPriorityDropdownOptions({onChange}),
+    [onChange]
   );
 
   return (
@@ -234,11 +205,7 @@ export function GroupPriorityDropdown({
           aria-label={t('Modify issue priority')}
           size="zero"
         >
-          <GroupPriorityBadge
-            showLabel={!hasIssueStreamTableLayout}
-            variant={hasIssueStreamTableLayout ? 'signal' : 'default'}
-            priority={value}
-          >
+          <GroupPriorityBadge showLabel priority={value}>
             <Chevron light direction={isOpen ? 'up' : 'down'} size="small" />
           </GroupPriorityBadge>
         </DropdownButton>

--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -4,7 +4,6 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import {EventOrGroupType} from 'sentry/types/event';
@@ -40,7 +39,7 @@ describe('EventOrGroupHeader', function () {
     jest.useRealTimers();
   });
 
-  const {organization, router} = initializeOrg();
+  const {router} = initializeOrg();
 
   describe('Group', function () {
     it('renders with `type = error`', function () {
@@ -89,26 +88,6 @@ describe('EventOrGroupHeader', function () {
       expect(screen.getByText('metadata value')).toBeInTheDocument();
     });
 
-    it('renders location', function () {
-      render(
-        <EventOrGroupHeader
-          data={{
-            ...group,
-            metadata: {
-              filename: 'path/to/file.swift',
-            },
-            platform: 'swift',
-            type: EventOrGroupType.ERROR,
-          }}
-          {...router}
-        />
-      );
-
-      expect(
-        screen.getByText(textWithMarkupMatcher('in path/to/file.swift'))
-      ).toBeInTheDocument();
-    });
-
     it('preloads group on hover', async function () {
       jest.useFakeTimers();
       const mockFetchGroup = MockApiClient.addMockResponse({
@@ -116,9 +95,7 @@ describe('EventOrGroupHeader', function () {
         body: group,
       });
 
-      render(<EventOrGroupHeader data={group} {...router} />, {
-        organization: {...organization, features: ['issue-stream-table-layout']},
-      });
+      render(<EventOrGroupHeader data={group} {...router} />);
 
       const groupLink = screen.getByRole('link');
 

--- a/static/app/components/eventOrGroupTitle.spec.tsx
+++ b/static/app/components/eventOrGroupTitle.spec.tsx
@@ -141,7 +141,6 @@ describe('EventOrGroupTitle', function () {
       render(<EventOrGroupTitle data={perfData} />);
 
       expect(screen.getByText('N+1 Query')).toBeInTheDocument();
-      expect(screen.getByText('transaction name')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -1,10 +1,8 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import type {Event} from 'sentry/types/event';
 import type {BaseGroup, GroupTombstoneHelper} from 'sentry/types/group';
 import {getTitle, isTombstone} from 'sentry/utils/events';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import GroupPreviewTooltip from './groupPreviewTooltip';
 
@@ -21,38 +19,13 @@ function EventOrGroupTitle({
   className,
   query,
 }: EventOrGroupTitleProps) {
-  const organization = useOrganization({allowNull: true});
   const {id, groupID} = data as Event;
 
-  const {title, subtitle} = getTitle(data);
+  const {title} = getTitle(data);
   const titleLabel = title ?? '';
 
-  const hasNewLayout =
-    organization?.features.includes('issue-stream-table-layout') ?? false;
-
-  const secondaryTitle = hasNewLayout ? null : subtitle;
-
-  if (hasNewLayout) {
-    return (
-      <span className={className}>
-        {!isTombstone(data) && withStackTracePreview ? (
-          <GroupPreviewTooltip
-            groupId={groupID ? groupID : id}
-            issueCategory={data.issueCategory}
-            groupingCurrentLevel={data.metadata?.current_level}
-            query={query}
-          >
-            <Title data-issue-title-primary>{titleLabel}</Title>
-          </GroupPreviewTooltip>
-        ) : (
-          titleLabel
-        )}
-      </span>
-    );
-  }
-
   return (
-    <Wrapper className={className}>
+    <span className={className}>
       {!isTombstone(data) && withStackTracePreview ? (
         <GroupPreviewTooltip
           groupId={groupID ? groupID : id}
@@ -60,49 +33,18 @@ function EventOrGroupTitle({
           groupingCurrentLevel={data.metadata?.current_level}
           query={query}
         >
-          {titleLabel}
+          <Title data-issue-title-primary>{titleLabel}</Title>
         </GroupPreviewTooltip>
       ) : (
         titleLabel
       )}
-      {secondaryTitle && (
-        <Fragment>
-          <Spacer width="10px" />
-          <Subtitle title={secondaryTitle}>{secondaryTitle}</Subtitle>
-          <br />
-        </Fragment>
-      )}
-    </Wrapper>
+    </span>
   );
 }
 
 export default EventOrGroupTitle;
 
-/**
- * &nbsp; is used instead of margin/padding to split title and subtitle
- * into 2 separate text nodes on the HTML AST. This allows the
- * title to be highlighted without spilling over to the subtitle.
- */
-function Spacer({width}: {width: string}) {
-  return <span style={{display: 'inline-block', width}}>&nbsp;</span>;
-}
-
-const Subtitle = styled('em')`
-  ${p => p.theme.overflowEllipsis};
-  display: inline-block;
-  color: ${p => p.theme.subText};
-  font-style: normal;
-  height: 100%;
-`;
-
 const Title = styled('span')`
   position: relative;
   font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const Wrapper = styled('span')`
-  display: inline-grid;
-  grid-template-columns: auto max-content 1fr max-content;
-
-  align-items: baseline;
 `;

--- a/static/app/components/events/errorLevel.tsx
+++ b/static/app/components/events/errorLevel.tsx
@@ -5,34 +5,19 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {Level} from 'sentry/types/event';
 import {capitalize} from 'sentry/utils/string/capitalize';
-import useOrganization from 'sentry/utils/useOrganization';
-
-const DEFAULT_SIZE = 13;
 
 type Props = {
   className?: string;
   level?: Level;
-  size?: number;
 };
 
-function ErrorLevel({className, level = 'unknown', size = 11}: Props) {
-  const organization = useOrganization({allowNull: true});
-  const hasNewIssueStreamTableLayout = organization?.features.includes(
-    'issue-stream-table-layout'
-  );
-
+function ErrorLevel({className, level = 'unknown'}: Props) {
   const levelLabel = t('Level: %s', capitalize(level));
   return (
     <Tooltip skipWrapper disabled={level === 'unknown'} title={levelLabel}>
-      {hasNewIssueStreamTableLayout ? (
-        <ColoredLine className={className} level={level} size={size}>
-          <VisuallyHidden>{levelLabel}</VisuallyHidden>
-        </ColoredLine>
-      ) : (
-        <ColoredCircle className={className} level={level} size={size}>
-          {levelLabel}
-        </ColoredCircle>
-      )}
+      <ColoredLine className={className} level={level}>
+        <VisuallyHidden>{levelLabel}</VisuallyHidden>
+      </ColoredLine>
     </Tooltip>
   );
 }
@@ -45,18 +30,6 @@ const ColoredLine = styled('span')<Props>`
   display: inline-block;
   flex-shrink: 0;
   height: 1em;
-  background-color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
-`;
-
-const ColoredCircle = styled('span')<Props>`
-  padding: 0;
-  position: relative;
-  width: ${p => p.size || DEFAULT_SIZE}px;
-  height: ${p => p.size || DEFAULT_SIZE}px;
-  text-indent: -9999em;
-  display: inline-block;
-  border-radius: 50%;
-  flex-shrink: 0;
   background-color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
 `;
 

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -7,7 +7,6 @@ import {space} from 'sentry/styles/space';
 import type {Event, EventOrGroupType, Level} from 'sentry/types/event';
 import type {BaseGroup, GroupTombstoneHelper} from 'sentry/types/group';
 import {eventTypeHasLogLevel} from 'sentry/utils/events';
-import useOrganization from 'sentry/utils/useOrganization';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
@@ -17,47 +16,21 @@ type Props = {
   type: EventOrGroupType;
   className?: string;
   level?: Level;
-  /**
-   * Size of the level indicator.
-   */
-  levelIndicatorSize?: 9 | 10 | 11;
   showUnhandled?: boolean;
 };
 
-function EventMessage({
-  className,
-  level,
-  levelIndicatorSize,
-  message,
-  type,
-  showUnhandled = false,
-}: Props) {
+function EventMessage({className, level, message, type, showUnhandled = false}: Props) {
   const hasStreamlinedUI = useHasStreamlinedUI();
-  const organization = useOrganization({allowNull: true});
   const showEventLevel = level && eventTypeHasLogLevel(type);
-  const hasNewIssueStreamTableLayout = organization?.features.includes(
-    'issue-stream-table-layout'
-  );
   const renderedMessage = message ? (
     <Message>{message}</Message>
   ) : (
     <NoMessage>({t('No error message')})</NoMessage>
   );
 
-  const showErrorLevelDivider = Boolean(
-    hasStreamlinedUI && showEventLevel && !hasNewIssueStreamTableLayout
-  );
-
   return (
     <LevelMessageContainer className={className}>
-      {showEventLevel && (
-        <ErrorLevelWithMargin
-          level={level}
-          size={levelIndicatorSize}
-          hasDivider={showErrorLevelDivider}
-        />
-      )}
-      {showErrorLevelDivider ? <Divider /> : null}
+      {showEventLevel && <ErrorLevelWithMargin level={level} />}
       {showUnhandled ? <UnhandledTag /> : null}
       {hasStreamlinedUI && showUnhandled ? <Divider /> : null}
       {renderedMessage}
@@ -83,8 +56,8 @@ const NoMessage = styled(Message)`
   color: ${p => p.theme.subText};
 `;
 
-const ErrorLevelWithMargin = styled(ErrorLevel)<{hasDivider: boolean}>`
-  margin-right: ${p => (p.hasDivider ? 0 : space(0.25))};
+const ErrorLevelWithMargin = styled(ErrorLevel)`
+  margin-right: ${space(0.25)};
 `;
 
 export default EventMessage;

--- a/static/app/components/issues/compactIssue.tsx
+++ b/static/app/components/issues/compactIssue.tsx
@@ -40,7 +40,7 @@ function CompactIssueHeader({data, organization, eventId}: HeaderProps) {
   return (
     <Fragment>
       <IssueHeaderMetaWrapper>
-        <StyledErrorLevel size={12} level={data.level} />
+        <StyledErrorLevel level={data.level} />
         <h3 className="truncate">
           <IconLink to={issueLink || ''}>
             {data.status === 'ignored' && <IconMute size="xs" />}

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -251,7 +251,6 @@ class GroupList extends Component<Props, State> {
     const {
       canSelectGroups,
       withChart,
-      organization,
       withColumns = ['graph', 'event', 'users', 'assignee'],
       renderEmptyMessage,
       renderErrorMessage,
@@ -268,9 +267,8 @@ class GroupList extends Component<Props, State> {
 
     const columns: GroupListColumn[] = [
       ...withColumns,
-      ...(organization.features.includes('issue-stream-table-layout')
-        ? ['firstSeen' as const, 'lastSeen' as const]
-        : []),
+      'firstSeen' as const,
+      'lastSeen' as const,
     ];
 
     if (error) {

--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -31,7 +31,7 @@ export function SavedSearchModalContent({organization}: SavedSearchModalContentP
 
   const selectFieldSortOptions = sortOptions.map(sortOption => ({
     value: sortOption,
-    label: getSortLabel(sortOption, organization),
+    label: getSortLabel(sortOption),
   }));
 
   return (

--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -84,13 +84,7 @@ export default function PriorityControl({
               data-test-id="priority-control-medium"
             />
           }
-          right={
-            <GroupPriorityBadge
-              showLabel
-              variant="signal"
-              priority={PriorityLevel.MEDIUM}
-            />
-          }
+          right={<GroupPriorityBadge showLabel priority={PriorityLevel.MEDIUM} />}
         />
       )}
       {priorityIsConfigurable(priority, PriorityLevel.HIGH) && (
@@ -110,13 +104,7 @@ export default function PriorityControl({
               data-test-id="priority-control-high"
             />
           }
-          right={
-            <GroupPriorityBadge
-              showLabel
-              variant="signal"
-              priority={PriorityLevel.HIGH}
-            />
-          }
+          right={<GroupPriorityBadge showLabel priority={PriorityLevel.HIGH} />}
         />
       )}
     </Grid>
@@ -176,7 +164,7 @@ function PrioritySelect({
       trigger={(props, isOpen) => {
         return (
           <EmptyButton {...props}>
-            <GroupPriorityBadge showLabel variant="signal" priority={value}>
+            <GroupPriorityBadge showLabel priority={value}>
               <InteractionStateLayer isPressed={isOpen} />
               <Chevron light direction={isOpen ? 'up' : 'down'} size="small" />
             </GroupPriorityBadge>
@@ -184,7 +172,7 @@ function PrioritySelect({
         );
       }}
       options={priorities.map(priority => ({
-        label: <GroupPriorityBadge showLabel variant="signal" priority={priority} />,
+        label: <GroupPriorityBadge showLabel priority={priority} />,
         value: priority,
         textValue: priority,
       }))}

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -81,7 +81,7 @@ function disableSortOptions(_widgetQuery: WidgetQuery) {
   };
 }
 
-function getTableSortOptions(organization: Organization, _widgetQuery: WidgetQuery) {
+function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQuery) {
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
@@ -90,7 +90,7 @@ function getTableSortOptions(organization: Organization, _widgetQuery: WidgetQue
     IssueSortOptions.USER,
   ];
   return sortOptions.map(sortOption => ({
-    label: getSortLabel(sortOption, organization),
+    label: getSortLabel(sortOption),
     value: sortOption,
   }));
 }

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -251,7 +251,6 @@ function GroupHeader({baseUrl, group, organization, event, project}: Props) {
               data={group}
               message={message}
               level={group.level}
-              levelIndicatorSize={11}
               type={group.type}
               showUnhandled={group.isUnhandled}
             />

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -239,9 +239,6 @@ function ActionSet({
               confirmText: label('reprioritize'),
             });
           },
-          hasIssueStreamTableLayout: organization.features.includes(
-            'issue-stream-table-layout'
-          ),
         })}
       />
       {!nestReview && <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />}

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -6,7 +6,6 @@ import ToolbarHeader from 'sentry/components/toolbarHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
-import useOrganization from 'sentry/utils/useOrganization';
 import {COLUMN_BREAKPOINTS} from 'sentry/views/issueList/actions/utils';
 
 type Props = {
@@ -22,10 +21,7 @@ function Headers({
   statsPeriod,
   onSelectStatsPeriod,
   isReprocessingQuery,
-  isSavedSearchesOpen,
 }: Props) {
-  const organization = useOrganization();
-
   return (
     <Fragment>
       {isReprocessingQuery ? (
@@ -36,42 +32,16 @@ function Headers({
         </Fragment>
       ) : (
         <Fragment>
-          {organization.features.includes('issue-stream-table-layout') ? (
-            <Fragment>
-              <LastSeenLabel breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
-                {t('Last Seen')}
-              </LastSeenLabel>
-              <FirstSeenLabel breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
-                {t('Age')}
-              </FirstSeenLabel>
-            </Fragment>
-          ) : null}
-          {organization.features.includes('issue-stream-table-layout') ? (
-            <NarrowGraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
-              <NarrowGraphLabelContents>
-                {t('Trend')}
-                <NarrowGraphToggles>
-                  {selection.datetime.period !== '24h' && (
-                    <GraphToggle
-                      active={statsPeriod === '24h'}
-                      onClick={() => onSelectStatsPeriod('24h')}
-                    >
-                      {t('24h')}
-                    </GraphToggle>
-                  )}
-                  <GraphToggle
-                    active={statsPeriod === 'auto'}
-                    onClick={() => onSelectStatsPeriod('auto')}
-                  >
-                    {selection.datetime.period || t('Custom')}
-                  </GraphToggle>
-                </NarrowGraphToggles>
-              </NarrowGraphLabelContents>
-            </NarrowGraphLabel>
-          ) : (
-            <GraphHeaderWrapper isSavedSearchesOpen={isSavedSearchesOpen}>
-              <GraphHeader>
-                <StyledToolbarHeader>{t('Graph:')}</StyledToolbarHeader>
+          <LastSeenLabel breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN} align="right">
+            {t('Last Seen')}
+          </LastSeenLabel>
+          <FirstSeenLabel breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN} align="right">
+            {t('Age')}
+          </FirstSeenLabel>
+          <GraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
+            <GraphLabelContents>
+              {t('Trend')}
+              <GraphToggles>
                 {selection.datetime.period !== '24h' && (
                   <GraphToggle
                     active={statsPeriod === '24h'}
@@ -86,42 +56,21 @@ function Headers({
                 >
                   {selection.datetime.period || t('Custom')}
                 </GraphToggle>
-              </GraphHeader>
-            </GraphHeaderWrapper>
-          )}
-          {organization.features.includes('issue-stream-table-layout') ? (
-            <Fragment>
-              <NarrowEventsOrUsersLabel
-                breakpoint={COLUMN_BREAKPOINTS.EVENTS}
-                align="right"
-              >
-                {t('Events')}
-              </NarrowEventsOrUsersLabel>
-              <NarrowEventsOrUsersLabel
-                breakpoint={COLUMN_BREAKPOINTS.USERS}
-                align="right"
-              >
-                {t('Users')}
-              </NarrowEventsOrUsersLabel>
-              <NarrowPriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY} align="left">
-                {t('Priority')}
-              </NarrowPriorityLabel>
-              <NarrowAssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE} align="right">
-                {t('Assignee')}
-              </NarrowAssigneeLabel>
-            </Fragment>
-          ) : (
-            <Fragment>
-              <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
-              <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
-              <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
-                <ToolbarHeader>{t('Priority')}</ToolbarHeader>
-              </PriorityLabel>
-              <AssigneeLabel isSavedSearchesOpen={isSavedSearchesOpen}>
-                <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
-              </AssigneeLabel>
-            </Fragment>
-          )}
+              </GraphToggles>
+            </GraphLabelContents>
+          </GraphLabel>
+          <EventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.EVENTS} align="right">
+            {t('Events')}
+          </EventsOrUsersLabel>
+          <EventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.USERS} align="right">
+            {t('Users')}
+          </EventsOrUsersLabel>
+          <PriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY} align="left">
+            {t('Priority')}
+          </PriorityLabel>
+          <AssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE} align="right">
+            {t('Assignee')}
+          </AssigneeLabel>
         </Fragment>
       )}
     </Fragment>
@@ -130,16 +79,7 @@ function Headers({
 
 export default Headers;
 
-const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
-  width: 180px;
-
-  @media (max-width: ${p =>
-      p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
-    display: none;
-  }
-`;
-
-const NarrowGraphLabel = styled(IssueStreamHeaderLabel)`
+const GraphLabel = styled(IssueStreamHeaderLabel)`
   width: 175px;
   flex: 1;
   display: flex;
@@ -147,24 +87,15 @@ const NarrowGraphLabel = styled(IssueStreamHeaderLabel)`
   padding: 0;
 `;
 
-const NarrowGraphLabelContents = styled('div')`
+const GraphLabelContents = styled('div')`
   display: flex;
   flex: 1;
   justify-content: space-between;
 `;
 
-const NarrowGraphToggles = styled('div')`
+const GraphToggles = styled('div')`
   font-weight: ${p => p.theme.fontWeightNormal};
   margin-right: ${space(2)};
-`;
-
-const GraphHeader = styled('div')`
-  display: flex;
-  margin-right: ${space(1.5)};
-`;
-
-const StyledToolbarHeader = styled(ToolbarHeader)`
-  flex: 1;
 `;
 
 const GraphToggle = styled('a')<{active: boolean}>`
@@ -187,20 +118,7 @@ const FirstSeenLabel = styled(IssueStreamHeaderLabel)`
   width: 50px;
 `;
 
-const EventsOrUsersLabel = styled(ToolbarHeader)`
-  display: inline-grid;
-  align-items: center;
-  justify-content: flex-end;
-  text-align: right;
-  width: 60px;
-  margin: 0 ${space(2)};
-
-  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
-    width: 80px;
-  }
-`;
-
-const NarrowEventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
+const EventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
   width: 60px;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
@@ -208,36 +126,11 @@ const NarrowEventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
   }
 `;
 
-const PriorityLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
-  justify-content: flex-end;
-  text-align: right;
-  width: 70px;
-  margin: 0 ${space(2)};
-
-  @media (max-width: ${p =>
-      p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
-    display: none;
-  }
-`;
-
-const NarrowPriorityLabel = styled(IssueStreamHeaderLabel)`
+const PriorityLabel = styled(IssueStreamHeaderLabel)`
   width: 64px;
 `;
 
-const AssigneeLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
-  justify-content: flex-end;
-  text-align: right;
-  width: 60px;
-  margin-left: ${space(2)};
-  margin-right: ${space(2)};
-
-  @media (max-width: ${p =>
-      p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
-    display: none;
-  }
-`;
-
-export const NarrowAssigneeLabel = styled(IssueStreamHeaderLabel)`
+export const AssigneeLabel = styled(IssueStreamHeaderLabel)`
   width: 66px;
 `;
 

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -38,8 +38,6 @@ const defaultProps = {
   statsPeriod: '24h',
   onDelete: jest.fn(),
   displayReprocessingActions: false,
-  onSortChange: jest.fn(),
-  sort: '',
 };
 
 function WrappedComponent(props: any) {
@@ -405,19 +403,6 @@ describe('IssueListActions', function () {
       expect(
         await screen.findByRole('menuitemradio', {name: 'Mark Reviewed'})
       ).toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  describe('sort', function () {
-    it('calls onSortChange with new sort value', async function () {
-      const mockOnSortChange = jest.fn();
-      render(<WrappedComponent onSortChange={mockOnSortChange} />);
-
-      await userEvent.click(screen.getByRole('button', {name: 'Last Seen'}));
-
-      await userEvent.click(screen.getByText(/Number of events/));
-
-      expect(mockOnSortChange).toHaveBeenCalledWith('freq');
     });
   });
 

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -34,7 +34,6 @@ import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueLi
 
 import ActionSet from './actionSet';
 import Headers from './headers';
-import IssueListSortOptions from './sortOptions';
 import {BULK_LIMIT, BULK_LIMIT_STR, ConfirmAction} from './utils';
 
 type IssueListActionsProps = {
@@ -43,11 +42,9 @@ type IssueListActionsProps = {
   groupIds: string[];
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
-  onSortChange: (sort: string) => void;
   query: string;
   queryCount: number;
   selection: PageFilters;
-  sort: string;
   statsPeriod: string;
   onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
 };
@@ -72,9 +69,7 @@ function ActionsBarPriority({
   handleDelete,
   handleMerge,
   handleUpdate,
-  sort,
   selectedProjectSlug,
-  onSortChange,
   onSelectStatsPeriod,
   isSavedSearchesOpen,
   statsPeriod,
@@ -90,23 +85,18 @@ function ActionsBarPriority({
   multiSelected: boolean;
   narrowViewport: boolean;
   onSelectStatsPeriod: (period: string) => void;
-  onSortChange: (sort: string) => void;
   pageSelected: boolean;
   query: string;
   queryCount: number;
   selectedIdsSet: Set<string>;
   selectedProjectSlug: string | undefined;
   selection: PageFilters;
-  sort: string;
   statsPeriod: string;
 }) {
-  const organization = useOrganization();
   const shouldDisplayActions = anySelected && !narrowViewport;
 
   return (
-    <ActionsBarContainer
-      narrowHeader={organization.features.includes('issue-stream-table-layout')}
-    >
+    <ActionsBarContainer>
       {!narrowViewport && (
         <ActionsCheckbox isReprocessingQuery={displayReprocessingActions}>
           <Checkbox
@@ -137,27 +127,15 @@ function ActionsBarPriority({
                 onUpdate={handleUpdate}
               />
             </HeaderButtonsWrapper>
-          ) : organization.features.includes('issue-stream-table-layout') ? (
+          ) : (
             <NarrowHeaderButtonsWrapper>
               <IssueStreamHeaderLabel hideDivider>{t('Issue')}</IssueStreamHeaderLabel>
             </NarrowHeaderButtonsWrapper>
-          ) : (
-            <HeaderButtonsWrapper key="sort" {...animationProps}>
-              <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
-            </HeaderButtonsWrapper>
           )}
         </AnimatePresence>
       )}
       <AnimatePresence initial={false} mode="wait">
-        {anySelected ? (
-          !organization.features.includes('issue-stream-table-layout') && (
-            <motion.div key="sort" {...animationProps}>
-              <SortDropdownMargin>
-                <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
-              </SortDropdownMargin>
-            </motion.div>
-          )
-        ) : (
+        {anySelected ? null : (
           <AnimatedHeaderItemsContainer key="headers" {...animationProps}>
             <Headers
               onSelectStatsPeriod={onSelectStatsPeriod}
@@ -180,11 +158,9 @@ function IssueListActions({
   onActionTaken,
   onDelete,
   onSelectStatsPeriod,
-  onSortChange,
   queryCount,
   query,
   selection,
-  sort,
   statsPeriod,
 }: IssueListActionsProps) {
   const api = useApi();
@@ -383,7 +359,6 @@ function IssueListActions({
         queryCount={queryCount}
         selection={selection}
         statsPeriod={statsPeriod}
-        onSortChange={onSortChange}
         allInQuerySelected={allInQuerySelected}
         pageSelected={pageSelected}
         selectedIdsSet={selectedIdsSet}
@@ -395,7 +370,6 @@ function IssueListActions({
         narrowViewport={disableActions}
         selectedProjectSlug={selectedProjectSlug}
         isSavedSearchesOpen={isSavedSearchesOpen}
-        sort={sort}
         anySelected={anySelected}
         onSelectStatsPeriod={onSelectStatsPeriod}
       />
@@ -523,11 +497,11 @@ const StickyActions = styled(Sticky)`
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
 `;
 
-const ActionsBarContainer = styled('div')<{narrowHeader: boolean}>`
+const ActionsBarContainer = styled('div')`
   display: flex;
-  min-height: ${p => (p.narrowHeader ? '36px' : '45px')};
-  padding-top: ${p => (p.narrowHeader ? space(0.5) : space(1))};
-  padding-bottom: ${p => (p.narrowHeader ? space(0.5) : space(1))};
+  min-height: 36px;
+  padding-top: ${space(0.5)};
+  padding-bottom: ${space(0.5)};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
   border-radius: 6px 6px 0 0;
@@ -581,10 +555,6 @@ const SelectAllNotice = styled('div')`
 
 const SelectAllLink = styled('a')`
   margin-left: ${space(1)};
-`;
-
-const SortDropdownMargin = styled('div')`
-  margin-right: ${space(1)};
 `;
 
 const AnimatedHeaderItemsContainer = styled(motion.div)`

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -2,7 +2,6 @@ import {CompactSelect} from 'sentry/components/core/compactSelect';
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
@@ -44,7 +43,6 @@ function IssueListSortOptions({
   triggerSize = 'xs',
   showIcon = true,
 }: Props) {
-  const organization = useOrganization();
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
@@ -62,7 +60,7 @@ function IssueListSortOptions({
       onChange={opt => onSelect(opt.value)}
       options={sortKeys.map(key => ({
         value: key,
-        label: getSortLabel(key, organization),
+        label: getSortLabel(key),
         details: getSortTooltip(key),
       }))}
       menuWidth={240}

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,4 +1,3 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -21,11 +20,10 @@ interface Props {
 function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
-  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
   const hasIssueViews = organization.features.includes('issue-stream-custom-views');
 
   return (
-    <FiltersContainer hasNewLayout={hasNewLayout}>
+    <FiltersContainer>
       <GuideAnchor
         target="issue_views_page_filters_persistence"
         disabled={!hasIssueViews}
@@ -39,65 +37,41 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
 
       <Search {...{query, onSearch}} />
 
-      {organization.features.includes('issue-stream-table-layout') && (
-        <Sort
-          query={query}
-          sort={sort}
-          onSelect={onSortChange}
-          triggerSize="md"
-          showIcon={false}
-        />
-      )}
+      <Sort
+        query={query}
+        sort={sort}
+        onSelect={onSortChange}
+        triggerSize="md"
+        showIcon={false}
+      />
     </FiltersContainer>
   );
 }
 
-const FiltersContainer = styled('div')<{hasNewLayout: boolean}>`
+const FiltersContainer = styled('div')`
   display: grid;
   column-gap: ${space(1)};
   row-gap: ${space(1)};
   margin-bottom: ${space(2)};
   width: 100%;
 
-  ${p =>
-    p.hasNewLayout
-      ? css`
-          grid-template-columns: 100%;
-          grid-template-areas:
-            'page-filters'
-            'search'
-            'sort';
+  grid-template-columns: 100%;
+  grid-template-areas:
+    'page-filters'
+    'search'
+    'sort';
 
-          @media (min-width: ${p.theme.breakpoints.xsmall}) {
-            grid-template-columns: auto 1fr;
-            grid-template-areas:
-              'page-filters sort'
-              'search search';
-          }
+  @media (min-width: ${p => p.theme.breakpoints.xsmall}) {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      'page-filters sort'
+      'search search';
+  }
 
-          @media (min-width: ${p.theme.breakpoints.large}) {
-            grid-template-columns: auto 1fr auto;
-            grid-template-areas: 'page-filters search sort';
-          }
-        `
-      : css`
-          grid-template-columns: 100%;
-          grid-template-areas:
-            'page-filters'
-            'search';
-
-          @media (min-width: ${p.theme.breakpoints.xsmall}) {
-            grid-template-columns: auto 1fr;
-            grid-template-areas:
-              'page-filters sort'
-              'search search';
-          }
-
-          @media (min-width: ${p.theme.breakpoints.large}) {
-            grid-template-columns: auto 1fr;
-            grid-template-areas: 'page-filters search';
-          }
-        `}
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: 'page-filters search sort';
+  }
 `;
 
 const Search = styled(IssueSearchWithSavedSearches)`

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -94,7 +94,6 @@ function GroupList({
   groupStatsPeriod,
   onActionTaken,
 }: GroupListProps) {
-  const organization = useOrganization();
   const theme = useTheme();
   const [isSavedSearchesOpen] = useSyncedLocalStorageState(
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
@@ -109,9 +108,8 @@ function GroupList({
 
   const columns: GroupListColumn[] = [
     'graph',
-    ...(organization.features.includes('issue-stream-table-layout')
-      ? ['firstSeen' as const, 'lastSeen' as const]
-      : []),
+    'firstSeen',
+    'lastSeen',
     'event',
     'users',
     'priority',

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -26,7 +26,6 @@ interface IssueListTableProps {
   onCursor: CursorHandler;
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
-  onSortChange: (sort: string) => void;
   organizationSavedSearches: SavedSearch[];
   pageLinks: string;
   paginationAnalyticsEvent: (direction: string) => void;
@@ -37,7 +36,6 @@ interface IssueListTableProps {
   refetchGroups: (fetchAllCounts?: boolean) => void;
   selectedProjectIds: number[];
   selection: PageFilters;
-  sort: string;
   statsPeriod: string;
 }
 
@@ -47,11 +45,9 @@ function IssueListTable({
   groupIds,
   onDelete,
   onSelectStatsPeriod,
-  onSortChange,
   query,
   queryCount,
   selection,
-  sort,
   statsPeriod,
   onActionTaken,
   issuesLoading,
@@ -87,8 +83,6 @@ function IssueListTable({
             groupIds={groupIds}
             allResultsVisible={allResultsVisible}
             displayReprocessingActions={displayReprocessingActions}
-            sort={sort}
-            onSortChange={onSortChange}
           />
         )}
         <PanelBody>

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -142,7 +142,7 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
           <Cell>
             <TimeCellContent timeFilters={view.timeFilters} />
           </Cell>
-          <Cell>{getSortLabel(view.querySort, organization)}</Cell>
+          <Cell>{getSortLabel(view.querySort)}</Cell>
           <Cell>
             <SharingCellContent visibility={view.visibility} />
           </Cell>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1095,8 +1095,6 @@ function IssueListOverview({router}: Props) {
               groupIds={groupIds}
               allResultsVisible={allResultsVisible()}
               displayReprocessingActions={displayReprocessingActions}
-              sort={sort}
-              onSortChange={onSortChange}
               memberList={memberList}
               selectedProjectIds={selection.projects}
               issuesLoading={issuesLoading}

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -185,12 +185,10 @@ export function isDefaultIssueStreamSearch({query, sort}: {query: string; sort: 
   return query === DEFAULT_QUERY && sort === DEFAULT_ISSUE_STREAM_SORT;
 }
 
-export function getSortLabel(key: string, organization: Organization) {
+export function getSortLabel(key: string) {
   switch (key) {
     case IssueSortOptions.NEW:
-      return organization.features.includes('issue-stream-table-layout')
-        ? t('Age')
-        : t('First Seen');
+      return t('Age');
     case IssueSortOptions.TRENDS:
       return t('Trends');
     case IssueSortOptions.FREQ:

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
-import EventMessage from 'sentry/components/events/eventMessage';
 import EventTitleError from 'sentry/components/eventTitleError';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import {IconStar} from 'sentry/icons';
@@ -11,7 +10,7 @@ import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {getLocation, getMessage, isTombstone} from 'sentry/utils/events';
+import {getLocation, isTombstone} from 'sentry/utils/events';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface EventOrGroupHeaderProps {
@@ -83,9 +82,6 @@ function IssueTitle(props: IssueTitleProps) {
 
 export function IssueSummary({data, event_id}: EventOrGroupHeaderProps) {
   const eventLocation = getLocation(data);
-  const organization = useOrganization();
-
-  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
 
   return (
     <div data-test-id="event-issue-header">
@@ -93,15 +89,6 @@ export function IssueSummary({data, event_id}: EventOrGroupHeaderProps) {
         <IssueTitle data={data} event_id={event_id} />
       </Title>
       {eventLocation ? <Location>{eventLocation}</Location> : null}
-      {hasNewLayout ? null : (
-        <StyledEventMessage
-          data={data}
-          level={'level' in data ? data.level : undefined}
-          message={getMessage(data)}
-          type={data.type}
-          levelIndicatorSize={9}
-        />
-      )}
     </div>
   );
 }
@@ -141,11 +128,6 @@ function Location(props: any) {
     </LocationWrapper>
   );
 }
-
-const StyledEventMessage = styled(EventMessage)`
-  margin: 0 0 5px;
-  gap: ${space(0.5)};
-`;
 
 const IconWrapper = styled('span')`
   position: relative;


### PR DESCRIPTION
The first part of the feature flag reference removals were done in https://github.com/getsentry/sentry/pull/88403, this was broken up into multiple PRs due to the size of the diff.

Merging into that branch because this needs to be merged all at once to avoid breaking the UI for single tenants that don't have the feature flag enabled.