### PR TITLE
ref(seer grouping): Small refactors to prep for multiple Seer results

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -254,11 +254,10 @@ def get_seer_similar_issues(
     event_grouphash: GroupHash,
     variants: dict[str, BaseVariant],
     num_neighbors: int = 1,
-) -> tuple[dict[str, Any], GroupHash | None]:
+) -> tuple[float | None, GroupHash | None]:
     """
-    Ask Seer for the given event's nearest neighbor(s) and return the seer response data, sorted
-    with the best matches first, along with a grouphash linked to the group Seer decided the event
-    should go in (if any), or None if no neighbor was near enough.
+    Ask Seer for the given event's nearest neighbor(s) and return the stacktrace distance and
+    matching GroupHash of the closest match (if any), or `(None, None)` if no match found.
     """
     event_hash = event.get_primary_hash()
     exception_type = get_path(event.data, "exception", "values", -1, "type")
@@ -287,6 +286,7 @@ def get_seer_similar_issues(
     # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data, seer_request_metric_tags)
     seer_results_json = [asdict(result) for result in seer_results]
+    stacktrace_distance = seer_results[0].stacktrace_distance if seer_results else None
     parent_grouphash = (
         GroupHash.objects.filter(
             hash=seer_results[0].parent_hash, project_id=event.project.id
@@ -317,6 +317,7 @@ def get_seer_similar_issues(
 
             if not fingerprints_match:
                 parent_grouphash = None
+                stacktrace_distance = None
                 seer_results_json = []
 
             if not parent_has_metadata:
@@ -345,11 +346,6 @@ def get_seer_similar_issues(
                 tags={"platform": event.platform, "result": "no_seer_match"},
             )
 
-    similar_issues_metadata = {
-        "results": seer_results_json,
-        "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-    }
-
     logger.info(
         "get_seer_similar_issues.results",
         extra={
@@ -361,7 +357,7 @@ def get_seer_similar_issues(
         },
     )
 
-    return (similar_issues_metadata, parent_grouphash)
+    return (stacktrace_distance, parent_grouphash)
 
 
 def maybe_check_seer_for_matching_grouphash(
@@ -376,9 +372,8 @@ def maybe_check_seer_for_matching_grouphash(
         record_did_call_seer_metric(event, call_made=True, blocker="none")
 
         try:
-            # If no matching group is found in Seer, we'll still get back result
-            # metadata, but `seer_matched_grouphash` will be None
-            seer_response_data, seer_matched_grouphash = get_seer_similar_issues(
+            # If no matching group is found in Seer, these will both be None
+            seer_match_distance, seer_matched_grouphash = get_seer_similar_issues(
                 event, event_grouphash, variants
             )
         except Exception as e:  # Insurance - in theory we shouldn't ever land here
@@ -427,13 +422,9 @@ def maybe_check_seer_for_matching_grouphash(
                 date_added=gh_metadata.date_added or timestamp,
                 seer_date_sent=gh_metadata.date_added or timestamp,
                 seer_event_sent=event.event_id,
-                seer_model=seer_response_data["similarity_model_version"],
+                seer_model=SEER_SIMILARITY_MODEL_VERSION,
                 seer_matched_grouphash=seer_matched_grouphash,
-                seer_match_distance=(
-                    seer_response_data["results"][0]["stacktrace_distance"]
-                    if seer_matched_grouphash
-                    else None
-                ),
+                seer_match_distance=seer_match_distance,
             )
 
     return seer_matched_grouphash

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -253,7 +253,6 @@ def get_seer_similar_issues(
     event: Event,
     event_grouphash: GroupHash,
     variants: dict[str, BaseVariant],
-    num_neighbors: int = 1,
 ) -> tuple[float | None, GroupHash | None]:
     """
     Ask Seer for the given event's nearest neighbor(s) and return the stacktrace distance and
@@ -275,7 +274,7 @@ def get_seer_similar_issues(
         "project_id": event.project.id,
         "stacktrace": stacktrace_string,
         "exception_type": filter_null_from_string(exception_type) if exception_type else None,
-        "k": num_neighbors,
+        "k": options.get("seer.similarity.ingest.num_matches_to_request"),
         "referrer": "ingest",
         "use_reranking": options.get("seer.similarity.ingest.use_reranking"),
     }

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -284,7 +284,7 @@ def get_seer_similar_issues(
 
     # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data, seer_request_metric_tags)
-    seer_results_json = [asdict(result) for result in seer_results]
+    matching_seer_result = asdict(seer_results[0]) if seer_results else None
     stacktrace_distance = seer_results[0].stacktrace_distance if seer_results else None
     parent_grouphash = (
         GroupHash.objects.filter(
@@ -317,7 +317,7 @@ def get_seer_similar_issues(
             if not fingerprints_match:
                 parent_grouphash = None
                 stacktrace_distance = None
-                seer_results_json = []
+                matching_seer_result = None
 
             if not parent_has_metadata:
                 result = "no_parent_metadata"
@@ -351,7 +351,7 @@ def get_seer_similar_issues(
             "event_id": event.event_id,
             "project_id": event.project.id,
             "hash": event_hash,
-            "results": seer_results_json,
+            "matching_result": matching_seer_result,
             "grouphash_returned": bool(parent_grouphash),
         },
     )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1031,6 +1031,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "seer.similarity.ingest.num_matches_to_request",
+    type=Int,
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # TODO: Once Seer grouping is GA-ed, we probably either want to turn this down or get rid of it in
 # favor of the default 10% sample rate
 register(

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from datetime import datetime
 from time import time
 from typing import Any
@@ -13,13 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.mocking import capture_results
 
-EMPTY_SEER_RESULTS = (
-    {
-        "results": [],
-        "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-    },
-    None,
-)
+EMPTY_SEER_RESULTS = (None, None)
 
 
 def get_event_data(dog: str = "Charlie") -> dict[str, Any]:
@@ -106,10 +99,6 @@ class SeerEventManagerGroupingTest(TestCase):
                 },
                 self.project,
             )
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [asdict(seer_result_data)],
-            }
             # In real life just filtering on group id wouldn't be enough to guarantee us a
             # single, specific GroupHash record, but since the database resets before each test,
             # here it's okay
@@ -119,9 +108,8 @@ class SeerEventManagerGroupingTest(TestCase):
             assert should_call_seer_spy.call_count == 1
             assert get_seer_similar_issues_spy.call_count == 1
 
-            # Metadata returned (metadata storage is tested separately in
-            # `test_stores_seer_results_in_grouphash_metadata`)
-            assert get_seer_similar_issues_return_values[0][0] == expected_metadata
+            # Stacktrace distance returned
+            assert get_seer_similar_issues_return_values[0][0] == 0.01
 
             # Parent grouphash returned and parent group used
             assert get_seer_similar_issues_return_values[0][1] == expected_grouphash

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -1,9 +1,7 @@
-from dataclasses import asdict
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sentry import options
-from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
@@ -105,7 +103,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "project_id": self.project.id,
                 "stacktrace": new_stacktrace_string,
                 "exception_type": "FailedToFetchError",
-                "k": 1,
+                "k": options.get("seer.similarity.ingest.num_matches_to_request"),
                 "referrer": "ingest",
                 "use_reranking": True,
             },
@@ -137,13 +135,8 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [asdict(seer_result_data[0])],
-            }
-
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
+                0.01,
                 existing_grouphash,
             )
 
@@ -177,13 +170,8 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [asdict(seer_result_data[0])],
-            }
-
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
+                0.01,
                 existing_grouphash,
             )
             assert_metrics_call(
@@ -216,15 +204,7 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
             assert_metrics_call(
                 mock_incr, "hybrid_fingerprint_seer_result", {"result": "no_fingerprint_match"}
             )
@@ -255,15 +235,7 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
             assert_metrics_call(
                 mock_incr, "hybrid_fingerprint_seer_result", {"result": "only_event_hybrid"}
             )
@@ -291,15 +263,7 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
             assert_metrics_call(
                 mock_incr, "hybrid_fingerprint_seer_result", {"result": "only_parent_hybrid"}
             )
@@ -343,15 +307,7 @@ class ParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=seer_result_data,
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
             assert_metrics_call(
                 mock_incr, "hybrid_fingerprint_seer_result", {"result": "no_parent_metadata"}
             )
@@ -365,15 +321,7 @@ class NoParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=[],
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
 
     @patch("sentry.grouping.ingest.seer.metrics.incr")
     def test_hybrid_fingerprint(self, mock_incr: MagicMock) -> None:
@@ -386,15 +334,7 @@ class NoParentGroupFoundTest(TestCase):
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=[],
         ):
-            expected_metadata = {
-                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "results": [],
-            }
-
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
-                expected_metadata,
-                None,
-            )
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
             assert_metrics_call(
                 mock_incr, "hybrid_fingerprint_seer_result", {"result": "no_seer_match"}
             )


### PR DESCRIPTION
This is a small refactor of the Seer grouping code.

- Add a new `seer.similarity.ingest.num_matches_to_request` option, defaulting to 1, and use it rather than a function parameter to control the number of matches we request from Seer during ingest.

- Log the Seer result used rather than all the results when logging the Seer response. (This will be important when we start requesting lots of results from Seer.)

- Simplify `get_seer_similar_issues` return value to only return the information needed by its sole caller, `maybe_check_seer_for_matching_grouphash`.