### PR TITLE
fix(taskworker) Improve compatibility with celery-beat

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1407,6 +1407,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.release_registry",
     "sentry.tempest.tasks",
     "sentry.tasks.beacon",
+    "sentry.tasks.options",
     "sentry.tasks.ping",
     # Used for tests
     "sentry.taskworker.tasks.examples",

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -26,7 +26,7 @@ from sentry.utils.rollback_metrics import incr_rollback_metrics
 @instrumented_task(
     name="sentry.demo_mode.tasks.sync_artifact_bundles",
     queue="demo_mode",
-    taskworker=TaskworkerConfig(namespace=demomode_tasks),
+    taskworker_config=TaskworkerConfig(namespace=demomode_tasks),
 )
 def sync_artifact_bundles():
 

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -10,7 +10,6 @@ from typing import Any, ParamSpec, TypeVar
 from celery import Task
 from django.conf import settings
 from django.db.models import Model
-from kombu import Producer
 
 from sentry import options
 from sentry.celery import app
@@ -82,9 +81,6 @@ def taskworker_override(
 
         random.seed(datetime.now().timestamp())
         if rollout > random.random():
-            producer = kwargs.get("producer")
-            if isinstance(producer, Producer):
-                del kwargs["producer"]
             return taskworker_attr(*args, **kwargs)
 
         return celery_task_attr(*args, **kwargs)

--- a/src/sentry/tasks/options.py
+++ b/src/sentry/tasks/options.py
@@ -13,12 +13,11 @@ from sentry.taskworker.namespaces import options_control_tasks, options_tasks
 ONE_HOUR = 60 * 60
 logger = logging.getLogger("sentry")
 
-
 @instrumented_task(
     name="sentry.tasks.options.sync_options_control",
     queue="options.control",
     silo_mode=SiloMode.CONTROL,
-    taskworker=TaskworkerConfig(namespace=options_control_tasks),
+    taskworker_config=TaskworkerConfig(namespace=options_control_tasks),
 )
 def sync_options_control(cutoff=ONE_HOUR):
     _sync_options(cutoff)
@@ -27,7 +26,7 @@ def sync_options_control(cutoff=ONE_HOUR):
 @instrumented_task(
     name="sentry.tasks.options.sync_options",
     queue="options",
-    taskworker=TaskworkerConfig(namespace=options_tasks),
+    taskworker_config=TaskworkerConfig(namespace=options_tasks),
 )
 def sync_options(cutoff=ONE_HOUR):
     _sync_options(cutoff)

--- a/src/sentry/tasks/options.py
+++ b/src/sentry/tasks/options.py
@@ -13,6 +13,7 @@ from sentry.taskworker.namespaces import options_control_tasks, options_tasks
 ONE_HOUR = 60 * 60
 logger = logging.getLogger("sentry")
 
+
 @instrumented_task(
     name="sentry.tasks.options.sync_options_control",
     queue="options.control",

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from sentry import options
-from sentry.celery import app
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.registry import TaskRegistry
@@ -74,22 +73,6 @@ class TestTaskworkerRollout(TestCase):
         test_task.delay("world")
         test_task.apply_async("world")
         assert mock_send_task.call_count == 2
-
-    @mock.patch("sentry.taskworker.registry.TaskNamespace.send_task")
-    @override_options(
-        {"taskworker.test_namespace.rollout": {"test.test_with_taskworker_rollout": 1.0}}
-    )
-    def test_with_taskworker_rollout_with_args_trim_producer(self, mock_send_task):
-        @instrumented_task(
-            name="test.test_with_taskworker_rollout",
-            taskworker_config=self.config,
-        )
-        def test_task(msg):
-            return f"hello {msg}"
-
-        with app.default_producer() as producer:
-            test_task.delay("world", producer=producer)
-        assert mock_send_task.call_count == 1
 
     @mock.patch("sentry.tasks.base.random.random")
     @mock.patch("sentry.celery.Task.apply_async")

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -50,10 +50,8 @@ def test_define_task_at_most_once_with_retry(task_namespace: TaskNamespace):
 
 
 def test_apply_async_expires(task_namespace: TaskNamespace) -> None:
-    calls = []
-
     def test_func(*args, **kwargs) -> None:
-        calls.append({"args": args, "kwargs": kwargs})
+        pass
 
     task = Task(
         name="test.test_func",

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytest
 import sentry_sdk
@@ -46,6 +47,27 @@ def test_define_task_at_most_once_with_retry(task_namespace: TaskNamespace):
             retry=Retry(times=3),
         )
     assert "You cannot enable at_most_once and have retries" in str(err)
+
+
+def test_apply_async_expires(task_namespace: TaskNamespace) -> None:
+    calls = []
+
+    def test_func(*args, **kwargs) -> None:
+        calls.append({"args": args, "kwargs": kwargs})
+
+    task = Task(
+        name="test.test_func",
+        func=test_func,
+        namespace=task_namespace,
+    )
+    with patch.object(task_namespace, "send_task") as mock_send:
+        task.apply_async(args=["arg2"], kwargs={"org_id": 2}, expires=10, producer=None)
+        assert mock_send.call_count == 1
+        call_params = mock_send.call_args
+
+    activation = call_params.args[0]
+    assert activation.expires == 10
+    assert activation.parameters == json.dumps({"args": ["arg2"], "kwargs": {"org_id": 2}})
 
 
 def test_delay_taskrunner_immediate_mode(task_namespace: TaskNamespace) -> None:
@@ -157,6 +179,11 @@ def test_create_activation(task_namespace: TaskNamespace) -> None:
     activation = int_expiry_task.create_activation([], {})
     assert activation.taskname == "test.with_int_expires"
     assert activation.expires == 300
+    assert activation.processing_deadline_duration == 30
+
+    activation = int_expiry_task.create_activation([], {}, expires=600)
+    assert activation.taskname == "test.with_int_expires"
+    assert activation.expires == 600
     assert activation.processing_deadline_duration == 30
 
     activation = at_most_once_task.create_activation([], {})


### PR DESCRIPTION
When beat spawns tasks it will provide the `expires` value as a parameter for that specific activation, which we need to preserve into the taskworker task.

We also don't need to trim out `producer` in the monkey patching if `apply_async` supports `**options`.