### PR TITLE
feat(issues): Preserve more performance trace preview spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -73,16 +73,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
   const traceScheduler = useMemo(() => new TraceScheduler(), []);
   const problemSpans = useMemo((): ReturnType<typeof getProblemSpansForSpanTree> => {
     if (props.event.type === 'transaction') {
-      const result = getProblemSpansForSpanTree(props.event);
-      if (result.affectedSpanIds.length > 4) {
-        // Too many spans to focus on, instead let them click into the preview
-        // n+1 will have hundreds of affected spans
-        return {
-          affectedSpanIds: result.affectedSpanIds.slice(0, 4),
-          focusedSpanIds: result.focusedSpanIds.slice(0, 4),
-        };
-      }
-      return result;
+      return getProblemSpansForSpanTree(props.event);
     }
 
     return {affectedSpanIds: [], focusedSpanIds: []};
@@ -264,6 +255,10 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
       // Preserve affectedSpanIds
       while (start < props.tree.list.length) {
         const currentNode = props.tree.list[start]!;
+        // Add more affected spans up to the minimum number of nodes to keep
+        if (preserveNodes.length >= MIN_NODES_TO_KEEP) {
+          break;
+        }
         if (
           currentNode.value &&
           'span_id' in currentNode.value &&
@@ -277,15 +272,12 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
       }
 
       let numSurroundingNodes = TRACE_PREVIEW_SURROUNDING_NODES;
-      let minShownNodes = MIN_NODES_TO_KEEP;
       if (props.event.type === 'transaction') {
         // Performance issues are tighter to focus on the suspect spans (of which there may be many)
         numSurroundingNodes = PERFORMANCE_ISSUE_SURROUNDING_NODES;
-        // Performance issues have multiple collapse sections already, keep smaller
-        minShownNodes = 0;
       }
 
-      props.tree.collapseList(preserveNodes, numSurroundingNodes, minShownNodes);
+      props.tree.collapseList(preserveNodes, numSurroundingNodes, MIN_NODES_TO_KEEP);
     }
 
     if (index === -1 || !node) {


### PR DESCRIPTION
Instead of keeping only the first 4 affected span ids for n+1 issues. Keep up to 10 and fill in the rest of the trace preview with additional surrounding spans to make it look more normal.

Helps keep the autogrouped section in view.

before
![image](https://github.com/user-attachments/assets/6fb7025e-c1c3-4156-99c3-90460180f03b)



after
![image](https://github.com/user-attachments/assets/6d1e4f1a-596a-47d3-92c9-306b18c9415a)
