### PR TITLE
perf(replays): Remove flush on every event

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -75,7 +75,6 @@ def emit_click_events(
 
     publisher = _initialize_publisher()
     publisher.publish("ingest-replay-events", json.dumps(action))
-    publisher.flush()
 
 
 @sentry_sdk.trace


### PR DESCRIPTION
We're flushing on every event.  We should flush rarely.  Ideally, we do this once when the consumer commits but I need time to write and validate.  In the meantime, this PR will revert us to the old behavior (no flushing) which is technically a bug since data can be lost.  Since we had this bug for a very long time without complaint its likely that the bug is either rare or common but not noticeable.