### PR TITLE
test(symbolicator): Catch the correct exception

### DIFF
--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -110,7 +110,7 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         # the docker image used in sentrys own tests is updated.
         try:
             make_snapshot()
-        except Exception:
+        except BaseException:
             make_snapshot(subname="new")
 
         return sorted(EventAttachment.objects.filter(event_id=event.event_id), key=lambda x: x.name)


### PR DESCRIPTION
The raised exception inherits from `BaseException`, so the previous code didn't work.

Ideally I'd want to catch the raised `Failed` but it doesn't seem like that is importable.