### PR TITLE
ref: Create separate schema for builtin HTTP sources

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -132,6 +132,7 @@ BUILTIN_HTTP_SOURCE_SCHEMA = {
     "type": "object",
     "properties": dict(
         headers={"type": "object", "patternProperties": {".*": {"type": "string"}}},
+        accept_invalid_certs={"type": "boolean"},
         **HTTP_SOURCE_SCHEMA_INNER,
     ),
     "required": ["type", "id", "url", "layout"],

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -109,14 +109,30 @@ APP_STORE_CONNECT_SCHEMA = {
     "additionalProperties": False,
 }
 
+# Abstract out commonalities between HTTP_SOURCE_SCHEMA
+# and BUILTIN_HTTP_SOURCE_SCHEMA
+HTTP_SOURCE_SCHEMA_INNER = {
+    "type": {"type": "string", "enum": ["http"]},
+    "url": {"type": "string"},
+    "username": {"type": "string"},
+    "password": {"type": "string"},
+    **COMMON_SOURCE_PROPERTIES,
+}
+
 HTTP_SOURCE_SCHEMA = {
     "type": "object",
+    "properties": HTTP_SOURCE_SCHEMA_INNER,
+    "required": ["type", "id", "url", "layout"],
+    "additionalProperties": False,
+}
+
+# Like HTTP_SOURCE_SCHEMA, but also allows a map of headers.
+# We don't want to expose that functionality via the API.
+BUILTIN_HTTP_SOURCE_SCHEMA = {
+    "type": "object",
     "properties": dict(
-        type={"type": "string", "enum": ["http"]},
-        url={"type": "string"},
-        username={"type": "string"},
-        password={"type": "string"},
-        **COMMON_SOURCE_PROPERTIES,
+        headers={"type": "object", "patternProperties": {".*": {"type": "string"}}},
+        **HTTP_SOURCE_SCHEMA_INNER,
     ),
     "required": ["type", "id", "url", "layout"],
     "additionalProperties": False,
@@ -154,6 +170,15 @@ GCS_SOURCE_SCHEMA = {
 SOURCE_SCHEMA = {
     "oneOf": [
         HTTP_SOURCE_SCHEMA,
+        S3_SOURCE_SCHEMA,
+        GCS_SOURCE_SCHEMA,
+        APP_STORE_CONNECT_SCHEMA,
+    ]
+}
+
+BUILTIN_SOURCE_SCHEMA = {
+    "oneOf": [
+        BUILTIN_HTTP_SOURCE_SCHEMA,
         S3_SOURCE_SCHEMA,
         GCS_SOURCE_SCHEMA,
         APP_STORE_CONNECT_SCHEMA,

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -2,7 +2,7 @@ import jsonschema
 import pytest
 from django.conf import settings
 
-from sentry.lang.native.sources import SOURCE_SCHEMA, filter_ignored_sources
+from sentry.lang.native.sources import BUILTIN_SOURCE_SCHEMA, filter_ignored_sources
 from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -10,7 +10,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 @django_db_all
 def test_validate_builtin_sources():
     for source in settings.SENTRY_BUILTIN_SOURCES.values():
-        jsonschema.validate(source, SOURCE_SCHEMA)
+        jsonschema.validate(source, BUILTIN_SOURCE_SCHEMA)
 
 
 class TestIgnoredSourcesFiltering:


### PR DESCRIPTION
We want to be able to configure sources with additional headers, but don't want to open this feature up to users at this time. Therefore we create a separate schema for builtin HTTP sources.

It also adds the `accept_invalid_certs` flag that was added to the NVIDIA source in https://github.com/getsentry/sentry/pull/66509 and removed again in https://github.com/getsentry/sentry/pull/80045 (when we added it we weren't yet validating builtin sources against the schema).