### PR TITLE
feat(replay): Show device.model in replay details tags list when SDK sends it

### DIFF
--- a/static/app/components/deviceName.tsx
+++ b/static/app/components/deviceName.tsx
@@ -26,7 +26,6 @@ interface DeviceNameProps {
 
 /**
  * This is used to map iOS Device Names to model name.
- * This asynchronously loads the ios-device-list library because of its size
  */
 function DeviceName({value, children}: DeviceNameProps): React.ReactElement | null {
   const deviceName = useMemo(() => deviceNameMapper(value), [value]);

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -24,6 +24,7 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
       : {}),
     ...(apiResponse.device?.brand ? {'device.brand': [apiResponse.device.brand]} : {}),
     ...(apiResponse.device?.family ? {'device.family': [apiResponse.device.family]} : {}),
+    ...(apiResponse.device?.model ? {'device.model': [apiResponse.device.model]} : {}),
     ...(apiResponse.device?.model_id
       ? {'device.model_id': [apiResponse.device.model_id]}
       : {}),

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -1,6 +1,7 @@
 import invariant from 'invariant';
 import {duration} from 'moment-timezone';
 
+import {deviceNameMapper} from 'sentry/components/deviceName';
 import isValidDate from 'sentry/utils/date/isValidDate';
 import getMinMax from 'sentry/utils/getMinMax';
 import type {ReplayRecord} from 'sentry/views/replays/types';
@@ -24,7 +25,9 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
       : {}),
     ...(apiResponse.device?.brand ? {'device.brand': [apiResponse.device.brand]} : {}),
     ...(apiResponse.device?.family ? {'device.family': [apiResponse.device.family]} : {}),
-    ...(apiResponse.device?.model ? {'device.model': [apiResponse.device.model]} : {}),
+    ...(apiResponse.device?.model
+      ? {'device.model': [deviceNameMapper(apiResponse.device.model)]}
+      : {}),
     ...(apiResponse.device?.model_id
       ? {'device.model_id': [apiResponse.device.model_id]}
       : {}),


### PR DESCRIPTION

<img width="475" alt="SCR-20250402-iuxt" src="https://github.com/user-attachments/assets/88a4b4cd-4607-402b-9a58-f91223988eee" />

Fixes https://github.com/getsentry/sentry/issues/88550