### PR TITLE
fix(nav): Dismiss help menu prompt when sidebar is collapsed

### DIFF
--- a/static/app/views/nav/useNavPrompts.tsx
+++ b/static/app/views/nav/useNavPrompts.tsx
@@ -30,19 +30,17 @@ export function useNavPrompts({
     options: {enabled: hasNavigationV2Banner},
   });
 
+  const shouldShowHelpMenuDot =
+    hasNavigationV2Banner &&
+    isDropdownPromptDismissed === false &&
+    (collapsed || isSidebarPromptDismissed);
+
   return {
     shouldShowSidebarBanner:
       hasNavigationV2Banner && !collapsed && isSidebarPromptDismissed === false,
-    shouldShowHelpMenuDot:
-      hasNavigationV2Banner &&
-      isDropdownPromptDismissed === false &&
-      (collapsed || isSidebarPromptDismissed),
+    shouldShowHelpMenuDot,
     onOpenHelpMenu: () => {
-      if (
-        hasNavigationV2Banner &&
-        isSidebarPromptDismissed === true &&
-        isDropdownPromptDismissed === false
-      ) {
+      if (shouldShowHelpMenuDot) {
         dismissDropdownPrompt();
       }
     },


### PR DESCRIPTION
Previous to this change, the help menu dot would not be dismissed until you first dismissed the banner, which does not show when the sidebar is collapsed. The new logic will always dismiss the dot after opening the help menu if it is visible.