### PR TITLE
ref(seer grouping): Prepare ingest for multiple Seer results

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -282,68 +282,44 @@ def get_seer_similar_issues(
 
     seer_request_metric_tags = {"hybrid_fingerprint": event_has_hybrid_fingerprint}
 
-    # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data, seer_request_metric_tags)
-    matching_seer_result = asdict(seer_results[0]) if seer_results else None
-    stacktrace_distance = seer_results[0].stacktrace_distance if seer_results else None
-    parent_grouphash = (
-        GroupHash.objects.filter(
-            hash=seer_results[0].parent_hash, project_id=event.project.id
-        ).first()
-        if seer_results
-        else None
+
+    # All of these will get overridden if we find a usable match
+    matching_seer_result = None  # JSON of result data
+    winning_parent_grouphash = None  # A GroupHash object
+    stacktrace_distance = None
+
+    parent_grouphashes = GroupHash.objects.filter(
+        hash__in=[result.parent_hash for result in seer_results],
+        project_id=event.project.id,
     )
+    parent_grouphashes_by_hash = {grouphash.hash: grouphash for grouphash in parent_grouphashes}
 
-    if parent_grouphash:
-        # In order for a grouphash returned by Seer to count as a match to an event with a hybrid
-        # fingerprint,
-        #   a) the Seer grouphash must also have come from a hybrid fingerprint, and
-        #   b) the two fingerprints much match.
+    parent_grouphashes_checked = 0
+
+    if parent_grouphashes:
+        # Search for a Seer match we can use. If there are no hybrid fingerprints involved, this
+        # will be the first match returned. If hybrid fingerprints *are* involved, this will be the
+        # first match returned whose fingerprint values match the incoming event.
         #
-        # The same is true in reverse: If a Seer grouphash is from a hybrid fingerprint, so must the
-        # new event be, and again the values must match.
-        parent_fingerprint = parent_grouphash.get_associated_fingerprint()
-        parent_has_hybrid_fingerprint = get_fingerprint_type(parent_fingerprint) == "hybrid"
-        parent_has_metadata = bool(
-            parent_grouphash.metadata and parent_grouphash.metadata.hashing_metadata
-        )
-
-        if event_has_hybrid_fingerprint or parent_has_hybrid_fingerprint:
-            # This check will catch both fingerprint type match and fingerprint value match
-            fingerprints_match = check_grouphashes_for_positive_fingerprint_match(
-                event_grouphash, parent_grouphash
+        # Similar issues are returned sorted in descending order of similarity, so we want to use
+        # the first match we find.
+        for seer_result in seer_results:
+            parent_grouphash = parent_grouphashes_by_hash[seer_result.parent_hash]
+            can_use_parent_grouphash = _should_use_seer_match_for_grouping(
+                event,
+                event_grouphash,
+                parent_grouphash,
+                event_has_hybrid_fingerprint,
+                parent_grouphashes_checked,
             )
+            parent_grouphashes_checked += 1
 
-            if not fingerprints_match:
-                parent_grouphash = None
-                stacktrace_distance = None
-                matching_seer_result = None
-
-            if not parent_has_metadata:
-                result = "no_parent_metadata"
-            elif event_has_hybrid_fingerprint and not parent_has_hybrid_fingerprint:
-                result = "only_event_hybrid"
-            elif parent_has_hybrid_fingerprint and not event_has_hybrid_fingerprint:
-                result = "only_parent_hybrid"
-            elif not fingerprints_match:
-                result = "no_fingerprint_match"
-            else:
-                result = "fingerprint_match"
-
-            metrics.incr(
-                "grouping.similarity.hybrid_fingerprint_seer_result",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"platform": event.platform, "result": result},
-            )
-    # For convenience and ease of graph creation in DD, we collect the no-match case as part of this
-    # metric in addition to collecting it as part of the overall seer request metric
-    else:
-        if event_has_hybrid_fingerprint:
-            metrics.incr(
-                "grouping.similarity.hybrid_fingerprint_seer_result",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"platform": event.platform, "result": "no_seer_match"},
-            )
+            if can_use_parent_grouphash:
+                winning_parent_grouphash = parent_grouphash
+                matching_seer_result = asdict(seer_result)
+                stacktrace_distance = seer_result.stacktrace_distance
+                break
 
     logger.info(
         "get_seer_similar_issues.results",
@@ -352,11 +328,11 @@ def get_seer_similar_issues(
             "project_id": event.project.id,
             "hash": event_hash,
             "matching_result": matching_seer_result,
-            "grouphash_returned": bool(parent_grouphash),
+            "grouphash_returned": bool(winning_parent_grouphash),
         },
     )
 
-    return (stacktrace_distance, parent_grouphash)
+    return (stacktrace_distance, winning_parent_grouphash)
 
 
 def _should_use_seer_match_for_grouping(


### PR DESCRIPTION
This refactors `get_seer_similar_issues`, which is used during ingestion, to allow it to handle multiple Seer matches. (Note that it does not actually change the number of results requested - which is still only 1 - but makes it so that when we do increase that number, we'll be able to handle what comes back.)

Key changes:

- Pull logic for checking whether a match can be used into a helper, `_should_use_seer_match_for_grouping`, to be called on each result.

- Run the results returned from Seer through that function regardless of the hybrid fingerprint status of the incoming event, because the closest Seer match(es) might be hybrid and therefore the same check is needed.

- Change the `grouping.similarity.hybrid_fingerprint_seer_result` metric to a `grouping.similarity.hybrid_fingerprint_match_check` metric, since there will now be multiple instances for a single incoming event, possibly with different values. A new metric in the spirit of the original (one encompassing the entire process for a given event) will be added back in in a follow-up PR.

We can see that these changes don't affect the eventual outcome of the process because the only changes to tests required by this refactor are ones having to do with the metric. (To keep things simple, tests testing the handling of multiple results will be added in [a follow-up PR](https://github.com/getsentry/sentry/pull/88621). The point of this PR is simply to do the refactor and show that the new code is equivalent to the old code.)