### PR TITLE
feat(onboarding): Set builting symbol sources to unity for all new unity platform projects

### DIFF
--- a/src/sentry/api/helpers/default_symbol_sources.py
+++ b/src/sentry/api/helpers/default_symbol_sources.py
@@ -4,6 +4,7 @@ from sentry.projects.services.project import RpcProject
 DEFAULT_SYMBOL_SOURCES = {
     "electron": ["ios", "microsoft", "electron"],
     "javascript-electron": ["ios", "microsoft", "electron"],
+    "unity": ["unity"],
 }
 
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -354,6 +354,27 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         )
         assert "electron" not in symbol_sources
 
+    def test_builtin_symbol_sources_unity(self):
+        """
+        Test that project option for builtin symbol sources contains ["unity"] when creating
+        a Unity project, but uses defaults for other platforms.
+        """
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="unity-app",
+            slug="unity-app",
+            platform="unity",
+            status_code=201,
+        )
+
+        unity_project = Project.objects.get(id=response.data["id"])
+        assert unity_project.platform == "unity"
+        symbol_sources = ProjectOption.objects.get_value(
+            project=unity_project, key="sentry:builtin_symbol_sources"
+        )
+        assert symbol_sources == ["unity"]
+
     @patch("sentry.api.endpoints.team_projects.TeamProjectsEndpoint.create_audit_entry")
     def test_create_project_with_origin(self, create_audit_entry):
         signal_handler = Mock()


### PR DESCRIPTION
Closes [TET-230: Add unity as a built in repository for debug files for every new Unity project](https://linear.app/getsentry/issue/TET-230/add-unity-as-a-built-in-repository-for-debug-files-for-every-new-unity)