### PR TITLE
feat(ourlogs):Add log outcomes to stats UI behind flag

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -397,6 +397,27 @@ export const DATA_CATEGORY_INFO = {
     uid: 21,
     isBilledCategory: true,
   },
+
+  [DataCategoryExact.LOG_ITEM]: {
+    name: DataCategoryExact.LOG_ITEM,
+    apiName: 'log_item',
+    plural: 'log_items',
+    displayName: 'log',
+    titleName: t('Logs'),
+    productName: t('Logging'),
+    uid: 23,
+    isBilledCategory: true,
+  },
+  [DataCategoryExact.LOG_BYTE]: {
+    name: DataCategoryExact.LOG_BYTE,
+    apiName: 'log_byte',
+    plural: 'log_bytess',
+    displayName: 'log byte',
+    titleName: t('Logs (bytes)'),
+    productName: t('Logging'),
+    uid: 24,
+    isBilledCategory: false,
+  },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;
 
 // Special Search characters

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -397,7 +397,6 @@ export const DATA_CATEGORY_INFO = {
     uid: 21,
     isBilledCategory: true,
   },
-
   [DataCategoryExact.LOG_ITEM]: {
     name: DataCategoryExact.LOG_ITEM,
     apiName: 'log_item',
@@ -406,14 +405,14 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Logs'),
     productName: t('Logging'),
     uid: 23,
-    isBilledCategory: true,
+    isBilledCategory: false,
   },
   [DataCategoryExact.LOG_BYTE]: {
     name: DataCategoryExact.LOG_BYTE,
     apiName: 'log_byte',
-    plural: 'log_bytess',
+    plural: 'log_bytes',
     displayName: 'log byte',
-    titleName: t('Logs (bytes)'),
+    titleName: t('Logs Storage'),
     productName: t('Logging'),
     uid: 24,
     isBilledCategory: false,

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -108,6 +108,9 @@ export enum DataCategoryExact {
   SPAN = 'span',
   SPAN_INDEXED = 'spanIndexed',
   UPTIME = 'uptime',
+
+  LOG_ITEM = 'logItem',
+  LOG_BYTE = 'logByte',
 }
 
 export interface DataCategoryInfo {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -255,7 +255,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (isSelfHostedErrorsOnly) {
         return opt.value === DATA_CATEGORY_INFO.error.plural;
       }
-      if (opt.value === DATA_CATEGORY_INFO.replay.plural) {
+      if (DATA_CATEGORY_INFO.replay.plural === opt.value) {
         return organization.features.includes('session-replay');
       }
       if (DATA_CATEGORY_INFO.span.plural === opt.value) {
@@ -263,6 +263,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       }
       if (DATA_CATEGORY_INFO.transaction.plural === opt.value) {
         return !organization.features.includes('spans-usage-tracking');
+      }
+      if (DATA_CATEGORY_INFO.logItem.plural === opt.value) {
+        return organization.features.includes('ourlogs-stats');
       }
       if (
         DATA_CATEGORY_INFO.profileDuration.plural === opt.value ||

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -264,7 +264,10 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (DATA_CATEGORY_INFO.transaction.plural === opt.value) {
         return !organization.features.includes('spans-usage-tracking');
       }
-      if (DATA_CATEGORY_INFO.logItem.plural === opt.value) {
+      if (
+        DATA_CATEGORY_INFO.logItem.plural === opt.value ||
+        DATA_CATEGORY_INFO.logByte.plural === opt.value
+      ) {
         return organization.features.includes('ourlogs-stats');
       }
       if (

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -92,6 +92,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     disabled: false,
     yAxisMinInterval: 100,
   },
+  {
+    label: DATA_CATEGORY_INFO.logItem.titleName,
+    value: DATA_CATEGORY_INFO.logItem.plural,
+    disabled: false,
+    yAxisMinInterval: 100,
+  },
 ];
 
 export enum ChartDataTransform {

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -98,6 +98,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     disabled: false,
     yAxisMinInterval: 100,
   },
+  {
+    label: DATA_CATEGORY_INFO.logByte.titleName,
+    value: DATA_CATEGORY_INFO.logByte.plural,
+    disabled: false,
+    yAxisMinInterval: 0.5 * GIGABYTE,
+  },
 ];
 
 export enum ChartDataTransform {

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -33,7 +33,10 @@ export function formatUsageWithUnits(
   dataCategory: DataCategoryInfo['plural'],
   options: FormatOptions = {isAbbreviated: false, useUnitScaling: false}
 ): string {
-  if (dataCategory === DATA_CATEGORY_INFO.attachment.plural) {
+  if (
+    dataCategory === DATA_CATEGORY_INFO.attachment.plural ||
+    dataCategory === DATA_CATEGORY_INFO.logByte.plural
+  ) {
     if (options.useUnitScaling) {
       return formatBytesBase10(usageQuantity);
     }
@@ -67,8 +70,12 @@ export function getFormatUsageOptions(
   dataCategory: DataCategoryInfo['plural']
 ): FormatOptions {
   return {
-    isAbbreviated: dataCategory !== DATA_CATEGORY_INFO.attachment.plural,
-    useUnitScaling: dataCategory === DATA_CATEGORY_INFO.attachment.plural,
+    isAbbreviated:
+      dataCategory !== DATA_CATEGORY_INFO.attachment.plural &&
+      dataCategory !== DATA_CATEGORY_INFO.logByte.plural,
+    useUnitScaling:
+      dataCategory === DATA_CATEGORY_INFO.attachment.plural ||
+      dataCategory === DATA_CATEGORY_INFO.logByte.plural,
   };
 }
 


### PR DESCRIPTION
### Summary
This adds log outcomes to the stat pages behind a feature flag. This is specifically only showing `LogItem` and won't be exposed to users as we don't yet know how logs relate to SKU etc.

#### Screenshots
|![Screenshot 2025-04-02 at 3 34 15 PM](https://github.com/user-attachments/assets/e3a4a704-c6e9-4d9e-84fb-e7616270098d)|
|-|

