### PR TITLE
fix(search): Improve spacing on search icons

### DIFF
--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -122,6 +122,7 @@ const Wrapper = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: ${space(1)};
 `;
 
 const Content = styled('div')`


### PR DESCRIPTION
Before

<img width="636" alt="image" src="https://github.com/user-attachments/assets/1b5d3427-59fa-4704-9a43-0037c81f9ebf" />

After

<img width="755" alt="image" src="https://github.com/user-attachments/assets/eb0116a4-06dd-438c-a83e-93f9bd8bdab9" />
