### PR TITLE
fix(insights): search not working db module

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -5,6 +5,7 @@ export const ALLOWED_WILDCARD_FIELDS = [
   'span.domain',
   'span.status_code',
   'log.body',
+  'sentry.normalized_description',
 ];
 export const EMPTY_OPTION_VALUE = '(empty)';
 


### PR DESCRIPTION
This pr adds the sentry.normalized_description as an allowed wildcard field which fixes an issue where the search bar always returns no results

This broke with https://github.com/getsentry/sentry/pull/88469