### PR TITLE
feat(rpc): add private attributes

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -23,7 +23,7 @@ from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.exceptions import InvalidParams
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import FieldsACL, SearchResolverConfig
 from sentry.snuba import (
     discover,
     errors,
@@ -465,7 +465,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     config=SearchResolverConfig(
                         auto_fields=True,
                         use_aggregate_conditions=use_aggregate_conditions,
-                        functions_acl={"time_spent_percentage"},
+                        fields_acl=FieldsACL(functions={"time_spent_percentage"}),
                     ),
                     sampling_mode=sampling_mode,
                 )

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -20,14 +20,9 @@ from sentry.api.exceptions import BadRequest
 from sentry.models.project import Project
 from sentry.search.eap import constants
 from sentry.search.eap.types import SupportedTraceItemType, TraceItemAttribute
-from sentry.search.eap.utils import translate_internal_to_public_alias
+from sentry.search.eap.utils import PRIVATE_ATTRIBUTES, translate_internal_to_public_alias
 from sentry.snuba.referrer import Referrer
 from sentry.utils import snuba_rpc
-
-DISALLOW_LIST = {
-    "sentry.organization_id",
-    "sentry.item_type",
-}
 
 
 def convert_rpc_attribute_to_json(
@@ -37,7 +32,7 @@ def convert_rpc_attribute_to_json(
     result: list[TraceItemAttribute] = []
     for attribute in attributes:
         internal_name = attribute["name"]
-        if internal_name in DISALLOW_LIST:
+        if internal_name in PRIVATE_ATTRIBUTES.get(trace_item_type, []):
             continue
         source = attribute["value"]
         if len(source) == 0:

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -74,6 +74,8 @@ class ResolvedAttribute(ResolvedColumn):
     # The internal rpc alias for this column
     internal_name: str
     is_aggregate: bool = field(default=False, init=False)
+    # There are columns in RPC that are available but we don't want rendered to the user
+    private: bool = False
 
     @property
     def proto_definition(self) -> AttributeKey:

--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -18,4 +18,16 @@ COMMON_COLUMNS = [
         internal_name="sentry.project_id",
         search_type="integer",
     ),
+    ResolvedAttribute(
+        public_alias="sentry.item_type",
+        search_type="integer",
+        internal_name="sentry.item_type",
+        private=True,
+    ),
+    ResolvedAttribute(
+        public_alias="sentry.organization_id",
+        search_type="integer",
+        internal_name="sentry.organization_id",
+        private=True,
+    ),
 ]

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -86,3 +86,9 @@ LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[s
         if not definition.secondary_alias and definition.search_type != "string"
     },
 }
+
+LOGS_PRIVATE_ATTRIBUTES: set[str] = {
+    definition.internal_name
+    for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()
+    if definition.private
+}

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -409,6 +409,12 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[
     },
 }
 
+SPANS_PRIVATE_ATTRIBUTES: set[str] = {
+    definition.internal_name
+    for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+    if definition.private
+}
+
 
 SPAN_VIRTUAL_CONTEXTS = {
     "device.class": VirtualColumnDefinition(

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -8,6 +8,12 @@ from sentry.search.events.types import EventsResponse
 
 
 @dataclass(frozen=True)
+class FieldsACL:
+    functions: set[str] = field(default_factory=set)
+    attributes: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
 class SearchResolverConfig:
     # Automatically add id, etc. if there are no aggregates
     auto_fields: bool = False
@@ -16,8 +22,8 @@ class SearchResolverConfig:
     # TODO: do we need parser_config_overrides? it looks like its just for alerts
     # Whether to process the results from snuba
     process_results: bool = True
-    # If a `FunctionDefinition` is private, it will only be available if it is in the `functions_acl`
-    functions_acl: set[str] = field(default_factory=set)
+    # If a field is private, it will only be available if it is in the `fields_acl`
+    fields_acl: FieldsACL = field(default_factory=lambda: FieldsACL())
 
 
 CONFIDENCES: dict[Reliability.ValueType, Literal["low", "high"]] = {

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -10,8 +10,14 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.constants import SAMPLING_MODES
-from sentry.search.eap.ourlogs.attributes import LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
+from sentry.search.eap.ourlogs.attributes import (
+    LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+    LOGS_PRIVATE_ATTRIBUTES,
+)
+from sentry.search.eap.spans.attributes import (
+    SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+    SPANS_PRIVATE_ATTRIBUTES,
+)
 from sentry.search.eap.types import SupportedTraceItemType
 
 # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
@@ -98,6 +104,12 @@ INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
 ] = {
     SupportedTraceItemType.SPANS: SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SupportedTraceItemType.LOGS: LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+}
+
+
+PRIVATE_ATTRIBUTES: dict[SupportedTraceItemType, set[str]] = {
+    SupportedTraceItemType.SPANS: SPANS_PRIVATE_ATTRIBUTES,
+    SupportedTraceItemType.LOGS: LOGS_PRIVATE_ATTRIBUTES,
 }
 
 


### PR DESCRIPTION
- This adds the fields that were in trace_item_details' DISALLOW_LIST to our full list of attributes, and then marks them private
- The goal here is that all possible columns in the RPC are defined in attributes and we define the expected behaviours for all of them