### PR TITLE
fix(replay): remove ghost tab on mobile replay

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -38,6 +38,10 @@ function FocusTabs({isVideoReplay}: Props) {
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
 
+  const tabs = Object.entries(getReplayTabs({isVideoReplay})).filter(
+    ([_, v]) => v !== null
+  );
+
   return (
     <TabContainer>
       <Tabs
@@ -56,7 +60,7 @@ function FocusTabs({isVideoReplay}: Props) {
         }}
       >
         <TabList>
-          {Object.entries(getReplayTabs({isVideoReplay})).map(([tab, label]) => (
+          {tabs.map(([tab, label]) => (
             <TabList.Item key={tab} data-test-id={`replay-details-${tab}-btn`}>
               {label}
             </TabList.Item>


### PR DESCRIPTION
before:

<img width="635" alt="Screenshot 2025-04-03 at 10 38 34 AM" src="https://github.com/user-attachments/assets/9cd53c28-e688-4d30-89d8-ebb627fdc1f2" />

after:

<img width="591" alt="SCR-20250403-jtgv" src="https://github.com/user-attachments/assets/135cf364-1eef-483a-b16e-dcd4958015b4" />
