### PR TITLE
ref(flags): Simplify onboarding and drawer platform lists

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -1,3 +1,4 @@
+import {platforms} from 'sentry/data/platforms';
 import type {PlatformKey} from 'sentry/types/project';
 
 export enum PlatformCategory {
@@ -589,65 +590,12 @@ export const feedbackOnboardingPlatforms: readonly PlatformKey[] = [
   ...feedbackCrashApiPlatforms,
 ];
 
-// Feature flag platforms with gettingStartedDocs.
-export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = [
-  'javascript',
-  'python',
-  'javascript-angular',
-  'javascript-astro',
-  'javascript-ember',
-  'javascript-gatsby',
-  'javascript-nextjs',
-  'javascript-nuxt',
-  'javascript-react',
-  'javascript-remix',
-  'javascript-solid',
-  'javascript-solidstart',
-  'javascript-svelte',
-  'javascript-sveltekit',
-  'javascript-tanstackstart-react',
-  'javascript-vue',
-  'python-aiohttp',
-  'python-bottle',
-  'python-django',
-  'python-falcon',
-  'python-fastapi',
-  'python-flask',
-  'python-pyramid',
-  'python-quart',
-  'python-sanic',
-  'python-starlette',
-  'python-tornado',
-];
+// Feature flag platforms with gettingStartedDocs. Note backend js platforms start with 'node-'.
+export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = platforms
+  .map(p => p.id)
+  .filter(id => id.startsWith('javascript') || id.startsWith('python'));
 
 // Feature flag platforms to show the issue details distribution drawer for.
-export const featureFlagDrawerPlatforms: readonly PlatformKey[] = [
-  'javascript',
-  'python',
-  'other',
-  'javascript-angular',
-  'javascript-astro',
-  'javascript-ember',
-  'javascript-gatsby',
-  'javascript-nextjs',
-  'javascript-nuxt',
-  'javascript-react',
-  'javascript-remix',
-  'javascript-solid',
-  'javascript-solidstart',
-  'javascript-svelte',
-  'javascript-sveltekit',
-  'javascript-tanstackstart-react',
-  'javascript-vue',
-  'python-aiohttp',
-  'python-bottle',
-  'python-django',
-  'python-falcon',
-  'python-fastapi',
-  'python-flask',
-  'python-pyramid',
-  'python-quart',
-  'python-sanic',
-  'python-starlette',
-  'python-tornado',
-];
+export const featureFlagDrawerPlatforms: readonly PlatformKey[] = platforms
+  .map(p => p.id)
+  .filter(id => id.startsWith('javascript') || id.startsWith('python'));


### PR DESCRIPTION
Simplifies these lists by filtering `static/app/data/platforms` by javascript and python prefixes. Note our PlatformKeys use the `node-` prefix for backend JS, which we don't support yet.

Removes 'other' from drawer platforms. We don't have a CTA for other, so there's no point always showing the empty state.

With these changes we're also including these python platforms we didn't have before:
`asgi awslambda celery chalice gcpfunctions pylons pymongo rq serverless tryton wsgi`