### PR TITLE
 fix(dashboards): Make add dashboard template button busy when clicked

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -108,11 +108,6 @@ function ManageDashboards() {
     columnCount: DASHBOARD_GRID_DEFAULT_NUM_COLUMNS,
   });
 
-  const [isAddingDashboardTemplate, setIsAddingDashboardTemplate] = useState({
-    isAdding: false,
-    dashboardId: '',
-  });
-
   const {
     data: dashboards,
     isLoading,
@@ -265,16 +260,7 @@ function ManageDashboards() {
             title={dashboard.title}
             description={dashboard.description}
             onPreview={() => onPreview(dashboard.id)}
-            onAdd={() => {
-              setIsAddingDashboardTemplate({isAdding: true, dashboardId: dashboard.id});
-              onAdd(dashboard).finally(() => {
-                setIsAddingDashboardTemplate({isAdding: false, dashboardId: ''});
-              });
-            }}
-            isAddingDashboardTemplate={
-              dashboard.id === isAddingDashboardTemplate.dashboardId &&
-              isAddingDashboardTemplate.isAdding
-            }
+            onAdd={() => onAdd(dashboard)}
             key={dashboard.title}
           />
         ))}

--- a/static/app/views/dashboards/manage/templateCard.tsx
+++ b/static/app/views/dashboards/manage/templateCard.tsx
@@ -8,12 +8,19 @@ import {space} from 'sentry/styles/space';
 
 type Props = {
   description: string;
+  isAddingDashboardTemplate: boolean;
   onAdd: () => void;
   onPreview: () => void;
   title: string;
 };
 
-function TemplateCard({title, description, onPreview, onAdd}: Props) {
+function TemplateCard({
+  title,
+  description,
+  onPreview,
+  onAdd,
+  isAddingDashboardTemplate,
+}: Props) {
   return (
     <StyledCard>
       <Header>
@@ -24,7 +31,11 @@ function TemplateCard({title, description, onPreview, onAdd}: Props) {
         </Title>
       </Header>
       <ButtonContainer>
-        <StyledButton onClick={onAdd} icon={<IconAdd isCircled />}>
+        <StyledButton
+          onClick={onAdd}
+          icon={<IconAdd isCircled />}
+          busy={isAddingDashboardTemplate}
+        >
           {t('Add Dashboard')}
         </StyledButton>
         <StyledButton priority="primary" onClick={onPreview}>

--- a/static/app/views/dashboards/manage/templateCard.tsx
+++ b/static/app/views/dashboards/manage/templateCard.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import Card from 'sentry/components/card';
@@ -8,19 +9,14 @@ import {space} from 'sentry/styles/space';
 
 type Props = {
   description: string;
-  isAddingDashboardTemplate: boolean;
-  onAdd: () => void;
+  onAdd: () => Promise<void>;
   onPreview: () => void;
   title: string;
 };
 
-function TemplateCard({
-  title,
-  description,
-  onPreview,
-  onAdd,
-  isAddingDashboardTemplate,
-}: Props) {
+function TemplateCard({title, description, onPreview, onAdd}: Props) {
+  const [isAddingDashboardTemplate, setIsAddingDashboardTemplate] = useState(false);
+
   return (
     <StyledCard>
       <Header>
@@ -32,7 +28,12 @@ function TemplateCard({
       </Header>
       <ButtonContainer>
         <StyledButton
-          onClick={onAdd}
+          onClick={() => {
+            setIsAddingDashboardTemplate(true);
+            onAdd().finally(() => {
+              setIsAddingDashboardTemplate(false);
+            });
+          }}
           icon={<IconAdd isCircled />}
           busy={isAddingDashboardTemplate}
         >


### PR DESCRIPTION
I added a state to control if the "Add Dashboard" button has been clicked. Once clicked it will appear busy until the dashboard was added. I've also added a loading message to indicate that the request is being sent to add the dashboard.

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/ad304df9-0ba7-40de-adb7-6d503295a533" />

Contributes to https://github.com/getsentry/sentry/issues/88191

