### PR TITLE
ref(ourlogs): Change column order so timestamp is first

### DIFF
--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -8,7 +8,7 @@ import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/log
  * These are the default fields that are shown in the logs table (aside from static columns like severity). The query will always add other hidden fields required to render details view etc.
  */
 export function defaultLogFields(): OurLogKnownFieldKey[] {
-  return [OurLogKnownFieldKey.BODY, OurLogKnownFieldKey.TIMESTAMP];
+  return [OurLogKnownFieldKey.TIMESTAMP, OurLogKnownFieldKey.BODY];
 }
 
 export function getLogFieldsFromLocation(location: Location): OurLogFieldKey[] {


### PR DESCRIPTION
### Summary
After some discussion we're rearranging which column appears first for the logs table by default. It's still editable by users so they can rearrange it if they so choose.



#### Screenshots
|![Screenshot 2025-04-03 at 2 03 32 PM](https://github.com/user-attachments/assets/06e73f35-2e1c-4dcf-8598-38da800651c4)|
|-|