### PR TITLE
chore(devservices): Tweak healthcheck settings for spotlight

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -165,6 +165,10 @@ services:
       - host.docker.internal:host-gateway
   spotlight:
     image: ghcr.io/getsentry/spotlight:latest
+    healthcheck:
+      interval: 5s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
     ports:
       - '127.0.0.1:8969:8969/tcp'

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -166,8 +166,8 @@ services:
   spotlight:
     image: ghcr.io/getsentry/spotlight:latest
     healthcheck:
-      interval: 5s
-      timeout: 5s
+      interval: 1s
+      timeout: 1s
       retries: 3
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Lowers time for spotlight to become healthy dramatically since docker defaults are high (30s)
https://docs.docker.com/reference/dockerfile/#healthcheck