### PR TITLE
test(ui): Remove useProject mocks, add lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,6 +290,12 @@ export default typescript.config([
           message:
             'Since React 19, it is no longer necessary to use forwardRef - refs can be passed as a normal prop',
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='jest'][callee.property.name='mock'][arguments.0.value='sentry/utils/useProjects']",
+          message:
+            'Please do not mock useProjects. Use `ProjectsStore.loadInitialData([ProjectFixture()])` instead. It can be used before the component is mounted or in a beforeEach hook.',
+        },
       ],
       'no-return-assign': 'error',
       'no-script-url': 'error',

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -9,29 +9,19 @@ import CreateAlertButton, {
   CreateAlertFromViewButton,
 } from 'sentry/components/createAlertButton';
 import GuideStore from 'sentry/stores/guideStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
-import useProjects from 'sentry/utils/useProjects';
 import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/data';
 
 const onClickMock = jest.fn();
 
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/actionCreators/navigation');
 
 describe('CreateAlertFromViewButton', () => {
   const organization = OrganizationFixture();
 
   beforeEach(() => {
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData([]);
   });
 
   afterEach(() => {
@@ -70,16 +60,7 @@ describe('CreateAlertFromViewButton', () => {
         access: [],
       },
     ];
-    jest.mocked(useProjects).mockReturnValue({
-      projects,
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData(projects);
 
     render(
       <CreateAlertFromViewButton
@@ -106,16 +87,7 @@ describe('CreateAlertFromViewButton', () => {
         access: [],
       },
     ];
-    jest.mocked(useProjects).mockReturnValue({
-      projects,
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData(projects);
 
     render(
       <CreateAlertFromViewButton
@@ -154,17 +126,7 @@ describe('CreateAlertFromViewButton', () => {
         access: ['alerts:read' as const],
       },
     ];
-
-    jest.mocked(useProjects).mockReturnValue({
-      projects,
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData(projects);
 
     render(
       <CreateAlertFromViewButton
@@ -258,16 +220,7 @@ describe('CreateAlertFromViewButton', () => {
     const router = RouterFixture();
 
     const projects = [ProjectFixture()];
-    jest.mocked(useProjects).mockReturnValue({
-      projects,
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData(projects);
 
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -8,18 +8,17 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventReplay from 'sentry/components/events/eventReplay';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {
   useHaveSelectedProjectsSentAnyReplayEvents,
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import ReplayReader from 'sentry/utils/replays/replayReader';
-import useProjects from 'sentry/utils/useProjects';
 import type {ReplayError} from 'sentry/views/replays/types';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 // Replay clip preview is very heavy, mock it out
 jest.mock(
@@ -117,16 +116,8 @@ describe('EventReplay', function () {
       body: {},
     });
 
-    jest.mocked(useProjects).mockReturnValue({
-      fetchError: null,
-      fetching: false,
-      hasMore: false,
-      initiallyLoaded: false,
-      onSearch: () => Promise.resolve(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      projects: [project],
-    });
+    ProjectsStore.loadInitialData([project]);
+
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -6,12 +6,11 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Breadcrumbs} from 'sentry/components/events/interfaces/breadcrumbs';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import useProjects from 'sentry/utils/useProjects';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
-jest.mock('sentry/utils/useProjects');
 
 describe('Breadcrumbs', () => {
   let props: React.ComponentProps<typeof Breadcrumbs>;
@@ -19,16 +18,7 @@ describe('Breadcrumbs', () => {
   beforeEach(() => {
     const project = ProjectFixture({platform: 'javascript'});
 
-    jest.mocked(useProjects).mockReturnValue({
-      fetchError: null,
-      fetching: false,
-      hasMore: false,
-      initiallyLoaded: false,
-      onSearch: () => Promise.resolve(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      projects: [project],
-    });
+    ProjectsStore.loadInitialData([project]);
 
     props = {
       organization: OrganizationFixture(),

--- a/static/app/components/replays/header/errorCounts.spec.tsx
+++ b/static/app/components/replays/header/errorCounts.spec.tsx
@@ -6,9 +6,7 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ErrorCounts from 'sentry/components/replays/header/errorCounts';
-import useProjects from 'sentry/utils/useProjects';
-
-jest.mock('sentry/utils/useProjects');
+import ProjectsStore from 'sentry/stores/projectsStore';
 
 const replayRecord = ReplayRecordFixture();
 const organization = OrganizationFixture();
@@ -17,32 +15,23 @@ const baseErrorProps = {id: '1', issue: '', timestamp: new Date().toISOString()}
 
 describe('ErrorCounts', () => {
   beforeEach(() => {
-    jest.mocked(useProjects).mockReturnValue({
-      fetching: false,
-      projects: [
-        ProjectFixture({
-          id: replayRecord.project_id,
-          slug: 'my-js-app',
-          platform: 'javascript',
-        }),
-        ProjectFixture({
-          id: '123123123',
-          slug: 'my-py-backend',
-          platform: 'python',
-        }),
-        ProjectFixture({
-          id: '234234234',
-          slug: 'my-node-service',
-          platform: 'node',
-        }),
-      ],
-      fetchError: null,
-      hasMore: false,
-      initiallyLoaded: true,
-      onSearch: () => Promise.resolve(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-    });
+    ProjectsStore.loadInitialData([
+      ProjectFixture({
+        id: replayRecord.project_id,
+        slug: 'my-js-app',
+        platform: 'javascript',
+      }),
+      ProjectFixture({
+        id: '123123123',
+        slug: 'my-py-backend',
+        platform: 'python',
+      }),
+      ProjectFixture({
+        id: '234234234',
+        slug: 'my-node-service',
+        platform: 'node',
+      }),
+    ]);
   });
 
   it('should render 0 when there are no errors in the array', () => {

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -12,26 +12,15 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
-import useProjects from 'sentry/utils/useProjects';
 import type {ReplayRecord} from 'sentry/views/replays/types';
-
-jest.mock('sentry/utils/useProjects');
 
 const {organization, project} = initializeOrg();
 
-jest.mocked(useProjects).mockReturnValue({
-  fetching: false,
-  projects: [project],
-  fetchError: null,
-  hasMore: false,
-  initiallyLoaded: true,
-  onSearch: () => Promise.resolve(),
-  reloadProjects: jest.fn(),
-  placeholders: [],
-});
+ProjectsStore.loadInitialData([project]);
 
 const mockInvalidateQueries = jest.fn();
 

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -3,12 +3,12 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import ResourcesLandingPage from 'sentry/views/insights/browser/resources/views/resourcesLandingPage';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/insights/types';
 
 const {
@@ -25,10 +25,6 @@ const {EPM, TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
-
 jest.mock('sentry/utils/useReleaseStats');
 
 const requestMocks: Record<string, jest.Mock> = {};
@@ -136,7 +132,6 @@ describe('ResourcesLandingPage', function () {
 });
 
 const setupMocks = () => {
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
     desyncedFilters: new Set(),
@@ -164,16 +159,9 @@ const setupMocks = () => {
     key: '',
   });
 
-  jest.mocked(useProjects).mockReturnValue({
-    fetchError: null,
-    fetching: false,
-    hasMore: false,
-    initiallyLoaded: true,
-    projects: [ProjectFixture({hasInsightsAssets: true})],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-  });
+  ProjectsStore.loadInitialData([
+    ProjectFixture({hasInsightsAssets: true, firstTransactionEvent: true}),
+  ]);
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
     isPending: false,

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -9,13 +9,12 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {PagePerformanceTable} from 'sentry/views/insights/browser/webVitals/components/tables/pagePerformanceTable';
 
 jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/usePageFilters');
 
 describe('PagePerformanceTable', function () {
@@ -44,23 +43,14 @@ describe('PagePerformanceTable', function () {
       },
     });
 
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [
-        ProjectFixture({
-          id: '11276',
-          name: 'frontend',
-          slug: 'frontend',
-          platform: 'python',
-        }),
-      ],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData([
+      ProjectFixture({
+        id: '11276',
+        name: 'frontend',
+        slug: 'frontend',
+        platform: 'python',
+      }),
+    ]);
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -3,16 +3,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import WebVitalsLandingPage from 'sentry/views/insights/browser/webVitals/views/webVitalsLandingPage';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 
 describe('WebVitalsLandingPage', function () {
   const organization = OrganizationFixture({
@@ -22,17 +19,9 @@ describe('WebVitalsLandingPage', function () {
   let eventsMock: jest.Mock;
 
   beforeEach(function () {
-    jest.mocked(useOnboardingProject).mockReturnValue(undefined);
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [ProjectFixture({hasInsightsVitals: true})],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData([
+      ProjectFixture({hasInsightsVitals: true, firstTransactionEvent: true}),
+    ]);
 
     jest.mocked(useLocation).mockReturnValue({
       pathname: '',

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -8,19 +8,15 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {CacheLandingPage} from 'sentry/views/insights/cache/views/cacheLandingPage';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
-
 jest.mock('sentry/utils/useReleaseStats');
 
 const requestMocks = {
@@ -62,25 +58,16 @@ describe('CacheLandingPage', function () {
     key: '',
   });
 
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [
-      ProjectFixture({
-        id: '1',
-        name: 'Backend',
-        slug: 'backend',
-        firstTransactionEvent: true,
-        hasInsightsCaches: true,
-        platform: 'javascript',
-      }),
-    ],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
-  });
+  ProjectsStore.loadInitialData([
+    ProjectFixture({
+      id: '1',
+      name: 'Backend',
+      slug: 'backend',
+      firstTransactionEvent: true,
+      hasInsightsCaches: true,
+      platform: 'javascript',
+    }),
+  ]);
 
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
@@ -281,26 +268,16 @@ describe('CacheLandingPage', function () {
   });
 
   it('shows module onboarding', async function () {
-    jest.mocked(useOnboardingProject).mockReturnValue(undefined);
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [
-        ProjectFixture({
-          id: '1',
-          name: 'Backend',
-          slug: 'backend',
-          firstTransactionEvent: true,
-          hasInsightsCaches: false,
-          platform: 'javascript',
-        }),
-      ],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData([
+      ProjectFixture({
+        id: '1',
+        name: 'Backend',
+        slug: 'backend',
+        firstTransactionEvent: true,
+        hasInsightsCaches: false,
+        platform: 'javascript',
+      }),
+    ]);
 
     render(<CacheLandingPage />, {organization});
 

--- a/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
@@ -2,16 +2,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ModuleName} from 'sentry/views/insights/types';
 
 import {ModulesOnboarding} from './modulesOnboarding';
 
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 
 describe('ModulesOnboarding', () => {
   afterEach(() => {
@@ -23,18 +20,7 @@ describe('ModulesOnboarding', () => {
     project.firstTransactionEvent = true;
     project.hasInsightsCaches = true;
 
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [project],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
-
-    jest.mocked(useOnboardingProject).mockReturnValue(undefined);
+    ProjectsStore.loadInitialData([project]);
 
     jest.mocked(usePageFilters).mockReturnValue({
       isReady: true,
@@ -64,15 +50,12 @@ describe('ModulesOnboarding', () => {
 
   it('renders onboarding content correctly', async () => {
     const project = ProjectFixture();
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [project],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
+    project.firstTransactionEvent = true;
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
     });
 
     jest.mocked(usePageFilters).mockReturnValue({
@@ -88,7 +71,7 @@ describe('ModulesOnboarding', () => {
           utc: false,
         },
         environments: [],
-        projects: [2],
+        projects: [Number(project.id)],
       },
     });
 
@@ -103,17 +86,8 @@ describe('ModulesOnboarding', () => {
 
   it('renders performance onboarding if onboardingProject', async () => {
     const project = ProjectFixture();
-    jest.mocked(useOnboardingProject).mockReturnValue(project);
-    jest.mocked(useProjects).mockReturnValue({
-      projects: [project],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    project.hasInsightsCaches = true;
+    ProjectsStore.loadInitialData([project]);
 
     jest.mocked(usePageFilters).mockReturnValue({
       isReady: true,
@@ -128,7 +102,7 @@ describe('ModulesOnboarding', () => {
           utc: false,
         },
         environments: [],
-        projects: [2],
+        projects: [Number(project.id)],
       },
     });
 

--- a/static/app/views/insights/crons/components/monitorForm.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.spec.tsx
@@ -8,13 +8,12 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useMembers} from 'sentry/utils/useMembers';
-import useProjects from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import MonitorForm from 'sentry/views/insights/crons/components/monitorForm';
 import {ScheduleType} from 'sentry/views/insights/crons/types';
 
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/useTeams');
 jest.mock('sentry/utils/useMembers');
 
@@ -26,16 +25,7 @@ describe('MonitorForm', function () {
   const {project, router} = initializeOrg({organization});
 
   beforeEach(() => {
-    jest.mocked(useProjects).mockReturnValue({
-      fetchError: null,
-      fetching: false,
-      hasMore: false,
-      initiallyLoaded: false,
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      projects: [project],
-    });
+    ProjectsStore.loadInitialData([project]);
 
     jest.mocked(useTeams).mockReturnValue({
       fetchError: null,

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -3,18 +3,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {DatabaseLandingPage} from 'sentry/views/insights/database/views/databaseLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
-
 jest.mock('sentry/utils/useReleaseStats');
 
 describe('DatabaseLandingPage', function () {
@@ -23,18 +19,9 @@ describe('DatabaseLandingPage', function () {
   let spanListRequestMock: jest.Mock;
   let spanChartsRequestMock: jest.Mock;
 
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [ProjectFixture({hasInsightsDb: true})],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
-  });
-
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
+  ProjectsStore.loadInitialData([
+    ProjectFixture({hasInsightsDb: true, firstTransactionEvent: true}),
+  ]);
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -3,18 +3,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {HTTPLandingPage} from 'sentry/views/insights/http/views/httpLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
-
 jest.mock('sentry/utils/useReleaseStats');
 
 describe('HTTPLandingPage', function () {
@@ -28,8 +24,6 @@ describe('HTTPLandingPage', function () {
 
   let spanListRequestMock!: jest.Mock;
   let regionFilterRequestMock!: jest.Mock;
-
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -58,26 +52,6 @@ describe('HTTPLandingPage', function () {
     key: '',
   });
 
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [
-      ProjectFixture({
-        id: '1',
-        name: 'Backend',
-        slug: 'backend',
-        firstTransactionEvent: true,
-        platform: 'javascript',
-        hasInsightsHttp: true,
-      }),
-    ],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
-  });
-
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
     isPending: false,
@@ -88,6 +62,17 @@ describe('HTTPLandingPage', function () {
 
   beforeEach(function () {
     jest.clearAllMocks();
+
+    ProjectsStore.loadInitialData([
+      ProjectFixture({
+        id: '1',
+        name: 'Backend',
+        slug: 'backend',
+        firstTransactionEvent: true,
+        platform: 'javascript',
+        hasInsightsHttp: true,
+      }),
+    ]);
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,

--- a/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
+++ b/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
@@ -3,15 +3,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useProjects');
 
 function mockPageFilters(projects: number[]) {
   jest.mocked(usePageFilters).mockReturnValue({
@@ -32,19 +31,6 @@ function mockPageFilters(projects: number[]) {
   });
 }
 
-function mockProjects(projects: Project[]) {
-  jest.mocked(useProjects).mockReturnValue({
-    fetchError: null,
-    fetching: false,
-    hasMore: false,
-    initiallyLoaded: false,
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    projects,
-  });
-}
-
 describe('useCrossPlatformProject', () => {
   let mockProject: Project;
   beforeEach(() => {
@@ -52,7 +38,7 @@ describe('useCrossPlatformProject', () => {
 
     mockProject = ProjectFixture({platform: 'flutter'});
     jest.mocked(useLocation).mockReturnValue(LocationFixture());
-    mockProjects([mockProject]);
+    ProjectsStore.loadInitialData([mockProject]);
   });
 
   it('returns null for project if >1 project is selected', () => {
@@ -83,7 +69,7 @@ describe('useCrossPlatformProject', () => {
   it('returns false for isProjectCrossPlatform if project is not cross platform', () => {
     const testProject = ProjectFixture({platform: 'python'});
 
-    mockProjects([testProject]);
+    ProjectsStore.loadInitialData([testProject]);
     mockPageFilters([parseInt(testProject.id, 10)]);
 
     const {result} = renderHook(useCrossPlatformProject);

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -4,33 +4,19 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import ScreenLoadSpans from 'sentry/views/insights/mobile/screenload/views/screenLoadSpansPage';
 
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
 
 function mockResponses(organization: Organization, project: Project) {
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
-
-  jest.mocked(useProjects).mockReturnValue({
-    fetchError: null,
-    fetching: false,
-    hasMore: false,
-    initiallyLoaded: false,
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    projects: [project],
-  });
+  ProjectsStore.loadInitialData([project]);
 
   jest.mocked(useLocation).mockReturnValue({
     action: 'PUSH',

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
@@ -4,36 +4,27 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {PLATFORM_LOCAL_STORAGE_KEY} from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import PageloadModule from 'sentry/views/insights/mobile/screenload/views/screenloadLandingPage';
 
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
 
 describe('PageloadModule', function () {
-  const project = ProjectFixture({platform: 'react-native', hasInsightsScreenLoad: true});
+  const project = ProjectFixture({
+    platform: 'react-native',
+    hasInsightsScreenLoad: true,
+    firstTransactionEvent: true,
+  });
   const organization = OrganizationFixture({
     features: ['insights-initial-modules', 'insights-entry-points'],
   });
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
-  jest.mocked(useProjects).mockReturnValue({
-    fetchError: null,
-    fetching: false,
-    hasMore: false,
-    initiallyLoaded: false,
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    projects: [project],
-  });
+  ProjectsStore.loadInitialData([project]);
 
   jest.mocked(useLocation).mockReturnValue({
     action: 'PUSH',

--- a/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
@@ -4,18 +4,15 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import BackendOverviewPage from 'sentry/views/insights/pages/backend/backendOverviewPage';
 
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useOrganization');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 
 let useLocationMock: jest.Mock;
 
@@ -30,8 +27,8 @@ const pageFilterSelection = PageFiltersFixture({
   },
 });
 const projects = [
-  ProjectFixture({id: '1', platform: 'javascript-react'}),
-  ProjectFixture({id: '2', platform: undefined}),
+  ProjectFixture({id: '1', platform: 'javascript-react', firstTransactionEvent: true}),
+  ProjectFixture({id: '2', platform: undefined, firstTransactionEvent: true}),
 ];
 
 let mainTableApiCall: jest.Mock;
@@ -188,15 +185,5 @@ const setupMocks = () => {
     shouldPersist: true,
     selection: pageFilterSelection,
   });
-  jest.mocked(useProjects).mockReturnValue({
-    projects,
-    fetchError: null,
-    hasMore: false,
-    initiallyLoaded: true,
-    onSearch: () => Promise.resolve(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-  });
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
+  ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -4,18 +4,15 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import FrontendOverviewPage from 'sentry/views/insights/pages/frontend/frontendOverviewPage';
 
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useOrganization');
-jest.mock('sentry/utils/useProjects');
-jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 
 const organization = OrganizationFixture({features: ['performance-view']});
 const pageFilterSelection = PageFiltersFixture({
@@ -28,8 +25,8 @@ const pageFilterSelection = PageFiltersFixture({
   },
 });
 const projects = [
-  ProjectFixture({id: '1', platform: 'javascript-react'}),
-  ProjectFixture({id: '2', platform: undefined}),
+  ProjectFixture({id: '1', platform: 'javascript-react', firstTransactionEvent: true}),
+  ProjectFixture({id: '2', platform: undefined, firstTransactionEvent: true}),
 ];
 
 let mainTableApiCall: jest.Mock;
@@ -201,15 +198,5 @@ const setupMocks = () => {
     shouldPersist: true,
     selection: pageFilterSelection,
   });
-  jest.mocked(useProjects).mockReturnValue({
-    projects,
-    fetchError: null,
-    hasMore: false,
-    initiallyLoaded: true,
-    onSearch: () => Promise.resolve(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-  });
-  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
+  ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -1,22 +1,23 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import PageWithProviders from 'sentry/views/insights/queues/views/destinationSummaryPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/useReleaseStats');
 
 describe('destinationSummaryPage', () => {
   const organization = OrganizationFixture({
     features: ['insights-addon-modules'],
   });
+  const project = ProjectFixture({firstTransactionEvent: true});
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -38,22 +39,11 @@ describe('destinationSummaryPage', () => {
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',
     search: '',
-    query: {statsPeriod: '10d', project: '1'},
+    query: {statsPeriod: '10d', project: project.id},
     hash: '',
     state: undefined,
     action: 'PUSH',
     key: '',
-  });
-
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
   });
 
   jest.mocked(useReleaseStats).mockReturnValue({
@@ -68,6 +58,7 @@ describe('destinationSummaryPage', () => {
   let eventsStatsMock: jest.Mock;
 
   beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -3,15 +3,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import QueuesLandingPage from 'sentry/views/insights/queues/views/queuesLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/useReleaseStats');
 
 describe('queuesLandingPage', () => {
@@ -49,17 +48,6 @@ describe('queuesLandingPage', () => {
     key: '',
   });
 
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [project],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
-  });
-
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
     isPending: false,
@@ -72,6 +60,7 @@ describe('queuesLandingPage', () => {
   let eventsStatsMock: jest.Mock;
 
   beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -11,13 +11,14 @@ import {
 
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {PlatformKey, Project} from 'sentry/types/project';
-import * as useProjects from 'sentry/utils/useProjects';
 import Onboarding from 'sentry/views/onboarding/onboarding';
 
 describe('Onboarding', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
   });
 
   it('renders the welcome page', function () {
@@ -347,16 +348,7 @@ describe('Onboarding', function () {
       slug: 'javascript-nextjs',
     });
 
-    jest.spyOn(useProjects, 'default').mockReturnValue({
-      projects: [nextJsProject],
-      onSearch: jest.fn(),
-      reloadProjects: jest.fn(),
-      placeholders: [],
-      fetching: false,
-      hasMore: null,
-      fetchError: null,
-      initiallyLoaded: false,
-    });
+    ProjectsStore.loadInitialData([nextJsProject]);
 
     const routeParams = {
       step: 'select-platform',

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -3,16 +3,15 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useParams} from 'sentry/utils/useParams';
-import useProjects from 'sentry/utils/useProjects';
 import SpanSummary from 'sentry/views/performance/transactionSummary/transactionSpans/spanSummary/content';
 
 jest.mock('sentry/utils/useParams');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useProjects');
 
 describe('SpanSummaryPage', function () {
   const organization = OrganizationFixture();
@@ -28,16 +27,7 @@ describe('SpanSummaryPage', function () {
     key: '',
   });
 
-  jest.mocked(useProjects).mockReturnValue({
-    projects: [],
-    onSearch: jest.fn(),
-    reloadProjects: jest.fn(),
-    placeholders: [],
-    fetching: false,
-    hasMore: null,
-    fetchError: null,
-    initiallyLoaded: false,
-  });
+  ProjectsStore.loadInitialData([project]);
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,


### PR DESCRIPTION
Our app bootstrap process initializes ProjectsStore with all available projects, we can do the same in our tests.

*Why avoid mocks*
- Changing hooks that have been mocked requires updating every test that has mocked that hook. It creates a tight relationship between hooks and random tests.
- Mocked tests do not test how components and hooks actually work.
