### PR TITLE
ref(shared-views): Change visibility query param to createdBy

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -34,7 +34,7 @@ class MemberPermission(OrganizationPermission):
 
 
 class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
-    createdBy = serializers.MultipleChoiceField(
+    createdBy = serializers.ChoiceField(
         choices=("me", "others"),
         required=False,
     )
@@ -108,7 +108,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         createdBy = serializer.validated_data.get("createdBy")
         if createdBy:
             # TODO(msun): add support for different sorting
-            if "me" in createdBy:
+            if createdBy == "me":
                 query = (
                     GroupSearchView.objects.filter(
                         organization=organization,
@@ -117,7 +117,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                     .prefetch_related("projects")
                     .order_by("name")
                 )
-            elif "others" in createdBy:
+            elif createdBy == "others":
                 query = (
                     GroupSearchView.objects.filter(
                         organization=organization,


### PR DESCRIPTION
All views are shared now, so we're making the table groups "My Views" and "Others" (names are _very_ subject to change) 

Previously, the groups were based on visibility, hence why we needed a "visibility" query param to filter based on ownership. Now, since we're filtering based on whether the user has created it, we need a new query param — "createdBy" (open to naming suggestions). 

Next steps are:
* Expose whether views are starred or not in the response schema 
* Add sorting options, including hoisting starred views to the top of the list. 


This query param is not being used by any public pages, so we do not need to worry about breaking user workflows by just  removing the visibility param. 