### PR TITLE
feat(alert-comparison): Add some more logging for timeseries comparison

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -162,7 +162,7 @@ def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultFor
         for element in data:
             element_value = element.get(alias) or 0
             element_time = element["time"]
-            aligned_results[element_time][key] = float(element_value)
+            aligned_results[element_time][key] = element_value
 
     fill_aligned_series(snql_result["result"].data["data"], snql_result["agg_alias"], "snql_value")
     fill_aligned_series(rpc_result["result"].data["data"], rpc_result["agg_alias"], "rpc_value")

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -214,7 +214,10 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
             scope.set_extra("mismatches", mismatches)
             scope.set_extra("alert_id", alert_rule.id)
 
-            scope.set_tag("buckets_mismatch.percentage", mismatches / len(aligned_timeseries) * 100)
+            scope.set_tag(
+                "buckets_mismatch.percentage", len(mismatches) / len(aligned_timeseries) * 100
+            )
+            scope.set_tag("buckets_mismatch.count", len(mismatches))
 
             mismatch_type, many_low_conf_buckets, many_low_sample_rate_buckets = get_mismatch_type(
                 mismatches

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Any, TypedDict
 
 import sentry_sdk
@@ -23,6 +24,25 @@ from sentry.snuba.spans_rpc import run_timeseries_query
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
+
+
+class MismatchType(Enum):
+    SNQL_ALWAYS_ZERO = "snql_always_zero"
+    RPC_ALWAYS_ZERO = "rpc_always_zero"
+    SNQL_ALWAYS_LOWER = "snql_always_lower"
+    RPC_ALWAYS_LOWER = "rpc_always_lower"
+    MORE_SPIKY = "more_spiky"
+    LESS_SPIKY = "less_spiky"
+
+
+def get_time_window_for_interval(interval: int):
+    if interval in [60, 300, 600]:
+        return timedelta(days=1)
+
+    if interval == 24 * 60 * 60:
+        return timedelta(days=14)
+
+    return timedelta(days=3)
 
 
 class TSResultForComparison(TypedDict):
@@ -75,17 +95,87 @@ def make_snql_request(
     return TSResultForComparison(result=results, agg_alias=get_function_alias(aggregate))
 
 
+def get_mismatch_type(mismatches: dict[int, dict[str, float]]):
+    all_snql_values_zero = True
+    all_rpc_values_zero = True
+    snql_always_lower = True
+    rpc_always_lower = True
+
+    has_high_diff = False
+
+    low_conf_bucket_count = 0
+    low_sampling_rate_bucket_count = 0
+
+    for values in mismatches.values():
+        snql_value = values["snql_value"]
+        rpc_value = values["rpc_value"]
+        diff = values["mismatch_percentage"]
+        confidence = values["confidence"]
+        sampling_rate = values["sampling_rate"]
+
+        if snql_value > 0:
+            all_snql_values_zero = False
+
+        if rpc_value > 0:
+            all_rpc_values_zero = False
+
+        if rpc_value >= snql_value:
+            rpc_always_lower = False
+
+        if snql_value >= rpc_value:
+            snql_always_lower = False
+
+        if snql_value > 0 and rpc_value > 0 and diff > 0.2:
+            has_high_diff = True
+
+        if confidence == "low":
+            low_conf_bucket_count += 1
+
+        if sampling_rate and sampling_rate < 0.05:
+            low_sampling_rate_bucket_count += 1
+
+    many_low_conf_buckets = low_conf_bucket_count > len(mismatches) / 2
+    many_low_sample_rate_buckets = low_sampling_rate_bucket_count > len(mismatches) / 2
+
+    if all_snql_values_zero:
+        return MismatchType.SNQL_ALWAYS_ZERO, many_low_conf_buckets, many_low_sample_rate_buckets
+
+    if all_rpc_values_zero:
+        return MismatchType.RPC_ALWAYS_ZERO, many_low_conf_buckets, many_low_sample_rate_buckets
+
+    if snql_always_lower:
+        return MismatchType.SNQL_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
+
+    if rpc_always_lower:
+        return MismatchType.RPC_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
+
+    if has_high_diff:
+        return MismatchType.MORE_SPIKY, many_low_conf_buckets, many_low_sample_rate_buckets
+
+    return MismatchType.LESS_SPIKY, many_low_conf_buckets, many_low_sample_rate_buckets
+
+
 def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultForComparison):
     aligned_results: dict[str, Any] = defaultdict(lambda: {"rpc_value": None, "snql_value": None})
 
-    def fill_aligned_series(data: dict[str, Any], alias: str, key: str):
-        for element in data["data"]:
+    def fill_aligned_series(data: list[dict[str, Any]], alias: str, key: str):
+        for element in data:
             element_value = element.get(alias) or 0
             element_time = element["time"]
             aligned_results[element_time][key] = float(element_value)
 
-    fill_aligned_series(snql_result["result"].data, snql_result["agg_alias"], "snql_value")
-    fill_aligned_series(rpc_result["result"].data, rpc_result["agg_alias"], "rpc_value")
+    fill_aligned_series(snql_result["result"].data["data"], snql_result["agg_alias"], "snql_value")
+    fill_aligned_series(rpc_result["result"].data["data"], rpc_result["agg_alias"], "rpc_value")
+    fill_aligned_series(
+        rpc_result["result"].data["processed_timeseries"].confidence,
+        rpc_result["agg_alias"],
+        "confidence",
+    )
+    fill_aligned_series(
+        rpc_result["result"].data["processed_timeseries"].sampling_rate,
+        rpc_result["agg_alias"],
+        "sampling_rate",
+    )
 
     return aligned_results
 
@@ -115,12 +205,24 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
                 "rpc_value": rpc_value,
                 "snql_value": snql_value,
                 "mismatch_percentage": diff,
+                "sampling_rate": values["sampling_rate"],
+                "confidence": values["confidence"],
             }
 
     if mismatches:
         with sentry_sdk.isolation_scope() as scope:
             scope.set_extra("mismatches", mismatches)
             scope.set_extra("alert_id", alert_rule.id)
