### PR TITLE
fix(provisioning): Set reserved CPEs to null on non-DS plan change

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -584,6 +584,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                   onChange={v => {
                     // Reset price fields if next plan is not AM Enterprise
                     const isManagedPlan = isAmEnterprisePlan(v as string);
+                    const chosenPlanIsAm3Ds = isAm3DsPlan(v as string);
                     const nextPrices = isManagedPlan
                       ? {}
                       : Object.keys(this.state.data)
@@ -591,13 +592,20 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                           .reduce((acc, key) => {
                             return {...acc, [key]: ''};
                           }, {});
-
+                    const nextReservedCpes = chosenPlanIsAm3Ds
+                      ? {}
+                      : Object.keys(this.state.data)
+                          .filter(key => key.startsWith('reservedCpe'))
+                          .reduce((acc, key) => {
+                            return {...acc, [key]: null};
+                          }, {});
                     this.setState(state => ({
                       ...state,
                       data: {
                         ...state.data,
                         plan: v,
                         ...nextPrices,
+                        ...nextReservedCpes,
                       },
                     }));
                   }}

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -584,18 +584,10 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                   onChange={v => {
                     // Reset price fields if next plan is not AM Enterprise
                     const isManagedPlan = isAmEnterprisePlan(v as string);
-                    const chosenPlanIsAm3Ds = isAm3DsPlan(v as string);
                     const nextPrices = isManagedPlan
                       ? {}
                       : Object.keys(this.state.data)
                           .filter(key => key.startsWith('customPrice'))
-                          .reduce((acc, key) => {
-                            return {...acc, [key]: ''};
-                          }, {});
-                    const nextReservedCpes = chosenPlanIsAm3Ds
-                      ? {}
-                      : Object.keys(this.state.data)
-                          .filter(key => key.startsWith('reservedCpe'))
                           .reduce((acc, key) => {
                             return {...acc, [key]: ''};
                           }, {});
@@ -606,7 +598,6 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                         ...state.data,
                         plan: v,
                         ...nextPrices,
-                        ...nextReservedCpes,
                       },
                     }));
                   }}


### PR DESCRIPTION
Fixes a bug where you couldn't submit the provisioning form because reserved CPEs were set to empty strings.