### PR TITLE
:wrench: chore(aci): update links for ticketing action descriptions

### DIFF
--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -1,0 +1,12 @@
+"""
+This file contains simple functions to generate links to Sentry pages
+
+We can use this as a basepoint to build out our templating system in the future
+"""
+
+
+def create_link_to_workflow(organization_id: int, workflow_id: int) -> str:
+    """
+    Create a link to a workflow
+    """
+    return f"/organizations/{organization_id}/workflows/{workflow_id}/"

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -18,6 +18,7 @@ from sentry.integrations.project_management.metrics import (
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.grouplink import GroupLink
+from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.shared_integrations.exceptions import (
     IntegrationFormError,
     IntegrationInstallationConfigurationError,
@@ -73,7 +74,7 @@ def build_description_workflow_engine_ui(
     generate_footer: Callable[[str], str],
 ) -> str:
     project = event.group.project
-    workflow_url = f"/organizations/{project.organization.slug}/workflows/{workflow_id}/"
+    workflow_url = create_link_to_workflow(project.organization.id, workflow_id)
 
     description: str = installation.get_group_description(event.group, event) + generate_footer(
         workflow_url

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from sentry.rules.actions.integrations.create_ticket.utils import (
+    build_description,
+    build_description_workflow_engine_ui,
+)
+from sentry.testutils.cases import TestCase
+
+
+class CreateTicketUtilsTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule = self.create_project_rule()
+
+    def test_build_description(self):
+        installation = MagicMock()
+        installation.get_group_description.return_value = "Test description"
+
+        def generate_footer(url):
+            return f"\n\nThis issue was created by a rule: {url}"
+
+        description = build_description(self.event, self.rule.id, installation, generate_footer)
+
+        expected_url = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rule.id}/"
+        assert (
+            description == f"Test description\n\nThis issue was created by a rule: {expected_url}"
+        )
+
+    def test_build_description_workflow_engine_ui(self):
+        installation = MagicMock()
+        installation.get_group_description.return_value = "Test description"
+        workflow_id = 123
+
+        def generate_footer(url):
+            return f"\n\nThis issue was created by a workflow: {url}"
+
+        description = build_description_workflow_engine_ui(
+            self.event, workflow_id, installation, generate_footer
+        )
+
+        expected_url = f"/organizations/{self.organization.slug}/workflows/{workflow_id}/"
+        assert (
+            description
+            == f"Test description\n\nThis issue was created by a workflow: {expected_url}"
+        )

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -38,7 +38,7 @@ class CreateTicketUtilsTest(TestCase):
             self.event, workflow_id, installation, generate_footer
         )
 
-        expected_url = f"/organizations/{self.organization.slug}/workflows/{workflow_id}/"
+        expected_url = f"/organizations/{self.organization.id}/workflows/{workflow_id}/"
         assert (
             description
             == f"Test description\n\nThis issue was created by a workflow: {expected_url}"


### PR DESCRIPTION
this updates the descriptions links for all ticketing actions for the notification action:

if we are invoking the handler from the notification action, we will create the legacy link from the `legacy_rule_id`

if we have enabled the workflow ui link building logic, we will use the `workflow_id`