### PR TITLE
fix(ui): button height inside pageFilterBar

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -138,11 +138,12 @@ except in mobile */
 
   /* Code related to Chonk styles */
 
-display: flex;
+  display: flex;
   position: relative;
 
   & > div > button {
     width: 100%;
+    height: 100%;
   }
 
   /* Disabled InteractionStateLayer */

--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -141,9 +141,9 @@ except in mobile */
   display: flex;
   position: relative;
 
-  & > div > button {
-    width: 100%;
+  & button[aria-haspopup] {
     height: 100%;
+    width: 100%;
   }
 
   /* Disabled InteractionStateLayer */


### PR DESCRIPTION
buttons used to not have an explicit height set, but in chonk, they do. These buttons in the pageFilterBar have a height of 37px, but they should grow as there's a middle element that isn't a Button, and it has a slightly different height.