### PR TITLE
:wrench: chore(aci): update sentry app payload for workflow engine

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -109,6 +109,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             "culprit": group.culprit,
             "message": event.message,
             "url": group.get_absolute_url(params={"referrer": "webhooks_plugin"}),
+            # TODO(ecosystem): We need to eventually change the key on this
             "triggering_rules": triggering_rules,
         }
         data["event"] = dict(event.data or {})

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.urls import reverse
 from requests.exceptions import RequestException
 
-from sentry import analytics, nodestore
+from sentry import analytics, features, nodestore
 from sentry.api.serializers import serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models.base import Model
@@ -521,12 +521,20 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
             "additional_payload_key": None,
             "additional_payload": None,
         }
+
         # If the future comes from a rule with a UI component form in the schema, append the issue alert payload
+        # TODO(ecosystem): We need to change this payload format after alerts create issues
+        id = f.rule.id
+        # if we are using the new workflow engine, we need to use the legacy rule id
+        if features.has("organizations:workflow-engine-trigger-actions", event.group.organization):
+            id = f.rule.data.get("actions", [{}])[0].get("legacy_rule_id")
+            assert id is not None
+
         settings = f.kwargs.get("schema_defined_settings")
         if settings:
             extra_kwargs["additional_payload_key"] = "issue_alert"
             extra_kwargs["additional_payload"] = {
-                "id": f.rule.id,
+                "id": id,
                 "title": f.rule.label,
                 "sentry_app_id": f.kwargs["sentry_app"].id,
                 "settings": settings,

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -87,6 +87,7 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
                 "Logger": group.logger,
                 "Level": group.get_level_display(),
                 "URL": group.get_absolute_url(),
+                # TODO(ecosystem): We need to eventually change the key on this
                 "Triggering Rules": json.dumps(triggering_rules),
             },
             "entity": group.culprit,

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -326,6 +326,70 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @with_feature("organizations:workflow-engine-trigger-actions")
+    def test_send_alert_event_with_additional_payload_legacy_rule_id(
+        self, mock_record, safe_urlopen
+    ):
+        rule = self.create_project_rule(
+            action_data=[
+                {
+                    "sentryAppInstallationUuid": self.install.uuid,
+                    "legacy_rule_id": "123",
+                }
+            ]
+        )
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        group_event = GroupEvent.from_event(event, event.group)
+        settings = [
+            {"name": "alert_prefix", "value": "[Not Good]"},
+            {"name": "channel", "value": "#ignored-errors"},
+            {"name": "best_emoji", "value": ":fire:"},
+            {"name": "teamId", "value": 1},
+            {"name": "assigneeId", "value": 3},
+        ]
+
+        rule_future = RuleFuture(
+            rule=rule,
+            kwargs={"sentry_app": self.sentry_app, "schema_defined_settings": settings},
+        )
+
+        with self.tasks():
+            notify_sentry_app(group_event, [rule_future])
+
+        ((args, kwargs),) = safe_urlopen.call_args_list
+        payload = json.loads(kwargs["data"])
+
+        assert payload["action"] == "triggered"
+        assert payload["data"]["triggered_rule"] == rule.label
+        assert payload["data"]["issue_alert"] == {
+            # Use the legacy rule id
+            "id": "123",
+            "title": rule.label,
+            "sentry_app_id": self.sentry_app.id,
+            "settings": settings,
+        }
+
+        buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
+        requests = buffer.get_requests()
+
+        assert len(requests) == 1
+        assert requests[0]["response_code"] == 200
+        assert requests[0]["event_type"] == "event_alert.triggered"
+
+        # SLO validation
+        assert_success_metric(mock_record=mock_record)
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=2
+        )
+
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_send_alert_event_with_groupevent(self, mock_record, safe_urlopen):
         event = self.store_event(data={}, project_id=self.project.id)
         occurrence_data = self.build_occurrence_data(


### PR DESCRIPTION
1. i added todo's for the ecosystem team to update the schema of payload we send plugins/sentry apps so they don't mention issue alerts
2. pass the `legacy_rule_id` to sentry apps when the action is triggered