### PR TITLE
ref(shared-views): Rename starred endpoints

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1842,12 +1842,12 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-group-search-view-visit",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-view/(?P<view_id>[^\/]+)/starred/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/starred/$",
         OrganizationGroupSearchViewStarredEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-starred",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views-starred-order/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/starred/order/$",
         OrganizationGroupSearchViewStarredOrderEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-starred-order",
     ),

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -66,7 +66,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
 
         serializer = OrganizationGroupSearchViewGetSerializer(data=request.GET)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         query = GroupSearchView.objects.filter(
             organization=organization, user_id=request.user.id


### PR DESCRIPTION
Slightly changes the names of two group search view starred endpoints to bring them in alignment with the rest of the endpoints. These endpoints are not used anywhere on our frontend so they can be modified without consequence. 