### PR TITLE
fix: icon assets color

### DIFF
--- a/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
@@ -245,7 +245,7 @@ function ResourceIcon(props: {fileExtension: string; spanOp: string}) {
     return <PlatformIcon platform="font" />;
   }
   if (spanOp === ResourceSpanOps.IMAGE || IMAGE_FILE_EXTENSIONS.includes(fileExtension)) {
-    return <IconImage color="black" legacySize="20px" />;
+    return <IconImage legacySize="20px" />;
   }
   return <PlatformIcon platform="unknown" />;
 }


### PR DESCRIPTION
![CleanShot 2025-04-03 at 16 50 19@2x](https://github.com/user-attachments/assets/d2dd16b5-b87f-494a-8d20-d47dd460fa32)

This was broken on dark mode. 

Come to think of it, we should really just disable black or white colors here