### PR TITLE
feat(eap): Create new EAP-powered Sidebar Widgets for Txn Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -98,8 +98,6 @@ function OTelSummaryContentInner({
   spanOperationBreakdownFilter,
   organization,
   projects,
-  isLoading,
-  error,
   projectId,
   transactionName,
 }: Props) {
@@ -126,15 +124,6 @@ function OTelSummaryContentInner({
     [location, navigate]
   );
 
-  function generateTagUrl(key: string, value: string) {
-    const query = generateQueryWithTag(location.query, {key: formatTagKey(key), value});
-
-    return {
-      ...location,
-      query,
-    };
-  }
-
   function handleTransactionsListSortChange(value: string) {
     const target = {
       pathname: location.pathname,
@@ -147,8 +136,6 @@ function OTelSummaryContentInner({
   const query = useMemo(() => {
     return decodeScalar(location.query.query, '');
   }, [location]);
-
-  const totalCount = totalValues === null ? null : totalValues['count()']!;
 
   // NOTE: This is not a robust check for whether or not a transaction is a front end
   // transaction, however it will suffice for now.
@@ -316,16 +303,6 @@ function OTelSummaryContentInner({
         />
       </Layout.Main>
       <Layout.Side>
-        <UserStats
-          organization={organization}
-          location={location}
-          isLoading={isLoading}
-          hasWebVitals={hasWebVitals}
-          error={error}
-          totals={totalValues}
-          transactionName={transactionName}
-          eventView={eventView}
-        />
         {!isFrontendView && (
           <StatusBreakdown
             eventView={eventView}
@@ -334,15 +311,8 @@ function OTelSummaryContentInner({
           />
         )}
         <SidebarSpacer />
-        <EAPSidebarCharts transactionName={transactionName} />
+        <EAPSidebarCharts transactionName={transactionName} hasWebVitals={hasWebVitals} />
         <SidebarSpacer />
-        <Tags
-          generateUrl={generateTagUrl}
-          totalValues={totalCount}
-          eventView={eventView}
-          organization={organization}
-          location={location}
-        />
       </Layout.Side>
     </Fragment>
   );

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -44,6 +44,7 @@ import {SpanIndexedField} from 'sentry/views/insights/types';
 import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 import {SpanCategoryFilter} from 'sentry/views/performance/transactionSummary/spanCategoryFilter';
 import {EAPChartsWidget} from 'sentry/views/performance/transactionSummary/transactionOverview/eapChartsWidget';
+import {EAPSidebarCharts} from 'sentry/views/performance/transactionSummary/transactionOverview/eapSidebarCharts';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
   makeVitalGroups,
@@ -333,14 +334,7 @@ function OTelSummaryContentInner({
           />
         )}
         <SidebarSpacer />
-        <SidebarCharts
-          organization={organization}
-          isLoading={isLoading}
-          error={error}
-          totals={totalValues}
-          eventView={eventView}
-          transactionName={transactionName}
-        />
+        <EAPSidebarCharts transactionName={transactionName} />
         <SidebarSpacer />
         <Tags
           generateUrl={generateTagUrl}

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
@@ -5,6 +6,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
@@ -39,6 +41,7 @@ type FailureRateWidgetProps = {
 
 function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   const organization = useOrganization();
+  const theme = useTheme();
 
   const {
     data: failureRateData,
@@ -62,7 +65,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   }
 
   const timeSeries = eapSeriesDataToTimeSeries(failureRateData);
-
+  const plottables = timeSeries.map(series => new Line(series, {color: theme.red300}));
   return (
     <Widget
       Title={t('Failure Rate')}
@@ -74,6 +77,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
           />
         </Widget.WidgetToolbar>
       }
+      Visualization={<TimeSeriesWidgetVisualization plottables={plottables} />}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -2,7 +2,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
-// import {SectionHeading} from 'sentry/components/charts/styles';
 import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+
+// import {SectionHeading} from 'sentry/components/charts/styles';
+import {space} from 'sentry/styles/space';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {useSpanIndexedSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+
+type Props = {
+  transactionName: string;
+};
+
+const REFERRER = 'eap-sidebar-charts';
+
+export function EAPSidebarCharts({transactionName}: Props) {
+  const {
+    data: failureRateData,
+    isPending: isFailureRatePending,
+    isError: isFailureRateError,
+  } = useSpanIndexedSeries(
+    {
+      search: new MutableSearch(`transaction:${transactionName}`),
+      yAxis: ['failure_rate()'],
+    },
+    REFERRER,
+    DiscoverDatasets.SPANS_EAP
+  );
+
+  if (isFailureRatePending || isFailureRateError) {
+    return (
+      <ChartContainer>
+        <TimeSeriesWidgetVisualization.LoadingPlaceholder />
+      </ChartContainer>
+    );
+  }
+
+  console.dir(failureRateData);
+
+  return <ChartContainer>EAPSidebarCharts</ChartContainer>;
+}
+
+const ChartContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+// const RelativeBox = styled('div')`
+//   position: relative;
+// `;
+
+// const ChartTitle = styled(SectionHeading)`
+//   margin: 0;
+// `;
+
+// const ChartLabel = styled('div')<{top: string}>`
+//   position: absolute;
+//   top: ${p => p.top};
+//   z-index: 1;
+// `;
+
+// const ChartValue = styled('div')`
+//   font-size: ${p => p.theme.fontSizeExtraLarge};
+// `;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -9,6 +9,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
+import {eapSeriesDataToTimeSeries} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 type Props = {
   hasWebVitals: boolean;
@@ -59,6 +60,8 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
       />
     );
   }
+
+  const timeSeries = eapSeriesDataToTimeSeries(failureRateData);
 
   return (
     <Widget

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -8,21 +8,19 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {
-  getTermHelp,
-  PERFORMANCE_TERMS,
-  PerformanceTerm,
-} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 type Props = {
+  hasWebVitals: boolean;
   transactionName: string;
 };
 
 const REFERRER = 'eap-sidebar-charts';
 
-export function EAPSidebarCharts({transactionName}: Props) {
+export function EAPSidebarCharts({transactionName, hasWebVitals}: Props) {
   return (
     <ChartContainer>
+      {hasWebVitals && <Widget Title={t('Web Vitals')} />}
       <FailureRateWidget transactionName={transactionName} />
     </ChartContainer>
   );
@@ -34,7 +32,11 @@ const ChartContainer = styled('div')`
   gap: ${space(1)};
 `;
 
-function FailureRateWidget({transactionName}: Props) {
+type FailureRateWidgetProps = {
+  transactionName: string;
+};
+
+function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   const organization = useOrganization();
 
   const {

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -1,11 +1,9 @@
 import {useTheme} from '@emotion/react';
 
-import type {DataUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -17,6 +15,7 @@ import {
 } from 'sentry/views/performance/transactionSummary/filter';
 import {transformData} from 'sentry/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils';
 import {EAPWidgetType} from 'sentry/views/performance/transactionSummary/transactionOverview/eapChartsWidget';
+import {eapSeriesDataToTimeSeries} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import DurationPercentileChart from './durationPercentileChart/chart';
 
@@ -112,21 +111,7 @@ function useDurationBreakdownVisualization({
     return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
   }
 
-  const timeSeries: TimeSeries[] = [];
-  Object.entries(spanSeriesData).forEach(([key, value]) => {
-    timeSeries.push({
-      field: key,
-      meta: {
-        type: value.meta?.fields?.[key] ?? null,
-        unit: value.meta?.units?.[key] as DataUnit,
-      },
-      data:
-        value.data.map(item => ({
-          timestamp: item.name.toString(),
-          value: item.value,
-        })) ?? [],
-    });
-  });
+  const timeSeries = eapSeriesDataToTimeSeries(spanSeriesData);
 
   const plottables = timeSeries.map(series => new Area(series));
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -1,8 +1,11 @@
 import type {Organization} from 'sentry/types/organization';
+import type {DataUnit} from 'sentry/utils/discover/fields';
 import type {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import type {MetricsEnhancedPerformanceDataContext} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import type {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 
 export function canUseTransactionMetricsData(
@@ -36,4 +39,25 @@ export function getTransactionMEPParamsIfApplicable(
   }
 
   return getMEPQueryParams(mepSetting, true);
+}
+
+type EAPSeriesData = Record<string, DiscoverSeries>;
+export function eapSeriesDataToTimeSeries(data: EAPSeriesData) {
+  const timeSeries: TimeSeries[] = [];
+  Object.entries(data).forEach(([key, value]) => {
+    timeSeries.push({
+      field: key,
+      meta: {
+        type: value.meta?.fields?.[key] ?? null,
+        unit: value.meta?.units?.[key] as DataUnit,
+      },
+      data:
+        value.data.map(item => ({
+          timestamp: item.name.toString(),
+          value: item.value,
+        })) ?? [],
+    });
+  });
+
+  return timeSeries;
 }


### PR DESCRIPTION
- Deletes old widgets from the sidebar (protected by feature flag)
- Implements the failure rate widget using the EAP dataset
- Migrate the failure rate sidebar widget to the new Discover widget component

The rest of the sidebar widgets will be migrated in follow-up PRs and will also include the subheading for the average value over the current time period

![image](https://github.com/user-attachments/assets/b3c7cc75-850d-4249-b0c7-f9b9ef123cf9)
