### PR TITLE
feat(pipeline): Add in pull detail wrapper component

### DIFF
--- a/static/app/views/pipeline/coverage/pulls/pullWraper.spec.tsx
+++ b/static/app/views/pipeline/coverage/pulls/pullWraper.spec.tsx
@@ -6,7 +6,7 @@ import PullDetailWrapper from 'sentry/views/pipeline/coverage/pulls/pullWraper';
 
 const COVERAGE_FEATURE = 'codecov-ui';
 
-describe('CoveragePageWrapper', () => {
+describe('PullDetailWrapper', () => {
   describe('when the wrapper is used', () => {
     it('renders the passed children', () => {
       render(

--- a/static/app/views/pipeline/coverage/pulls/pullWraper.spec.tsx
+++ b/static/app/views/pipeline/coverage/pulls/pullWraper.spec.tsx
@@ -1,0 +1,35 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PullDetailWrapper from 'sentry/views/pipeline/coverage/pulls/pullWraper';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CoveragePageWrapper', () => {
+  describe('when the wrapper is used', () => {
+    it('renders the passed children', () => {
+      render(
+        <PullDetailWrapper>
+          <p>Test content</p>
+        </PullDetailWrapper>,
+        {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
+      );
+
+      const testContent = screen.getByText('Test content');
+      expect(testContent).toBeInTheDocument();
+    });
+
+    it('renders the document title', () => {
+      render(
+        <PullDetailWrapper>
+          <p>Test content</p>
+        </PullDetailWrapper>,
+        {organization: OrganizationFixture({features: [COVERAGE_FEATURE]})}
+      );
+
+      const testTitle = screen.getByText('Pull Page Wrapper');
+      expect(testTitle).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/pipeline/coverage/pulls/pullWraper.tsx
+++ b/static/app/views/pipeline/coverage/pulls/pullWraper.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function PullDetailWrapper({children}: Props) {
+  const organization = useOrganization();
+
+  return (
+    // TODO: Update title to be some form of Pull + ID
+    <SentryDocumentTitle title="Pull Page Wrapper" orgSlug={organization.slug}>
+      <Layout.Header unified>
+        <Layout.HeaderContent>
+          <HeaderContentBar>
+            <Layout.Title>
+              <p>Pull Page Wrapper</p>
+              <FeatureBadge type="new" variant="badge" />
+            </Layout.Title>
+          </HeaderContentBar>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>{children}</Layout.Main>
+      </Layout.Body>
+    </SentryDocumentTitle>
+  );
+}
+
+const HeaderContentBar = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+`;


### PR DESCRIPTION
Adds in a component that will be used to wrap the upcoming pull detail page for pipeline. This files content is placeholder for now and will be updated before release.
