### PR TITLE
feat(nextjs-insights): add endpoint to transform EAP response into array / tree structure

### DIFF
--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -24,8 +24,6 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
     def _separate_span_description_info(self, queryresult):
         # Regex to split string into '{component_type} {space} ({path})'
         pattern = re.compile(r"^(.*?)\s+\((.*?)\)$")
-
-        # Process each line
         for line in queryresult["data"]:
             match = pattern.match(line["span.description"])
             if match:
@@ -34,6 +32,9 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
                 path_components = path.strip("/").split("/")
                 if not path_components or (len(path_components) == 1 and path_components[0] == ""):
                     path_components = ["/"]  # Handle root path case
+            else:
+                line["function.nextjs.component_type"] = None
+                line["function.nextjs.path"] = None
 
             line["function.nextjs.component_type"] = component_type
             line["function.nextjs.path"] = path_components

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -1,0 +1,41 @@
+import logging
+import re
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.endpoints.organization_events import OrganizationEventsEndpoint
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
+    def get(self, request: Request, organization) -> Response:
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+        request["useRpc"] = True
+        request["noPagination"] = True
+
+        queryresult = super().get(request, organization)
+        return self._separate_span_description_info(queryresult)
+
+    def _separate_span_description_info(self, queryresult):
+        # Regex to split string into '{component_type} {space} ({path})'
+        pattern = re.compile(r"^(.*?)\s+\((.*?)\)$")
+
+        # Process each line
+        for line in queryresult["data"]:
+            match = pattern.match(line["span.description"])
+            if match:
+                component_type = match.group(1)
+                path = match.group(2)
+                path_components = path.strip("/").split("/")
+                if not path_components or (len(path_components) == 1 and path_components[0] == ""):
+                    path_components = ["/"]  # Handle root path case
+
+            line["function.nextjs.component_type"] = component_type
+            line["function.nextjs.path"] = path_components
+
+        return queryresult

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -14,13 +14,16 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
     """
-    Endpoint for querying data for Next.js Insights. The goal here, feature-wise is to render a tree of files and
-    components for Next.js. The information about this is currently stored in the span.description field, and will
-    later be added to attributes via the Next.js SDK, where the path will be transmitted as an array. EAP will also
-    add a feature to store and query array data, which will enable us to more flexible query the data and "paginate"
-    per level of the tree. For now, we have to make due with the regex logic in this endpoint to enable the
-    functionality. As soon as we have the features in other parts of the system, this endpoint will be replaced by the
-     original /events/ endpoint and this endpoint will be deleted.
+    Endpoint for querying Next.js Insights data to display a tree view of files and components.
+
+    Currently, the component and path information is extracted from the span.description field using a regex.
+    In the future, this data will be properly structured through:
+    1. The Next.js SDK adding these as explicit attributes
+    2. EAP adding support for array data storage and querying
+
+    These improvements will enable more efficient querying and level-by-level tree navigation.
+    This endpoint is temporary and will be replaced by the standard /events/ endpoint once
+    these features are implemented elsewhere in the system.
     """
 
     publish_status = {

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -23,7 +23,7 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
         return self._separate_span_description_info(response)
 
     def _separate_span_description_info(self, response):
-        # Regex to split string into '{component_type} {space} ({path})'
+        # Regex to split string into '{component_type}{space}({path})'
         pattern = re.compile(r"^(.*?)\s+\((.*?)\)$")
 
         for line in response.data["data"]:
@@ -34,10 +34,10 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
                 path_components = path.strip("/").split("/")
                 if not path_components or (len(path_components) == 1 and path_components[0] == ""):
                     path_components = ["/"]  # Handle root path case
-            else:
-                line["function.nextjs.component_type"] = None
-                line["function.nextjs.path"] = None
 
+            else:
+                component_type = None
+                path_components = []
             line["function.nextjs.component_type"] = component_type
             line["function.nextjs.path"] = path_components
 

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -4,6 +4,7 @@ import re
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.endpoints.organization_events import OrganizationEventsEndpoint
 
@@ -12,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -13,6 +13,16 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
+    """
+    Endpoint for querying data for Next.js Insights. The goal here, feature-wise is to render a tree of files and
+    components for Next.js. The information about this is currently stored in the span.description field, and will
+    later be added to attributes via the Next.js SDK, where the path will be transmitted as an array. EAP will also
+    add a feature to store and query array data, which will enable us to more flexible query the data and "paginate"
+    per level of the tree. For now, we have to make due with the regex logic in this endpoint to enable the
+    functionality. As soon as we have the features in other parts of the system, this endpoint will be replaced by the
+     original /events/ endpoint and this endpoint will be deleted.
+    """
+
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -16,6 +16,7 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
     OrganizationEventsRootCauseAnalysisEndpoint,
 )
 from sentry.api.endpoints.organization_fork import OrganizationForkEndpoint
