### PR TITLE
fix(ourlogs): Allow numeric comparison for attributes

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2515,6 +2515,16 @@ export const getFieldDefinition = (
         return LOG_FIELD_DEFINITIONS[key];
       }
 
+      // In EAP we have numeric tags that can be passed as parameters to
+      // aggregate functions. We assign value type based on kind, so that we can filter
+      // on them when suggesting function parameters.
+      if (kind === FieldKind.MEASUREMENT) {
+        return {
+          kind: FieldKind.FIELD,
+          valueType: FieldValueType.NUMBER,
+        };
+      }
+
       if (kind === FieldKind.TAG) {
         return {
           kind: FieldKind.FIELD,


### PR DESCRIPTION
### Summary
Logs also has numeric attributes all hooked up, the field map for the search builder was just missing the 'measurement' trick to switch to numeric.

#### Screenshots
|before|after|
|--|--|
|![Screenshot 2025-04-07 at 2 25 08 PM](https://github.com/user-attachments/assets/22880c2b-a1be-42da-b431-b55d298ba218)|![Screenshot 2025-04-07 at 2 24 52 PM](https://github.com/user-attachments/assets/fafc1f40-3f0e-4e8d-b28f-9c77f0ebf31b)|



Closes LOGS-7
