### PR TITLE
fix(derive_code_mapping): Grab absPath instead of abs_path

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -140,8 +140,8 @@ class FrameInfo:
         return frame_file_path
 
     def frame_info_from_module(self, frame: Mapping[str, Any]) -> None:
-        if frame.get("module") and frame.get("abs_path"):
-            stack_root, filepath = get_path_from_module(frame["module"], frame["abs_path"])
+        if frame.get("module") and frame.get("absPath"):
+            stack_root, filepath = get_path_from_module(frame["module"], frame["absPath"])
             self.stack_root = stack_root
             self.raw_path = filepath
             self.normalized_path = filepath

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -140,8 +140,8 @@ class FrameInfo:
         return frame_file_path
 
     def frame_info_from_module(self, frame: Mapping[str, Any]) -> None:
-        if frame.get("module") and frame.get("absPath"):
-            stack_root, filepath = get_path_from_module(frame["module"], frame["absPath"])
+        if frame.get("module") and frame.get("abs_path"):
+            stack_root, filepath = get_path_from_module(frame["module"], frame["abs_path"])
             self.stack_root = stack_root
             self.raw_path = filepath
             self.normalized_path = filepath

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -26,7 +26,7 @@ def get_file_and_repo_matches(request: Request, organization: Organization) -> l
 
 def get_frame_info_from_request(request: Request) -> FrameInfo:
     frame = {
-        "absPath": request.GET.get("absPath"),
+        "abs_path": request.GET.get("absPath"),
         # Currently, the only required parameter, thus, avoiding the `get` method
         "filename": request.GET["stacktraceFilename"],
         "module": request.GET.get("module"),


### PR DESCRIPTION
This is necessary for using the "Set up code mapping" modal for Java projects.

Fixes [SENTRY-3RDY](https://sentry.sentry.io/issues/6505158896/)