### PR TITLE
feat(explore): Make rpc default

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -144,16 +144,13 @@ export function useExplorePageParams(): ReadablePageParams {
 }
 
 export function useExploreDataset(): DiscoverDatasets {
-  const organization = useOrganization();
   const pageParams = useExplorePageParams();
 
   if (defined(pageParams.dataset)) {
     return pageParams.dataset;
   }
 
-  return organization.features.includes('visibility-explore-rpc')
-    ? DiscoverDatasets.SPANS_EAP_RPC
-    : DiscoverDatasets.SPANS_EAP;
+  return DiscoverDatasets.SPANS_EAP_RPC;
 }
 
 export function useExploreFields(): string[] {

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('sentry/components/lazyRender', () => ({
 describe('MultiQueryModeContent', function () {
   const {organization, project} = initializeOrg({
     organization: {
-      features: ['visibility-explore-rpc', 'performance-saved-queries'],
+      features: ['performance-saved-queries'],
     },
   });
   let eventsRequest: any;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -52,9 +52,7 @@ jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(fu
 });
 
 describe('SpansTabContent', function () {
-  const {organization, project} = initializeOrg({
-    organization: {features: ['visibility-explore-rpc']},
-  });
+  const {organization, project} = initializeOrg();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -93,16 +93,16 @@ describe('ExploreToolbar', function () {
     const rpcSpans = within(section).getByRole('radio', {name: 'EAP RPC Spans'});
     const indexedSpans = within(section).getByRole('radio', {name: 'Indexed Spans'});
 
-    expect(eapSpans).toBeChecked();
-    expect(rpcSpans).not.toBeChecked();
-    expect(indexedSpans).not.toBeChecked();
-    expect(dataset).toEqual(DiscoverDatasets.SPANS_EAP);
-
-    await userEvent.click(rpcSpans);
     expect(eapSpans).not.toBeChecked();
     expect(rpcSpans).toBeChecked();
     expect(indexedSpans).not.toBeChecked();
     expect(dataset).toEqual(DiscoverDatasets.SPANS_EAP_RPC);
+
+    await userEvent.click(eapSpans);
+    expect(eapSpans).toBeChecked();
+    expect(rpcSpans).not.toBeChecked();
+    expect(indexedSpans).not.toBeChecked();
+    expect(dataset).toEqual(DiscoverDatasets.SPANS_EAP);
 
     await userEvent.click(indexedSpans);
     expect(eapSpans).not.toBeChecked();


### PR DESCRIPTION
RPC has been the default in saas for a while now and is available where needed.