### PR TITLE
feat(symbol sources): Add `has_index` flag

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -80,6 +80,7 @@ COMMON_SOURCE_PROPERTIES = {
     "layout": LAYOUT_SCHEMA,
     "filters": FILTERS_SCHEMA,
     "is_public": {"type": "boolean"},
+    "has_index": {"type": "boolean"},
 }
 
 APP_STORE_CONNECT_SCHEMA = {


### PR DESCRIPTION
https://github.com/getsentry/symbolicator/pull/1663 adds the ability for sources to indicate that they support indexes to Symbolicator. This is done via a flag called `has_index`.