+
+            scope.set_tag("buckets_mismatch.percentage", mismatches / len(aligned_timeseries) * 100)
+
+            mismatch_type, many_low_conf_buckets, many_low_sample_rate_buckets = get_mismatch_type(
+                mismatches
+            )
+            scope.set_tag("mismatch_type", mismatch_type.value)
+            scope.set_tag("many_low_conf_buckets", many_low_conf_buckets)
+            scope.set_tag("many_low_sample_rate_buckets", many_low_sample_rate_buckets)
+
             sentry_sdk.capture_message("Timeseries mismatch", level="info")
             logger.info("Alert %s has too many mismatches", alert_rule.id)
 
@@ -174,11 +276,12 @@ def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
     if snuba_query.environment:
         environments = [snuba_query.environment]
 
+    time_window = get_time_window_for_interval(snuba_query.time_window)
     snuba_params = SnubaParams(
         environments=environments,
         projects=[project],
         organization=organization,
-        start=now - timedelta(days=1),
+        start=now - time_window,
         end=now,
         granularity_secs=snuba_query.time_window,
     )

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -21,21 +21,40 @@ def apply_is_segment_condition(query: str) -> str:
 
 
 def column_switcheroo(term):
+    """Swaps out the entire column name."""
     parsed_mri = parse_mri(term)
     if parsed_mri:
         term = parsed_mri.name
 
+    swapped_term = term
     if term == "transaction.duration":
-        return "span.duration"
+        swapped_term = "span.duration"
 
-    return term
+    if term == "http.method":
+        swapped_term = "transaction.method"
+
+    if term == "title":
+        swapped_term = "transaction"
+
+    return swapped_term, swapped_term != term
 
 
 def function_switcheroo(term):
+    """Swaps out the entire function, including args."""
+    swapped_term = term
     if term == "count()":
-        return "count(span.duration)"
+        swapped_term = "count(span.duration)"
 
-    return term
+    return swapped_term, swapped_term != term
+
+
+def search_term_switcheroo(term):
+    """Swaps out a single search term, both key and value."""
+    swapped_term = term
+    if term == "event.type:transaction":
+        swapped_term = "is_transaction:1"
+
+    return swapped_term, swapped_term != term
 
 
 class TranslationVisitor(NodeVisitor):
@@ -43,19 +62,27 @@ class TranslationVisitor(NodeVisitor):
         super().__init__()
 
     def visit_raw_aggregate_param(self, node, children):
-        return column_switcheroo(node.text)
+        return column_switcheroo(node.text)[0]
 
     def visit_aggregate_key(self, node, children):
-        if children[0] == "count":
-            return function_switcheroo("count()")
+        term, did_update = function_switcheroo(node.text)
+        if did_update:
+            return term
+
+        return children or node.text
+
+    def visit_text_filter(self, node, children):
+        term, did_update = search_term_switcheroo(node.text)
+        if did_update:
+            return term
 
         return children or node.text
 
     def visit_key(self, node, children):
-        return column_switcheroo(node.text)
+        return column_switcheroo(node.text)[0]
 
     def visit_value(self, node, children):
-        return column_switcheroo(node.text)
+        return column_switcheroo(node.text)[0]
 
     def generic_visit(self, node, children):
         return children or node.text
@@ -85,11 +112,11 @@ def translate_columns(columns):
         match = fields.is_function(column)
 
         if not match:
-            translated_columns.append(column_switcheroo(column))
+            translated_columns.append(column_switcheroo(column)[0])
             continue
 
-        translated_func = function_switcheroo(column)
-        if translated_func != column:
+        translated_func, did_update = function_switcheroo(column)
+        if did_update:
             translated_columns.append(translated_func)
             continue
 
@@ -98,7 +125,7 @@ def translate_columns(columns):
         translated_arguments = []
 
         for argument in arguments:
-            translated_arguments.append(column_switcheroo(argument))
+            translated_arguments.append(column_switcheroo(argument)[0])
 
         new_arg = ",".join(translated_arguments)
         translated_columns.append(f"{raw_function}({new_arg})")

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -27,12 +27,24 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "((tags[foo]:10 OR span.duration:11) AND (p95(span.duration):<10)) AND is_transaction:1",
         ),
         pytest.param(
-            "count(   ):<10",
+            "count():<10",
             "(count(span.duration):<10) AND is_transaction:1",
         ),
         pytest.param(
             "sum(c:spans/ai.total_cost@usd):<10",
             "(sum(ai.total_cost):<10) AND is_transaction:1",
+        ),
+        pytest.param(
+            "event.type:transaction AND has:measurement.lcp",
+            "(is_transaction:1 AND has:measurement.lcp) AND is_transaction:1",
+        ),
+        pytest.param(
+            "title:/api/0/foo AND http.method:POST",
+            "(transaction:/api/0/foo AND transaction.method:POST) AND is_transaction:1",
+        ),
+        pytest.param(
+            "title:tasks.spike_protection.run_spike_projection",
+            "(transaction:tasks.spike_protection.run_spike_projection) AND is_transaction:1",
         ),
     ],
 )


### PR DESCRIPTION
Add some logging so we can track why alerts are mismatched. This should give me a high level overview of why timeseries are mismatched, let us aggregate some data.

Translation for http.method, title and event.type:transaction filter.