### PR TITLE
fix(autofix): Poll for PR state

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -1,8 +1,8 @@
-import {Fragment, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import ClippedBox from 'sentry/components/clippedBox';
 import {Button, LinkButton} from 'sentry/components/core/button';
@@ -15,7 +15,6 @@ import {
   type AutofixChangesStep,
   type AutofixCodebaseChange,
   AutofixStatus,
-  type AutofixUpdateEndpointResponse,
   type CommentThread,
 } from 'sentry/components/events/autofix/types';
 import {
@@ -167,248 +166,6 @@ const CodeText = styled('code')`
   white-space: nowrap;
 `;
 
-function CreatePRsButton({
-  changes,
-  groupId,
-  runId,
-  isBusy,
-  onBusyStateChange,
-}: {
-  changes: AutofixCodebaseChange[];
-  groupId: string;
-  isBusy: boolean;
-  onBusyStateChange: (busy: boolean) => void;
-  runId: string;
-}) {
-  const api = useApi();
-  const queryClient = useQueryClient();
-  const [hasClickedCreatePr, setHasClickedCreatePr] = useState(false);
-
-  const createPRs = () => {
-    setHasClickedCreatePr(true);
-    onBusyStateChange(true);
-    for (const change of changes) {
-      createPr({change});
-    }
-  };
-
-  const {mutate: createPr} = useMutation({
-    mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'create_pr',
-            repo_external_id: change.repo_external_id,
-          },
-        },
-      });
-    },
-    onSuccess: (data: AutofixUpdateEndpointResponse) => {
-      if (data.status === 'error') {
-        addErrorMessage(data.message ?? t('Failed to create a pull request'));
-        setHasClickedCreatePr(false);
-        onBusyStateChange(false);
-      } else {
-        addSuccessMessage(t('Created pull requests.'));
-        queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
-        setHasClickedCreatePr(false);
-        onBusyStateChange(false);
-      }
-    },
-    onError: () => {
-      setHasClickedCreatePr(false);
-      onBusyStateChange(false);
-      addErrorMessage(t('Failed to create a pull request'));
-    },
-  });
-
-  return (
-    <Button
-      priority="primary"
-      onClick={createPRs}
-      icon={hasClickedCreatePr && <StyledLoadingIndicator size={14} mini />}
-      size="sm"
-      busy={hasClickedCreatePr}
-      disabled={isBusy}
-      analyticsEventName="Autofix: Create PR Clicked"
-      analyticsEventKey="autofix.create_pr_clicked"
-      analyticsParams={{group_id: groupId}}
-    >
-      Draft PR{changes.length > 1 ? 's' : ''}
-    </Button>
-  );
-}
-
-function CreateBranchButton({
-  changes,
-  groupId,
-  runId,
-  isBusy,
-  onBusyStateChange,
-}: {
-  changes: AutofixCodebaseChange[];
-  groupId: string;
-  isBusy: boolean;
-  onBusyStateChange: (busy: boolean) => void;
-  runId: string;
-}) {
-  const api = useApi();
-  const queryClient = useQueryClient();
-  const [hasClickedPushToBranch, setHasClickedPushToBranch] = useState(false);
-
-  const pushToBranch = () => {
-    setHasClickedPushToBranch(true);
-    onBusyStateChange(true);
-    for (const change of changes) {
-      createBranch({change});
-    }
-  };
-
-  const {mutate: createBranch} = useMutation({
-    mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'create_branch',
-            repo_external_id: change.repo_external_id,
-          },
-        },
-      });
-    },
-    onSuccess: (data: AutofixUpdateEndpointResponse) => {
-      if (data.status === 'error') {
-        addErrorMessage(data.message ?? t('Failed to create a pull request'));
-        setHasClickedPushToBranch(false);
-        onBusyStateChange(false);
-      }
-      addSuccessMessage(t('Pushed to branches.'));
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
-      setHasClickedPushToBranch(false);
-      onBusyStateChange(false);
-    },
-    onError: () => {
-      setHasClickedPushToBranch(false);
-      onBusyStateChange(false);
-      addErrorMessage(t('Failed to push to branches.'));
-    },
-  });
-
-  return (
-    <Button
-      onClick={pushToBranch}
-      icon={hasClickedPushToBranch && <StyledLoadingIndicator size={14} mini />}
-      size="sm"
-      busy={hasClickedPushToBranch}
-      disabled={isBusy}
-      analyticsEventName="Autofix: Push to Branch Clicked"
-      analyticsEventKey="autofix.push_to_branch_clicked"
-      analyticsParams={{group_id: groupId}}
-    >
-      Check Out Locally
-    </Button>
-  );
-}
-
-function SetupAndCreateBranchButton({
-  changes,
-  groupId,
-  runId,
-  isBusy,
-  onBusyStateChange,
-}: {
-  changes: AutofixCodebaseChange[];
-  groupId: string;
-  isBusy: boolean;
-  onBusyStateChange: (busy: boolean) => void;
-  runId: string;
-}) {
-  const {codebases} = useAutofixRepos(groupId);
-
-  if (
-    !changes.every(
-      change =>
-        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
-    )
-  ) {
-    return (
-      <Button
-        onClick={() => {
-          openModal(deps => <AutofixSetupWriteAccessModal {...deps} groupId={groupId} />);
-        }}
-        size="sm"
-        analyticsEventName="Autofix: Create Branch Setup Clicked"
-        analyticsEventKey="autofix.create_branch_setup_clicked"
-        analyticsParams={{group_id: groupId}}
-        title={t('Enable write access to create branches')}
-      >
-        {t('Check Out Locally')}
-      </Button>
-    );
-  }
-
-  return (
-    <CreateBranchButton
-      changes={changes}
-      groupId={groupId}
-      runId={runId}
-      isBusy={isBusy}
-      onBusyStateChange={onBusyStateChange}
-    />
-  );
-}
-
-function SetupAndCreatePRsButton({
-  changes,
-  groupId,
-  runId,
-  isBusy,
-  onBusyStateChange,
-}: {
-  changes: AutofixCodebaseChange[];
-  groupId: string;
-  isBusy: boolean;
-  onBusyStateChange: (busy: boolean) => void;
-  runId: string;
-}) {
-  const {codebases} = useAutofixRepos(groupId);
-  if (
-    !changes.every(
-      change =>
-        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
-    )
-  ) {
-    return (
-      <Button
-        priority="primary"
-        onClick={() => {
-          openModal(deps => <AutofixSetupWriteAccessModal {...deps} groupId={groupId} />);
-        }}
-        size="sm"
-        analyticsEventName="Autofix: Create PR Setup Clicked"
-        analyticsEventKey="autofix.create_pr_setup_clicked"
-        analyticsParams={{group_id: groupId}}
-        title={t('Enable write access to create pull requests')}
-      >
-        {t('Draft PR')}
-      </Button>
-    );
-  }
-
-  return (
-    <CreatePRsButton
-      changes={changes}
-      groupId={groupId}
-      runId={runId}
-      isBusy={isBusy}
-      onBusyStateChange={onBusyStateChange}
-    />
-  );
-}
-
 export function AutofixChanges({
   step,
   groupId,
@@ -419,8 +176,26 @@ export function AutofixChanges({
   isChangesFirstAppearance,
 }: AutofixChangesProps) {
   const {data} = useAutofixData({groupId});
-  const [isBusy, setIsBusy] = useState(false);
+  const isBusy = step.status === AutofixStatus.PROCESSING;
   const iconCodeRef = useRef<HTMLDivElement>(null);
+  const [isPrProcessing, setIsPrProcessing] = useState(false);
+  const [isBranchProcessing, setIsBranchProcessing] = useState(false);
+
+  useEffect(() => {
+    if (step.status === AutofixStatus.COMPLETED) {
+      const prsNowExist =
+        step.changes.length > 0 && step.changes.every(c => c.pull_request);
+      const branchesNowExist =
+        step.changes.length > 0 && step.changes.every(c => c.branch_name);
+
+      if (prsNowExist) {
+        setIsPrProcessing(false);
+      }
+      if (branchesNowExist) {
+        setIsBranchProcessing(false);
+      }
+    }
+  }, [step.status, step.changes]);
 
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
     return (
@@ -494,16 +269,16 @@ export function AutofixChanges({
                       changes={step.changes}
                       groupId={groupId}
                       runId={runId}
-                      isBusy={isBusy}
-                      onBusyStateChange={setIsBusy}
+                      isBusy={isBusy || isPrProcessing}
+                      onProcessingChange={setIsBranchProcessing}
                     />
                   )}
                   <SetupAndCreatePRsButton
                     changes={step.changes}
                     groupId={groupId}
                     runId={runId}
-                    isBusy={isBusy}
-                    onBusyStateChange={setIsBusy}
+                    isBusy={isBusy || isBranchProcessing}
+                    onProcessingChange={setIsPrProcessing}
                   />
                 </ButtonBar>
               )}
@@ -650,7 +425,248 @@ const HeaderIconWrapper = styled('div')`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  && {
-    margin: 0;
-  }
+  right: ${space(1)};
+  top: 5px;
 `;
+
+function CreatePRsButton({
+  changes,
+  groupId,
+  runId,
+  isBusy,
+  onProcessingChange,
+}: {
+  changes: AutofixCodebaseChange[];
+  groupId: string;
+  isBusy: boolean;
+  onProcessingChange: (processing: boolean) => void;
+  runId: string;
+}) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [hasClicked, setHasClicked] = useState(false);
+
+  // Reset hasClicked state and notify parent when isBusy goes from true to false
+  useEffect(() => {
+    if (!isBusy) {
+      setHasClicked(false);
+      onProcessingChange(false);
+    }
+  }, [isBusy, onProcessingChange]);
+
+  const {mutate: createPr} = useMutation({
+    mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'create_pr',
+            repo_external_id: change.repo_external_id,
+          },
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      setHasClicked(true);
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to create a pull request'));
+      setHasClicked(false);
+      onProcessingChange(false);
+    },
+  });
+
+  const createPRs = () => {
+    setHasClicked(true);
+    onProcessingChange(true);
+    for (const change of changes) {
+      createPr({change});
+    }
+  };
+
+  return (
+    <Button
+      priority="primary"
+      onClick={createPRs}
+      icon={hasClicked && <StyledLoadingIndicator size={14} mini />}
+      size="sm"
+      busy={isBusy || hasClicked}
+      disabled={isBusy || hasClicked}
+      analyticsEventName="Autofix: Create PR Clicked"
+      analyticsEventKey="autofix.create_pr_clicked"
+      analyticsParams={{group_id: groupId}}
+    >
+      Draft PR{changes.length > 1 ? 's' : ''}
+    </Button>
+  );
+}
+
+function CreateBranchButton({
+  changes,
+  groupId,
+  runId,
+  isBusy,
+  onProcessingChange,
+}: {
+  changes: AutofixCodebaseChange[];
+  groupId: string;
+  isBusy: boolean;
+  onProcessingChange: (processing: boolean) => void;
+  runId: string;
+}) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [hasClicked, setHasClicked] = useState(false);
+
+  // Reset hasClicked state and notify parent when isBusy goes from true to false
+  useEffect(() => {
+    if (!isBusy) {
+      setHasClicked(false);
+      onProcessingChange(false);
+    }
+  }, [isBusy, onProcessingChange]);
+
+  const {mutate: createBranch} = useMutation({
+    mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'create_branch',
+            repo_external_id: change.repo_external_id,
+          },
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to push to branches.'));
+      setHasClicked(false);
+      onProcessingChange(false);
+    },
+  });
+
+  const pushToBranch = () => {
+    setHasClicked(true);
+    onProcessingChange(true);
+    for (const change of changes) {
+      createBranch({change});
+    }
+  };
+
+  return (
+    <Button
+      onClick={pushToBranch}
+      icon={hasClicked && <StyledLoadingIndicator size={14} mini />}
+      size="sm"
+      busy={isBusy || hasClicked}
+      disabled={isBusy || hasClicked}
+      analyticsEventName="Autofix: Push to Branch Clicked"
+      analyticsEventKey="autofix.push_to_branch_clicked"
+      analyticsParams={{group_id: groupId}}
+    >
+      Check Out Locally
+    </Button>
+  );
+}
+
+function SetupAndCreateBranchButton({
+  changes,
+  groupId,
+  runId,
+  isBusy,
+  onProcessingChange,
+}: {
+  changes: AutofixCodebaseChange[];
+  groupId: string;
+  isBusy: boolean;
+  onProcessingChange: (processing: boolean) => void;
+  runId: string;
+}) {
+  const {codebases} = useAutofixRepos(groupId);
+
+  if (
+    !changes.every(
+      change =>
+        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
+    )
+  ) {
+    return (
+      <Button
+        onClick={() => {
+          openModal(deps => <AutofixSetupWriteAccessModal {...deps} groupId={groupId} />);
+        }}
+        size="sm"
+        analyticsEventName="Autofix: Create Branch Setup Clicked"
+        analyticsEventKey="autofix.create_branch_setup_clicked"
+        analyticsParams={{group_id: groupId}}
+        title={t('Enable write access to create branches')}
+      >
+        {t('Check Out Locally')}
+      </Button>
+    );
+  }
+
+  return (
+    <CreateBranchButton
+      changes={changes}
+      groupId={groupId}
+      runId={runId}
+      isBusy={isBusy}
+      onProcessingChange={onProcessingChange}
+    />
+  );
+}
+
+function SetupAndCreatePRsButton({
+  changes,
+  groupId,
+  runId,
+  isBusy,
+  onProcessingChange,
+}: {
+  changes: AutofixCodebaseChange[];
+  groupId: string;
+  isBusy: boolean;
+  onProcessingChange: (processing: boolean) => void;
+  runId: string;
+}) {
+  const {codebases} = useAutofixRepos(groupId);
+  if (
+    !changes.every(
+      change =>
+        change.repo_external_id && codebases[change.repo_external_id]?.is_writeable
+    )
+  ) {
+    return (
+      <Button
+        priority="primary"
+        onClick={() => {
+          openModal(deps => <AutofixSetupWriteAccessModal {...deps} groupId={groupId} />);
+        }}
+        size="sm"
+        analyticsEventName="Autofix: Create PR Setup Clicked"
+        analyticsEventKey="autofix.create_pr_setup_clicked"
+        analyticsParams={{group_id: groupId}}
+        title={t('Enable write access to create pull requests')}
+      >
+        {t('Draft PR')}
+      </Button>
+    );
+  }
+
+  return (
+    <CreatePRsButton
+      changes={changes}
+      groupId={groupId}
+      runId={runId}
+      isBusy={isBusy}
+      onProcessingChange={onProcessingChange}
+    />
+  );
+}

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -374,7 +374,7 @@ function AutofixInsightCards({
                 initial={{height: 0, opacity: 0}}
                 animate={{height: 'auto', opacity: 1}}
                 exit={{height: 0, opacity: 0}}
-                transition={{duration: 0.3}}
+                transition={{duration: 0.2}}
               >
                 {insights.map((insight, index) =>
                   insight ? (

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -139,7 +139,7 @@ export function useSelectCause({groupId, runId}: {groupId: string; runId: string
           };
         }
       );
-      addSuccessMessage("Great, let's move forward with this root cause.");
+      addSuccessMessage('On it.');
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when selecting the root cause.'));

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -99,7 +99,7 @@ export function useSelectSolution({groupId, runId}: {groupId: string; runId: str
           };
         }
       );
-      addSuccessMessage("Great, let's move forward with this solution.");
+      addSuccessMessage('On it.');
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when selecting the solution.'));

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -245,15 +245,16 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
           </div>
         );
       })}
