### PR TITLE
:recycle: ref(notifications): remove `link_to_event` param for build_title_link

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -33,7 +33,6 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         event: GroupEvent | None = None,
         tags: set[str] | None = None,
         rules: list[Rule] | None = None,
-        link_to_event: bool = False,
         issue_details: bool = False,
         notification: ProjectNotification | None = None,
     ) -> None:
@@ -41,7 +40,6 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         self.event = event
         self.tags = tags
         self.rules = rules
-        self.link_to_event = link_to_event
         self.issue_details = issue_details
         self.notification = notification
 
@@ -65,7 +63,6 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
                 url=get_title_link(
                     self.group,
                     self.event,
-                    self.link_to_event,
                     self.issue_details,
                     self.notification,
                     ExternalProviders.DISCORD,

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -133,7 +133,6 @@ def get_rule_environment_param(
 def get_title_link(
     group: Group,
     event: Event | GroupEvent | None,
-    link_to_event: bool,
     issue_details: bool,
     notification: BaseNotification | None,
     provider: ExternalProviders,
@@ -151,7 +150,7 @@ def get_title_link(
         other_params["alert_rule_id"] = str(rule_id)
         other_params["alert_type"] = "issue"
 
-    if event and link_to_event:
+    if event:
         url = group.get_absolute_url(
             params={"referrer": EXTERNAL_PROVIDERS[provider], **other_params},
             event_id=event.event_id,

--- a/src/sentry/integrations/msteams/card_builder/notifications.py
+++ b/src/sentry/integrations/msteams/card_builder/notifications.py
@@ -133,7 +133,7 @@ class MSTeamsIssueNotificationsMessageBuilder(MSTeamsNotificationsMessageBuilder
     def create_attachment_title_block(self) -> TextBlock | None:
         title = build_attachment_title(self.group)
         title_link = get_title_link(
-            self.group, None, False, True, self.notification, ExternalProviders.MSTEAMS
+            self.group, None, True, self.notification, ExternalProviders.MSTEAMS
         )
 
         return (

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -427,7 +427,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         identity: RpcIdentity | None = None,
         actions: Sequence[MessageAction | BlockKitMessageAction] | None = None,
         rules: list[Rule] | None = None,
-        link_to_event: bool = False,
         issue_details: bool = False,
         notification: ProjectNotification | None = None,
         recipient: Actor | None = None,
@@ -442,7 +441,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.identity = identity
         self.actions = actions
         self.rules = rules
-        self.link_to_event = link_to_event
         self.issue_details = issue_details
         self.notification = notification
         self.recipient = recipient
@@ -462,7 +460,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title_link = get_title_link(
             self.group,
             self.event,
-            self.link_to_event,
             self.issue_details,
             self.notification,
             ExternalProviders.SLACK,

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -79,7 +79,7 @@ def _unfurl_issues(integration: Integration, links: list[UnfurlableUrl]) -> Unfu
                 else None
             )
             out[link.url] = SlackIssuesMessageBuilder(
-                group=group_by_id[issue_id], event=event, link_to_event=True, is_unfurl=True
+                group=group_by_id[issue_id], event=event, is_unfurl=True
             ).build()
     return out
 

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -205,7 +205,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
     def get_title_link(self, recipient: Actor, provider: ExternalProviders) -> str | None:
         from sentry.integrations.messaging.message_builder import get_title_link
 
-        return get_title_link(self.group, None, False, True, self, provider)
+        return get_title_link(self.group, None, True, self, provider)
 
     def build_attachment_title(self, recipient: Actor) -> str:
         from sentry.integrations.messaging.message_builder import build_attachment_title

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -96,7 +96,7 @@ class DummyNotificationWithMoreFields(DummyNotification):
     def get_title_link(self, *args):
         from sentry.integrations.messaging.message_builder import get_title_link
 
-        return get_title_link(self.group, None, False, True, self, ExternalProviders.SLACK)
+        return get_title_link(self.group, None, True, self, ExternalProviders.SLACK)
 
 
 TEST_ISSUE_OCCURRENCE = IssueOccurrence(

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -134,7 +134,6 @@ class DiscordIssueAlertTest(RuleTestCase):
                 self.event.group,
                 self.event,
                 False,
-                False,
                 None,
                 ExternalProviders.DISCORD,
                 notification_uuid=notification_uuid,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -74,7 +74,6 @@ def build_test_message_blocks(
     users: set[User],
     group: Group,
     event: Event | None = None,
-    link_to_event: bool = False,
     tags: dict[str, str] | None = None,
     suggested_assignees: str | None = None,
     initial_assignee: Team | User | None = None,
@@ -93,7 +92,7 @@ def build_test_message_blocks(
         title = event.title
         if title == "<unlabeled event>":
             formatted_title = "&lt;unlabeled event&gt;"
-        if link_to_event:
+        if event:
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
     if rule:
@@ -317,13 +316,12 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
 
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), link_to_event=True
+            group, event.for_group(group)
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
             event=event,
-            link_to_event=True,
         )
 
         test_message = build_test_message_blocks(
@@ -407,13 +405,12 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
 
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), link_to_event=True
+            group, event.for_group(group)
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
             event=event,
-            link_to_event=True,
         )
 
         test_message = build_test_message_blocks(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -226,9 +226,7 @@ class UnfurlTest(TestCase):
         assert unfurls[links[0].url] == SlackIssuesMessageBuilder(self.group).build()
         assert (
             unfurls[links[1].url]
-            == SlackIssuesMessageBuilder(
-                group2, event.for_group(group2), link_to_event=True
-            ).build()
+            == SlackIssuesMessageBuilder(group2, event.for_group(group2)).build()
         )
 
     def test_unfurl_issues_block_kit(self):
@@ -255,9 +253,7 @@ class UnfurlTest(TestCase):
         assert unfurls[links[0].url] == SlackIssuesMessageBuilder(self.group).build()
         assert (
             unfurls[links[1].url]
-            == SlackIssuesMessageBuilder(
-                group2, event.for_group(group2), link_to_event=True
-            ).build()
+            == SlackIssuesMessageBuilder(group2, event.for_group(group2)).build()
         )
 
     def test_escape_issue(self):


### PR DESCRIPTION
part 1 of refactoring this method.

if `event` is passed, we should just be adding it to the link because thats the only purpose of that param. we shouldn't need a separate param for this.