### PR TITLE
feat(alerts): Load best effort data for spans dataset

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -26,6 +26,7 @@ import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {getAggregateAlias, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
+import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 export type TimeSeriesData = {
   allTimeseriesData?: EventsStatsData;
@@ -199,6 +200,10 @@ type EventsRequestPartialProps = {
    * Sample rate used for data extrapolation in OnDemandMetricsRequest
    */
   sampleRate?: number;
+  /**
+   * The type of sampling mode used for EAP dataset requests
+   */
+  sampling?: SamplingMode;
   /**
    * Should loading be shown.
    */

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -59,6 +59,7 @@ import {getComparisonMarkLines} from 'sentry/views/alerts/utils/getComparisonMar
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import type {MetricRule, Trigger} from '../../types';
 import {
@@ -747,7 +748,20 @@ class TriggersChart extends PureComponent<Props, State> {
             {noop}
           </EventsRequest>
         ) : null}
-        <EventsRequest {...baseProps} period={period} dataLoadedCallback={onDataLoaded}>
+        <EventsRequest
+          {...baseProps}
+          period={period}
+          dataLoadedCallback={onDataLoaded}
+          // Span alerts only need to do a best effort request and do not need
+          // preflight requests. A user needs to see the highest fidelity data possible
+          // to set up the alert.
+          sampling={
+            organization.features.includes('visibility-explore-progressive-loading') &&
+            dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
+              ? SAMPLING_MODE.BEST_EFFORT
+              : undefined
+          }
+        >
           {({
             loading,
             errored,


### PR DESCRIPTION
Span alerts should always use the best effort method of querying. This ensures that the query will be guaranteed to finish as well as showing the most accurate data possible.

`EventsRequest` just needs to pass down the `sampling` mode prop. Since the `doEventsRequest` method that gets called downstream already accepts `sampling` as an argument and passes it to the request, I only need to add this at the top level.