### PR TITLE
feat(explore): Use better stale times for useSpansQuery hook

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -85,6 +85,11 @@ export const useSortedTimeSeries = <
     eventView.interval = interval;
   }
 
+  const usesRelativeDateRange =
+    !defined(eventView.start) &&
+    !defined(eventView.end) &&
+    defined(eventView.statsPeriod);
+
   const intervalInMilliseconds = eventView.interval
     ? intervalToMilliseconds(eventView.interval)
     : undefined;
@@ -113,9 +118,11 @@ export const useSortedTimeSeries = <
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
       staleTime:
-        !defined(intervalInMilliseconds) || intervalInMilliseconds === 0
-          ? Infinity
-          : intervalInMilliseconds,
+        usesRelativeDateRange &&
+        defined(intervalInMilliseconds) &&
+        intervalInMilliseconds !== 0
+          ? intervalInMilliseconds
+          : Infinity,
     },
     referrer,
   });

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -5,6 +5,7 @@ import type {
   GroupedMultiSeriesEventsStats,
   MultiSeriesEventsStats,
 } from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {DataUnit} from 'sentry/utils/discover/fields';
 import {
@@ -12,6 +13,7 @@ import {
   useGenericDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -83,6 +85,10 @@ export const useSortedTimeSeries = <
     eventView.interval = interval;
   }
 
+  const intervalInMilliseconds = eventView.interval
+    ? intervalToMilliseconds(eventView.interval)
+    : undefined;
+
   const result = useGenericDiscoverQuery<
     MultiSeriesEventsStats | GroupedMultiSeriesEventsStats,
     DiscoverQueryProps
@@ -106,7 +112,10 @@ export const useSortedTimeSeries = <
       refetchOnWindowFocus: false,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
-      staleTime: Infinity,
+      staleTime:
+        !defined(intervalInMilliseconds) || intervalInMilliseconds === 0
+          ? Infinity
+          : intervalInMilliseconds,
     },
     referrer,
   });

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -208,7 +208,7 @@ export function useWrappedDiscoverQuery<T>({
     !defined(eventView.end) &&
     defined(eventView.statsPeriod);
 
-  const statsPeriodInMilliseconds = getStaleTimeForRelativePeriodTable(
+  const staleTimeForRelativePeriod = getStaleTimeForRelativePeriodTable(
     eventView.statsPeriod
   );
 
@@ -224,7 +224,7 @@ export function useWrappedDiscoverQuery<T>({
       refetchOnWindowFocus: false,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
-      staleTime: usesRelativeDateRange ? statsPeriodInMilliseconds : Infinity,
+      staleTime: usesRelativeDateRange ? staleTimeForRelativePeriod : Infinity,
     },
     queryExtras,
     noPagination,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -104,7 +104,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
   const {isReady: pageFiltersReady} = usePageFilters();
   const intervalInMilliseconds = eventView.interval
     ? intervalToMilliseconds(eventView.interval)
-    : 0;
+    : undefined;
   const result = useGenericDiscoverQuery<
     {
       data: any[];
@@ -135,7 +135,10 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
       refetchOnWindowFocus: false,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
-      staleTime: intervalInMilliseconds === 0 ? Infinity : intervalInMilliseconds,
+      staleTime:
+        !defined(intervalInMilliseconds) || intervalInMilliseconds === 0
+          ? Infinity
+          : intervalInMilliseconds,
     },
     referrer,
   });


### PR DESCRIPTION
Updates the stale time for spans query hooks. 
For timeseries, stale time interval is the duration of timeseries bucket interval. 
For tables, doing a ladder - we want to show more up-to-date data on tables. 
Only updates for relative time periods.