### PR TITLE
feat(billing): Delete billing metric history modal in admin

### DIFF
--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -1,0 +1,368 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import ModalStore from 'sentry/stores/modalStore';
+import {Organization} from 'sentry/types/organization';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import deleteBillingMetricHistory from 'admin/components/deleteBillingMetricHistory';
+
+describe('DeleteBillingMetricHistory', function () {
+  // Add afterEach to clean up after tests
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
+    ModalStore.reset();
+  });
+
+  const organization = OrganizationFixture({
+    features: ['delete-billing-metric-history-admin'],
+  });
+
+  const openDeleteModal = (
+    props: {organization: Organization; onSuccess?: () => void} = {organization}
+  ) => {
+    deleteBillingMetricHistory({
+      organization,
+      onSuccess: props.onSuccess || jest.fn(),
+    });
+    renderGlobalModal();
+  };
+
+  it('renders modal with billing config data', async function () {
+    // Mock the billing config API call
+    const billingConfigMock = MockApiClient.addMockResponse({
+      url: '/api/0/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+          '2': {
+            api_name: 'transactions',
+            billed_category: 2,
+            display_name: 'Transactions',
+            name: 'transactions',
+            order: 2,
+            product_name: 'Performance',
+            singular: 'transaction',
+            tally_type: 2,
+          },
+        },
+        outcomes: {
+          '0': 'Accepted',
+          '1': 'Filtered',
+          '2': 'Rate Limited',
+        },
+        reason_codes: {
+          '0': 'Default',
+          '1': 'Quota',
+          '2': 'Rate Limit',
+        },
+      },
+    });
+
+    openDeleteModal();
+
+    // Check that the billing config API was called
+    expect(billingConfigMock).toHaveBeenCalled();
+
+    // Check that the modal is rendered with the correct title
+    expect(screen.getByText('Delete Billing Metric History')).toBeInTheDocument();
+
+    // Wait for the loading indicator to disappear and for content to appear
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Check for the description text
+    await waitFor(() => {
+      expect(
+        screen.getByText('Delete billing metric history for a specific data category.')
+      ).toBeInTheDocument();
+    });
+
+    // Check that the form elements are rendered
+    expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+  });
+
+  it('successfully deletes billing metric history when form is submitted', async function () {
+    // Mock the billing config API call
+    MockApiClient.addMockResponse({
+      url: '/api/0/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+          '2': {
+            api_name: 'transactions',
+            billed_category: 2,
+            display_name: 'Transactions',
+            name: 'transactions',
+            order: 2,
+            product_name: 'Performance',
+            singular: 'transaction',
+            tally_type: 2,
+          },
+        },
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
+
+    // Mock the success indicator
+    const successIndicator = jest.spyOn(
+      require('sentry/actionCreators/indicator'),
+      'addSuccessMessage'
+    );
+
+    // Mock the API endpoint for deleting billing metric history
+    const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
+      url: `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      method: 'POST',
+      body: {},
+    });
+
+    const onSuccess = jest.fn();
+    openDeleteModal({organization, onSuccess});
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Wait for the form to be visible
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    });
+
+    // Select a data category
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Category'}),
+      'Transactions (2)'
+    );
+
+    // Click the Delete button
+    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+    // Check that the API call was made with the correct parameters
+    expect(deleteBillingMetricHistoryMock).toHaveBeenCalledWith(
+      `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: {
+          data_category: 2,
+        },
+      })
+    );
+
+    // Check that the success message was shown
+    expect(successIndicator).toHaveBeenCalledWith(
+      'Successfully deleted billing metric history.'
+    );
+
+    // Check that the onSuccess callback was called
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('shows error message when API request fails', async function () {
+    // Mock the billing config API call
+    MockApiClient.addMockResponse({
+      url: '/api/0/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+        },
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
+
+    // Mock the error indicator
+    const errorIndicator = jest.spyOn(
+      require('sentry/actionCreators/indicator'),
+      'addErrorMessage'
+    );
+
+    // Mock the API endpoint to return an error
+    const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
+      url: `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'An error occurred while deleting billing metric history.',
+      },
+    });
+
+    openDeleteModal();
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Wait for the form to be visible
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    });
+
+    // Select a data category
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Category'}),
+      'Errors (1)'
+    );
+
+    // Click the Delete button
+    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+    // Check that the API call was made
+    expect(deleteBillingMetricHistoryMock).toHaveBeenCalled();
+
+    // Check that the error message was shown
+    await waitFor(() => {
+      expect(errorIndicator).toHaveBeenCalledWith(
+        'An error occurred while deleting billing metric history.'
+      );
+    });
+  });
+
+  it('disables Submit button when no data category is selected', async function () {
+    // Mock the billing config API call
+    MockApiClient.addMockResponse({
+      url: '/api/0/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+        },
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
+
+    openDeleteModal();
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Wait for the form to be visible
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    });
+
+    // Check that the Delete button is disabled when no data category is selected
+    expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
+
+    // Select a data category
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Category'}),
+      'Errors (1)'
+    );
+
+    // Now the Delete button should be enabled
+    expect(screen.getByRole('button', {name: 'Delete'})).not.toBeDisabled();
+  });
+
+  it('closes modal when Cancel button is clicked', async function () {
+    // Mock the billing config API call
+    MockApiClient.addMockResponse({
+      url: '/api/0/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+        },
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
+
+    openDeleteModal();
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Check that the modal is rendered with the correct title
+    expect(screen.getByText('Delete Billing Metric History')).toBeInTheDocument();
+
+    // Wait for the form to be visible
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    });
+
+    // Click the Cancel button
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    // Check that the modal is closed
+    expect(screen.queryByText('Delete Billing Metric History')).not.toBeInTheDocument();
+  });
+});
+
+describe('deleteBillingMetricHistory export function', function () {
+  it('opens modal with correct props', function () {
+    const organization = OrganizationFixture();
+    const onSuccess = jest.fn();
+    const openModalMock = jest.spyOn(require('sentry/actionCreators/modal'), 'openModal');
+
+    deleteBillingMetricHistory({organization, onSuccess});
+
+    expect(openModalMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        closeEvents: 'escape-key',
+      })
+    );
+  });
+});

--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -1,7 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import ModalStore from 'sentry/stores/modalStore';
-import {Organization} from 'sentry/types/organization';
 import {
   render,
   renderGlobalModal,
@@ -10,6 +8,9 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
+
+import ModalStore from 'sentry/stores/modalStore';
+import type {Organization} from 'sentry/types/organization';
 
 import deleteBillingMetricHistory from 'admin/components/deleteBillingMetricHistory';
 
@@ -302,7 +303,7 @@ describe('DeleteBillingMetricHistory', function () {
     );
 
     // Now the Delete button should be enabled
-    expect(screen.getByRole('button', {name: 'Delete'})).not.toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Delete'})).toBeEnabled();
   });
 
   it('closes modal when Cancel button is clicked', async function () {

--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
-  render,
   renderGlobalModal,
   screen,
   userEvent,

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -73,6 +73,7 @@ function DeleteBillingMetricHistoryModal({
   );
   const onSubmit = () => {
     if (dataCategory === null) {
+      addErrorMessage('Please select a data category.');
       return;
     }
 

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -1,0 +1,131 @@
+import {Fragment, useState} from 'react';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
+import SelectField from 'sentry/components/forms/fields/selectField';
+import Form from 'sentry/components/forms/form';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+type CategoryInfo = {
+  api_name: string;
+  billed_category: number;
+  display_name: string;
+  name: string;
+  order: number;
+  product_name: string;
+  singular: string;
+  tally_type: number;
+};
+
+type BillingConfig = {
+  category_info: Record<string, CategoryInfo>;
+  outcomes: Record<string, string>;
+  reason_codes: Record<string, string>;
+};
+
+type Props = {
+  onSuccess: () => void;
+  organization: Organization;
+};
+
+type ModalProps = Props & ModalRenderProps;
+
+function DeleteBillingMetricHistoryModal({
+  onSuccess,
+  organization,
+  closeModal,
+  Header,
+  Body,
+}: ModalProps) {
+  const api = useApi();
+  const [dataCategory, setDataCategory] = useState<number | null>(null);
+  const orgSlug = organization.slug;
+
+  const {data: billingConfig = null, isPending: isLoadingBillingConfig} =
+    useApiQuery<BillingConfig>(['/api/0/billing-config/'], {
+      staleTime: Infinity,
+    });
+
+  if (isLoadingBillingConfig || !billingConfig) {
+    return (
+      <Fragment>
+        <Header closeButton>Delete Billing Metric History</Header>
+        <Body>
+          <LoadingIndicator />
+        </Body>
+      </Fragment>
+    );
+  }
+
+  const dataCategoryChoices = Object.entries(billingConfig.category_info).map(
+    ([key, value]) => {
+      const billingMetric = Number(key);
+      return [billingMetric, `${value.display_name} (${billingMetric})`] as [
+        number,
+        string,
+      ];
+    }
+  );
+  const onSubmit = () => {
+    if (dataCategory === null) {
+      return;
+    }
+
+    api.request(`/api/0/_admin/${orgSlug}/delete-billing-metric-history/`, {
+      method: 'POST',
+      data: {
+        data_category: dataCategory,
+      },
+      success: () => {
+        addSuccessMessage('Successfully deleted billing metric history.');
+        closeModal();
+        onSuccess();
+      },
+      error: error => {
+        const errorMsg =
+          error.responseJSON?.detail || 'Unable to delete billing metric history.';
+        addErrorMessage(errorMsg);
+      },
+    });
+  };
+
+  return (
+    <Fragment>
+      <Header closeButton>Delete Billing Metric History</Header>
+      <Body>
+        <div>Delete billing metric history for a specific data category.</div>
+        <br />
+        <Form onSubmit={onSubmit} submitLabel={t('Delete')} onCancel={closeModal}>
+          <SelectField
+            inline={false}
+            stacked
+            flexibleControlStateSize
+            label="Data Category"
+            name="data_category"
+            value={dataCategory}
+            onChange={(value: number) => {
+              setDataCategory(value);
+            }}
+            choices={dataCategoryChoices}
+            required
+            help="Warning: This action cannot be undone. The selected billing metric history will be permanently deleted."
+          />
+        </Form>
+      </Body>
+    </Fragment>
+  );
+}
+
+type Options = Pick<Props, 'onSuccess' | 'organization'>;
+
+const deleteBillingMetricHistory = (opts: Options) =>
+  openModal(deps => <DeleteBillingMetricHistoryModal {...deps} {...opts} />, {
+    closeEvents: 'escape-key',
+  });
+
+export default deleteBillingMetricHistory;

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -4529,8 +4529,8 @@ describe('Customer Details', function () {
         screen.getAllByRole('button', {name: /customers actions/i})[1]!
       );
 
-      // The delete option should not be present
-      expect(screen.queryByText('Delete Billing Metric History')).toBeInTheDocument();
+      // The delete option should be present
+      expect(screen.getByText('Delete Billing Metric History')).toBeInTheDocument();
     });
 
     it('does not show option when feature flag is missing', async function () {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -4503,64 +4503,12 @@ describe('Customer Details', function () {
       ModalStore.reset();
     });
 
-    it('renders and properly functions', async function () {
+    it('shows option when feature flag is enabled', async function () {
       // Set up organization with the required feature flag
       const orgWithDeleteFeature = OrganizationFixture({
         features: ['delete-billing-metric-history-admin'],
       });
       setUpMocks(orgWithDeleteFeature);
-
-      // Mock the billing config API call
-      const billingConfigMock = MockApiClient.addMockResponse({
-        url: '/api/0/billing-config/',
-        body: {
-          category_info: {
-            '1': {
-              api_name: 'errors',
-              billed_category: 1,
-              display_name: 'Errors',
-              name: 'errors',
-              order: 1,
-              product_name: 'Error Tracking',
-              singular: 'error',
-              tally_type: 1,
-            },
-            '2': {
-              api_name: 'transactions',
-              billed_category: 2,
-              display_name: 'Transactions',
-              name: 'transactions',
-              order: 2,
-              product_name: 'Performance',
-              singular: 'transaction',
-              tally_type: 2,
-            },
-          },
-          outcomes: {
-            '0': 'Accepted',
-            '1': 'Filtered',
-            '2': 'Rate Limited',
-          },
-          reason_codes: {
-            '0': 'Default',
-            '1': 'Quota',
-            '2': 'Rate Limit',
-          },
-        },
-      });
-
-      // Mock success indicator
-      const successIndicator = jest.spyOn(
-        require('sentry/actionCreators/indicator'),
-        'addSuccessMessage'
-      );
-
-      // Mock the API endpoint for deleting billing metric history
-      const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
-        url: `/api/0/_admin/${orgWithDeleteFeature.slug}/delete-billing-metric-history/`,
-        method: 'POST',
-        body: {},
-      });
 
       render(
         <CustomerDetails
@@ -4581,50 +4529,8 @@ describe('Customer Details', function () {
         screen.getAllByRole('button', {name: /customers actions/i})[1]!
       );
 
-      // Click on the "Delete Billing Metric History" option
-      await userEvent.click(screen.getByText('Delete Billing Metric History'));
-
-      // Check modal content
-      await screen.findByText('Delete Billing Metric History');
-      expect(
-        screen.getByText('Delete billing metric history for a specific data category.')
-      ).toBeInTheDocument();
-
-      // Ensure billing config was loaded
-      expect(billingConfigMock).toHaveBeenCalled();
-
-      // Wait for the select field to be populated with choices
-      await waitFor(() => {
-        const selectField = screen.getByRole('textbox', {name: 'Data Category'});
-        expect(selectField).toBeInTheDocument();
-      });
-
-      // Select a data category
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Data Category'}),
-        'Transactions (2)'
-      );
-
-      // Click the Delete button
-      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
-
-      // Check that the API call was made with the correct parameters
-      await waitFor(() => {
-        expect(deleteBillingMetricHistoryMock).toHaveBeenCalledWith(
-          `/api/0/_admin/${orgWithDeleteFeature.slug}/delete-billing-metric-history/`,
-          expect.objectContaining({
-            method: 'POST',
-            data: {
-              data_category: 2,
-            },
-          })
-        );
-      });
-
-      // Check that the success message was shown
-      expect(successIndicator).toHaveBeenCalledWith(
-        'Successfully deleted billing metric history.'
-      );
+      // The delete option should not be present
+      expect(screen.queryByText('Delete Billing Metric History')).toBeInTheDocument();
     });
 
     it('does not show option when feature flag is missing', async function () {
@@ -4654,100 +4560,6 @@ describe('Customer Details', function () {
 
       // The delete option should not be present
       expect(screen.queryByText('Delete Billing Metric History')).not.toBeInTheDocument();
-    });
-
-    it('handles API error gracefully', async function () {
-      // Set up organization with the required feature flag
-      const orgWithDeleteFeature = OrganizationFixture({
-        features: ['delete-billing-metric-history-admin'],
-      });
-      setUpMocks(orgWithDeleteFeature);
-
-      // Mock the billing config API call
-      MockApiClient.addMockResponse({
-        url: '/api/0/billing-config/',
-        body: {
-          category_info: {
-            '1': {
-              api_name: 'errors',
-              billed_category: 1,
-              display_name: 'Errors',
-              name: 'errors',
-              order: 1,
-              product_name: 'Error Tracking',
-              singular: 'error',
-              tally_type: 1,
-            },
-          },
-          outcomes: {'0': 'Accepted'},
-          reason_codes: {'0': 'Default'},
-        },
-      });
-
-      // Mock the error indicator
-      const errorIndicator = jest.spyOn(
-        require('sentry/actionCreators/indicator'),
-        'addErrorMessage'
-      );
-
-      // Mock the API endpoint to return an error
-      const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
-        url: `/api/0/_admin/${orgWithDeleteFeature.slug}/delete-billing-metric-history/`,
-        method: 'POST',
-        statusCode: 400,
-        body: {
-          detail: 'An error occurred while deleting billing metric history.',
-        },
-      });
-
-      render(
-        <CustomerDetails
-          router={router}
-          location={router.location}
-          routes={router.routes}
-          routeParams={router.params}
-          route={{}}
-          params={{orgId: orgWithDeleteFeature.slug}}
-        />
-      );
-      renderGlobalModal();
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      // Open the actions dropdown
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[1]!
-      );
-
-      // Click on the "Delete Billing Metric History" option
-      await userEvent.click(screen.getByText('Delete Billing Metric History'));
-
-      // Check modal content
-      await screen.findByText('Delete Billing Metric History');
-      expect(
-        screen.getByText('Delete billing metric history for a specific data category.')
-      ).toBeInTheDocument();
-
-      // Select a data category
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Data Category'}),
-        'Errors (1)'
-      );
-
-      // Click the Delete button
-      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
-
-      // Check that the API call was made
-      expect(deleteBillingMetricHistoryMock).toHaveBeenCalled();
-
-      // Check that the error message was shown
-      await waitFor(() => {
-        expect(errorIndicator).toHaveBeenCalledWith(
-          'An error occurred while deleting billing metric history.'
-        );
-      });
     });
   });
 });

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -45,6 +45,7 @@ import OrganizationStatus from 'admin/components/customers/organizationStatus';
 import PendingChanges from 'admin/components/customers/pendingChanges';
 import type {ActionItem, BadgeItem} from 'admin/components/detailsPage';
 import DetailsPage from 'admin/components/detailsPage';
+import deleteBillingMetricHistory from 'admin/components/deleteBillingMetricHistory';
 import ForkCustomerAction from 'admin/components/forkCustomer';
 import triggerEndPeriodEarlyModal from 'admin/components/nextBillingPeriodAction';
 import triggerProvisionSubscription from 'admin/components/provisionSubscriptionAction';
@@ -364,6 +365,9 @@ class CustomerDetails extends DeprecatedAsyncComponent<Props, State> {
 
     const orgFeatures = organization?.features ?? [];
     const hasAdminTestFeatures = orgFeatures.includes('add-billing-metric-usage-admin');
+    const hasAdminDeleteBillingMetricHistory = orgFeatures.includes(
+      'delete-billing-metric-history-admin'
+    );
 
     const activeDataType = this.activeDataType;
     return (
@@ -754,6 +758,18 @@ class CustomerDetails extends DeprecatedAsyncComponent<Props, State> {
               visible: hasAdminTestFeatures,
               onAction: () =>
                 addBillingMetricUsage({
+                  onSuccess: () => this.reloadData(),
+                  organization,
+                }),
+            },
+            {
+              key: 'deleteBillingMetricHistory',
+              name: 'Delete Billing Metric History',
+              help: 'Delete billing metric history for a specific data category.',
+              skipConfirmModal: true,
+              visible: hasAdminDeleteBillingMetricHistory,
+              onAction: () =>
+                deleteBillingMetricHistory({
                   onSuccess: () => this.reloadData(),
                   organization,
                 }),

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -43,9 +43,9 @@ import {
 } from 'admin/components/customers/customerStatsFilters';
 import OrganizationStatus from 'admin/components/customers/organizationStatus';
 import PendingChanges from 'admin/components/customers/pendingChanges';
+import deleteBillingMetricHistory from 'admin/components/deleteBillingMetricHistory';
 import type {ActionItem, BadgeItem} from 'admin/components/detailsPage';
 import DetailsPage from 'admin/components/detailsPage';
-import deleteBillingMetricHistory from 'admin/components/deleteBillingMetricHistory';
 import ForkCustomerAction from 'admin/components/forkCustomer';
 import triggerEndPeriodEarlyModal from 'admin/components/nextBillingPeriodAction';
 import triggerProvisionSubscription from 'admin/components/provisionSubscriptionAction';


### PR DESCRIPTION
<img width="689" alt="Screenshot 2025-04-02 at 7 53 54 PM" src="https://github.com/user-attachments/assets/9d50d4b4-8a54-4525-82a8-8f59c85969e1" />

This is the admin UI piece for https://github.com/getsentry/getsentry/pull/17096.