### PR TITLE
:sparkles: feat(aci): add workflow_id when creating an ephemeral rule in noa

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -144,7 +144,10 @@ class BaseIssueAlertHandler(ABC):
             if alert_rule_workflow.rule is None:
                 raise ValueError("Rule not found when querying for AlertRuleWorkflow")
 
-            data["legacy_rule_id"] = alert_rule_workflow.rule.id
+            data["actions"][0]["legacy_rule_id"] = alert_rule_workflow.rule.id
+        # In the new UI, we need this for to build the link to the new rule in the notification action
+        else:
+            data["actions"][0]["workflow_id"] = job.workflow_id
 
         rule = Rule(
             id=action.id,

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -142,9 +142,9 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
                     "server": "1234567890",
                     "channel_id": "channel456",
                     "tags": "environment,user,my_tag",
+                    "legacy_rule_id": self.rule.id,
                 }
             ],
-            "legacy_rule_id": self.rule.id,
         }
         assert rule.status == ObjectStatus.ACTIVE
         assert rule.source == RuleSource.ISSUE
@@ -170,6 +170,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
                     "server": "1234567890",
                     "channel_id": "channel456",
                     "tags": "environment,user,my_tag",
+                    "workflow_id": self.workflow.id,
                 }
             ]
         }
@@ -196,9 +197,9 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
                     "server": "1234567890",
                     "channel_id": "channel456",
                     "tags": "environment,user,my_tag",
+                    "legacy_rule_id": self.rule.id,
                 }
             ],
-            "legacy_rule_id": self.rule.id,
         }
         assert rule.status == ObjectStatus.ACTIVE
         assert rule.source == RuleSource.ISSUE
@@ -226,6 +227,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
                     "server": "1234567890",
                     "channel_id": "channel456",
                     "tags": "environment,user,my_tag",
+                    "workflow_id": self.workflow.id,
                 }
             ]
         }


### PR DESCRIPTION
in the new world, a link to a `rule` maps to a `workflow`. this means when we are building the link for notifications, we will need a `workflow_id`. 

to make it happen, i am passing the `workflow_id` down from the noa.

i also made a small mistake where i added the `legacy_rule_id` in the wrong portion of the data blob.

for context, when we are instantiating an issue alert handler, we pass `rule.data.actions` which is what the handler has access to, so we need to put those key-values inside the `action` key

https://github.com/getsentry/sentry/blob/22504295693ce64779a6f32098823857560cd002/src/sentry/rules/processing/processor.py#L162-L163