### PR TITLE
fix(auth): accept invite and create new account, render login form

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -189,11 +189,13 @@ class AuthLoginView(BaseView):
         context = self.get_default_context(request=request)
 
         register_form = self.initialize_register_form(request=request)
+        login_form = AuthenticationForm(request=request)
         context.update(
             {
                 "op": "register",
                 "CAN_REGISTER": True,
                 "register_form": register_form,
+                "login_form": login_form,
             }
         )
         return self.respond_login(request=request, context=context, **kwargs)


### PR DESCRIPTION
If somebody is accepting an invite and wants to create a new account, we take them to the page to register for a new account. But if they change their mind and want to login with an existing account we should render the form to allow that.

Before

https://github.com/user-attachments/assets/66a40a73-1f3f-47be-80a7-5fb9baed5a00


After

https://github.com/user-attachments/assets/2d3054d2-ebe7-4e55-9039-d029ead4b905

