### PR TITLE
ref(feedback search): suggest platform.name instead of platform

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -35,6 +35,8 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
+  // Prefer issues 'trace' field which has a better description. 'trace.id' tag is for display purposes only.
+  'trace.id',
 ];
 
 const EXCLUDED_SUGGESTIONS: string[] = [

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -35,8 +35,6 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
-  // Prefer issues 'trace' field which has a better description. 'trace.id' tag is for display purposes only.
-  'trace.id',
 ];
 
 const EXCLUDED_SUGGESTIONS: string[] = [

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2397,7 +2397,7 @@ export const FEEDBACK_FIELDS = [
   FeedbackFieldKey.MESSAGE,
   FeedbackFieldKey.OS_NAME,
   FeedbackFieldKey.OS_VERSION,
-  FieldKey.PLATFORM,
+  FieldKey.PLATFORM_NAME,
   FieldKey.SDK_NAME,
   FieldKey.SDK_VERSION,
   FieldKey.TIMESTAMP,


### PR DESCRIPTION
The platform.name search works but platform doesn't. platform also doesn't have accurate suggestions (which is strange since you can see in the UI our feedbacks are tagged with platform).


https://github.com/user-attachments/assets/0586438e-2e9a-429c-b006-78020e47b87d



