### PR TITLE
test(ui): Fix act warnings in relocation test

### DIFF
--- a/static/app/views/relocation/index.spec.tsx
+++ b/static/app/views/relocation/index.spec.tsx
@@ -17,7 +17,6 @@ IAxCAaGQJVsg9dhKOORjAf4XK9aXHvy/jUSyT43opj6AgNqXlKEQjb1NBA8qbJJS
 
 describe('Relocation Onboarding Container', function () {
   beforeEach(function () {
-    MockApiClient.asyncDelay = undefined;
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/publickeys/relocations/',
@@ -25,19 +24,16 @@ describe('Relocation Onboarding Container', function () {
         public_key: fakePublicKey,
       },
     });
-
-    // The tests fail because we have a "component update was not wrapped in act" error. It should
-    // be safe to ignore this error, but we should remove the mock once we move to react testing
-    // library.
-    //
-
-    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    MockApiClient.addMockResponse({
+      url: '/relocations/',
+      body: [],
+    });
   });
 
-  it('should render if feature enabled', function () {
+  it('should render if feature enabled', async function () {
     const {routerProps, router, organization} = initializeOrg({
       router: {
-        params: {step: '1'},
+        params: {step: 'get-started'},
       },
     });
     ConfigStore.set('features', new Set(['relocation:enabled']));
@@ -46,14 +42,17 @@ describe('Relocation Onboarding Container', function () {
       organization,
     });
     expect(
+      await screen.findByText(/Choose where to store your organization's data/)
+    ).toBeInTheDocument();
+    expect(
       screen.queryByText("You don't have access to this feature")
     ).not.toBeInTheDocument();
   });
 
-  it('should not render if feature disabled', function () {
+  it('should not render if feature disabled', async function () {
     const {routerProps, router, organization} = initializeOrg({
       router: {
-        params: {step: '1'},
+        params: {step: 'get-started'},
       },
     });
     ConfigStore.set('features', new Set([]));
@@ -61,6 +60,8 @@ describe('Relocation Onboarding Container', function () {
       router,
       organization,
     });
-    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+    expect(
+      await screen.findByText("You don't have access to this feature")
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -44,7 +44,6 @@ describe('Relocation', function () {
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
-    MockApiClient.asyncDelay = undefined;
     sessionStorage.clear();
 
     ConfigStore.set('regions', [
@@ -67,18 +66,14 @@ describe('Relocation', function () {
         public_key: fakePublicKey,
       },
     });
-
-    // The tests fail because we have a "component update was not wrapped in act" error. It should
-    // be safe to ignore this error, but we should remove the mock once we move to react testing
-    // library.
-    //
-
-    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    MockApiClient.addMockResponse({
+      url: `/promocodes-external/${fakePromoCode}`,
+      body: {},
+    });
   });
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    MockApiClient.asyncDelay = undefined;
     sessionStorage.clear();
   });
 
@@ -295,15 +290,6 @@ describe('Relocation', function () {
       ).toBeInTheDocument();
       expect(screen.getByText('key.pub')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
-    });
-
-    it('should show loading indicator if key retrieval still in progress', function () {
-      MockApiClient.asyncDelay = 1;
-
-      renderPage('public-key');
-
-      expect(screen.queryByRole('button', {name: 'Continue'})).not.toBeInTheDocument();
-      expect(screen.queryByText('key.pub')).not.toBeInTheDocument();
     });
 
     it('should show loading indicator and error message if key retrieval failed', async function () {


### PR DESCRIPTION
Old todo about switching to react testing library.
