### PR TITLE
 chore(fe): Convert `<IntegrationListDirectory />` to an FC

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
@@ -7,8 +7,9 @@ import {
   PublishedAppsFixture,
   SentryAppInstallsFixture,
 } from 'sentry-fixture/integrationListDirectory';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationListDirectory from 'sentry/views/settings/organizationIntegrations/integrationListDirectory';
@@ -22,40 +23,37 @@ describe('IntegrationListDirectory', function () {
     MockApiClient.clearMockResponses();
   });
 
-  const {organization: org, router, routerProps} = initializeOrg();
+  const router = RouterFixture();
+  const organization = OrganizationFixture();
 
   describe('Renders view', function () {
     beforeEach(() => {
       mockResponse([
-        [`/organizations/${org.slug}/config/integrations/`, ProviderListFixture()],
         [
-          `/organizations/${org.slug}/integrations/`,
+          `/organizations/${organization.slug}/config/integrations/`,
+          ProviderListFixture(),
+        ],
+        [
+          `/organizations/${organization.slug}/integrations/`,
           [BitbucketIntegrationConfigFixture()],
         ],
-        [`/organizations/${org.slug}/sentry-apps/`, OrgOwnedAppsFixture()],
+        [`/organizations/${organization.slug}/sentry-apps/`, OrgOwnedAppsFixture()],
         ['/sentry-apps/', PublishedAppsFixture()],
         ['/doc-integrations/', [DocIntegrationFixture()]],
         [
-          `/organizations/${org.slug}/sentry-app-installations/`,
+          `/organizations/${organization.slug}/sentry-app-installations/`,
           SentryAppInstallsFixture(),
         ],
-        [`/organizations/${org.slug}/plugins/configs/`, PluginListConfigFixture()],
-        [`/organizations/${org.slug}/repos/?status=unmigratable`, []],
+        [
+          `/organizations/${organization.slug}/plugins/configs/`,
+          PluginListConfigFixture(),
+        ],
       ]);
     });
 
     it('shows installed integrations at the top in order of weight', async function () {
-      render(
-        <IntegrationListDirectory
-          {...routerProps}
-          params={{orgId: org.slug}}
-          routeParams={{orgId: org.slug}}
-          hideHeader={false}
-        />,
-        {
-          router,
-        }
-      );
+      render(<IntegrationListDirectory />, {organization, router});
+      expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
       expect(await screen.findByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
 
@@ -71,30 +69,16 @@ describe('IntegrationListDirectory', function () {
     });
 
     it('does not show legacy plugin that has a First Party Integration if not installed', async function () {
-      render(
-        <IntegrationListDirectory
-          {...routerProps}
-          params={{orgId: org.slug}}
-          routeParams={{orgId: org.slug}}
-          hideHeader={false}
-        />,
-        {router}
-      );
+      render(<IntegrationListDirectory />, {organization, router});
+      expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
       expect(await screen.findByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
       expect(screen.queryByText('GitHub (Legacy)')).not.toBeInTheDocument();
     });
 
     it('shows legacy plugin that has a First Party Integration if installed', async function () {
-      render(
-        <IntegrationListDirectory
-          {...routerProps}
-          params={{orgId: org.slug}}
-          routeParams={{orgId: org.slug}}
-          hideHeader={false}
-        />,
-        {router}
-      );
+      render(<IntegrationListDirectory />, {organization, router});
+      expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
       expect(await screen.findByText('PagerDuty (Legacy)')).toBeInTheDocument();
     });


### PR DESCRIPTION
Converts this component to three different components and one hook. Mostly done to isolate concerns, these aren't reused anywhere but it made it easier to read in my opinion. Also moved some functions to utils since this component did a lot.

ref: https://github.com/getsentry/frontend-tsc/issues/2