### PR TITLE
fix(ui): positioning of search icon

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -359,7 +359,7 @@ const ActionButton = styled(Button)`
 const PositionedSearchIconContainer = styled('div')`
   position: absolute;
   left: ${space(1.5)};
-  top: ${space(0.75)};
+  top: ${space(1)};
 `;
 
 const SearchIcon = styled(IconSearch)`


### PR DESCRIPTION
this looks better in both chonk and the old design

before:

![Screenshot 2025-04-02 at 11 17 34](https://github.com/user-attachments/assets/cd8026f9-2ebd-4efd-85f3-daa55118a8df)
![Screenshot 2025-04-02 at 11 17 40](https://github.com/user-attachments/assets/a443ea30-8bce-4ec5-b053-e1c746dadbda)

after:

![Screenshot 2025-04-02 at 11 17 13](https://github.com/user-attachments/assets/8baf84d4-e2cf-43b6-b54a-7413248ac223)
![Screenshot 2025-04-02 at 11 17 20](https://github.com/user-attachments/assets/6fc25a19-88de-46d5-9ba4-13f4e73010ca)
