### PR TITLE
fix(profiling): Fix logic for node onboarding snippets

### DIFF
--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -40,7 +40,7 @@ describe('awslambda onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -69,8 +69,9 @@ describe('awslambda onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -95,9 +96,16 @@ describe('awslambda onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -107,13 +107,5 @@ describe('awslambda onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -38,6 +38,9 @@ describe('express onboarding docs', function () {
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
   });
 
   it('enables performance setting the tracesSampleRate to 1', () => {
@@ -65,11 +68,9 @@ describe('express onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -94,9 +95,16 @@ describe('express onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -106,13 +106,5 @@ describe('express onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -47,7 +47,7 @@ describe('connect onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -76,8 +76,9 @@ describe('connect onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -102,9 +103,16 @@ describe('connect onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -114,13 +114,5 @@ describe('connect onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -48,7 +48,7 @@ describe('express onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -77,8 +77,9 @@ describe('express onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
   it('continuous profiling', () => {
@@ -102,9 +103,16 @@ describe('express onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -114,13 +114,5 @@ describe('express onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -48,7 +48,7 @@ describe('fastify onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -77,8 +77,9 @@ describe('fastify onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -103,9 +104,16 @@ describe('fastify onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -115,13 +115,5 @@ describe('fastify onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -42,7 +42,7 @@ describe('gcpfunctions onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -71,8 +71,9 @@ describe('gcpfunctions onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -97,9 +98,16 @@ describe('gcpfunctions onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -109,13 +109,5 @@ describe('gcpfunctions onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -48,7 +48,7 @@ describe('hapi onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -77,8 +77,9 @@ describe('hapi onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -103,9 +104,16 @@ describe('hapi onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -115,13 +115,5 @@ describe('hapi onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -48,7 +48,7 @@ describe('koa onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -77,8 +77,9 @@ describe('koa onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -103,9 +104,16 @@ describe('koa onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -115,13 +115,5 @@ describe('koa onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -48,7 +48,7 @@ describe('Nest.js onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -77,8 +77,9 @@ describe('Nest.js onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -103,9 +104,16 @@ describe('Nest.js onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -115,13 +115,5 @@ describe('Nest.js onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -40,7 +40,7 @@ describe('node onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1.0/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -69,8 +69,9 @@ describe('node onboarding docs', function () {
         )
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
 
@@ -95,9 +96,16 @@ describe('node onboarding docs', function () {
       )
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+
     // Profiles sample rate should not be set for continuous profiling
     expect(
-      screen.queryByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
 
     // Should have start and stop profiling calls

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -107,13 +107,5 @@ describe('node onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -175,15 +175,18 @@ Sentry.init({
       tracesSampleRate: 1.0, //  Capture 100% of the transactions`
       : ''
   }${
-    params.isProfilingSelected
+    params.isProfilingSelected &&
+    params.profilingOptions?.defaultProfilingMode !== 'continuous'
       ? `
     // Set sampling rate for profiling - this is evaluated only once per SDK.init call
-    profileSessionSampleRate: 1.0,`
+    profilesSampleRate: 1.0,`
       : ''
   }${
     params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode === 'continuous'
       ? `
+    // Set sampling rate for profiling - this is evaluated only once per SDK.init call
+    profileSessionSampleRate: 1.0,
     // Trace lifecycle automatically enables profiling during active traces
     profileLifecycle: 'trace',`
       : ''

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -196,23 +196,12 @@ Sentry.init({
     params.profilingOptions?.defaultProfilingMode === 'continuous'
       ? `
 
-// Manually call startProfiler and stopProfiler
-// to profile the code in between
-Sentry.profiler.startProfiler();
-${
-  params.isPerformanceSelected
-    ? `
-// Starts a transaction that will also be profiled
+// Profiling happens automatically after setting it up with \`Sentry.init()\`.
+// All spans (unless those discarded by sampling) will have profiling data attached to them.
 Sentry.startSpan({
-  name: "My First Transaction",
+  name: "My Span",
 }, () => {
-  // the code executing inside the transaction will be wrapped in a span and profiled
-});
-`
-    : '// this code will be profiled'
-}
-// Calls to stopProfiler are optional - if you don't stop the profile session, it will keep profiling
-// your application until the process exits or stopProfiler is called.
-Sentry.profiler.stopProfiler();`
+  // The code executed here will be profiled
+});`
       : ''
   }`;


### PR DESCRIPTION
- Fix profiling snippet. The content for the two profiling modes was switched up. `profileLifecycle: 'trace',` should only be displayed if continuous profiling is enabled.
- Simplify nested ternary
- Remove unused code