### PR TITLE
:wrench: chore: refactor opsgenie client to decompose send notification

### DIFF
--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -126,7 +126,7 @@ def send_incident_alert_notification(
     )
 
     try:
-        resp = client.send_notification(attachment)
+        resp = client.send_metric_alert_notification(attachment)
         logger.info(
             "rule.success.opsgenie_incident_alert",
             extra={


### PR DESCRIPTION
the opsgenie client's `send_notification` was also building the payload, which makes things coupled and was making updating the link building logic a little bit more difficult, so i am breaking this logic down.

