### PR TITLE
fix(issue-views): Do not navigate if dragging

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -175,6 +175,12 @@ export function IssueViewNavItemContent({
                 e.stopPropagation();
                 e.preventDefault();
               }}
+              onClick={e => {
+                if (isDragging) {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }
+              }}
             >
               <StyledInteractionStateLayer isPressed={isDragging === view.id} />
               <IconGrabbable color="gray300" />


### PR DESCRIPTION
Minor improvement to the dragging interaction — do not navigate to the view if you were reordering it. 