### PR TITLE
fix(ourlogs): Missing body from attr keys

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -12,7 +12,6 @@ from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType as ProtoTraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import ExistsFilter, TraceItemFilter
 
 from sentry import features, options
 from sentry.api.api_owners import ApiOwner
@@ -96,17 +95,6 @@ def as_attribute_key(
     }
 
 
-def empty_filter(trace_item_type: SupportedTraceItemType):
-    column_name = (
-        "sentry.body" if trace_item_type == SupportedTraceItemType.LOGS else "sentry.description"
-    )
-    return TraceItemFilter(
-        exists_filter=ExistsFilter(
-            key=AttributeKey(name=column_name),
-        )
-    )
-
-
 @region_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
@@ -151,7 +139,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
 
-        filter = filter or empty_filter(trace_item_type)
         attr_type = (
             AttributeKey.Type.TYPE_DOUBLE
             if attribute_type == "number"

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -113,6 +113,25 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
         assert "test.attribute2" in keys
         assert "log.severity_text" in keys
 
+    def test_body_attribute(self):
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "sentry.body": {"string_value": "value1"},
+                },
+            ),
+        ]
+        self.store_ourlogs(logs)
+
+        response = self.do_request()
+
+        assert response.status_code == 200, response.content
+        keys = {item["key"] for item in response.data}
+        assert len(keys) == 3
+        assert "log.body" in keys
+
 
 class OrganizationTraceItemAttributeValuesEndpointTest(OrganizationEventsEndpointTestBase):
     viewname = "sentry-api-0-organization-trace-item-attribute-values"


### PR DESCRIPTION
### Summary
This adds a test since 'log.body' disappeared from this endpoint at some point. Removing the empty filter (which is no longer necessary to put us on eap_items) does the trick.


