### PR TITLE
ref: add a type assertion for marker

### DIFF
--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -89,7 +89,7 @@ export default class PercentageAreaChart extends Component<Props> {
                 )
                 .map(
                   ({marker, seriesName, data}) =>
-                    `<div><span class="tooltip-label">${marker} <strong>${seriesName}</strong></span> ${(data as any)[1]}%</div>`
+                    `<div><span class="tooltip-label">${marker as string} <strong>${seriesName}</strong></span> ${(data as any)[1]}%</div>`
                 )
                 .join(''),
               '</div>',

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -577,7 +577,7 @@ export function getMetricChartTooltipFormatter({
         )}</strong></span></div>`,
       `<div><span class="tooltip-label">${marker} <strong>${seriesName}</strong></span>${pointYFormatted}</div>`,
       comparisonSeries &&
-        `<div><span class="tooltip-label">${comparisonSeries.marker} <strong>${comparisonSeriesName}</strong></span>${comparisonPointYFormatted}</div>`,
+        `<div><span class="tooltip-label">${comparisonSeries.marker as string} <strong>${comparisonSeriesName}</strong></span>${comparisonPointYFormatted}</div>`,
       `</div>`,
       `<div class="tooltip-footer">`,
       `<span>${startTime} &mdash; ${endTime}</span>`,

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -267,7 +267,7 @@ class ReleasesAdoptionChart extends Component<Props> {
                                 .map(
                                   s =>
                                     `<div><span class="tooltip-label">${
-                                      s.marker
+                                      s.marker as string
                                     }<strong>${
                                       s.seriesName &&
                                       truncationFormatter(s.seriesName, 32)

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -161,7 +161,7 @@ const MemoryChartSeries = memo(
               const seriesTooltips = toArray(values).map(
                 value => `
             <div>
-              <span className="tooltip-label">${value.marker}<strong>${value.seriesName}</strong></span>
+              <span className="tooltip-label">${value.marker as string}<strong>${value.seriesName}</strong></span>
               ${formatBytesBase2((value.data as any)[1])}
             </div>
           `

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -155,7 +155,7 @@ function chartTooltip(category: DataCategory, displayMode: 'usage' | 'cost') {
             // @ts-expect-error TS(2339): Property 'dropped' does not exist on type 'OptionD... Remove this comment to see the full error message
             const dropped = s.data.dropped as DroppedBreakdown | undefined;
             if (typeof dropped === 'undefined' || value === '0') {
-              return `<div><span class="tooltip-label">${s.marker} <strong>${label}</strong></span> ${value}</div>`;
+              return `<div><span class="tooltip-label">${s.marker as string} <strong>${label}</strong></span> ${value}</div>`;
             }
             const other = tooltipValueFormatter(dropped.other);
             const overQuota = tooltipValueFormatter(dropped.overQuota);
@@ -163,7 +163,7 @@ function chartTooltip(category: DataCategory, displayMode: 'usage' | 'cost') {
             // Used to shift breakdown over the same amount as series markers.
             const indent = '<span style="display: inline-block; width: 15px"></span>';
             const labels = [
-              `<div><span class="tooltip-label">${s.marker} <strong>${t(
+              `<div><span class="tooltip-label">${s.marker as string} <strong>${t(
                 'Dropped'
               )}</strong></span> ${value}</div>`,
               `<div><span class="tooltip-label">${indent} <strong>${t(


### PR DESCRIPTION
it's a complex type that potentially can't be stringified, but I guess in our cases it's just always a string at runtime