### PR TITLE
feat(pipeline): Add in page for Coverage Trend

### DIFF
--- a/static/app/views/pipeline/coverage/coverageTrend.spec.tsx
+++ b/static/app/views/pipeline/coverage/coverageTrend.spec.tsx
@@ -1,0 +1,20 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CoverageTrendPage from 'sentry/views/pipeline/coverage/coverageTrend';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CoveragePageWrapper', () => {
+  describe('when the wrapper is used', () => {
+    it('renders the passed children', () => {
+      render(<CoverageTrendPage />, {
+        organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
+      });
+
+      const coverageTrend = screen.getByText('Coverage Trend');
+      expect(coverageTrend).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/pipeline/coverage/coverageTrend.tsx
+++ b/static/app/views/pipeline/coverage/coverageTrend.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export default function CoverageTrendPage() {
+  return (
+    <LayoutGap>
+      <p>Coverage Trend</p>
+    </LayoutGap>
+  );
+}
+
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;


### PR DESCRIPTION
This PR adds in a new component that will eventually be used to house the upcoming "Coverage Trend" page.
