### PR TITLE
fix(issues): Properly redirect to reprocessed issue

### DIFF
--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,3 +1,4 @@
+import * as qs from 'query-string';
 import {ConfigFixture} from 'sentry-fixture/config';
 import {EnvironmentsFixture} from 'sentry-fixture/environments';
 import {EventFixture} from 'sentry-fixture/event';
@@ -52,9 +53,7 @@ describe('groupDetails', () => {
   const initRouter = {
     location: {
       pathname: `/organizations/org-slug/issues/${group.id}/`,
-      query: {},
-      search: '?foo=bar',
-      hash: '#hash',
+      query: {project: group.project.id},
     },
     params: {
       groupId: group.id,
@@ -90,6 +89,8 @@ describe('groupDetails', () => {
   }
 
   const createWrapper = (init = defaultInit) => {
+    // Add project id to the url to skip over the _allp redirect
+    window.location.search = qs.stringify({project: group.project.id});
     return render(
       <GroupDetails {...init.routerProps}>
         <MockComponent />
@@ -237,7 +238,7 @@ describe('groupDetails', () => {
         ...initRouter,
         location: LocationFixture({
           ...initRouter.location,
-          query: {environment: 'staging'},
+          query: {environment: 'staging', project: group.project.id},
         }),
       },
     });
@@ -360,7 +361,7 @@ describe('groupDetails', () => {
   });
 
   it('does not refire for request with streamlined UI', async function () {
-    (useHasStreamlinedUI as jest.Mock).mockReturnValue(true);
+    jest.mocked(useHasStreamlinedUI).mockReturnValue(true);
     // Bunch of mocks to load streamlined UI
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/flags/logs/',
@@ -399,8 +400,7 @@ describe('groupDetails', () => {
       url: `/organizations/${defaultInit.organization.slug}/sentry-app-components/`,
       body: [],
     });
-
-    const recommendedWithSearchMock = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/recommended/`,
       query: {
         query: 'foo:bar',
@@ -412,7 +412,9 @@ describe('groupDetails', () => {
       },
     });
     createWrapper();
-    await waitFor(() => expect(recommendedWithSearchMock).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText("We couldn't track down an event")
+    ).toBeInTheDocument();
     await waitFor(() => expect(mockNavigate).not.toHaveBeenCalled());
   });
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -407,10 +407,9 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     params.groupId,
   ]);
 
-  const allProjectsFlag = location.query._allp;
-
   useEffect(() => {
     const locationQuery = qs.parse(window.location.search) || {};
+    const allProjectsFlag = locationQuery._allp;
 
     // We use _allp as a temporary measure to know they came from the
     // issue list page with no project selected (all projects included in
@@ -443,7 +442,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
       navigate({...window.location, query: locationQuery}, {replace: true});
       setAllProjectChanged(true);
     }
-  }, [allProjectsFlag, group?.project.id, allProjectChanged, navigate]);
+  }, [group?.project.id, allProjectChanged, navigate]);
 
   const errorType = groupError ? getFetchDataRequestErrorType(groupError.status) : null;
   useEffect(() => {


### PR DESCRIPTION
Previously we were using recreateRoute which doesn't seem to handle self hosted urls that have disabled customer domains. Fixes an issue where params and query params were backwards.

Removes use of useRouter and browserHistory

fixes #88881