### PR TITLE
chore(taskworker) Remove countdown usage in data_export

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -54,7 +54,6 @@ def assemble_download(
     bytes_written=0,
     environment_id=None,
     export_retries=3,
-    countdown=60,
     **kwargs,
 ):
     with sentry_sdk.start_span(op="assemble"):
@@ -148,7 +147,6 @@ def assemble_download(
                         "environment_id": environment_id,
                         "export_retries": export_retries - 1,
                     },
-                    countdown=countdown,
                 )
             else:
                 return data_export.email_failure(message=str(error))
@@ -187,7 +185,6 @@ def assemble_download(
                         "environment_id": environment_id,
                         "export_retries": export_retries,
                     },
-                    countdown=3,
                 )
             else:
                 metrics.distribution("dataexport.row_count", next_offset, sample_rate=1.0)

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -457,7 +457,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             },
         ]
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         de = ExportedData.objects.get(id=de.id)
         assert de.date_finished is not None
         assert de.date_expired is not None
@@ -482,87 +482,87 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
 
         mock_query.side_effect = QueryIllegalTypeOfArgument("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Invalid query. Argument to function is wrong type."
 
         # unicode
         mock_query.side_effect = QueryIllegalTypeOfArgument("\xfc")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Invalid query. Argument to function is wrong type."
 
         mock_query.side_effect = SnubaError("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Please try again."
 
         # unicode
         mock_query.side_effect = SnubaError("\xfc")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Please try again."
 
         mock_query.side_effect = RateLimitExceeded("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryMemoryLimitExceeded("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryExecutionTimeMaximum("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryTooManySimultaneous("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = DatasetSelectionError("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 
         mock_query.side_effect = QueryConnectionFailed("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 
         mock_query.side_effect = QuerySizeExceeded("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 
         mock_query.side_effect = QueryExecutionError("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 
         mock_query.side_effect = SchemaValidationError("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 
         mock_query.side_effect = UnqualifiedQueryError("test")
         with self.tasks():
-            assemble_download(de.id, count_down=0)
+            assemble_download(de.id)
         error = emailer.call_args[1]["message"]
         assert error == "Internal error. Your query failed to run."
 


### PR DESCRIPTION
We don't need to add arbitrary delays between export batches, the volume of these tasks is low enough that tasks are waiting in backlogs.

Refs #88091