### PR TITLE
:wrench: chore(slack): don't prefetch assignee options

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -401,7 +401,6 @@ def build_actions(
             label="Select Assignee...",
             type="select",
             selected_options=format_actor_options_slack([assignee]) if assignee else [],
-            option_groups=get_option_groups(group),
         )
         return assign_button
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -489,7 +489,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         group = self.create_group(project=project2)
 
         SlackIssuesMessageBuilder(group).build()
-        assert mock_get_option_groups.called
 
         team_option_groups, member_option_groups = mock_get_option_groups(group)
         assert len(team_option_groups["options"]) == 2


### PR DESCRIPTION
this pr will fix a subset of the issues in https://sentry.sentry.io/issues/5392362510/?project=1

`get_options_groups` made an expensive RPC call which is prone to timeouts

in reality, when we are building the assignee dropdown, we shouldn't be adding option groups since we actually don't need it. 

the assignee dropdown is a dynamic field, for which slack sends us webhooks when a user types something. we then respond back with possible options.

i tested that the behavior locally and nothing seems to have broken:

https://github.com/user-attachments/assets/de6b314d-6b00-4b1e-90cb-aeb16cde2b62

