### PR TITLE
loadingindicator: scale border width with size

### DIFF
--- a/static/app/components/loadingIndicator.stories.tsx
+++ b/static/app/components/loadingIndicator.stories.tsx
@@ -1,23 +1,22 @@
-import styled from '@emotion/styled';
-
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import JSXProperty from 'sentry/components/stories/jsxProperty';
+import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook('LoadingIndicator', story => {
-  story('Default', () => <LoadingIndicator />);
-
-  story('Mini', () => <LoadingIndicator mini />);
-  story('Sizes', () => (
+  story('Default', () => (
     <div>
-      <LoadingIndicator size={24} />
-      <StyledLoadingIndicator size={24} />
+      <p>
+        Setting custom size on <JSXProperty name="size" value={24} /> will cause the
+        border width to scale proportionally with the size of the loading indicator.
+      </p>
+      <SideBySide>
+        <LoadingIndicator />
+        <LoadingIndicator size={48} />
+        <LoadingIndicator size={24} />
+      </SideBySide>
     </div>
   ));
 
-  story('With Message', () => <LoadingIndicator>Loading...</LoadingIndicator>);
+  story('Loading text', () => <LoadingIndicator>Loading...</LoadingIndicator>);
 });
-
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  width: 24px;
-  height: 24px;
-`;

--- a/static/app/components/loadingIndicator.tsx
+++ b/static/app/components/loadingIndicator.tsx
@@ -5,6 +5,9 @@ interface LoadingIndicatorProps {
   children?: NonNullable<React.ReactNode>;
   className?: string;
   ['data-test-id']?: string;
+  /**
+   * @deprecated Use `size` instead.
+   */
   mini?: boolean;
   overlay?: boolean;
   relative?: boolean;
@@ -26,11 +29,30 @@ function LoadingIndicator(props: LoadingIndicatorProps) {
         className={classNames('loading-indicator', {
           relative: props.relative,
         })}
-        style={props.size ? {width: props.size, height: props.size} : undefined}
+        style={
+          props.size
+            ? {
+                width: props.size,
+                height: props.size,
+                borderWidth: getLoadingIndicatorBorderWidth(props.size),
+              }
+            : undefined
+        }
       />
       {props.children && <div className="loading-message">{props.children}</div>}
     </div>
   );
+}
+
+function getLoadingIndicatorBorderWidth(size: number | undefined): number | undefined {
+  if (!size) {
+    return undefined;
+  }
+  if (size > 64) {
+    return 6;
+  }
+
+  return 2 + ((size - 24) / 40) * (6 - 2);
 }
 
 export default withProfiler(LoadingIndicator, {


### PR DESCRIPTION

![CleanShot 2025-04-04 at 13 07 02@2x](https://github.com/user-attachments/assets/dabea5f3-aad1-44ec-8854-e7031d6f2f98)

vs

![CleanShot 2025-04-04 at 13 07 34@2x](https://github.com/user-attachments/assets/88277651-02df-4673-a43b-c7f9dcfc685f)


Bothered me since forever. I have also deprecated the mini loader prop, but it's using a bunch of loader classes that make managing it very annoying