### PR TITLE
fix(ui): get rid of theme.inactive

### DIFF
--- a/static/app/components/charts/components/legend.tsx
+++ b/static/app/components/charts/components/legend.tsx
@@ -43,7 +43,7 @@ export default function Legend(
         fontFamily: theme.text.family,
         lineHeight: 14,
       },
-      inactiveColor: theme.inactive,
+      inactiveColor: theme.subText,
     },
     rest
   );

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -777,12 +777,6 @@ const generateAliases = (
   focusBorder: tokens.border.accent,
 
   /**
-   * Inactive
-   * NOTE: Used in only a few places, but unclear how this would map to chonkUI
-   */
-  inactive: colors.gray300,
-
-  /**
    * Link color indicates that something is clickable
    */
   linkColor: tokens.component.link.accent.default,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -346,11 +346,6 @@ export const generateThemeAliases = (colors: Colors) => ({
   focusBorder: colors.purple300,
 
   /**
-   * Inactive
-   */
-  inactive: colors.gray300,
-
-  /**
    * Link color indicates that something is clickable
    */
   linkColor: colors.blue400,

--- a/static/app/views/dashboards/addWidget.tsx
+++ b/static/app/views/dashboards/addWidget.tsx
@@ -95,7 +95,7 @@ function AddWidget({onAddWidget, onAddWidgetFromNewWidgetBuilder}: Props) {
                 'aria-label': t('Add Widget'),
                 size: 'md',
                 showChevron: false,
-                icon: <IconAdd isCircled size="lg" color="inactive" />,
+                icon: <IconAdd isCircled size="lg" color="subText" />,
                 borderless: true,
               }}
             />
@@ -104,7 +104,7 @@ function AddWidget({onAddWidget, onAddWidgetFromNewWidgetBuilder}: Props) {
           <InnerWrapper onClick={() => onAddWidget(defaultDataset)}>
             <AddButton
               data-test-id="widget-add"
-              icon={<IconAdd size="lg" isCircled color="inactive" />}
+              icon={<IconAdd size="lg" isCircled color="subText" />}
               aria-label={t('Add widget')}
             />
           </InnerWrapper>


### PR DESCRIPTION
`theme.inactive` was statically mapped to `gray300`, which doesn’t work in chonk.

There were only two usages:

- for `inactiveColor` in chart legends, `subText` works great
- for the `addWidget` icon, I also went with `subText` even though it’s not great semantically.

before:

![Screenshot 2025-04-02 at 13 30 10](https://github.com/user-attachments/assets/93c81fad-a448-4524-8d9e-21f47da0c053)

after:

![Screenshot 2025-04-02 at 13 30 37](https://github.com/user-attachments/assets/191d5b94-8290-470f-ba4a-22efdcab4c62)
