### PR TITLE
ref(insights): make the eap toggle nicer

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -88,9 +88,11 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
+  const location = useLocation();
+  const useEap = location.query?.useEap === '1';
   return useDiscover<Fields, MetricsResponse>(
     options,
-    DiscoverDatasets.METRICS,
+    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
     referrer
   );
 };

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -107,7 +107,7 @@ export const useSpanSamples = (options: Options) => {
     project: pageFilter.selection.projects,
     environment: pageFilter.selection.environments,
     query: query.formatString(),
-    useEap: location.query?.useEap,
+    useRpc: location.query?.useEap,
     ...(additionalFields?.length ? {additionalFields} : {}),
   };
   const {data, ...result} = useApiQuery<{data: SpanSample[]}>(

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -107,6 +107,7 @@ export const useSpanSamples = (options: Options) => {
     project: pageFilter.selection.projects,
     environment: pageFilter.selection.environments,
     query: query.formatString(),
+    useEap: location.query?.useEap,
     ...(additionalFields?.length ? {additionalFields} : {}),
   };
   const {data, ...result} = useApiQuery<{data: SpanSample[]}>(

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,16 +1,18 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import type {Key} from '@react-types/shared';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import {Badge} from 'sentry/components/core/badge';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import {Switch} from 'sentry/components/core/switch';
+import DropdownButton from 'sentry/components/dropdownButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import {TabList} from 'sentry/components/tabs';
 import type {TabListItemProps} from 'sentry/components/tabs/item';
-import {IconBusiness} from 'sentry/icons';
+import {IconBusiness, IconLab} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -114,6 +116,12 @@ export function DomainViewHeader({
       })),
   ];
 
+  const handleExperimentDropdownAction = (key: Key) => {
+    if (key === 'eap') {
+      toggleUseEap();
+    }
+  };
+
   return (
     <Fragment>
       <Layout.Header>
@@ -142,8 +150,24 @@ export function DomainViewHeader({
             {additonalHeaderActions}
             {hasEapFlag && (
               <Fragment>
-                Use Eap
-                <Switch checked={useEap} onChange={() => toggleUseEap()} />
+                <DropdownMenu
+                  trigger={triggerProps => (
+                    <StyledDropdownButton {...triggerProps} size={'sm'}>
+                      {/* Passing icon as child to avoid extra icon margin */}
+                      <IconLab isSolid />
+                    </StyledDropdownButton>
+                  )}
+                  onAction={handleExperimentDropdownAction}
+                  items={[
+                    {
+                      key: 'eap',
+                      label: useEap
+                        ? 'Switch to Metrics Dataset'
+                        : 'Switch to EAP Dataset',
+                    },
+                  ]}
+                  position="bottom-end"
+                />
               </Fragment>
             )}
           </ButtonBar>
@@ -190,4 +214,11 @@ const TabContainer = styled('div')`
   align-items: center;
   text-align: left;
   gap: ${space(0.5)};
+`;
+
+const StyledDropdownButton = styled(DropdownButton)`
+  color: ${p => p.theme.button.primary.background};
+  :hover {
+    color: ${p => p.theme.button.primary.background};
+  }
 `;


### PR DESCRIPTION
1. Makes the eap toggle within insights nicer, matches styling of issues page toggle
<img width="263" alt="image" src="https://github.com/user-attachments/assets/701c07d8-bf2d-4cfc-b0e9-1f1437e35c98" />

2. Also adds `useEap` flag in a couple missing queries