### PR TITLE
fix(devenv): Skip more frontend checks if `SENTRY_DEVENV_SKIP_FRONTEND=1`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,6 +23,12 @@ SENTRY_ROOT="$(
 
 source "${SENTRY_ROOT}/scripts/lib.sh"
 
+bold="$(tput bold)"
+red="$(tput setaf 1)"
+green="$(tput setaf 2)"
+yellow="$(tput setaf 3)"
+reset="$(tput sgr0)"
+
 # XXX: we can't trap bash EXIT, because it'll override direnv's finalizing routines.
 #      consequently, using "exit" anywhere will skip this notice from showing.
 #      so need to use set -e, and return 1.

--- a/.envrc
+++ b/.envrc
@@ -178,16 +178,18 @@ python3 -m tools.docker_memory_check
 
 debug "Checking node..."
 
-if ! require node; then
-    die "You don't seem to have node installed. Please run devenv sync."
-fi
+if [ "${SENTRY_DEVENV_SKIP_FRONTEND}" != "1" ]; then
+    if ! require node; then
+        die "You don't seem to have node installed. Please run devenv sync."
+    fi
 
-if ! node -pe "process.exit(Number(!(process.version == 'v' + require('./.volta.json').volta.node )))"; then
-    die "Unexpected $(command -v node) version. Please run devenv sync."
-fi
+    if ! node -pe "process.exit(Number(!(process.version == 'v' + require('./.volta.json').volta.node )))"; then
+        die "Unexpected $(command -v node) version. Please run devenv sync."
+    fi
 
-if [ ! -x "node_modules/.bin/webpack" ]; then
-    die "You don't seem to have yarn packages installed. Please run devenv sync."
+    if [ ! -x "node_modules/.bin/webpack" ]; then
+        die "You don't seem to have yarn packages installed. Please run devenv sync."
+    fi
 fi
 
 PATH_add node_modules/.bin


### PR DESCRIPTION
These checks sometimes start failing since we're not running the frontend updates. Skipping them, since they're not required if we're skipping loading frontend stuff.

<!-- Describe your PR here. -->