### PR TITLE
feat(issues): Add /suspect/tags/ endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -215,6 +215,9 @@ from sentry.issues.endpoints.organization_group_search_view_starred_order import
 from sentry.issues.endpoints.organization_group_suspect_flags import (
     OrganizationGroupSuspectFlagsEndpoint,
 )
+from sentry.issues.endpoints.organization_group_suspect_tags import (
+    OrganizationGroupSuspectTagsEndpoint,
+)
 from sentry.issues.endpoints.organization_issue_metrics import OrganizationIssueMetricsEndpoint
 from sentry.monitors.endpoints.organization_monitor_checkin_index import (
     OrganizationMonitorCheckInIndexEndpoint,
@@ -785,6 +788,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^\/]+)/suspect/flags/$",
             OrganizationGroupSuspectFlagsEndpoint.as_view(),
             name=f"{name_prefix}-suspect-flags",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^\/]+)/suspect/tags/$",
+            OrganizationGroupSuspectTagsEndpoint.as_view(),
+            name=f"{name_prefix}-suspect-tags",
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/(?:user-feedback|user-reports)/$",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -347,6 +347,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:feature-flag-distribution-flyout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable suspect feature flags endpoint.
     manager.add("organizations:feature-flag-suspect-flags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable suspect feature tags endpoint.
+    manager.add("organizations:issues-suspect-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new release insights charts
     manager.add("organizations:insights-session-health-tab-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Lets organizations manage grouping configs

--- a/src/sentry/issues/endpoints/organization_group_suspect_tags.py
+++ b/src/sentry/issues/endpoints/organization_group_suspect_tags.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import EnvironmentMixin, region_silo_endpoint
+from sentry.api.bases import GroupEndpoint
+from sentry.api.helpers.environments import get_environments
+from sentry.api.utils import get_date_range_from_params
+from sentry.issues.suspect_tags import get_suspect_tag_scores
+from sentry.models.group import Group
+
+
+@region_silo_endpoint
+class OrganizationGroupSuspectTagsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+
+    def get(self, request: Request, group: Group) -> Response:
+        """Stats bucketed by time."""
+        if not features.has(
+            "organizations:issues-suspect-tags",
+            group.organization,
+            actor=request.user,
+        ):
+            return Response(status=404)
+
+        environments = [e.name for e in get_environments(request, group.organization)]
+        group_id = group.id
+        organization_id = group.organization.id
+        project_id = group.project.id
+        start, end = get_date_range_from_params(request.GET)
+
+        # Clamp the range to be within the issue's first and last seen timestamps.
+        start, end = max(start, group.first_seen), min(end, group.last_seen)
+
+        # To increase our cache hit-rate we round the dates down to the nearest 5 minute interval.
+        if end - start > timedelta(minutes=5):
+            start = start.replace(minute=(start.minute // 5) * 5, second=0, microsecond=0)
+            end = end.replace(minute=(end.minute // 5) * 5, second=0, microsecond=0)
+
+        return Response(
+            {
+                "data": [
+                    {"tag": tag, "score": score}
+                    for tag, score in get_suspect_tag_scores(
+                        organization_id,
+                        project_id,
+                        start,
+                        end,
+                        environments,
+                        group_id,
+                    )
+                ]
+            },
+            status=200,
+        )

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
@@ -1,0 +1,84 @@
+import datetime
+import time
+import uuid
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+
+
+class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
+    endpoint = "sentry-api-0-organization-group-suspect-tags"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    @property
+    def features(self):
+        return {"organizations:issues-suspect-tags": True}
+
+    def test_get(self):
+        today = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(minutes=5)
+        group = self.create_group(
+            first_seen=today - datetime.timedelta(hours=1),
+            last_seen=today + datetime.timedelta(hours=1),
+        )
+
+        self._mock_event(
+            today,
+            hash="a" * 32,
+            tags={"key": True, "other": False},
+            group_id=group.id,
+            project_id=self.project.id,
+        )
+        self._mock_event(
+            today,
+            hash="a" * 32,
+            tags={"key": False, "other": False},
+            group_id=2,
+            project_id=self.project.id,
+        )
+
+        with self.feature(self.features):
+            response = self.client.get(f"/api/0/issues/{group.id}/suspect/tags/")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "data": [
+                {"tag": "key", "score": 2.7622287114272543},
+                {"tag": "other", "score": 0.0},
+            ]
+        }
+
+    def test_get_no_tag_access(self):
+        """Does not have feature-tag access."""
+        group = self.create_group()
+        response = self.client.get(f"/api/0/issues/{group.id}/suspect/tags/")
+        assert response.status_code == 404
+
+    def test_get_no_group(self):
+        """Group not found."""
+        with self.feature(self.features):
+            response = self.client.get("/api/0/issues/22/suspect/tags/")
+            assert response.status_code == 404
+
+    def _mock_event(self, ts, hash="a" * 32, group_id=None, project_id=1, tags=None):
+        self.snuba_insert(
+            (
+                2,
+                "insert",
+                {
+                    "event_id": uuid.uuid4().hex,
+                    "primary_hash": hash,
+                    "group_id": group_id if group_id else int(hash[:16], 16),
+                    "project_id": project_id,
+                    "message": "message",
+                    "platform": "python",
+                    "datetime": ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "data": {
+                        "received": time.mktime(ts.timetuple()),
+                        "tags": list(tags.items()),
+                    },
+                },
+                {},
+            )
+        )

--- a/tests/sentry/issues/test_suspect_tags.py
+++ b/tests/sentry/issues/test_suspect_tags.py
@@ -10,7 +10,7 @@ from sentry.issues.suspect_tags import (
 from sentry.testutils.cases import SnubaTestCase, TestCase
 
 
-class SnubaTest(TestCase, SnubaTestCase):
+class SuspectTagsTest(TestCase, SnubaTestCase):
     def mock_event(self, ts, hash="a" * 32, group_id=None, project_id=1, tags=None):
         self.snuba_insert(
             (

--- a/tests/sentry/issues/test_suspect_tags.py
+++ b/tests/sentry/issues/test_suspect_tags.py
@@ -1,0 +1,69 @@
+import datetime
+import time
+import uuid
+
+from sentry.issues.suspect_tags import (
+    get_suspect_tag_scores,
+    query_baseline_set,
+    query_selection_set,
+)
+from sentry.testutils.cases import SnubaTestCase, TestCase
+
+
+class SnubaTest(TestCase, SnubaTestCase):
+    def mock_event(self, ts, hash="a" * 32, group_id=None, project_id=1, tags=None):
+        self.snuba_insert(
+            (
+                2,
+                "insert",
+                {
+                    "event_id": uuid.uuid4().hex,
+                    "primary_hash": hash,
+                    "group_id": group_id if group_id else int(hash[:16], 16),
+                    "project_id": project_id,
+                    "message": "message",
+                    "platform": "python",
+                    "datetime": ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "data": {
+                        "received": time.mktime(ts.timetuple()),
+                        "tags": list(tags.items()),
+                    },
+                },
+                {},
+            )
+        )
+
+    def test_query_baseline_set(self):
+        before = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
+        today = before + datetime.timedelta(hours=1)
+        later = today + datetime.timedelta(hours=1)
+
+        self.mock_event(today, hash="a" * 32, tags={"key": True, "other": False})
+        self.mock_event(today, hash="a" * 32, tags={"key": False, "other": False})
+
+        results = query_baseline_set(
+            1, 1, before, later, environments=[], tag_keys=["key", "other"]
+        )
+        assert results == [("key", "false", 1), ("key", "true", 1), ("other", "false", 2)]
+
+    def test_query_selection_set(self):
+        before = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
+        today = before + datetime.timedelta(hours=1)
+        later = today + datetime.timedelta(hours=1)
+
+        self.mock_event(today, hash="a" * 32, tags={"key": True, "other": False}, group_id=1)
+        self.mock_event(today, hash="a" * 32, tags={"key": False, "other": False}, group_id=2)
+
+        results = query_selection_set(1, 1, before, later, environments=[], group_id=1)
+        assert results == [("key", "true", 1), ("other", "false", 1)]
+
+    def test_get_suspect_tag_scores(self):
+        before = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
+        today = before + datetime.timedelta(hours=1)
+        later = today + datetime.timedelta(hours=1)
+
+        self.mock_event(today, hash="a" * 32, tags={"key": True, "other": False}, group_id=1)
+        self.mock_event(today, hash="a" * 32, tags={"key": False, "other": False}, group_id=2)
+
+        results = get_suspect_tag_scores(1, 1, before, later, envs=[], group_id=1)
+        assert results == [("key", 2.7622287114272543), ("other", 0.0)]


### PR DESCRIPTION
This is not expected to be the final version of the endpoint.  This is a starting point for the issues team to work off of.  For now it uses the feature flag logic which may or may not be applicable to tags.

The endpoint and the suspect_tags module are copies of the suspect-flags endpoint and module (with context appropriate changes).  The two units of work should expect to diverge over time.  There is no need to abstract these modules for re-use.  It will only introduce dependencies between our teams.