### PR TITLE
ref(shared-views): Update all views fetch params and table titles

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -12,15 +12,15 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {IssueViewsTable} from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsTable';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import {GroupSearchViewVisibility} from 'sentry/views/issueList/types';
+import {GroupSearchViewCreatedBy} from 'sentry/views/issueList/types';
 
 type IssueViewSectionProps = {
+  createdBy: GroupSearchViewCreatedBy;
   cursorQueryParam: string;
   limit: number;
-  visibility: GroupSearchViewVisibility;
 };
 
-function IssueViewSection({visibility, limit, cursorQueryParam}: IssueViewSectionProps) {
+function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSectionProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
@@ -36,7 +36,7 @@ function IssueViewSection({visibility, limit, cursorQueryParam}: IssueViewSectio
     getResponseHeader,
   } = useFetchGroupSearchViews({
     orgSlug: organization.slug,
-    visibility,
+    createdBy,
     limit,
     cursor,
   });
@@ -89,15 +89,15 @@ export default function IssueViewsList() {
             }}
             placeholder=""
           />
-          <TableHeading>{t('Owned by Me')}</TableHeading>
+          <TableHeading>{t('My Views')}</TableHeading>
           <IssueViewSection
-            visibility={GroupSearchViewVisibility.OWNER}
+            createdBy={GroupSearchViewCreatedBy.ME}
             limit={10}
             cursorQueryParam="mc"
           />
-          <TableHeading>{t('Shared with Me')}</TableHeading>
+          <TableHeading>{t('Others')}</TableHeading>
           <IssueViewSection
-            visibility={GroupSearchViewVisibility.ORGANIZATION}
+            createdBy={GroupSearchViewCreatedBy.OTHERS}
             limit={10}
             cursorQueryParam="sc"
           />

--- a/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
@@ -2,19 +2,19 @@ import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {
   GroupSearchView,
-  GroupSearchViewVisibility,
+  GroupSearchViewCreatedBy,
 } from 'sentry/views/issueList/types';
 
 type FetchGroupSearchViewsParameters = {
   orgSlug: string;
+  createdBy?: GroupSearchViewCreatedBy;
   cursor?: string;
   limit?: number;
-  visibility?: GroupSearchViewVisibility;
 };
 
 export const makeFetchGroupSearchViewsKey = ({
   orgSlug,
-  visibility,
+  createdBy,
   limit,
   cursor,
 }: FetchGroupSearchViewsParameters): ApiQueryKey =>
@@ -23,7 +23,7 @@ export const makeFetchGroupSearchViewsKey = ({
     {
       query: {
         per_page: limit,
-        visibility,
+        createdBy,
         cursor,
       },
     },

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -21,6 +21,11 @@ export enum GroupSearchViewVisibility {
   ORGANIZATION = 'organization',
 }
 
+export enum GroupSearchViewCreatedBy {
+  ME = 'me',
+  OTHERS = 'others',
+}
+
 export type GroupSearchView = {
   environments: string[];
   id: string;


### PR DESCRIPTION
Refactors the frontend to respect the change to the `GET` `/group-serach-view/` endpoint [here](https://github.com/getsentry/sentry/pull/88754)


Also updates the headers for the tables in the All Views page to be "My Views" and "Others" 