### PR TITLE
feat(pipeline): Add CoverageOnboardingPage component and tests 

### DIFF
--- a/static/app/views/pipeline/coverage/onboarding.spec.tsx
+++ b/static/app/views/pipeline/coverage/onboarding.spec.tsx
@@ -1,0 +1,18 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CoverageOnboardingPage from 'sentry/views/pipeline/coverage/onboarding';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CoverageOnboardingPage', () => {
+  it('renders the placeholder content', () => {
+    render(<CoverageOnboardingPage />, {
+      organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
+    });
+
+    const testContent = screen.getByText('Coverage Onboarding');
+    expect(testContent).toBeInTheDocument();
+  });
+});

--- a/static/app/views/pipeline/coverage/onboarding.tsx
+++ b/static/app/views/pipeline/coverage/onboarding.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export default function CoverageOnboardingPage() {
+  return (
+    <LayoutGap>
+      <p>Coverage Onboarding</p>
+    </LayoutGap>
+  );
+}
+
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;


### PR DESCRIPTION
This PR adds the CoverageOnboardingPage component and its tests