### PR TITLE
 chore(fe): Convert `<IntegrationOrganizationLink />` to an FC

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -1,9 +1,9 @@
 import pick from 'lodash/pick';
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {VercelProviderFixture} from 'sentry-fixture/vercelIntegration';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
@@ -12,66 +12,79 @@ import type {Organization} from 'sentry/types/organization';
 import {generateOrgSlugUrl} from 'sentry/utils';
 import IntegrationOrganizationLink from 'sentry/views/integrationOrganizationLink';
 
+function setupConfigStore(organization: Organization) {
+  const defaultConfig = ConfigFixture();
+  window.__initialData = {
+    ...defaultConfig,
+    customerDomain: {
+      subdomain: organization.slug,
+      organizationUrl: `https://${organization.slug}.sentry.io`,
+      sentryUrl: 'https://sentry.io',
+    },
+    links: {
+      ...defaultConfig.links,
+      sentryUrl: 'https://sentry.io',
+    },
+  };
+  ConfigStore.loadInitialData(window.__initialData);
+}
+
+function teardownConfigStore() {
+  window.__initialData = ConfigFixture();
+  ConfigStore.loadInitialData(window.__initialData);
+}
+
 describe('IntegrationOrganizationLink', () => {
-  let org1: Organization;
-  let org2: Organization;
+  const org1 = OrganizationFixture({
+    slug: 'org1',
+    name: 'Organization 1',
+  });
+  const org2 = OrganizationFixture({
+    slug: 'org2',
+    name: 'Organization 2',
+  });
   let getOrgsMock: jest.Mock;
+
+  const router = RouterFixture({
+    params: {integrationSlug: 'vercel'},
+  });
+
   beforeEach(() => {
-    MockApiClient.clearMockResponses();
     window.location.assign = jest.fn();
 
-    org1 = OrganizationFixture({
-      slug: 'org1',
-      name: 'Organization 1',
-    });
-
-    org2 = OrganizationFixture({
-      slug: 'org2',
-      name: 'Organization 2',
-    });
-
+    MockApiClient.clearMockResponses();
     const org1Lite = pick(org1, ['slug', 'name', 'id']);
     const org2Lite = pick(org2, ['slug', 'name', 'id']);
-
     getOrgsMock = MockApiClient.addMockResponse({
-      url: '/organizations/?include_feature_flags=1',
+      url: '/organizations/',
+      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
       body: [org1Lite, org2Lite],
     });
   });
 
-  it('selecting org changes the url', async () => {
-    const preselectedOrg = OrganizationFixture();
-    const {routerProps} = initializeOrg({organization: preselectedOrg});
+  afterEach(() => {
+    teardownConfigStore();
+  });
 
-    window.__initialData = ConfigFixture({
-      customerDomain: {
-        subdomain: 'foobar',
-        organizationUrl: 'https://foobar.sentry.io',
-        sentryUrl: 'https://sentry.io',
-      },
-      links: {
-        ...window.__initialData?.links,
-        sentryUrl: 'https://sentry.io',
-      },
-    });
-    ConfigStore.loadInitialData(window.__initialData);
+  it('selecting org changes the url', async () => {
+    const preselectedOrg = OrganizationFixture({slug: 'foobar'});
+
+    setupConfigStore(preselectedOrg);
 
     const getOrgMock = MockApiClient.addMockResponse({
-      url: `/organizations/foobar/`,
+      url: `/organizations/${preselectedOrg.slug}/`,
+      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
       body: preselectedOrg,
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/foobar/config/integrations/?provider_key=vercel`,
+      url: `/organizations/${preselectedOrg.slug}/config/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'vercel'})],
       body: {providers: [VercelProviderFixture()]},
     });
 
-    render(
-      <IntegrationOrganizationLink
-        {...routerProps}
-        params={{integrationSlug: 'vercel'}}
-      />
-    );
+    render(<IntegrationOrganizationLink />, {router});
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
     expect(getOrgsMock).toHaveBeenCalled();
     expect(getOrgMock).toHaveBeenCalled();
@@ -81,40 +94,22 @@ describe('IntegrationOrganizationLink', () => {
     expect(window.location.assign).toHaveBeenCalledWith(generateOrgSlugUrl(org2.slug));
   });
   it('Selecting the same org as the domain allows you to install', async () => {
-    const initialData = initializeOrg({organization: org2});
-
-    window.__initialData = ConfigFixture({
-      customerDomain: {
-        subdomain: org2.slug,
-        organizationUrl: `https://${org2.slug}.sentry.io`,
-        sentryUrl: 'https://sentry.io',
-      },
-      links: {
-        ...window.__initialData?.links,
-        sentryUrl: 'https://sentry.io',
-      },
-    });
-    ConfigStore.loadInitialData(window.__initialData);
+    setupConfigStore(org2);
 
     const getProviderMock = MockApiClient.addMockResponse({
-      url: `/organizations/${org2.slug}/config/integrations/?provider_key=vercel`,
+      url: `/organizations/${org2.slug}/config/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'vercel'})],
       body: {providers: [VercelProviderFixture()]},
     });
 
     const getOrgMock = MockApiClient.addMockResponse({
       url: `/organizations/${org2.slug}/`,
+      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
       body: org2,
     });
 
-    render(
-      <IntegrationOrganizationLink
-        {...initialData.routerProps}
-        params={{integrationSlug: 'vercel'}}
-      />,
-      {
-        router: initialData.router,
-      }
-    );
+    render(<IntegrationOrganizationLink />, {router});
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
     // Select the same organization as the domain
     await selectEvent.select(screen.getByRole('textbox'), org2.name);

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -1,11 +1,11 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import {Select} from 'sentry/components/core/select';
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import IdBadge from 'sentry/components/idBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -15,7 +15,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {generateOrgSlugUrl, urlEncode} from 'sentry/utils';
 import type {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
@@ -24,20 +23,14 @@ import {
   trackIntegrationAnalytics,
 } from 'sentry/utils/integrationUtil';
 import {singleLineRenderer} from 'sentry/utils/marked';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import RouteError from 'sentry/views/routeError';
 import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import IntegrationLayout from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
-
-// installationId present for Github flow
-type Props = RouteComponentProps<{integrationSlug: string; installationId?: string}>;
-
-type State = DeprecatedAsyncComponent['state'] & {
-  installationData?: GitHubIntegrationInstallation;
-  installationDataLoading?: boolean;
-  organization?: Organization;
-  provider?: IntegrationProvider;
-  selectedOrgSlug?: string;
-};
 
 interface GitHubIntegrationInstallation {
   account: {
@@ -50,166 +43,184 @@ interface GitHubIntegrationInstallation {
   };
 }
 
-export default class IntegrationOrganizationLink extends DeprecatedAsyncComponent<
-  Props,
-  State
-> {
-  disableErrorReport = false;
-
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    return [['organizations', '/organizations/?include_feature_flags=1']];
+function trackExternalAnalytics({
+  eventName,
+  startSession,
+  organization,
+  provider,
+}: {
+  eventName: IntegrationAnalyticsKey;
+  organization: Organization | null;
+  provider: IntegrationProvider | null;
+  startSession?: boolean;
+}) {
+  if (!organization || !provider) {
+    return;
   }
 
-  trackIntegrationAnalytics = (
-    eventName: IntegrationAnalyticsKey,
-    startSession?: boolean
-  ) => {
-    const {organization, provider} = this.state;
-    // should have these set but need to make TS happy
-    if (!organization || !provider) {
-      return;
-    }
+  trackIntegrationAnalytics(
+    eventName,
+    {
+      integration_type: 'first_party',
+      integration: provider.key,
+      // We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
+      already_installed: false,
+      view: 'external_install',
+      organization,
+    },
+    {startSession: !!startSession}
+  );
+}
 
-    trackIntegrationAnalytics(
-      eventName,
-      {
-        integration_type: 'first_party',
-        integration: provider.key,
-        // We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
-        already_installed: false,
-        view: 'external_install',
-        organization,
-      },
-      {startSession: !!startSession}
-    );
-  };
+export default function IntegrationOrganizationLink() {
+  const api = useApi({persistInFlight: true});
+  const location = useLocation();
+  const [reloading, setReloading] = useState(false);
+  const {integrationSlug, installationId} = useParams<{
+    integrationSlug: string;
+    // installationId present for Github flow
+    installationId?: string;
+  }>();
+  const [organization, setOrganization] = useState<Organization | null>(null);
+  const [selectedOrgSlug, setSelectedOrgSlug] = useState<string | null>(null);
+  const [installationData, setInstallationData] =
+    useState<GitHubIntegrationInstallation | null>(null);
 
-  trackOpened() {
-    this.trackIntegrationAnalytics('integrations.integration_viewed', true);
-  }
+  const {
+    data: organizations = [],
+    isPending: isPendingOrganizations,
+    error: organizationsError,
+  } = useApiQuery<Organization[]>(
+    ['/organizations/', {query: {include_feature_flags: 1}}],
+    {staleTime: Infinity}
+  );
 
-  trackInstallationStart() {
-    this.trackIntegrationAnalytics('integrations.installation_start');
-  }
+  const isProviderQueryEnabled = !!selectedOrgSlug;
+  const providerQuery = useApiQuery<IntegrationProvider[]>(
+    [
+      `/organizations/${selectedOrgSlug}/config/integrations/`,
+      {query: {provider_key: integrationSlug}},
+    ],
+    {staleTime: Infinity, enabled: !!isProviderQueryEnabled}
+  );
+  const provider = providerQuery.data?.[0] ?? null;
+  const isPendingProviders = isProviderQueryEnabled && providerQuery.isPending;
+  const providerError = providerQuery.error;
+  const selectOrganization = useCallback(
+    async (orgSlug: string) => {
+      const customerDomain = ConfigStore.get('customerDomain');
+      // redirect to the org if it's different than the org being selected
+      if (customerDomain?.subdomain && orgSlug !== customerDomain?.subdomain) {
+        const urlWithQuery = generateOrgSlugUrl(orgSlug) + location.search;
+        window.location.assign(urlWithQuery);
+        return;
+      }
+      // otherwise proceed as normal
+      setSelectedOrgSlug(orgSlug); // TODO(Leander): reloading: true, and orgniazation: undefined?
+      setReloading(true);
 
-  get integrationSlug() {
-    return this.props.params.integrationSlug;
-  }
+      try {
+        // TODO(Leander): Figure out a way to get this into useApiQuery calls instead
+        const [incomingOrganization, incomingConfig]: [
+          Organization,
+          {providers: IntegrationProvider[]},
+        ] = await Promise.all([
+          api.requestPromise(`/organizations/${orgSlug}/`, {
+            query: {
+              include_feature_flags: 1,
+            },
+          }),
+          api.requestPromise(
+            `/organizations/${orgSlug}/config/integrations/?provider_key=${integrationSlug}`
+          ),
+        ]);
+        const incomingProvider = incomingConfig.providers[0] ?? null;
 
-  get queryParams() {
-    return this.props.location.query;
-  }
+        // should never happen with a valid provider
+        if (!incomingProvider) {
+          throw new Error('Invalid provider');
+        }
 
-  getOrgBySlug = (orgSlug: string): Organization | undefined => {
-    return this.state.organizations.find((org: Organization) => org.slug === orgSlug);
-  };
+        let installData = undefined;
+        if (integrationSlug === 'github') {
+          try {
+            // The API endpoint /extensions/github/installation is not prefixed with /api/0
+            // so we have to use this workaround.
+            installData = await api.requestPromise(
+              `/../../extensions/github/installation/${installationId}/`
+            );
+          } catch (_err) {
+            addErrorMessage(t('Failed to retrieve GitHub installation details'));
+          }
+        }
 
-  onLoadAllEndpointsSuccess() {
-    // auto select the org if there is only one
-    const {organizations} = this.state;
+        setOrganization(incomingOrganization);
+        setProvider(incomingProvider);
+        setReloading(false);
+        setInstallationData(installData);
+        trackExternalAnalytics({
+          eventName: 'integrations.integration_viewed',
+          startSession: true,
+          organization: incomingOrganization,
+          provider: incomingProvider,
+        });
+      } catch (_err) {
+        addErrorMessage(t('Failed to retrieve organization or integration details'));
+        setReloading(false);
+      }
+    },
+    [location.search, api, integrationSlug, installationId]
+  );
+
+  useEffect(() => {
+    // If only one organization, select it and redirect
     if (organizations.length === 1) {
-      this.onSelectOrg(organizations[0].slug);
+      const urlWithQuery = generateOrgSlugUrl(organizations[0]?.slug) + location.search;
+      window.location.assign(urlWithQuery);
     }
-
-    // now check the subomdain and use that org slug if it exists
+    // Now, check the subdomain and use that org slug if it exists
     const customerDomain = ConfigStore.get('customerDomain');
     if (customerDomain?.subdomain) {
-      this.onSelectOrg(customerDomain.subdomain);
+      selectOrganization(customerDomain.subdomain);
     }
-  }
+  }, [organizations, location.search, selectOrganization]);
 
-  onSelectOrg = async (orgSlug: string) => {
-    const customerDomain = ConfigStore.get('customerDomain');
-    // redirect to the org if it's different than the org being selected
-    if (customerDomain?.subdomain && orgSlug !== customerDomain?.subdomain) {
-      const urlWithQuery = generateOrgSlugUrl(orgSlug) + this.props.location.search;
-      window.location.assign(urlWithQuery);
-      return;
-    }
-
-    // otherwise proceed as normal
-    this.setState({selectedOrgSlug: orgSlug, reloading: true, organization: undefined});
-
-    try {
-      const [organization, {providers}]: [
-        Organization,
-        {providers: IntegrationProvider[]},
-      ] = await Promise.all([
-        this.api.requestPromise(`/organizations/${orgSlug}/`, {
-          query: {
-            include_feature_flags: 1,
-          },
-        }),
-        this.api.requestPromise(
-          `/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
-        ),
-      ]);
-
-      // should never happen with a valid provider
-      if (providers.length === 0) {
-        throw new Error('Invalid provider');
-      }
-
-      let installationData = undefined;
-      if (this.integrationSlug === 'github') {
-        const {installationId} = this.props.params;
-        try {
-          // The API endpoint /extensions/github/installation is not prefixed with /api/0
-          // so we have to use this workaround.
-          installationData = await this.api.requestPromise(
-            `/../../extensions/github/installation/${installationId}/`
-          );
-        } catch (_err) {
-          addErrorMessage(t('Failed to retrieve GitHub installation details'));
-        }
-        this.setState({installationDataLoading: false});
-      }
-
-      this.setState(
-        {organization, reloading: false, provider: providers[0], installationData},
-        this.trackOpened
-      );
-    } catch (_err) {
-      addErrorMessage(t('Failed to retrieve organization or integration details'));
-      this.setState({reloading: false});
-    }
-  };
-
-  hasAccess = () => {
-    const {organization} = this.state;
+  const hasAccess = useMemo(() => {
     return organization?.access.includes('org:integrations');
-  };
+  }, [organization]);
 
   // used with Github to redirect to the integration detail
-  onInstallWithInstallationId = (data: Integration) => {
-    const {organization} = this.state;
-    const orgId = organization?.slug;
-    const normalizedUrl = normalizeUrl(
-      `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
-    );
-    window.location.assign(
-      `${organization?.links.organizationUrl || ''}${normalizedUrl}`
-    );
-  };
+  const onInstallWithInstallationId = useCallback(
+    (data: Integration) => {
+      const orgId = organization?.slug;
+      const normalizedUrl = normalizeUrl(
+        `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
+      );
+      window.location.assign(
+        `${organization?.links.organizationUrl || ''}${normalizedUrl}`
+      );
+    },
+    [organization]
+  );
 
   // non-Github redirects to the extension view where the backend will finish the installation
-  finishInstallation = () => {
+  const finishInstallation = useCallback(() => {
     // add the selected org to the query parameters and then redirect back to configure
-    const {selectedOrgSlug, organization} = this.state;
-    const query = {orgSlug: selectedOrgSlug, ...this.queryParams};
-    this.trackInstallationStart();
+    const query = {orgSlug: selectedOrgSlug, ...location.query};
+    trackExternalAnalytics({
+      eventName: 'integrations.installation_start',
+      organization,
+      provider,
+    });
     // need to send to control silo to finish the installation
     window.location.assign(
       `${organization?.links.organizationUrl || ''}/extensions/${
-        this.integrationSlug
+        integrationSlug
       }/configure/?${urlEncode(query)}`
     );
-  };
+  }, [integrationSlug, location.query, organization, provider, selectedOrgSlug]);
 
-  renderAddButton() {
-    const {installationId} = this.props.params;
-    const {organization, provider} = this.state;
-    // should never happen but we need this check for TS
+  const renderAddButton = useCallback(() => {
     if (!provider || !organization) {
       return null;
     }
@@ -236,20 +247,20 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
         {({disabled, disabledReason}) => (
           <AddIntegration
             provider={provider}
-            onInstall={this.onInstallWithInstallationId}
+            onInstall={onInstallWithInstallationId}
             organization={organization}
           >
             {addIntegrationWithInstallationId => (
               <ButtonWrapper>
                 <Button
                   priority="primary"
-                  disabled={!this.hasAccess() || disabled}
+                  disabled={!hasAccess || disabled}
                   onClick={() =>
                     installationId
                       ? addIntegrationWithInstallationId({
                           installation_id: installationId,
                         })
-                      : this.finishInstallation()
+                      : finishInstallation()
                   }
                 >
                   {t('Install %s', provider.name)}
@@ -261,10 +272,16 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
         )}
       </IntegrationFeatures>
     );
-  }
+  }, [
+    installationId,
+    provider,
+    organization,
+    hasAccess,
+    onInstallWithInstallationId,
+    finishInstallation,
+  ]);
 
-  renderBottom() {
-    const {organization, selectedOrgSlug, provider, reloading} = this.state;
+  const renderBottom = useCallback(() => {
     const {FeatureList} = getIntegrationFeatureGate();
     if (reloading) {
       return <LoadingIndicator />;
@@ -272,7 +289,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
 
     return (
       <Fragment>
-        {selectedOrgSlug && organization && !this.hasAccess() && (
+        {selectedOrgSlug && organization && !hasAccess && (
           <Alert.Container>
             <Alert type="error" showIcon>
               <p>
@@ -288,7 +305,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
           </Alert.Container>
         )}
 
-        {provider && organization && this.hasAccess() && FeatureList && (
+        {provider && organization && hasAccess && FeatureList && (
           <Fragment>
             <p>
               {tct(
@@ -303,24 +320,17 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
             />
           </Fragment>
         )}
-
-        <div className="form-actions">{this.renderAddButton()}</div>
+        <div className="form-actions">{renderAddButton()}</div>
       </Fragment>
     );
-  }
+  }, [reloading, hasAccess, provider, organization, renderAddButton, selectedOrgSlug]);
 
-  renderCallout() {
-    const {installationData, installationDataLoading} = this.state;
-
-    if (this.integrationSlug !== 'github') {
+  const renderCallout = useCallback(() => {
+    if (integrationSlug !== 'github') {
       return null;
     }
 
     if (!installationData) {
-      if (installationDataLoading !== false) {
-        return null;
-      }
-
       return (
         <Alert.Container>
           <Alert type="warning" showIcon>
@@ -364,51 +374,58 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
         </Alert>
       </Alert.Container>
     );
+  }, [integrationSlug, installationData]);
+
+  if (isPendingOrganizations || isPendingProviders) {
+    return <LoadingIndicator />;
   }
 
-  renderBody() {
-    const {selectedOrgSlug} = this.state;
-    const options = this.state.organizations.map((org: Organization) => ({
-      value: org.slug,
-      label: (
-        <IdBadge
-          organization={org}
-          avatarSize={20}
-          displayName={org.name}
-          avatarProps={{consistentWidth: true}}
+  if (organizationsError) {
+    return <RouteError error={organizationsError} />;
+  }
+
+  if (providerError) {
+    return <RouteError error={providerError} />;
+  }
+
+  const options = organizations.map((org: Organization) => ({
+    value: org.slug,
+    label: (
+      <IdBadge
+        organization={org}
+        avatarSize={20}
+        displayName={org.name}
+        avatarProps={{consistentWidth: true}}
+      />
+    ),
+  }));
+
+  return (
+    <NarrowLayout>
+      <SentryDocumentTitle title={t('Choose Installation Organization')} />
+      <h3>{t('Finish integration installation')}</h3>
+      {renderCallout()}
+      <p>
+        {tct(
+          `Please pick a specific [organization:organization] to link with
+          your integration installation of [integation].`,
+          {
+            organization: <strong />,
+            integation: <strong>{integrationSlug}</strong>,
+          }
+        )}
+      </p>
+      <FieldGroup label={t('Organization')} inline={false} stacked required>
+        <Select
+          onChange={(option: SelectOption<string>) => selectOrganization(option.value)}
+          value={selectedOrgSlug}
+          placeholder={t('Select an organization')}
+          options={options}
         />
-      ),
-    }));
-
-    return (
-      <NarrowLayout>
-        <SentryDocumentTitle title={t('Choose Installation Organization')} />
-        <h3>{t('Finish integration installation')}</h3>
-        {this.renderCallout()}
-        <p>
-          {tct(
-            `Please pick a specific [organization:organization] to link with
-            your integration installation of [integation].`,
-            {
-              organization: <strong />,
-              integation: <strong>{this.integrationSlug}</strong>,
-            }
-          )}
-        </p>
-
-        <FieldGroup label={t('Organization')} inline={false} stacked required>
-          <Select
-            // @ts-expect-error TS(7031): Binding element 'orgSlug' implicitly has an 'any' ... Remove this comment to see the full error message
-            onChange={({value: orgSlug}) => this.onSelectOrg(orgSlug)}
-            value={selectedOrgSlug}
-            placeholder={t('Select an organization')}
-            options={options}
-          />
-        </FieldGroup>
-        {this.renderBottom()}
-      </NarrowLayout>
-    );
-  }
+      </FieldGroup>
+      {renderBottom()}
+    </NarrowLayout>
+  );
 }
 
 const InstallLink = styled('pre')`

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -202,7 +202,7 @@ export default function IntegrationOrganizationLink() {
     );
   }, [integrationSlug, location.query, organization, provider, selectedOrgSlug]);
 
-  const renderAddButton = useCallback(() => {
+  const renderAddButton = useMemo(() => {
     if (!provider || !organization) {
       return null;
     }
@@ -263,7 +263,7 @@ export default function IntegrationOrganizationLink() {
     finishInstallation,
   ]);
 
-  const renderBottom = useCallback(() => {
+  const renderBottom = useMemo(() => {
     const {FeatureList} = getIntegrationFeatureGate();
 
     if (isPendingSelection) {
@@ -303,7 +303,7 @@ export default function IntegrationOrganizationLink() {
             />
           </Fragment>
         )}
-        <div className="form-actions">{renderAddButton()}</div>
+        <div className="form-actions">{renderAddButton}</div>
       </Fragment>
     );
   }, [
@@ -409,7 +409,7 @@ export default function IntegrationOrganizationLink() {
           options={options}
         />
       </FieldGroup>
-      {renderBottom()}
+      {renderBottom}
     </NarrowLayout>
   );
 }

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -104,14 +104,16 @@ export default function IntegrationOrganizationLink() {
   }, [organizationQuery.error]);
 
   const isProviderQueryEnabled = !!selectedOrgSlug;
-  const providerQuery = useApiQuery<IntegrationProvider[]>(
+  const providerQuery = useApiQuery<{
+    providers: IntegrationProvider[];
+  }>(
     [
       `/organizations/${selectedOrgSlug}/config/integrations/`,
       {query: {provider_key: integrationSlug}},
     ],
     {staleTime: Infinity, enabled: isProviderQueryEnabled}
   );
-  const provider = providerQuery.data?.[0] ?? null;
+  const provider = providerQuery.data?.providers[0] ?? null;
   const isPendingProviders = isProviderQueryEnabled && providerQuery.isPending;
 
   useEffect(() => {
@@ -263,6 +265,7 @@ export default function IntegrationOrganizationLink() {
 
   const renderBottom = useCallback(() => {
     const {FeatureList} = getIntegrationFeatureGate();
+
     if (isPendingSelection) {
       return <LoadingIndicator />;
     }


### PR DESCRIPTION
Converts this class to a functional component. it's structured quite a bit differently in order to use `ApiQuery` instead of the direct usage of `api`. It seemed to work with tests, and I believe the logic is the same, but the `onSelectOrg` function from the previous version had quite a few side effects that I've pulled out. Instead, the ApiQuery hooks should fire when the `selectedOrgSlug` changes.

ref: https://github.com/getsentry/frontend-tsc/issues/2