### PR TITLE
ref(workflow_engine): Refactor the IssueOccurrence creation in detectors

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -28,7 +28,6 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
         self, group_key: DetectorGroupKey, new_status: PriorityLevel
     ) -> tuple[DetectorOccurrence, EventData]:
         # Returning a placeholder for now, this may require us passing more info
-
         occurrence = DetectorOccurrence(
             issue_title="Some Issue Title",
             subtitle="An Issue Subtitle",
@@ -37,15 +36,8 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
             culprit="Some culprit",
         )
 
-        event_data = {
-            "timestamp": occurrence.detection_time,
-            "project_id": occurrence.project_id,
-            "event_id": occurrence.event_id,
-            "platform": "python",
-            "received": occurrence.detection_time,
-            "tags": {},
-        }
-        return occurrence, event_data
+        # TODO - Add any additional data we want
+        return occurrence, {}
 
     @property
     def counter_names(self) -> list[str]:

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -29,14 +29,12 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
     ) -> tuple[DetectorOccurrence, EventData]:
         # Returning a placeholder for now, this may require us passing more info
 
-        # don't want to expose fingerprint, event_id, project_id, id, detection_time, or initial_issue_priority.
-        # -- platform should handle all of this.
         occurrence = DetectorOccurrence(
-            issue_title="Some Issue",
-            subtitle="Some subtitle",
+            issue_title="Some Issue Title",
+            subtitle="An Issue Subtitle",
             type=MetricAlertFire,
             level="error",
-            culprit="Some culprit",  # TODO -- should this be done in the detector as the data condition?
+            culprit="Some culprit",
         )
 
         event_data = {

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -1,9 +1,10 @@
 __all__ = [
-    "DetectorHandler",
     "DetectorEvaluationResult",
+    "DetectorHandler",
+    "DetectorOccurrence",
     "DetectorStateData",
     "StatefulDetectorHandler",
 ]
 
-from .base import DetectorEvaluationResult, DetectorHandler, DetectorStateData
+from .base import DetectorEvaluationResult, DetectorHandler, DetectorOccurrence, DetectorStateData
 from .stateful import StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -3,8 +3,9 @@ __all__ = [
     "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
+    "EventData",
     "StatefulDetectorHandler",
 ]
 
 from .base import DetectorEvaluationResult, DetectorHandler, DetectorOccurrence, DetectorStateData
-from .stateful import StatefulDetectorHandler
+from .stateful import EventData, StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -1,15 +1,29 @@
 import abc
 import dataclasses
 import logging
+from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any, Generic, TypeVar
 
-from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True)
+class DetectorOccurrence(IssueOccurrence):
+    id: str | None
+    project_id: int | None
+    # Event id pointing to an event in nodestore
+    event_id: str | None
+    fingerprint: Sequence[str] | None
+    evidence_data: Mapping[str, Any] | None
+    evidence_display: Sequence[IssueEvidence] | None
+    detection_time: datetime | None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -2,11 +2,12 @@ import abc
 import dataclasses
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import datetime
 from typing import Any, Generic, TypeVar
 
+from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.types.actor import Actor
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
@@ -14,16 +15,18 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-@dataclasses.dataclass(frozen=True)
-class DetectorOccurrence(IssueOccurrence):
-    id: str | None
-    project_id: int | None
-    # Event id pointing to an event in nodestore
-    event_id: str | None
-    fingerprint: Sequence[str] | None
-    evidence_data: Mapping[str, Any] | None
-    evidence_display: Sequence[IssueEvidence] | None
-    detection_time: datetime | None
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DetectorOccurrence:
+    issue_title: str
+    subtitle: str
+    resource_id: str | None = None
+    evidence_data: Mapping[str, Any] | None = None
+    evidence_display: Sequence[IssueEvidence] | None = None
+    type: type[GroupType]
+    level: str
+    culprit: str
+    initial_issue_priority: int | None = None
+    assignee: Actor | None = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -218,20 +218,28 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
                     group_key, PriorityLevel(new_status)
                 )
 
+                evidence_data = {
+                    **detector_occurrence.evidence_data,
+                    "detector_id": self.detector.id,
+                    "value": value,
+                }
+
                 result = IssueOccurrence(
-                    id=detector_occurrence.id or str(uuid4()),
-                    project_id=detector_occurrence.project_id or self.detector.project_id,
-                    event_id=detector_occurrence.event_id or str(uuid4()),
-                    detection_time=detector_occurrence.detection_time or datetime.now(),
-                    resource_id=detector_occurrence.resource_id,
-                    fingerprint=self.build_fingerprint(group_key),
-                    evidence_data={
-                        **detector_occurrence.evidence_data,
-                        "detector_id": self.detector.id,
-                        "value": value,
-                    },
-                    evidence_display=detector_occurrence.evidence_display or [],
-                    initial_issue_priority=new_status,
+                    str(uuid4()),
+                    self.detector.project_id,
+                    str(uuid4()),
+                    self.build_fingerprint(group_key),
+                    detector_occurrence.issue_title,
+                    detector_occurrence.subtitle,
+                    detector_occurrence.resource_id,
+                    evidence_data,
+                    detector_occurrence.evidence_display or [],
+                    detector_occurrence.type,
+                    datetime.now(),
+                    detector_occurrence.level,
+                    detector_occurrence.culprit or "error",
+                    detector_occurrence.initial_issue_priority or new_status,
+                    detector_occurrence.assignee,
                 )
 
             return DetectorEvaluationResult(


### PR DESCRIPTION
## Description
Rather than having the detector handler create an issue occurrence , have it create a detector occurrence instead.

This will allow us to have the platform add things like the value, detector id, detection time, etc - so the detector handler just has to do the mapping and unique tasks per detector.

🚧🚧🚧🚧🚧🚧 In progress  🚧🚧🚧🚧🚧🚧 