### PR TITLE
feat(shared-views): Add get issue view details endpoint

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -8,6 +8,65 @@ from sentry.testutils.silo import assume_test_silo_mode
 from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
 
 
+class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-details"
+    method = "get"
+
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data()
+
+        # Get the first view's ID for testing
+        self.view_id = str(self.base_data["user_one_views"][0].id)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_get_view_success(self) -> None:
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        # Verify correct view was returned
+        view = GroupSearchView.objects.get(id=self.view_id)
+        assert response.data["id"] == self.view_id
+        assert response.data["name"] == view.name
+        assert response.data["query"] == view.query
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_get_nonexistent_view(self) -> None:
+        nonexistent_id = "37373"
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": nonexistent_id},
+        )
+
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_get_view_from_another_user(self) -> None:
+        # Get a view ID from user_two
+        view_id = str(self.base_data["user_two_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        response = self.client.get(url)
+        assert response.status_code == 200
+        view = GroupSearchView.objects.get(id=view_id)
+        assert response.data["id"] == view_id
+        assert response.data["name"] == view.name
+        assert response.data["query"] == view.query
+
+    def test_get_without_feature_flag(self) -> None:
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+
 class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
     endpoint = "sentry-api-0-organization-group-search-view-details"
     method = "delete"


### PR DESCRIPTION
This PR implements the `GET` method for the `/group-search-views/:viewId` endpoint. It returns the details of an issue view. 