### PR TITLE
fix(issues): Collapse individual span evidence sections

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -345,19 +345,17 @@ export function SpanEvidenceKeyValueList({
   const Component = PREVIEW_COMPONENTS[issueType] ?? DefaultSpanEvidence;
 
   return (
-    <ClippedBox clipHeight={300}>
-      <Component
-        theme={theme}
-        event={event}
-        issueType={issueType}
-        organization={organization}
-        location={location}
-        projectSlug={projectSlug}
-        parentSpan={spanInfo?.parentSpan ?? null}
-        offendingSpans={spanInfo?.offendingSpans ?? []}
-        causeSpans={spanInfo?.causeSpans ?? []}
-      />
-    </ClippedBox>
+    <Component
+      theme={theme}
+      event={event}
+      issueType={issueType}
+      organization={organization}
+      location={location}
+      projectSlug={projectSlug}
+      parentSpan={spanInfo?.parentSpan ?? null}
+      offendingSpans={spanInfo?.offendingSpans ?? []}
+      causeSpans={spanInfo?.causeSpans ?? []}
+    />
   );
 }
 
@@ -541,9 +539,11 @@ function getSpanEvidenceValue(span: Span | null) {
 
   if (span.op === 'db' && span.description) {
     return (
-      <StyledCodeSnippet language="sql">
-        {formatter.toString(span.description)}
-      </StyledCodeSnippet>
+      <NoPaddingClippedBox clipHeight={200}>
+        <StyledCodeSnippet language="sql">
+          {formatter.toString(span.description)}
+        </StyledCodeSnippet>
+      </NoPaddingClippedBox>
     );
   }
 
@@ -730,3 +730,7 @@ function formatBasePath(span: Span, baseURL?: string): string {
 
   return spanURL?.pathname ?? '';
 }
+
+const NoPaddingClippedBox = styled(ClippedBox)`
+  padding: 0;
+`;


### PR DESCRIPTION
Instead of clipping the entire section. Clip individual queries. Clipping the entire section was hiding the Repeating Span section on n+1 queries which is the important part.

before
![image](https://github.com/user-attachments/assets/39293344-7846-4943-8219-285e6dc28eec)


after
![image](https://github.com/user-attachments/assets/7dd4671c-34fb-42aa-93d6-f73a3f0b5ca7)

