### PR TITLE
fix(checkout): Only show event price in first step

### DIFF
--- a/static/gsApp/views/amCheckout/steps/contractSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/contractSelect.spec.tsx
@@ -71,6 +71,10 @@ describe('ContractSelect', function () {
     expect(screen.getByText('Annual Contract')).toBeInTheDocument();
     expect(screen.getByDisplayValue('monthly')).toBeInTheDocument();
     expect(screen.getByDisplayValue('annual')).toBeInTheDocument();
+
+    // does not show event price tags
+    expect(screen.queryByText(/\ error/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\ span/)).not.toBeInTheDocument();
   });
 
   it('renders with correct default prices', async function () {

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -230,6 +230,7 @@ function PlanSelect({
                   : undefined
               }
               shouldShowDefaultPayAsYouGo={shouldShowDefaultPayAsYouGo}
+              shouldShowEventPrice
             />
           );
         })}

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -53,8 +53,14 @@ type Props = {
    * Optional warning at the bottom of the row
    */
   planWarning?: React.ReactNode;
-
+  /**
+   * Optional flag to show default pay as you go values
+   */
   shouldShowDefaultPayAsYouGo?: boolean;
+  /**
+   * Optional flag to show event price tags
+   */
+  shouldShowEventPrice?: boolean;
 };
 
 function PlanSelectRow({
@@ -72,6 +78,7 @@ function PlanSelectRow({
   discountInfo,
   badge,
   shouldShowDefaultPayAsYouGo = false,
+  shouldShowEventPrice = false,
 }: Props) {
   const billingInterval = getShortInterval(plan.billingInterval);
   const {features, description, hasMoreLink} = planContent;
@@ -84,11 +91,15 @@ function PlanSelectRow({
 
   const describeId = `plan-details-${plan.id}`;
   const hasFeatures = !!Object.keys(features || {}).length;
-  const errorsStartingPrice = plan.planCategories.errors
-    ? plan.planCategories.errors[1]?.onDemandPrice
+  const errorsStartingPrice = shouldShowEventPrice
+    ? plan.planCategories.errors
+      ? plan.planCategories.errors[1]?.onDemandPrice
+      : null
     : null;
-  const spansStartingPrice = plan.planCategories.spans
-    ? plan.planCategories.spans[1]?.onDemandPrice
+  const spansStartingPrice = shouldShowEventPrice
+    ? plan.planCategories.spans
+      ? plan.planCategories.spans[1]?.onDemandPrice
+      : null
     : null;
 
   return (


### PR DESCRIPTION
Contract select step uses the same component as plan select step, so this makes sure we don't show per event price tags there.