### PR TITLE
fix(nav): Prevent rare error where user does not exist

### DIFF
--- a/static/app/views/nav/prefersStackedNav.tsx
+++ b/static/app/views/nav/prefersStackedNav.tsx
@@ -8,5 +8,5 @@ export function prefersStackedNav() {
 export function usePrefersStackedNav() {
   const user = useUser();
 
-  return user.options?.prefersStackedNavigation ?? false;
+  return user?.options?.prefersStackedNavigation ?? false;
 }


### PR DESCRIPTION
Fixes JAVASCRIPT-2Y5E

I don't know how this is possible, but in some cases I guess the config store user object can become null? We might need to fix that or at least the typings but for now this solves the sentry error.