### PR TITLE
feat(cp): stats page estimation with profiles

### DIFF
--- a/static/app/views/organizationStats/mapSeriesToChart.spec.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.spec.ts
@@ -284,4 +284,74 @@ describe('mapSeriesToChart func', function () {
       {value: ['Jan 2 12:00 AM - 1:00 AM (+00:00)', 2]},
     ]);
   });
+
+  it('should correctly sum up the profiles', function () {
+    const groups = [
+      {
+        by: {
+          outcome: 'invalid',
+          reason: 'bad',
+          category: 'profile',
+        },
+        totals: {
+          'sum(quantity)': 10,
+        },
+        series: {
+          'sum(quantity)': [1, 2],
+        },
+      },
+      {
+        by: {
+          outcome: 'accepted',
+          reason: 'good',
+          category: 'profile',
+        },
+        totals: {
+          'sum(quantity)': 10,
+        },
+        series: {
+          'sum(quantity)': [3, 4],
+        },
+      },
+      {
+        by: {
+          outcome: 'accepted',
+          reason: 'good',
+          category: 'profile_duration',
+        },
+        totals: {
+          'sum(quantity)': 10,
+        },
+        series: {
+          'sum(quantity)': [1, 2],
+        },
+      },
+    ];
+
+    const mappedSeries = mapSeriesToChart({
+      orgStats: {
+        start: '2021-01-01T00:00:00Z',
+        end: '2021-01-07T00:00:00Z',
+        intervals: ['2021-01-01T00:00:00Z', '2021-01-02T00:00:00Z'],
+        groups,
+      },
+      chartDateInterval: '1h',
+      chartDateUtc: true,
+      dataCategory: 'profile_duration',
+      shouldEstimateDroppedProfiles: true,
+      endpointQuery: {},
+    });
+
+    // multiplies dropped profiles by 9000
+    expect(mappedSeries.chartStats.invalid).toEqual([
+      {value: ['Jan 1 12:00 AM - 1:00 AM (+00:00)', 9000]},
+      {value: ['Jan 2 12:00 AM - 1:00 AM (+00:00)', 18000]},
+    ]);
+
+    // does not add accepted profiles to accepted profile duration
+    expect(mappedSeries.chartStats.accepted).toEqual([
+      {value: ['Jan 1 12:00 AM - 1:00 AM (+00:00)', 1]},
+      {value: ['Jan 2 12:00 AM - 1:00 AM (+00:00)', 2]},
+    ]);
+  });
 });

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -16,9 +16,14 @@ import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 // used for estimated dropped continuous profile hours and ui profile hours from profile chunks and profile chunks ui
 export function droppedProfileChunkMultiplier(
   category: number | string | undefined,
-  outcome: number | string | undefined
+  outcome: number | string | undefined,
+  shouldEstimateDroppedProfiles?: boolean
 ) {
-  if (category === 'profile_chunk' || category === 'profile_chunk_ui') {
+  if (
+    category === 'profile_chunk' ||
+    category === 'profile_chunk_ui' ||
+    (shouldEstimateDroppedProfiles && category === 'profile')
+  ) {
     if (outcome === Outcome.ACCEPTED) {
       return 0;
     }
@@ -33,12 +38,14 @@ export function mapSeriesToChart({
   chartDateUtc,
   endpointQuery,
   chartDateInterval,
+  shouldEstimateDroppedProfiles = false,
 }: {
   chartDateInterval: IntervalPeriod;
   chartDateUtc: boolean;
   dataCategory: DataCategoryInfo['plural'];
   endpointQuery: Record<string, unknown>;
   orgStats?: UsageSeries;
+  shouldEstimateDroppedProfiles?: boolean;
 }): {
   cardStats: {
     accepted?: string;
@@ -117,7 +124,7 @@ export function mapSeriesToChart({
       } else {
         const value =
           group.totals['sum(quantity)']! *
-          droppedProfileChunkMultiplier(category, outcome);
+          droppedProfileChunkMultiplier(category, outcome, shouldEstimateDroppedProfiles);
         if (outcome !== Outcome.CLIENT_DISCARD) {
           count.total += value;
         }
@@ -130,7 +137,9 @@ export function mapSeriesToChart({
       }
 
       group.series['sum(quantity)']!.forEach((stat, i) => {
-        stat = stat * droppedProfileChunkMultiplier(category, outcome);
+        stat =
+          stat *
+          droppedProfileChunkMultiplier(category, outcome, shouldEstimateDroppedProfiles);
         const dataObject = {name: orgStats.intervals[i]!, value: stat};
 
         const strigfiedReason = String(group.by.reason ?? '');

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -155,6 +155,9 @@ class UsageStatsOrganization<
       category.push(
         dataCategoryApiName === 'profile_duration' ? 'profile_chunk' : 'profile_chunk_ui'
       );
+      if (dataCategoryApiName === 'profile_duration') {
+        category.push('profile');
+      }
     }
 
     return {

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -155,9 +155,6 @@ class UsageStatsOrganization<
       category.push(
         dataCategoryApiName === 'profile_duration' ? 'profile_chunk' : 'profile_chunk_ui'
       );
-      if (dataCategoryApiName === 'profile_duration') {
-        category.push('profile');
-      }
     }
 
     return {


### PR DESCRIPTION
closes https://github.com/getsentry/getsentry/issues/17077

Use `profile` to estimate dropped profile hours for non-AM2