### PR TITLE
fix(issue summary): Cleanup Slack alert design

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -638,9 +638,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             if "\n" in original_message:
                 original_message = original_message.strip().split("\n")[0] + "..."
 
-            blocks.append(
-                self.get_text_block(f"*{original_title}*: `{original_message}`", small=True)
-            )
+            original_text = f"*{original_title}*"
+            if original_message:
+                original_text += f": `{original_message}`"
+
+            blocks.append(self.get_text_block(original_text, small=True))
             blocks.append(self.get_text_block(summary_text, small=True))
         else:
             text = text.lstrip(" ")

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -27,7 +27,6 @@ from sentry.integrations.slack.message_builder.types import (
     ACTION_EMOJI,
     ACTIONED_CATEGORY_TO_EMOJI,
     CATEGORY_TO_EMOJI,
-    ISSUE_SUMMARY_TO_EMOJI,
     LEVEL_TO_EMOJI,
     SLACK_URL_FORMAT,
     SlackBlock,
@@ -575,10 +574,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 footer_text = footer_text[:-4]  # chop off the empty space
 
             if self.issue_summary:
-                footer_text += f"    {ISSUE_SUMMARY_TO_EMOJI.get('seer')} Powered by Seer"
+                footer_text += "    Powered by Seer"
 
             return self.get_context_block(text=footer_text)
         else:
+            if self.issue_summary:
+                footer += " | Powered by Seer"
             return self.get_context_block(text=footer, timestamp=timestamp)
 
     def build(self, notification_uuid: str | None = None) -> SlackBlock:
@@ -634,6 +635,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if summary_text := self.get_issue_summary_text():
             original_title = build_attachment_title(event_or_group)
             original_message = text.lstrip(" ")
+            if "\n" in original_message:
+                original_message = original_message.strip().split("\n")[0] + "..."
 
             blocks.append(
                 self.get_text_block(f"*{original_title}*: `{original_message}`", small=True)

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -37,7 +37,3 @@ ACTIONED_CATEGORY_TO_EMOJI = {
     GroupCategory.FEEDBACK: ACTION_EMOJI + " :busts_in_silhouette:",
     GroupCategory.CRON: ACTION_EMOJI + " :spiral_calendar_pad:",
 }
-
-ISSUE_SUMMARY_TO_EMOJI = {
-    "seer": ":eye:",
-}


### PR DESCRIPTION
- removes the eye emoji
- adds the "Seer" label in footers where it was missing
- handles error messages that are multiline and were messing up formatting