### PR TITLE
feat(sentry-answers): Expand matching for 'failed to fetch' errors

### DIFF
--- a/static/app/utils/issueTypeConfig/errorConfig.tsx
+++ b/static/app/utils/issueTypeConfig/errorConfig.tsx
@@ -80,12 +80,12 @@ const ErrorInfoChecks: ErrorInfo[] = [
     errorHelpType: ErrorHelpType.HYDRATION_ERROR,
   },
   {
-    errorTitle: 'TypeError: Load failed',
+    errorTitle: 'Load failed',
     projectPlatforms: ['javascript'],
     errorHelpType: ErrorHelpType.LOAD_FAILED,
   },
   {
-    errorTitle: 'Failed to fetch',
+    errorTitle: /Failed to fetch|NetworkError when attempting to fetch resource/,
     projectPlatforms: ['javascript'],
     errorHelpType: ErrorHelpType.FAILED_TO_FETCH,
   },


### PR DESCRIPTION
Makes this a bit more broad and matches Firefox network errors to "failed to fetch" errors.