### PR TITLE
fix(dashboards): Allow non daily bar graphs when using spans

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -518,11 +518,7 @@ function getEventsSeriesRequest(
   const {displayType, limit} = widget;
   const {environments, projects} = pageFilters;
   const {start, end, period: statsPeriod} = pageFilters.datetime;
-  const interval = getWidgetInterval(
-    displayType,
-    {start, end, period: statsPeriod},
-    '1m'
-  );
+  const interval = getWidgetInterval(widget, {start, end, period: statsPeriod}, '1m');
   const isMEPEnabled = defined(mepSetting) && mepSetting !== MEPState.TRANSACTIONS_ONLY;
 
   let requestData: any;

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -197,7 +197,7 @@ function getReleasesSeriesRequest(
   pageFilters: PageFilters
 ) {
   const query = widget.queries[queryIndex]!;
-  const {displayType, limit} = widget;
+  const {limit} = widget;
 
   const {datetime} = pageFilters;
   const {start, end, period} = datetime;
@@ -206,7 +206,7 @@ function getReleasesSeriesRequest(
 
   const includeTotals = query.columns.length > 0 ? 1 : 0;
   const interval = getWidgetInterval(
-    displayType,
+    widget,
     {start, end, period},
     '5m',
     // requesting medium fidelity for release sort because metrics api can't return 100 rows of high fidelity series data

--- a/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.tsx
+++ b/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.tsx
@@ -29,11 +29,7 @@ export function getSeriesRequestData(
   const {displayType, limit} = widget;
   const {environments, projects} = pageFilters;
   const {start, end, period: statsPeriod} = pageFilters.datetime;
-  const interval = getWidgetInterval(
-    displayType,
-    {start, end, period: statsPeriod},
-    '1m'
-  );
+  const interval = getWidgetInterval(widget, {start, end, period: statsPeriod}, '1m');
 
   let requestData: EventsStatsOptions<true>;
   if (displayType === DisplayType.TOP_N) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -205,17 +205,23 @@ export function miniWidget(displayType: DisplayType): string {
 }
 
 export function getWidgetInterval(
-  displayType: DisplayType,
+  widget: Widget,
   datetimeObj: Partial<PageFilters['datetime']>,
-  widgetInterval?: string,
+  widgetIntervalOverride?: string,
   fidelity?: Fidelity
 ): string {
   // Don't fetch more than 66 bins as we're plotting on a small area.
   const MAX_BIN_COUNT = 66;
 
-  // Bars charts are daily totals to aligned with discover. It also makes them
-  // usefully different from line/area charts until we expose the interval control, or remove it.
-  let interval = displayType === 'bar' ? '1d' : widgetInterval;
+  let interval =
+    widget.widgetType === WidgetType.SPANS
+      ? // For span based widgets, we want to permit non 1d bar charts.
+        undefined
+      : // Bars charts are daily totals to aligned with discover. It also makes them
+        // usefully different from line/area charts until we expose the interval control, or remove it.
+        widget.displayType === 'bar'
+        ? '1d'
+        : widgetIntervalOverride;
   if (!interval) {
     // Default to 5 minutes
     interval = '5m';
@@ -230,13 +236,16 @@ export function getWidgetInterval(
     if (selectedRange > SIX_HOURS && selectedRange <= TWENTY_FOUR_HOURS) {
       interval = '1h';
     }
-    return displayType === 'bar' ? '1d' : interval;
+    return widget.displayType === 'bar' ? '1d' : interval;
   }
 
   // selectedRange is in minutes, desiredPeriod is in hours
   // convert desiredPeriod to minutes
   if (selectedRange / (desiredPeriod * 60) > MAX_BIN_COUNT) {
-    const highInterval = getInterval(datetimeObj, 'high');
+    const highInterval = getInterval(
+      datetimeObj,
+      widget.widgetType === WidgetType.SPANS ? 'spans' : 'high'
+    );
     // Only return high fidelity interval if desired interval is higher fidelity
     if (desiredPeriod < parsePeriodToHours(highInterval)) {
       return highInterval;

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -136,7 +136,7 @@ export function getWidgetExploreUrl(
     sort: locationQueryParams.sort || undefined,
     interval:
       decodeScalar(locationQueryParams.interval) ??
-      getWidgetInterval(widget.displayType, selection.datetime),
+      getWidgetInterval(widget, selection.datetime),
   };
 
   return getExploreUrl(queryParams);


### PR DESCRIPTION
When using eap spans in dashboards, we should permit non daily bar graphs. Here we use the fidelity latter defined for spans.