### PR TITLE
fix(insights): http sample panel not setting eap flag

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -50,6 +50,12 @@ export default function SubregionSelector({size}: Props) {
       };
     }) ?? [];
 
+  options.push({
+    value: 'none',
+    label: t('No region detected'),
+    textValue: t('No region detected'),
+  });
+
   const tooltip = t('These correspond to the subregions of the UN M49 standard.');
 
   return (

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -6,12 +6,14 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpanSamples} from 'sentry/views/insights/http/queries/useSpanSamples';
 import {SpanIndexedField, type SpanIndexedProperty} from 'sentry/views/insights/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useLocation');
 
 describe('useSpanSamples', () => {
   const organization = OrganizationFixture();
@@ -39,6 +41,16 @@ describe('useSpanSamples', () => {
       environments: ['prod'],
       projects: [],
     },
+  });
+
+  jest.mocked(useLocation).mockReturnValue({
+    query: {},
+    action: 'PUSH',
+    pathname: '',
+    hash: '',
+    key: '',
+    search: '',
+    state: undefined,
   });
 
   beforeEach(() => {

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -3,6 +3,7 @@
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
@@ -34,7 +35,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
   } = options;
 
   const {selection} = usePageFilters();
-
+  const location = useLocation();
   const organization = useOrganization();
 
   if (defined(min) && min < 0) {
@@ -81,6 +82,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
           upperBound: max,
           additionalFields: fields,
           referrer,
+          useRpc: location.query?.useEap,
         },
       },
     ],


### PR DESCRIPTION
We should set `useRpc = 1` when we want the sample panel to use eap rpc