### PR TITLE
fix(span-buffer): Do not flush forever after rebalancing

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -82,6 +82,8 @@ from sentry.utils import metrics, redis
 # The segment ID in the Kafka protocol is only the span ID.
 SegmentKey = bytes
 
+QueueKey = bytes
+
 
 def _segment_key_to_span_id(segment_key: SegmentKey) -> bytes:
     return parse_segment_key(segment_key)[2]
@@ -125,6 +127,11 @@ class Span(NamedTuple):
 
 class OutputSpan(NamedTuple):
     payload: dict[str, Any]
+
+
+class FlushedSegment(NamedTuple):
+    queue_key: QueueKey
+    spans: list[OutputSpan]
 
 
 class SpansBuffer:
@@ -296,10 +303,10 @@ class SpansBuffer:
 
         return trees
 
-    def flush_segments(
-        self, now: int, max_segments: int = 0
-    ) -> tuple[int, dict[SegmentKey, list[OutputSpan]]]:
+    def flush_segments(self, now: int, max_segments: int = 0) -> dict[SegmentKey, FlushedSegment]:
         cutoff = now
+
+        queue_keys = []
 
         with metrics.timer("spans.buffer.flush_segments.load_segment_ids"):
             with self.client.pipeline(transaction=False) as p:
@@ -309,19 +316,20 @@ class SpansBuffer:
                         key, 0, cutoff, start=0 if max_segments else None, num=max_segments or None
                     )
                     p.zcard(key)
+                    queue_keys.append(key)
 
                 result = iter(p.execute())
 
-        segment_keys = []
+        segment_keys: list[tuple[QueueKey, SegmentKey]] = []
         queue_sizes = []
 
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
             with self.client.pipeline(transaction=False) as p:
                 # ZRANGEBYSCORE output
-                for segment_span_ids in result:
+                for queue_key, segment_span_ids in zip(queue_keys, result):
                     # process return value of zrevrangebyscore
                     for segment_key in segment_span_ids:
-                        segment_keys.append(segment_key)
+                        segment_keys.append((queue_key, segment_key))
                         p.smembers(segment_key)
 
                     # ZCARD output
@@ -340,10 +348,10 @@ class SpansBuffer:
 
         num_has_root_spans = 0
 
-        for segment_key, segment in zip(segment_keys, segments):
+        for (queue_key, segment_key), segment in zip(segment_keys, segments):
             segment_span_id = _segment_key_to_span_id(segment_key).decode("ascii")
 
-            return_segment = []
+            output_spans = []
             has_root_span = False
             metrics.timing("spans.buffer.flush_segments.num_spans_per_segment", len(segment))
             for payload in segment:
@@ -369,30 +377,30 @@ class SpansBuffer:
                     },
                 )
 
-                return_segment.append(OutputSpan(payload=val))
+                output_spans.append(OutputSpan(payload=val))
 
-            return_segments[segment_key] = return_segment
+            return_segments[segment_key] = FlushedSegment(queue_key=queue_key, spans=output_spans)
             num_has_root_spans += int(has_root_span)
+
         metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
         metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
 
-        return sum(queue_sizes), return_segments
+        return return_segments
 
-    def done_flush_segments(self, segment_keys: dict[SegmentKey, list[OutputSpan]]):
+    def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
         with metrics.timer("spans.buffer.done_flush_segments"):
             with self.client.pipeline(transaction=False) as p:
-                for segment_key, output_spans in segment_keys.items():
+                for segment_key, flushed_segment in segment_keys.items():
                     hrs_key = b"span-buf:hrs:" + segment_key
                     p.delete(hrs_key)
                     p.unlink(segment_key)
 
                     project_id, trace_id, _ = parse_segment_key(segment_key)
                     redirect_map_key = b"span-buf:sr:{%s:%s}" % (project_id, trace_id)
-                    shard = self.assigned_shards[int(trace_id, 16) % len(self.assigned_shards)]
-                    p.zrem(f"span-buf:q:{shard}".encode("ascii"), segment_key)
+                    p.zrem(flushed_segment.queue_key, segment_key)
 
-                    for span_batch in itertools.batched(output_spans, 100):
+                    for span_batch in itertools.batched(flushed_segment.spans, 100):
                         p.hdel(
                             redirect_map_key,
                             *[output_span.payload["span_id"] for output_span in span_batch],

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import itertools
+from unittest import mock
 
 import pytest
 import rapidjson
 from sentry_redis_tools.clients import StrictRedis
 
-from sentry.spans.buffer import OutputSpan, SegmentKey, Span, SpansBuffer
+from sentry.spans.buffer import FlushedSegment, OutputSpan, SegmentKey, Span, SpansBuffer
 
 
 def shallow_permutations(spans: list[Span]) -> list[list[Span]]:
@@ -35,9 +36,9 @@ def _output_segment(span_id: bytes, segment_id: bytes, is_segment: bool) -> Outp
     )
 
 
