### PR TITLE
fix(taskworker) Reduce usage of countdown

### DIFF
--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -62,10 +62,7 @@ def process_resource_change(instance, **kwargs):
 
         # CODEOWNERS file added or modified, trigger auto-sync
         if instance.filename in filepaths and instance.type in ["A", "M"]:
-            # Trigger the task after 5min to make sure all records in the transactions has been saved.
-            code_owners_auto_sync.apply_async(
-                kwargs={"commit_id": instance.commit_id}, countdown=60 * 5
-            )
+            code_owners_auto_sync.delay(commit_id=instance.commit_id)
 
     transaction.on_commit(_spawn_task, router.db_for_write(CommitFileChange))
 

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -58,7 +58,7 @@ class FileBlobTest(TestCase):
                 blob.delete()
         # Even though postgres failed we should still queue
         # a task to delete the filestore object.
-        assert mock_delete_file_region.apply_async.call_count == 1
+        assert mock_delete_file_region.delay.call_count == 1
 
         # blob is still around.
         assert FileBlob.objects.get(id=blob.id)


### PR DESCRIPTION
Remove usage of short `countdown` durations for tasks and use `transaction.on_commit()` instead. These tasks appear to be using `countdown` as a way to prevent tasks being processed before postgres transactions are complete.

Refs #88091