### PR TITLE
fix(flamegraph): Dedupe flamegraph profile references

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphSidePanel.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphSidePanel.tsx
@@ -65,9 +65,24 @@ export function AggregateFlamegraphSidePanel({
 
   const examples = useMemo(() => {
     const referenceNodes = frame ? [frame] : flamegraph.root.children;
-    return referenceNodes
-      .flatMap(n => n.profileIds?.map(example => ({example, node: n})) || [])
-      .sort((a, b) => getReferenceStart(b.example) - getReferenceStart(a.example));
+
+    const seen: Set<Profiling.ProfileReference> = new Set();
+
+    const allExamples = [];
+
+    for (const node of referenceNodes) {
+      for (const example of node.profileIds || []) {
+        if (seen.has(example)) {
+          continue;
+        }
+        seen.add(example);
+        allExamples.push({example, node});
+      }
+    }
+
+    return [...allExamples].sort(
+      (a, b) => getReferenceStart(b.example) - getReferenceStart(a.example)
+    );
   }, [flamegraph, frame]);
 
   return (


### PR DESCRIPTION
When there are multiple roots, we need to make sure to deduplicate the references otherwise the same reference can show up multiple times.