### PR TITLE
fix(issue-views): Fix my projects being set by default

### DIFF
--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -173,7 +173,7 @@ function IssueViewsIssueListHeaderTabsContent({
       statsPeriod,
       utc,
     } = router.location.query;
-    const {queryEnvs, queryProjects} = normalizeProjectsEnvironments(project, env);
+    const {queryProjects, queryEnvs} = normalizeProjectsEnvironments(project, env);
     const queryTimeFilters =
       start || end || statsPeriod || utc
         ? {
@@ -251,12 +251,12 @@ function IssueViewsIssueListHeaderTabsContent({
         const newUnsavedChanges: Partial<IssueViewParams> = {
           query: query === originalQuery ? undefined : query,
           querySort: sort === originalSort ? undefined : issueSortOption,
-          projects: isEqual(queryProjects?.sort(), originalProjects.sort())
+          projects: isEqual((queryProjects ?? []).sort(), originalProjects.sort())
             ? undefined
-            : queryProjects,
-          environments: isEqual(queryEnvs?.sort(), originalEnvironments.sort())
+            : (queryProjects ?? []),
+          environments: isEqual((queryEnvs ?? []).sort(), originalEnvironments.sort())
             ? undefined
-            : queryEnvs,
+            : (queryEnvs ?? []),
           timeFilters:
             queryTimeFilters &&
             isEqual(
@@ -498,8 +498,6 @@ export const normalizeProjectsEnvironments = (
     if (!isNaN(parsed)) {
       queryProjects = [parsed];
     }
-  } else if (project === undefined) {
-    queryProjects = [];
   }
 
   let queryEnvs: string[] | undefined = undefined;
@@ -507,8 +505,6 @@ export const normalizeProjectsEnvironments = (
     queryEnvs = env;
   } else if (env) {
     queryEnvs = [env];
-  } else if (env === undefined) {
-    queryEnvs = [];
   }
 
   return {queryEnvs, queryProjects};


### PR DESCRIPTION
Fixes a bug in the old issue views UI where selecting the issues tab overwrites the default view's project filter with "My Projects" 

Introduced [here](https://github.com/getsentry/sentry/pull/88468)