### PR TITLE
ui(ourlogs): More logs ui changes

### DIFF
--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -47,7 +47,6 @@ const SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE = [
 
 const SCHEMA_HINTS_HIDDEN_KEYS_LOGS = [
   OurLogKnownFieldKey.SEVERITY_NUMBER, // Severity number is a detail saved by the OTel protocol, and may not be required. 'level' is a mandatory field on the new 'log' ItemType schema.
-  OurLogKnownFieldKey.SENTRY_PROJECT_ID, // Public alias since int<->string alias reversing is broken. Should be removed in the future.
   OurLogKnownFieldKey.ITEM_TYPE, // This is a detail internal to the trace items table.
   OurLogKnownFieldKey.ID, // This is a detail internal to the trace items table.
 ];

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -52,7 +52,6 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
   OurLogKnownFieldKey.SEVERITY_TEXT,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.PROJECT_ID,
-  OurLogKnownFieldKey.SENTRY_PROJECT_ID,
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.ITEM_TYPE,
 ];

--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -5,14 +5,10 @@ import {LOGS_FIELDS_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams
 import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 /**
- * These are the default fields that are shown in the logs table. The query will always add other hidden fields required to render details view etc.
+ * These are the default fields that are shown in the logs table (aside from static columns like severity). The query will always add other hidden fields required to render details view etc.
  */
 export function defaultLogFields(): OurLogKnownFieldKey[] {
-  return [
-    OurLogKnownFieldKey.SEVERITY_TEXT,
-    OurLogKnownFieldKey.BODY,
-    OurLogKnownFieldKey.TIMESTAMP,
-  ];
+  return [OurLogKnownFieldKey.BODY, OurLogKnownFieldKey.TIMESTAMP];
 }
 
 export function getLogFieldsFromLocation(location: Location): OurLogFieldKey[] {

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -65,10 +65,10 @@ type TraceItemDetailsQueryParams = {
 };
 
 export type TraceItemResponseAttribute =
-  | {type: 'str'; value: string}
-  | {type: 'int'; value: number}
-  | {type: 'float'; value: number}
-  | {type: 'bool'; value: boolean};
+  | {name: string; type: 'str'; value: string}
+  | {name: string; type: 'int'; value: number}
+  | {name: string; type: 'float'; value: number}
+  | {name: string; type: 'bool'; value: boolean};
 
 /**
  * Query hook fetching trace item details in EAP.

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -21,6 +21,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.PROJECT_ID,
   OurLogKnownFieldKey.TRACE_ID,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
+  OurLogKnownFieldKey.SEVERITY_TEXT,
 ];
 
 /**

--- a/static/app/views/explore/logs/logFieldsTree.spec.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.spec.tsx
@@ -37,7 +37,7 @@ describe('logFieldsTree', () => {
       {
         type: 'str',
         value: '123',
-        name: OurLogKnownFieldKey.SENTRY_PROJECT_ID,
+        name: 'sentry.project_id',
       } as TraceItemResponseAttribute,
       {
         type: 'str',
@@ -61,7 +61,6 @@ describe('logFieldsTree', () => {
             },
             useFullSeverityText: false,
             renderSeverityCircle: false,
-            wrapBody: false,
             organization,
             location: LocationFixture(),
           }}

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -31,7 +31,7 @@ import {
   adjustAliases,
   adjustLogTraceID,
   getLogAttributeItem,
-  removePrefixes,
+  prettifyAttributeName,
 } from 'sentry/views/explore/logs/utils';
 
 const MAX_TREE_DEPTH = 4;
@@ -517,28 +517,25 @@ function LogFieldsTreeValue({
  * Filters out hidden attributes, replaces sentry. prefixed keys, and simplifies the value
  */
 function getAttribute(
-  attribute: Record<string, any>,
+  attribute: TraceItemResponseAttribute,
   hiddenAttributes: OurLogFieldKey[]
 ): Attribute | undefined {
-  const attributeKey = attribute.name;
   // Filter out hidden attributes
-  if (hiddenAttributes.includes(attributeKey)) {
+  if (hiddenAttributes.includes(attribute.name)) {
     return undefined;
   }
 
-  // Replace the key name with the new key name
-  const newKeyName = removePrefixes(attributeKey);
-
   const attributeValue =
     attribute.type === 'bool' ? String(attribute.value) : attribute.value;
+
   if (!defined(attributeValue)) {
     return undefined;
   }
 
   return {
-    attribute_key: newKeyName,
+    attribute_key: prettifyAttributeName(attribute.name),
     attribute_value: attributeValue,
-    original_attribute_key: adjustAliases(attributeKey),
+    original_attribute_key: adjustAliases(attribute.name),
   };
 }
 

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -27,6 +27,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useLogAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
+import {HiddenLogDetailFields} from 'sentry/views/explore/logs/constants';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
@@ -70,6 +71,7 @@ export function LogsTabContent({
           onColumnsChange={setFields}
           stringTags={stringTags}
           numberTags={numberTags}
+          hiddenKeys={HiddenLogDetailFields}
         />
       ),
       {closeEvents: 'escape-key'}

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -26,7 +26,11 @@ import {
   useSetLogsSortBys,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogRowContent} from 'sentry/views/explore/logs/logsTableRow';
-import {LogTableBody, LogTableRow} from 'sentry/views/explore/logs/styles';
+import {
+  FirstTableHeadCell,
+  LogTableBody,
+  LogTableRow,
+} from 'sentry/views/explore/logs/styles';
 import type {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
 import {EmptyStateText} from 'sentry/views/traces/styles';
 
@@ -55,6 +59,7 @@ export function LogsTable({
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const {initialTableStyles, onResizeMouseDown} = useTableStyles(fields, tableRef, {
     minimumColumnWidth: 50,
+    prefixColumnWidth: 'min-content',
   });
 
   const isEmpty = !isPending && !isError && (data?.length ?? 0) === 0;
@@ -68,6 +73,9 @@ export function LogsTable({
         {showHeader ? (
           <TableHead>
             <LogTableRow>
+              <FirstTableHeadCell isFirst align="left">
+                <TableHeadCellContent isFrozen />
+              </FirstTableHeadCell>
               {fields.map((field, index) => {
                 const direction = sortBys.find(s => s.field === field)?.kind;
 

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -8,7 +8,12 @@ import Panel from 'sentry/components/panels/panel';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {space} from 'sentry/styles/space';
 import {unreachable} from 'sentry/utils/unreachable';
-import {TableBody, TableBodyCell, TableRow} from 'sentry/views/explore/components/table';
+import {
+  TableBody,
+  TableBodyCell,
+  TableHeadCell,
+  TableRow,
+} from 'sentry/views/explore/components/table';
 import {SeverityLevel} from 'sentry/views/explore/logs/utils';
 
 export const StyledPanel = styled(Panel)`
@@ -37,9 +42,13 @@ export const StyledPanelItem = styled(PanelItem)<{
 `;
 
 export const LogTableRow = styled(TableRow)`
-  cursor: pointer;
-
   &:not(thead > &) {
+    cursor: pointer;
+
+    &:hover {
+      background-color: ${p => p.theme.backgroundSecondary};
+    }
+
     &:not(:last-child) {
       border-bottom: 0;
     }
@@ -102,10 +111,6 @@ export const DetailsGrid = styled(StyledPanel)`
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   padding: ${space(1)} ${space(2)};
-`;
-
-export const NonClickableCell = styled('div')`
-  cursor: auto;
 `;
 
 export const LogDetailsTitle = styled('div')`
@@ -193,7 +198,6 @@ export const WrappingText = styled('div')<{wrap?: boolean}>`
   overflow: hidden;
   text-overflow: ellipsis;
   ${p => (p.wrap ? 'text-wrap: auto;' : '')}
-  cursor: auto;
 `;
 
 export const AlignedCellContent = styled('div')<{
@@ -203,6 +207,17 @@ export const AlignedCellContent = styled('div')<{
   align-items: center;
   flex-direction: row;
   justify-content: ${p => p.align || 'left'};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+export const FirstTableHeadCell = styled(TableHeadCell)`
+  padding-right: ${space(1)};
+  padding-left: ${space(2)};
+`;
+
+export const LogsTableBodyFirstCell = styled(LogTableBodyCell)`
+  padding-right: 0;
+  padding-left: ${space(1)};
 `;
 
 export function getLogColors(level: SeverityLevel, theme: Theme) {

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -22,7 +22,6 @@ export enum OurLogKnownFieldKey {
   ORGANIZATION_ID = 'organization.id',
   PROJECT_ID = 'project.id',
   SPAN_ID = 'span_id',
-  SENTRY_PROJECT_ID = 'sentry.project_id',
   PARENT_SPAN_ID = 'sentry.trace.parent_span_id',
   TIMESTAMP = 'timestamp',
   // From the EAP dataset directly not using a column alias, should be hidden.

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -62,6 +62,7 @@ export function useExploreLogsTableRow(props: {
     traceId: props.traceId,
     traceItemType: TraceItemDataset.LOGS,
     referrer: 'api.explore.log-item-details',
+    enabled: props.enabled,
   });
 }
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -137,7 +137,10 @@ export function removePrefixes(key: string) {
 
 export function adjustAliases(key: string) {
   switch (key) {
-    case OurLogKnownFieldKey.SENTRY_PROJECT_ID:
+    case 'sentry.project_id':
+      warn(
+        fmt`Field ${key} is deprecated. Please use ${OurLogKnownFieldKey.PROJECT_ID} instead.`
+      );
       return OurLogKnownFieldKey.PROJECT_ID; // Public alias since int<->string alias reversing is broken. Should be removed in the future.
     default:
       return key;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -9,6 +9,7 @@ import {
   CurrencyUnit,
   DurationUnit,
   fieldAlignment,
+  prettifyTagKey,
 } from 'sentry/utils/discover/fields';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {TableColumn} from 'sentry/views/discover/table/types';
@@ -133,6 +134,10 @@ export function logsFieldAlignment(...args: Parameters<typeof fieldAlignment>) {
 
 export function removePrefixes(key: string) {
   return key.replace('log.', '').replace('sentry.', '');
+}
+
+export function prettifyAttributeName(name: string) {
+  return removePrefixes(prettifyTagKey(name));
 }
 
 export function adjustAliases(key: string) {

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -28,6 +28,7 @@ interface ColumnEditorModalProps extends ModalRenderProps {
   numberTags: TagCollection;
   onColumnsChange: (fields: string[]) => void;
   stringTags: TagCollection;
+  hiddenKeys?: string[];
 }
 
 export function ColumnEditorModal({
@@ -39,6 +40,7 @@ export function ColumnEditorModal({
   onColumnsChange,
   numberTags,
   stringTags,
+  hiddenKeys,
 }: ColumnEditorModalProps) {
   const tags: Array<SelectOption<string>> = useMemo(() => {
     const allTags = [
@@ -75,19 +77,21 @@ export function ColumnEditorModal({
         };
       }),
     ];
-    allTags.sort((a, b) => {
-      if (a.label < b.label) {
-        return -1;
-      }
+    allTags
+      .filter(tag => !hiddenKeys?.includes(tag.label))
+      .sort((a, b) => {
+        if (a.label < b.label) {
+          return -1;
+        }
 
-      if (a.label > b.label) {
-        return 1;
-      }
+        if (a.label > b.label) {
+          return 1;
+        }
 
-      return 0;
-    });
+        return 0;
+      });
     return allTags;
-  }, [columns, stringTags, numberTags]);
+  }, [columns, stringTags, numberTags, hiddenKeys]);
 
   // We keep a temporary state for the columns so that we can apply the changes
   // only when the user clicks on the apply button.

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -43,7 +43,7 @@ export function ColumnEditorModal({
   hiddenKeys,
 }: ColumnEditorModalProps) {
   const tags: Array<SelectOption<string>> = useMemo(() => {
-    const allTags = [
+    let allTags = [
       ...columns
         .filter(
           column =>
@@ -77,9 +77,9 @@ export function ColumnEditorModal({
         };
       }),
     ];
-    allTags
-      .filter(tag => !hiddenKeys?.includes(tag.label))
-      .sort((a, b) => {
+    allTags = allTags
+      .filter(tag => !(hiddenKeys ?? []).includes(tag.label))
+      .toSorted((a, b) => {
         if (a.label < b.label) {
           return -1;
         }


### PR DESCRIPTION
### Summary
- Switch table row font to monospaced
- Reduce severity to just a dot vs. dot + text
- Make rows entirely clickable (unless you are selecting text)
- Add hover effect to each row line
- Remove 'sentry.project_id' from the UI completely, only ever use the public alias (backend endpoints should also stop returning it)

#### Screenshots
|![Screenshot 2025-04-02 at 1 07 33 PM](https://github.com/user-attachments/assets/41d227ee-668b-4cb6-84ed-4ad242d8a64c)|
|-|