### PR TITLE
fix(ourlogs): Prettify attribute name in log table header

### DIFF
--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -25,6 +25,7 @@ import {
   useSetLogsCursor,
   useSetLogsSortBys,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogRowContent} from 'sentry/views/explore/logs/logsTableRow';
 import {
   FirstTableHeadCell,
@@ -53,6 +54,9 @@ export function LogsTable({
   const search = useLogsSearch();
   const setCursor = useSetLogsCursor();
   const isTableEditingFrozen = useLogsIsTableEditingFrozen();
+  const {attributes: stringAttributes} = useTraceItemAttributes('string');
+  const {attributes: numberAttributes} = useTraceItemAttributes('number');
+
   const {data, isError, isPending, pageLinks, meta} = tableData;
 
   const tableRef = useRef<HTMLTableElement>(null);
@@ -81,7 +85,11 @@ export function LogsTable({
 
                 const fieldType = meta?.fields?.[field];
                 const align = logsFieldAlignment(field, fieldType);
-                const headerLabel = getTableHeaderLabel(field);
+                const headerLabel = getTableHeaderLabel(
+                  field,
+                  stringAttributes,
+                  numberAttributes
+                );
 
                 if (isPending) {
                   return <TableHeadCell key={index} isFirst={index === 0} />;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -132,7 +133,7 @@ export function logsFieldAlignment(...args: Parameters<typeof fieldAlignment>) {
   return fieldAlignment(...args);
 }
 
-export function removePrefixes(key: string) {
+function removePrefixes(key: string) {
   return key.replace('log.', '').replace('sentry.', '');
 }
 
@@ -152,8 +153,16 @@ export function adjustAliases(key: string) {
   }
 }
 
-export function getTableHeaderLabel(field: OurLogFieldKey) {
-  return LogAttributesHumanLabel[field] ?? removePrefixes(field);
+export function getTableHeaderLabel(
+  field: OurLogFieldKey,
+  stringAttributes: TagCollection,
+  numberAttributes: TagCollection
+) {
+  const attribute = stringAttributes[field] ?? numberAttributes[field] ?? null;
+
+  return (
+    LogAttributesHumanLabel[field] ?? attribute?.name ?? prettifyAttributeName(field)
+  );
 }
 
 export function isLogAttributeUnit(unit: string | null): unit is LogAttributeUnits {


### PR DESCRIPTION
### Summary
We're returning 'tags[...,number]' now we should prettify the header as well.

