### PR TITLE
:recycle: ref(aci): update metric alert title link to go to issue details page

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -224,6 +224,7 @@ def incident_attachment_info(
             raise ValueError("Group is required for workflow engine UI links")
 
         # We don't need to save the query param the alert rule id here because the link is to the group and not the alert rule
+        # TODO(iamrajjoshi): This this through and perhaps
         title_link_params.pop("alert", None)
 
         title_link = build_title_link_workflow_engine_ui(
@@ -279,7 +280,7 @@ def metric_alert_unfurl_attachment_info(
         title_link_params["alert"] = str(selected_incident.identifier)
 
     title = get_title(status, alert_rule.name)
-    title_link = build_title_link(alert_rule.id, alert_rule.organization, None, title_link_params)
+    title_link = build_title_link(alert_rule.id, alert_rule.organization, title_link_params)
 
     if metric_value is None:
         if (

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -225,13 +225,14 @@ def incident_attachment_info(
 
         # We don't need to save the query param the alert rule id here because the link is to the group and not the alert rule
         # TODO(iamrajjoshi): This this through and perhaps
-        title_link_params.pop("alert", None)
+        workflow_engine_ui_params = title_link_params.copy()
+        workflow_engine_ui_params.pop("alert", None)
 
         title_link = build_title_link_workflow_engine_ui(
             metric_issue_context.group.id,
             organization,
             metric_issue_context.group.project.id,
-            title_link_params,
+            workflow_engine_ui_params,
         )
     else:
         title_link = build_title_link(

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -93,9 +93,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         metric_issue_context = MetricIssueContext.from_legacy_models(
             incident, IncidentStatus.CLOSED, metric_value
         )
-        metric_issue_context.group = self.create_group(
-            self.project,
-        )
+        metric_issue_context.group = self.group
 
         data = incident_attachment_info(
             organization=incident.organization,

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -94,6 +94,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
             incident, IncidentStatus.CLOSED, metric_value
         )
         metric_issue_context.group = self.group
+        assert metric_issue_context.group is not None
 
         data = incident_attachment_info(
             organization=incident.organization,

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -13,6 +13,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -62,6 +63,54 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert (
             data["title_link"]
             == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer={referrer}&detection_type=static&notification_uuid={notification_uuid}"
+        )
+        assert (
+            data["logo_url"]
+            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
+        )
+
+    @with_feature("organizations:workflow-engine-trigger-actions")
+    @with_feature("organizations:workflow-engine-ui-links")
+    def test_returns_correct_info_with_workflow_engine_ui_links(self):
+        alert_rule = self.create_alert_rule()
+        date_started = self.now
+        incident = self.create_incident(
+            self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CLOSED.value,
+            date_started=date_started,
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        metric_value = 123
+        referrer = "metric_alert_custom"
+        notification_uuid = str(uuid.uuid4())
+
+        metric_issue_context = MetricIssueContext.from_legacy_models(
+            incident, IncidentStatus.CLOSED, metric_value
+        )
+        metric_issue_context.group = self.create_group(
+            self.project,
+        )
+
+        data = incident_attachment_info(
+            organization=incident.organization,
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            metric_issue_context=metric_issue_context,
+            notification_uuid=notification_uuid,
+            referrer=referrer,
+        )
+
+        assert data["title"] == f"Resolved: {alert_rule.name}"
+        assert data["status"] == "Resolved"
+        assert data["text"] == "123 events in the last 10 minutes"
+        assert (
+            data["title_link"]
+            == f"http://testserver/{incident.organization.slug}/{self.project.id}/issues/{metric_issue_context.group.id}/?referrer={referrer}&detection_type=static&notification_uuid={notification_uuid}"
         )
         assert (
             data["logo_url"]


### PR DESCRIPTION
this pr updates the link we use for the title of a metric alert to go to the issue details page if the notification action was triggered and we want to create links to the new ui