### PR TITLE
fix(perf): Missing transaction filter for chart query

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -110,6 +110,7 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
   if (spanCategoryUrlParam) {
     query.addFilterValue('span.category', spanCategoryUrlParam);
   }
+  query.addFilterValue('is_transaction', '1');
 
   const {
     data: spanSeriesData,


### PR DESCRIPTION
This filter needs to be applied in order for the transaction summary chart widget to properly query only the transaction (aka service entry span) durations. Without this, the chart was applying to all spans in the transaction.