### PR TITLE
:wrench: chore(aci): update link to go to automation details page

### DIFF
--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -9,4 +9,4 @@ def create_link_to_workflow(organization_id: int, workflow_id: int) -> str:
     """
     Create a link to a workflow
     """
-    return f"/organizations/{organization_id}/workflows/{workflow_id}/"
+    return f"/organizations/{organization_id}/issues/automations/{workflow_id}/"

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -218,7 +218,7 @@ class OpsgenieClientTest(APITestCase):
             "details": {
                 "Project Name": self.project.name,
                 "Triggering Workflows": "my rule",
-                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/workflows/{123}/",
+                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/issues/automations/{123}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
                 "Logger": "",

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -38,7 +38,7 @@ class CreateTicketUtilsTest(TestCase):
             self.event, workflow_id, installation, generate_footer
         )
 
-        expected_url = f"/organizations/{self.organization.id}/workflows/{workflow_id}/"
+        expected_url = f"/organizations/{self.organization.id}/issues/automations/{workflow_id}/"
         assert (
             description
             == f"Test description\n\nThis issue was created by a workflow: {expected_url}"


### PR DESCRIPTION
small pr to correct the link so it goes to the frontend automations page which maps to workflows in the backend. 