### PR TITLE
fix(migrations): Fix migration executor db routing checks

### DIFF
--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -2,6 +2,7 @@ import difflib
 import logging
 import os
 
+from django.apps import apps
 from django.contrib.contenttypes.management import RenameContentType
 from django.contrib.postgres.operations import CreateExtension
 from django.db.migrations.executor import MigrationExecutor
@@ -69,7 +70,11 @@ class SentryMigrationExecutor(MigrationExecutor):
         - RunSQL, RunPython need to provide hints['tables']
         """
 
-        if migration.app_label not in {"sentry", "getsentry"}:
+        app_config = apps.get_app_config(migration.app_label)
+        for prefix in ["sentry", "getsentry"]:
+            if app_config.name.startswith(prefix):
+                break
+        else:
             return
 
         def _check_operations(operations):

--- a/src/sentry/uptime/migrations/0022_add_trace_sampling_to_uptime_monitors.py
+++ b/src/sentry/uptime/migrations/0022_add_trace_sampling_to_uptime_monitors.py
@@ -52,6 +52,7 @@ class Migration(CheckedMigration):
         #
         # This was never cleaned up so we're doing that here
         SafeRunSQL(
-            "DROP INDEX CONCURRENTLY IF EXISTS uptime_uptimesubscription_unique_subscription_check_2"
+            "DROP INDEX CONCURRENTLY IF EXISTS uptime_uptimesubscription_unique_subscription_check_2",
+            hints={"tables": ["uptime_uptimesubscription"]},
         ),
     ]

--- a/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
+++ b/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
@@ -31,11 +31,13 @@ class Migration(CheckedMigration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
-                    """DROP INDEX CONCURRENTLY IF EXISTS "detector_state_unique_group_key";"""
+                    """DROP INDEX CONCURRENTLY IF EXISTS "detector_state_unique_group_key";""",
+                    hints={"tables": ["workflow_engine_detectorstate"]},
                 ),
                 migrations.RunSQL(
                     """CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "detector_state_unique_group_key"
-                    ON "workflow_engine_detectorstate" ("detector_id", (COALESCE("detector_group_key", '')))"""
+                    ON "workflow_engine_detectorstate" ("detector_id", (COALESCE("detector_group_key", '')))""",
+                    hints={"tables": ["workflow_engine_detectorstate"]},
                 ),
             ],
             state_operations=[

--- a/tests/sentry/new_migrations/monkey/test_executor.py
+++ b/tests/sentry/new_migrations/monkey/test_executor.py
@@ -29,9 +29,7 @@ def mock_getsentry_if_not_registered():
         return
 
     with (
-        patch.dict(
-            apps.app_configs, {"getsentry": DummyGetsentryAppConfig("getsentry", "getsentry")}
-        ),
+        patch.dict(apps.app_configs, {"getsentry": DummyGetsentryAppConfig("getsentry", None)}),
         patch.object(settings, "INSTALLED_APPS", new=settings.INSTALLED_APPS + ("getsentry",)),
     ):
         yield


### PR DESCRIPTION
These checks don't run on modules that aren't `sentry` or `getsentry`. All of our modules that have migrations should be included here.

<!-- Describe your PR here. -->