### PR TITLE
ref(shared-views): Change view creation entrypoints to save as organization visibility

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -7,7 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize
-from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
@@ -63,6 +63,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
                 "name": "Default Search",
                 "query": result["query"],
                 "query_sort": result["sort"],
+                "visibility": GroupSearchViewVisibility.ORGANIZATION,
             },
         )
         default_view_id = default_view.id if created else default_view

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -195,6 +195,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
             is_all_projects=validated_data["isAllProjects"],
             environments=validated_data["environments"],
             time_filters=validated_data["timeFilters"],
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
         view.projects.set(validated_data["projects"])
 
@@ -334,7 +335,10 @@ def _update_existing_view(
             organization=org,
             user_id=user_id,
             group_search_view=gsv,
-            defaults={"position": position},
+            defaults={
+                "position": position,
+                "visibility": GroupSearchViewVisibility.ORGANIZATION,
+            },
         )
         return gsv
     except GroupSearchView.DoesNotExist:
@@ -357,6 +361,7 @@ def _create_view(
         is_all_projects=view.get("isAllProjects", False),
         environments=view.get("environments", []),
         time_filters=view.get("timeFilters", {"period": "14d"}),
+        visibility=GroupSearchViewVisibility.ORGANIZATION,
     )
     if "projects" in view:
         gsv.projects.set(view["projects"] or [])


### PR DESCRIPTION
As part of transitioning to a shared-by-default model for views, we need to make all existing views have Organization level visibility. 

This PR updates all entrypoints for creating views to have Organization visibility. In a subsequent PR, I will backfill all existing views. 

This visibility column is not used by any public frontend pages, so this will not have any visible effects for users. 