### PR TITLE
fix(eap-spans): `bounded_sample` function should accept decimal places

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -22,7 +22,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.events.types import SnubaParams
 
-ResolvedArgument: TypeAlias = AttributeKey | str | int
+ResolvedArgument: TypeAlias = AttributeKey | str | int | float
 ResolvedArguments: TypeAlias = list[ResolvedArgument]
 
 
@@ -97,7 +97,7 @@ class BaseArgumentDefinition:
 @dataclass
 class ValueArgumentDefinition(BaseArgumentDefinition):
     # the type of the argument itself, if the type is a non-string you should ensure an appropriate validator is provided to avoid conversion errors
-    argument_types: set[Literal["integer", "string"]] | None = None
+    argument_types: set[Literal["integer", "string", "number"]] | None = None
 
 
 @dataclass

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -835,6 +835,8 @@ class SearchResolver:
                     for type in argument_definition.argument_types:
                         if type == "integer":
                             parsed_args.append(int(argument))
+                        if type == "number":
+                            parsed_args.append(float(argument))
                         else:
                             parsed_args.append(argument)
                     continue

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -110,8 +110,8 @@ def resolve_http_response_count(args: ResolvedArguments) -> tuple[AttributeKey, 
 
 def resolve_bounded_sample(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
     attribute = cast(AttributeKey, args[0])
-    lower_bound = cast(int, args[1])
-    upper_bound = cast(int | None, args[2])
+    lower_bound = cast(float, args[1])
+    upper_bound = cast(float | None, args[2])
 
     lower_bound_filter = TraceItemFilter(
         comparison_filter=ComparisonFilter(
@@ -214,8 +214,8 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         default_search_type="boolean",
         arguments=[
             AttributeArgumentDefinition(attribute_types={"millisecond"}),
-            ValueArgumentDefinition(argument_types={"integer"}),
-            ValueArgumentDefinition(argument_types={"integer"}, default_arg=None),
+            ValueArgumentDefinition(argument_types={"number"}),
+            ValueArgumentDefinition(argument_types={"number"}, default_arg=None),
         ],
         aggregate_resolver=resolve_bounded_sample,
         processor=lambda x: x > 0,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -22,7 +22,7 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
 )
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
-from sentry.search.eap.utils import literal_validator
+from sentry.search.eap.utils import literal_validator, number_validator
 
 
 def count_processor(count_value: int | None) -> int:
@@ -214,8 +214,10 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         default_search_type="boolean",
         arguments=[
             AttributeArgumentDefinition(attribute_types={"millisecond"}),
-            ValueArgumentDefinition(argument_types={"number"}),
-            ValueArgumentDefinition(argument_types={"number"}, default_arg=None),
+            ValueArgumentDefinition(argument_types={"number"}, validator=number_validator),
+            ValueArgumentDefinition(
+                argument_types={"number"}, validator=number_validator, default_arg=None
+            ),
         ],
         aggregate_resolver=resolve_bounded_sample,
         processor=lambda x: x > 0,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -34,11 +34,9 @@ def literal_validator(values: list[Any]) -> Callable[[str], bool]:
 
 
 def number_validator(input: str) -> bool:
-    try:
-        float(input)
+    if input.replace(".", "", 1).isdecimal():
         return True
-    except ValueError:
-        return False
+    raise InvalidSearchQuery(f"Invalid parameter {input}. Must be numeric type")
 
 
 def add_start_end_conditions(

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -33,6 +33,14 @@ def literal_validator(values: list[Any]) -> Callable[[str], bool]:
     return _validator
 
 
+def number_validator(input: str) -> bool:
+    try:
+        float(input)
+        return True
+    except ValueError:
+        return False
+
+
 def add_start_end_conditions(
     in_msg: TimeSeriesRequest, start: datetime, end: datetime
 ) -> TimeSeriesRequest:

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -36,7 +36,7 @@ def literal_validator(values: list[Any]) -> Callable[[str], bool]:
 def number_validator(input: str) -> bool:
     if input.replace(".", "", 1).isdecimal():
         return True
-    raise InvalidSearchQuery(f"Invalid parameter {input}. Must be numeric type")
+    raise InvalidSearchQuery(f"Invalid parameter {input}. Must be numeric")
 
 
 def add_start_end_conditions(

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -585,7 +585,7 @@ class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestB
             {
                 "query": "",
                 "lowerBound": "0",
-                "firstBound": "10",
+                "firstBound": "10.0",
                 "secondBound": "20",
                 "upperBound": "200",
                 "project": self.project.id,


### PR DESCRIPTION
1. fixes SENTRY-3RGM
2. Adds `number_validator` to `bounded_sample` args