### PR TITLE
feat(insights): convert more web vitals to eap

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -9,14 +9,13 @@ import type {WebVitalsScoreBreakdown} from 'sentry/views/insights/browser/webVit
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import {getWeights} from 'sentry/views/insights/browser/webVitals/utils/getWeights';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {InsightsTimeSeriesWidget} from 'sentry/views/insights/common/components/insightsTimeSeriesWidget';
 import {
   type DiscoverSeries,
   useMetricsSeries,
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
-
-import {DEFAULT_QUERY_FILTER} from '../../settings';
 
 import {WebVitalsWeightList} from './webVitalWeightList';
 
@@ -52,10 +51,9 @@ export function PerformanceScoreBreakdownChart({
 }: Props) {
   const theme = useTheme();
   const segmentColors = theme.chart.getColorPalette(3).slice(0, 5);
+  const defaultQuery = useDefaultWebVitalsQuery();
 
-  const search = new MutableSearch(
-    `${DEFAULT_QUERY_FILTER} has:measurements.score.total`
-  );
+  const search = new MutableSearch(`${defaultQuery} has:measurements.score.total`);
 
   if (transaction) {
     search.addFilterValue('transaction', transaction);

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -67,7 +67,7 @@ export function PageOverviewSidebar({
   });
 
   const {countDiff, currentSeries, currentCount, initialCount} = processSeriesData(
-    data?.count,
+    data['count()'].data,
     isLoading,
     pageFilters.selection.datetime,
     shouldDoublePeriod
@@ -86,7 +86,7 @@ export function PageOverviewSidebar({
     currentCount: currentInpCount,
     initialCount: initialInpCount,
   } = processSeriesData(
-    data.countInp,
+    data['count_scores(measurements.score.inp)'].data,
     isLoading,
     pageFilters.selection.datetime,
     shouldDoublePeriod

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -5,14 +5,12 @@ import styled from '@emotion/styled';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import type {LineChartSeries} from 'sentry/components/charts/lineChart';
 import {LineChart} from 'sentry/components/charts/lineChart';
-import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {SeriesDataUnit} from 'sentry/types/echarts';
-import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MiniAggregateWaterfall} from 'sentry/views/insights/browser/webVitals/components/miniAggregateWaterfall';
@@ -45,26 +43,14 @@ export function PageOverviewSidebar({
   const theme = useTheme();
   const pageFilters = usePageFilters();
   const {period, start, end, utc} = pageFilters.selection.datetime;
-  const shouldDoublePeriod = shouldFetchPreviousPeriod({
-    includePrevious: true,
-    period,
-    start,
-    end,
-  });
-  const doubledPeriod = getPeriod({period, start, end}, {shouldDoublePeriod});
-  const doubledDatetime: PageFilters['datetime'] = {
-    period: doubledPeriod.statsPeriod ?? null,
-    start: doubledPeriod.start ?? null,
-    end: doubledPeriod.end ?? null,
-    utc,
-  };
 
   const {data, isLoading: isLoading} = useProjectRawWebVitalsValuesTimeseriesQuery({
     transaction,
-    datetime: doubledDatetime,
     browserTypes,
     subregions,
   });
+
+  const shouldDoublePeriod = false;
 
   const {countDiff, currentSeries, currentCount, initialCount} = processSeriesData(
     data['count()'].data,

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -151,7 +151,7 @@ export function PageOverviewWebVitalsDetailPanel({
   const webVitalData: LineChartSeries = {
     data:
       !isTimeseriesLoading && webVital
-        ? timeseriesData?.[webVital].map(({name, value}) => ({
+        ? timeseriesData?.[`p75(measurements.${webVital})`].data.map(({name, value}) => ({
             name,
             value,
           }))

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -75,12 +75,6 @@ describe('WebVitalsDetailPanel', function () {
             'p75(measurements.cls)',
             'p75(measurements.ttfb)',
             'p75(measurements.inp)',
-            'p75(transaction.duration)',
-            'count_web_vitals(measurements.lcp, any)',
-            'count_web_vitals(measurements.fcp, any)',
-            'count_web_vitals(measurements.cls, any)',
-            'count_web_vitals(measurements.ttfb, any)',
-            'count_web_vitals(measurements.inp, any)',
             'count()',
           ],
           query:

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -122,7 +122,7 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
   const webVitalData: LineChartSeries = {
     data:
       !isTimeseriesLoading && webVital
-        ? timeseriesData?.[webVital].map(({name, value}) => ({
+        ? timeseriesData?.[`p75(measurements.${webVital})`].data.map(({name, value}) => ({
             name,
             value,
           }))

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -1,7 +1,7 @@
 import type {Tag} from 'sentry/types/group';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
 
@@ -19,6 +19,7 @@ export const useProjectRawWebVitalsQuery = ({
   subregions,
 }: Props = {}) => {
   const search = new MutableSearch([]);
+  const defaultQuery = useDefaultWebVitalsQuery();
   if (transaction) {
     search.addFilterValue('transaction', transaction);
   }
@@ -34,7 +35,7 @@ export const useProjectRawWebVitalsQuery = ({
 
   return useMetrics(
     {
-      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      search: [defaultQuery, search.formatString()].join(' ').trim(),
       limit: 50,
       fields: [
         'p75(measurements.lcp)',
@@ -42,12 +43,6 @@ export const useProjectRawWebVitalsQuery = ({
         'p75(measurements.cls)',
         'p75(measurements.ttfb)',
         'p75(measurements.inp)',
-        'p75(transaction.duration)',
-        'count_web_vitals(measurements.lcp, any)',
-        'count_web_vitals(measurements.fcp, any)',
-        'count_web_vitals(measurements.cls, any)',
-        'count_web_vitals(measurements.ttfb, any)',
-        'count_web_vitals(measurements.inp, any)',
         'count()',
       ],
     },

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -1,36 +1,26 @@
 import {getInterval} from 'sentry/components/charts/utils';
-import type {PageFilters} from 'sentry/types/core';
-import type {SeriesDataUnit} from 'sentry/types/echarts';
-import type {MetaType} from 'sentry/utils/discover/eventView';
-import EventView from 'sentry/utils/discover/eventView';
-import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
-import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
+import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
   browserTypes?: BrowserType[];
-  datetime?: PageFilters['datetime'];
   subregions?: SubregionCode[];
   transaction?: string | null;
 };
 
 export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   transaction,
-  datetime,
   browserTypes,
   subregions,
 }: Props) => {
   const pageFilters = usePageFilters();
-  const location = useLocation();
-  const organization = useOrganization();
+  const defaultQuery = useDefaultWebVitalsQuery();
   const search = new MutableSearch([]);
+
   if (transaction) {
     search.addFilterValue('transaction', transaction);
   }
@@ -40,8 +30,11 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   if (subregions) {
     search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
   }
-  const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
+
+  const result = useMetricsSeries(
     {
+      search: [defaultQuery, search.formatString()].join(' ').trim(),
+      interval: getInterval(pageFilters.selection.datetime, 'low'),
       yAxis: [
         'p75(measurements.lcp)',
         'p75(measurements.fcp)',
@@ -51,85 +44,9 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
         'count()',
         'count_scores(measurements.score.inp)',
       ],
-      name: 'Web Vitals',
-      query: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
-      version: 2,
-      fields: [],
-      interval: getInterval(pageFilters.selection.datetime, 'low'),
-      dataset: DiscoverDatasets.METRICS,
     },
-    {
-      ...pageFilters.selection,
-      datetime: datetime ?? pageFilters.selection.datetime,
-    }
+    'api.performance.browser.web-vitals.timeseries'
   );
 
-  const result = useGenericDiscoverQuery<
-    {
-      data: any[];
-      meta: MetaType;
-    },
-    DiscoverQueryProps
-  >({
-    route: 'events-stats',
-    eventView: projectTimeSeriesEventView,
-    location,
-    orgSlug: organization.slug,
-    getRequestPayload: () => ({
-      ...projectTimeSeriesEventView.getEventsAPIPayload(location),
-      yAxis: projectTimeSeriesEventView.yAxis,
-      topEvents: projectTimeSeriesEventView.topEvents,
-      excludeOther: 0,
-      partial: 1,
-      orderby: undefined,
-      interval: projectTimeSeriesEventView.interval,
-    }),
-    options: {
-      refetchOnWindowFocus: false,
-    },
-    referrer: 'api.performance.browser.web-vitals.timeseries',
-  });
-
-  const data: {
-    cls: SeriesDataUnit[];
-    count: SeriesDataUnit[];
-    countInp: SeriesDataUnit[];
-    fcp: SeriesDataUnit[];
-    inp: SeriesDataUnit[];
-    lcp: SeriesDataUnit[];
-    ttfb: SeriesDataUnit[];
-  } = {
-    lcp: [],
-    fcp: [],
-    cls: [],
-    ttfb: [],
-    inp: [],
-    count: [],
-    countInp: [],
-  };
-
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  result?.data?.['p75(measurements.lcp)']?.data.forEach((interval: any, index: any) => {
-    const map: Array<{key: string; series: SeriesDataUnit[]}> = [
-      {key: 'p75(measurements.cls)', series: data.cls},
-      {key: 'p75(measurements.lcp)', series: data.lcp},
-      {key: 'p75(measurements.fcp)', series: data.fcp},
-      {key: 'p75(measurements.ttfb)', series: data.ttfb},
-      {key: 'p75(measurements.inp)', series: data.inp},
-      {key: 'count()', series: data.count},
-      {key: 'count_scores(measurements.score.inp)', series: data.countInp},
-    ];
-    map.forEach(({key, series}) => {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      if (result?.data?.[key].data[index][1][0].count !== null) {
-        series.push({
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          value: result?.data?.[key].data[index][1][0].count,
-          name: interval[0] * 1000,
-        });
-      }
-    });
-  });
-
-  return {data, isLoading: result.isPending};
+  return result;
 };

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -1,9 +1,9 @@
 import type {Tag} from 'sentry/types/group';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   type MetricsProperty,
@@ -54,6 +54,8 @@ export const useProjectWebVitalsScoresQuery = ({
   browserTypes,
   subregions,
 }: Props = {}) => {
+  const defaultQuery = useDefaultWebVitalsQuery();
+
   const search = new MutableSearch([]);
   if (transaction) {
     search.addFilterValue('transaction', transaction);
@@ -72,7 +74,7 @@ export const useProjectWebVitalsScoresQuery = ({
     {
       cursor: '',
       limit: 50,
-      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      search: [defaultQuery, search.formatString()].join(' ').trim(),
       fields: [
         'performance_score(measurements.score.lcp)',
         'performance_score(measurements.score.fcp)',

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -10,8 +10,8 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -42,6 +42,8 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   const pageFilters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
+  const defaultQuery = useDefaultWebVitalsQuery();
+
   const search = new MutableSearch([
     'has:measurements.score.total',
     ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
@@ -66,7 +68,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
         'count()',
       ],
       name: 'Web Vitals',
-      query: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      query: [defaultQuery, search.formatString()].join(' ').trim(),
       version: 2,
       fields: [],
       interval: getInterval(pageFilters.selection.datetime, 'low'),

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -1,12 +1,13 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import {getWebVitalScoresFromTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {
   RowWithScoreAndOpportunity,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {
@@ -40,13 +41,27 @@ export const useTransactionWebVitalsScoresQuery = ({
   browserTypes,
   subregions,
 }: Props) => {
+  const location = useLocation();
   const sort = useWebVitalsSort({sortName, defaultSort});
+  const defaultQuery = useDefaultWebVitalsQuery();
+
+  const useEap = location.query?.useEap === '1';
+
+  const totalOpportunityScoreField: MetricsProperty = useEap
+    ? 'opportunity_score(measurements.score.total)'
+    : 'total_opportunity_score()';
+
   if (sort !== undefined) {
     if (sort.field === 'avg(measurements.score.total)') {
       sort.field = 'performance_score(measurements.score.total)';
     }
-    if (sort.field === 'opportunity_score(measurements.score.total)') {
-      sort.field = 'total_opportunity_score()';
+    if (
+      [
+        'opportunity_score(measurements.score.total)',
+        'total_opportunity_score()',
+      ].includes(sort.field)
+    ) {
+      sort.field = totalOpportunityScoreField;
     }
   }
 
@@ -67,7 +82,7 @@ export const useTransactionWebVitalsScoresQuery = ({
   const {data, isPending, ...rest} = useMetrics(
     {
       limit: limit ?? 50,
-      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      search: [defaultQuery, search.formatString()].join(' ').trim(),
       sorts: [sort],
       enabled,
       fields: [
@@ -90,7 +105,7 @@ export const useTransactionWebVitalsScoresQuery = ({
         `count_scores(measurements.score.cls)`,
         `count_scores(measurements.score.inp)`,
         `count_scores(measurements.score.ttfb)`,
-        'total_opportunity_score()',
+        totalOpportunityScoreField,
       ],
     },
     'api.performance.browser.web-vitals.transactions-scores'
@@ -135,7 +150,7 @@ export const useTransactionWebVitalsScoresQuery = ({
             // Map back opportunity score key so we don't have to handle both keys in the UI
             opportunity: row[
               webVital === 'total'
-                ? 'total_opportunity_score()'
+                ? totalOpportunityScoreField
                 : (`opportunity_score(measurements.score.${webVital})` as MetricsProperty)
             ] as number,
           };

--- a/static/app/views/insights/browser/webVitals/settings.ts
+++ b/static/app/views/insights/browser/webVitals/settings.ts
@@ -14,4 +14,7 @@ export const MODULE_DOC_LINK =
 export const DEFAULT_QUERY_FILTER =
   'transaction.op:[pageload,""] span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,""] !transaction:"<< unparameterized >>"';
 
+export const DEFAULT_EAP_QUERY_FILTER =
+  'span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,pageload,""] !transaction:"<< unparameterized >>"';
+
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/browser/webVitals/utils/useDefaultQuery.ts
+++ b/static/app/views/insights/browser/webVitals/utils/useDefaultQuery.ts
@@ -1,0 +1,16 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import {
+  DEFAULT_EAP_QUERY_FILTER,
+  DEFAULT_QUERY_FILTER,
+} from 'sentry/views/insights/browser/webVitals/settings';
+
+export const useDefaultWebVitalsQuery = () => {
+  const location = useLocation();
+  const useEap = location.query?.useEap === '1';
+
+  if (useEap) {
+    return DEFAULT_EAP_QUERY_FILTER;
+  }
+
+  return DEFAULT_QUERY_FILTER;
+};

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -89,12 +89,6 @@ describe('PageOverview', function () {
             'p75(measurements.cls)',
             'p75(measurements.ttfb)',
             'p75(measurements.inp)',
-            'p75(transaction.duration)',
-            'count_web_vitals(measurements.lcp, any)',
-            'count_web_vitals(measurements.fcp, any)',
-            'count_web_vitals(measurements.cls, any)',
-            'count_web_vitals(measurements.ttfb, any)',
-            'count_web_vitals(measurements.inp, any)',
             'count()',
           ],
           query:

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -125,12 +125,6 @@ describe('WebVitalsLandingPage', function () {
             'p75(measurements.cls)',
             'p75(measurements.ttfb)',
             'p75(measurements.inp)',
-            'p75(transaction.duration)',
-            'count_web_vitals(measurements.lcp, any)',
-            'count_web_vitals(measurements.fcp, any)',
-            'count_web_vitals(measurements.cls, any)',
-            'count_web_vitals(measurements.ttfb, any)',
-            'count_web_vitals(measurements.inp, any)',
             'count()',
           ],
           query:

--- a/static/app/views/insights/common/queries/getSeriesEventView.tsx
+++ b/static/app/views/insights/common/queries/getSeriesEventView.tsx
@@ -10,7 +10,7 @@ import {getIntervalForMetricFunction} from 'sentry/views/insights/database/utils
 import {DEFAULT_INTERVAL} from 'sentry/views/insights/settings';
 
 export function getSeriesEventView(
-  search: MutableSearch | undefined,
+  search: MutableSearch | string | undefined,
   fields: string[] = [],
   pageFilters: PageFilters,
   yAxis: string[],
@@ -37,7 +37,7 @@ export function getSeriesEventView(
   return EventView.fromNewQueryWithPageFilters(
     {
       name: '',
-      query: search?.formatString() ?? undefined,
+      query: typeof search === 'string' ? search : (search?.formatString() ?? ''),
       fields,
       yAxis,
       dataset: dataset || DiscoverDatasets.SPANS_METRICS,

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -39,7 +39,7 @@ interface UseMetricsSeriesOptions<Fields> {
   interval?: string;
   overriddenRoute?: string;
   referrer?: string;
-  search?: MutableSearch;
+  search?: MutableSearch | string; // TODO: Remove string type and always require MutableSearch
   transformAliasToInputFormat?: boolean;
   yAxis?: Fields;
 }
@@ -61,7 +61,13 @@ export const useMetricsSeries = <Fields extends MetricsProperty[]>(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string
 ) => {
-  return useDiscoverSeries<Fields>(options, DiscoverDatasets.METRICS, referrer);
+  const location = useLocation();
+  const useEap = location.query?.useEap === '1';
+  return useDiscoverSeries<Fields>(
+    options,
+    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
+    referrer
+  );
 };
 
 /**


### PR DESCRIPTION
1. add default query for eap (eap does not have transaction.op, but instead uses span.op)
2. Use `useMetrics` in a few more spots that I missed in https://github.com/getsentry/sentry/pull/88693/
3. Update `useMetricsSeries` to conditionally fetch eap data
4. Use `opportunity_score(measurements.score.total` if eap is enabled, otherwise use `total_opportunity_score`
5. Remove several unused fields