### PR TITLE
fix(autofix): Remove code mappings check for github banner

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -14,7 +14,6 @@ from sentry.api.bases.group import GroupAiEndpoint
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
-from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -46,11 +45,6 @@ def get_autofix_integration_setup_problems(
 
     if not installation:
         return "integration_missing"
-
-    code_mappings = get_sorted_code_mapping_configs(project)
-
-    if not code_mappings:
-        return "integration_no_code_mappings"
 
     return None
 

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from sentry.api.endpoints.group_autofix_setup_check import get_repos_and_access
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -113,22 +112,6 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         assert response.data["genAIConsent"] == {
             "ok": False,
             "reason": None,
-        }
-
-    def test_no_code_mappings(self):
-        RepositoryProjectPathConfig.objects.filter(
-            organization_integration_id=self.organization_integration.id
-        ).delete()
-
-        group = self.create_group()
-        self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
-        assert response.data["integration"] == {
-            "ok": False,
-            "reason": "integration_no_code_mappings",
         }
 
     def test_missing_integration(self):


### PR DESCRIPTION
We use this check to show the github integration banner. as code mappings are no longer required we should remove this condition.
