### PR TITLE
settings: fix tabs

### DIFF
--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -20,7 +20,6 @@ import type {Authenticator} from 'sentry/types/auth';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {OrganizationSummary} from 'sentry/types/organization';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
-import recreateRoute from 'sentry/utils/recreateRoute';
 import useApi from 'sentry/utils/useApi';
 import RemoveConfirm from 'sentry/views/settings/account/accountSecurity/components/removeConfirm';
 import TwoFactorRequired from 'sentry/views/settings/account/accountSecurity/components/twoFactorRequired';
@@ -49,8 +48,6 @@ function AccountSecurity({
   hasVerifiedEmail,
   orgsRequire2fa,
   handleRefresh,
-  routes,
-  params,
   location,
 }: Props) {
   const api = useApi();
@@ -93,6 +90,7 @@ function AccountSecurity({
         ? 'sessionHistory'
         : 'settings';
 
+  const routePrefix = `/settings/account/security/`;
   return (
     <SentryDocumentTitle title={t('Security')}>
       <SettingsPageHeader
@@ -101,13 +99,10 @@ function AccountSecurity({
           <TabsContainer>
             <Tabs value={activeTab}>
               <TabList>
-                <TabList.Item key="settings" to={recreateRoute('', {params, routes})}>
+                <TabList.Item key="settings" to={`${routePrefix}`}>
                   {t('Settings')}
                 </TabList.Item>
-                <TabList.Item
-                  key="sessionHistory"
-                  to={recreateRoute('session-history', {params, routes})}
-                >
+                <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
                   {t('Session History')}
                 </TabList.Item>
               </TabList>

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
@@ -13,7 +13,6 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {InternetProtocol} from 'sentry/types/user';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import recreateRoute from 'sentry/utils/recreateRoute';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import SessionRow from './sessionRow';
@@ -21,7 +20,7 @@ import {tableLayout} from './utils';
 
 type IpListType = InternetProtocol[] | null;
 
-function SessionHistory({location, routes, params}: RouteComponentProps) {
+function SessionHistory({location}: RouteComponentProps) {
   const {
     data: ipList = [],
     isLoading,
@@ -51,8 +50,7 @@ function SessionHistory({location, routes, params}: RouteComponentProps) {
         ? 'sessionHistory'
         : 'settings';
 
-  const recreateRouteProps = {routes, params, location};
-
+  const routePrefix = `/settings/account/security/`;
   return (
     <SentryDocumentTitle title={t('Session History')}>
       <SettingsPageHeader
@@ -61,16 +59,10 @@ function SessionHistory({location, routes, params}: RouteComponentProps) {
           <TabsContainer>
             <Tabs value={activeTab}>
               <TabList>
-                <TabList.Item
-                  key="settings"
-                  to={recreateRoute('', {...recreateRouteProps, stepBack: -1})}
-                >
+                <TabList.Item key="settings" to={`${routePrefix}`}>
                   {t('Settings')}
                 </TabList.Item>
-                <TabList.Item
-                  key="sessionHistory"
-                  to={recreateRoute('', recreateRouteProps)}
-                >
+                <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
                   {t('Session History')}
                 </TabList.Item>
               </TabList>


### PR DESCRIPTION
This looks like it mighthave been broken before my tab change, as it was calling `recreateRoute('')` for both paths? I'm not sure if recreateRoute is even needed then given this signature, but maybe someone with more knowledge can correct me here please