### PR TITLE
feat(profiling-onboarding): Android instructions

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -53,7 +53,7 @@ plugins {
   id "io.sentry.android.gradle" version "${getPackageVersion(
     params,
     'sentry.java.android.gradle-plugin',
-    '3.12.0'
+    '5.3.0'
   )}"
 }`;
 
@@ -470,12 +470,143 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   nextSteps: () => [],
 };
 
+const profilingOnboarding: OnboardingConfig<PlatformOptions> = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Android profiling is available starting in SDK version [code:6.16.0] and is supported on API level 22 and up. App start profiling is available starting in SDK version [code:7.3.0].',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          partialLoading: params.sourcePackageRegistries?.isLoading,
+          code: [
+            {
+              label: 'Groovy',
+              value: 'groovy',
+              language: 'groovy',
+              filename: 'app/build.gradle',
+              code: getManualInstallSnippet(params),
+            },
+          ],
+          additionalInfo: tct(
+            'Version [versionPlugin] of the plugin will automatically add the Sentry Android SDK (version [versionSdk]) to your app.',
+            {
+              versionPlugin: (
+                <code>
+                  {getPackageVersion(
+                    params,
+                    'sentry.java.android.gradle-plugin',
+                    '5.3.0'
+                  )}
+                </code>
+              ),
+              versionSdk: (
+                <code>{getPackageVersion(params, 'sentry.java.android', '8.6.0')}</code>
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct('Set up profiling in your [code:AndroidManifest.xml] file.', {
+        code: <code />,
+      }),
+      configurations: [
+        {
+          language: 'xml',
+          code: [
+            {
+              label: 'XML',
+              value: 'xml',
+              language: 'xml',
+              filename: 'AndroidManifest.xml',
+              code: `
+<application>
+  <meta-data
+    android:name="io.sentry.dsn"
+    android:value="${params.dsn.public}"
+  />
+  <meta-data
+    android:name="io.sentry.traces.sample-rate"
+    android:value="1.0"
+  />${
+    params.profilingOptions?.defaultProfilingMode === 'continuous'
+      ? `
+  <!-- Set sampling rate for profiling, adjust in production env - this is evaluated only once per session -->
+  <!-- note: there is a known issue in the Android Runtime that can be triggered by Profiling in certain circumstances -->
+  <!-- see https://docs.sentry.io/platforms/android/profiling/troubleshooting/ -->
+  <meta-data
+    android:name="io.sentry.traces.profiling.session-sample-rate"
+    android:value="1.0"
+  />
+  <!-- Set profiling lifecycle, can be \`manual\` (controlled through \`Sentry.startProfiler()\` and \`Sentry.stopProfiler()\`) or \`trace\` (automatically starts and stop a profile whenever a sampled trace starts and finishes) -->
+  <meta-data
+    android:name="io.sentry.traces.profiling.lifecycle"
+    android:value="trace"
+  />
+  <!-- Enable profiling on app start -->
+  <meta-data
+    android:name="io.sentry.traces.profiling.start-on-app-start"
+    android:value="true"
+  />`
+      : `
+  <!-- Set sampling rate for profiling, adjust in production env - this is relative to sampled transactions -->
+  <!-- note: there is a known issue in the Android Runtime that can be triggered by Profiling in certain circumstances -->
+  <!-- see https://docs.sentry.io/platforms/android/profiling/troubleshooting/ -->
+  <meta-data
+    android:name="io.sentry.traces.profiling.sample-rate"
+    android:value="1.0"
+  />
+  <!-- Enable profiling on app start -->
+  <meta-data
+    android:name="io.sentry.traces.profiling.enable-app-start"
+    android:value="true"
+  />`
+  }
+</application>
+`,
+            },
+          ],
+        },
+        {
+          description: tct(
+            'For more detailed information on profiling, see the [link:profiling documentation].',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/android/profiling/`}
+                />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'To confirm that profiling is working correctly, run your application and check the Sentry profiles page for the collected profiles.'
+      ),
+    },
+  ],
+};
+
 const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiJava,
   crashReportOnboarding: feedbackOnboardingCrashApiJava,
   platformOptions,
-  profilingOnboarding: onboarding,
+  profilingOnboarding,
   replayOnboarding,
 };
 

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -19,6 +19,7 @@ import {
   type DocsParams,
   ProductSolution,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -224,6 +225,9 @@ export function Onboarding() {
     projSlug: project?.slug,
   });
 
+  const {isPending: isLoadingRegistry, data: registryData} =
+    useSourcePackageRegistries(organization);
+
   const doesSupportProfiling = currentPlatform
     ? profilingPlatforms.includes(currentPlatform.id)
     : false;
@@ -296,8 +300,8 @@ export function Onboarding() {
     isProfilingSelected: true,
     isReplaySelected: false,
     sourcePackageRegistries: {
-      isLoading: false,
-      data: undefined,
+      isLoading: isLoadingRegistry,
+      data: registryData,
     },
     platformOptions: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
     docsLocation: DocsPageLocation.PROFILING_PAGE,


### PR DESCRIPTION
Add profiling instructions for android.


https://github.com/user-attachments/assets/6a6fbf43-b5f4-476d-a366-81f59e882482

- closes https://linear.app/getsentry/issue/TET-250/profiling-onboarding-for-android-platforms