### PR TITLE
theme: fix scorebar

### DIFF
--- a/static/app/components/scoreBar.tsx
+++ b/static/app/components/scoreBar.tsx
@@ -73,8 +73,7 @@ const Bar = styled('div')<BarProps>`
   border-radius: ${p => p.radius}px;
   margin: 2px;
   /* @TODO(jonasbadalic) This used to be defined on the theme, but is component specific and had no dark mode color. */
-  ${p => p.empty && `background-color: #e2dee6;`}
-  ${p => p.color && `background-color: ${p.color};`}
+  background-color: ${p => (p.empty ? p.theme.gray200 : p.color)};
 
   width: ${p => (p.vertical ? p.size : p.thickness)}px;
   height: ${p => (p.vertical ? p.thickness : p.size)}px;


### PR DESCRIPTION
This looked very white in light mode
Before
![CleanShot 2025-04-02 at 15 47 09@2x](https://github.com/user-attachments/assets/6a7ff079-3f93-4188-b461-90970490b3e5)
After
![CleanShot 2025-04-02 at 15 47 14@2x](https://github.com/user-attachments/assets/48040f70-92af-451f-ac71-ae3567ec5531)
