### PR TITLE
feat(aci): detector permission checks for DetectorWorkflow endpoint

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -213,6 +213,17 @@ class OrganizationAlertRulePermission(OrganizationPermission):
     }
 
 
+class OrganizationDetectorPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
+        # grant org:read permission, but raise permission denied if the members aren't allowed
+        # to create alerts and the user isn't a team admin
+        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "PUT": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "DELETE": ["org:read", "org:write", "org:admin", "alerts:write"],
+    }
+
+
 class OrgAuthTokenPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -1,5 +1,7 @@
 from django.db import IntegrityError, router, transaction
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
 
 from sentry import audit_log
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
@@ -7,6 +9,31 @@ from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
+
+
+def check_can_edit_detector(detector: Detector, request: Request) -> None:
+    """
+    Determine if the requesting user has access to detector edit. If the request does not have the "alerts:write"
+    permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
+    in their request.
+    """
+    # if the requesting user has any of these org-level permissions, then they can create an alert
+    if request.access.has_scope("org:admin") or request.access.has_scope("org:write"):
+        return
+
+    project = detector.project
+
+    if request.access.has_project_scope(project, "alerts:write"):
+        # team admins can modify all detectors for projects they have access to
+        has_team_admin_access = request.access.has_project_scope(project, "project:write")
+        if has_team_admin_access:
+            return
+        # members can modify user-created detectors for projects they have access to
+        has_project_access = request.access.has_project_scope(project, "project:read")
+        if has_project_access and detector.created_by_id is not None:
+            return
+
+    raise PermissionDenied
 
 
 class DetectorWorkflowValidator(CamelSnakeSerializer):
@@ -20,6 +47,7 @@ class DetectorWorkflowValidator(CamelSnakeSerializer):
                     project__organization=self.context["organization"],
                     id=validated_data["detector_id"],
                 )
+                check_can_edit_detector(detector, self.context["request"])
                 workflow = Workflow.objects.get(
                     organization=self.context["organization"], id=validated_data["workflow_id"]
                 )


### PR DESCRIPTION
detectors should have similar permissions to alerts today, with additional restrictions on default detectors created by Sentry

- Sentry created (default) detectors
    - Organization-level owner, manager (users with `org:write` or `org:admin`)
    - Team-level admins for projects where they are team admins (those who have `project:write` on the project)
- User created (custom) detectors
    - Anyone on the team can create/edit if “Let members create alerts” is enabled (in this case all users have `alert:write` on projects)
    - Otherwise if “Let members create alerts” is disabled, only organization-level owner, manager, or team-level admin roles can create/edit detectors
    - These permissions should be restricted to only projects that members are associated with in the case that "Open team membership" is disabled