### PR TITLE
fix(flamegraph): Limit flamegraph height in profile summary tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -294,6 +294,7 @@ const TransactionProfilesContentContainer = styled('div')`
   flex: 1;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  max-height: 85vh;
 `;
 
 const ProfileVisualizationContainer = styled('div')`


### PR DESCRIPTION
The list of profile references can cause the panel to grow. If there are too many, the canvas will grow to a size where it doesn't render correctly anymore. Limit the size of the list of profile references which will limit the size of the canvas.