-def _normalize_output(output: dict[SegmentKey, list[OutputSpan]]):
+def _normalize_output(output: dict[SegmentKey, FlushedSegment]):
     for segment in output.values():
-        segment.sort(key=lambda span: span.payload["span_id"])
+        segment.spans.sort(key=lambda span: span.payload["span_id"])
 
 
 @pytest.fixture(params=["cluster", "single"])
@@ -150,19 +151,22 @@ def test_basic(buffer: SpansBuffer, spans):
 
     assert_ttls(buffer.client)
 
-    assert buffer.flush_segments(now=5) == (1, {})
-    _, rv = buffer.flush_segments(now=11)
+    assert buffer.flush_segments(now=5) == {}
+    rv = buffer.flush_segments(now=11)
     _normalize_output(rv)
     assert rv == {
-        _segment_id(1, "a" * 32, "b" * 16): [
-            _output_segment(b"a" * 16, b"b" * 16, False),
-            _output_segment(b"b" * 16, b"b" * 16, True),
-            _output_segment(b"c" * 16, b"b" * 16, False),
-            _output_segment(b"d" * 16, b"b" * 16, False),
-        ]
+        _segment_id(1, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"a" * 16, b"b" * 16, False),
+                _output_segment(b"b" * 16, b"b" * 16, True),
+                _output_segment(b"c" * 16, b"b" * 16, False),
+                _output_segment(b"d" * 16, b"b" * 16, False),
+            ],
+        )
     }
     buffer.done_flush_segments(rv)
-    assert buffer.flush_segments(now=30) == (0, {})
+    assert buffer.flush_segments(now=30) == {}
 
     assert_clean(buffer.client)
 
@@ -211,20 +215,23 @@ def test_deep(buffer: SpansBuffer, spans):
 
     assert_ttls(buffer.client)
 
-    _, rv = buffer.flush_segments(now=10)
+    rv = buffer.flush_segments(now=10)
     _normalize_output(rv)
     assert rv == {
-        _segment_id(1, "a" * 32, "a" * 16): [
-            _output_segment(b"a" * 16, b"a" * 16, True),
-            _output_segment(b"b" * 16, b"a" * 16, False),
-            _output_segment(b"c" * 16, b"a" * 16, False),
-            _output_segment(b"d" * 16, b"a" * 16, False),
-        ]
+        _segment_id(1, "a" * 32, "a" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"a" * 16, b"a" * 16, True),
+                _output_segment(b"b" * 16, b"a" * 16, False),
+                _output_segment(b"c" * 16, b"a" * 16, False),
+                _output_segment(b"d" * 16, b"a" * 16, False),
+            ],
+        )
     }
 
     buffer.done_flush_segments(rv)
 
-    _, rv = buffer.flush_segments(now=60)
+    rv = buffer.flush_segments(now=60)
     assert rv == {}
 
     assert_clean(buffer.client)
@@ -280,21 +287,24 @@ def test_deep2(buffer: SpansBuffer, spans):
 
     assert_ttls(buffer.client)
 
-    _, rv = buffer.flush_segments(now=10)
+    rv = buffer.flush_segments(now=10)
     _normalize_output(rv)
     assert rv == {
-        _segment_id(1, "a" * 32, "a" * 16): [
-            _output_segment(b"a" * 16, b"a" * 16, True),
-            _output_segment(b"b" * 16, b"a" * 16, False),
-            _output_segment(b"c" * 16, b"a" * 16, False),
-            _output_segment(b"d" * 16, b"a" * 16, False),
-            _output_segment(b"e" * 16, b"a" * 16, False),
-        ]
+        _segment_id(1, "a" * 32, "a" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"a" * 16, b"a" * 16, True),
+                _output_segment(b"b" * 16, b"a" * 16, False),
+                _output_segment(b"c" * 16, b"a" * 16, False),
+                _output_segment(b"d" * 16, b"a" * 16, False),
+                _output_segment(b"e" * 16, b"a" * 16, False),
+            ],
+        )
     }
 
     buffer.done_flush_segments(rv)
 
-    _, rv = buffer.flush_segments(now=60)
+    rv = buffer.flush_segments(now=60)
     assert rv == {}
 
     assert_clean(buffer.client)
@@ -343,25 +353,32 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
 
     assert_ttls(buffer.client)
 
