### PR TITLE
chore(inc-1100): Bump sentry-redis-tools to retry on timeout error

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -69,7 +69,7 @@ sentry-arroyo>=2.20.6
 sentry-kafka-schemas>=1.1.4
 sentry-ophio==1.0.0
 sentry-protos>=0.1.65
-sentry-redis-tools>=0.4.0
+sentry-redis-tools>=0.5.0
 sentry-relay>=0.9.7
 sentry-sdk[http2]>=2.25.0
 slack-sdk>=3.27.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -69,7 +69,7 @@ sentry-arroyo>=2.20.6
 sentry-kafka-schemas>=1.1.4
 sentry-ophio==1.0.0
 sentry-protos>=0.1.65
-sentry-redis-tools>=0.1.7
+sentry-redis-tools>=0.4.0
 sentry-relay>=0.9.7
 sentry-sdk[http2]>=2.25.0
 slack-sdk>=3.27.2

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -190,7 +190,7 @@ sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
 sentry-protos==0.1.65
-sentry-redis-tools==0.1.7
+sentry-redis-tools==0.4.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -190,7 +190,7 @@ sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
 sentry-protos==0.1.65
-sentry-redis-tools==0.4.0
+sentry-redis-tools==0.5.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
 sentry-protos==0.1.65
-sentry-redis-tools==0.4.0
+sentry-redis-tools==0.5.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
 sentry-protos==0.1.65
-sentry-redis-tools==0.1.7
+sentry-redis-tools==0.4.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.0
 sentry-usage-accountant==0.0.10


### PR DESCRIPTION
In #inc-1100 we saw backpressure kick in for transaction ingestion in `de` and `us` regions because of TimeoutErrors when connecting to the redis cluster. 
https://github.com/getsentry/sentry-redis-tools/releases/tag/0.4.0 adds support to retry on TimeoutErrors