### PR TITLE
fix(logs): Upgrade sentry log integration to fix dogfooding issues

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.65
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.7
-sentry-sdk[http2]>=2.25.0
+sentry-sdk[http2]>=2.25.1
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -192,7 +192,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.65
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.25.0
+sentry-sdk==2.25.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.65
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.7
-sentry-sdk==2.25.0
+sentry-sdk==2.25.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -257,7 +257,7 @@ def before_send(event: Event, _: Hint) -> Event | None:
     return event
 
 
-def before_send_log(log: Log, _: Hint) -> Log:
+def before_send_log(log: Log, _: Hint) -> Log | None:
     if in_random_rollout("ourlogs.sentry-emit-rollout"):
         return log
     return None

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -18,7 +18,7 @@ from sentry_sdk._types import AnnotatedValue
 from sentry_sdk.client import get_options
 from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
 from sentry_sdk.transport import make_transport
-from sentry_sdk.types import Event, Hint
+from sentry_sdk.types import Event, Hint, Log
 from sentry_sdk.utils import logger as sdk_logger
 
 from sentry import options
@@ -257,7 +257,7 @@ def before_send(event: Event, _: Hint) -> Event | None:
     return event
 
 
-def before_send_log(log: Any, _: Hint) -> Any:
+def before_send_log(log: Log, _: Hint) -> Log:
     if in_random_rollout("ourlogs.sentry-emit-rollout"):
         return log
     return None

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -257,7 +257,7 @@ def before_send(event: Event, _: Hint) -> Event | None:
     return event
 
 
-def before_emit_log(log: Any, _: Hint) -> Any:
+def before_send_log(log: Any, _: Hint) -> Any:
     if in_random_rollout("ourlogs.sentry-emit-rollout"):
         return log
     return None
@@ -293,8 +293,8 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     )
     sdk_options.setdefault("_experiments", {}).update(
         transport_http2=True,
-        before_emit_log=before_emit_log,
-        enable_sentry_logs=True,
+        before_send_log=before_send_log,
+        enable_logs=True,
     )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN


### PR DESCRIPTION
- Some things you tried to log would fail because they weren't JSON-able
- There is now batching logic to reduce CPU load
- Various things have been renamed (like before_emit_log -> before_send_log)