### PR TITLE
feat(pipeline): Add in wrapper component for Commit Detail Page

### DIFF
--- a/static/app/views/pipeline/coverage/commits/commitWrapper.spec.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitWrapper.spec.tsx
@@ -2,17 +2,17 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import CommitsPageWrapper from 'sentry/views/pipeline/coverage/commits/commitWrapper';
+import CommitDetailWrapper from 'sentry/views/pipeline/coverage/commits/commitWrapper';
 
 const COVERAGE_FEATURE = 'codecov-ui';
 
-describe('CoveragePageWrapper', () => {
+describe('CommitDetailWrapper', () => {
   describe('when the wrapper is used', () => {
     it('renders the passed children', () => {
       render(
-        <CommitsPageWrapper>
+        <CommitDetailWrapper>
           <p>Test content</p>
-        </CommitsPageWrapper>,
+        </CommitDetailWrapper>,
         {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
       );
 
@@ -22,9 +22,9 @@ describe('CoveragePageWrapper', () => {
 
     it('renders the document title', () => {
       render(
-        <CommitsPageWrapper>
+        <CommitDetailWrapper>
           <p>Test content</p>
-        </CommitsPageWrapper>,
+        </CommitDetailWrapper>,
         {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
       );
 

--- a/static/app/views/pipeline/coverage/commits/commitWrapper.spec.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitWrapper.spec.tsx
@@ -1,0 +1,35 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CommitsPageWrapper from 'sentry/views/pipeline/coverage/commits/commitWrapper';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CoveragePageWrapper', () => {
+  describe('when the wrapper is used', () => {
+    it('renders the passed children', () => {
+      render(
+        <CommitsPageWrapper>
+          <p>Test content</p>
+        </CommitsPageWrapper>,
+        {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
+      );
+
+      const testContent = screen.getByText('Test content');
+      expect(testContent).toBeInTheDocument();
+    });
+
+    it('renders the document title', () => {
+      render(
+        <CommitsPageWrapper>
+          <p>Test content</p>
+        </CommitsPageWrapper>,
+        {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
+      );
+
+      const testTitle = screen.getByText('Commit Page Wrapper');
+      expect(testTitle).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/pipeline/coverage/commits/commitWrapper.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitWrapper.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function CommitsPageWrapper({children}: Props) {
+  const organization = useOrganization();
+
+  return (
+    // TODO: Update title to be some form of Commit + SHA
+    <SentryDocumentTitle title="Commit Page Wrapper" orgSlug={organization.slug}>
+      <Layout.Header unified>
+        <Layout.HeaderContent>
+          <HeaderContentBar>
+            <Layout.Title>
+              <p>Commit Page Wrapper</p>
+              <FeatureBadge type="new" variant="badge" />
+            </Layout.Title>
+          </HeaderContentBar>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>{children}</Layout.Main>
+      </Layout.Body>
+    </SentryDocumentTitle>
+  );
+}
+
+const HeaderContentBar = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+`;

--- a/static/app/views/pipeline/coverage/commits/commitWrapper.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitWrapper.tsx
@@ -9,7 +9,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export default function CommitsPageWrapper({children}: Props) {
+export default function CommitDetailWrapper({children}: Props) {
   const organization = useOrganization();
 
   return (


### PR DESCRIPTION
This PR adds in the a component for the upcoming pipeline commit detail page. Currently there are just place holder values that will be updated at a later time before being released.
