### PR TITLE
feat(insights): convert queue model to eap

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -903,7 +903,11 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
   },
   time_spent_percentage: fieldName => data => {
     const parsedFunction = parseFunction(fieldName);
-    const column = parsedFunction?.arguments?.[1] ?? SpanMetricsField.SPAN_SELF_TIME;
+    let column = parsedFunction?.arguments?.[1] ?? SpanMetricsField.SPAN_SELF_TIME;
+    // TODO - remove with eap, in eap this function only has one arg
+    if (parsedFunction?.arguments?.[0] === SpanMetricsField.SPAN_DURATION) {
+      column = SpanMetricsField.SPAN_DURATION;
+    }
     return (
       <TimeSpentCell
         percentage={data[fieldName]}

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -68,7 +68,7 @@ export const SORTABLE_FIELDS = new Set([
   'count_op(queue.process)',
   'avg_if(span.duration,span.op,queue.process)',
   'avg(messaging.message.receive.latency)',
-  'time_spent_percentage(app,span.duration)',
+  'time_spent_percentage(span.duration)',
 ]);
 
 const NUMERIC_FIELDS = new Set([

--- a/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
@@ -55,7 +55,7 @@ describe('queuesTable', () => {
   it('renders', async () => {
     render(
       <QueuesTable
-        sort={{field: 'time_spent_percentage(app,span.duration)', kind: 'desc'}}
+        sort={{field: 'time_spent_percentage(span.duration)', kind: 'desc'}}
       />,
       {organization}
     );

--- a/static/app/views/insights/queues/components/tables/queuesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.tsx
@@ -77,7 +77,7 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'time_spent_percentage(app,span.duration)',
+    key: 'time_spent_percentage(span.duration)',
     name: t('Time Spent'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -89,7 +89,7 @@ const SORTABLE_FIELDS = [
   'count_op(queue.process)',
   'avg_if(span.duration,span.op,queue.process)',
   'avg(messaging.message.receive.latency)',
-  `${SpanFunction.TIME_SPENT_PERCENTAGE}(app,span.duration)`,
+  `${SpanFunction.TIME_SPENT_PERCENTAGE}(span.duration)`,
 ] as const;
 
 type ValidSort = Sort & {

--- a/static/app/views/insights/queues/components/tables/transactionsTable.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.tsx
@@ -75,7 +75,7 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'time_spent_percentage(app,span.duration)',
+    key: 'time_spent_percentage(span.duration)',
     name: t('Time Spent'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -87,7 +87,7 @@ const SORTABLE_FIELDS = [
   'count_op(queue.process)',
   'avg_if(span.duration,span.op,queue.process)',
   'avg(messaging.message.receive.latency)',
-  `${SpanFunction.TIME_SPENT_PERCENTAGE}(app,span.duration)`,
+  `${SpanFunction.TIME_SPENT_PERCENTAGE}(span.duration)`,
 ] as const;
 
 type ValidSort = Sort & {
@@ -99,7 +99,7 @@ export function isAValidSort(sort: Sort): sort is ValidSort {
 }
 
 const DEFAULT_SORT = {
-  field: 'time_spent_percentage(app,span.duration)' as const,
+  field: 'time_spent_percentage(span.duration)' as const,
   kind: 'desc' as const,
 };
 

--- a/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_QUERY_FILTER,
   TABLE_ROWS_LIMIT,
 } from 'sentry/views/insights/queues/settings';
+import type {SpanMetricsProperty} from 'sentry/views/insights/types';
 
 type Props = {
   referrer: Referrer;
@@ -25,12 +26,24 @@ export function useQueuesByDestinationQuery({
 }: Props) {
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.DESTINATIONS_CURSOR]);
+  const useEap = location.query?.useEap === '1';
+
+  const timeSpentField: SpanMetricsProperty = useEap
+    ? 'time_spent_percentage(span.duration)'
+    : 'time_spent_percentage(app,span.duration)';
+
+  if (
+    sort?.field === 'time_spent_percentage(span.duration)' ||
+    sort?.field === 'time_spent_percentage(app,span.duration)'
+  ) {
+    sort.field = timeSpentField;
+  }
 
   const mutableSearch = new MutableSearch(DEFAULT_QUERY_FILTER);
   if (destination) {
     mutableSearch.addFilterValue('messaging.destination.name', destination, false);
   }
-  const response = useSpanMetrics(
+  const result = useSpanMetrics(
     {
       search: mutableSearch,
       fields: [
@@ -44,7 +57,7 @@ export function useQueuesByDestinationQuery({
         'avg_if(span.duration,span.op,queue.process)',
         'avg(messaging.message.receive.latency)',
         'trace_status_rate(ok)',
-        'time_spent_percentage(app,span.duration)',
+        timeSpentField,
       ],
       enabled,
       sorts: sort ? [sort] : [],
@@ -54,5 +67,18 @@ export function useQueuesByDestinationQuery({
     referrer
   );
 
-  return response;
+  // TODO - temporary until eap is enabled
+  const finalData = result.data.map(item => ({
+    ...item,
+    ['time_spent_percentage(span.duration)']: item[timeSpentField] ?? 0,
+  }));
+
+  if (result.meta?.fields) {
+    result.meta.fields['time_spent_percentage(span.duration)'] = 'percentage';
+  }
+
+  return {
+    ...result,
+    data: finalData,
+  };
 }

--- a/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_QUERY_FILTER,
   TABLE_ROWS_LIMIT,
 } from 'sentry/views/insights/queues/settings';
+import type {SpanMetricsProperty} from 'sentry/views/insights/types';
 
 type Props = {
   referrer: Referrer;
@@ -24,13 +25,26 @@ export function useQueuesByTransactionQuery({
   referrer,
 }: Props) {
   const location = useLocation();
+  const useEap = location.query?.useEap === '1';
   const cursor = decodeScalar(location.query?.[QueryParameterNames.TRANSACTIONS_CURSOR]);
 
   const mutableSearch = new MutableSearch(DEFAULT_QUERY_FILTER);
   if (destination) {
     mutableSearch.addFilterValue('messaging.destination.name', destination);
   }
-  const response = useSpanMetrics(
+
+  const timeSpentField: SpanMetricsProperty = useEap
+    ? 'time_spent_percentage(span.duration)'
+    : 'time_spent_percentage(app,span.duration)';
+
+  if (
+    sort?.field === 'time_spent_percentage(span.duration)' ||
+    sort?.field === 'time_spent_percentage(app,span.duration)'
+  ) {
+    sort.field = timeSpentField;
+  }
+
+  const result = useSpanMetrics(
     {
       search: mutableSearch,
       fields: [
@@ -45,7 +59,7 @@ export function useQueuesByTransactionQuery({
         'avg_if(span.duration,span.op,queue.process)',
         'avg(messaging.message.receive.latency)',
         'trace_status_rate(ok)',
-        'time_spent_percentage(app,span.duration)',
+        timeSpentField,
       ],
       enabled,
       sorts: sort ? [sort] : [],
@@ -55,5 +69,15 @@ export function useQueuesByTransactionQuery({
     referrer
   );
 
-  return response;
+  // TODO - temporary until eap is enabled
+  const finalData = result.data.map(item => ({
+    ...item,
+    ['time_spent_percentage(span.duration)']: item[timeSpentField] ?? 0,
+  }));
+
+  if (result.meta?.fields) {
+    result.meta.fields['time_spent_percentage(span.duration)'] = 'percentage';
+  }
+
+  return {...result, data: finalData};
 }

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -107,7 +107,7 @@ function DestinationSummaryPage() {
                         value={data[0]?.['sum(span.duration)']}
                         unit={DurationUnit.MILLISECOND}
                         tooltip={getTimeSpentExplanation(
-                          data[0]?.['time_spent_percentage(app,span.duration)']!
+                          data[0]?.['time_spent_percentage(span.duration)'] || 0
                         )}
                         isLoading={isPending}
                       />

--- a/static/app/views/insights/queues/views/queuesLandingPage.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.tsx
@@ -29,7 +29,7 @@ import {Referrer} from 'sentry/views/insights/queues/referrers';
 import {ModuleName} from 'sentry/views/insights/types';
 
 const DEFAULT_SORT = {
-  field: 'time_spent_percentage(app,span.duration)' as const,
+  field: 'time_spent_percentage(span.duration)' as const,
   kind: 'desc' as const,
 };
 


### PR DESCRIPTION
In eap the `time_spent_percentage` function only takes in one parameter (span.self_time or span.duration), while the metrics takes in two parameters, (app or local, span.self_time or span.duration). This PR adds a conditional to query for one or another depending on if eap is enabled.