### PR TITLE
feat(dashboards): Add `onClick` support to `Samples` plottable

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -59,6 +59,10 @@ export interface Plottable {
    */
   label?: string;
   /**
+   * `TimeSeriesWidgetVisualization` will call this function if the user clicks a point on a series that originated from this plottable.
+   */
+  onClick?: (dataIndex: number) => void;
+  /**
    * `TimeSeriesWidgetVisualization` will call this function if the user highlights (via mouse, or imperatively) a point on a series that originated from this plottable.
    */
   onHighlight?: (dataIndex: number) => void;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -51,7 +51,11 @@ export type SamplesConfig = {
    */
   baselineValue?: number;
   /**
-   * Callback for ECharts' `onHighlight`. Called with the sample that corresponds to the highlighted sample in the chart
+   * Callback for ECharts' `onClick` mouse event. Called with the sample that corresponds to the highlighted sample in the chart
+   */
+  onClick?: (datum: ValidSampleRow) => void;
+  /**
+   * Callback for ECharts' `onHighlight`. Called with the sample that corresponds to the clicked sample in the chart
    */
   onHighlight?: (datum: ValidSampleRow) => void;
 };
@@ -199,6 +203,15 @@ export class Samples implements Plottable {
     }
 
     return sample;
+  }
+
+  onClick(dataIndex: number): void {
+    const {config} = this;
+
+    const sample = this.#getSampleByIndex(dataIndex);
+    if (sample) {
+      config.onClick?.(sample);
+    }
   }
 
   onHighlight(dataIndex: number): void {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -181,26 +181,33 @@ export class Samples implements Plottable {
     return new Samples(this.constrainSamples(boundaryStart, boundaryEnd), this.config);
   }
 
-  onHighlight(dataIndex: number): void {
-    const {config} = this;
-
+  #getSampleByIndex(dataIndex: number): ValidSampleRow | undefined {
     const sample = this.sampleTableData.data.at(dataIndex);
 
     if (!sample) {
-      error('`Samples` plottable `onHighlight` out-of-range error', {
+      error('`Samples` plottable data out-of-range error', {
         dataIndex,
       });
-      return;
+      return undefined;
     }
 
     if (!isValidSampleRow(sample)) {
       warn('`Samples` plottable `onHighlight` almost received an invalid row', {
         dataIndex,
       });
-      return;
+      return undefined;
     }
 
-    config.onHighlight?.(sample);
+    return sample;
+  }
+
+  onHighlight(dataIndex: number): void {
+    const {config} = this;
+
+    const sample = this.#getSampleByIndex(dataIndex);
+    if (sample) {
+      config.onHighlight?.(sample);
+    }
   }
 
   toSeries(plottingOptions: SamplesPlottingOptions): SeriesOption[] {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -588,7 +588,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         </p>
 
         <MediumWidget>
-          <TimeSeriesWidgetVisualization plottables={[samplesPlottable]} render />
+          <TimeSeriesWidgetVisualization plottables={[samplesPlottable]} />
 
           <p>Clicked sample ID: {sampleId}</p>
         </MediumWidget>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -564,6 +564,38 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
+  story('Click Events', () => {
+    const [sampleId, setSampleId] = useState<string>();
+
+    const samplesPlottable = useMemo(() => {
+      return new Samples(shiftedSpanSamples, {
+        alias: 'Span Samples',
+        attributeName: 'p99(span.duration)',
+        baselineValue: 175,
+        baselineLabel: 'Average',
+        onClick: row => {
+          setSampleId(row.id);
+        },
+      });
+    }, []);
+
+    return (
+      <Fragment>
+        <p>
+          You can respond to chart click events by passing the <code>onClick</code>{' '}
+          configuration option, if it's supported by the relevant plottable. Right now,
+          only the <code>Samples</code> plottable supports this configuration option.
+        </p>
+
+        <MediumWidget>
+          <TimeSeriesWidgetVisualization plottables={[samplesPlottable]} render />
+
+          <p>Clicked sample ID: {sampleId}</p>
+        </MediumWidget>
+      </Fragment>
+    );
+  });
+
   story('Highlighting', () => {
     const [sampleId, setSampleId] = useState<string>();
 


### PR DESCRIPTION
Very similar to how `onHighlight` works! A lot of the code is shared, so I extracted some helper functions in `Plottable` and `TimeSeriesWidgetVisualization`.
