### PR TITLE
theme: add nav items

### DIFF
--- a/static/app/bootstrap/processInitQueue.tsx
+++ b/static/app/bootstrap/processInitQueue.tsx
@@ -5,9 +5,16 @@ import {exportedGlobals} from 'sentry/bootstrap/exportGlobals';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
 import type {OnSentryInitConfiguration} from 'sentry/types/system';
 import {SentryInitRenderReactComponent} from 'sentry/types/system';
+import {
+  DEFAULT_QUERY_CLIENT_CONFIG,
+  QueryClient,
+  QueryClientProvider,
+} from 'sentry/utils/queryClient';
 
 import {renderDom} from './renderDom';
 import {renderOnDomReady} from './renderOnDomReady';
+
+const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
 
 const COMPONENT_MAP = {
   [SentryInitRenderReactComponent.INDICATORS]: () =>
@@ -56,9 +63,11 @@ async function processItem(initConfig: OnSentryInitConfiguration) {
            * This is because config is not available at this point (user might not be logged in yet),
            * and so we dont know which theme to pick.
            */
-          <ThemeAndStyleProvider>
-            <PasswordStrength value={e.target.value} />
-          </ThemeAndStyleProvider>
+          <QueryClientProvider client={queryClient}>
+            <ThemeAndStyleProvider>
+              <PasswordStrength value={e.target.value} />
+            </ThemeAndStyleProvider>
+          </QueryClientProvider>
         );
       })
     );
@@ -85,9 +94,11 @@ async function processItem(initConfig: OnSentryInitConfiguration) {
            * This is because config is not available at this point (user might not be logged in yet),
            * and so we dont know which theme to pick.
            */
-          <ThemeAndStyleProvider>
-            <Component {...props} />
-          </ThemeAndStyleProvider>
+          <QueryClientProvider client={queryClient}>
+            <ThemeAndStyleProvider>
+              <Component {...props} />
+            </ThemeAndStyleProvider>
+          </QueryClientProvider>
         ),
         initConfig.container,
         initConfig.props

--- a/static/app/components/devtoolbar/components/providers.tsx
+++ b/static/app/components/devtoolbar/components/providers.tsx
@@ -37,17 +37,17 @@ export default function Providers({children, config, container}: Props) {
 
   return (
     <CacheProvider value={myCache}>
-      <ThemeProvider theme={lightTheme}>
-        <ConfigurationContextProvider config={config}>
-          <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={lightTheme}>
+          <ConfigurationContextProvider config={config}>
             <VisibilityContextProvider>
               <ToolbarRouterContextProvider>
                 <FeatureFlagsContextProvider>{children}</FeatureFlagsContextProvider>
               </ToolbarRouterContextProvider>
             </VisibilityContextProvider>
-          </QueryClientProvider>
-        </ConfigurationContextProvider>
-      </ThemeProvider>
+          </ConfigurationContextProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
     </CacheProvider>
   );
 }

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -105,8 +105,19 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   {t('Try New Navigation')} <Badge type="alpha">Alpha</Badge>
                 </SidebarMenuItem>
               )}
-              {organization?.features?.includes('chonk-ui') &&
-                !user.options.prefersChonkUI && (
+              {organization?.features?.includes('chonk-ui') ? (
+                user.options.prefersChonkUI ? (
+                  <SidebarMenuItem
+                    onClick={() => {
+                      mutateUserOptions({prefersChonkUI: false});
+                      trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
+                        organization,
+                      });
+                    }}
+                  >
+                    {t('Switch to old UI theme')}
+                  </SidebarMenuItem>
+                ) : (
                   <SidebarMenuItem
                     onClick={() => {
                       mutateUserOptions({prefersChonkUI: true});
@@ -117,7 +128,8 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   >
                     {t('Try New UI2 Theme')} <Badge type="internal">Internal</Badge>
                   </SidebarMenuItem>
-                )}
+                )
+              ) : null}
             </HelpMenu>
           )}
         </HelpRoot>

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -103,6 +103,18 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   {t('Try New Navigation')} <Badge type="alpha">Alpha</Badge>
                 </SidebarMenuItem>
               )}
+              {organization?.features?.includes('chonk-ui') && (
+                <SidebarMenuItem
+                  onClick={() => {
+                    mutateUserOptions({prefersChonkUI: true});
+                    trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
+                      organization,
+                    });
+                  }}
+                >
+                  {t('Try New UI2 Theme')} <Badge type="internal">Internal</Badge>
+                </SidebarMenuItem>
+              )}
             </HelpMenu>
           )}
         </HelpRoot>

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -13,6 +13,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
+import {useUser} from 'sentry/utils/useUser';
 import {useNavPrompts} from 'sentry/views/nav/useNavPrompts';
 
 import SidebarDropdownMenu from './sidebarDropdownMenu.styled';
@@ -27,6 +28,7 @@ type Props = Pick<
 };
 
 function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
