### PR TITLE
fix(dashboards): Improve series alias resolution

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -26,7 +26,7 @@ export class Area extends ContinuousTimeSeries implements Plottable {
     const plottableSeries: LineSeriesOption[] = [];
 
     const commonOptions = {
-      name: this.label,
+      name: this.name,
       color,
       animation: false,
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -36,7 +36,7 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
 
     return [
       BarSeries({
-        name: this.label,
+        name: this.name,
         stack: config.stack,
         yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
         color,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -56,6 +56,10 @@ export abstract class ContinuousTimeSeries<
     this.config = config;
   }
 
+  get name(): string {
+    return this.timeSeries.field;
+  }
+
   get label(): string {
     return this.config?.alias ?? formatSeriesName(this.timeSeries.field);
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -26,7 +26,7 @@ export class Line extends ContinuousTimeSeries implements Plottable {
     const plottableSeries: LineSeriesOption[] = [];
 
     const commonOptions: LineSeriesOption = {
-      name: this.label,
+      name: this.name,
       color,
       animation: false,
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -32,6 +32,10 @@ export interface Plottable {
    */
   isEmpty: boolean;
   /**
+   * Name of the series. This is used under-the-hood in ECharts.
+   */
+  name: string;
+  /**
    * Whether this plottable needs a color from a shared palette. For example, data series plottables share a palette which is created based on how many series will be plotted.
    */
   needsColor: boolean;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -104,6 +104,10 @@ export class Samples implements Plottable {
     return this.#timestamps.at(-1) ?? null;
   }
 
+  get name(): string {
+    return `${this.config.attributeName} samples`;
+  }
+
   get label(): string {
     return this.config?.alias ?? t('%s Samples', this.config.attributeName);
   }
@@ -150,7 +154,7 @@ export class Samples implements Plottable {
 
     const series: ScatterSeriesOption = {
       type: 'scatter',
-      name: this.label,
+      name: this.name,
       data: samples.data.filter(isValidSampleRow).map(sample => {
         const value = sample[config.attributeName];
         return [sample.timestamp, value ?? ECHARTS_MISSING_DATA_VALUE, sample.id];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -668,23 +668,34 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         </p>
         <p>
           You can also provide aliases for plottables like <code>Line</code> This will
-          give the legends and tooltips a friendlier name. In this example, verbose names
-          like "p99(span.duration)" are truncated, and the p99 series is hidden by
-          default.
+          give the legends and tooltips a friendlier name. In the first example, verbose
+          names like "p99(span.duration)" are truncated, and the p99 series is hidden by
+          default. The legend will always include an entry for every plottable, even if
+          some plottables have the same alias, as you can see in the second example.
         </p>
 
         <code>{JSON.stringify(legendSelection)}</code>
 
-        <MediumWidget>
-          <TimeSeriesWidgetVisualization
-            plottables={[
-              new Area(sampleDurationTimeSeries, {alias: 'p50'}),
-              new Area(sampleDurationTimeSeries2, {alias: 'p99'}),
-            ]}
-            legendSelection={legendSelection}
-            onLegendSelectionChange={setLegendSelection}
-          />
-        </MediumWidget>
+        <SideBySide>
+          <MediumWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Area(sampleDurationTimeSeries, {alias: 'p50'}),
+                new Area(sampleDurationTimeSeries2, {alias: 'p99'}),
+              ]}
+              legendSelection={legendSelection}
+              onLegendSelectionChange={setLegendSelection}
+            />
+          </MediumWidget>
+          <MediumWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Area(sampleDurationTimeSeries, {alias: 'Duration'}),
+                new Area(sampleDurationTimeSeries2, {alias: 'Duration'}),
+              ]}
+            />
+          </MediumWidget>
+        </SideBySide>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -313,6 +313,13 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       ? theme.chart.getColorPalette(paletteSize - 2) // -2 because getColorPalette artificially adds 1, I'm not sure why
       : [];
 
+  // Create a lookup of series names (given to ECharts) to labels (from
+  // Plottable). This makes it easier to look up alises when rendering tooltips
+  // and legends
+  const aliases = Object.fromEntries(
+    props.plottables.map(plottable => [plottable.name, plottable.label])
+  );
+
   // Create tooltip formatter
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = (
     params,
@@ -368,7 +375,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           return defined(sampleId) ? sampleId.toString() : seriesName;
         }
 
-        return seriesName;
+        return aliases[seriesName] ?? seriesName;
       },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.
@@ -502,7 +509,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
               left: 0,
               formatter(seriesName: string) {
                 return truncationFormatter(
-                  seriesName,
+                  aliases[seriesName] ?? seriesName,
                   true,
                   // Escaping the legend string will cause some special
                   // characters to render as their HTML equivalents.

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -354,9 +354,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     return getFormatter({
       isGroupedByDate: true,
       showTimeInTooltip: true,
-      nameFormatter: function (name, nameFormatterParams) {
+      nameFormatter: function (seriesName, nameFormatterParams) {
         if (!nameFormatterParams) {
-          return name;
+          return seriesName;
         }
 
         if (
@@ -365,10 +365,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         ) {
           // For scatter series, the third point in the `data` array should be the sample's ID
           const sampleId = nameFormatterParams.data.at(2);
-          return defined(sampleId) ? sampleId.toString() : name;
+          return defined(sampleId) ? sampleId.toString() : seriesName;
         }
 
-        return name;
+        return seriesName;
       },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.


### PR DESCRIPTION
Fixes DAIN-143. There's a subtle bug (introduced in https://github.com/getsentry/sentry/pull/87023/) in which if multiple plottables had the same alias, ECharts would merge them in the legend. e.g., imagine plotting `span.duration` for two really long queries. The truncation series name formatter would clip the names, and if the first parts of the queries match they'd have the same name, and the same legend entry. Confusing! This PR resolves that problem, and ensures that every plottable has a legend entry.

## Changes
- add `Plottable.name`, a string property that's passed directly to ECharts. This is a steady under-the-hood value that ECharts uses when passing stuff around
- resolve all aliases ahead-of-time, so they're fast to look up
- defer to aliases when rendering tooltips and legends
