### PR TITLE
fix(taskworker) Update TASKWORKER_IMPORTS

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1398,11 +1398,12 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 # Like celery, taskworkers need to import task modules to make tasks
 # accessible to the worker.
 TASKWORKER_IMPORTS: tuple[str, ...] = (
+    "sentry.deletions.tasks.hybrid_cloud",
     "sentry.deletions.tasks.scheduled",
     "sentry.tasks.auth.auth",
     "sentry.tasks.auth.check_auth",
     "sentry.tasks.release_registry",
-    "sentry.tempest.tasks" "sentry.deletions.tasks.hybrid_cloud",
+    "sentry.tempest.tasks",
     # Used for tests
     "sentry.taskworker.tasks.examples",
 )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1398,6 +1398,11 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 # Like celery, taskworkers need to import task modules to make tasks
 # accessible to the worker.
 TASKWORKER_IMPORTS: tuple[str, ...] = (
+    "sentry.deletions.tasks.scheduled",
+    "sentry.tasks.auth.auth",
+    "sentry.tasks.auth.check_auth",
+    "sentry.tasks.release_registry",
+    "sentry.tempest.tasks" "sentry.deletions.tasks.hybrid_cloud",
     # Used for tests
     "sentry.taskworker.tasks.examples",
 )


### PR DESCRIPTION
We forgot to update the worker import list when adding the first batch of namespaces.