### PR TITLE
feat(issue-views): Allow frontend to fetch and view non-starred issue…

### DIFF
--- a/static/app/views/issueList/index.spec.tsx
+++ b/static/app/views/issueList/index.spec.tsx
@@ -1,0 +1,89 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import IssueListContainer from 'sentry/views/issueList';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+describe('IssueListContainer', function () {
+  const defaultProps = {
+    children: <div>Foo</div>,
+  };
+
+  const organization = OrganizationFixture({
+    features: ['issue-view-sharing'],
+  });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/issues/views/100/',
+    },
+    route: '/organizations/:orgId/issues/views/:viewId/',
+  };
+
+  const mockGroupSearchView = GroupSearchViewFixture({id: '100'});
+
+  describe('issue views', function () {
+    beforeEach(function () {
+      PageFiltersStore.init();
+      PageFiltersStore.onInitializeUrlState(
+        {
+          projects: [],
+          environments: [],
+          datetime: {start: null, end: null, period: '14d', utc: null},
+        },
+        new Set(['projects'])
+      );
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/100/',
+        body: mockGroupSearchView,
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/100/visit/',
+        method: 'POST',
+      });
+    });
+
+    it('marks the current issue view as seen', async function () {
+      const mockUpdateLastVisited = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/100/visit/',
+        method: 'POST',
+        body: {},
+      });
+
+      render(<IssueListContainer {...defaultProps} />, {
+        organization,
+        enableRouterMocks: false,
+        initialRouterConfig,
+      });
+
+      await screen.findByText('Foo');
+
+      expect(mockUpdateLastVisited).toHaveBeenCalledTimes(1);
+    });
+
+    it('hydrates issue view query params', async function () {
+      const {router} = render(<IssueListContainer {...defaultProps} />, {
+        organization,
+        enableRouterMocks: false,
+        initialRouterConfig,
+      });
+
+      await screen.findByText('Foo');
+
+      await waitFor(() => {
+        expect(router.location.query).toEqual({
+          project: '1',
+          environment: 'prod',
+          sort: IssueSortOptions.DATE,
+          statsPeriod: '7d',
+          query: 'is:unresolved',
+        });
+      });
+    });
+  });
+});

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -1,17 +1,71 @@
+import {useEffect} from 'react';
+import * as qs from 'query-string';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import usePrevious from 'sentry/utils/usePrevious';
+import {getIssueViewQueryParams} from 'sentry/views/issueList/issueViews/getIssueViewQueryParams';
+import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {usePrefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
+import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
 
 type Props = {
   children: React.ReactNode;
 };
 
-function IssueListContainer({children}: Props) {
+function useUpdateViewLastVisited({view}: {view: GroupSearchView | undefined}) {
+  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
+
+  useEffect(() => {
+    if (view?.id) {
+      updateViewLastVisited({viewId: view.id});
+    }
+  }, [view?.id, updateViewLastVisited]);
+}
+
+// If loading `/issues/views/:viewId/` without any query params, append the
+// ones from the view to the URL. It's important that we only do this when
+// necessary because the URL params are used to override the view data.
+function useHydrateIssueViewQueryParams({view}: {view: GroupSearchView | undefined}) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const previousViewData = usePrevious(view);
+
+  useEffect(() => {
+    const query = qs.parse(window.location.search);
+
+    if (
+      view &&
+      !previousViewData &&
+      !query[URL_PARAM.PROJECT] &&
+      !query[URL_PARAM.ENVIRONMENT] &&
+      !DATE_TIME_KEYS.some(key => query[key])
+    ) {
+      navigate(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/issues/views/${view.id}/`,
+          query: {
+            ...getIssueViewQueryParams({view}),
+            ...query,
+          },
+        }),
+        {replace: true}
+      );
+    }
+  }, [view, previousViewData, navigate, organization.slug]);
+}
+
+function StreamWrapper({children}: Props) {
   const organization = useOrganization();
   useRouteAnalyticsHookSetup();
   const prefersStackedNav = usePrefersStackedNav();
@@ -22,16 +76,46 @@ function IssueListContainer({children}: Props) {
     !organization.features.includes('issue-stream-custom-views') || onNewIssuesFeed;
 
   return (
+    <PageFiltersContainer
+      skipLoadLastUsed={!useGlobalPageFilters}
+      disablePersistence={!useGlobalPageFilters}
+      skipInitializeUrlParams={
+        !onNewIssuesFeed && organization.features.includes('issue-stream-custom-views')
+      }
+    >
+      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+    </PageFiltersContainer>
+  );
+}
+
+function IssueViewWrapper({children}: Props) {
+  const organization = useOrganization();
+  const {data: groupSearchView, isLoading} = useSelectedGroupSearchView();
+  useUpdateViewLastVisited({view: groupSearchView});
+  useHydrateIssueViewQueryParams({view: groupSearchView});
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <SentryDocumentTitle title={groupSearchView?.name} orgSlug={organization.slug}>
+      <StreamWrapper>{children}</StreamWrapper>
+    </SentryDocumentTitle>
+  );
+}
+
+function IssueListContainer({children}: Props) {
+  const organization = useOrganization();
+  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
+
+  return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
-      <PageFiltersContainer
-        skipLoadLastUsed={!useGlobalPageFilters}
-        disablePersistence={!useGlobalPageFilters}
-        skipInitializeUrlParams={
-          !onNewIssuesFeed && organization.features.includes('issue-stream-custom-views')
-        }
-      >
-        <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
-      </PageFiltersContainer>
+      {hasIssueViewSharing ? (
+        <IssueViewWrapper>{children}</IssueViewWrapper>
+      ) : (
+        <StreamWrapper>{children}</StreamWrapper>
+      )}
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/issueList/issueViews/getIssueViewQueryParams.tsx
+++ b/static/app/views/issueList/issueViews/getIssueViewQueryParams.tsx
@@ -1,0 +1,12 @@
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+export function getIssueViewQueryParams({view}: {view: GroupSearchView}) {
+  return {
+    query: view.query,
+    sort: view.querySort,
+    project: view.projects.length > 0 ? view.projects : undefined,
+    environment: view.environments.length > 0 ? view.environments : undefined,
+    ...normalizeDateTimeParams(view.timeFilters),
+  };
+}

--- a/static/app/views/issueList/issueViews/useSelectedGroupSeachView.tsx
+++ b/static/app/views/issueList/issueViews/useSelectedGroupSeachView.tsx
@@ -1,0 +1,36 @@
+import {defined} from 'sentry/utils';
+import {getApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useFetchGroupSearchView} from 'sentry/views/issueList/queries/useFetchGroupSearchView';
+import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+// Returns the query for the search view that is currently selected according
+// to the URL.
+export function useSelectedGroupSearchView() {
+  const organization = useOrganization();
+  const {viewId} = useParams<{viewId?: string}>();
+  const queryClient = useQueryClient();
+
+  // The view may have already been loaded by the starred views query,
+  // so load that in `initialData` to avoid an unncessary request.
+  const queryFromStarredViews = getApiQueryData<GroupSearchView[]>(
+    queryClient,
+    makeFetchGroupSearchViewsKey({
+      orgSlug: organization.slug,
+    })
+  );
+  const matchingView = queryFromStarredViews?.find(v => v.id === viewId);
+
+  return useFetchGroupSearchView(
+    {
+      id: viewId ?? 0,
+      orgSlug: organization.slug,
+    },
+    {
+      enabled: defined(viewId),
+      initialData: matchingView ? [matchingView, '200', undefined] : undefined,
+    }
+  );
+}

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -4,10 +4,8 @@ import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingA
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
 import {usePrefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
 type LeftNavViewsHeaderProps = {
@@ -16,24 +14,18 @@ type LeftNavViewsHeaderProps = {
 
 function LeftNavViewsHeader({selectedProjectIds}: LeftNavViewsHeaderProps) {
   const {projects} = useProjects();
-  const organization = useOrganization();
-  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
   const prefersStackedNav = usePrefersStackedNav();
 
   const selectedProjects = projects.filter(({id}) =>
     selectedProjectIds.includes(Number(id))
   );
 
-  const {data: groupSearchViews} = useFetchGroupSearchViews({
-    orgSlug: organization.slug,
-  });
-
-  const viewTitle = groupSearchViews?.find(v => v.id === viewId)?.name;
+  const {data: groupSearchView} = useSelectedGroupSearchView();
 
   return (
     <Layout.Header noActionWrap unified={prefersStackedNav}>
       <Layout.HeaderContent unified={prefersStackedNav}>
-        <Layout.Title>{viewTitle ?? t('Issues')}</Layout.Title>
+        <Layout.Title>{groupSearchView?.name ?? t('Issues')}</Layout.Title>
       </Layout.HeaderContent>
       <Layout.HeaderActions />
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />

--- a/static/app/views/issueList/queries/useFetchGroupSearchView.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchView.tsx
@@ -1,0 +1,26 @@
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+type FetchGroupSearchViewsParameters = {
+  id: string | number;
+  orgSlug: string;
+};
+
+export const makeFetchGroupSearchViewKey = ({
+  id,
+  orgSlug,
+}: FetchGroupSearchViewsParameters): ApiQueryKey => [
+  `/organizations/${orgSlug}/group-search-views/${id}/`,
+];
+
+export const useFetchGroupSearchView = (
+  parameters: FetchGroupSearchViewsParameters,
+  options: Partial<UseApiQueryOptions<GroupSearchView>> = {}
+) => {
+  return useApiQuery<GroupSearchView>(makeFetchGroupSearchViewKey(parameters), {
+    staleTime: 0,
+    retry: false,
+    ...options,
+  });
+};

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -57,20 +57,6 @@ export function IssueViewNavItems({
     }
   }, [loadedViews, views, setViews]);
 
-  // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
-  // then redirect to the "All Issues" page
-  useEffect(() => {
-    if (viewId && !views.find(v => v.id === viewId)) {
-      navigate(
-        normalizeUrl({
-          pathname: `${baseUrl}/`,
-          query: queryParams,
-        })
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewId]);
-
   const replaceWithPersistentViewIds = useCallback(
     (responseViews: GroupSearchView[]) => {
       const newlyCreatedViews = responseViews.filter(

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -1,37 +1,23 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, useRef} from 'react';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewNavItems} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
-import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function IssuesSecondaryNav() {
   const organization = useOrganization();
-
   const sectionRef = useRef<HTMLDivElement>(null);
-  const {viewId} = useParams<{viewId?: string}>();
 
   const {data: groupSearchViews} = useFetchGroupSearchViews({
     orgSlug: organization.slug,
   });
-  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
-
-  useEffect(() => {
-    if (groupSearchViews && viewId) {
-      const view = groupSearchViews.find(v => v.id === viewId);
-      if (view) {
-        updateViewLastVisited({viewId: view.id});
-      }
-    }
-  }, [groupSearchViews, viewId, updateViewLastVisited]);
 
   const baseUrl = `/organizations/${organization.slug}/issues`;
 

--- a/tests/js/fixtures/groupSearchView.ts
+++ b/tests/js/fixtures/groupSearchView.ts
@@ -1,0 +1,22 @@
+import { GroupSearchView, GroupSearchViewVisibility } from "sentry/views/issueList/types";
+import { IssueSortOptions } from "sentry/views/issueList/utils";
+
+export function GroupSearchViewFixture(params: Partial<GroupSearchView> = {}): GroupSearchView {
+  return {
+    id: '123',
+    name: 'Test View',
+    query: 'is:unresolved',
+    querySort: IssueSortOptions.DATE,
+    projects: [1],
+    environments: ['prod'],
+    timeFilters: {
+      start: null,
+      end: null,
+      period: '7d',
+      utc: null,
+    },
+    lastVisited: null,
+    visibility: GroupSearchViewVisibility.ORGANIZATION,
+    ...params,
+  };
+}


### PR DESCRIPTION
Note that this is still under the `issue-view-sharing` feature flag.

This PR allows you to load any issue view when navigating to `/issues/views/:viewId/`. We now block the issue stream on the issue view being loaded in the `IssueListContainer` component.