### PR TITLE
fix(stories): grid alignment

### DIFF
--- a/static/app/components/stories/sideBySide.tsx
+++ b/static/app/components/stories/sideBySide.tsx
@@ -14,6 +14,8 @@ export const Grid = styled('div')<{columns?: number}>`
   grid-template-columns: ${p =>
     p.columns ? `repeat(${p.columns}, 1fr)` : 'repeat(auto-fit, minmax(300px, 1fr))'};
   gap: ${space(2)};
+  grid-auto-rows: auto;
+  align-items: start;
 `;
 
 export default SideBySide;


### PR DESCRIPTION
in a grid layout, all items get the same height per default, but that is bad for our side-by-side view where we show different item sizes.