### PR TITLE
fix: button styles

### DIFF
--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -262,7 +262,6 @@ export function HybridFilter<Value extends SelectKey>({
                     {t('Cancel')}
                   </Button>
                   <Button
-                    borderless
                     size="xs"
                     priority="primary"
                     disabled={disableCommit}


### PR DESCRIPTION
Borderless used to have no effect in the old UI, but we treat it as a separate variant in Chonk as it will ultimately be removed or migrated to use the transparent variant.

Thanks for reporting the issue @s1gr1d 