### PR TITLE
feat(uptime): Add basic detector config schema for uptime

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -17,7 +17,6 @@ from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.uptime.models import ProjectUptimeSubscriptionMode
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
@@ -619,12 +618,14 @@ class UptimeDomainCheckFailure(GroupType):
         "properties": {
             "mode": {
                 "type": ["integer"],
-                "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+                # TODO: Enable this when we can move this grouptype out of this file
+                # "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
             },
             "environment": {"type": ["string"]},
         },
         "additionalProperties": False,
     }
+
 
 @dataclass(frozen=True)
 class MetricIssuePOC(GroupType):

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -17,6 +17,7 @@ from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
+from sentry.uptime.models import ProjectUptimeSubscriptionMode
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
@@ -610,7 +611,20 @@ class UptimeDomainCheckFailure(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
-
+    detector_config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A representation of an uptime alert",
+        "type": "object",
+        "required": ["mode", "environment"],
+        "properties": {
+            "mode": {
+                "type": ["integer"],
+                "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+            },
+            "environment": {"type": ["string"]},
+        },
+        "additionalProperties": False,
+    }
 
 @dataclass(frozen=True)
 class MetricIssuePOC(GroupType):

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -1,8 +1,8 @@
 import pytest
 from jsonschema import ValidationError
 
+from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.testutils.cases import TestCase
-from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import ProjectUptimeSubscriptionMode
 
 

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -1,0 +1,109 @@
+import pytest
+from jsonschema import ValidationError
+
+from sentry.testutils.cases import TestCase
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
+from sentry.uptime.models import ProjectUptimeSubscriptionMode
+
+
+class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.uptime_monitor = self.create_project_uptime_subscription()
+
+    def test_detector_correct_schema(self):
+        self.create_detector(
+            name=self.uptime_monitor.name,
+            project_id=self.project.id,
+            type=UptimeDomainCheckFailure.slug,
+            config={
+                "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                "environment": "hi",
+            },
+        )
+
+    def test_incorrect_config(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config=["some", "stuff"],
+            )
+
+    def test_mismatched_schema(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={
+                    "mode": "hi",
+                    "environment": "hi",
+                },
+            )
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={
+                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "environment": 1,
+                },
+            )
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={
+                    "bad_mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "environment": "hi",
+                },
+            )
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={
+                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "environment": "hi",
+                    "junk": "hi",
+                },
+            )
+
+    def test_missing_required(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={},
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={
+                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                },
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.uptime_monitor.name,
+                project_id=self.project.id,
+                type=UptimeDomainCheckFailure.slug,
+                config={"environment": "hi"},
+            )


### PR DESCRIPTION
This adds a basic config schema for uptime. For now it includes mode and environment.

<!-- Describe your PR here. -->