### PR TITLE
feat(ourlogs): Persist the columns and the column order

### DIFF
--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -12,11 +12,5 @@ export function defaultLogFields(): OurLogKnownFieldKey[] {
 }
 
 export function getLogFieldsFromLocation(location: Location): OurLogFieldKey[] {
-  const fields = decodeList(location.query[LOGS_FIELDS_KEY]);
-
-  if (fields.length) {
-    return fields;
-  }
-
-  return defaultLogFields();
+  return decodeList(location.query[LOGS_FIELDS_KEY]);
 }

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -9,6 +9,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {
@@ -210,7 +211,16 @@ export function useLogsSortBys() {
 
 export function useLogsFields() {
   const {fields} = useLogsPageParams();
-  return fields;
+  const [persistentFields, _] = useLocalStorageState('logs-params-v0', {
+    fields: defaultLogFields(),
+  });
+  if (fields?.length) {
+    return fields;
+  }
+  if (persistentFields?.fields?.length) {
+    return persistentFields?.fields;
+  }
+  return defaultLogFields();
 }
 
 export function useLogsProjectIds() {
@@ -220,11 +230,13 @@ export function useLogsProjectIds() {
 
 export function useSetLogsFields() {
   const setPageParams = useSetLogsPageParams();
+  const [_, setPersistentParams] = useLocalStorageState('logs-params-v0', {});
   return useCallback(
     (fields: string[]) => {
       setPageParams({fields});
+      setPersistentParams({fields});
     },
-    [setPageParams]
+    [setPageParams, setPersistentParams]
   );
 }
 

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -18,6 +18,7 @@ import SchemaHintsList, {
 } from 'sentry/views/explore/components/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {
   type LogPageParamsUpdate,
   useLogsFields,
@@ -73,6 +74,9 @@ export function LogsTabContent({
           stringTags={stringAttributes}
           numberTags={numberAttributes}
           hiddenKeys={HiddenColumnEditorLogFields}
+          handleReset={() => {
+            setFields(defaultLogFields());
+          }}
           isDocsButtonHidden
         />
       ),

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -28,6 +28,7 @@ interface ColumnEditorModalProps extends ModalRenderProps {
   numberTags: TagCollection;
   onColumnsChange: (fields: string[]) => void;
   stringTags: TagCollection;
+  handleReset?: () => void;
   hiddenKeys?: string[];
   isDocsButtonHidden?: boolean;
 }
@@ -43,6 +44,7 @@ export function ColumnEditorModal({
   stringTags,
   hiddenKeys,
   isDocsButtonHidden = false,
+  handleReset,
 }: ColumnEditorModalProps) {
   const tags: Array<SelectOption<string>> = useMemo(() => {
     let allTags = [
@@ -144,6 +146,17 @@ export function ColumnEditorModal({
                   {t('Read the Docs')}
                 </LinkButton>
               )}
+              {handleReset ? (
+                <Button
+                  aria-label={t('Reset')}
+                  onClick={() => {
+                    handleReset();
+                    closeModal();
+                  }}
+                >
+                  {t('Reset')}
+                </Button>
+              ) : null}
               <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
                 {t('Apply')}
               </Button>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -62,6 +62,7 @@ interface SamplesExploreTablesProps extends BaseExploreTablesProps {
   isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
+  useResetButtons?: boolean;
 }
 
 function ExploreSamplesTable(props: SamplesExploreTablesProps) {

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -62,7 +62,6 @@ interface SamplesExploreTablesProps extends BaseExploreTablesProps {
   isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
   tracesTableResult: TracesTableResult;
-  useResetButtons?: boolean;
 }
 
 function ExploreSamplesTable(props: SamplesExploreTablesProps) {


### PR DESCRIPTION
Currently, if you 'edit columns' in the log page, the columns are not saved across navigations.

This saves the column choices in browser storage.

Fixes [LOGS-3](https://linear.app/getsentry/issue/LOGS-3/save-table-structure-changes-for-future-sessions)