### PR TITLE
fix(node-profiling): Onboarding instructions

### DIFF
--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -47,6 +47,9 @@ describe('express onboarding docs', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+    ).toBeInTheDocument();
   });
 
   it('enables performance setting the tracesSampleRate to 1', () => {
@@ -59,9 +62,6 @@ describe('express onboarding docs', function () {
 
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -47,6 +47,9 @@ describe('fastify onboarding docs', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+    ).toBeInTheDocument();
   });
 
   it('enables performance setting the tracesSampleRate to 1', () => {
@@ -59,9 +62,6 @@ describe('fastify onboarding docs', function () {
 
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -41,6 +41,9 @@ describe('gcpfunctions onboarding docs', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+    ).toBeInTheDocument();
   });
 
   it('enables performance setting the tracesSampleRate to 1', () => {
@@ -53,9 +56,6 @@ describe('gcpfunctions onboarding docs', function () {
 
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -47,6 +47,9 @@ describe('hapi onboarding docs', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+    ).toBeInTheDocument();
   });
 
   it('enables performance setting the tracesSampleRate to 1', () => {
@@ -59,9 +62,6 @@ describe('hapi onboarding docs', function () {
 
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -202,8 +202,7 @@ export const getSdkInitSnippet = (
             : ''
 }
 Sentry.init({
-  dsn: "${params.dsn.public}",
-  ${
+  dsn: "${params.dsn.public}",${
     params.isProfilingSelected
       ? `integrations: [
     nodeProfilingIntegration(),
@@ -213,24 +212,26 @@ Sentry.init({
     params.isPerformanceSelected
       ? `
       // Tracing
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions\n`
+      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
       : ''
   }${
-    params.isProfilingSelected &&
-    params.profilingOptions?.defaultProfilingMode !== 'continuous'
-      ? `
+    params.isProfilingSelected
+      ? params.profilingOptions?.defaultProfilingMode === 'continuous'
+        ? `
+    // Set sampling rate for profiling - this is evaluated only once per SDK.init
+    profileSessionSampleRate: 1.0,`
+        : `
     // Set sampling rate for profiling - this is evaluated only once per SDK.init call
     profileSessionSampleRate: 1.0,
     // Trace lifecycle automatically enables profiling during active traces
     profileLifecycle: 'trace',`
-      : `
-    // Set sampling rate for profiling - this is evaluated only once per SDK.init
-    profileSessionSampleRate: 1.0,
-    `
-  }});${
+      : ''
+  }
+  });${
     params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode === 'continuous'
       ? `
+
 // Manually call startProfiler and stopProfiler
 // to profile the code in between
 Sentry.profiler.startProfiler();


### PR DESCRIPTION
Fix `profileSessionSampleRate` being visible without profiling being selected.
Fix line breaks.