### PR TITLE
fix(ui): chonk styling of searchTokens

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -326,6 +326,7 @@ const Key = styled('span')<{negated: boolean}>`
   ${filterCss};
   border-right: none;
   font-weight: ${p => p.theme.fontWeightBold};
+  color: ${p => p.theme.subText};
   ${p =>
     p.negated
       ? css`

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -844,12 +844,12 @@ const generateAliases = (
 
   // @todo(jonasbadalic) should these reference chonk colors?
   searchTokenBackground: {
-    valid: colors.chonk.blue100,
-    validActive: color(colors.chonk.blue100).opaquer(1.0).string(),
-    invalid: colors.chonk.red100,
-    invalidActive: color(colors.chonk.red100).opaquer(0.8).string(),
-    warning: colors.chonk.yellow100,
-    warningActive: color(colors.chonk.yellow100).opaquer(0.8).string(),
+    valid: colors.blue100,
+    validActive: color(colors.blue100).opaquer(1.0).string(),
+    invalid: colors.red100,
+    invalidActive: color(colors.red100).opaquer(0.8).string(),
+    warning: colors.yellow100,
+    warningActive: color(colors.yellow100).opaquer(0.8).string(),
   },
 
   /**
@@ -857,12 +857,12 @@ const generateAliases = (
    * NOTE: Not being used anymore in the new Search UI
    */
   searchTokenBorder: {
-    valid: colors.chonk.blue200,
-    validActive: color(colors.chonk.blue200).opaquer(1).string(),
-    invalid: colors.chonk.red200,
-    invalidActive: color(colors.chonk.red200).opaquer(1).string(),
-    warning: colors.chonk.yellow200,
-    warningActive: color(colors.chonk.yellow200).opaquer(1).string(),
+    valid: colors.blue200,
+    validActive: color(colors.blue200).opaquer(1).string(),
+    invalid: colors.red200,
+    invalidActive: color(colors.red200).opaquer(1).string(),
+    warning: colors.yellow200,
+    warningActive: color(colors.yellow200).opaquer(1).string(),
   },
 
   /**


### PR DESCRIPTION
before:

![Screenshot 2025-04-02 at 16 23 15](https://github.com/user-attachments/assets/5ff95790-6e54-4986-b24a-c2cee6a120b1)
![Screenshot 2025-04-02 at 16 23 21](https://github.com/user-attachments/assets/f63dce1b-1034-498b-901d-e76626ba77b5)

after:

![Screenshot 2025-04-02 at 16 23 31](https://github.com/user-attachments/assets/c030fa1d-e40d-4319-987c-ac958e2a6a57)
![Screenshot 2025-04-02 at 16 23 37](https://github.com/user-attachments/assets/651d27bd-f5cf-4702-a992-18c617f45663)

note: texts still don’t have a lot of contrast because this is a `disabled` select, which adds a `0.6` opacity in chonk (which it didn’t do in the old theme)