### PR TITLE
icons: add white background to plugin and integration icon

### DIFF
--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -1473,7 +1473,7 @@ const PLUGIN_ICON_KEYS: Array<PluginIconProps['pluginId']> = [
   'victorops',
 ];
 
-const PLUGIN_ICONS = Object.keys(PLUGIN_ICON_KEYS).map(key => ({
+const PLUGIN_ICONS = PLUGIN_ICON_KEYS.map(key => ({
   id: key,
   name: key,
   keywords: [key],
@@ -1539,7 +1539,7 @@ const IDENTITY_ICON_KEYS: Array<IdentityIconProps['providerId']> = [
   'vsts',
 ];
 
-const IDENTITY_ICONS = Object.keys(IDENTITY_ICON_KEYS).map(key => ({
+const IDENTITY_ICONS = IDENTITY_ICON_KEYS.map(key => ({
   id: key,
   name: key,
   keywords: [key],

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -78,18 +78,33 @@ export interface PluginIconProps extends React.RefAttributes<HTMLDivElement> {
 
 export function PluginIcon({pluginId, size = 20, ref}: PluginIconProps) {
   return (
-    <StyledPluginIcon size={size} pluginSrc={getPluginIconSource(pluginId)} ref={ref} />
+    <StyledPluginIconContainer size={size}>
+      <StyledPluginIcon size={size} pluginSrc={getPluginIconSource(pluginId)} ref={ref} />
+    </StyledPluginIconContainer>
   );
 }
+
+const StyledPluginIconContainer = styled('div')<{
+  size: number;
+}>`
+  height: ${p => p.size}px;
+  width: ${p => p.size}px;
+  min-width: ${p => p.size}px;
+  background-color: ${p => p.theme.white};
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 const StyledPluginIcon = styled('div')<{
   pluginSrc: string;
   size: number;
 }>`
   position: relative;
-  height: ${p => p.size}px;
-  width: ${p => p.size}px;
-  min-width: ${p => p.size}px;
+  height: ${p => p.size - p.size * 0.2}px;
+  width: ${p => p.size - p.size * 0.2}px;
+  min-width: ${p => p.size - p.size * 0.2}px;
   border-radius: 2px;
   border: 0;
   display: inline-block;

--- a/static/app/views/settings/components/identityIcon.tsx
+++ b/static/app/views/settings/components/identityIcon.tsx
@@ -52,18 +52,30 @@ export interface IdentityIconProps extends React.RefAttributes<HTMLDivElement> {
 
 export function IdentityIcon({providerId, size = 36, ref}: IdentityIconProps) {
   return (
-    <StyledIdentityIcon
-      ref={ref}
-      size={size}
-      identitySrc={getIdentityIconSource(providerId)}
-    />
+    <StyledIdentityIconContainer size={size}>
+      <StyledIdentityIcon
+        ref={ref}
+        size={size}
+        identitySrc={getIdentityIconSource(providerId)}
+      />
+    </StyledIdentityIconContainer>
   );
 }
 
-const StyledIdentityIcon = styled('div')<{identitySrc: string; size: number}>`
-  position: relative;
+const StyledIdentityIconContainer = styled('div')<{size: number}>`
   height: ${p => p.size}px;
   width: ${p => p.size}px;
+  background-color: ${p => p.theme.white};
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledIdentityIcon = styled('div')<{identitySrc: string; size: number}>`
+  position: relative;
+  height: ${p => p.size - p.size * 0.2}px;
+  width: ${p => p.size - p.size * 0.2}px;
   border-radius: 2px;
   border: 0;
   display: inline-block;


### PR DESCRIPTION
Dark icons are nearly invisible in dark mode, so add white background around all of our icons platform and integration icons

![CleanShot 2025-04-07 at 15 38 39@2x](https://github.com/user-attachments/assets/43b0c4da-2c83-4174-bdfc-c983f8fefb1f)
