### PR TITLE
fix(autofix): fix highlight popup behavior

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -9,6 +9,7 @@ import {Button, LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
+import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/autofixSetupWriteAccessModal';
 import {
   type AutofixChangesStep,
@@ -22,7 +23,6 @@ import {
   useAutofixData,
 } from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
-import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {IconCode, IconCopy, IconOpen} from 'sentry/icons';
@@ -57,30 +57,28 @@ function AutofixRepoChange({
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const selection = useTextSelection(containerRef);
-
   return (
     <Content>
-      {selection && (
-        <AutofixHighlightPopup
-          selectedText={selection.selectedText}
-          referenceElement={selection.referenceElement}
-          groupId={groupId}
-          runId={runId}
-          stepIndex={previousDefaultStepIndex ?? 0}
-          retainInsightCardIndex={
-            previousInsightCount !== undefined && previousInsightCount >= 0
-              ? previousInsightCount
-              : null
-          }
-        />
-      )}
       <RepoChangesHeader>
-        <div ref={containerRef}>
-          <PullRequestTitle>{change.repo_name}</PullRequestTitle>
-          <Title>{change.title}</Title>
-          <p dangerouslySetInnerHTML={{__html: singleLineRenderer(change.description)}} />
+        <div>
+          <AutofixHighlightWrapper
+            groupId={groupId}
+            runId={runId}
+            stepIndex={previousDefaultStepIndex ?? 0}
+            retainInsightCardIndex={
+              previousInsightCount !== undefined && previousInsightCount >= 0
+                ? previousInsightCount
+                : null
+            }
+          >
+            <div>
+              <PullRequestTitle>{change.repo_name}</PullRequestTitle>
+              <Title>{change.title}</Title>
+              <p
+                dangerouslySetInnerHTML={{__html: singleLineRenderer(change.description)}}
+              />
+            </div>
+          </AutofixHighlightWrapper>
         </div>
       </RepoChangesHeader>
       <AutofixDiff

--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -96,9 +96,9 @@ describe('AutofixDiff', function () {
       screen.getAllByText('src/sentry/processing/backpressure/memory.py')
     ).toHaveLength(2); // one in the header of the diff and one in the popup
 
-    const textarea = screen.getByRole('textbox');
-    await userEvent.clear(textarea);
-    await userEvent.type(textarea, 'New content');
+    const textarea = screen.getAllByRole('textbox')[0];
+    await userEvent.clear(textarea!);
+    await userEvent.type(textarea!, 'New content');
 
     MockApiClient.addMockResponse({
       url: '/issues/1/autofix/update/',
@@ -136,9 +136,9 @@ describe('AutofixDiff', function () {
 
     await userEvent.click(screen.getByRole('button', {name: 'Edit changes'}));
 
-    const textarea = screen.getByRole('textbox');
-    await userEvent.clear(textarea);
-    await userEvent.type(textarea, 'New content');
+    const textarea = screen.getAllByRole('textbox')[0];
+    await userEvent.clear(textarea!);
+    await userEvent.type(textarea!, 'New content');
 
     MockApiClient.addMockResponse({
       url: '/issues/1/autofix/update/',

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -5,6 +5,7 @@ import {type Change, diffWords} from 'diff';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import {TextArea} from 'sentry/components/core/textarea';
+import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {
   type DiffLine,
   DiffLineType,
@@ -587,14 +588,11 @@ function FileDiff({
   groupId: string;
   isExpandable: boolean;
   runId: string;
-  previousDefaultStepIndex?: number;
-  previousInsightCount?: number;
   repoId?: string;
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  // const selection = useTextSelection(containerRef);
 
   return (
     <FileDiffWrapper>
@@ -618,20 +616,6 @@ function FileDiff({
           />
         )}
       </FileHeader>
-      {/* {selection && (
-        <AutofixHighlightPopup
-          selectedText={selection.selectedText}
-          referenceElement={selection.referenceElement}
-          groupId={groupId}
-          runId={runId}
-          stepIndex={previousDefaultStepIndex ?? 0}
-          retainInsightCardIndex={
-            previousInsightCount !== undefined && previousInsightCount >= 0
-              ? previousInsightCount - 1
-              : -1
-          }
-        />
-      )} */}
       {isExpanded && (
         <DiffContainer ref={containerRef}>
           {file.hunks.map(({section_header, source_start, lines}, index) => {
@@ -672,17 +656,26 @@ export function AutofixDiff({
   return (
     <DiffsColumn>
       {diff.map(file => (
-        <FileDiff
+        <AutofixHighlightWrapper
           key={file.path}
-          file={file}
           groupId={groupId}
           runId={runId}
-          repoId={repoId}
-          editable={editable}
-          previousDefaultStepIndex={previousDefaultStepIndex}
-          previousInsightCount={previousInsightCount}
-          isExpandable={isExpandable}
-        />
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount - 1
+              : -1
+          }
+        >
+          <FileDiff
+            file={file}
+            groupId={groupId}
+            runId={runId}
+            repoId={repoId}
+            editable={editable}
+            isExpandable={isExpandable}
+          />
+        </AutofixHighlightWrapper>
       ))}
     </DiffsColumn>
   );

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -20,7 +20,6 @@ import {
   makeAutofixQueryKey,
   useAutofixData,
 } from 'sentry/components/events/autofix/useAutofix';
-import {useDrawerWidth} from 'sentry/components/globalDrawer/components';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -355,7 +354,6 @@ function getOptimalPosition(
 function AutofixHighlightPopup(props: Props) {
   const {referenceElement} = props;
   const popupRef = useRef<HTMLDivElement>(null);
-  const drawerWidth = useDrawerWidth();
   const [position, setPosition] = useState<{
     left: number;
     top: number;
@@ -375,6 +373,11 @@ function AutofixHighlightPopup(props: Props) {
       const referenceRect = referenceElement.getBoundingClientRect();
       const popupRect = popupRef.current!.getBoundingClientRect();
       const viewportWidth = window.innerWidth;
+
+      const drawerElement = document.querySelector('.drawer-panel');
+      const drawerWidth = drawerElement
+        ? drawerElement.getBoundingClientRect().width
+        : undefined;
 
       // Calculate available width for the popup
       const availableWidth = viewportWidth - (drawerWidth ?? viewportWidth * 0.5) - 16;
@@ -414,7 +417,7 @@ function AutofixHighlightPopup(props: Props) {
       });
       window.removeEventListener('resize', updatePosition);
     };
-  }, [referenceElement, drawerWidth]);
+  }, [referenceElement]);
 
   const handleFocus = () => {
     setIsFocused(true);

--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -1,0 +1,54 @@
+import React, {useRef} from 'react';
+import {AnimatePresence} from 'framer-motion';
+
+import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
+import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
+
+interface AutofixHighlightWrapperProps {
+  children: React.ReactNode;
+  groupId: string;
+  runId: string;
+  stepIndex: number;
+  className?: string;
+  isAgentComment?: boolean;
+  retainInsightCardIndex?: number | null;
+}
+
+/**
+ * A wrapper component that handles text selection and renders AutofixHighlightPopup
+ * when text is selected within its children.
+ */
+export function AutofixHighlightWrapper({
+  children,
+  groupId,
+  runId,
+  stepIndex,
+  retainInsightCardIndex = null,
+  isAgentComment = false,
+  className,
+}: AutofixHighlightWrapperProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selection = useTextSelection(containerRef);
+
+  return (
+    <React.Fragment>
+      <div ref={containerRef} className={className}>
+        {children}
+      </div>
+
+      <AnimatePresence>
+        {selection && (
+          <AutofixHighlightPopup
+            selectedText={selection.selectedText}
+            referenceElement={selection.referenceElement}
+            groupId={groupId}
+            runId={runId}
+            stepIndex={stepIndex}
+            retainInsightCardIndex={retainInsightCardIndex}
+            isAgentComment={isAgentComment}
+          />
+        )}
+      </AnimatePresence>
+    </React.Fragment>
+  );
+}

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -232,17 +232,15 @@ function AutofixInsightCard({
                   >
                     <ContextBody>
                       {insight.justification || !insight.change_diff ? (
-                        <p>
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html: marked(
-                                replaceHeadersWithBold(
-                                  insight.justification || t('No details here.')
-                                )
-                              ),
-                            }}
-                          />
-                        </p>
+                        <MiniHeader
+                          dangerouslySetInnerHTML={{
+                            __html: marked(
+                              replaceHeadersWithBold(
+                                insight.justification || t('No details here.')
+                              )
+                            ),
+                          }}
+                        />
                       ) : (
                         <DiffContainer>
                           <AutofixDiff

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -176,13 +176,11 @@ function AutofixInsightCard({
                   stepIndex={stepIndex}
                   retainInsightCardIndex={insightCardAboveIndex}
                 >
-                  <MiniHeader>
-                    <div
-                      dangerouslySetInnerHTML={{
-                        __html: singleLineRenderer(insight.insight),
-                      }}
-                    />
-                  </MiniHeader>
+                  <MiniHeader
+                    dangerouslySetInnerHTML={{
+                      __html: singleLineRenderer(insight.insight),
+                    }}
+                  />
                 </AutofixHighlightWrapper>
 
                 <RightSection>
@@ -232,7 +230,7 @@ function AutofixInsightCard({
                   >
                     <ContextBody>
                       {insight.justification || !insight.change_diff ? (
-                        <MiniHeader
+                        <p
                           dangerouslySetInnerHTML={{
                             __html: marked(
                               replaceHeadersWithBold(

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
+import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRootCause';
 import type {AutofixInsight} from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
@@ -16,9 +17,6 @@ import {space} from 'sentry/styles/space';
 import marked, {singleLineRenderer} from 'sentry/utils/marked';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
-
-import AutofixHighlightPopup from './autofixHighlightPopup';
-import {useTextSelection} from './useTextSelection';
 
 export function ExpandableInsightContext({
   children,
@@ -85,10 +83,6 @@ function AutofixInsightCard({
   isNewInsight,
 }: AutofixInsightCardProps) {
   const isLastInsightInStep = index === insightCount - 1;
-  const headerRef = useRef<HTMLDivElement>(null);
-  const justificationRef = useRef<HTMLDivElement>(null);
-  const headerSelection = useTextSelection(headerRef);
-  const justificationSelection = useTextSelection(justificationRef);
   const isUserMessage = insight.justification === 'USER';
   const [expanded, setExpanded] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -125,28 +119,6 @@ function AutofixInsightCard({
 
   return (
     <ContentWrapper>
-      <AnimatePresence>
-        {headerSelection && (
-          <AutofixHighlightPopup
-            selectedText={headerSelection.selectedText}
-            referenceElement={headerSelection.referenceElement}
-            groupId={groupId}
-            runId={runId}
-            stepIndex={stepIndex}
-            retainInsightCardIndex={insightCardAboveIndex}
-          />
-        )}
-        {justificationSelection && (
-          <AutofixHighlightPopup
-            selectedText={justificationSelection.selectedText}
-            referenceElement={justificationSelection.referenceElement}
-            groupId={groupId}
-            runId={runId}
-            stepIndex={stepIndex}
-            retainInsightCardIndex={insightCardAboveIndex}
-          />
-        )}
-      </AnimatePresence>
       <AnimatePresence initial={isNewInsight}>
         <AnimationWrapper key="content">
           {hasCardAbove && (
@@ -198,12 +170,20 @@ function AutofixInsightCard({
                 onClick={isUserMessage ? undefined : toggleExpand}
                 isUserMessage={isUserMessage}
               >
-                <MiniHeader
-                  ref={headerRef}
-                  dangerouslySetInnerHTML={{
-                    __html: singleLineRenderer(insight.insight),
-                  }}
-                />
+                <AutofixHighlightWrapper
+                  groupId={groupId}
+                  runId={runId}
+                  stepIndex={stepIndex}
+                  retainInsightCardIndex={insightCardAboveIndex}
+                >
+                  <MiniHeader>
+                    <div
+                      dangerouslySetInnerHTML={{
+                        __html: singleLineRenderer(insight.insight),
+                      }}
+                    />
+                  </MiniHeader>
+                </AutofixHighlightWrapper>
 
                 <RightSection>
                   {!isUserMessage && (
@@ -244,30 +224,38 @@ function AutofixInsightCard({
                     bounce: 0.1,
                   }}
                 >
-                  <ContextBody>
-                    {insight.justification || !insight.change_diff ? (
-                      <p
-                        ref={justificationRef}
-                        dangerouslySetInnerHTML={{
-                          __html: marked(
-                            replaceHeadersWithBold(
-                              insight.justification || t('No details here.')
-                            )
-                          ),
-                        }}
-                      />
-                    ) : (
-                      <DiffContainer>
-                        <AutofixDiff
-                          diff={insight.change_diff}
-                          groupId={groupId}
-                          runId={runId}
-                          editable={false}
-                          isExpandable={false}
-                        />
-                      </DiffContainer>
-                    )}
-                  </ContextBody>
+                  <AutofixHighlightWrapper
+                    groupId={groupId}
+                    runId={runId}
+                    stepIndex={stepIndex}
+                    retainInsightCardIndex={insightCardAboveIndex}
+                  >
+                    <ContextBody>
+                      {insight.justification || !insight.change_diff ? (
+                        <p>
+                          <div
+                            dangerouslySetInnerHTML={{
+                              __html: marked(
+                                replaceHeadersWithBold(
+                                  insight.justification || t('No details here.')
+                                )
+                              ),
+                            }}
+                          />
+                        </p>
+                      ) : (
+                        <DiffContainer>
+                          <AutofixDiff
+                            diff={insight.change_diff}
+                            groupId={groupId}
+                            runId={runId}
+                            editable={false}
+                            isExpandable={false}
+                          />
+                        </DiffContainer>
+                      )}
+                    </ContextBody>
+                  </AutofixHighlightWrapper>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -8,6 +8,7 @@ import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import AutofixThumbsUpDownButtons from 'sentry/components/events/autofix/autofixThumbsUpDownButtons';
 import {
   type AutofixFeedback,
@@ -33,7 +34,6 @@ import {Divider} from 'sentry/views/issueDetails/divider';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
-import {useTextSelection} from './useTextSelection';
 
 type AutofixRootCauseProps = {
   causes: AutofixRootCauseData[];
@@ -171,37 +171,37 @@ function RootCauseDescription({
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const selection = useTextSelection(containerRef);
-
   return (
     <CauseDescription>
-      <AnimatePresence>
-        {selection && (
-          <AutofixHighlightPopup
-            selectedText={selection.selectedText}
-            referenceElement={selection.referenceElement}
-            groupId={groupId}
-            runId={runId}
-            stepIndex={previousDefaultStepIndex ?? 0}
-            retainInsightCardIndex={
-              previousInsightCount !== undefined && previousInsightCount >= 0
-                ? previousInsightCount
-                : null
-            }
-          />
-        )}
-      </AnimatePresence>
-      <div ref={containerRef}>
-        {cause.description && (
+      {cause.description && (
+        <AutofixHighlightWrapper
+          groupId={groupId}
+          runId={runId}
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount
+              : null
+          }
+        >
           <Description
             dangerouslySetInnerHTML={{__html: singleLineRenderer(cause.description)}}
           />
-        )}
-        {cause.root_cause_reproduction && (
-          <AutofixTimeline events={cause.root_cause_reproduction} />
-        )}
-      </div>
+        </AutofixHighlightWrapper>
+      )}
+      {cause.root_cause_reproduction && (
+        <AutofixTimeline
+          events={cause.root_cause_reproduction}
+          groupId={groupId}
+          runId={runId}
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount
+              : null
+          }
+        />
+      )}
     </CauseDescription>
   );
 }

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -204,7 +204,6 @@ describe('AutofixSolution', () => {
     render(<AutofixSolution {...defaultProps} />);
 
     expect(screen.getByText('Fix the bug')).toBeInTheDocument();
-    expect(screen.getByText('Some code and analysis')).toBeInTheDocument();
   });
 
   it('passes the solution array when Code It Up button is clicked', async () => {

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -9,6 +9,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
+import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import AutofixThumbsUpDownButtons from 'sentry/components/events/autofix/autofixThumbsUpDownButtons';
 import {
   type AutofixFeedback,
@@ -43,7 +44,6 @@ import useApi from 'sentry/utils/useApi';
 import {Divider} from 'sentry/views/issueDetails/divider';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
-import {useTextSelection} from './useTextSelection';
 
 export function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
@@ -163,39 +163,37 @@ function SolutionDescription({
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const selection = useTextSelection(containerRef);
-
   return (
     <SolutionDescriptionWrapper>
-      <AnimatePresence>
-        {selection && (
-          <AutofixHighlightPopup
-            selectedText={selection.selectedText}
-            referenceElement={selection.referenceElement}
-            groupId={groupId}
-            runId={runId}
-            stepIndex={previousDefaultStepIndex ?? 0}
-            retainInsightCardIndex={
-              previousInsightCount !== undefined && previousInsightCount >= 0
-                ? previousInsightCount
-                : null
-            }
-          />
-        )}
-      </AnimatePresence>
-      <div ref={containerRef}>
-        {description && (
+      {description && (
+        <AutofixHighlightWrapper
+          groupId={groupId}
+          runId={runId}
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount
+              : null
+          }
+        >
           <Description
             dangerouslySetInnerHTML={{__html: singleLineRenderer(description)}}
           />
-        )}
-        <SolutionEventList
-          events={solution}
-          onDeleteItem={onDeleteItem}
-          onToggleActive={onToggleActive}
-        />
-      </div>
+        </AutofixHighlightWrapper>
+      )}
+      <SolutionEventList
+        events={solution}
+        onDeleteItem={onDeleteItem}
+        onToggleActive={onToggleActive}
+        groupId={groupId}
+        runId={runId}
+        stepIndex={previousDefaultStepIndex ?? 0}
+        retainInsightCardIndex={
+          previousInsightCount !== undefined && previousInsightCount >= 0
+            ? previousInsightCount
+            : null
+        }
+      />
     </SolutionDescriptionWrapper>
   );
 }
@@ -208,27 +206,25 @@ const Description = styled('div')`
 
 type SolutionEventListProps = {
   events: AutofixSolutionTimelineEvent[];
+  groupId: string;
   onDeleteItem: (index: number) => void;
   onToggleActive: (index: number) => void;
+  runId: string;
+  retainInsightCardIndex?: number | null;
+  stepIndex?: number;
 };
 
 function SolutionEventList({
   events,
   onDeleteItem,
   onToggleActive,
+  groupId,
+  runId,
+  stepIndex = 0,
+  retainInsightCardIndex = null,
 }: SolutionEventListProps) {
   // Track which events are expanded
-  const [expandedItems, setExpandedItems] = useState<number[]>(() => {
-    if (!events?.length || events.length > 3) {
-      return [];
-    }
-
-    // For 3 or fewer items, find the first highlighted and active item or default to first item
-    const firstHighlightedIndex = events.findIndex(
-      event => event.is_most_important_event && event.is_active !== false
-    );
-    return [firstHighlightedIndex === -1 ? 0 : firstHighlightedIndex];
-  });
+  const [expandedItems, setExpandedItems] = useState<number[]>([]);
 
   const toggleItem = useCallback((index: number) => {
     setExpandedItems(current =>
@@ -283,11 +279,18 @@ function SolutionEventList({
                 isSelected={isSelected}
                 data-test-id={`autofix-solution-timeline-item-${index}`}
               >
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: singleLineRenderer(event.title),
-                  }}
-                />
+                <AutofixHighlightWrapper
+                  groupId={groupId}
+                  runId={runId}
+                  stepIndex={stepIndex}
+                  retainInsightCardIndex={retainInsightCardIndex}
+                >
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: singleLineRenderer(event.title),
+                    }}
+                  />
+                </AutofixHighlightWrapper>
                 <IconWrapper>
                   {!isHumanAction && event.code_snippet_and_analysis && isSelected && (
                     <StyledIconChevron
@@ -333,11 +336,18 @@ function SolutionEventList({
                     transition={{duration: 0.2}}
                   >
                     <Timeline.Text>
-                      <StyledSpan
-                        dangerouslySetInnerHTML={{
-                          __html: singleLineRenderer(event.code_snippet_and_analysis),
-                        }}
-                      />
+                      <AutofixHighlightWrapper
+                        groupId={groupId}
+                        runId={runId}
+                        stepIndex={stepIndex}
+                        retainInsightCardIndex={retainInsightCardIndex}
+                      >
+                        <StyledSpan
+                          dangerouslySetInnerHTML={{
+                            __html: singleLineRenderer(event.code_snippet_and_analysis),
+                          }}
+                        />
+                      </AutofixHighlightWrapper>
                     </Timeline.Text>
                   </AnimatedContent>
                 )}

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -36,7 +36,7 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement | nul
       }
 
       // Get the text content of the clicked element or its container
-      const clickedText = target.textContent?.trim() || '';
+      const clickedText = containerRef.current?.textContent?.trim() || '';
       if (!clickedText) {
         setSelection(null);
         return;

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -19,10 +19,6 @@ import {
 
 const DrawerWidthContext = createContext<number | undefined>(undefined);
 
-export function useDrawerWidth() {
-  return useContext(DrawerWidthContext);
-}
-
 interface DrawerContentContextType {
   ariaLabel: string;
   onClose: DrawerOptions['onClose'];


### PR DESCRIPTION
The popup now selects "blocks" of content instead of single words with the new wrapper. This also fixes the anchoring.