### PR TITLE
hide `effectiveSampleRate` if dynamic sampling is off

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -731,9 +731,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             context["role"] = access.role  # Deprecated
             context["orgRole"] = access.role
 
-        org_volume = get_organization_volume(obj.id, timedelta(hours=24))
-        if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
-            context["effectiveSampleRate"] = org_volume.indexed / org_volume.total
+        if features.has("organizations:dynamic-sampling", obj):
+            org_volume = get_organization_volume(obj.id, timedelta(hours=24))
+            if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
+                context["effectiveSampleRate"] = org_volume.indexed / org_volume.total
 
         if sample_rate is not None:
             context["planSampleRate"] = sample_rate


### PR DESCRIPTION
The `effectiveSampleRate` field is only used in the admin page and only if `dynamic-sampling` feature is enabled:
https://github.com/getsentry/sentry/blob/96ea80358e49291768a61f83599b3c99d306547b/static/gsAdmin/components/customers/customerOverview.tsx#L399-L401

By adding this extra condition on the backend, we remove the extra request sent to Snuba (caused by `get_organization_volume()` on self-hosted instances for `/api/0/organizations/ORG_SLUG/` and similar endpoints that are using this serializer.