### PR TITLE
fix(dashboards-eap): Show preflight table results during loading

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -58,7 +58,7 @@ import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 import {getFormatter} from '../../../components/charts/components/tooltip';
 import {getDatasetConfig} from '../datasetConfig/base';
 import type {Widget} from '../types';
-import {DisplayType} from '../types';
+import {DisplayType, WidgetType} from '../types';
 import type WidgetLegendSelectionState from '../widgetLegendSelectionState';
 import {BigNumberWidgetVisualization} from '../widgets/bigNumberWidget/bigNumberWidgetVisualization';
 
@@ -165,7 +165,9 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
             location={location}
             fields={fields}
             title={tableResults.length > 1 ? result.title : ''}
-            loading={loading}
+            // Bypass the loading state for span widgets because this renders the loading placeholder
+            // and we want to show the underlying data during preflight instead
+            loading={widget.widgetType === WidgetType.SPANS ? false : loading}
             loader={<LoadingPlaceholder />}
             metadata={result.meta}
             data={result.data}

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -171,7 +171,6 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
               children({
                 ...(bestEffortChildrenProps ?? preflightProps),
                 loading: preflightProps.loading,
-                isProgressivelyLoading: false,
               })
             ) : (
               <GenericWidgetQueries<SeriesResult, TableResult>

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -170,7 +170,8 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
               // the best effort query has completed.
               children({
                 ...(bestEffortChildrenProps ?? preflightProps),
-                isProgressivelyLoading: preflightProps.loading,
+                loading: preflightProps.loading,
+                isProgressivelyLoading: false,
               })
             ) : (
               <GenericWidgetQueries<SeriesResult, TableResult>


### PR DESCRIPTION
When the table was loading, it would show a placeholder over the data so we wouldn't be able to see the preflight results. This removes the placeholder for span table widgets so we can see the underlying data.

I also had to update the widget queries component to pass along the loading prop or else it used to get overridden by the cached (i.e. stored in a state variable) results from the best effort request.