### PR TITLE
fix(dashboards-eap): Call onDataFetched for widgetviewer

### DIFF
--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -187,10 +187,11 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
                 dashboardFilters={dashboardFilters}
                 afterFetchSeriesData={afterFetchSeriesData}
                 samplingMode={SAMPLING_MODE.BEST_EFFORT}
-                onDataFetched={() => {
+                onDataFetched={results => {
                   // Reset the query phase to preflight so that the next time this component
                   // renders, it will start with only the preflight query
                   setQueryPhase(SAMPLING_MODE.PREFLIGHT);
+                  onDataFetched?.(results);
                 }}
               >
                 {bestEffortProps => {


### PR DESCRIPTION
Missed this. This needs to get called so we can cache the right data for the widget viewer. Without it, the extrapolation message also doesn't seem to show.