### PR TITLE
fix(search): Hide second email in IdBadge

### DIFF
--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -70,8 +70,8 @@ function SearchResult({item, matches, highlighted}: Props) {
 
       const badgeProps = {
         displayName: title,
-        displayEmail: DescriptionNode,
         description: DescriptionNode,
+        hideEmail: true,
         useLink: false,
         orgId: params.orgId,
         avatarSize: 32,


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="272" src="https://i.imgur.com/UiH364U.png" />

After

<img alt="clipboard.png" width="275" src="https://i.imgur.com/z5heUvN.png" />