### PR TITLE
chore(issue summary): Remove dividers from AI summary alert

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -636,12 +636,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             original_title = build_attachment_title(event_or_group)
             original_message = text.lstrip(" ")
 
-            blocks.append(self.get_divider())
             blocks.append(
                 self.get_text_block(f"*{original_title}*: `{original_message}`", small=True)
             )
             blocks.append(self.get_text_block(summary_text, small=True))
-            blocks.append(self.get_divider())
         else:
             text = text.lstrip(" ")
             # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -985,10 +985,10 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             assert "IntegrationError" not in blocks["blocks"][0]["text"]["text"]
 
             # Verify that the AI content is used in the context block
-            content_block = blocks["blocks"][2]["elements"][0]["text"]
+            content_block = blocks["blocks"][1]["elements"][0]["text"]
             assert "Identity not found" in content_block
 
-            content_block = blocks["blocks"][3]["elements"][0]["text"]
+            content_block = blocks["blocks"][2]["elements"][0]["text"]
             assert "This is a possible cause" in content_block
 
     @override_options({"alerts.issue_summary_timeout": 5})


### PR DESCRIPTION
Just removing the dividers from the summary content in the alert body.