-      {((activeLog && lastStep!.status === 'PROCESSING') || lastStep!.output_stream) && (
-        <AutofixOutputStream
-          stream={lastStep!.output_stream ?? ''}
-          activeLog={activeLog}
-          groupId={groupId}
-          runId={runId}
-          responseRequired={lastStep!.status === 'WAITING_FOR_USER_RESPONSE'}
-        />
-      )}
+      {((activeLog && lastStep!.status === 'PROCESSING') || lastStep!.output_stream) &&
+        lastStep!.type !== AutofixStepType.CHANGES && (
+          <AutofixOutputStream
+            stream={lastStep!.output_stream ?? ''}
+            activeLog={activeLog}
+            groupId={groupId}
+            runId={runId}
+            responseRequired={lastStep!.status === 'WAITING_FOR_USER_RESPONSE'}
+          />
+        )}
     </StepsContainer>
   );
 }

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -92,6 +92,13 @@ const isPolling = (
     return true;
   }
 
+  if (
+    autofixData.status === AutofixStatus.PROCESSING ||
+    autofixData?.steps.some(step => step.status === AutofixStatus.PROCESSING)
+  ) {
+    return true;
+  }
+
   // Check if there's any active comment thread that hasn't been completed
   const hasActiveCommentThread = autofixData.steps.some(
     step =>


### PR DESCRIPTION
When creating a branch/PR, we now poll for the state instead of waiting for an API response. This should be more reliable.