### PR TITLE
:bug: fix: update how we fetch workflow_id and legacy_rule_id from ru…

### DIFF
--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -44,7 +44,7 @@ class OpsgenieClient(ApiClient):
         workflow_urls = []
         for rule in rules:
             # fetch the workflow_id from the rule.data
-            workflow_id = rule.data.get("workflow_id")
+            workflow_id = rule.data.get("actions", [{}])[0].get("workflow_id")
             assert workflow_id is not None
             workflow_urls.append(
                 organization.absolute_url(create_link_to_workflow(organization.id, workflow_id))
@@ -57,7 +57,7 @@ class OpsgenieClient(ApiClient):
         for rule in rules:
             rule_id = rule.id
             if features.has("organizations:workflow-engine-trigger-actions", organization):
-                rule_id = rule.data.get("legacy_rule_id")
+                rule_id = rule.data.get("actions", [{}])[0].get("legacy_rule_id")
 
             assert rule_id is not None
             path = f"/organizations/{organization.slug}/alerts/rules/{group.project.slug}/{rule_id}/details/"

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -10,6 +10,7 @@ from sentry.integrations.on_call.metrics import OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
+from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.links import create_link_to_workflow
 
 OPSGENIE_API_VERSION = "v2"
@@ -44,7 +45,7 @@ class OpsgenieClient(ApiClient):
         workflow_urls = []
         for rule in rules:
             # fetch the workflow_id from the rule.data
-            workflow_id = rule.data.get("actions", [{}])[0].get("workflow_id")
+            workflow_id = get_key_from_rule_data(rule, "workflow_id")
             assert workflow_id is not None
             workflow_urls.append(
                 organization.absolute_url(create_link_to_workflow(organization.id, workflow_id))
@@ -57,7 +58,7 @@ class OpsgenieClient(ApiClient):
         for rule in rules:
             rule_id = rule.id
             if features.has("organizations:workflow-engine-trigger-actions", organization):
-                rule_id = rule.data.get("actions", [{}])[0].get("legacy_rule_id")
+                rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
 
             assert rule_id is not None
             path = f"/organizations/{organization.slug}/alerts/rules/{group.project.slug}/{rule_id}/details/"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -19,6 +19,7 @@ from sentry.issues.grouptype import (
     ProfileFunctionRegressionType,
 )
 from sentry.models.group import Group
+from sentry.models.rule import Rule
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import (
     ActionTargetType,
@@ -62,6 +63,10 @@ def get_group_substatus_text(group: Group) -> str:
 
 
 GENERIC_TEMPLATE_NAME = "generic"
+
+
+def get_key_from_rule_data(rule: Rule, key: str) -> str:
+    return rule.data.get("actions", [{}])[0].get(key)
 
 
 class AlertRuleNotification(ProjectNotification):

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -5,7 +5,7 @@ We can use this as a basepoint to build out our templating system in the future
 """
 
 
-def create_link_to_workflow(organization_id: int, workflow_id: int) -> str:
+def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -133,8 +133,12 @@ class OpsgenieClientTest(APITestCase):
         group = event.group
         assert group is not None
 
-        rule = Rule.objects.create(
-            project=self.project, label="my rule", data={"legacy_rule_id": 123}
+        rule = self.create_project_rule(
+            action_data=[
+                {
+                    "legacy_rule_id": "123",
+                }
+            ]
         )
         client: OpsgenieClient = self.installation.get_keyring_client("team-123")
         with self.options({"system.url-prefix": "http://example.com"}):
@@ -157,7 +161,7 @@ class OpsgenieClientTest(APITestCase):
             "priority": "P2",
             "details": {
                 "Project Name": self.project.name,
-                "Triggering Rules": "my rule",
+                "Triggering Rules": rule.label,
                 "Triggering Rule URLs": f"http://example.com/organizations/baz/alerts/rules/{self.project.slug}/{123}/details/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
@@ -195,7 +199,13 @@ class OpsgenieClientTest(APITestCase):
         group = event.group
         assert group is not None
 
-        rule = Rule.objects.create(project=self.project, label="my rule", data={"workflow_id": 123})
+        rule = self.create_project_rule(
+            action_data=[
+                {
+                    "workflow_id": "123",
+                }
+            ]
+        )
         client: OpsgenieClient = self.installation.get_keyring_client("team-123")
         with self.options({"system.url-prefix": "http://example.com"}):
             payload = client.build_issue_alert_payload(
@@ -217,7 +227,7 @@ class OpsgenieClientTest(APITestCase):
             "priority": "P2",
             "details": {
                 "Project Name": self.project.name,
-                "Triggering Workflows": "my rule",
+                "Triggering Workflows": rule.label,
                 "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/workflows/{123}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,


### PR DESCRIPTION
i realized i made a mistake for how i fetch the `workflow_id` and `legacy_rule_id`.

the format that the noa passes down is:

https://github.com/getsentry/sentry/blob/fb887ee11cea9e130db2fea435c3f67a21313dab/src/sentry/notifications/notification_action/types.py#L130-L132

essentially
```
{
	"action" : [
			{
				...
			}
	]
}
```