-    assert buffer.flush_segments(now=5) == (2, {})
-    _, rv = buffer.flush_segments(now=11)
-    assert rv == {_segment_id(2, "a" * 32, "b" * 16): [_output_segment(b"b" * 16, b"b" * 16, True)]}
-    buffer.done_flush_segments(rv)
-
-    # TODO: flush faster, since we already saw parent in other project
-    assert buffer.flush_segments(now=30) == (1, {})
-    _, rv = buffer.flush_segments(now=60)
-    _normalize_output(rv)
+    assert buffer.flush_segments(now=5) == {}
+    rv = buffer.flush_segments(now=11)
     assert rv == {
-        _segment_id(1, "a" * 32, "b" * 16): [
-            _output_segment(b"c" * 16, b"b" * 16, False),
-            _output_segment(b"d" * 16, b"b" * 16, False),
-            _output_segment(b"e" * 16, b"b" * 16, False),
-        ]
+        _segment_id(2, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY, spans=[_output_segment(b"b" * 16, b"b" * 16, True)]
+        )
     }
     buffer.done_flush_segments(rv)
 
-    assert buffer.flush_segments(now=90) == (0, {})
+    # TODO: flush faster, since we already saw parent in other project
+    assert buffer.flush_segments(now=30) == {}
+    rv = buffer.flush_segments(now=60)
+    _normalize_output(rv)
+    assert rv == {
+        _segment_id(1, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"c" * 16, b"b" * 16, False),
+                _output_segment(b"d" * 16, b"b" * 16, False),
+                _output_segment(b"e" * 16, b"b" * 16, False),
+            ],
+        )
+    }
+    buffer.done_flush_segments(rv)
+
+    assert buffer.flush_segments(now=90) == {}
 
     assert_clean(buffer.client)
 
@@ -408,28 +425,70 @@ def test_parent_in_other_project_and_nested_is_segment_span(buffer: SpansBuffer,
 
     assert_ttls(buffer.client)
 
-    assert buffer.flush_segments(now=5) == (3, {})
-    _, rv = buffer.flush_segments(now=11)
+    assert buffer.flush_segments(now=5) == {}
+    rv = buffer.flush_segments(now=11)
     assert rv == {
-        _segment_id(2, "a" * 32, "b" * 16): [_output_segment(b"b" * 16, b"b" * 16, True)],
-        _segment_id(1, "a" * 32, "c" * 16): [
-            _output_segment(b"c" * 16, b"c" * 16, True),
-        ],
+        _segment_id(2, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY, spans=[_output_segment(b"b" * 16, b"b" * 16, True)]
+        ),
+        _segment_id(1, "a" * 32, "c" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"c" * 16, b"c" * 16, True),
+            ],
+        ),
     }
     buffer.done_flush_segments(rv)
 
     # TODO: flush faster, since we already saw parent in other project
-    assert buffer.flush_segments(now=30) == (1, {})
-    _, rv = buffer.flush_segments(now=60)
+    assert buffer.flush_segments(now=30) == {}
+    rv = buffer.flush_segments(now=60)
     _normalize_output(rv)
     assert rv == {
-        _segment_id(1, "a" * 32, "b" * 16): [
-            _output_segment(b"d" * 16, b"b" * 16, False),
-            _output_segment(b"e" * 16, b"b" * 16, False),
-        ],
+        _segment_id(1, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            spans=[
+                _output_segment(b"d" * 16, b"b" * 16, False),
+                _output_segment(b"e" * 16, b"b" * 16, False),
+            ],
+        ),
     }
+
     buffer.done_flush_segments(rv)
 
-    assert buffer.flush_segments(now=90) == (0, {})
+    assert buffer.flush_segments(now=90) == {}
+
+    assert_clean(buffer.client)
+
+
+def test_flush_rebalance(buffer: SpansBuffer):
+    spans = [
+        Span(
+            payload=_payload(b"a" * 16),
+            trace_id="a" * 32,
+            span_id="a" * 16,
+            parent_span_id=None,
+            project_id=1,
+            is_segment_span=True,
+        )
+    ]
+
+    process_spans(spans, buffer, now=0)
+    assert_ttls(buffer.client)
+
+    assert buffer.flush_segments(now=5) == {}
+    rv = buffer.flush_segments(now=11)
+    assert rv == {
+        _segment_id(1, "a" * 32, "a" * 16): FlushedSegment(
+            queue_key=mock.ANY, spans=[_output_segment(b"a" * 16, b"a" * 16, True)]
+        ),
+    }
+
+    # Clear out assigned shards, simulating a rebalance operation.
+    buffer.assigned_shards.clear()
+    buffer.done_flush_segments(rv)
+
+    rv = buffer.flush_segments(now=20)
+    assert not rv
 
     assert_clean(buffer.client)

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Sequence
 from unittest import mock
 
 import pytest
@@ -80,7 +81,7 @@ class _SplitBatch:
     pass
 
 
-def process_spans(spans: list[Span | _SplitBatch], buffer: SpansBuffer, now):
+def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now):
     """
     Call buffer.process_spans on the list of spans.
 


### PR DESCRIPTION
When rebalancing happens, segments get sharded into different queues
than before. Meaning that done_flush_segments tries to delete the "done"
key from the wrong queue. Pull through the queue_key to
done_flush_segments to fix that.
