### PR TITLE
feat(spans): Introduce a flag to detect perf issues on spans

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -242,6 +242,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-issues-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Temporary flag to test search performance that's running slow in S4S
     manager.add("organizations:performance-issues-search", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
+    # Detect performance issues in the new standalone spans pipeline instead of on transactions
+    manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Enable consecutive http performance issue type
     manager.add("organizations:performance-large-http-payload-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable internal view for bannerless MEP view

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -69,6 +69,7 @@ EXPOSABLE_FEATURES = [
     "organizations:ourlogs-ingestion",
     "organizations:view-hierarchy-scrubbing",
     "projects:ourlogs-breadcrumb-extraction",
+    "organizations:performance-issues-spans",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
Performance issue detection currently runs on transaction events in `save-transaction`. We want to cut over atomically so that no single transaction/root span is processed twice by issue detection. The last place where the span and transaction are joined is in Relay, so we will introduce a flag in Relay that allows us to define where issue detection runs.

The flag is controlled by an organization feature flag `organizations:performance-issues-spans`. The flag is exposed to Relay. When enabled, Relay writes attributes into the root span and transactions, which control whether detection runs in their respective processing routine.

See https://github.com/getsentry/streaming-planning/issues/121