### PR TITLE
feat(explore): Only fetch preflight over 7d

### DIFF
--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -4,9 +4,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   QUERY_MODE,
   SAMPLING_MODE,
@@ -14,6 +16,8 @@ import {
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/usePageFilters');
 
 function useMockHookImpl({
   enabled,
@@ -56,6 +60,23 @@ describe('useProgressiveQuery', function () {
     mockRequestUrl = MockApiClient.addMockResponse({
       url: '/test',
       body: 'test',
+    });
+
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [2],
+      },
     });
   });
 
@@ -153,4 +174,66 @@ describe('useProgressiveQuery', function () {
       })
     );
   });
+
+  it.each([
+    ['larger period', {period: '14d', start: null, end: null, utc: false}, 2],
+    ['smaller period', {period: '4d', start: null, end: null, utc: false}, 1],
+    [
+      'absolute date with larger period (8d)',
+      {period: null, start: '2024-01-01', end: '2024-01-09', utc: false},
+      2,
+    ],
+    [
+      'absolute date with smaller period (1d)',
+      {period: null, start: '2024-01-01', end: '2024-01-02', utc: false},
+      1,
+    ],
+  ])(
+    'makes the correct number of requests for a %s',
+    async function (
+      _periodType: string,
+      mockedDatetime: PageFilters['datetime'],
+      expectedCalls: number
+    ) {
+      jest.mocked(usePageFilters).mockReturnValue({
+        isReady: true,
+        desyncedFilters: new Set(),
+        pinnedFilters: new Set(),
+        shouldPersist: true,
+        selection: {
+          datetime: mockedDatetime,
+          environments: [],
+          projects: [],
+        },
+      });
+
+      renderHook(
+        () =>
+          useProgressiveQuery({
+            queryHookImplementation: useMockHookImpl,
+            queryHookArgs: {enabled: true, query: 'test value'},
+            queryMode: QUERY_MODE.PARALLEL,
+          }),
+        {
+          wrapper: createWrapper(
+            OrganizationFixture({
+              features: ['visibility-explore-progressive-loading'],
+            })
+          ),
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockRequestUrl).toHaveBeenCalledTimes(expectedCalls);
+      });
+      if (expectedCalls === 1) {
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+          '/test',
+          expect.objectContaining({
+            query: {samplingMode: SAMPLING_MODE.BEST_EFFORT, query: 'test value'},
+          })
+        );
+      }
+    }
+  );
 });


### PR DESCRIPTION
If the request is shorter, the gains from doing the preflight aren't that much and the chart looks jumpy when the best effort request completes. Skips the preflight for anything less than 7d at the moment.