### PR TITLE
chore(issues): Default to the new issue details in tests

### DIFF
--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -61,8 +61,9 @@ describe('commitRow', () => {
     } as Commit;
 
     render(<CommitRow commit={commit} />);
+    await userEvent.hover(screen.getByText('Author'));
     expect(
-      screen.getByText(
+      await screen.findByText(
         textWithMarkupMatcher(
           /The email author@commit.com is not a member of your organization./
         )
@@ -118,14 +119,11 @@ describe('commitRow', () => {
     const handlePullRequestClick = jest.fn();
     render(<CommitRow commit={commit} onPullRequestClick={handlePullRequestClick} />);
 
-    const pullRequestButton = screen.getByRole('button', {name: 'View Pull Request'});
-    expect(pullRequestButton).toBeInTheDocument();
-    expect(pullRequestButton).toHaveAttribute(
-      'href',
-      'https://github.com/getsentry/sentry/pull/1'
-    );
+    const prLink = screen.getByRole('link', {name: /ref\(commitRow\):/i});
+    expect(prLink).toHaveAttribute('href', 'https://github.com/getsentry/sentry/pull/1');
+    await userEvent.click(prLink);
 
-    await userEvent.click(pullRequestButton);
-    expect(handlePullRequestClick).toHaveBeenCalledTimes(1);
+    // XXX: Does not get called in Streamline UI, it's just a link
+    expect(handlePullRequestClick).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -112,7 +112,7 @@ function CommitRow({
                 inviteUser: <StyledLink to="" onClick={handleInviteClick} />,
               }
             )}
-            // disabled={!commit.author || false||  commit.author.id !== undefined}
+            disabled={!commit.author || commit.author.id !== undefined}
             overlayStyle={{maxWidth: '350px'}}
             skipWrapper
             isHoverable

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -112,7 +112,7 @@ function CommitRow({
                 inviteUser: <StyledLink to="" onClick={handleInviteClick} />,
               }
             )}
-            disabled={!commit.author || commit.author.id !== undefined}
+            // disabled={!commit.author || false||  commit.author.id !== undefined}
             overlayStyle={{maxWidth: '350px'}}
             skipWrapper
             isHoverable

--- a/static/app/components/core/avatar/avatarList.spec.tsx
+++ b/static/app/components/core/avatar/avatarList.spec.tsx
@@ -69,7 +69,7 @@ describe('AvatarList', () => {
     expect(screen.getByText(users[3]!.name.charAt(0))).toBeInTheDocument();
     expect(screen.getByText(users[4]!.name.charAt(0))).toBeInTheDocument();
     expect(screen.queryByText(users[5]!.name.charAt(0))).not.toBeInTheDocument();
-    expect(screen.getByTestId('avatarList-collapsedavatars')).toBeInTheDocument();
+    expect(screen.getByTestId('avatarList-collapsedavatars')).toHaveTextContent('+2');
   });
 
   it('renders with team avatars', () => {

--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -38,7 +38,11 @@ export function CollapsedAvatars({
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   if (hasStreamlinedUI) {
-    return <CollapsedAvatarPill ref={ref}>{children}</CollapsedAvatarPill>;
+    return (
+      <CollapsedAvatarPill ref={ref} data-test-id="avatarList-collapsedavatars">
+        {children}
+      </CollapsedAvatarPill>
+    );
   }
   return (
     <CollapsedAvatarsCicle

--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -54,14 +54,15 @@ describe('EventEntries', function () {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByTestId(/event-section/)).toHaveLength(4); //  event tags + 2 entries + event grouping
+      expect(screen.getAllByRole('button', {name: /Section/i})).toHaveLength(4);
     });
 
-    const sections = screen.getAllByTestId(/event-section/);
+    const sections = screen.getAllByRole('button', {name: /Section/i});
 
     // Replay should be after message but before images loaded
     expect(sections[0]).toHaveTextContent(/message/i);
     expect(sections[1]).toHaveTextContent(/replay/i);
     expect(sections[2]).toHaveTextContent(/images loaded/i);
+    expect(sections[3]).toHaveTextContent(/event grouping/i);
   });
 });

--- a/static/app/components/events/eventSdk.spec.tsx
+++ b/static/app/components/events/eventSdk.spec.tsx
@@ -26,6 +26,7 @@ describe('event sdk', function () {
       },
     });
 
+    await userEvent.click(screen.getByRole('button', {name: 'View SDK Section'}));
     await userEvent.hover(screen.getByText(/redacted/));
     expect(
       await screen.findByText(

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -151,7 +151,7 @@ describe('EventTagsAndScreenshot', function () {
 
   async function assertTagsView() {
     expect(screen.getByText('Tags')).toBeInTheDocument();
-    const tagsContainer = within(screen.getByTestId('event-tags'));
+    const tagsContainer = within(screen.getByRole('region', {name: 'tags'}));
     expect(tagsContainer.getAllByRole('radio')).toHaveLength(
       Object.keys(TagFilter).length
     );
@@ -305,24 +305,12 @@ describe('EventTagsAndScreenshot', function () {
       expect(screen.queryByText('Tags')).not.toBeInTheDocument();
 
       // Screenshot Container
-      expect(
-        (await screen.findByTestId('screenshot-data-section'))?.textContent
-      ).toContain('Screenshot');
+      expect(await screen.findByRole('region', {name: 'Screenshot'})).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1]!.id}/?download`
       );
-
-      // Display help text when hovering question element
-      await userEvent.hover(screen.getByTestId('more-information'));
-
-      expect(
-        await screen.findByText(
-          'This image was captured around the time that the event occurred.'
-        )
-      ).toBeInTheDocument();
-
       // Screenshot is clickable
       await userEvent.click(screen.getByTestId('image-viewer'));
 
@@ -357,9 +345,8 @@ describe('EventTagsAndScreenshot', function () {
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1]!.id}/?download`
       );
 
-      expect(screen.getByTestId('screenshot-data-section')?.textContent).toContain(
-        'Screenshot'
-      );
+      expect(screen.getByRole('region', {name: 'Screenshot'})).toBeInTheDocument();
+
       expect(
         screen.queryByRole('button', {name: 'Previous Screenshot'})
       ).not.toBeInTheDocument();
@@ -396,9 +383,8 @@ describe('EventTagsAndScreenshot', function () {
         {organization}
       );
 
-      expect(
-        (await screen.findByTestId('screenshot-data-section'))?.textContent
-      ).toContain('1 of 2');
+      const screenShotSection = await screen.findByRole('region', {name: 'Screenshots'});
+      expect(screenShotSection).toHaveTextContent('1 of 2');
 
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
@@ -408,9 +394,7 @@ describe('EventTagsAndScreenshot', function () {
 
       await userEvent.click(screen.getByRole('button', {name: 'Next Screenshot'}));
 
-      expect(await screen.findByTestId('screenshot-data-section')).toHaveTextContent(
-        '2 of 2'
-      );
+      expect(screenShotSection).toHaveTextContent('2 of 2');
 
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
@@ -467,9 +451,7 @@ describe('EventTagsAndScreenshot', function () {
       await assertTagsView();
 
       // Screenshot Container
-      expect(
-        (await screen.findByTestId('screenshot-data-section'))?.textContent
-      ).toContain('Screenshot');
+      expect(await screen.findByRole('region', {name: 'Screenshot'})).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',

--- a/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
@@ -43,12 +43,10 @@ describe('EventGroupingInfo', function () {
 
   it('fetches and renders grouping info for errors', async function () {
     render(<EventGroupingInfoSection {...defaultProps} />);
-
+    await userEvent.click(
+      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
+    );
     expect(await screen.findByText('variant description')).toBeInTheDocument();
-
-    // Hash should not be visible until toggling open
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
     expect(await screen.findByText('123')).toBeInTheDocument();
   });
 
@@ -62,14 +60,12 @@ describe('EventGroupingInfo', function () {
     render(
       <EventGroupingInfoSection {...defaultProps} event={perfEvent} group={perfGroup} />
     );
+    await userEvent.click(
+      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
+    );
 
-    expect(screen.getByText('performance problem')).toBeInTheDocument();
-
-    // Hash should not be visible until toggling open
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
+    expect(await screen.findByText('performance problem')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
-
     // Should not make grouping-info request
     expect(groupingInfoRequest).not.toHaveBeenCalled();
   });
@@ -84,8 +80,9 @@ describe('EventGroupingInfo', function () {
     });
 
     render(<EventGroupingInfoSection {...defaultProps} showGroupingConfig />);
-
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
+    await userEvent.click(
+      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
+    );
 
     // Should show first hash
     await screen.findByText('123');

--- a/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
@@ -47,7 +47,7 @@ describe('EventGroupingInfo', function () {
       screen.getByRole('button', {name: 'View Event Grouping Information Section'})
     );
     expect(await screen.findByText('variant description')).toBeInTheDocument();
-    expect(await screen.findByText('123')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
   });
 
   it('gets performance grouping info from group/event data', async function () {
@@ -59,9 +59,6 @@ describe('EventGroupingInfo', function () {
 
     render(
       <EventGroupingInfoSection {...defaultProps} event={perfEvent} group={perfGroup} />
-    );
-    await userEvent.click(
-      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
     );
 
     expect(await screen.findByText('performance problem')).toBeInTheDocument();
@@ -80,9 +77,6 @@ describe('EventGroupingInfo', function () {
     });
 
     render(<EventGroupingInfoSection {...defaultProps} showGroupingConfig />);
-    await userEvent.click(
-      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
-    );
 
     // Should show first hash
     await screen.findByText('123');

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -56,16 +56,10 @@ describe('HighlightsDataSection', function () {
       />,
       {organization}
     );
-    expect(screen.getByText('Event Highlights')).toBeInTheDocument();
+    expect(screen.getByText('Highlights')).toBeInTheDocument();
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText("There's nothing here...")).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Add Highlights'})).toBeInTheDocument();
-    const viewAllButton = screen.getByRole('button', {name: 'View All'});
-    await userEvent.click(viewAllButton);
-    expect(analyticsSpy).toHaveBeenCalledWith(
-      'highlights.issue_details.view_all_clicked',
-      expect.anything()
-    );
     const editButton = screen.getByRole('button', {name: 'Edit'});
     await userEvent.click(editButton);
     expect(analyticsSpy).toHaveBeenCalledWith(
@@ -90,7 +84,7 @@ describe('HighlightsDataSection', function () {
     render(<HighlightsDataSection event={event} project={project} />, {
       organization,
     });
-    expect(screen.getByText('Event Highlights')).toBeInTheDocument();
+    expect(screen.getByText('Highlights')).toBeInTheDocument();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     for (const tagKey of highlightTags) {
       const row = screen

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -43,11 +43,16 @@ describe('DebugMeta', function () {
     );
     renderGlobalModal();
 
-    screen.getByRole('heading', {name: 'Images Loaded'});
+    expect(screen.getByRole('region', {name: 'Images Loaded'})).toBeInTheDocument();
     const imageName = image?.debug_file as string;
     expect(screen.queryByText(imageName)).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
+    await userEvent.click(
+      screen.getByRole('button', {name: 'View Images Loaded Section'})
+    );
+    expect(
+      await screen.findByRole('button', {name: 'Collapse Images Loaded Section'})
+    ).toBeInTheDocument();
     expect(screen.getByText('Ok')).toBeInTheDocument();
     expect(screen.getByText(imageName)).toBeInTheDocument();
     expect(screen.getByText('Symbolication')).toBeInTheDocument();
@@ -89,7 +94,6 @@ describe('DebugMeta', function () {
     renderGlobalModal();
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
     await userEvent.click(screen.getByRole('button', {name: 'View'}));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(
@@ -115,8 +119,7 @@ describe('DebugMeta', function () {
     const imageName = image?.debug_file as string;
     const codeFile = image?.code_file as string;
 
-    screen.getByRole('heading', {name: 'Images Loaded'});
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
+    expect(screen.getByRole('region', {name: 'Images Loaded'})).toBeInTheDocument();
     const imageNode = screen.getByText(imageName);
     expect(imageNode).toBeInTheDocument();
 
@@ -158,8 +161,7 @@ describe('DebugMeta', function () {
       {organization}
     );
 
-    screen.getByRole('heading', {name: 'Images Loaded'});
-    await userEvent.click(screen.getByRole('button', {name: 'Show Details'}));
+    expect(screen.getByText('Images Loaded')).toBeInTheDocument();
     expect(screen.getByText(firstImage?.debug_file as string)).toBeInTheDocument();
     expect(screen.getByText(secondImage?.debug_file)).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -238,7 +238,7 @@ describe('Threads', function () {
 
         // Title
         expect(
-          await screen.findByRole('heading', {name: 'Stack Trace'})
+          await screen.findByRole('region', {name: 'Stack Trace'})
         ).toBeInTheDocument();
 
         // Actions
@@ -1013,7 +1013,9 @@ describe('Threads', function () {
           },
         };
         render(<Threads {...newProps} />, {organization});
-        expect(await screen.findByTestId('event-section-threads')).toBeInTheDocument();
+        expect(
+          await screen.findByRole('region', {name: 'Stack Trace'})
+        ).toBeInTheDocument();
         expect(screen.queryByText('Thread Tags')).not.toBeInTheDocument();
       });
 

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -6,6 +6,7 @@ import {AlertLink} from 'sentry/components/core/alert/alertLink';
 import GroupReleaseChart from 'sentry/components/group/releaseChart';
 import SeenInfo from 'sentry/components/group/seenInfo';
 import Placeholder from 'sentry/components/placeholder';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -16,9 +17,6 @@ import type {CurrentRelease, Release} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-
-import QuestionTooltip from '../questionTooltip';
 
 type Props = {
   environments: string[];
@@ -64,8 +62,6 @@ function GroupReleaseStats({
     }
   );
 
-  const hasStreamlinedUI = useHasStreamlinedUI();
-
   const firstRelease = groupReleaseData?.firstRelease;
   const lastRelease = groupReleaseData?.lastRelease;
 
@@ -109,58 +105,56 @@ function GroupReleaseStats({
               lastSeen={group.lastSeen}
             />
           </GraphContainer>
-          {!hasStreamlinedUI && (
-            <div>
-              <SidebarSection.Wrap>
-                <SidebarSection.Title>
-                  <GuideAnchor target="issue_sidebar_releases" position="left">
-                    {t('Last Seen')}
-                  </GuideAnchor>
-                  <QuestionTooltip
-                    title={t('When the most recent event in this issue was captured.')}
-                    size="xs"
-                  />
-                </SidebarSection.Title>
-                <StyledSidebarSectionContent>
-                  <SeenInfo
-                    organization={organization}
-                    projectId={projectId}
-                    projectSlug={projectSlug}
-                    date={getDynamicText({
-                      value: group.lastSeen,
-                      fixed: '2016-01-13T03:08:25Z',
-                    })}
-                    dateGlobal={allEnvironments.lastSeen}
-                    environment={shortEnvironmentLabel}
-                    release={lastRelease}
-                  />
-                </StyledSidebarSectionContent>
-              </SidebarSection.Wrap>
-              <SidebarSection.Wrap>
-                <SidebarSection.Title>
-                  {t('First Seen')}
-                  <QuestionTooltip
-                    title={t('When the first event in this issue was captured.')}
-                    size="xs"
-                  />
-                </SidebarSection.Title>
-                <StyledSidebarSectionContent>
-                  <SeenInfo
-                    organization={organization}
-                    projectId={projectId}
-                    projectSlug={projectSlug}
-                    date={getDynamicText({
-                      value: group.firstSeen,
-                      fixed: '2015-08-13T03:08:25Z',
-                    })}
-                    dateGlobal={allEnvironments.firstSeen}
-                    environment={shortEnvironmentLabel}
-                    release={firstRelease}
-                  />
-                </StyledSidebarSectionContent>
-              </SidebarSection.Wrap>
-            </div>
-          )}
+          <div>
+            <SidebarSection.Wrap>
+              <SidebarSection.Title>
+                <GuideAnchor target="issue_sidebar_releases" position="left">
+                  {t('Last Seen')}
+                </GuideAnchor>
+                <QuestionTooltip
+                  title={t('When the most recent event in this issue was captured.')}
+                  size="xs"
+                />
+              </SidebarSection.Title>
+              <StyledSidebarSectionContent>
+                <SeenInfo
+                  organization={organization}
+                  projectId={projectId}
+                  projectSlug={projectSlug}
+                  date={getDynamicText({
+                    value: group.lastSeen,
+                    fixed: '2016-01-13T03:08:25Z',
+                  })}
+                  dateGlobal={allEnvironments.lastSeen}
+                  environment={shortEnvironmentLabel}
+                  release={lastRelease}
+                />
+              </StyledSidebarSectionContent>
+            </SidebarSection.Wrap>
+            <SidebarSection.Wrap>
+              <SidebarSection.Title>
+                {t('First Seen')}
+                <QuestionTooltip
+                  title={t('When the first event in this issue was captured.')}
+                  size="xs"
+                />
+              </SidebarSection.Title>
+              <StyledSidebarSectionContent>
+                <SeenInfo
+                  organization={organization}
+                  projectId={projectId}
+                  projectSlug={projectSlug}
+                  date={getDynamicText({
+                    value: group.firstSeen,
+                    fixed: '2015-08-13T03:08:25Z',
+                  })}
+                  dateGlobal={allEnvironments.firstSeen}
+                  environment={shortEnvironmentLabel}
+                  release={firstRelease}
+                />
+              </StyledSidebarSectionContent>
+            </SidebarSection.Wrap>
+          </div>
           {hasRelease ? null : (
             <SidebarSection.Wrap>
               <SidebarSection.Title>{t('Releases')}</SidebarSection.Title>

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -316,7 +316,7 @@ describe('GroupActions', function () {
       />
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Resolved'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Unresolve'}));
 
     expect(issuesApi).toHaveBeenCalledWith(
       `/projects/${organization.slug}/project/issues/`,

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -21,9 +20,7 @@ jest.mock('sentry/views/issueDetails/issueDetailsTour', () => ({
 }));
 
 describe('NewIssueExperienceButton', function () {
-  const organization = OrganizationFixture();
-  const user = UserFixture();
-  user.options.prefersIssueDetailsStreamlinedUI = true;
+  const organization = OrganizationFixture({streamlineOnly: null});
 
   beforeEach(() => {
     ConfigStore.init();
@@ -78,18 +75,12 @@ describe('NewIssueExperienceButton', function () {
 
     render(<NewIssueExperienceButton />, {organization});
 
-    const button = screen.getByRole('button', {
+    const newExperienceButton = screen.getByRole('button', {
       name: 'Switch to the new issue experience',
     });
 
-    await userEvent.click(button);
+    await userEvent.click(newExperienceButton);
 
-    const dropdownButton = screen.getByRole('button', {name: 'Manage issue experience'});
-    await userEvent.click(dropdownButton);
-    const oldExperienceButton = screen.getByRole('menuitemradio', {
-      name: 'Switch to the old issue experience',
-    });
-    expect(oldExperienceButton).toBeInTheDocument();
     // User option should be saved
     await waitFor(() => {
       expect(mockChangeUserSettings).toHaveBeenCalledWith(
@@ -105,6 +96,10 @@ describe('NewIssueExperienceButton', function () {
     });
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
 
+    await userEvent.click(screen.getByRole('button', {name: 'Manage issue experience'}));
+    const oldExperienceButton = screen.getByRole('menuitemradio', {
+      name: 'Switch to the old issue experience',
+    });
     // Clicking again toggles it off
     await userEvent.click(oldExperienceButton);
     // Old text should be back

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -1,11 +1,12 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {RepositoryFixture} from 'sentry-fixture/repository';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -31,9 +32,12 @@ describe('GroupActivity', function () {
   beforeEach(function () {
     project = ProjectFixture();
     ProjectsStore.loadInitialData([project]);
-    ConfigStore.init();
-    ConfigStore.set('user', UserFixture({id: '123'}));
     GroupStore.init();
+    // XXX: Explicitly using legacy UI since this component is not used in the new one
+    ConfigStore.init();
+    const user = UserFixture({id: '123'});
+    user.options.prefersIssueDetailsStreamlinedUI = false;
+    ConfigStore.set('user', user);
   });
 
   afterEach(() => {
@@ -61,11 +65,10 @@ describe('GroupActivity', function () {
       project,
     });
     GroupStore.add([group]);
-
-    const {organization, router} = initializeOrg({
-      router: {
-        params: {orgId: 'org-slug', groupId: group.id},
-      },
+    // XXX: Explicitly using legacy UI since this component is not used in the new one
+    const organization = OrganizationFixture({streamlineOnly: false});
+    const router = RouterFixture({
+      params: {orgId: organization.slug, groupId: group.id},
     });
 
     MockApiClient.addMockResponse({
@@ -75,7 +78,7 @@ describe('GroupActivity', function () {
 
     TeamStore.loadInitialData([TeamFixture({id: '999', slug: 'no-team'})]);
     OrganizationStore.onUpdate(organization, {replace: true});
-    return render(<GroupActivity />, {router, organization});
+    render(<GroupActivity />, {router, organization});
   }
 
   it('renders a NoteInput', async function () {
@@ -404,7 +407,9 @@ describe('GroupActivity', function () {
         url: '/organizations/org-slug/issues/1337/comments/note-1/',
         method: 'DELETE',
       });
-      ConfigStore.set('user', UserFixture({id: '123', isSuperuser: true}));
+      const user = UserFixture({id: '123', isSuperuser: true});
+      user.options.prefersIssueDetailsStreamlinedUI = false;
+      ConfigStore.set('user', user);
     });
 
     it('should remove remove the item from the GroupStore make a DELETE API request', async function () {

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -77,7 +77,11 @@ describe('GroupEventAttachments', function () {
     expect(getAttachmentsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/group-id/attachments/',
       expect.objectContaining({
-        query: {screenshot: '1'},
+        query: {
+          screenshot: '1',
+          environment: [],
+          statsPeriod: '14d',
+        },
       })
     );
   });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useEffect, useMemo} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -221,7 +220,7 @@ function GroupEventDetails() {
                 {renderContent()}
               </MainLayoutComponent>
               {hasStreamlinedUI ? null : (
-                <StyledLayoutSide hasStreamlinedUi={hasStreamlinedUI}>
+                <StyledLayoutSide>
                   <GroupSidebar
                     organization={organization}
                     project={project}
@@ -264,22 +263,15 @@ const StyledLayoutMain = styled(Layout.Main)`
   }
 `;
 
-const StyledLayoutSide = styled(Layout.Side)<{hasStreamlinedUi: boolean}>`
-  ${p =>
-    p.hasStreamlinedUi
-      ? css`
-          padding: ${space(1.5)} ${space(2)};
-        `
-      : css`
-          padding: ${space(3)} ${space(2)} ${space(3)};
-
-          @media (min-width: ${p.theme.breakpoints.large}) {
-            padding-right: ${space(4)};
-          }
-        `}
+const StyledLayoutSide = styled(Layout.Side)`
+  padding: ${space(3)} ${space(2)} ${space(3)};
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
-    padding-left: ${p => (p.hasStreamlinedUi ? space(0.5) : 0)};
+    padding-right: ${space(4)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    padding-left: 0;
   }
 `;
 

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -2,6 +2,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {
   render,
@@ -11,6 +12,7 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import GroupEvents from 'sentry/views/issueDetails/groupEvents';
@@ -23,7 +25,14 @@ describe('groupEvents', () => {
 
   beforeEach(() => {
     group = GroupFixture();
-    organization = OrganizationFixture({features: ['event-attachments']});
+    // XXX: Explicitly using legacy UI since this component is not used in the new one
+    const user = UserFixture({id: '123'});
+    user.options.prefersIssueDetailsStreamlinedUI = false;
+    ConfigStore.set('user', user);
+    organization = OrganizationFixture({
+      features: ['event-attachments'],
+      streamlineOnly: false,
+    });
     router = RouterFixture({
       params: {orgId: 'org-slug', groupId: group.id},
       location: LocationFixture({

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -85,7 +85,7 @@ const AllEventsFilters = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-// TODO(streamlined-ui): Remove this file completely and change rotue to new events list
+// TODO(streamlined-ui): Remove this file completely and change route to new events list
 function IssueEventsList() {
   const hasStreamlinedUI = useHasStreamlinedUI();
   const params = useParams<{groupId: string}>();

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -40,10 +40,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useUser} from 'sentry/utils/useUser';
 import {ParticipantList} from 'sentry/views/issueDetails/participantList';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
-import {ExternalIssueSidebarList} from 'sentry/views/issueDetails/streamline/sidebar/externalIssueSidebarList';
 import SeerSection from 'sentry/views/issueDetails/streamline/sidebar/seerSection';
 import {makeFetchGroupQueryKey} from 'sentry/views/issueDetails/useGroup';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 type Props = {
   environments: string[];
@@ -84,7 +82,6 @@ export default function GroupSidebar({
   const activeUser = useUser();
   const {data: allEnvironmentsGroupData} = useFetchAllEnvsGroupData(organization, group);
   const {data: currentRelease} = useFetchCurrentRelease(organization, group);
-  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const location = useLocation();
 
@@ -263,15 +260,7 @@ export default function GroupSidebar({
           <SeerSection group={group} project={project} event={event} />
         </ErrorBoundary>
       )}
-
-      {hasStreamlinedUI && event && (
-        <ErrorBoundary mini>
-          <ExternalIssueSidebarList group={group} event={event} project={project} />
-        </ErrorBoundary>
-      )}
-      {!hasStreamlinedUI && (
-        <AssignedTo group={group} event={event} project={project} onAssign={onAssign} />
-      )}
+      <AssignedTo group={group} event={event} project={project} onAssign={onAssign} />
       {issueTypeConfig.stats.enabled && (
         <GroupReleaseStats
           organization={organization}
@@ -282,12 +271,12 @@ export default function GroupSidebar({
           currentRelease={currentRelease}
         />
       )}
-      {!hasStreamlinedUI && event && (
+      {event && (
         <ErrorBoundary mini>
           <ExternalIssueList project={project} group={group} event={event} />
         </ErrorBoundary>
       )}
-      {!hasStreamlinedUI && renderPluginIssue()}
+      {renderPluginIssue()}
       {issueTypeConfig.pages.tagsTab.enabled && (
         <TagFacets
           environments={environments}
@@ -308,8 +297,8 @@ export default function GroupSidebar({
       {issueTypeConfig.regression.enabled && event && (
         <EventThroughput event={event} group={group} />
       )}
-      {!hasStreamlinedUI && renderParticipantData()}
-      {!hasStreamlinedUI && renderSeenByList()}
+      {renderParticipantData()}
+      {renderSeenByList()}
     </Container>
   );
 }

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -161,6 +161,8 @@ export function FoldSection({
   );
   const labelPrefix = isCollapsed ? t('View') : t('Collapse');
   const labelSuffix = typeof title === 'string' ? title + t(' Section') : t('Section');
+  // XXX: We should eventually only use titles as string, or explicitly pass them to stay accessible
+  const titleLabel = typeof title === 'string' ? title : sectionKey;
 
   return (
     <Fragment>
@@ -169,6 +171,7 @@ export function FoldSection({
         id={sectionKey}
         scrollMargin={navScrollMargin ?? 0}
         role="region"
+        aria-label={titleLabel}
         className={className}
       >
         <SectionExpander

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -13,19 +13,18 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import StreamlinedGroupHeader from 'sentry/views/issueDetails/streamline/header/header';
 import {ReprocessingStatus} from 'sentry/views/issueDetails/utils';
 
+jest.mock('sentry/utils/useFeedbackForm', () => ({
+  useFeedbackForm: () => jest.fn(),
+}));
+
 jest.mock('sentry/views/issueDetails/issueDetailsTour', () => ({
   ...jest.requireActual('sentry/views/issueDetails/issueDetailsTour'),
   useIssueDetailsTour: () => mockTour(),
 }));
 
-jest.mock('sentry/views/issueDetails/utils', () => ({
-  ...jest.requireActual('sentry/views/issueDetails/utils'),
-  useHasStreamlinedUI: () => true,
-}));
-
 describe('StreamlinedGroupHeader', () => {
   const baseUrl = 'BASE_URL/';
-  const organization = OrganizationFixture({streamlineOnly: null});
+  const organization = OrganizationFixture();
   const project = ProjectFixture({
     platform: 'javascript',
     teams: [TeamFixture()],

--- a/static/app/views/issueDetails/streamline/header/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.spec.tsx
@@ -25,7 +25,7 @@ jest.mock('sentry/views/issueDetails/utils', () => ({
 
 describe('StreamlinedGroupHeader', () => {
   const baseUrl = 'BASE_URL/';
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({streamlineOnly: null});
   const project = ProjectFixture({
     platform: 'javascript',
     teams: [TeamFixture()],

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -4,7 +4,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {EntryType} from 'sentry/types/event';
 import {type Group, IssueCategory} from 'sentry/types/group';
@@ -92,44 +92,9 @@ describe('SeerSection', () => {
       {organization: customOrganization}
     );
 
-    expect(screen.getByText('How to fix ChunkLoadErrors')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'READ MORE'})).toBeInTheDocument();
-  });
-
-  it('toggles resources content when clicking Read More/Show Less', async () => {
-    const customOrganization = OrganizationFixture({
-      hideAiFeatures: true,
-      genAIConsent: false,
-    });
-
-    const disabledIssueSummaryGroup: Group = {
-      ...mockGroup,
-      issueCategory: IssueCategory.PERFORMANCE,
-      title: 'ChunkLoadError',
-      platform: 'javascript',
-    };
-
-    const javascriptProject: Project = {...mockProject, platform: 'javascript'};
-
-    render(
-      <SeerSection
-        event={mockEvent}
-        group={disabledIssueSummaryGroup}
-        project={javascriptProject}
-      />,
-      {organization: customOrganization}
-    );
-
-    const readMoreButton = screen.getByRole('button', {name: 'READ MORE'});
-    await userEvent.click(readMoreButton);
-
-    expect(screen.getByRole('button', {name: 'SHOW LESS'})).toBeInTheDocument();
-
-    const showLessButton = screen.getByRole('button', {name: 'SHOW LESS'});
-    await userEvent.click(showLessButton);
-
-    expect(screen.queryByRole('button', {name: 'SHOW LESS'})).not.toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'READ MORE'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'How to fix ChunkLoadErrors'})
+    ).toBeInTheDocument();
   });
 
   describe('Seer button text', () => {
@@ -216,7 +181,7 @@ describe('SeerSection', () => {
       });
     });
 
-    it('shows "READ MORE" when only resources are available', async () => {
+    it('shows resource link when available', () => {
       const disabledIssueSummaryGroup: Group = {
         ...mockGroup,
         issueCategory: IssueCategory.PERFORMANCE,
@@ -245,7 +210,9 @@ describe('SeerSection', () => {
         {organization}
       );
 
-      expect(await screen.findByRole('button', {name: 'READ MORE'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'How to fix ChunkLoadErrors'})
+      ).toBeInTheDocument();
     });
 
     it('does not show CTA button when region is de', () => {

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -18,20 +18,19 @@ const contextWrapper = (organization: Organization) => {
 
 describe('useHasStreamlinedUI', () => {
   it('respects the user preferences', () => {
-    ConfigStore.init();
     const user = UserFixture();
     user.options.prefersIssueDetailsStreamlinedUI = true;
     act(() => ConfigStore.set('user', user));
 
     const {result: userPrefersStreamline} = renderHook(useHasStreamlinedUI, {
-      wrapper: contextWrapper(OrganizationFixture()),
+      wrapper: contextWrapper(OrganizationFixture({streamlineOnly: null})),
     });
     expect(userPrefersStreamline.current).toBe(true);
 
     user.options.prefersIssueDetailsStreamlinedUI = false;
     act(() => ConfigStore.set('user', user));
     const {result: userPrefersLegacy} = renderHook(useHasStreamlinedUI, {
-      wrapper: contextWrapper(OrganizationFixture()),
+      wrapper: contextWrapper(OrganizationFixture({streamlineOnly: null})),
     });
     expect(userPrefersLegacy.current).toBe(false);
   });
@@ -39,6 +38,7 @@ describe('useHasStreamlinedUI', () => {
   it('ignores preferences if enforce flag is set and user has not opted out', () => {
     const enforceOrg = OrganizationFixture({
       features: ['issue-details-streamline-enforce'],
+      streamlineOnly: null,
     });
 
     ConfigStore.init();
@@ -55,6 +55,7 @@ describe('useHasStreamlinedUI', () => {
   it('respects preferences if enforce flag is set and user has opted out', () => {
     const enforceOrg = OrganizationFixture({
       features: ['issue-details-streamline-enforce'],
+      streamlineOnly: null,
     });
 
     ConfigStore.init();

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -48,6 +48,10 @@ describe('SharedGroupDetails', function () {
         errors: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/test-org/project-slug/events/1/committers/`,
+      body: [],
+    });
   });
 
   afterEach(function () {

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -80,7 +80,7 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     relayPiiConfig: null,
     require2FA: false,
     requiresSso: false,
-    streamlineOnly: null,
+    streamlineOnly: true,
     safeFields: [],
     samplingMode: 'organization',
     scrubIPAddresses: false,

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -15,7 +15,7 @@ export function UserFixture(params: Partial<User> = {}): User {
       defaultIssueEvent: 'recommended',
       avatarType: 'letter_avatar',
       stacktraceOrder: -1,
-      prefersIssueDetailsStreamlinedUI: false,
+      prefersIssueDetailsStreamlinedUI: true,
       prefersSpecializedProjectOverview: {},
       prefersStackedNavigation: false,
       prefersChonkUI: false,


### PR DESCRIPTION
Only one of these is probably necessary to convert all of the `useHasStreamlineUI` invocations to return `true`, but this also works.