### PR TITLE
fix(issue-stream): Add back page filter params on issues feed

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -17,18 +17,18 @@ function IssueListContainer({children}: Props) {
   const prefersStackedNav = usePrefersStackedNav();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
 
+  const onNewIssuesFeed = prefersStackedNav && !viewId;
   const useGlobalPageFilters =
-    !organization.features.includes('issue-stream-custom-views') ||
-    (prefersStackedNav && !viewId);
+    !organization.features.includes('issue-stream-custom-views') || onNewIssuesFeed;
 
   return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
       <PageFiltersContainer
         skipLoadLastUsed={!useGlobalPageFilters}
         disablePersistence={!useGlobalPageFilters}
-        skipInitializeUrlParams={organization.features.includes(
-          'issue-stream-custom-views'
-        )}
+        skipInitializeUrlParams={
+          !onNewIssuesFeed && organization.features.includes('issue-stream-custom-views')
+        }
       >
         <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
       </PageFiltersContainer>


### PR DESCRIPTION
This allows the page filters to add the `project`/`environments`/`timePeriod` query params when you load the issues feed at `/issues/`. It's important for the query params to be present because otherwise the page filters will assume there are 0 projects selected on first render. This also just makes the experience more consistent because these query params exist on issue views and did on the old non-issueviews experience.

However, this does not fix caching in all circumstances. I've found that it works when I have  the default `14d` time filters selected, but not anything else. When another time range is selected, the page filters store will assume that it is the default on first render. I assume that this has something to do with the time range being modified on issue details, but I'm not sure. This requires more investigation, but for now this improves the behavior in some cases.