### PR TITLE
ref(insights): update web vitals to use `useMetrics`

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -121,7 +121,7 @@ export function PageOverviewWebVitalsDetailPanel({
     subregions,
   });
 
-  const projectScore = getWebVitalScoresFromTableDataRow(projectScoresData?.data?.[0]);
+  const projectScore = getWebVitalScoresFromTableDataRow(projectScoresData?.[0]);
 
   const {data: transactionsTableData, isLoading: isTransactionWebVitalsQueryLoading} =
     useTransactionSamplesCategorizedQuery({
@@ -429,9 +429,9 @@ export function PageOverviewWebVitalsDetailPanel({
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const webVitalScore = projectScore[`${webVital}Score`];
-  const webVitalValue = projectData?.data[0]?.[`p75(measurements.${webVital})`] as
-    | number
-    | undefined;
+  const webVitalValue = webVital
+    ? (projectData?.[0]?.[`p75(measurements.${webVital})`] as number | undefined)
+    : undefined;
 
   return (
     <PageAlertProvider>

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -63,6 +63,7 @@ type WebVitalLabelProps = {
   location: Location;
   onHover: (webVital: WebVitals) => void;
   onUnHover: () => void;
+  projectData: ProjectData[];
   webVital: WebVitals;
   webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
 };

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -63,8 +63,8 @@ type WebVitalLabelProps = {
   location: Location;
   onHover: (webVital: WebVitals) => void;
   onUnHover: () => void;
-  projectData: ProjectData[];
   webVital: WebVitals;
+  projectData?: ProjectData[];
   webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
 };
 

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -6,7 +6,6 @@ import type {Location} from 'history';
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMouseTracking from 'sentry/utils/useMouseTracking';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -30,6 +29,14 @@ type WebVitalsLabelCoordinates = {
   [p in WebVitals]?: Coordinates;
 };
 
+type ProjectData = {
+  'p75(measurements.cls)': number;
+  'p75(measurements.fcp)': number;
+  'p75(measurements.inp)': number;
+  'p75(measurements.lcp)': number;
+  'p75(measurements.ttfb)': number;
+};
+
 type Props = {
   height: number;
   projectScore: ProjectScore;
@@ -42,7 +49,7 @@ type Props = {
   inPerformanceWidget?: boolean;
   labelHeightPadding?: number;
   labelWidthPadding?: number;
-  projectData?: TableData;
+  projectData?: ProjectData[];
   radiusPadding?: number;
   size?: number;
   webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
@@ -57,7 +64,6 @@ type WebVitalLabelProps = {
   onHover: (webVital: WebVitals) => void;
   onUnHover: () => void;
   webVital: WebVitals;
-  projectData?: TableData;
   webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
 };
 
@@ -76,10 +82,9 @@ function WebVitalLabel({
   const yOffset = webVitalLabelCoordinates?.[webVital]?.y ?? 0;
   const webvitalInfo =
     webVital === 'cls'
-      ? Math.round((projectData?.data?.[0]?.['p75(measurements.cls)'] as number) * 100) /
-        100
+      ? Math.round((projectData?.[0]?.['p75(measurements.cls)'] as number) * 100) / 100
       : getFormattedDuration(
-          (projectData?.data?.[0]?.[`p75(measurements.${webVital})`] as number) / 1000
+          (projectData?.[0]?.[`p75(measurements.${webVital})`] as number) / 1000
         );
 
   return (

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
@@ -2,10 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import WebVitalMeters from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
+import WebVitalMeters, {
+  type ProjectData,
+} from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 
 jest.mock('sentry/utils/useLocation');
@@ -20,9 +21,7 @@ describe('WebVitalMeters', function () {
     ttfbScore: 100,
     inpScore: 100,
   };
-  const projectData: TableData = {
-    data: [],
-  };
+  const projectData: ProjectData[] = [];
 
   beforeEach(function () {
     jest.mocked(useLocation).mockReturnValue({

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -8,7 +8,6 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {VITAL_DESCRIPTIONS} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
@@ -22,9 +21,17 @@ import {
   STATUS_TEXT,
 } from 'sentry/views/insights/browser/webVitals/utils/scoreToStatus';
 
+type ProjectData = {
+  'p75(measurements.cls)': number;
+  'p75(measurements.fcp)': number;
+  'p75(measurements.inp)': number;
+  'p75(measurements.lcp)': number;
+  'p75(measurements.ttfb)': number;
+};
+
 type Props = {
   onClick?: (webVital: WebVitals) => void;
-  projectData?: TableData;
+  projectData?: ProjectData[];
   projectScore?: ProjectScore;
   showTooltip?: boolean;
   transaction?: string;
@@ -71,9 +78,9 @@ export default function WebVitalMeters({
 
   const renderVitals = () => {
     return webVitals.map((webVital, index) => {
-      const webVitalKey = `p75(measurements.${webVital})`;
+      const webVitalKey: keyof ProjectData = `p75(measurements.${webVital})`;
       const score = projectScore[`${webVital}Score`];
-      const meterValue = projectData?.data?.[0]?.[webVitalKey] as number;
+      const meterValue = projectData?.[0]?.[webVitalKey];
 
       if (!score) {
         return null;

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -21,7 +21,7 @@ import {
   STATUS_TEXT,
 } from 'sentry/views/insights/browser/webVitals/utils/scoreToStatus';
 
-type ProjectData = {
+export type ProjectData = {
   'p75(measurements.cls)': number;
   'p75(measurements.fcp)': number;
   'p75(measurements.inp)': number;

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -73,7 +73,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
     subregions,
   });
 
-  const projectScore = getWebVitalScoresFromTableDataRow(projectScoresData?.data?.[0]);
+  const projectScore = getWebVitalScoresFromTableDataRow(projectScoresData?.[0]);
   const {data, isPending} = useTransactionWebVitalsScoresQuery({
     limit: 100,
     webVital: webVital ?? 'total',
@@ -96,9 +96,9 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
     if (!data) {
       return [];
     }
-    const sumWeights = projectScoresData?.data?.[0]?.[
-      `sum(measurements.score.weight.${webVital})`
-    ] as number;
+    const sumWeights = webVital
+      ? projectScoresData?.[0]?.[`sum(measurements.score.weight.${webVital})`] || 0
+      : 0;
     return data
       .map(row => ({
         ...row,
@@ -114,7 +114,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
         return b.opportunity - a.opportunity;
       })
       .slice(0, MAX_ROWS);
-  }, [data, projectScoresData?.data, webVital]);
+  }, [data, projectScoresData, webVital]);
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
     useProjectRawWebVitalsValuesTimeseriesQuery({browserTypes, subregions});
@@ -235,7 +235,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const webVitalScore = projectScore[`${webVital}Score`];
-  const webVitalValue = projectData?.data?.[0]?.[mapWebVitalToColumn(webVital)] as
+  const webVitalValue = projectData?.[0]?.[mapWebVitalToColumn(webVital)] as
     | number
     | undefined;
 

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -1,18 +1,12 @@
 import type {Tag} from 'sentry/types/group';
-import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
   browserTypes?: BrowserType[];
-  dataset?: DiscoverDatasets;
   subregions?: SubregionCode[];
   tag?: Tag;
   transaction?: string;
@@ -21,13 +15,9 @@ type Props = {
 export const useProjectRawWebVitalsQuery = ({
   transaction,
   tag,
-  dataset,
   browserTypes,
   subregions,
 }: Props = {}) => {
-  const organization = useOrganization();
-  const pageFilters = usePageFilters();
-  const location = useLocation();
   const search = new MutableSearch([]);
   if (transaction) {
     search.addFilterValue('transaction', transaction);
@@ -42,8 +32,10 @@ export const useProjectRawWebVitalsQuery = ({
     search.addDisjunctionFilterValues(SpanMetricsField.BROWSER_NAME, browserTypes);
   }
 
-  const projectEventView = EventView.fromNewQueryWithPageFilters(
+  return useMetrics(
     {
+      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      limit: 50,
       fields: [
         'p75(measurements.lcp)',
         'p75(measurements.fcp)',
@@ -58,25 +50,7 @@ export const useProjectRawWebVitalsQuery = ({
         'count_web_vitals(measurements.inp, any)',
         'count()',
       ],
-      name: 'Web Vitals',
-      query: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
-      version: 2,
-      dataset: dataset ?? DiscoverDatasets.METRICS,
     },
-    pageFilters.selection
+    'api.performance.browser.web-vitals.project'
   );
-
-  const result = useDiscoverQuery({
-    eventView: projectEventView,
-    limit: 50,
-    location,
-    orgSlug: organization.slug,
-    cursor: '',
-    options: {
-      refetchOnWindowFocus: false,
-    },
-    skipAbort: true,
-    referrer: 'api.performance.browser.web-vitals.project',
-  });
-  return result;
 };

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow.tsx
@@ -1,32 +1,45 @@
-import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import type {WebVitalsRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
 import type {
   ProjectScore,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
 
-function getWebVitalScore(data: TableDataRow, webVital: WebVitals): number {
+type Data = Pick<
+  WebVitalsRow,
+  | 'performance_score(measurements.score.cls)'
+  | 'performance_score(measurements.score.fcp)'
+  | 'performance_score(measurements.score.inp)'
+  | 'performance_score(measurements.score.lcp)'
+  | 'performance_score(measurements.score.ttfb)'
+  | 'avg(measurements.score.total)'
+  | 'count_scores(measurements.score.cls)'
+  | 'count_scores(measurements.score.fcp)'
+  | 'count_scores(measurements.score.inp)'
+  | 'count_scores(measurements.score.lcp)'
+  | 'count_scores(measurements.score.ttfb)'
+  | 'count_scores(measurements.score.total)'
+>;
+
+function getWebVitalScore(data: Data, webVital: WebVitals): number {
   return (data[`performance_score(measurements.score.${webVital})`] as number) * 100;
 }
 
-function getTotalScore(data: TableDataRow): number {
+function getTotalScore(data: Data): number {
   return (data[`avg(measurements.score.total)`] as number) * 100;
 }
 
-function getWebVitalScoreCount(
-  data: TableDataRow,
-  webVital: WebVitals | 'total'
-): number {
+function getWebVitalScoreCount(data: Data, webVital: WebVitals | 'total'): number {
   return data[`count_scores(measurements.score.${webVital})`] as number;
 }
 
-function hasWebVitalScore(data: TableDataRow, webVital: WebVitals): boolean {
+function hasWebVitalScore(data: Data, webVital: WebVitals): boolean {
   if (data.hasOwnProperty(`count_scores(measurements.score.${webVital})`)) {
     return getWebVitalScoreCount(data, webVital) > 0;
   }
   return false;
 }
 
-export function getWebVitalScoresFromTableDataRow(data?: TableDataRow): ProjectScore {
+export function getWebVitalScoresFromTableDataRow(data?: WebVitalsRow): ProjectScore {
   if (!data) {
     return {};
   }

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -41,7 +41,6 @@ export type WebVitalsRow = {
 type Props = {
   browserTypes?: BrowserType[];
   dataset?: DiscoverDatasets;
-  enabled?: boolean;
   subregions?: SubregionCode[];
   tag?: Tag;
   transaction?: string;
@@ -51,7 +50,6 @@ type Props = {
 export const useProjectWebVitalsScoresQuery = ({
   transaction,
   tag,
-  enabled = true,
   weightWebVital = 'total',
   browserTypes,
   subregions,
@@ -70,19 +68,10 @@ export const useProjectWebVitalsScoresQuery = ({
     search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
   }
 
-  const weightToFieldMap: Record<WebVitals, MetricsProperty> = {
-    cls: 'sum(measurements.score.weight.cls)',
-    fcp: 'sum(measurements.score.weight.fcp)',
-    inp: 'sum(measurements.score.weight.inp)',
-    lcp: 'sum(measurements.score.weight.lcp)',
-    ttfb: 'sum(measurements.score.weight.ttfb)',
-  };
-
   const result = useMetrics(
     {
       cursor: '',
       limit: 50,
-      enabled,
       search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       fields: [
         'performance_score(measurements.score.lcp)',
@@ -103,7 +92,9 @@ export const useProjectWebVitalsScoresQuery = ({
         'count_scores(measurements.score.cls)',
         'count_scores(measurements.score.ttfb)',
         `count_scores(measurements.score.inp)`,
-        ...(weightWebVital === 'total' ? [] : [weightToFieldMap[weightWebVital]]), // TODO: fix typing
+        ...(weightWebVital === 'total'
+          ? []
+          : [`sum(measurements.score.weight.${weightWebVital})` as MetricsProperty]),
       ],
     },
     'api.performance.browser.web-vitals.project-scores'

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -1,15 +1,42 @@
 import type {Tag} from 'sentry/types/group';
-import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
+import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {
+  type MetricsProperty,
+  SpanIndexedField,
+  type SubregionCode,
+} from 'sentry/views/insights/types';
+
+export type WebVitalsRow = {
+  'avg(measurements.score.cls)': number;
+  'avg(measurements.score.fcp)': number;
+  'avg(measurements.score.inp)': number;
+  'avg(measurements.score.lcp)': number;
+  'avg(measurements.score.total)': number;
+  'avg(measurements.score.ttfb)': number;
+  'count()': number;
+  'count_scores(measurements.score.cls)': number;
+  'count_scores(measurements.score.fcp)': number;
+  'count_scores(measurements.score.inp)': number;
+  'count_scores(measurements.score.lcp)': number;
+  'count_scores(measurements.score.total)': number;
+  'count_scores(measurements.score.ttfb)': number;
+  'performance_score(measurements.score.cls)': number;
+  'performance_score(measurements.score.fcp)': number;
+  'performance_score(measurements.score.inp)': number;
+  'performance_score(measurements.score.lcp)': number;
+  'performance_score(measurements.score.total)': number;
+  'performance_score(measurements.score.ttfb)': number;
+  'sum(measurements.score.weight.cls)': number | undefined;
+  'sum(measurements.score.weight.fcp)': number | undefined;
+  'sum(measurements.score.weight.inp)': number | undefined;
+  'sum(measurements.score.weight.lcp)': number | undefined;
+  'sum(measurements.score.weight.ttfb)': number | undefined;
+};
 
 type Props = {
   browserTypes?: BrowserType[];
@@ -24,16 +51,11 @@ type Props = {
 export const useProjectWebVitalsScoresQuery = ({
   transaction,
   tag,
-  dataset,
   enabled = true,
   weightWebVital = 'total',
   browserTypes,
   subregions,
 }: Props = {}) => {
-  const organization = useOrganization();
-  const pageFilters = usePageFilters();
-  const location = useLocation();
-
   const search = new MutableSearch([]);
   if (transaction) {
     search.addFilterValue('transaction', transaction);
@@ -48,8 +70,20 @@ export const useProjectWebVitalsScoresQuery = ({
     search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
   }
 
-  const projectEventView = EventView.fromNewQueryWithPageFilters(
+  const weightToFieldMap: Record<WebVitals, MetricsProperty> = {
+    cls: 'sum(measurements.score.weight.cls)',
+    fcp: 'sum(measurements.score.weight.fcp)',
+    inp: 'sum(measurements.score.weight.inp)',
+    lcp: 'sum(measurements.score.weight.lcp)',
+    ttfb: 'sum(measurements.score.weight.ttfb)',
+  };
+
+  const result = useMetrics(
     {
+      cursor: '',
+      limit: 50,
+      enabled,
+      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       fields: [
         'performance_score(measurements.score.lcp)',
         'performance_score(measurements.score.fcp)',
@@ -69,39 +103,19 @@ export const useProjectWebVitalsScoresQuery = ({
         'count_scores(measurements.score.cls)',
         'count_scores(measurements.score.ttfb)',
         `count_scores(measurements.score.inp)`,
-        ...(weightWebVital === 'total'
-          ? []
-          : [`sum(measurements.score.weight.${weightWebVital})`]),
+        ...(weightWebVital === 'total' ? [] : [weightToFieldMap[weightWebVital]]), // TODO: fix typing
       ],
-      name: 'Web Vitals',
-      query: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
-      version: 2,
-      dataset: dataset ?? DiscoverDatasets.METRICS,
     },
-    pageFilters.selection
+    'api.performance.browser.web-vitals.project-scores'
   );
 
-  const result = useDiscoverQuery({
-    eventView: projectEventView,
-    limit: 50,
-    location,
-    orgSlug: organization.slug,
-    cursor: '',
-    options: {
-      enabled,
-      refetchOnWindowFocus: false,
-    },
-    skipAbort: true,
-    referrer: 'api.performance.browser.web-vitals.project-scores',
-  });
+  const data = result.data;
 
   // Map performance_score(measurements.score.total) to avg(measurements.score.total) so we don't have to handle both keys in the UI
-  if (
-    result.data?.data?.[0]?.['performance_score(measurements.score.total)'] !== undefined
-  ) {
-    result.data.data[0]['avg(measurements.score.total)'] =
-      result.data.data[0]['performance_score(measurements.score.total)'];
+  if (data?.[0]?.['performance_score(measurements.score.total)'] !== undefined) {
+    data[0]['avg(measurements.score.total)'] =
+      data[0]['performance_score(measurements.score.total)'];
   }
 
-  return result;
+  return {...result, data: data as WebVitalsRow[]};
 };

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -65,11 +65,11 @@ export const useTransactionWebVitalsScoresQuery = ({
   }
 
   const vitalToFieldMap: Record<WebVitals, MetricsProperty> = {
-    cls: 'performance_score(measurements.score.weight.cls)',
-    fcp: 'performance_score(measurements.score.weight.fcp)',
-    inp: 'performance_score(measurements.score.weight.inp)',
-    lcp: 'performance_score(measurements.score.weight.lcp)',
-    ttfb: 'performance_score(measurements.score.weight.ttfb)',
+    cls: 'performance_score(measurements.score.cls)',
+    fcp: 'performance_score(measurements.score.fcp)',
+    inp: 'performance_score(measurements.score.inp)',
+    lcp: 'performance_score(measurements.score.lcp)',
+    ttfb: 'performance_score(measurements.score.ttfb)',
   };
 
   const {data, isPending, ...rest} = useMetrics(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -64,14 +64,6 @@ export const useTransactionWebVitalsScoresQuery = ({
     search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
   }
 
-  const vitalToFieldMap: Record<WebVitals, MetricsProperty> = {
-    cls: 'performance_score(measurements.score.cls)',
-    fcp: 'performance_score(measurements.score.fcp)',
-    inp: 'performance_score(measurements.score.inp)',
-    lcp: 'performance_score(measurements.score.lcp)',
-    ttfb: 'performance_score(measurements.score.ttfb)',
-  };
-
   const {data, isPending, ...rest} = useMetrics(
     {
       limit: limit ?? 50,
@@ -96,7 +88,9 @@ export const useTransactionWebVitalsScoresQuery = ({
         `count_scores(measurements.score.inp)`,
         `count_scores(measurements.score.ttfb)`,
         'total_opportunity_score()',
-        ...(webVital === 'total' ? [] : [vitalToFieldMap[webVital]]),
+        ...(webVital === 'total'
+          ? []
+          : [`performance_score(measurements.score.${webVital})` as MetricsProperty]),
       ],
     },
     'api.performance.browser.web-vitals.transactions-scores'
@@ -147,7 +141,7 @@ export const useTransactionWebVitalsScoresQuery = ({
             opportunity: row[
               webVital === 'total'
                 ? 'total_opportunity_score()'
-                : vitalToFieldMap[webVital]
+                : (`opportunity_score(measurements.score.${webVital})` as MetricsProperty)
             ] as number,
           };
         })

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -18,7 +18,6 @@ import {
 type Props = {
   browserTypes?: BrowserType[];
   defaultSort?: Sort;
-  enabled?: boolean;
   limit?: number;
   query?: string;
   shouldEscapeFilters?: boolean;
@@ -33,7 +32,6 @@ export const useTransactionWebVitalsScoresQuery = ({
   transaction,
   defaultSort,
   sortName = 'sort',
-  enabled = true,
   webVital = 'total',
   query,
   shouldEscapeFilters = true,
@@ -68,7 +66,6 @@ export const useTransactionWebVitalsScoresQuery = ({
     {
       limit: limit ?? 50,
       search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
-      enabled,
       sorts: [sort],
       fields: [
         'project.id',
@@ -79,6 +76,9 @@ export const useTransactionWebVitalsScoresQuery = ({
         'p75(measurements.cls)',
         'p75(measurements.ttfb)',
         'p75(measurements.inp)',
+        ...(webVital === 'total'
+          ? []
+          : [`performance_score(measurements.score.${webVital})` as MetricsProperty]),
         `opportunity_score(measurements.score.${webVital})`,
         'performance_score(measurements.score.total)',
         'count()',
@@ -88,9 +88,6 @@ export const useTransactionWebVitalsScoresQuery = ({
         `count_scores(measurements.score.inp)`,
         `count_scores(measurements.score.ttfb)`,
         'total_opportunity_score()',
-        ...(webVital === 'total'
-          ? []
-          : [`performance_score(measurements.score.${webVital})` as MetricsProperty]),
       ],
     },
     'api.performance.browser.web-vitals.transactions-scores'

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -18,6 +18,7 @@ import {
 type Props = {
   browserTypes?: BrowserType[];
   defaultSort?: Sort;
+  enabled?: boolean;
   limit?: number;
   query?: string;
   shouldEscapeFilters?: boolean;
@@ -33,6 +34,7 @@ export const useTransactionWebVitalsScoresQuery = ({
   defaultSort,
   sortName = 'sort',
   webVital = 'total',
+  enabled,
   query,
   shouldEscapeFilters = true,
   browserTypes,
@@ -67,6 +69,7 @@ export const useTransactionWebVitalsScoresQuery = ({
       limit: limit ?? 50,
       search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       sorts: [sort],
+      enabled,
       fields: [
         'project.id',
         'project',

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -137,7 +137,7 @@ export function PageOverview() {
   const projectScore =
     isProjectScoresLoading || isPending
       ? undefined
-      : getWebVitalScoresFromTableDataRow(projectScores?.data?.[0]);
+      : getWebVitalScoresFromTableDataRow(projectScores?.[0]);
 
   const handleTabChange = (value: string) => {
     trackAnalytics('insight.vital.overview.toggle_tab', {

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -55,7 +55,7 @@ export function WebVitalsLandingPage() {
   const projectScore =
     isProjectScoresLoading || isPending
       ? undefined
-      : getWebVitalScoresFromTableDataRow(projectScores?.data?.[0]);
+      : getWebVitalScoresFromTableDataRow(projectScores?.[0]);
 
   const {openVitalsDrawer} = useWebVitalsDrawer({
     Component: <WebVitalsDetailPanel webVital={state.webVital} />,

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -88,9 +88,11 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
+  const location = useLocation();
+  const useEap = location.query?.useEap === '1';
   return useDiscover<Fields, MetricsResponse>(
     options,
-    DiscoverDatasets.METRICS,
+    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
     referrer
   );
 };

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -416,7 +416,14 @@ export enum SpanFunction {
 
 // TODO - add more functions and fields, combine shared ones, etc
 
-export const METRICS_FUNCTIONS = ['count', 'performance_score'] as const;
+export const METRICS_FUNCTIONS = [
+  'count',
+  'performance_score',
+  'count_scores',
+  'opportunity_score',
+  'total_opportunity_score',
+  'p75',
+] as const;
 
 export enum MetricsFields {
   TRANSACTION_DURATION = 'transaction.duration',
@@ -427,6 +434,25 @@ export enum MetricsFields {
   INP_SCORE = 'measurements.score.inp',
   CLS_SCORE = 'measurements.score.cls',
   TTFB_SCORE = 'measurements.score.ttfb',
+  TOTAL_SCORE = 'measurements.score.total',
+  LCP_WEIGHT = 'measurements.score.weight.lcp',
+  FCP_WEIGHT = 'measurements.score.weight.fcp',
+  INP_WEIGHT = 'measurements.score.weight.inp',
+  CLS_WEIGHT = 'measurements.score.weight.cls',
+  TTFB_WEIGHT = 'measurements.score.weight.ttfb',
+  TOTAL_WEIGHT = 'measurements.score.weight.total',
+  PROJECT_ID = 'project.id',
+  LCP = 'measurements.lcp',
+  FCP = 'measurements.fcp',
+  INP = 'measurements.inp',
+  CLS = 'measurements.cls',
+  TTFB = 'measurements.ttfb',
+  ID = 'id',
+  TRACE = 'trace',
+  USER_DISPLAY = 'user.display',
+  REPLAY_ID = 'replayId',
+  TIMESTAMP = 'timestamp',
+  PROFILE_ID = 'profile.id',
 }
 
 export type MetricsNumberFields =
@@ -435,9 +461,30 @@ export type MetricsNumberFields =
   | MetricsFields.FCP_SCORE
   | MetricsFields.INP_SCORE
   | MetricsFields.CLS_SCORE
-  | MetricsFields.TTFB_SCORE;
+  | MetricsFields.TTFB_SCORE
+  | MetricsFields.TOTAL_SCORE
+  | MetricsFields.LCP_WEIGHT
+  | MetricsFields.FCP_WEIGHT
+  | MetricsFields.INP_WEIGHT
+  | MetricsFields.CLS_WEIGHT
+  | MetricsFields.TTFB_WEIGHT
+  | MetricsFields.TOTAL_WEIGHT
+  | MetricsFields.LCP
+  | MetricsFields.FCP
+  | MetricsFields.INP
+  | MetricsFields.CLS
+  | MetricsFields.TTFB;
 
-export type MetricsStringFields = MetricsFields.TRANSACTION;
+export type MetricsStringFields =
+  | MetricsFields.TRANSACTION
+  | MetricsFields.PROJECT
+  | MetricsFields.PROJECT_ID
+  | MetricsFields.ID
+  | MetricsFields.TRACE
+  | MetricsFields.USER_DISPLAY
+  | MetricsFields.REPLAY_ID
+  | MetricsFields.TIMESTAMP
+  | MetricsFields.PROFILE_ID;
 
 export type MetricsFunctions = (typeof METRICS_FUNCTIONS)[number];
 
@@ -449,6 +496,8 @@ export type MetricsResponse = {
   [Function in MetricsFunctions as `${Function}()`]: number;
 } & {
   [Property in MetricsStringFields as `${Property}`]: string;
+} & {
+  [Property in MetricsNumberFields as `count_web_vitals(${Property}, any)`]: string[];
 };
 
 export type MetricsProperty = keyof MetricsResponse;

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -1072,6 +1072,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Best Page Opportunities'
     );
+
     expect(eventsMock).toHaveBeenCalledTimes(2);
     expect(eventsMock).toHaveBeenNthCalledWith(
       2,

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -96,7 +96,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
   const getHeaders = () =>
     transactionWebVitals.map((listItem, i) => {
       const transaction = (listItem.transaction as string | undefined) ?? '';
-      const scoreCount = projectScoresData?.data?.[0]?.[
+      const scoreCount = projectScoresData?.[0]?.[
         'count_scores(measurements.score.total)'
       ] as number;
       const opportunity = scoreCount ? (listItem.opportunity ?? 0) * 100 : 0;

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -28,7 +28,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const projectScore =
     isProjectScoresLoading || isPending
       ? undefined
-      : getWebVitalScoresFromTableDataRow(projectScores?.data?.[0]);
+      : getWebVitalScoresFromTableDataRow(projectScores?.[0]);
   const ringSegmentColors = theme.chart.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
@@ -60,7 +60,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
                 {provided.children({
                   data,
                   isLoading: loading,
-                  hasData: !loading && (data?.data?.[0]?.['count()'] as number) > 0,
+                  hasData: !loading && (data?.[0]?.['count()'] as number) > 0,
                 })}
               </Fragment>
             );


### PR DESCRIPTION
1. Adds conditional to use eap in the `useMetrics` hook
2. Converts web vitals to use `useMetrics` instead of `useDiscoverQuery` which supports the eap conditional and much better typing