### PR TITLE
feat(pipeline): Add CoveragePage component and tests

### DIFF
--- a/static/app/views/pipeline/coverage/coverage.spec.tsx
+++ b/static/app/views/pipeline/coverage/coverage.spec.tsx
@@ -1,0 +1,18 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CoveragePage from 'sentry/views/pipeline/coverage/coverage';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('CoveragePage', () => {
+  it('renders the placeholder content', () => {
+    render(<CoveragePage />, {
+      organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
+    });
+
+    const testContent = screen.getByText('Coverage Analytics');
+    expect(testContent).toBeInTheDocument();
+  });
+});

--- a/static/app/views/pipeline/coverage/coverage.tsx
+++ b/static/app/views/pipeline/coverage/coverage.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export default function CoveragePage() {
+  return (
+    <LayoutGap>
+      <p>Coverage Analytics</p>
+    </LayoutGap>
+  );
+}
+
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;


### PR DESCRIPTION
This PR adds the CoveragePage component and its tests. Favouring this PR over https://github.com/getsentry/sentry/pull/88629