+from sentry.api.endpoints.organization_insights_tree import OrganizationInsightsTreeEndpoint
 from sentry.api.endpoints.organization_member_invite.details import (
     OrganizationMemberInviteDetailsEndpoint,
 )
@@ -2865,6 +2866,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-project-seer-preferences",
     ),
     *workflow_urls.project_urlpatterns,
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/insights/tree/$",
+        OrganizationInsightsTreeEndpoint.as_view(),
+        name="sentry-api-0-organization-insights-tree",
+    ),
 ]
 
 TEAM_URLS = [

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -32,51 +32,6 @@ class OrganizationInsightsTreeEndpointTest(
         self._store_nextjs_function_spans()
         self._store_unrelated_spans()
 
-    @patch("sentry.snuba.spans_rpc.run_table_query")
-    def test_get_nextjs_function_data(self, mock_run_table_query):
-        self.login_as(user=self.user)
-        with self.feature(self.FEATURES):
-            response = self.client.get(
-                self.url,
-                data={
-                    "statsPeriod": "14d",
-                    "useRpc": True,
-                    "noPagination": True,
-                    "query": "span.op:function.nextjs",
-                    "mode": "aggregate",
-                    "field": ["span.description", "avg(span.duration)", "count(span.duration)"],
-                    "project": self.project.id,
-                    "dataset": "spans",
-                },
-            )
-        assert response.status_code == 200
-        span_descriptions = [row["span.description"] for row in response.data["data"]]
-        assert "Page Server Component (/app/[category]/[product]/)" in span_descriptions
-
-        root_route_idx = span_descriptions.index("Page Server Component (/)")
-        element = response.data["data"][root_route_idx]
-        assert element["function.nextjs.component_type"] == "Page Server Component"
-        assert element["function.nextjs.path"] == ["/"]
-
-        unparameterized_route_idx = span_descriptions.index(
-            "Page.generateMetadata (/app/dashboard/)"
-        )
-        element = response.data["data"][unparameterized_route_idx]
-        assert element["function.nextjs.component_type"] == "Page.generateMetadata"
-        assert element["function.nextjs.path"] == ["app", "dashboard"]
-
-        parameterized_route_idx = span_descriptions.index(
-            "Page Server Component (/app/[category]/[product]/)"
-        )
-        element = response.data["data"][parameterized_route_idx]
-        assert element["function.nextjs.component_type"] == "Page Server Component"
-        assert element["function.nextjs.path"] == ["app", "[category]", "[product]"]
-
-        catchall_route_idx = span_descriptions.index("Page Server Component (/app/[...slug]/)")
-        element = response.data["data"][catchall_route_idx]
-        assert element["function.nextjs.component_type"] == "Page Server Component"
-        assert element["function.nextjs.path"] == ["app", "[...slug]"]
-
     def _store_nextjs_function_spans(self):
         descriptions = [
             "Page Server Component (/app/dashboard/)",
@@ -130,3 +85,50 @@ class OrganizationInsightsTreeEndpointTest(
             span["sentry_tags"]["op"] = "db"
             self.store_span(span, is_eap=True)
             spans.append(span)
+
+    @patch("sentry.snuba.spans_rpc.run_table_query")
+    def test_get_nextjs_function_data(self, mock_run_table_query):
+        self.login_as(user=self.user)
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "statsPeriod": "14d",
+                    "useRpc": True,
+                    "noPagination": True,
+                    "query": "span.op:function.nextjs",
+                    "mode": "aggregate",
+                    "field": ["span.description", "avg(span.duration)", "count(span.duration)"],
+                    "project": self.project.id,
+                    "dataset": "spans",
+                },
+            )
+        assert response.status_code == 200
+        span_descriptions = [row["span.description"] for row in response.data["data"]]
+        assert "Page Server Component (/app/[category]/[product]/)" in span_descriptions
+
+        root_route_idx = span_descriptions.index("Page Server Component (/)")
+        element = response.data["data"][root_route_idx]
+        assert element["function.nextjs.component_type"] == "Page Server Component"
+        assert element["function.nextjs.path"] == ["/"]
+
+        unparameterized_route_idx = span_descriptions.index(
+            "Page.generateMetadata (/app/dashboard/)"
+        )
+        element = response.data["data"][unparameterized_route_idx]
+        assert element["function.nextjs.component_type"] == "Page.generateMetadata"
+        assert element["function.nextjs.path"] == ["app", "dashboard"]
+
+        parameterized_route_idx = span_descriptions.index(
+            "Page Server Component (/app/[category]/[product]/)"
+        )
+        element = response.data["data"][parameterized_route_idx]
+        assert element["function.nextjs.component_type"] == "Page Server Component"
+        assert element["function.nextjs.path"] == ["app", "[category]", "[product]"]
+
+        catchall_route_idx = span_descriptions.index("Page Server Component (/app/[...slug]/)")
+        element = response.data["data"][catchall_route_idx]
+        assert element["function.nextjs.component_type"] == "Page Server Component"
+        assert element["function.nextjs.path"] == ["app", "[...slug]"]
+
+        assert "INSERT value INTO table" not in span_descriptions

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
-from sentry.utils.samples import load_data
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
@@ -20,17 +19,8 @@ class OrganizationInsightsTreeEndpointTest(
 
     def setUp(self):
         super().setUp()
-        self.nine_mins_ago = before_now(minutes=9)
         self.ten_mins_ago = before_now(minutes=10)
-        self.ten_mins_ago_iso = self.ten_mins_ago.replace(microsecond=0).isoformat()
-        self.eleven_mins_ago = before_now(minutes=11)
-        self.eleven_mins_ago_iso = self.eleven_mins_ago.isoformat()
-        self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)
         self.features = {}
-
-        self.ten_mins_ago = before_now(minutes=10)
-        self.ten_mins_ago_iso = self.ten_mins_ago.replace(microsecond=0).isoformat()
-        self.login_as(user=self.user)
         self.url = reverse(
             self.url_name,
             kwargs={
@@ -38,13 +28,13 @@ class OrganizationInsightsTreeEndpointTest(
             },
         )
 
-    @patch("sentry.snuba.spans_rpc.run_table_query")
-    def test_get_nextjs_function_data(self, mock_run_table_query):
-
         self.create_environment(self.project, name="production")
         self._store_nextjs_function_spans()
         self._store_unrelated_spans()
 
+    @patch("sentry.snuba.spans_rpc.run_table_query")
+    def test_get_nextjs_function_data(self, mock_run_table_query):
+        self.login_as(user=self.user)
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -62,6 +62,7 @@ class OrganizationInsightsTreeEndpointTest(
             "Page Server Component (/app/[id]/)",
             "Page Server Component (/app/[...slug]/)",
             "Page Server Component (/app/[[...optional]]/)",
+            "unrelated description",
         ]
 
         spans = []

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from sentry.testutils.cases import SnubaTestCase, SpanTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.skips import requires_snuba
+from sentry.utils.samples import load_data
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+
+@pytest.mark.snuba
+@requires_snuba
+class OrganizationInsightsTreeEndpointTest(
+    OrganizationEventsEndpointTestBase, SnubaTestCase, SpanTestCase
+):
+    url_name = "sentry-api-0-organization-insights-tree"
+    FEATURES = ["organizations:trace-spans-format"]
+
+    def setUp(self):
+        super().setUp()
+        self.nine_mins_ago = before_now(minutes=9)
+        self.ten_mins_ago = before_now(minutes=10)
+        self.ten_mins_ago_iso = self.ten_mins_ago.replace(microsecond=0).isoformat()
+        self.eleven_mins_ago = before_now(minutes=11)
+        self.eleven_mins_ago_iso = self.eleven_mins_ago.isoformat()
+        self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)
+        self.features = {}
+
+        self.ten_mins_ago = before_now(minutes=10)
+        self.ten_mins_ago_iso = self.ten_mins_ago.replace(microsecond=0).isoformat()
+        self.login_as(user=self.user)
+        self.url = reverse(
+            self.url_name,
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+            },
+        )
+
+    @patch("sentry.snuba.spans_rpc.run_table_query")
+    def test_get_nextjs_function_data(self, mock_run_table_query):
+
+        self.create_environment(self.project, name="production")
+        spans = [
+            self.create_span(
+                {"description": "Page Server Component (/path/to/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Loading Server Component (/path/to/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Layout Server Component (/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Not-found Server Component (/path/to/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Page.generateMetadata (/path/to/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Page Server Component (/path/to/deep/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Page Server Component (/path/to/deep/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "Layout Server Component (/path/to/component/)"},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            ),
+        ]
+
+        for span in spans:
+            span["sentry_tags"]["op"] = "function.nextjs"
+            self.store_span(span, is_eap=True)
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "statsPeriod": "14d",
+                    "useRpc": True,
+                    "noPagination": True,
+                    "query": "span.op:function.nextjs",
+                    "mode": "aggregate",
+                    "field": ["span.description", "avg(span.duration)", "count(span.duration)"],
+                    "project": self.project.id,
+                    "dataset": "spans",
+                },
+            )
+        assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -42,68 +42,40 @@ class OrganizationInsightsTreeEndpointTest(
     def test_get_nextjs_function_data(self, mock_run_table_query):
 
         self.create_environment(self.project, name="production")
-        spans = [
-            self.create_span(
-                {"description": "Page Server Component (/path/to/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Loading Server Component (/path/to/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Layout Server Component (/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Not-found Server Component (/path/to/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Page.generateMetadata (/path/to/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Page Server Component (/path/to/deep/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Page Server Component (/path/to/deep/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "Layout Server Component (/path/to/component/)"},
-                organization=self.project.organization,
-                project=self.project,
-                duration=100,
-                start_ts=self.ten_mins_ago,
-            ),
+        descriptions = [
+            "Page Server Component (/app/dashboard/)",
+            "Loading Server Component (/app/dashboard/)",
+            "Layout Server Component (/app/)",
+            "Not-found Server Component (/app/dashboard/)",
+            "Head Server Component (/app/dashboard/)",
+            "Unknown Server Component (/app/dashboard/)",
+            "Page.generateMetadata (/app/dashboard/)",
+            "Page.generateImageMetadata (/app/dashboard/)",
+            "Page.generateViewport (/app/dashboard/)",
+            "Page Server Component (/app/dashboard/settings/)",
+            "Page Server Component (/app/dashboard/users/)",
+            "Layout Server Component (/app/dashboard/)",
+            "Page Server Component (/)",
+            "Page Server Component (/app/dashboard/[userId]/)",
+            "Page Server Component (/app/[category]/[product]/)",
+            "Layout Server Component (/app/[id]/)",
+            "Page Server Component (/app/[id]/)",
+            "Page Server Component (/app/[...slug]/)",
+            "Page Server Component (/app/[[...optional]]/)",
         ]
 
-        for span in spans:
+        spans = []
+        for description in descriptions:
+            span = self.create_span(
+                {"description": description},
+                organization=self.project.organization,
+                project=self.project,
+                duration=100,
+                start_ts=self.ten_mins_ago,
+            )
             span["sentry_tags"]["op"] = "function.nextjs"
             self.store_span(span, is_eap=True)
+            spans.append(span)
 
         with self.feature(self.FEATURES):
             response = self.client.get(


### PR DESCRIPTION
- Closes https://github.com/getsentry/projects/issues/878
- Adds a new endpoint as subclass of OrganizationEventsEndpoint, because we basically just do post-processing on the result, and ensure that certain parameter values are set correctly.
- Parses current span.description into its components using a regex, then split the path using string functions. Adds two new fields to the API response: `nextjs.function.component_type` and `nextjs.function.path`
- Purpose of the endpoint is to generate an representation of the component type and path of a component that is both easily usable by the frontend _and_ will not need a rewrite when EAP starts supporting arrays.