### PR TITLE
feat(sdk): Enable storing previous trace link in `sessionStorage`

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -68,6 +68,7 @@ function getSentryIntegrations() {
       _experiments: {
         enableStandaloneClsSpans: true,
       },
+      linkPreviousTrace: 'session-storage',
     }),
     Sentry.browserProfilingIntegration(),
     Sentry.thirdPartyErrorFilterIntegration({


### PR DESCRIPTION
To fully dogfood linked traces, let's enable storing the previous trace data in `sessionStorage` so that it remains across page reloads. This is an opt-in feature for Sentry SDK users.

