### PR TITLE
ref(shared-views): Refactor delete endpoint permissions and model deletions

### DIFF
--- a/src/sentry/models/groupsearchviewstarred.py
+++ b/src/sentry/models/groupsearchviewstarred.py
@@ -142,6 +142,10 @@ class GroupSearchViewStarredManager(BaseManager["GroupSearchViewStarred"]):
             ).update(position=models.F("position") - 1)
             return True
 
+    def clear_starred_view_for_all_members(self, organization: Organization, view: GroupSearchView):
+        for starred_view in self.filter(organization=organization, group_search_view=view):
+            self.delete_starred_view(organization, starred_view.user_id, view)
+
 
 @region_silo_model
 class GroupSearchViewStarred(DefaultFieldsModel):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -1,8 +1,11 @@
 from django.urls import reverse
+from django.utils import timezone
 
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
@@ -54,17 +57,38 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_view_from_another_user(self) -> None:
         # Get a view ID from user_two
-        view_id = str(self.base_data["user_two_views"][0].id)
+        self.login_as(user=self.user_2)
+        view_id = str(self.base_data["user_one_views"][0].id)
         url = reverse(
             "sentry-api-0-organization-group-search-view-details",
             kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
         )
 
         response = self.client.delete(url)
-        assert response.status_code == 404
+        assert response.status_code == 403
 
         # Verify the view still exists (this will error out if not)
         GroupSearchView.objects.get(id=view_id)
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_admin_can_delete_view_from_another_user(self) -> None:
+        self.admin_user = self.create_user()
+        self.create_member(
+            user=self.admin_user,
+            organization=self.organization,
+            role="admin",
+        )
+        self.login_as(user=self.admin_user)
+        view_id = str(self.base_data["user_one_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        response = self.client.delete(url)
+        assert response.status_code == 204
+
+        assert not GroupSearchView.objects.filter(id=view_id).exists()
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_first_starred_view_decrements_succeeding_positions(self) -> None:
@@ -121,6 +145,112 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         assert response.status_code == 404
 
         GroupSearchView.objects.get(id=self.view_id)
+
+
+class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-details"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user_1 = self.user
+        self.user_2 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_2)
+
+        self.user_1_view = GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=self.user_1.id,
+            name="User 1's View",
+            query="is:unresolved",
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_1.id,
+            group_search_view=self.user_1_view,
+            position=0,
+        )
+        GroupSearchViewLastVisited.objects.create(
+            organization=self.organization,
+            user_id=self.user_1.id,
+            group_search_view=self.user_1_view,
+            last_visited=timezone.now(),
+        )
+
+        self.user_2_view = GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            name="User 2's View",
+            query="is:unresolved",
+        )
+
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=self.user_1_view,
+            position=0,
+        )
+        GroupSearchViewStarred.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=self.user_2_view,
+            position=1,
+        )
+
+        GroupSearchViewLastVisited.objects.create(
+            organization=self.organization,
+            user_id=self.user_2.id,
+            group_search_view=self.user_1_view,
+            last_visited=timezone.now(),
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_cannot_delete_other_users_view(self) -> None:
+        self.login_as(user=self.user_2)
+
+        response = self.client.delete(
+            reverse(
+                self.endpoint,
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "view_id": self.user_1_view.id,
+                },
+            )
+        )
+
+        assert response.status_code == 403
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_deleting_my_view_deletes_from_others_starred_views(self) -> None:
+        self.login_as(user=self.user_1)
+
+        response = self.client.delete(
+            reverse(
+                self.endpoint,
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "view_id": self.user_1_view.id,
+                },
+            )
+        )
+
+        assert response.status_code == 204
+        # User 2 starred User 1's view. After User 1 deletes the view, it should not be starred for anyone anymore
+        assert not GroupSearchViewStarred.objects.filter(
+            organization_id=self.organization.id, group_search_view=self.user_1_view
+        ).exists()
+        # User 2's other starred view should be moved up to position 0
+        assert (
+            GroupSearchViewStarred.objects.get(
+                organization_id=self.organization.id,
+                user_id=self.user_2.id,
+                group_search_view=self.user_2_view,
+            ).position
+            == 0
+        )
+        # All last visited entries should be deleted as well
+        assert not GroupSearchViewLastVisited.objects.filter(
+            organization_id=self.organization.id, group_search_view=self.user_1_view
+        ).exists()
 
 
 class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):


### PR DESCRIPTION
This PR makes the following refactors to the `DELETE` `/group-search-view/:viewId` endpoint: 

1. Now, in addition to the creator of the view, org admins can also delete the view
2. Upon deletion, any users that had that view starred before will see that view deleted.
3. Any "last viewed" entries for that view are also deleted. 