### PR TITLE
fix(ui): overlapping icons on dashboard in chonk

### DIFF
--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -209,6 +209,7 @@ const ContextMenuWrapper = styled('div')`
   right: ${space(2)};
   bottom: ${space(1)};
   display: flex;
+  ${p => (p.theme.isChonk ? `gap: ${space(0.5)};` : '')}
 `;
 
 const StyledButton = styled(Button)`


### PR DESCRIPTION
`chonk` has a wider focus-ring, so some `gap` is needed when layouting items. doesn’t affect the current theme.

before:
![Screenshot 2025-04-02 at 13 09 31](https://github.com/user-attachments/assets/74d3a022-cca7-4b88-a33b-3ffea343ad4f)

after:
![Screenshot 2025-04-02 at 13 09 53](https://github.com/user-attachments/assets/ad6c3d18-b535-4227-9202-e8020425fcbc)