### PR TITLE
fix(onboarding): Streamline code snippet colors

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -41,7 +41,12 @@ export function OnboardingCodeSnippet({
 
   return (
     <Fragment>
-      <CodeSnippet language={language} {...props} onAfterHighlight={handleAfterHighlight}>
+      <CodeSnippet
+        dark
+        language={language}
+        {...props}
+        onAfterHighlight={handleAfterHighlight}
+      >
         {/* Trim whitespace from code snippets and beautify javascript code */}
         {language === 'javascript'
           ? beautify.js(children, {

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -59,7 +59,6 @@ export function TabbedCodeSnippet({
 
   return (
     <OnboardingCodeSnippet
-      dark
       language={language}
       onCopy={onCopy}
       onSelectAndCopy={onSelectAndCopy}
@@ -173,7 +172,6 @@ function getConfiguration({
         language &&
         code && (
           <OnboardingCodeSnippet
-            dark
             language={language}
             onCopy={onCopy}
             onSelectAndCopy={onSelectAndCopy}


### PR DESCRIPTION
Move defining the dark mode into the OnboardingCodeSnippet component to ensure a streamlined experience in all our onboarding docs.
