### PR TITLE
fix(visibility): Return `meta` in span samples responses

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -8,7 +8,11 @@ from rest_framework.response import Response
 from sentry import features, options, search
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase, OrganizationEventsV2EndpointBase
+from sentry.api.bases import (
+    NoProjects,
+    OrganizationEventsEndpointBase,
+    OrganizationEventsV2EndpointBase,
+)
 from sentry.api.event_search import parse_search_query
 from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.serializers import serialize
@@ -180,7 +184,9 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
             return Response({})
 
         use_rpc = request.GET.get("useRpc", "0") == "1"
-        transform_alias_to_input_format = request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
+        transform_alias_to_input_format = (
+            request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
+        )
 
         if use_rpc:
             result = get_eap_span_samples(request, snuba_params)
@@ -199,7 +205,9 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
         )
 
 
-def get_span_samples(request: Request, snuba_params: SnubaParams, transform_alias_to_input_format: bool):
+def get_span_samples(
+    request: Request, snuba_params: SnubaParams, transform_alias_to_input_format: bool
+):
     is_frontend = is_frontend_request(request)
     buckets = request.GET.get("intervals", 3)
     lower_bound = request.GET.get("lowerBound", 0)
@@ -275,7 +283,7 @@ def get_span_samples(request: Request, snuba_params: SnubaParams, transform_alia
         limit=9,
         referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
         query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
-        transform_alias_to_input_format=transform_alias_to_input_format
+        transform_alias_to_input_format=transform_alias_to_input_format,
     )
 
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -180,11 +180,12 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
             return Response({})
 
         use_rpc = request.GET.get("useRpc", "0") == "1"
+        transform_alias_to_input_format = request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
 
         if use_rpc:
             result = get_eap_span_samples(request, snuba_params)
         else:
-            result = get_span_samples(request, snuba_params)
+            result = get_span_samples(request, snuba_params, transform_alias_to_input_format)
 
         return Response(
             self.handle_results_with_meta(
@@ -198,7 +199,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
         )
 
 
-def get_span_samples(request: Request, snuba_params: SnubaParams):
+def get_span_samples(request: Request, snuba_params: SnubaParams, transform_alias_to_input_format: bool):
     is_frontend = is_frontend_request(request)
     buckets = request.GET.get("intervals", 3)
     lower_bound = request.GET.get("lowerBound", 0)
@@ -274,6 +275,7 @@ def get_span_samples(request: Request, snuba_params: SnubaParams):
         limit=9,
         referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
         query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
+        transform_alias_to_input_format=transform_alias_to_input_format
     )
 
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -184,14 +184,11 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
             return Response({})
 
         use_rpc = request.GET.get("useRpc", "0") == "1"
-        transform_alias_to_input_format = (
-            request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
-        )
 
         if use_rpc:
             result = get_eap_span_samples(request, snuba_params)
         else:
-            result = get_span_samples(request, snuba_params, transform_alias_to_input_format)
+            result = get_span_samples(request, snuba_params)
 
         return Response(
             self.handle_results_with_meta(
@@ -205,9 +202,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
         )
 
 
-def get_span_samples(
-    request: Request, snuba_params: SnubaParams, transform_alias_to_input_format: bool
-):
+def get_span_samples(request: Request, snuba_params: SnubaParams):
     is_frontend = is_frontend_request(request)
     buckets = request.GET.get("intervals", 3)
     lower_bound = request.GET.get("lowerBound", 0)
@@ -283,7 +278,7 @@ def get_span_samples(
         limit=9,
         referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
         query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
-        transform_alias_to_input_format=transform_alias_to_input_format,
+        transform_alias_to_input_format=True,
     )
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -455,7 +455,7 @@ class OrganizationEventsRelatedIssuesEndpoint(APITestCase, SnubaTestCase):
         assert int(response.data[0]["id"]) == event.group_id
 
 
-class OrganizationSpansSamplesEndpoint(APITestCase, SnubaTestCase):
+class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointTestBase, SnubaTestCase):
     url_name = "sentry-api-0-organization-spans-samples"
 
     @mock.patch("sentry.search.events.builder.base.raw_snql_query")
@@ -530,6 +530,49 @@ class OrganizationSpansSamplesEndpoint(APITestCase, SnubaTestCase):
                 "MATCH (spans SAMPLE 100000000.0)"
                 in mock_raw_snql_query.call_args_list[0][0][0].serialize()
             )
+
+    def test_basic_query(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        url = reverse(self.url_name, kwargs={"organization_id_or_slug": project.organization.slug})
+
+        span = self.create_span(
+            {
+                "span_id": "ab4d0a103a55489c",
+                "op": "db",
+                "description": "SELECT *",
+                "sentry_tags": {
+                    "op": "db",
+                    "category": "db",
+                },
+            },
+            duration=200,
+            start_ts=self.ten_mins_ago,
+        )
+        self.store_span(span)
+
+        response = self.client.get(
+            url,
+            {
+                "query": "",
+                "lowerBound": "0",
+                "firstBound": "100",
+                "secondBound": "200",
+                "upperBound": "300",
+                "column": "span.duration",
+                "project": self.project.id,
+                "transformAliasToInputFormat": "1",
+            },
+            format="json",
+        )
+
+        data = response.data["data"]
+
+        assert data[0]["span.duration"] == 200
+        assert data[0]["span_id"] == "ab4d0a103a55489c"
+        assert data[0]["project"] == self.project.slug
+
+        assert response.status_code == 200, response.content
 
 
 class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestBase):

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -561,7 +561,6 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointTestBase, Snuba
                 "upperBound": "300",
                 "column": "span.duration",
                 "project": self.project.id,
-                "transformAliasToInputFormat": "1",
             },
             format="json",
         )

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -566,13 +566,18 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointTestBase, Snuba
             format="json",
         )
 
+        assert response.status_code == 200, response.content
+
         data = response.data["data"]
 
         assert data[0]["span.duration"] == 200
         assert data[0]["span_id"] == "ab4d0a103a55489c"
         assert data[0]["project"] == self.project.slug
 
-        assert response.status_code == 200, response.content
+        meta = response.data["meta"]
+
+        assert meta["fields"]["span.duration"] == "duration"
+        assert meta["units"]["span.duration"] == "millisecond"
 
 
 class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestBase):
@@ -631,6 +636,7 @@ class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestB
                 "firstBound": "10",
                 "secondBound": "20",
                 "upperBound": "200",
+                "column": "span.duration",
                 "project": self.project.id,
             },
         )
@@ -641,3 +647,7 @@ class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestB
         assert data[1]["span_id"] == spans[2]["span_id"]
         assert data[2]["span_id"] == spans[3]["span_id"]
         assert data[3]["span_id"] == spans[4]["span_id"]
+
+        meta = response.data["meta"]
+        assert meta["fields"]["span.duration"] == "duration"
+        assert meta["units"]["span.duration"] == "millisecond"


### PR DESCRIPTION
Right now, `/spans-samples` doesn't return any meta, only `"data"`. This PR runs the response through `handle_results_with_meta` and returns it, which includes the correct standard meta.

Closes [DAIN-49: Return `meta` from span samples endpoint](https://linear.app/getsentry/issue/DAIN-49/return-meta-from-span-samples-endpoint)