### PR TITLE
feat(pipeline): Add in commit detail page component

### DIFF
--- a/static/app/views/pipeline/coverage/commits/commitDetail.spec.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitDetail.spec.tsx
@@ -1,0 +1,18 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CommitDetailPage from 'sentry/views/pipeline/coverage/commits/commitDetail';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CommitDetailPage', () => {
+  it('renders the passed children', () => {
+    render(<CommitDetailPage />, {
+      organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
+    });
+
+    const testContent = screen.getByText('Commit Detail Page');
+    expect(testContent).toBeInTheDocument();
+  });
+});

--- a/static/app/views/pipeline/coverage/commits/commitDetail.spec.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitDetail.spec.tsx
@@ -7,7 +7,7 @@ import CommitDetailPage from 'sentry/views/pipeline/coverage/commits/commitDetai
 const COVERAGE_FEATURE = 'codecov-ui';
 
 describe('CommitDetailPage', () => {
-  it('renders the passed children', () => {
+  it('renders the placeholder content', () => {
     render(<CommitDetailPage />, {
       organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
     });

--- a/static/app/views/pipeline/coverage/commits/commitDetail.tsx
+++ b/static/app/views/pipeline/coverage/commits/commitDetail.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export default function CommitDetailPage() {
+  return (
+    <LayoutGap>
+      <p>Commit Detail Page</p>
+    </LayoutGap>
+  );
+}
+
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;


### PR DESCRIPTION
This page adds in the file/base component that will be used later to build out the commit detail page.
