### PR TITLE
fix(uptime): check that subscription_id exists

### DIFF
--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -46,6 +46,10 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         project: Project,
         uptime_subscription: ProjectUptimeSubscription,
     ) -> Response:
+
+        if uptime_subscription.uptime_subscription.subscription_id is None:
+            return Response([])
+
         start, end = get_date_range_from_params(request.GET)
 
         def data_fn(offset: int, limit: int) -> Any:

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -154,3 +154,19 @@ class ProjectUptimeAlertCheckIndexEndpoint(
         )
         assert response.data is not None
         assert len(response.data) == 0
+
+    def test_get_with_none_subscription_id(self):
+        # Create a subscription with None subscription_id
+        subscription = self.create_uptime_subscription(
+            url="https://example.com", subscription_id=None
+        )
+        project_uptime_subscription = self.create_project_uptime_subscription(
+            uptime_subscription=subscription
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            project_uptime_subscription.id,
+        )
+        assert response.data == []


### PR DESCRIPTION
It is possible for the uptime subscription_id to be null. This causes problems downstream in EAP. I have not looked at our data model more closely, but it seems strange we allow subscription_id to be null

Fixes [SNUBA-81E](https://sentry.sentry.io/issues/6459505413/)