### PR TITLE
ref: fix sentry.middleware.env to actually tear down request

### DIFF
--- a/src/sentry/middleware/env.py
+++ b/src/sentry/middleware/env.py
@@ -1,27 +1,16 @@
-from django.core.signals import request_finished
-from django.utils.deprecation import MiddlewareMixin
-from rest_framework.request import Request
+from collections.abc import Callable
+
+from django.http.request import HttpRequest
+from django.http.response import HttpResponseBase
 
 from sentry.app import env
 
 
-# In test environments, we sometimes run requests inline with other requests, so we're forced to maintain the full
-# stack of requests happening inside of a process.  This does not normally happen in production however.
-class SentryEnvMiddleware(MiddlewareMixin):
-    def process_request(self, request: Request):
-        # bind request to env
-        if env.request_stack is None:
-            env.request_stack = []
-        if env.request:
-            env.request_stack.append(env.request)
-        env.request = request
+def SentryEnvMiddleware(
+    get_response: Callable[[HttpRequest], HttpResponseBase]
+) -> Callable[[HttpRequest], HttpResponseBase]:
+    def SentryEnvMiddleware_impl(request: HttpRequest) -> HttpResponseBase:
+        with env.active_request(request):
+            return get_response(request)
 
-
-def clear_request(**kwargs):
-    if env.request_stack:
-        env.request = env.request_stack.pop()
-    else:
-        env.request = None
-
-
-request_finished.connect(clear_request)
+    return SentryEnvMiddleware_impl

--- a/src/sentry/testutils/requests.py
+++ b/src/sentry/testutils/requests.py
@@ -10,7 +10,6 @@ from django.http import HttpRequest
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
-from sentry.app import env
 from sentry.middleware.auth import AuthenticationMiddleware
 from sentry.middleware.placeholder import placeholder_get_response
 from sentry.testutils.factories import Factories
@@ -32,10 +31,7 @@ def request_factory(f):
             else:
                 request.user = user
                 request.auth = None
-            env.request = request
             cache.clear()
-        else:
-            env.clear()
         return result
 
     return wrapper

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -172,7 +172,7 @@ class ProjectSerializerTest(TestCase):
         req.user = self.user
         req.superuser.set_logged_in(req.user)
 
-        with mock.patch.object(env, "request", req):
+        with env.active_request(req):
             result = serialize(self.project, self.user)
             assert result["access"] == TEAM_ADMIN["scopes"]
             assert result["hasAccess"] is True

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.conf import settings
 
 from sentry.api.serializers import serialize
@@ -227,7 +225,7 @@ class TeamSerializerTest(TestCase):
         req.user = user
         req.superuser.set_logged_in(req.user)
 
-        with mock.patch.object(env, "request", req):
+        with env.active_request(req):
             result = serialize(team, user)
             assert result["access"] == TEAM_ADMIN["scopes"]
             assert result["hasAccess"] is True

--- a/tests/sentry/manager/test_team_manager.py
+++ b/tests/sentry/manager/test_team_manager.py
@@ -1,14 +1,9 @@
-from sentry.app import env
 from sentry.models.team import Team
 from sentry.testutils.cases import TestCase
 from sentry.users.services.user.service import user_service
 
 
 class TeamManagerTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        env.clear()
-
     def test_simple(self):
         user = self.create_user()
         org = self.create_organization()

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -10,7 +10,6 @@ from django.test import override_settings
 from django.urls import get_resolver
 
 from sentry import options
-from sentry.app import env
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
@@ -61,13 +60,6 @@ def make_user_request_from_org_with_auth_identities(org=None):
 @request_factory
 def none_request() -> None:
     return None
-
-
-@pytest.fixture(autouse=True)
-def clear_env_request():
-    env.clear()
-    yield
-    env.clear()
 
 
 multiregion_client_config_test = control_silo_test(


### PR DESCRIPTION
request_finished is not always called!

fixes this test pollution (and likely a memory leak?):

```console
$ pytest -s tests/sentry/web/frontend/test_group_tag_export.py::GroupTagExportTest::test_region_subdomain_no_conflict_with_slug "$(tail -1 last-failure)"
============================= test session starts ==============================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /Users/asottile/workspace/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, repeat-0.9.3, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 2 items                                                              

tests/sentry/web/frontend/test_group_tag_export.py .
tests/sentry/templatetags/test_sentry_helpers.py F

=================================== FAILURES ===================================
_ test_org_url[{% org_url organization '/issues/' query='referrer=alert' %}-http://testserver/issues/?referrer=alert] _
tests/sentry/templatetags/test_sentry_helpers.py:94: in test_org_url
    assert result == output
E   AssertionError: assert 'http://sentr...eferrer=alert' == 'http://tests...eferrer=alert'
E     
E     - http://testserver/issues/?referrer=alert
E     + http://sentry.testserver/issues/?referrer=alert
E     ?        +++++++
=========================== short test summary info ============================
FAILED tests/sentry/templatetags/test_sentry_helpers.py::test_org_url[{% org_url organization '/issues/' query='referrer=alert' %}-http://testserver/issues/?referrer=alert] - AssertionError: assert 'http://sentr...eferrer=alert' == 'http://tests...ef...
========================= 1 failed, 1 passed in 6.14s ==========================
```

<!-- Describe your PR here. -->