### PR TITLE
feat(insights): add use eap hook

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -1,6 +1,5 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import {getWebVitalScoresFromTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow';
 import type {
   RowWithScoreAndOpportunity,
@@ -10,6 +9,7 @@ import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/qu
 import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {
   type MetricsProperty,
   SpanIndexedField,
@@ -41,11 +41,10 @@ export const useTransactionWebVitalsScoresQuery = ({
   browserTypes,
   subregions,
 }: Props) => {
-  const location = useLocation();
   const sort = useWebVitalsSort({sortName, defaultSort});
   const defaultQuery = useDefaultWebVitalsQuery();
 
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
 
   const totalOpportunityScoreField: MetricsProperty = useEap
     ? 'opportunity_score(measurements.score.total)'

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -3,10 +3,10 @@ import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {OurLogFieldKey, OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   EAPSpanProperty,
   EAPSpanResponse,
@@ -75,8 +75,7 @@ export const useSpanMetrics = <Fields extends SpanMetricsProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
-  const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   return useDiscover<Fields, SpanMetricsResponse>(
     options,
     useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_METRICS,
@@ -88,8 +87,7 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
-  const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   return useDiscover<Fields, MetricsResponse>(
     options,
     useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -16,6 +16,7 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   MetricsProperty,
   SpanFunctions,
@@ -48,8 +49,7 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string
 ) => {
-  const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   return useDiscoverSeries<Fields>(
     options,
     useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_METRICS,
@@ -61,8 +61,7 @@ export const useMetricsSeries = <Fields extends MetricsProperty[]>(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string
 ) => {
-  const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   return useDiscoverSeries<Fields>(
     options,
     useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
@@ -80,9 +79,10 @@ export const useSpanIndexedSeries = <
   referrer: string,
   dataset?: DiscoverDatasets
 ) => {
+  const useEap = useInsightsEap();
   return useDiscoverSeries<Fields>(
     options,
-    dataset ?? DiscoverDatasets.SPANS_INDEXED,
+    useEap ? DiscoverDatasets.SPANS_EAP_RPC : (dataset ?? DiscoverDatasets.SPANS_INDEXED),
     referrer
   );
 };

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -9,6 +9,7 @@ import {computeAxisMax} from 'sentry/views/insights/common/components/chart';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DATE_FORMAT} from 'sentry/views/insights/common/queries/useSpansQuery';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   SpanIndexedFieldTypes,
   SpanMetricsQueryFilters,
@@ -107,7 +108,7 @@ export const useSpanSamples = (options: Options) => {
     project: pageFilter.selection.projects,
     environment: pageFilter.selection.environments,
     query: query.formatString(),
-    useRpc: location.query?.useEap,
+    useRpc: useInsightsEap(),
     ...(additionalFields?.length ? {additionalFields} : {}),
   };
   const {data, ...result} = useApiQuery<{data: SpanSample[]}>(

--- a/static/app/views/insights/common/utils/useEap.tsx
+++ b/static/app/views/insights/common/utils/useEap.tsx
@@ -1,0 +1,13 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export const useInsightsEap = (): boolean => {
+  const organization = useOrganization();
+  const location = useLocation();
+  const hasEapFlag = organization.features.includes('insights-modules-use-eap');
+  if (!hasEapFlag) {
+    return false;
+  }
+
+  return location.query?.useEap === '1';
+};

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -81,7 +81,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
           upperBound: max,
           additionalFields: fields,
           referrer,
-          useRpc: useInsightsEap(),
+          useRpc: useInsightsEap() ? '1' : undefined,
         },
       },
     ],

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -3,10 +3,10 @@
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   SpanIndexedField,
   SpanIndexedProperty,
@@ -35,7 +35,6 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
   } = options;
 
   const {selection} = usePageFilters();
-  const location = useLocation();
   const organization = useOrganization();
 
   if (defined(min) && min < 0) {
@@ -82,7 +81,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
           upperBound: max,
           additionalFields: fields,
           referrer,
-          useRpc: location.query?.useEap,
+          useRpc: useInsightsEap(),
         },
       },
     ],

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -18,6 +18,7 @@ import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {
   type RoutableModuleNames,
@@ -64,7 +65,7 @@ export function DomainViewHeader({
   const navigate = useNavigate();
   const moduleURLBuilder = useModuleURLBuilder();
   const [isLaravelInsightsEnabled] = useIsLaravelInsightsEnabled();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   const hasEapFlag = organization.features.includes('insights-modules-use-eap');
 
   const toggleUseEap = () => {


### PR DESCRIPTION
Adds a `useEap` hook to insights, this will make the migration to eap easier is a few ways
1. When we release eap, we can just update `useEap` to return true when the feature is enabled rather then check the query params.
2. I'm noticing we have to make the eap check in more places then i originally thought, so its better to have a single hook to handle it then checking `location.query.useEap` everytime.