+  const user = useUser();
   const {shouldShowHelpMenuDot, onOpenHelpMenu} = useNavPrompts({
     collapsed,
     organization,
@@ -103,18 +105,19 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   {t('Try New Navigation')} <Badge type="alpha">Alpha</Badge>
                 </SidebarMenuItem>
               )}
-              {organization?.features?.includes('chonk-ui') && (
-                <SidebarMenuItem
-                  onClick={() => {
-                    mutateUserOptions({prefersChonkUI: true});
-                    trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
-                      organization,
-                    });
-                  }}
-                >
-                  {t('Try New UI2 Theme')} <Badge type="internal">Internal</Badge>
-                </SidebarMenuItem>
-              )}
+              {organization?.features?.includes('chonk-ui') &&
+                !user.options.prefersChonkUI && (
+                  <SidebarMenuItem
+                    onClick={() => {
+                      mutateUserOptions({prefersChonkUI: true});
+                      trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
+                        organization,
+                      });
+                    }}
+                  >
+                    {t('Try New UI2 Theme')} <Badge type="internal">Internal</Badge>
+                  </SidebarMenuItem>
+                )}
             </HelpMenu>
           )}
         </HelpRoot>

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -30,16 +30,16 @@ function Main() {
   const [router] = useState(buildRouter);
 
   return (
-    <ThemeAndStyleProvider>
-      <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <ThemeAndStyleProvider>
         <OnboardingContextProvider>
           <RouterProvider router={router} />
         </OnboardingContextProvider>
         {USE_REACT_QUERY_DEVTOOL && (
           <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
         )}
-      </QueryClientProvider>
-    </ThemeAndStyleProvider>
+      </ThemeAndStyleProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/static/app/utils/theme/withChonk.spec.tsx
+++ b/static/app/utils/theme/withChonk.spec.tsx
@@ -1,11 +1,14 @@
 import {createRef} from 'react';
 import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
+import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
+import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 
 import {withChonk} from './withChonk';
@@ -34,7 +37,13 @@ function ChonkComponentWithRef({
 
 describe('withChonk', () => {
   beforeEach(() => {
-    localStorage.clear();
+    ConfigStore.loadInitialData(
+      ConfigFixture({
+        user: UserFixture({
+          options: {...UserFixture().options, prefersChonkUI: false},
+        }),
+      })
+    );
     OrganizationStore.onUpdate(OrganizationFixture({features: []}));
   });
 
@@ -51,7 +60,14 @@ describe('withChonk', () => {
   });
 
   it('renders chonk component when chonk is enabled', () => {
-    localStorage.setItem('chonk-theme', JSON.stringify({theme: 'dark'}));
+    ConfigStore.loadInitialData(
+      ConfigFixture({
+        user: UserFixture({
+          options: {...UserFixture().options, prefersChonkUI: true},
+        }),
+      })
+    );
+
     OrganizationStore.onUpdate(
       OrganizationFixture({
         features: ['chonk-ui'],
@@ -87,7 +103,14 @@ describe('withChonk', () => {
   });
 
   it('passes ref to chonk component', () => {
-    localStorage.setItem('chonk-theme', JSON.stringify({theme: 'dark'}));
+    ConfigStore.loadInitialData(
+      ConfigFixture({
+        user: UserFixture({
+          options: {...UserFixture().options, prefersChonkUI: true},
+        }),
+      })
+    );
+
     OrganizationStore.onUpdate(
       OrganizationFixture({
         features: ['chonk-ui'],

--- a/static/app/views/integrationPipeline/pipelineView.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.tsx
@@ -4,6 +4,11 @@ import {createMemoryRouter, RouterProvider} from 'react-router-dom';
 import Indicators from 'sentry/components/indicators';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
+import {
+  DEFAULT_QUERY_CLIENT_CONFIG,
+  QueryClient,
+  QueryClientProvider,
+} from 'sentry/utils/queryClient';
 
 import AwsLambdaCloudformation from './awsLambdaCloudformation';
 import AwsLambdaFailureDetails from './awsLambdaFailureDetails';
@@ -34,6 +39,8 @@ function buildRouter(Component: React.ComponentType, props: any) {
   return router;
 }
 
+const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
+
 /**
  * This component is a wrapper for specific pipeline views for integrations
  */
@@ -51,10 +58,12 @@ function PipelineView({pipelineName, ...props}: Props) {
   const [router] = useState(() => buildRouter(Component, props));
 
   return (
-    <ThemeAndStyleProvider>
-      <Indicators className="indicators-container" />
-      <RouterProvider router={router} />
-    </ThemeAndStyleProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeAndStyleProvider>
+        <Indicators className="indicators-container" />
+        <RouterProvider router={router} />
+      </ThemeAndStyleProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -33,6 +33,7 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'performance-trace-explorer',
   'profiling',
+  'chonk-ui',
 ];
 
 const mockUsingCustomerDomain = jest.fn();
@@ -374,6 +375,44 @@ describe('Nav', function () {
 
       // Shows the reminder on help menu
       await screen.findByText('Come back anytime');
+    });
+  });
+
+  describe('chonk-ui', function () {
+    describe('enabled', function () {
+      it('shows the chonk-ui toggle in the help menu', async function () {
+        renderNav();
+        const helpMenu = screen.getByRole('button', {name: 'Help'});
+        await userEvent.click(helpMenu);
+
+        expect(screen.getByText('Try New UI2 Theme')).toBeInTheDocument();
+      });
+
+      it('shows the chonk-ui toggle to old theme', async function () {
+        ConfigStore.set('user', {
+          ...ConfigStore.get('user'),
+          options: {
+            ...ConfigStore.get('user').options,
+            prefersChonkUI: true,
+          },
+        });
+
+        renderNav();
+        const helpMenu = screen.getByRole('button', {name: 'Help'});
+        await userEvent.click(helpMenu);
+
+        expect(screen.getByText('Switch to old UI theme')).toBeInTheDocument();
+      });
+    });
+
+    describe('disabled', function () {
+      it('does not show the chonk-ui toggle in the help menu', async function () {
+        renderNav();
+        const helpMenu = screen.getByRole('button', {name: 'Help'});
+        await userEvent.click(helpMenu);
+
+        expect(screen.queryByText('Try New UI2 Theme')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -133,7 +133,17 @@ export function PrimaryNavigationHelp() {
                   );
                 },
               },
-            ],
+              organization?.features?.includes('chonk-ui') && {
+                key: 'new-chonk-ui',
+                label: t('Switch to old UI theme'),
+                onAction() {
+                  mutateUserOptions({prefersChonkUI: false});
+                  trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
+                    organization,
+                  });
+                },
+              },
+            ].filter(n => !!n),
           },
         ]}
         analyticsKey="help"

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -8,6 +8,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 import {activateZendesk, zendeskIsLoaded} from 'sentry/utils/zendesk';
 import {SidebarMenu} from 'sentry/views/nav/primary/components';
 import {
@@ -49,6 +50,7 @@ function getContactSupportItem({
 
 export function PrimaryNavigationHelp() {
   const organization = useOrganization();
+  const user = useUser();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
   const contactSupportItem = getContactSupportItem({organization});
   const openForm = useFeedbackForm();
@@ -133,16 +135,17 @@ export function PrimaryNavigationHelp() {
                   );
                 },
               },
-              organization?.features?.includes('chonk-ui') && {
-                key: 'new-chonk-ui',
-                label: t('Switch to old UI theme'),
-                onAction() {
-                  mutateUserOptions({prefersChonkUI: false});
-                  trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
-                    organization,
-                  });
+              organization?.features?.includes('chonk-ui') &&
+                user.options.prefersChonkUI && {
+                  key: 'new-chonk-ui',
+                  label: t('Switch to old UI theme'),
+                  onAction() {
+                    mutateUserOptions({prefersChonkUI: false});
+                    trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
+                      organization,
+                    });
+                  },
                 },
-              },
             ].filter(n => !!n),
           },
         ]}

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -135,17 +135,29 @@ export function PrimaryNavigationHelp() {
                   );
                 },
               },
-              organization?.features?.includes('chonk-ui') &&
-                user.options.prefersChonkUI && {
-                  key: 'new-chonk-ui',
-                  label: t('Switch to old UI theme'),
-                  onAction() {
-                    mutateUserOptions({prefersChonkUI: false});
-                    trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
-                      organization,
-                    });
-                  },
-                },
+              organization?.features?.includes('chonk-ui')
+                ? user.options.prefersChonkUI
+                  ? {
+                      key: 'new-chonk-ui',
+                      label: t('Switch to old UI theme'),
+                      onAction() {
+                        mutateUserOptions({prefersChonkUI: false});
+                        trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
+                          organization,
+                        });
+                      },
+                    }
+                  : {
+                      key: 'new-chonk-ui',
+                      label: t('Try New UI2 Theme'),
+                      onAction() {
+                        mutateUserOptions({prefersChonkUI: true});
+                        trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
+                          organization,
+                        });
+                      },
+                    }
+                : null,
             ].filter(n => !!n),
           },
         ]}

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -176,11 +176,9 @@ function makeAllTheProviders(options: ProviderOptions) {
 
     return (
       <CacheProvider value={{...cache, compat: true}}>
-        <ThemeProvider theme={ThemeFixture()}>
-          <QueryClientProvider client={makeTestQueryClient()}>
-            {wrappedContent}
-          </QueryClientProvider>
-        </ThemeProvider>
+        <QueryClientProvider client={makeTestQueryClient()}>
+          <ThemeProvider theme={ThemeFixture()}>{wrappedContent}</ThemeProvider>
+        </QueryClientProvider>
       </CacheProvider>
     );
   };


### PR DESCRIPTION
Add the ability to switch themes via help navigation, similarly to what issues team is doing with stacked navigation.

The difference here is that in our case, the functionality is ultimately still gated by the feature flag, and we've effectively swapped out the localStorage preference for the user option stored by our backend.

https://github.com/user-attachments/assets/68ee770b-c6bb-4270-92a1-a941b4a57ed8

