### PR TITLE
ref(flags): Add other to flag onboarding platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -593,6 +593,7 @@ export const feedbackOnboardingPlatforms: readonly PlatformKey[] = [
 export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = [
   'javascript',
   'python',
+  'other',
   'javascript-angular',
   'javascript-astro',
   'javascript-ember',


### PR DESCRIPTION
For FF eval tracking onboarding sidebar, and show/hide CTA logic. We support 'other' but need to include it in this list, for checks like https://github.com/getsentry/sentry/blob/0c51afcf436e4269ce46102902ea3ae8790a58e5/static/app/components/events/featureFlags/eventFeatureFlagList.tsx#L223