### PR TITLE
fix(dashboards): Prevent undefined error in manage dashboards

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -169,7 +169,8 @@ function ManageDashboards() {
           const paginationObject = parseLinkHeader(dashboardsPageLinks);
           if (
             dashboards?.length &&
-            paginationObject.next!.results &&
+            paginationObject?.next &&
+            paginationObject?.next?.results &&
             rowCount * columnCount > dashboards.length
           ) {
             refetchDashboards();


### PR DESCRIPTION
Addresses [JAVASCRIPT-2WS0](https://sentry.sentry.io/issues/6075516427/)
if the pagination does not exist, `pagination.next!.results` would throw an error saying it's undefined. I've added an extra check to see if `pagination.next` is defined before checking the results
