### PR TITLE
feat(guided-steps): Introduce initialStep prop

### DIFF
--- a/static/app/components/guidedSteps/guidedSteps.spec.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.spec.tsx
@@ -114,4 +114,27 @@ describe('GuidedSteps', function () {
       within(screen.getByTestId('guided-step-1')).getByTestId('icon-check-mark')
     ).toBeInTheDocument();
   });
+
+  it('custom current step on load', function () {
+    render(
+      <GuidedSteps initialStep={2}>
+        <GuidedSteps.Step stepKey="step-1" title="Step 1 Title">
+          This is the first step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="step-2" title="Step 2 Title">
+          This is the second step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="step-3" title="Step 3 Title">
+          This is the third step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    );
+
+    expect(screen.queryByText('This is the first step.')).not.toBeInTheDocument();
+    expect(screen.getByText('This is the second step.')).toBeInTheDocument();
+    expect(screen.queryByText('This is the third step.')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/guidedSteps/guidedSteps.stories.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.stories.tsx
@@ -8,6 +8,9 @@ import {
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
+import {decodeInteger} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 export default storyBook('GuidedSteps', story => {
   story('Default', () => (
@@ -108,6 +111,49 @@ export default storyBook('GuidedSteps', story => {
             </GuidedSteps.Step>
           </GuidedSteps>
         </SizingWindow>
+      </Fragment>
+    );
+  });
+
+  story('Show initial step based on url parameter', () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    return (
+      <Fragment>
+        <p>
+          When the page loads, the component will display the current step based on the
+          URL parameter—if one is present. This is especially useful for scenarios like
+          onboarding flows with empty states, where preserving the step state across
+          refreshes helps improve the user experience. This is accomplished by passing a
+          value to the <code>initialStep</code> prop and updating the URL param by using
+          the <code>onStepChange</code> prop.
+        </p>
+        <GuidedSteps
+          initialStep={decodeInteger(location.query.guidedStep)}
+          onStepChange={step => {
+            navigate({
+              pathname: location.pathname,
+              query: {
+                ...location.query,
+                guidedStep: step,
+              },
+            });
+          }}
+        >
+          <GuidedSteps.Step title="Step 1 Title" stepKey="step-1">
+            This is the first step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+          <GuidedSteps.Step title="Step 2 Title" stepKey="step-2">
+            This is the second step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+          <GuidedSteps.Step title="Step 3 Title" stepKey="step-3">
+            This is the third step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+        </GuidedSteps>
       </Fragment>
     );
   });

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -18,13 +18,18 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {decodeInteger} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import FirstEventIndicator from 'sentry/views/onboarding/components/firstEventIndicator';
 
 export default function UpdatedEmptyState({project}: {project?: Project}) {
   const api = useApi();
   const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -123,7 +128,18 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
         <Body>
           <Setup>
             <BodyTitle>{t('Set up the Sentry SDK')}</BodyTitle>
-            <GuidedSteps>
+            <GuidedSteps
+              initialStep={decodeInteger(location.query.guidedStep)}
+              onStepChange={step => {
+                navigate({
+                  pathname: location.pathname,
+                  query: {
+                    ...location.query,
+                    guidedStep: step,
+                  },
+                });
+              }}
+            >
               <GuidedSteps.Step stepKey="install-sentry" title={t('Install Sentry')}>
                 <div>
                   <div>

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -58,8 +58,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import EventWaiter from 'sentry/utils/eventWaiter';
+import {decodeInteger} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useProjects from 'sentry/utils/useProjects';
 
 import {traceAnalytics} from './newTraceDetails/traceAnalytics';
@@ -475,6 +477,8 @@ function OnboardingPanel({
 
 export function Onboarding({organization, project}: OnboardingProps) {
   const api = useApi();
+  const location = useLocation();
+  const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const [received, setReceived] = useState<boolean>(false);
   const showNewUi = organization.features.includes('tracing-onboarding-new-ui');
@@ -630,7 +634,18 @@ export function Onboarding({organization, project}: OnboardingProps) {
   return (
     <OnboardingPanel project={project}>
       <BodyTitle>{t('Set up the Sentry SDK')}</BodyTitle>
-      <GuidedSteps>
+      <GuidedSteps
+        initialStep={decodeInteger(location.query.guidedStep)}
+        onStepChange={step => {
+          navigate({
+            pathname: location.pathname,
+            query: {
+              ...location.query,
+              guidedStep: step,
+            },
+          });
+        }}
+      >
         <GuidedSteps.Step stepKey="install-sentry" title={t('Install Sentry')}>
           <div>
             <div>

--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -7,10 +7,13 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {decodeInteger} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 export default function EmptyState() {
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <div>
@@ -25,7 +28,18 @@ export default function EmptyState() {
       <Body>
         <Setup>
           <BodyTitle>{t('Install instructions')}</BodyTitle>
-          <GuidedSteps>
+          <GuidedSteps
+            initialStep={decodeInteger(location.query.guidedStep)}
+            onStepChange={step => {
+              navigate({
+                pathname: location.pathname,
+                query: {
+                  ...location.query,
+                  guidedStep: step,
+                },
+              });
+            }}
+          >
             <GuidedSteps.Step
               stepKey="step-1"
               title={t('Retrieve Back Office Server Credential from Sony')}


### PR DESCRIPTION
This PR:

- Introduces the new initialStep prop to the GuidedSteps component.
- Adds a new story to demonstrate this functionality, allowing users to see the URL parameter update when the step changes and ensuring the current step is preserved upon page refresh.
- Implements tests to verify that the new functionality works as expected.
- Updates the onboarding empty states to use the new prop,  preserving the current step across page refreshes.

_________________________

- follow-up of https://github.com/getsentry/sentry/pull/88779#discussion_r2029099350
- closes https://github.com/getsentry/sentry/pull/88779
