### PR TITLE
feat(insights): Append ECharts tooltips to `document.body`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -569,6 +569,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         axisPointer: {
           type: 'cross',
         },
+        appendToBody: true,
         formatter: formatTooltip,
       }}
       xAxis={{


### PR DESCRIPTION
Using the `appendToBody` option, we can have ECharts render tooltips to `<body>`. This means that if ECharts is inside of a DOM element w/ `overflow: hidden` (e.g. Global Drawer), the tooltip will not get cutoff. A small side-effect of this is that for every chart that is rendered, we will have an empty `<div>` element. (e.g. if you have 20 charts on the page, you will have 20 empty divs in the body el).
