### PR TITLE
ref(feedback): large messages - sample logs and remove sentry events

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -8,7 +8,6 @@ from typing import Any, TypedDict
 from uuid import uuid4
 
 import jsonschema
-import sentry_sdk
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -268,16 +267,17 @@ def should_filter_feedback(
                 "referrer": source.value,
             },
         )
-        logger.info(
-            "Feedback message exceeds max size.",
-            extra={
-                "project_id": project_id,
-                "entrypoint": "create_feedback_issue",
-                "referrer": source.value,
-            },
-        )
-        # For Sentry employee debugging. Sentry will capture a truncated `feedback_message` in local variables.
-        sentry_sdk.capture_message("Feedback message exceeds max size.", "warning")
+        if random.random() < 0.1:
+            logger.info(
+                "Feedback message exceeds max size.",
+                extra={
+                    "project_id": project_id,
+                    "entrypoint": "create_feedback_issue",
+                    "referrer": source.value,
+                    "length": len(message),
+                    "feedback_message": message[:100],
+                },
+            )
         return True, "Too Large"
 
     return False, None

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
+import random
 from datetime import datetime, timedelta
 
-import sentry_sdk
 from django.db import IntegrityError, router
 from django.utils import timezone
 
@@ -201,16 +201,17 @@ def should_filter_user_report(
                 "referrer": source.value,
             },
         )
-        logger.info(
-            "Feedback message exceeds max size.",
-            extra={
-                "project_id": project_id,
-                "entrypoint": "save_userreport",
-                "referrer": source.value,
-            },
-        )
-        # For Sentry employee debugging. Sentry will capture a truncated `feedback_message` in local variables.
-        sentry_sdk.capture_message("Feedback message exceeds max size.", "warning")
+        if random.random() < 0.1:
+            logger.info(
+                "Feedback message exceeds max size.",
+                extra={
+                    "project_id": project_id,
+                    "entrypoint": "save_userreport",
+                    "referrer": source.value,
+                    "length": len(comments),
+                    "feedback_message": comments[:100],
+                },
+            )
         return True, "Too Large"
 
     return False, None


### PR DESCRIPTION
Now that we're emitting outcomes, large messages are less of a concern and IMO we don't need to emit to Sentry. Instead we can sample 10% of logs and log the project, msg length, and truncated msg

Closes [SENTRY-3H5W](https://sentry.sentry.io/issues/6024268838/events/ce7330ead5494df990be7d70f655c8d7/)