### PR TITLE
feat(taskworker): Make hybridcloud taskworker compatible 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1400,6 +1400,8 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.deletions.tasks.hybrid_cloud",
     "sentry.deletions.tasks.scheduled",
+    "sentry.hybridcloud.tasks.deliver_from_outbox",
+    "sentry.hybridcloud.tasks.deliver_webhooks",
     "sentry.incidents.tasks",
     "sentry.monitors.tasks.clock_pulse",
     "sentry.monitors.tasks.detect_broken_monitor_envs",

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -17,6 +17,8 @@ from sentry.hybridcloud.models.outbox import (
 from sentry.hybridcloud.tasks.backfill_outboxes import backfill_outboxes_for
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import hybridcloud_control_tasks, hybridcloud_tasks
 from sentry.utils import metrics
 from sentry.utils.env import in_test_environment
 
@@ -25,6 +27,9 @@ from sentry.utils.env import in_test_environment
     name="sentry.tasks.enqueue_outbox_jobs_control",
     queue="outbox.control",
     silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_control_tasks,
+    ),
 )
 def enqueue_outbox_jobs_control(
     concurrency: int | None = None, process_outbox_backfills: bool = True, **kwargs: Any
@@ -38,7 +43,12 @@ def enqueue_outbox_jobs_control(
 
 
 @instrumented_task(
-    name="sentry.tasks.enqueue_outbox_jobs", queue="outbox", silo_mode=SiloMode.REGION
+    name="sentry.tasks.enqueue_outbox_jobs",
+    queue="outbox",
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_tasks,
+    ),
 )
 def enqueue_outbox_jobs(
     concurrency: int | None = None, process_outbox_backfills: bool = True, **kwargs: Any
@@ -128,7 +138,12 @@ def schedule_batch(
 
 
 @instrumented_task(
-    name="sentry.tasks.drain_outbox_shards", queue="outbox", silo_mode=SiloMode.REGION
+    name="sentry.tasks.drain_outbox_shards",
+    queue="outbox",
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_tasks,
+    ),
 )
 def drain_outbox_shards(
     outbox_identifier_low: int = 0,
@@ -152,6 +167,9 @@ def drain_outbox_shards(
     name="sentry.tasks.drain_outbox_shards_control",
     queue="outbox.control",
     silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_control_tasks,
+    ),
 )
 def drain_outbox_shards_control(
     outbox_identifier_low: int = 0,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -24,6 +24,8 @@ from sentry.shared_integrations.exceptions import (
 from sentry.silo.base import SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
 from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import hybridcloud_control_tasks
 from sentry.types.region import get_region_by_name
 from sentry.utils import metrics
 
@@ -79,6 +81,9 @@ class DeliveryFailed(Exception):
     name="sentry.hybridcloud.tasks.deliver_webhooks.schedule_webhook_delivery",
     queue="webhook.control",
     silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_control_tasks,
+    ),
 )
 def schedule_webhook_delivery(**kwargs: Never) -> None:
     """
@@ -148,6 +153,9 @@ def schedule_webhook_delivery(**kwargs: Never) -> None:
     name="sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox",
     queue="webhook.control",
     silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_control_tasks,
+    ),
 )
 def drain_mailbox(payload_id: int) -> None:
     """
@@ -220,6 +228,9 @@ def drain_mailbox(payload_id: int) -> None:
     name="sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel",
     queue="webhook.control",
     silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=hybridcloud_control_tasks,
+    ),
 )
 def drain_mailbox_parallel(payload_id: int) -> None:
     """

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3255,3 +3255,13 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "taskworker.hybridcloud.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "taskworker.hybridcloud.control.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -24,6 +24,10 @@ demomode_tasks = taskregistry.create_namespace("demomode")
 
 digests_tasks = taskregistry.create_namespace("digests")
 
+hybridcloud_tasks = taskregistry.create_namespace("hybridcloud")
+
+hybridcloud_control_tasks = taskregistry.create_namespace("hybridcloud.control")
+
 options_tasks = taskregistry.create_namespace("options")
 
 options_control_tasks = taskregistry.create_namespace("options.control")


### PR DESCRIPTION
This work is required to migrate tasks from celery to the new taskbroker system. The sentry option will be used to control the rollout of these tasks. The full migration plan is describe in this [document](https://www.notion.so/sentry/Rollout-Planning-1bd8b10e4b5d80aeaaa7dba0efca83bc).

Notable changes/callouts
Most of relocation tasks use retry_backof, retry_backoff_jitter, and soft_time_limit which taskworker does not support
LastAction (action taken when retries are exhausted) is set to discard
sentry.relocation.fulfill_cross_region_export_request uses reject_on_worker_lost which is already the default behaviour