### PR TITLE
feat(schema-hints): Make drawer resizable

### DIFF
--- a/static/app/components/globalDrawer/useDrawerResizing.tsx
+++ b/static/app/components/globalDrawer/useDrawerResizing.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@emotion/react';
 import useMedia from 'sentry/utils/useMedia';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
-const MIN_WIDTH_PERCENT = 30;
+const MIN_WIDTH_PERCENT = 20;
 const MAX_WIDTH_PERCENT = 85;
 const DEFAULT_WIDTH_PERCENT = 50;
 

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -220,7 +220,8 @@ function SchemaHintsList({
             {
               ariaLabel: t('Schema Hints Drawer'),
               drawerWidth: SCHEMA_HINTS_DRAWER_WIDTH,
-              resizable: false,
+              drawerKey: 'schema-hints-drawer',
+              resizable: true,
               drawerCss: css`
                 height: calc(100% - ${space(4)});
               `,


### PR DESCRIPTION
Drawers can be resizable now so I'm adding that functionality to the schema hints drawer (by Dora's request). 