### PR TITLE
fix(schema-hints): Separate drawer styling from the page

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -399,7 +399,7 @@ const SchemaHintOption = styled(Button)`
   }
 `;
 
-export const SchemaHintsSection = styled('div')<{withSchemaHintsDrawer: boolean}>`
+export const SchemaHintsSection = styled('div')`
   display: grid;
   /* This is to ensure the hints section spans all the columns */
   grid-column: 1/-1;
@@ -408,8 +408,7 @@ export const SchemaHintsSection = styled('div')<{withSchemaHintsDrawer: boolean}
   height: fit-content;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    grid-template-columns: 1fr ${p =>
-        p.withSchemaHintsDrawer ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'};
+    grid-template-columns: 1fr;
     margin-bottom: 0;
     margin-top: 0;
   }

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -13,7 +13,6 @@ import {IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {useSchemaHintsOnLargeScreen} from 'sentry/views/explore/components/schemaHintsDrawer';
 import SchemaHintsList, {
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHintsList';
@@ -53,7 +52,6 @@ export function LogsTabContent({
   const setFields = useSetLogsFields();
   const setLogsPageParams = useSetLogsPageParams();
   const tableData = useExploreLogsTable({});
-  const isSchemaHintsDrawerOpenOnLargeScreen = useSchemaHintsOnLargeScreen();
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
     useTraceItemAttributes('string');
@@ -112,9 +110,7 @@ export function LogsTabContent({
           </Button>
         </FilterBarContainer>
         <Feature features="organizations:traces-schema-hints">
-          <SchemaHintsSection
-            withSchemaHintsDrawer={isSchemaHintsDrawerOpenOnLargeScreen}
-          >
+          <SchemaHintsSection>
             <SchemaHintsList
               supportedAggregates={[]}
               numberTags={numberAttributes}

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -29,9 +29,7 @@ import {
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ExploreCharts} from 'sentry/views/explore/charts';
-import {useSchemaHintsOnLargeScreen} from 'sentry/views/explore/components/schemaHintsDrawer';
 import SchemaHintsList, {
-  SCHEMA_HINTS_DRAWER_WIDTH,
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
@@ -106,8 +104,6 @@ export function SpansTabContentImpl({
       visitQuery(id);
     }
   }, [id, visitQuery]);
-
-  const isSchemaHintsDrawerOpenOnLargeScreen = useSchemaHintsOnLargeScreen();
 
   const toolbarExtras = [
     ...(organization?.features?.includes('visibility-explore-dataset')
@@ -209,9 +205,6 @@ export function SpansTabContentImpl({
     <Body
       withToolbar={expanded}
       withHints={organization.features.includes('traces-schema-hints')}
-      thirdColumnWidth={
-        isSchemaHintsDrawerOpenOnLargeScreen ? SCHEMA_HINTS_DRAWER_WIDTH : '0px'
-      }
     >
       <TopSection>
         <StyledPageFilterBar condensed>
@@ -264,7 +257,7 @@ export function SpansTabContentImpl({
         )}
       </TopSection>
       <Feature features="organizations:traces-schema-hints">
-        <SchemaHintsSection withSchemaHintsDrawer={isSchemaHintsDrawerOpenOnLargeScreen}>
+        <SchemaHintsSection>
           <SchemaHintsList
             supportedAggregates={
               mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
@@ -394,7 +387,7 @@ function checkIsAllowedSelection(
 }
 
 const Body = styled(Layout.Body)<{
-  thirdColumnWidth: string;
+  // thirdColumnWidth: string;
   withHints: boolean;
   withToolbar: boolean;
 }>`
@@ -402,8 +395,8 @@ const Body = styled(Layout.Body)<{
     display: grid;
     ${p =>
       p.withToolbar
-        ? `grid-template-columns: 300px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`
-        : `grid-template-columns: 0px minmax(100px, auto) ${p.withHints ? p.thirdColumnWidth : ''};`}
+        ? `grid-template-columns: 300px minmax(100px, auto);`
+        : `grid-template-columns: 0px minmax(100px, auto);`}
     grid-template-rows: auto ${p => (p.withHints ? 'auto 1fr' : '1fr')};
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};


### PR DESCRIPTION
Having the drawer show up on the page was causing a lot of lag and repainting on the frontend. I've changed the drawer to just be a drawer. Here's what it looks like:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2e0e62af-42df-4203-afb3-c57a12e5e345) | ![image](https://github.com/user-attachments/assets/f6edecd9-5d5c-4785-91ae-2898b691a582) | 