### PR TITLE
loadingindicator: cleanup api

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -73,7 +73,7 @@ export function AssigneeBadge({
 
   const loadingIcon = (
     <Fragment>
-      <StyledLoadingIndicator mini hideMessage relative size={AVATAR_SIZE} />
+      <StyledLoadingIndicator mini relative size={AVATAR_SIZE} />
       {showLabel && 'Loading...'}
       <Chevron light color="subText" direction={chevronDirection} size="small" />
     </Fragment>

--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -486,8 +486,6 @@ const MenuTitle = styled('span')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   && {
     margin: 0 ${space(0.5)} 0 ${space(1)};
-    height: 12px;
-    width: 12px;
   }
 `;
 

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -642,8 +642,6 @@ const MenuTitle = styled('span')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   && {
     margin: 0 ${space(0.5)} 0 ${space(1)};
-    height: 12px;
-    width: 12px;
   }
 `;
 

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -228,7 +228,7 @@ function CreatePRsButton({
     <Button
       priority="primary"
       onClick={createPRs}
-      icon={hasClickedCreatePr && <ProcessingStatusIndicator size={14} mini />}
+      icon={hasClickedCreatePr && <StyledLoadingIndicator size={14} mini />}
       size="sm"
       busy={hasClickedCreatePr}
       disabled={isBusy}
@@ -300,7 +300,7 @@ function CreateBranchButton({
   return (
     <Button
       onClick={pushToBranch}
-      icon={hasClickedPushToBranch && <ProcessingStatusIndicator size={14} mini />}
+      icon={hasClickedPushToBranch && <StyledLoadingIndicator size={14} mini />}
       size="sm"
       busy={hasClickedPushToBranch}
       disabled={isBusy}
@@ -649,10 +649,8 @@ const HeaderIconWrapper = styled('div')`
   justify-content: center;
 `;
 
-const ProcessingStatusIndicator = styled(LoadingIndicator)`
+const StyledLoadingIndicator = styled(LoadingIndicator)`
   && {
     margin: 0;
-    height: 14px;
-    width: 14px;
   }
 `;

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -228,9 +228,7 @@ function CreatePRsButton({
     <Button
       priority="primary"
       onClick={createPRs}
-      icon={
-        hasClickedCreatePr && <ProcessingStatusIndicator size={14} mini hideMessage />
-      }
+      icon={hasClickedCreatePr && <ProcessingStatusIndicator size={14} mini />}
       size="sm"
       busy={hasClickedCreatePr}
       disabled={isBusy}
@@ -302,9 +300,7 @@ function CreateBranchButton({
   return (
     <Button
       onClick={pushToBranch}
-      icon={
-        hasClickedPushToBranch && <ProcessingStatusIndicator size={14} mini hideMessage />
-      }
+      icon={hasClickedPushToBranch && <ProcessingStatusIndicator size={14} mini />}
       size="sm"
       busy={hasClickedPushToBranch}
       disabled={isBusy}

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -142,7 +142,7 @@ function TagTreeColumns({
   });
   const assembledColumns = useMemo(() => {
     if (isPending) {
-      return <TreeLoadingIndicator hideMessage />;
+      return <TreeLoadingIndicator />;
     }
 
     if (!project) {

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -228,7 +228,7 @@ function HighlightsData({
     <HighlightContainer columnCount={columnCount} ref={containerRef}>
       {isPending ? (
         <EmptyHighlights>
-          <HighlightsLoadingIndicator hideMessage size={50} />
+          <HighlightsLoadingIndicator size={50} />
         </EmptyHighlights>
       ) : hasDisabledHighlights ? (
         <EmptyHighlights>

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -126,7 +126,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
       // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
       return (
         <StyledDiscoverButton href="#" size="xs" disabled>
-          <StyledLoadingIndicator size={12} />
+          <StyledLoadingIndicator size={16} />
         </StyledDiscoverButton>
       );
     }
@@ -662,7 +662,6 @@ const ValueTd = styled('td')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   display: flex;
   align-items: center;
-  height: ${space(2)};
   margin: 0;
 `;
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -133,7 +133,7 @@ function SpanDetail(props: Props) {
       // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
       return (
         <StyledDiscoverButton href="#" size="xs" disabled>
-          <StyledLoadingIndicator size={12} />
+          <StyledLoadingIndicator size={16} />
         </StyledDiscoverButton>
       );
     }
@@ -641,7 +641,6 @@ const ValueTd = styled('td')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   display: flex;
   align-items: center;
-  height: ${space(2)};
   margin: 0;
 `;
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -343,7 +343,5 @@ const StyledSidebarTitle = styled(SidebarSection.Title)`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  width: 24px;
-  height: 24px;
   margin: 0 !important;
 `;

--- a/static/app/components/groupPreviewTooltip/evidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.tsx
@@ -47,7 +47,7 @@ function SpanEvidencePreviewBody({
   if (isPending) {
     return (
       <EmptyWrapper>
-        <LoadingIndicator hideMessage size={32} />
+        <LoadingIndicator size={32} />
       </EmptyWrapper>
     );
   }

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -51,7 +51,7 @@ function SpanEvidencePreviewBody({
   if (isPending) {
     return (
       <EmptyWrapper>
-        <LoadingIndicator hideMessage size={32} />
+        <LoadingIndicator size={32} />
       </EmptyWrapper>
     );
   }

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -136,7 +136,7 @@ function StackTracePreviewBody({
   if (isPending) {
     return (
       <NoStackTraceWrapper>
-        <LoadingIndicator hideMessage size={32} />
+        <LoadingIndicator size={32} />
       </NoStackTraceWrapper>
     );
   }

--- a/static/app/components/loadingIndicator.stories.tsx
+++ b/static/app/components/loadingIndicator.stories.tsx
@@ -9,8 +9,8 @@ export default storyBook('LoadingIndicator', story => {
   story('Mini', () => <LoadingIndicator mini />);
   story('Sizes', () => (
     <div>
-      <LoadingIndicator size={24} overlay />
-      <StyledLoadingIndicator size={24} overlay />
+      <LoadingIndicator size={24} />
+      <StyledLoadingIndicator size={24} />
     </div>
   ));
 

--- a/static/app/components/loadingIndicator.stories.tsx
+++ b/static/app/components/loadingIndicator.stories.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import storyBook from 'sentry/stories/storyBook';
 
@@ -5,6 +7,17 @@ export default storyBook('LoadingIndicator', story => {
   story('Default', () => <LoadingIndicator />);
 
   story('Mini', () => <LoadingIndicator mini />);
+  story('Sizes', () => (
+    <div>
+      <LoadingIndicator size={24} overlay />
+      <StyledLoadingIndicator size={24} overlay />
+    </div>
+  ));
 
   story('With Message', () => <LoadingIndicator>Loading...</LoadingIndicator>);
 });
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  width: 24px;
+  height: 24px;
+`;

--- a/static/app/components/loadingIndicator.tsx
+++ b/static/app/components/loadingIndicator.tsx
@@ -1,58 +1,34 @@
 import {withProfiler} from '@sentry/react';
 import classNames from 'classnames';
 
-type Props = {
-  children?: React.ReactNode;
+interface LoadingIndicatorProps {
+  children?: NonNullable<React.ReactNode>;
   className?: string;
-  dark?: boolean;
   ['data-test-id']?: string;
-  hideMessage?: boolean;
-  hideSpinner?: boolean;
   mini?: boolean;
   overlay?: boolean;
   relative?: boolean;
   size?: number;
   style?: React.CSSProperties;
-};
+}
 
-function LoadingIndicator(props: Props) {
-  const {
-    hideMessage,
-    mini,
-    overlay,
-    dark,
-    children,
-    className,
-    style,
-    relative,
-    size,
-    hideSpinner,
-    ['data-test-id']: dataTestId,
-  } = props;
-  const cx = classNames(className, {
-    overlay,
-    dark,
-    loading: true,
-    mini,
-  });
-
-  const loadingCx = classNames({
-    relative,
-    'loading-indicator': true,
-  });
-
-  let loadingStyle: React.CSSProperties = {};
-  if (size) {
-    loadingStyle = {
-      width: size,
-      height: size,
-    };
-  }
-
+function LoadingIndicator(props: LoadingIndicatorProps) {
   return (
-    <div className={cx} style={style} data-test-id={dataTestId ?? 'loading-indicator'}>
-      {!hideSpinner && <div className={loadingCx} style={loadingStyle} />}
-      {!hideMessage && <div className="loading-message">{children}</div>}
+    <div
+      className={classNames('loading', props.className, {
+        overlay: props.overlay,
+        mini: props.mini,
+      })}
+      style={props.style}
+      data-test-id={props['data-test-id'] ?? 'loading-indicator'}
+    >
+      <div
+        className={classNames('loading-indicator', {
+          relative: props.relative,
+        })}
+        style={props.size ? {width: props.size, height: props.size} : undefined}
+      />
+      {props.children && <div className="loading-message">{props.children}</div>}
     </div>
   );
 }

--- a/static/app/components/modals/inviteMembersModal/emailValue.tsx
+++ b/static/app/components/modals/inviteMembersModal/emailValue.tsx
@@ -29,7 +29,7 @@ function EmailValue<Option extends OptionTypeBase>({
       <Tooltip disabled={!error} title={error}>
         <EmailLabel>
           {children}
-          {!status.sent && !status.error && <SendingIndicator hideMessage size={14} />}
+          {!status.sent && !status.error && <SendingIndicator size={14} />}
           {status.error && <IconWarning legacySize="10px" />}
         </EmailLabel>
       </Tooltip>

--- a/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
@@ -75,7 +75,7 @@ export default function InviteStatusMessage({
   if (sendingInvites) {
     return (
       <StatusMessage>
-        <LoadingIndicator mini relative hideMessage size={16} />
+        <LoadingIndicator mini relative size={16} />
         {willInvite
           ? t('Sending organization invitations\u2026')
           : t('Sending invite requests\u2026')}

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -110,7 +110,7 @@ export function InviteMissingMembersModal({
     if (sendingInvites) {
       return (
         <StatusMessage>
-          <LoadingIndicator mini relative hideMessage size={16} />
+          <LoadingIndicator mini relative size={16} />
           {t('Sending organization invitations\u2026')}
         </StatusMessage>
       );

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -198,7 +198,7 @@ export function FlamegraphContextMenu(props: FlamegraphContextMenuProps) {
               })}
               icon={
                 sourceCodeLink.isPending ? (
-                  <StyledLoadingIndicator size={10} hideMessage />
+                  <StyledLoadingIndicator size={10} />
                 ) : (
                   <IconGithub size="xs" />
                 )
@@ -448,7 +448,7 @@ export function ContinuousFlamegraphContextMenu(props: FlamegraphContextMenuProp
               })}
               icon={
                 sourceCodeLink.isPending ? (
-                  <StyledLoadingIndicator size={10} hideMessage />
+                  <StyledLoadingIndicator size={10} />
                 ) : (
                   <IconGithub size="xs" />
                 )

--- a/static/app/components/search/list.tsx
+++ b/static/app/components/search/list.tsx
@@ -70,7 +70,7 @@ function List({
     <DropdownBox className={dropdownClassName}>
       {isLoading ? (
         <LoadingWrapper>
-          <LoadingIndicator mini hideMessage relative />
+          <LoadingIndicator mini relative />
         </LoadingWrapper>
       ) : hasResults ? (
         resultList.map((result, index) => {

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -290,7 +290,7 @@ function RuleListRow({
           <ActorAvatar actor={ownerActor} size={24} />
         ) : (
           <AssigneeWrapper>
-            {!projectsLoaded && <StyledLoadingIndicator mini />}
+            {!projectsLoaded && <StyledLoadingIndicator mini size={16} />}
             {projectsLoaded && (
               <DropdownAutoComplete
                 data-test-id="alert-row-assignee"
@@ -432,7 +432,6 @@ const MarginLeft = styled('div')`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  height: 24px;
   margin: 0;
   margin-right: ${space(1.5)};
 `;

--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -15,12 +15,7 @@ type NoContextProps = {
 export function NoContext({isLoading}: NoContextProps) {
   return isLoading ? (
     <NoContextWrapper>
-      <LoadingIndicator
-        data-test-id="quick-context-loading-indicator"
-        hideMessage
-        mini
-        style={{width: '24px'}}
-      />
+      <LoadingIndicator data-test-id="quick-context-loading-indicator" mini size={24} />
     </NoContextWrapper>
   ) : (
     <NoContextWrapper>{t('Failed to load context for column.')}</NoContextWrapper>

--- a/static/app/views/explore/components/progressiveLoadingIndicator.tsx
+++ b/static/app/views/explore/components/progressiveLoadingIndicator.tsx
@@ -18,7 +18,6 @@ function ProgressiveLoadingIndicator() {
     <Tooltip title={t('This widget is currently loading higher fidelity data.')}>
       <_ProgressiveLoadingIndicator
         relative
-        hideMessage
         mini
         size={16}
         data-test-id="progressive-loading-indicator"

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -65,7 +65,7 @@ export function FullSpanDescription({
   if (areIndexedSpansLoading || (isLoading && isFetching)) {
     return (
       <PaddedSpinner>
-        <LoadingIndicator mini hideMessage relative />
+        <LoadingIndicator mini relative />
       </PaddedSpinner>
     );
   }

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -203,7 +203,7 @@ export function SeerSectionCtaButton({
       {getButtonText()}
       <ChevronContainer>
         {isAutofixInProgress ? (
-          <StyledLoadingIndicator mini size={14} hideMessage />
+          <StyledLoadingIndicator mini size={14} />
         ) : (
           <Chevron direction="right" size="large" />
         )}

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -55,7 +55,7 @@ function GroupListBody({
   const organization = useOrganization();
 
   if (loading) {
-    return <LoadingIndicator hideMessage />;
+    return <LoadingIndicator />;
   }
 
   if (error) {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -90,8 +90,6 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
 }
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  width: 14px;
-  height: 14px !important;
   margin: 0 !important;
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -335,7 +335,7 @@ function TagsHeatMap(
                 if (isTransactionsLoading) {
                   return (
                     <LoadingContainer>
-                      <LoadingIndicator size={40} hideMessage />
+                      <LoadingIndicator size={40} />
                     </LoadingContainer>
                   );
                 }

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -162,8 +162,6 @@ const ButtonWrapper = styled('div')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   && {
     /* margin: 0 ${space(0.5)} 0 ${space(1)}; */
-    height: 14px;
-    width: 14px;
   }
 `;
 

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -119,7 +119,7 @@ function MemberInviteModalCustomization({
       if (trialStarting) {
         return (
           <TrialInfo>
-            <LoadingIndicator mini relative hideMessage size={16} />
+            <LoadingIndicator mini relative size={16} />
             {trialStartText}
           </TrialInfo>
         );


### PR DESCRIPTION
Remove unused options and remove hideMessage option in favor of checking the children prop. Also removes most usages where width/height is set in favor of the size API.