### PR TITLE
ref(eap): Use EAP & RPC for widget charts in txn summ

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -58,7 +58,12 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
 };
 
 export const useEAPSeries = <
-  Fields extends MetricsProperty[] | SpanIndexedField[] | SpanFunctions[] | string[],
+  Fields extends
+    | MetricsProperty[]
+    | SpanMetricsProperty[]
+    | SpanIndexedField[]
+    | SpanFunctions[]
+    | string[],
 >(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -57,6 +57,15 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
   );
 };
 
+export const useEAPSeries = <
+  Fields extends MetricsProperty[] | SpanIndexedField[] | SpanFunctions[] | string[],
+>(
+  options: UseMetricsSeriesOptions<Fields> = {},
+  referrer: string
+) => {
+  return useDiscoverSeries<Fields>(options, DiscoverDatasets.SPANS_EAP_RPC, referrer);
+};
+
 export const useMetricsSeries = <Fields extends MetricsProperty[]>(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -1,7 +1,6 @@
 import {useTheme} from '@emotion/react';
 
 import type {DataUnit} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -10,7 +9,7 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useSpanIndexedSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 import {
   filterToColor,
@@ -87,7 +86,7 @@ function useDurationBreakdownVisualization({
     data: spanSeriesData,
     isPending: isSpanSeriesPending,
     isError: isSpanSeriesError,
-  } = useSpanIndexedSeries(
+  } = useEAPSeries(
     {
       yAxis: [
         'avg(span.duration)',
@@ -102,9 +101,7 @@ function useDurationBreakdownVisualization({
       transformAliasToInputFormat: true,
       enabled,
     },
-
-    REFERRER,
-    DiscoverDatasets.SPANS_EAP
+    REFERRER
   );
 
   if (!enabled) {


### PR DESCRIPTION
The EAP-powered transaction summary was using the EAP dataset but not with RPC enabled. This PR changes it to use both.