### PR TITLE
fix: remove divider from menuListItem and dropdownMenu

### DIFF
--- a/static/app/components/core/menuListItem/index.chonk.tsx
+++ b/static/app/components/core/menuListItem/index.chonk.tsx
@@ -99,7 +99,6 @@ export const ChonkInnerWrap = chonkStyled('div', {
 
 export const ChonkContentWrap = chonkStyled('div')<{
   isFocused: boolean;
-  showDivider: boolean;
   size: FormSize;
 }>`
     position: relative;
@@ -109,21 +108,6 @@ export const ChonkContentWrap = chonkStyled('div')<{
     gap: ${space(1)};
     justify-content: space-between;
     padding: 0;
-
-    ${p =>
-      p.showDivider &&
-      !p.isFocused &&
-      `
-      li:not(:last-child) &::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        bottom: 0;
-        width: 100%;
-        height: 1px;
-        box-shadow:  0 1px 0 0 ${p.theme.innerBorder};
-      }
-    `}
   `;
 
 export const ChonkLeadingItems = chonkStyled('div')<{

--- a/static/app/components/core/menuListItem/index.tsx
+++ b/static/app/components/core/menuListItem/index.tsx
@@ -90,7 +90,6 @@ interface OtherProps {
   isPressed?: boolean;
   isSelected?: boolean;
   labelProps?: Partial<React.ComponentProps<typeof Label>>;
-  showDivider?: boolean;
 }
 
 interface Props extends MenuListItemProps, OtherProps {
@@ -104,7 +103,6 @@ function BaseMenuListItem({
   priority = 'default',
   size,
   disabled = false,
-  showDivider = false,
   leadingItems = false,
   trailingItems = false,
   isFocused = false,
@@ -153,7 +151,7 @@ function BaseMenuListItem({
                 : leadingItems}
             </LeadingItems>
           )}
-          <ContentWrap isFocused={isFocused} showDivider={showDivider} size={size}>
+          <ContentWrap isFocused={isFocused} size={size}>
             <LabelWrap>
               <Label id={labelId} data-test-id="menu-list-item-label" {...labelProps}>
                 {label}
@@ -368,7 +366,6 @@ const getVerticalPadding = (size: Props['size']) => {
 const ContentWrap = withChonk(
   styled('div')<{
     isFocused: boolean;
-    showDivider: boolean;
     size: Props['size'];
   }>`
     position: relative;
@@ -378,21 +375,6 @@ const ContentWrap = withChonk(
     gap: ${space(1)};
     justify-content: space-between;
     padding: ${p => getVerticalPadding(p.size)} 0;
-
-    ${p =>
-      p.showDivider &&
-      !p.isFocused &&
-      `
-      li:not(:last-child) &::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        bottom: 0;
-        width: 100%;
-        height: 1px;
-        box-shadow:  0 1px 0 0 ${p.theme.innerBorder};
-      }
-    `}
   `,
   ChonkContentWrap
 );

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -96,10 +96,6 @@ interface DropdownMenuItemProps {
    * Tag name for item wrapper
    */
   renderAs?: React.ElementType;
-  /**
-   * Whether to show a divider below this item
-   */
-  showDivider?: boolean;
 }
 
 /**
@@ -112,7 +108,6 @@ function DropdownMenuItem({
   state,
   closeOnSelect,
   onClose,
-  showDivider,
   renderAs = 'li',
   ref,
   ...props
@@ -239,7 +234,6 @@ function DropdownMenuItem({
       label={itemLabel}
       disabled={isDisabled}
       isFocused={isFocused}
-      showDivider={showDivider}
       innerWrapProps={makeInnerWrapProps()}
       labelProps={labelProps}
       detailsProps={descriptionProps}

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -140,8 +140,6 @@ function DropdownMenuList({
     [menuProps, hasFocus]
   );
 
-  const showDividers = stateCollection.some(item => !!item.props.details);
-
   // Render a single menu item
   const renderItem = (node: Node<MenuItemProps>) => {
     return (
@@ -150,7 +148,6 @@ function DropdownMenuList({
         state={state}
         onClose={onClose}
         closeOnSelect={closeOnSelect}
-        showDivider={showDividers}
       />
     );
   };
@@ -166,7 +163,6 @@ function DropdownMenuList({
         renderAs="div"
         node={node}
         state={state}
-        showDivider={showDividers}
         closeOnSelect={false}
         {...omit(triggerProps, [
           'onClick',


### PR DESCRIPTION
they were barely visible in the old theme, and don't look good in the new one