### PR TITLE
ref(onboarding): Add extras to logger in record_first_event

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -206,8 +206,12 @@ def record_first_event(project, event, **kwargs):
             # this should never happen since the SECOND_PLATFORM task should be created
             # when the project is created
             logger.warning(
-                "Creating second platform task in record_first_event for project %s",
-                project.id,
+                "Creating second platform task in record_first_event for project",
+                extra={
+                    "project_id": project.id,
+                    "project_updated": rows_affected,
+                    "project_created": created,
+                },
             )
             analytics.record(
                 "second_platform.added",


### PR DESCRIPTION
We're likely creating a new entry in the `onboardingtasks` table each time an event is sent to a new project. This shouldn't happen, and we plan to refactor the code soon. But just to confirm and be 100% sure that entries are being created rather than updated (since there will never be a pending 'second platform'  task), I'm adding this info to the log.


- Contributes to https://github.com/getsentry/projects/issues/869