### PR TITLE
fix(aci): Remove the migration operation to add constraint

### DIFF
--- a/src/sentry/migrations/0857_update_group_open_periods_constraint.py
+++ b/src/sentry/migrations/0857_update_group_open_periods_constraint.py
@@ -3,7 +3,6 @@
 from django.db import migrations
 
 from sentry.new_migrations.migrations import CheckedMigration
-from sentry.new_migrations.monkey.special import SafeRunSQL
 
 
 class Migration(CheckedMigration):
@@ -30,13 +29,16 @@ class Migration(CheckedMigration):
             model_name="groupopenperiod",
             name="exclude_open_period_overlap",
         ),
-        SafeRunSQL(
-            """ALTER TABLE "sentry_groupopenperiod"
-                ADD CONSTRAINT "exclude_open_period_overlap" EXCLUDE USING GIST (
-                    "group_id" gist_int8_ops WITH =,
-                    (TSTZRANGE("date_started", "date_ended", '[)')) WITH &&
-                );""",
-            use_statement_timeout=False,
-            hints={"tables": ["sentry_groupopenperiod"]},
-        ),
+        # These two operations weren't able to run together in the right sequence -
+        # commenting this out to include in a later migration. This migration now
+        # only drops the exclusion constraint.
+        # SafeRunSQL(
+        #     """ALTER TABLE "sentry_groupopenperiod"
+        #         ADD CONSTRAINT "exclude_open_period_overlap" EXCLUDE USING GIST (
+        #             "group_id" gist_int8_ops WITH =,
+        #             (TSTZRANGE("date_started", "date_ended", '[)')) WITH &&
+        #         );""",
+        #     use_statement_timeout=False,
+        #     hints={"tables": ["sentry_groupopenperiod"]},
+        # ),
     ]


### PR DESCRIPTION
This migration failed in prod yesterday because the `RemoveConstraint` operation didn't take place before the `SafeRunSQL` to add a modified constraint. Splitting these operations up to keep it simple - this migration now only drops the exclusion constraint on an empty table.

Still marking this migration as post_deployment to run manually in case there are other errors 🤞 