### PR TITLE
chonk: fix badge type

### DIFF
--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -7,6 +7,8 @@ import type {TooltipProps} from 'sentry/components/tooltip';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 
 const defaultTitles: Record<FeatureBadgeProps['type'], string> = {
   alpha: t('This feature is internal and available for QA purposes'),
@@ -73,15 +75,22 @@ function InnerFeatureBadge({
   );
 }
 
-const StyledBadge = styled(Badge)`
-  margin: 0;
-  padding: 0 ${space(0.75)};
-  line-height: ${space(2)};
-  height: ${space(2)};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  font-size: ${p => p.theme.fontSizeExtraSmall};
-  vertical-align: middle;
+const ChonkStyledBadge = chonkStyled(Badge)`
+  text-transform: capitalize;
 `;
+
+const StyledBadge = withChonk(
+  styled(Badge)`
+    margin: 0;
+    padding: 0 ${space(0.75)};
+    line-height: ${space(2)};
+    height: ${space(2)};
+    font-weight: ${p => p.theme.fontWeightNormal};
+    font-size: ${p => p.theme.fontSizeExtraSmall};
+    vertical-align: middle;
+  `,
+  ChonkStyledBadge
+);
 
 /**
  * Requires the result of styled(Badge) to be exported as it


### PR DESCRIPTION
![CleanShot 2025-04-02 at 10 18 17@2x](https://github.com/user-attachments/assets/144b3131-a369-40f0-899d-b0e9cb679c52)

To (screenshot is missing capitalize, but it was added)

![CleanShot 2025-04-02 at 10 18 21@2x](https://github.com/user-attachments/assets/759ae6d2-39ef-401a-bc92-8b3402cad07f)
