### PR TITLE
feat(bootstrap): Remove OrganizationLoaderContext from sudo modal

### DIFF
--- a/static/app/bootstrap/bootstrapRequests.tsx
+++ b/static/app/bootstrap/bootstrapRequests.tsx
@@ -87,7 +87,7 @@ export function useBootstrapProjectsQuery(orgSlug: string | null) {
   return projectsQuery;
 }
 
-function getBootstrapOrganizationQueryOptions(orgSlug: string | null) {
+export function getBootstrapOrganizationQueryOptions(orgSlug: string | null) {
   return queryOptions({
     queryKey: ['bootstrap-organization', orgSlug],
     queryFn: orgSlug
@@ -136,7 +136,7 @@ function createTeamsObject(response: ApiResult): {
   return {teams, hasMore, cursor};
 }
 
-function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
+export function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
   return queryOptions({
     queryKey: ['bootstrap-teams', orgSlug],
     queryFn: orgSlug
@@ -172,7 +172,7 @@ function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
   });
 }
 
-function getBootstrapProjectsQueryOptions(orgSlug: string | null) {
+export function getBootstrapProjectsQueryOptions(orgSlug: string | null) {
   return queryOptions({
     queryKey: ['bootstrap-projects', orgSlug],
     queryFn: orgSlug

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -111,7 +111,10 @@ describe('Sudo Modal', function () {
     expect(sudoMock).not.toHaveBeenCalled();
 
     // "Sudo" auth
-    await userEvent.type(screen.getByRole('textbox', {name: 'Password'}), 'password');
+    await userEvent.type(
+      await screen.findByRole('textbox', {name: 'Password'}),
+      'password'
+    );
     await userEvent.click(screen.getByRole('button', {name: 'Confirm Password'}));
 
     expect(sudoMock).toHaveBeenCalledWith(
@@ -150,10 +153,10 @@ describe('Sudo Modal', function () {
 
     // Should have Modal + input
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+    expect(await screen.findByRole('button', {name: 'Continue'})).toHaveAttribute(
       'href',
       '/auth/login/?next=http%3A%2F%2Flocalhost%2F'
     );
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -20,10 +20,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useParams} from 'sentry/utils/useParams';
 
-interface OrganizationLoaderContextProps {
-  bootstrapIsPending: boolean;
-}
-
 interface Props {
   children: ReactNode;
 }
@@ -32,13 +28,6 @@ interface Props {
  * Holds the current organization if loaded.
  */
 export const OrganizationContext = createContext<Organization | null>(null);
-
-/**
- * Holds a function to load the organization.
- */
-export const OrganizationLoaderContext = createContext<OrganizationLoaderContextProps>({
-  bootstrapIsPending: false,
-});
 
 /**
  * Record if the organization was bootstrapped in the last 10 minutes
@@ -166,9 +155,5 @@ export function OrganizationContextProvider({children}: Props) {
     }
   }, [orgSlug]);
 
-  return (
-    <OrganizationLoaderContext value={{bootstrapIsPending}}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </OrganizationLoaderContext>
-  );
+  return <OrganizationContext value={organization}>{children}</OrganizationContext>;
 }


### PR DESCRIPTION
Now that we're using react query we can share the queries directly instead of another context and clean up a useEffect that was waiting for these requests to finish in the sudo modal.
