### PR TITLE
feat(ui): Add Scroll Restoration to app

### DIFF
--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -1,3 +1,4 @@
+import {ScrollRestoration} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import DemoHeader from 'sentry/components/demo/demoHeader';
@@ -59,6 +60,7 @@ function OrganizationLayout({children}: Props) {
       <OrganizationContainer>
         <App organization={organization}>{children}</App>
       </OrganizationContainer>
+      <ScrollRestoration />
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
Adds the scroll restoration component that should handle going back to the top of the page on navigate for us. https://reactrouter.com/6.30.0/components/scroll-restoration

This is mostly an issue when you've scrolled down on the issue stream and visit an issue that has been loaded previously or preloaded via the preview.