### PR TITLE
feat(seer grouping): Add metrics to track Seer result handling

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -365,6 +365,8 @@ def get_seer_similar_issues(
             "event_id": event.event_id,
             "project_id": event.project.id,
             "hash": event_hash,
+            "num_seer_matches": len(seer_results),
+            "num_seer_matches_checked": parent_grouphashes_checked,
             "matching_result": matching_seer_result,
             "grouphash_returned": bool(winning_parent_grouphash),
         },


### PR DESCRIPTION
This adds new metrics to `get_seer_similar_issues`, so we'll be able to see the affects of requesting multiple results from Seer during ingest once we start doing that. Metrics added:

- `grouping.similarity.seer_results_returned`: Just because we ask Seer for the 100 closest matches (say), it doesn't mean Seer's necessarily going to find 100 which exceed the `should_group` threshold. It's therefore useful to know how many matches Seer is actually finding, so we can get a sense for when increasing the number requested stops making a difference.

- `grouping.similarity.hybrid_fingerprint_results_checked`: This similarly will help us evaluate the number of results we're requesting. If we almost always find a match within the first 50 results, for example, it doesn't make sense to request many more than that, even if they exists. Both this and the metric above are tagged with platform, so we can determine if it would make sense to vary the number of matches requested based on platform.

- `grouping.similarity.get_seer_similar_issues`: This replaces the `grouping.similarity.hybrid_fingerprint_seer_result` metric which was removed in https://github.com/getsentry/sentry/pull/88619, and tracks the overall result of the `get_seer_similar_issues` call. It's different from the old metric in two ways, though: 1) In the case in which the Seer match(es) is/are rejected, it's not as specific as the old one about the reason, since if Seer returns multiple results, it might be a combo of reasons. 2) It also includes non-hybrid cases. (It includes an `is_hybrid` tag to differentiate one from the other.)

This PR also adds the above data to our logs.