### PR TITLE
fix(ourlogs): Allow overriding initial column widths for GridEditable

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -67,6 +67,7 @@ export function useTableStyles(
   options?: {
     minimumColumnWidth?: number;
     prefixColumnWidth?: 'min-content' | number;
+    staticColumnWidths?: Record<string, number | '1fr'>;
   }
 ) {
   const minimumColumnWidth = options?.minimumColumnWidth ?? MINIMUM_COLUMN_WIDTH;
@@ -85,14 +86,20 @@ export function useTableStyles(
   }, [fields]);
 
   const initialTableStyles = useMemo(() => {
-    const gridTemplateColumns = fields.map(() => `minmax(${minimumColumnWidth}px, auto)`);
+    const gridTemplateColumns = fields.map(field => {
+      const staticWidth = options?.staticColumnWidths?.[field];
+      if (staticWidth) {
+        return typeof staticWidth === 'number' ? `${staticWidth}px` : staticWidth;
+      }
+      return `minmax(${minimumColumnWidth}px, auto)`;
+    });
     if (defined(prefixColumnWidth)) {
       gridTemplateColumns.unshift(prefixColumnWidth);
     }
     return {
       gridTemplateColumns: gridTemplateColumns.join(' '),
     };
-  }, [fields, minimumColumnWidth, prefixColumnWidth]);
+  }, [fields, minimumColumnWidth, prefixColumnWidth, options?.staticColumnWidths]);
 
   const onResizeMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>, index: number) => {

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -32,6 +32,7 @@ import {
   LogTableBody,
   LogTableRow,
 } from 'sentry/views/explore/logs/styles';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import type {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
 import {EmptyStateText} from 'sentry/views/traces/styles';
 
@@ -66,6 +67,9 @@ export function LogsTable({
   const {initialTableStyles, onResizeMouseDown} = useTableStyles(fields, tableRef, {
     minimumColumnWidth: 50,
     prefixColumnWidth: 'min-content',
+    staticColumnWidths: {
+      [OurLogKnownFieldKey.BODY]: '1fr',
+    },
   });
 
   const isEmpty = !isPending && !isError && (data?.length ?? 0) === 0;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -128,7 +128,7 @@ export function getLogBodySearchTerms(search: MutableSearch): string[] {
 export function logsFieldAlignment(...args: Parameters<typeof fieldAlignment>) {
   const field = args[0];
   if (field === OurLogKnownFieldKey.TIMESTAMP) {
-    return 'right';
+    return 'left';
   }
   return fieldAlignment(...args);
 }


### PR DESCRIPTION
### Summary
This allows passing a Record which can override column widths on a table by their fieldname. Allows px or '1fr' for auto expanding rows (like body in logs)

#### Screenshots
|![Screenshot 2025-04-03 at 7 24 52 PM](https://github.com/user-attachments/assets/65a5eb40-23ef-4cbb-944f-d5ca0b1c9ca2)|
|-|
