### PR TITLE
Add timestamp precise to the trace item details tests

### DIFF
--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -35,7 +35,6 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                 },
             )
 
-    @pytest.mark.skip("disabled while snuba adds a precise timestamp")
     def test_simple(self):
         logs = [
             self.create_ourlog(
@@ -82,15 +81,29 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
         trace_details_response = self.do_request("logs", item_id)
 
         assert trace_details_response.status_code == 200, trace_details_response.content
+
+        timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data["attributes"] == [
             {"name": "bool_attr", "type": "bool", "value": True},
             {"name": "log.severity_number", "type": "float", "value": 0.0},
             {"name": "tags[bool_attr,number]", "type": "float", "value": 1.0},
             {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
             {"name": "tags[int_attr,number]", "type": "float", "value": 2.0},
+            # this is stored as a float for searching, so it is not actually very precise
+            {
+                "name": "tags[sentry.timestamp_precise,number]",
+                "type": "float",
+                "value": pytest.approx(float(timestamp_nanos), abs=1e12),
+            },
             {"name": "log.severity_number", "type": "int", "value": "0"},
             {"name": "project_id", "type": "int", "value": str(self.project.id)},
             {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
+            # this is the precise one
+            {
+                "name": "tags[sentry.timestamp_precise,number]",
+                "type": "int",
+                "value": str(timestamp_nanos),
+            },
             {"name": "log.body", "type": "str", "value": "foo"},
             {"name": "log.severity_text", "type": "str", "value": "INFO"},
             {"name": "str_attr", "type": "str", "value": "1"},
@@ -102,7 +115,6 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
             == self.one_min_ago.replace(microsecond=0, tzinfo=None).isoformat() + "Z"
         )
 
-    @pytest.mark.skip("disabled while snuba adds a precise timestamp")
     def test_simple_using_logs_item_type(self):
         logs = [
             self.create_ourlog(
@@ -149,6 +161,8 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
         trace_details_response = self.do_request("logs", item_id)
 
         assert trace_details_response.status_code == 200, trace_details_response.content
+
+        timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data == {
             "attributes": [
                 {"name": "bool_attr", "type": "bool", "value": True},
@@ -156,9 +170,21 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                 {"name": "tags[bool_attr,number]", "type": "float", "value": 1.0},
                 {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
                 {"name": "tags[int_attr,number]", "type": "float", "value": 2.0},
+                # this is stored as a float for searching, so it is not actually very precise
+                {
+                    "name": "tags[sentry.timestamp_precise,number]",
+                    "type": "float",
+                    "value": pytest.approx(float(timestamp_nanos), abs=1e12),
+                },
                 {"name": "log.severity_number", "type": "int", "value": "0"},
                 {"name": "project_id", "type": "int", "value": str(self.project.id)},
                 {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
+                # this is the precise one
+                {
+                    "name": "tags[sentry.timestamp_precise,number]",
+                    "type": "int",
+                    "value": str(timestamp_nanos),
+                },
                 {"name": "log.body", "type": "str", "value": "foo"},
                 {"name": "log.severity_text", "type": "str", "value": "INFO"},
                 {"name": "str_attr", "type": "str", "value": "1"},


### PR DESCRIPTION
Snuba now returns a precise timestamp, let's make sure that it works with a Sentry test.
