### PR TITLE
fix(dashboards-eap): Show best effort data when completed

### DIFF
--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -19,6 +19,37 @@ describe('spansWidgetQueries', () => {
     widget = WidgetFixture();
   });
 
+  function mockPreflightAndBestEffortRequests({
+    type,
+    preflightData,
+    bestEffortData,
+  }: {
+    bestEffortData: Record<string, any>;
+    preflightData: Record<string, any>;
+    type: 'events' | 'events-stats';
+  }) {
+    const preflightMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/${type}/`,
+      body: preflightData,
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === 'PREFLIGHT';
+        },
+      ],
+    });
+    const bestEffortMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/${type}/`,
+      body: bestEffortData,
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === 'BEST_EFFORT';
+        },
+      ],
+    });
+
+    return {preflightMock, bestEffortMock};
+  }
+
   it('calculates the confidence for a single series', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
@@ -95,9 +126,7 @@ describe('spansWidgetQueries', () => {
     expect(await screen.findByText('high')).toBeInTheDocument();
   });
 
-  // TODO: Flaky test
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('triggers a preflight and then a best effort request', async () => {
+  it('triggers a preflight and then a best effort request', async () => {
     widget = WidgetFixture({
       queries: [
         {
@@ -111,13 +140,20 @@ describe('spansWidgetQueries', () => {
       ],
       displayType: DisplayType.LINE,
     });
-    const eventsStatsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-stats/',
-      body: {
+    const {preflightMock, bestEffortMock} = mockPreflightAndBestEffortRequests({
+      type: 'events-stats',
+      preflightData: {
         data: [
           [1, [{count: 1}]],
           [2, [{count: 2}]],
           [3, [{count: 3}]],
+        ],
+      },
+      bestEffortData: {
+        data: [
+          [1, [{count: 100}]],
+          [2, [{count: 200}]],
+          [3, [{count: 300}]],
         ],
       },
     });
@@ -142,10 +178,16 @@ describe('spansWidgetQueries', () => {
       </OrganizationContext.Provider>
     );
 
+    expect(preflightMock).toHaveBeenCalledTimes(1);
+    expect(bestEffortMock).toHaveBeenCalledTimes(0);
+
+    // Preflight data is returned
     expect(await screen.findByText('1')).toBeInTheDocument();
-    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
-    expect(eventsStatsMock).toHaveBeenNthCalledWith(
-      1,
+
+    expect(preflightMock).toHaveBeenCalledTimes(1);
+    expect(bestEffortMock).toHaveBeenCalledTimes(1);
+
+    expect(preflightMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
@@ -153,8 +195,7 @@ describe('spansWidgetQueries', () => {
         }),
       })
     );
-    expect(eventsStatsMock).toHaveBeenNthCalledWith(
-      2,
+    expect(bestEffortMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
@@ -163,8 +204,31 @@ describe('spansWidgetQueries', () => {
       })
     );
 
-    // Reset the mock so we can test that the rerender only triggers two requests
-    eventsStatsMock.mockReset();
+    // Best effort data is returned
+    expect(await screen.findByText('100')).toBeInTheDocument();
+
+    // Reset the mocks so we can test that the rerender only triggers two requests
+    MockApiClient.clearMockResponses();
+    const {
+      preflightMock: rerenderedPreflightMock,
+      bestEffortMock: rerenderedBestEffortMock,
+    } = mockPreflightAndBestEffortRequests({
+      type: 'events-stats',
+      preflightData: {
+        data: [
+          [1, [{count: '4'}]],
+          [2, [{count: '5'}]],
+          [3, [{count: '6'}]],
+        ],
+      },
+      bestEffortData: {
+        data: [
+          [1, [{count: '400'}]],
+          [2, [{count: '500'}]],
+          [3, [{count: '600'}]],
+        ],
+      },
+    });
 
     // Rerender the component and check that the preflight is called before the best effort
     rerender(
@@ -187,10 +251,16 @@ describe('spansWidgetQueries', () => {
       </OrganizationContext.Provider>
     );
 
-    expect(await screen.findByText('1')).toBeInTheDocument();
-    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
-    expect(eventsStatsMock).toHaveBeenNthCalledWith(
-      1,
+    expect(rerenderedPreflightMock).toHaveBeenCalledTimes(1);
+    expect(rerenderedBestEffortMock).toHaveBeenCalledTimes(0);
+
+    // Preflight data is returned
+    expect(await screen.findByText('4')).toBeInTheDocument();
+
+    expect(rerenderedPreflightMock).toHaveBeenCalledTimes(1);
+    expect(rerenderedBestEffortMock).toHaveBeenCalledTimes(1);
+
+    expect(rerenderedPreflightMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
@@ -198,8 +268,7 @@ describe('spansWidgetQueries', () => {
         }),
       })
     );
-    expect(eventsStatsMock).toHaveBeenNthCalledWith(
-      2,
+    expect(rerenderedBestEffortMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
@@ -207,5 +276,8 @@ describe('spansWidgetQueries', () => {
         }),
       })
     );
+
+    // Best effort data is returned
+    expect(await screen.findByText('400')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
There was a bug where the state we were setting was causing the wrong data to appear after the best effort request was completed. This stores the best effort request data so when we have it, we can just show it. I also updated a test to validate which response is being rendered when.