### PR TITLE
ref(db): Refactor GroupeRelease to reduce rollbacks

### DIFF
--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -1,8 +1,10 @@
+import random
 from datetime import timedelta
 
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -52,27 +54,39 @@ class GroupRelease(Model):
 
         instance = cache.get(cache_key)
         if instance is None:
-            try:
-                with transaction.atomic(router.db_for_write(cls)):
-                    instance, created = (
-                        cls.objects.create(
-                            release_id=release.id,
-                            group_id=group.id,
-                            environment=environment.name,
-                            project_id=group.project_id,
-                            first_seen=datetime,
-                            last_seen=datetime,
-                        ),
-                        True,
-                    )
-            except IntegrityError:
-                incr_rollback_metrics(cls)
-                instance, created = (
-                    cls.objects.get(
-                        release_id=release.id, group_id=group.id, environment=environment.name
-                    ),
-                    False,
+            if random.random() < options.get("grouprelease.new_get_or_create.rollout"):
+                instance, created = cls.objects.get_or_create(
+                    release_id=release.id,
+                    group_id=group.id,
+                    environment=environment.name,
+                    defaults={
+                        "first_seen": datetime,
+                        "last_seen": datetime,
+                        "project_id": group.project_id,
+                    },
                 )
+            else:
+                try:
+                    with transaction.atomic(router.db_for_write(cls)):
+                        instance, created = (
+                            cls.objects.create(
+                                release_id=release.id,
+                                group_id=group.id,
+                                environment=environment.name,
+                                project_id=group.project_id,
+                                first_seen=datetime,
+                                last_seen=datetime,
+                            ),
+                            True,
+                        )
+                except IntegrityError:
+                    incr_rollback_metrics(cls)
+                    instance, created = (
+                        cls.objects.get(
+                            release_id=release.id, group_id=group.id, environment=environment.name
+                        ),
+                        False,
+                    )
         else:
             created = False
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2803,6 +2803,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch for GroupRelease.get_or_create refactor
+register(
+    "grouprelease.new_get_or_create.rollout",
+    default=0.0,
+    type=Float,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for Postgres query timeout error handling
 register(
     "api.postgres-query-timeout-error-handling.enabled",

--- a/tests/sentry/models/test_grouprelease.py
+++ b/tests/sentry/models/test_grouprelease.py
@@ -6,10 +6,56 @@ from sentry.models.environment import Environment
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.release import Release
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 
 
 class GetOrCreateTest(TestCase):
     def test_simple(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
+        release = Release.objects.create(version="abc", organization_id=project.organization_id)
+        release.add_project(project)
+        env = Environment.objects.create(organization_id=project.organization_id, name="prod")
+        datetime = timezone.now()
+
+        grouprelease = GroupRelease.get_or_create(
+            group=group, release=release, environment=env, datetime=datetime
+        )
+
+        assert grouprelease.project_id == project.id
+        assert grouprelease.group_id == group.id
+        assert grouprelease.release_id == release.id
+        assert grouprelease.environment == "prod"
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime
+
+        datetime_new = timezone.now() + timedelta(days=1)
+
+        grouprelease = GroupRelease.get_or_create(
+            group=group, release=release, environment=env, datetime=datetime_new
+        )
+
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime_new
+
+        datetime_new2 = datetime_new + timedelta(seconds=1)
+
+        # this should not update immediately as the window is too close
+        grouprelease = GroupRelease.get_or_create(
+            group=group, release=release, environment=env, datetime=datetime_new2
+        )
+
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime_new
+
+    @override_options({"grouprelease.new_get_or_create.rollout": 1.0})
+    def test_simple_with_new_option(self):
+        """
+        Same test as test_simple, but with the new option enabled which has refactored
+        the get_or_create method.
+
+        Note (vgrozdanic): this test will be removed after the rollout is complete.
+        """
         project = self.create_project()
         group = self.create_group(project=project)
         release = Release.objects.create(version="abc", organization_id=project.organization_id)


### PR DESCRIPTION
Refactor of `get_or_create` method of `GroupRelease` model, preparing it for gradual rollout and to decrease the number of rollbacks it does since almost every attempt of insertions for this model results in a rollback. 


## Why are we doing this

Currently we are doing around 300 rollbacks per second, mostly caused by overly optimistic writes - almost all of the writes result in the rollback because the data already exists in the table, and for those occasions `get_or_create` is more suitable since SELECT statement is more performant than ROLLBACK when they happen most of the times.

[Datadog notebok with investagtion](https://app.datadoghq.com/notebook/12067672/postgres-rollback-investigation?range=604800000&start=1743184480708&live=true), where 3 problematic models where detected:
- `GroupRelease`
- `Commit`
- `EnvironmentProject`

Models will be refactored one at the time, and the refactor will be rolled out gradually: 10% - 50% - 100%