### PR TITLE
chore(eap): Add trace_id to proto sent to snuba in traceitemdetails

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,7 +68,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.20.8
 sentry-kafka-schemas>=1.1.4
 sentry-ophio==1.0.0
-sentry-protos>=0.1.65
+sentry-protos>=0.1.66
 sentry-redis-tools>=0.5.0
 sentry-relay>=0.9.7
 sentry-sdk[http2]>=2.25.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -189,7 +189,7 @@ sentry-forked-djangorestframework-stubs==3.15.3.post1
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
-sentry-protos==0.1.65
+sentry-protos==0.1.66
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -127,7 +127,7 @@ sentry-arroyo==2.20.8
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0
-sentry-protos==0.1.65
+sentry-protos==0.1.66
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.7
 sentry-sdk==2.25.1

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -8,8 +8,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import TraceItemDetailsRequest
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -148,18 +146,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
                 trace_item_type=trace_item_type,
                 request_id=str(uuid.uuid4()),
             ),
-            filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_STRING,
-                        name="sentry.trace_id",
-                    ),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(
-                        val_str=trace_id,
-                    ),
-                )
-            ),
+            trace_id=trace_id,
         )
 
         resp = MessageToDict(snuba_rpc.trace_item_details_rpc(req))


### PR DESCRIPTION
Snuba now supports sending a trace with the request directly (instead of as a filter)