### PR TITLE
chore(taskworker) Remove more countdown for deletions

### DIFF
--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -51,7 +51,6 @@ def delete_groups(
                 "transaction_id": transaction_id,
                 "eventstream_state": eventstream_state,
             },
-            countdown=15,
         )
     else:
         # all groups have been deleted


### PR DESCRIPTION
We don't need to add arbitrary delays to chained deletion tasks. They can be processed as soon as a worker becomes available.

Refs #88091