### PR TITLE
feat(aci): create WorkflowFireHistory objects for triggered workflows and update when meeting filters

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -48,7 +48,6 @@ from sentry.workflow_engine.processors.workflow import (
     create_workflow_fire_histories,
     evaluate_workflows_action_filters,
     log_fired_workflows,
-    update_workflow_fire_histories,
 )
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
@@ -412,9 +411,7 @@ def fire_actions_for_groups(
                 action_filters.add(dcg)
 
         # process action filters
-        filtered_actions = filter_recently_fired_workflow_actions(action_filters, group)
-        # update WorkflowFireHistory for the filtered actions (created before enqueuing)
-        update_workflow_fire_histories(filtered_actions, event_data)
+        filtered_actions = filter_recently_fired_workflow_actions(action_filters, event_data)
 
         # process workflow_triggers
         workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -33,7 +33,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers im
     BaseEventFrequencyQueryHandler,
     slow_condition_query_handler_registry,
 )
-from sentry.workflow_engine.models import Action, DataCondition, DataConditionGroup, Workflow
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Workflow
 from sentry.workflow_engine.models.data_condition import (
     PERCENT_CONDITIONS,
     SLOW_CONDITIONS,
@@ -45,8 +45,10 @@ from sentry.workflow_engine.processors.data_condition_group import evaluate_data
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    create_workflow_fire_histories,
     evaluate_workflows_action_filters,
     log_fired_workflows,
+    update_workflow_fire_histories,
 )
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
@@ -398,8 +400,8 @@ def fire_actions_for_groups(
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
     for group, group_event in group_to_groupevent.items():
-        job = WorkflowEventData(event=group_event)
-        detector = get_detector_by_event(job)
+        event_data = WorkflowEventData(event=group_event)
+        detector = get_detector_by_event(event_data)
 
         workflow_triggers: set[DataConditionGroup] = set()
         action_filters: set[DataConditionGroup] = set()
@@ -410,13 +412,18 @@ def fire_actions_for_groups(
                 action_filters.add(dcg)
 
         # process action filters
-        filtered_actions: list[Action] = list(
-            filter_recently_fired_workflow_actions(action_filters, group)
-        )
+        filtered_actions = filter_recently_fired_workflow_actions(action_filters, group)
+        # update WorkflowFireHistory for the filtered actions (created before enqueuing)
+        update_workflow_fire_histories(filtered_actions, event_data)
 
         # process workflow_triggers
         workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))
-        filtered_actions.extend(list(evaluate_workflows_action_filters(workflows, job)))
+
+        # create WorkflowFireHistory (updated in evaluate_workflows_action_filters)
+        create_workflow_fire_histories(workflows, event_data)
+        filtered_actions = filtered_actions.union(
+            evaluate_workflows_action_filters(workflows, event_data)
+        )
 
         # temporary fetching of organization, so not passing in as parameter
         organization = group.project.organization
@@ -437,8 +444,8 @@ def fire_actions_for_groups(
         ):
             log_fired_workflows(
                 log_name="workflow_engine.delayed_workflow.fired_workflow",
-                actions=filtered_actions,
-                job=job,
+                actions=list(filtered_actions),
+                event_data=event_data,
             )
 
         if features.has(
@@ -446,7 +453,7 @@ def fire_actions_for_groups(
             organization,
         ):
             for action in filtered_actions:
-                action.trigger(job, detector)
+                action.trigger(event_data, detector)
 
 
 def cleanup_redis_buffer(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -143,9 +143,7 @@ def evaluate_workflows_action_filters(
             if evaluation:
                 filtered_action_groups.add(action_condition)
 
-    actions_to_fire = filter_recently_fired_workflow_actions(filtered_action_groups, event_data)
-
-    return actions_to_fire
+    return filter_recently_fired_workflow_actions(filtered_action_groups, event_data)
 
 
 def log_fired_workflows(

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -3,9 +3,12 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
-from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
+from sentry.workflow_engine.processors.action import (
+    filter_recently_fired_workflow_actions,
+    update_workflow_fire_histories,
+)
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -36,7 +39,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.group
+            set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action}
 
@@ -58,10 +61,27 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.group
+            set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action, action_3}
 
         for status in [status_1, status_2, status_3]:
             status.refresh_from_db()
             assert status.date_updated == timezone.now()
+
+    def test_update_workflow_fire_histories(self):
+        WorkflowFireHistory.objects.create(
+            workflow=self.workflow, group=self.group, event_id=self.group_event.event_id
+        )
+
+        actions = Action.objects.all()
+        update_workflow_fire_histories(actions, self.event_data)
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=self.workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_fired_actions=True,
+            ).count()
+            == 1
+        )

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -71,10 +71,15 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
 
     def test_update_workflow_fire_histories(self):
         WorkflowFireHistory.objects.create(
-            workflow=self.workflow, group=self.group, event_id=self.group_event.event_id
+            workflow=self.workflow,
+            group=self.group,
+            event_id=self.group_event.event_id,
+            has_fired_actions=False,
         )
 
         actions = Action.objects.all()
