### PR TITLE
fix: check if unit is a member of an enum with Object.values().includes()

### DIFF
--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -168,8 +168,8 @@ export function getTableHeaderLabel(
 export function isLogAttributeUnit(unit: string | null): unit is LogAttributeUnits {
   return (
     unit === null ||
-    unit === `${DurationUnit}` ||
-    unit === `${CurrencyUnit}` ||
+    Object.values(DurationUnit).includes(unit as DurationUnit) ||
+    Object.values(CurrencyUnit).includes(unit as CurrencyUnit) ||
     unit === 'count' ||
     unit === 'percentage' ||
     unit === 'percent_change'


### PR DESCRIPTION
stringifying an enum results in [object Object], which is not intended.

This was caught by https://typescript-eslint.io/rules/no-base-to-string/