### PR TITLE
ref(insights): update asset module to use eap

### DIFF
--- a/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
+++ b/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
@@ -1,10 +1,4 @@
-import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   FONT_FILE_EXTENSIONS,
   IMAGE_FILE_EXTENSIONS,
@@ -13,6 +7,7 @@ import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 import type {ModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import type {ValidSort} from 'sentry/views/insights/browser/resources/utils/useResourceSort';
+import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/insights/types';
 
 const {
@@ -22,7 +17,6 @@ const {
   SPAN_SELF_TIME,
   RESOURCE_RENDER_BLOCKING_STATUS,
   HTTP_RESPONSE_CONTENT_LENGTH,
-  PROJECT_ID,
   FILE_EXTENSION,
   USER_GEO_SUBREGION,
   NORMALIZED_DESCRIPTION,
@@ -73,19 +67,19 @@ export const useResourcesQuery = ({
   cursor,
   referrer,
 }: Props) => {
-  const pageFilters = usePageFilters();
-  const location = useLocation();
   const resourceFilters = useResourceModuleFilters();
-  const {slug: orgSlug} = useOrganization();
 
   const queryConditions = [
     ...(query ? [] : getResourcesEventViewQuery(resourceFilters, defaultResourceTypes)),
     query,
   ];
 
-  // TODO - we should be using metrics data here
-  const eventView = EventView.fromNewQueryWithPageFilters(
+  return useSpanMetrics(
     {
+      sorts: [sort],
+      search: queryConditions.join(' '),
+      cursor,
+      limit,
       fields: [
         NORMALIZED_DESCRIPTION,
         SPAN_OP,
@@ -98,48 +92,9 @@ export const useResourcesQuery = ({
         `${TIME_SPENT_PERCENTAGE}()`,
         `sum(${SPAN_SELF_TIME})`,
       ],
-      name: 'Resource module - resource table',
-      query: queryConditions.join(' '),
-      orderby: '-count',
-      version: 2,
-      dataset: DiscoverDatasets.SPANS_METRICS,
     },
-    pageFilters.selection
+    referrer
   );
-
-  if (sort) {
-    eventView.sorts = [sort];
-  }
-
-  const result = useDiscoverQuery({
-    eventView,
-    limit: limit ?? 100,
-    location,
-    orgSlug,
-    options: {
-      refetchOnWindowFocus: false,
-    },
-    cursor,
-    referrer,
-  });
-
-  const data = result?.data?.data.map(row => ({
-    [SPAN_OP]: row[SPAN_OP]!.toString() as `resource.${string}`,
-    [NORMALIZED_DESCRIPTION]: row[NORMALIZED_DESCRIPTION]!.toString(),
-    ['avg(span.self_time)']: row[`avg(${SPAN_SELF_TIME})`] as number,
-    'count()': row['count()'] as number,
-    'epm()': row['epm()'] as number,
-    [SPAN_GROUP]: row[SPAN_GROUP]!.toString(),
-    [PROJECT_ID]: row[PROJECT_ID] as number,
-    [`avg(http.response_content_length)`]: row[
-      `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`
-    ] as number,
-    [`time_spent_percentage()`]: row[`${TIME_SPENT_PERCENTAGE}()`] as number,
-    ['count_unique(transaction)']: row['count_unique(transaction)'] as number,
-    [`sum(span.self_time)`]: row[`sum(${SPAN_SELF_TIME})`] as number,
-  }));
-
-  return {...result, data: data || []};
 };
 
 export const getDomainFilter = (selectedDomain: string | undefined) => {

--- a/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
+++ b/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
@@ -25,11 +25,11 @@ const {
 const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 type Props = {
+  limit: number;
   referrer: string;
   sort: ValidSort;
   cursor?: string;
   defaultResourceTypes?: string[];
-  limit?: number;
   query?: string;
 };
 
@@ -79,7 +79,7 @@ export const useResourcesQuery = ({
       sorts: [sort],
       search: queryConditions.join(' '),
       cursor,
-      limit,
+      limit: limit || 100,
       fields: [
         NORMALIZED_DESCRIPTION,
         SPAN_OP,

--- a/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
+++ b/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
@@ -25,11 +25,11 @@ const {
 const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 type Props = {
-  limit: number;
   referrer: string;
   sort: ValidSort;
   cursor?: string;
   defaultResourceTypes?: string[];
+  limit?: number;
   query?: string;
 };
 

--- a/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
@@ -64,7 +64,7 @@ type Row = {
   'project.id': number;
   'sentry.normalized_description': string;
   'span.group': string;
-  'span.op': `resource.${'script' | 'img' | 'css' | 'iframe' | string}`;
+  'span.op': string;
   'sum(span.self_time)': number;
   'time_spent_percentage()': number;
 };

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -78,7 +78,7 @@ describe('ResourcesLandingPage', function () {
         "project": [],
         "query": "has:sentry.normalized_description span.module:resource !sentry.normalized_description:"browser-extension://*" span.op:[resource.script,resource.css,resource.font,resource.img]",
         "referrer": "api.starfish.get-span-domains",
-        "sort": "-count",
+        "sort": "-count()",
         "statsPeriod": "10d",
       },
       "skipAbort": undefined,

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -38,10 +38,12 @@ export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
+  const location = useLocation();
+  const useEap = location.query?.useEap === '1';
   // Indexed spans dataset always returns an `id`
   return useDiscover<Fields | [SpanIndexedField.ID], SpanIndexedResponse>(
     options,
-    DiscoverDatasets.SPANS_INDEXED,
+    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_INDEXED,
     referrer
   );
 };

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -14,7 +14,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {buildEventViewQuery} from 'sentry/views/insights/common/utils/buildEventViewQuery';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {useWasSearchSpaceExhausted} from 'sentry/views/insights/common/utils/useWasSearchSpaceExhausted';
@@ -30,10 +30,6 @@ type Props = {
   spanCategory?: string;
   value?: string;
 };
-
-interface DomainData {
-  'span.domain': string[];
-}
 
 export function DomainSelector({
   value = '',
@@ -70,12 +66,15 @@ export function DomainSelector({
     data: domainData,
     isPending,
     pageLinks,
-  } = useSpansQuery<DomainData[]>({
-    eventView,
-    initialData: [],
-    limit: LIMIT,
-    referrer: 'api.starfish.get-span-domains',
-  });
+  } = useSpanMetrics(
+    {
+      limit: LIMIT,
+      search: eventView.query,
+      sorts: [{field: 'count()', kind: 'desc'}],
+      fields: [SpanMetricsField.SPAN_DOMAIN, 'count()'],
+    },
+    'api.starfish.get-span-domains'
+  );
 
   const wasSearchSpaceExhausted = useWasSearchSpaceExhausted({
     query: searchQuery,


### PR DESCRIPTION
Some of the assets  module was not using eap even with the eap flag toggled. This fixes this issue by
1. Converts to  `useSpansMetrics` from the old discover hook in domain selector and resource table query. Use span metrics has the conditional to toggle eap.
2. Add `useEap` flag into `useSpansIndexed`