### PR TITLE
ref: fix test pollution in api.bases.test_group

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -22,7 +22,7 @@ class AuthenticationTest(AuthProviderTestCase):
 
         member = self.create_member(user=self.user, organization=self.organization, teams=[team])
 
-        setattr(member.flags, "sso:linked", True)
+        member.flags["sso:linked"] = True
         member.save()
         event = self.store_event(data={}, project_id=self.project.id)
         group_id = event.group_id

--- a/tests/sentry/api/bases/test_group.py
+++ b/tests/sentry/api/bases/test_group.py
@@ -1,11 +1,11 @@
+from typing import ContextManager
+
 from rest_framework.views import APIView
 
 from sentry.api.bases.group import GroupAiEndpoint, GroupAiPermission
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.requests import drf_request_from_request
-
-DEMO_USER_ID = 2
 
 
 class GroupAiPermissionTest(TestCase):
@@ -14,6 +14,10 @@ class GroupAiPermissionTest(TestCase):
         self.permission = GroupAiPermission()
         self.project = self.create_project()
         self.group = self.create_group(project=self.project)
+        self.demo_user = self.create_user()
+
+    def _demo_mode_enabled(self) -> ContextManager[None]:
+        return override_options({"demo-mode.enabled": True, "demo-mode.users": [self.demo_user.id]})
 
     def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
         request = self.make_request(user=user, auth=auth, method=method, is_superuser=is_superuser)
@@ -22,31 +26,23 @@ class GroupAiPermissionTest(TestCase):
             drf_request, APIView()
         ) and self.permission.has_object_permission(drf_request, APIView(), obj)
 
-    @override_options({"demo-mode.enabled": True, "demo-mode.users": [DEMO_USER_ID]})
     def test_demo_user_safe_methods(self):
-        demo_user = self.create_user(id=DEMO_USER_ID)
+        with self._demo_mode_enabled():
+            for method in ("GET", "HEAD", "OPTIONS"):
+                assert self.has_object_perm(method, self.group, user=self.demo_user)
 
-        for method in ("GET", "HEAD", "OPTIONS"):
-            assert self.has_object_perm(method, self.group, user=demo_user)
-
-    @override_options({"demo-mode.enabled": True, "demo-mode.users": [DEMO_USER_ID]})
     def test_demo_user_post_allowed(self):
-        demo_user = self.create_user(id=DEMO_USER_ID)
-        assert self.has_object_perm("POST", self.group, user=demo_user)
+        with self._demo_mode_enabled():
+            assert self.has_object_perm("POST", self.group, user=self.demo_user)
 
-    @override_options({"demo-mode.enabled": True, "demo-mode.users": [DEMO_USER_ID]})
     def test_demo_user_unsafe_methods_blocked(self):
-        demo_user = self.create_user(id=DEMO_USER_ID)
+        with self._demo_mode_enabled():
+            for method in ("PUT", "DELETE", "PATCH"):
+                assert not self.has_object_perm(method, self.group, user=self.demo_user)
 
-        for method in ("PUT", "DELETE", "PATCH"):
-            assert not self.has_object_perm(method, self.group, user=demo_user)
-
-    @override_options({"demo-mode.enabled": False, "demo-mode.users": [DEMO_USER_ID]})
     def test_demo_user_demo_mode_disabled(self):
-        demo_user = self.create_user(id=DEMO_USER_ID)
-
         for method in ("GET", "POST", "PUT", "DELETE"):
-            assert not self.has_object_perm(method, self.group, user=demo_user)
+            assert not self.has_object_perm(method, self.group, user=self.demo_user)
 
     def test_regular_user_with_access(self):
         user = self.create_user()


### PR DESCRIPTION
the hardcoded user id would collide with any test running before it causing the test to fail

example test pollution before fixing:

```console
$ pytest tests/integration/test_api.py::AuthenticationTest::test_sso_redirect_url_external_removed $(tail -1 hmmm)
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, repeat-0.9.3, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/integration/test_api.py .                                          [ 50%]
tests/sentry/api/bases/test_group.py F                                   [100%]

=================================== FAILURES ===================================
___________ GroupAiPermissionTest.test_demo_user_demo_mode_disabled ____________
tests/sentry/api/bases/test_group.py:46: in test_demo_user_demo_mode_disabled
    demo_user = self.create_user(id=DEMO_USER_ID)
src/sentry/testutils/fixtures.py:278: in create_user
    return Factories.create_user(*args, **kwargs)
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/contextlib.py:85: in inner
    return func(*args, **kwds)
src/sentry/testutils/factories.py:923: in create_user
    assert UserEmail.objects.filter(user=user, email=email).update(is_verified=True)
E   AssertionError: assert 0
E    +  where 0 = <bound method BaseQuerySet.update of <BaseQuerySet []>>(is_verified=True)
E    +    where <bound method BaseQuerySet.update of <BaseQuerySet []>> = <BaseQuerySet []>.update
E    +      where <BaseQuerySet []> = <bound method QuerySet.filter of <sentry.db.models.manager.base.UserEmailManager object at 0x118377380>>(user=<User at 0x159617e30: id=2>, email='7ae013e303f3455c8d0e13c83735eedb@example.com')
E    +        where <bound method QuerySet.filter of <sentry.db.models.manager.base.UserEmailManager object at 0x118377380>> = <sentry.db.models.manager.base.UserEmailManager object at 0x118377380>.filter
E    +          where <sentry.db.models.manager.base.UserEmailManager object at 0x118377380> = UserEmail.objects
=========================== short test summary info ============================
FAILED tests/sentry/api/bases/test_group.py::GroupAiPermissionTest::test_demo_user_demo_mode_disabled - AssertionError: assert 0
========================= 1 failed, 1 passed in 6.12s ==========================
%4|1743794058.198|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (211 bytes) still in queue or transit: use flush() to wait for outstanding message delivery

```

<!-- Describe your PR here. -->