### PR TITLE
ref(feedback): remove explicit trace.id tag from ingest pipeline

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -366,11 +366,6 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
     if user_email and "user.email" not in event_fixed["tags"]:
         event_fixed["tags"]["user.email"] = user_email
 
-    # Set the trace.id tag to expose it for the feedback UI.
-    trace_id = get_path(event_fixed, "contexts", "trace", "trace_id")
-    if trace_id:
-        event_fixed["tags"]["trace.id"] = trace_id
-
     # make sure event data is valid for issue platform
     validate_issue_platform_event_schema(event_fixed)
 

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -35,8 +35,6 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
-  // Prefer issues 'trace' field which has a better description. 'trace.id' tag is for display purposes only.
-  'trace.id',
 ];
 
 const EXCLUDED_SUGGESTIONS: string[] = [

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -783,7 +783,6 @@ def test_create_feedback_tags(default_project, mock_produce_occurrence_to_kafka)
     produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
     tags = produced_event["tags"]
     assert tags["user.email"] == "josh.ferge@sentry.io"
-    assert tags["trace.id"] == "abc123"
 
     # Uses feedback contact_email if user context doesn't have one
     del event["user"]["email"]
@@ -800,14 +799,12 @@ def test_create_feedback_tags_skips_if_empty(default_project, mock_produce_occur
     event = mock_feedback_event(default_project.id, datetime.now(UTC))
     event["user"].pop("email", None)
     event["contexts"]["feedback"].pop("contact_email", None)
-    event["contexts"].pop("trace", None)
     create_feedback_issue(event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 1
     produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
     tags = produced_event["tags"]
     assert "user.email" not in tags
-    assert "trace.id" not in tags
 
 
 @django_db_all


### PR DESCRIPTION
This tag isn't useful since trace is already searchable through `trace`. The trace id isn't useful if there's no trace data, and if there is, we display a [`TraceDataSection`](https://github.com/getsentry/sentry/blob/87a0f9ef5d29c11d5aed754e7d96b7116b8c3dc6/static/app/components/feedback/feedbackItem/traceDataSection.tsx#L21) with a link to the trace view.

For shims, we're still attaching trace context [here](https://github.com/getsentry/sentry/blob/87a0f9ef5d29c11d5aed754e7d96b7116b8c3dc6/src/sentry/feedback/usecases/create_feedback.py#L490-L491).