### PR TITLE
fix: don't pass custom props to motion.div

### DIFF
--- a/static/app/views/dashboards/widgetWrapper.tsx
+++ b/static/app/views/dashboards/widgetWrapper.tsx
@@ -4,7 +4,9 @@ import {motion} from 'framer-motion';
 
 import type {Widget} from './types';
 
-const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
+const WidgetWrapper = styled(motion.div, {
+  shouldForwardProp: prop => prop !== 'displayType',
+})<{displayType: Widget['displayType']}>`
   position: relative;
   touch-action: manipulation;
 


### PR DESCRIPTION
[From the emotion docs](https://emotion.sh/docs/styled#customizing-prop-forwarding):

> By default, Emotion passes all props (except for theme) to custom components and only props that are valid html attributes for string tags.

`motion.div` is a custom component, so the `displayTime` ends up in the dom, yielding this warning:

![Screenshot 2025-04-04 at 11 23 13](https://github.com/user-attachments/assets/845a8d9b-3613-4f07-97fe-ad27d1ae3f09)

This PR ensures we don’t forward `displayType`, as it’s only used to do custom styling inside the styled component.