### PR TITLE
chore(ourlogs): Do not show the resizer over the log details

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -100,6 +100,7 @@ export const DetailsWrapper = styled('div')`
   flex-direction: column;
   white-space: nowrap;
   grid-column: 1 / -1;
+  z-index: ${2 /* place above the grid resizing lines */};
 `;
 
 export const DetailsGrid = styled(StyledPanel)`


### PR DESCRIPTION
<img width="738" alt="Screenshot 2025-04-07 at 11 42 38 AM" src="https://github.com/user-attachments/assets/aa847efb-9e44-4a5f-bb90-f90df07aa4e1" />
