### PR TITLE
feat(schema-hints): Add column when schema hints is added to query

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -30,6 +30,8 @@ import {
   removeHiddenKeys,
   SchemaHintsSources,
 } from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
+import type {LogPageParamsUpdate} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import type {WritablePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
@@ -45,7 +47,8 @@ interface SchemaHintsListProps extends SchemaHintsPageParams {
 
 export interface SchemaHintsPageParams {
   exploreQuery: string;
-  setExploreQuery: (query: string) => void;
+  setPageParams: (pageParams: WritablePageParams | LogPageParamsUpdate) => void;
+  tableColumns: string[];
 }
 
 const seeFullListTag: Tag = {
@@ -90,7 +93,8 @@ function SchemaHintsList({
   stringTags,
   isLoading,
   exploreQuery,
-  setExploreQuery,
+  tableColumns,
+  setPageParams,
   source = SchemaHintsSources.EXPLORE,
 }: SchemaHintsListProps) {
   const schemaHintsContainerRef = useRef<HTMLDivElement>(null);
@@ -207,7 +211,9 @@ function SchemaHintsList({
               <SchemaHintsDrawer
                 hints={filterTagsSorted}
                 exploreQuery={exploreQuery}
-                setExploreQuery={setExploreQuery}
+                tableColumns={tableColumns}
+                setPageParams={setPageParams}
+                source={source}
               />
             ),
             {
@@ -224,8 +230,8 @@ function SchemaHintsList({
                   location.pathname !== newLocation.pathname ||
                   // will close if anything but the filter query has changed
                   !isEqual(
-                    omit(location.query, ['query']),
-                    omit(newLocation.query, ['query'])
+                    omit(location.query, ['query', 'field', 'search', 'logsQuery']),
+                    omit(newLocation.query, ['query', 'field', 'search', 'logsQuery'])
                   )
                 );
               },
@@ -260,7 +266,24 @@ function SchemaHintsList({
         getFieldDefinition(hint.key, 'span', hint.kind)?.valueType ===
         FieldValueType.BOOLEAN;
       addFilterToQuery(newSearchQuery, hint, isBoolean);
-      setExploreQuery(newSearchQuery.formatString());
+
+      const newTableColumns = tableColumns.includes(hint.key)
+        ? tableColumns
+        : [...tableColumns, hint.key];
+      const newQuery = newSearchQuery.formatString();
+
+      setPageParams(
+        source === SchemaHintsSources.LOGS
+          ? {
+              search: newSearchQuery,
+              fields: newTableColumns,
+            }
+          : {
+              query: newQuery,
+              fields: newTableColumns,
+            }
+      );
+
       trackAnalytics('trace.explorer.schema_hints_click', {
         hint_key: hint.key,
         source: 'list',
@@ -269,9 +292,11 @@ function SchemaHintsList({
     },
     [
       exploreQuery,
-      setExploreQuery,
-      isDrawerOpen,
+      tableColumns,
+      setPageParams,
+      source,
       organization,
+      isDrawerOpen,
       openDrawer,
       filterTagsSorted,
       location.pathname,

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -65,6 +65,7 @@ export function TraceItemSearchQueryBuilder({
   portalTarget,
   projects: _projects,
   supportedAggregates = [],
+  submitOnFilterChange = false,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
@@ -86,6 +87,7 @@ export function TraceItemSearchQueryBuilder({
       fieldDefinitionGetter={getTraceItemFieldDefinitionFunction(itemType, filterTags)}
       onSearch={onSearch}
       onBlur={onBlur}
+      onChange={submitOnFilterChange ? onSearch : undefined}
       getFilterTokenWarning={getFilterTokenWarning}
       searchSource={searchSource}
       filterKeySections={filterKeySections}

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -44,7 +44,7 @@ interface LogsPageParams {
   readonly projectIds?: number[];
 }
 
-type LogPageParamsUpdate = Partial<LogsPageParams>;
+export type LogPageParamsUpdate = Partial<LogsPageParams>;
 
 const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
   createDefinedContext<LogsPageParams>({

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -52,7 +52,7 @@ interface ReadablePageParams {
   title?: string;
 }
 
-interface WritablePageParams {
+export interface WritablePageParams {
   dataset?: DiscoverDatasets | null;
   fields?: string[] | null;
   groupBys?: string[] | null;

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -20,9 +20,11 @@ import SchemaHintsList, {
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {
+  type LogPageParamsUpdate,
   useLogsFields,
   useLogsSearch,
   useSetLogsFields,
+  useSetLogsPageParams,
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -49,6 +51,7 @@ export function LogsTabContent({
   const logsSearch = useLogsSearch();
   const fields = useLogsFields();
   const setFields = useSetLogsFields();
+  const setLogsPageParams = useSetLogsPageParams();
   const tableData = useExploreLogsTable({});
   const isSchemaHintsDrawerOpenOnLargeScreen = useSchemaHintsOnLargeScreen();
 
@@ -100,6 +103,7 @@ export function LogsTabContent({
             numberAttributes={numberTags}
             stringAttributes={stringTags}
             itemType={TraceItemDataset.LOGS}
+            submitOnFilterChange
           />
 
           <Button onClick={openColumnEditor} icon={<IconTable />}>
@@ -116,8 +120,11 @@ export function LogsTabContent({
               stringTags={stringTags}
               isLoading={numberTagsLoading || stringTagsLoading}
               exploreQuery={logsSearch.formatString()}
-              setExploreQuery={setLogsQuery}
               source={SchemaHintsSources.LOGS}
+              setPageParams={pageParams =>
+                setLogsPageParams(pageParams as LogPageParamsUpdate)
+              }
+              tableColumns={fields}
             />
           </SchemaHintsSection>
         </Feature>

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -38,9 +38,11 @@ import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUti
 import {
   PageParamsProvider,
   useExploreDataset,
+  useExploreFields,
   useExploreMode,
   useExploreQuery,
   useExploreVisualizes,
+  useSetExplorePageParams,
   useSetExploreQuery,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -92,6 +94,8 @@ export function SpansTabContentImpl({
 
   const query = useExploreQuery();
   const setQuery = useSetExploreQuery();
+  const fields = useExploreFields();
+  const setExplorePageParams = useSetExplorePageParams();
 
   const isSchemaHintsDrawerOpenOnLargeScreen = useSchemaHintsOnLargeScreen();
 
@@ -259,8 +263,9 @@ export function SpansTabContentImpl({
             stringTags={stringTags}
             isLoading={numberTagsLoading || stringTagsLoading}
             exploreQuery={query}
-            setExploreQuery={setQuery}
             source={SchemaHintsSources.EXPLORE}
+            tableColumns={fields}
+            setPageParams={setExplorePageParams}
           />
         </SchemaHintsSection>
       </Feature>
@@ -387,8 +392,8 @@ const Body = styled(Layout.Body)<{
     display: grid;
     ${p =>
       p.withToolbar
-        ? `grid-template-columns: 300px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`
-        : `grid-template-columns: 0px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`}
+        ? `grid-template-columns: 300px minmax(100px, auto);`
+        : `grid-template-columns: 0px minmax(100px, auto)`}
     grid-template-rows: auto ${p => (p.withHints ? 'auto 1fr' : '1fr')};
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -392,8 +392,8 @@ const Body = styled(Layout.Body)<{
     display: grid;
     ${p =>
       p.withToolbar
-        ? `grid-template-columns: 300px minmax(100px, auto);`
-        : `grid-template-columns: 0px minmax(100px, auto)`}
+        ? `grid-template-columns: 300px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`
+        : `grid-template-columns: 0px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`}
     grid-template-rows: auto ${p => (p.withHints ? 'auto 1fr' : '1fr')};
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};


### PR DESCRIPTION
When a query is added from schema hints, we'll add the column as well. Addresses[ this suggestion](https://www.notion.so/sentry/Adding-a-filter-by-clicking-these-pills-should-also-add-a-column-to-the-table-1c08b10e4b5d80e4a321db1b2c16cd11?pvs=4) from bug bash