+        assert actions.count() == 1
+
         update_workflow_fire_histories(actions, self.event_data)
         assert (
             WorkflowFireHistory.objects.filter(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -27,6 +27,7 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Detector,
     Workflow,
+    WorkflowFireHistory,
 )
 from sentry.workflow_engine.models.data_condition import (
     PERCENT_CONDITIONS,
@@ -799,6 +800,41 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.event2.for_group(self.group2),
             WorkflowDataConditionGroupType.ACTION_FILTER,
         )
+
+    @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
+    def test_fire_actions_for_groups__workflow_fire_history(self, mock_process):
+        mock_process.return_value = (True, []), []
+
+        self.trigger_group_to_dcg_model[DataConditionHandler.Group.WORKFLOW_TRIGGER] = {
+            self.workflow1_dcgs[0].id: self.workflow1.id,
+        }
+        self.trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER] = {
+            self.workflow2_dcgs[1].id: self.workflow2.id,
+        }
+        self.groups_to_dcgs = {
+            self.group1.id: {self.workflow1_dcgs[0]},
+            self.group2.id: {self.workflow2_dcgs[1]},
+        }
+        # WorkflowFireHistory for enqueued filter (already triggered)
+        wfh = WorkflowFireHistory.objects.create(
+            workflow=self.workflow2,
+            group_id=self.group2.id,
+            event_id=self.event2.event_id,
+        )
+
+        fire_actions_for_groups(
+            self.groups_to_dcgs, self.trigger_group_to_dcg_model, self.group_to_groupevent
+        )
+
+        wfh.refresh_from_db()
+        assert wfh.has_fired_actions is True
+
+        assert WorkflowFireHistory.objects.filter(
+            workflow=self.workflow1,
+            group_id=self.group1.id,
+            event_id=self.event1.event_id,
+            has_fired_actions=True,
+        ).exists()
 
 
 class TestCleanupRedisBuffer(TestDelayedWorkflowBase):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -21,16 +21,19 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     DataConditionGroupAction,
     Workflow,
+    WorkflowFireHistory,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     WorkflowDataConditionGroupType,
+    create_workflow_fire_histories,
     delete_workflow,
     enqueue_workflow,
     evaluate_workflow_triggers,
     evaluate_workflows_action_filters,
     process_workflows,
+    update_workflow_fire_histories,
 )
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -578,6 +581,93 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         assert not triggered_actions
 
         # TODO @saponifi3d - Add a check to ensure the second condition is enqueued for later evaluation
+
+
+class TestWorkflowFireHistory(BaseWorkflowTest):
+    def setUp(self):
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
+        )
+        self.event_data = WorkflowEventData(event=self.group_event)
+
+    def test_create_workflow_fire_histories(self):
+        create_workflow_fire_histories({self.workflow}, self.event_data)
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=self.workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_fired_actions=False,
+            ).count()
+            == 1
+        )
+
+    def test_update_workflow_fire_histories(self):
+        create_workflow_fire_histories({self.workflow}, self.event_data)
+        actions = Action.objects.all()
+        update_workflow_fire_histories(actions, self.event_data)
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=self.workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_fired_actions=True,
+            ).count()
+            == 1
+        )
+
+    def test_evaluate_filters_updates_histories(self):
+        # only updates workflows that meet filters
+        self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.EVENT_SEEN_COUNT,
+            comparison=1,
+            condition_result=True,
+        )
+
+        workflow = self.create_workflow()
+        action_group, _ = self.create_workflow_action(workflow=workflow)
+        self.create_data_condition(
+            condition_group=action_group,
+            type=Condition.EVENT_SEEN_COUNT,
+            comparison=5,
+            condition_result=True,
+        )  # condition is not met
+
+        create_workflow_fire_histories({self.workflow, workflow}, self.event_data)
+
+        triggered_actions = evaluate_workflows_action_filters(
+            {self.workflow, workflow}, self.event_data
+        )
+        assert set(triggered_actions) == {self.action}
+
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=self.workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_fired_actions=True,
+            ).count()
+            == 1
+        )
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_fired_actions=False,
+            ).count()
+            == 1
+        )
 
 
 class TestEnqueueWorkflows(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -33,7 +33,6 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflow_triggers,
     evaluate_workflows_action_filters,
     process_workflows,
-    update_workflow_fire_histories,
 )
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -158,7 +157,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        mock_filter.assert_called_with({workflow_filters}, self.group)
+        mock_filter.assert_called_with({workflow_filters}, self.event_data)
 
     def test_same_environment_only(self):
         env = self.create_environment(project=self.project)
@@ -607,20 +606,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
                 group=self.group,
                 event_id=self.group_event.event_id,
                 has_fired_actions=False,
-            ).count()
-            == 1
-        )
-
-    def test_update_workflow_fire_histories(self):
-        create_workflow_fire_histories({self.workflow}, self.event_data)
-        actions = Action.objects.all()
-        update_workflow_fire_histories(actions, self.event_data)
-        assert (
-            WorkflowFireHistory.objects.filter(
-                workflow=self.workflow,
-                group=self.group,
-                event_id=self.group_event.event_id,
-                has_fired_actions=True,
             ).count()
             == 1
         )


### PR DESCRIPTION
We've decided that `WorkflowFireHistory` will track every time a workflow has been triggered. Note that we only fire actions if subsequent workflow filters are met.

Create these objects for triggered workflows in regular processing and delayed processing.

I added a column (`has_fired_actions`) to track whether a workflow also met its filters and fired actions -- `WorkflowFireHistory` objects with `has_fired_actions=True` should be 1:1 with `RuleFireHistory` today. Update this column if filters are met (there is 1 filter group per `Rule/Workflow` during the rollout period, this is not guaranteed in the future).