### PR TITLE
chore(profiling): Stop reporting unactionable unknown sdk errors

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -176,6 +176,8 @@ def process_profile_task(
             if features.has("organizations:profiling-sdks", organization):
                 try:
                     track_latest_sdk(project, profile)
+                except (UnknownClientSDKException, UnknownProfileTypeException):
+                    pass
                 except Exception as e:
                     sentry_sdk.capture_exception(e)
 


### PR DESCRIPTION
There's not much we can do about this error until we can reject profile chunks below the minimum sdk version. So stop reporting it since it's just noise.