### PR TITLE
chore(grouping): Add hashing tests to strong typing list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -464,6 +464,7 @@ module = [
     "tests.sentry.grouping.seer_similarity.test_seer",
     "tests.sentry.grouping.seer_similarity.test_seer_eligibility",
     "tests.sentry.grouping.test_fingerprinting",
+    "tests.sentry.grouping.test_hashing",
     "tests.sentry.hybridcloud.*",
     "tests.sentry.incidents.serializers.*",
     "tests.sentry.integrations.msteams.webhook.*",


### PR DESCRIPTION
This adds the few remaining types necessary for the `test_hashing` module to be included in strong typing.