### PR TITLE
feat(explore): Remove 1d option from explore 7d period

### DIFF
--- a/static/app/views/explore/hooks/useChartInterval.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.tsx
@@ -109,7 +109,7 @@ const MINIMUM_INTERVAL = new GranularityLadder([
 const MAXIMUM_INTERVAL = new GranularityLadder([
   [THIRTY_DAYS, '1d'],
   [TWO_WEEKS, '1d'],
-  [ONE_WEEK, '1d'],
+  [ONE_WEEK, '12h'],
   [FORTY_EIGHT_HOURS, '4h'],
   [SIX_HOURS, '1h'],
   [0, '15m'],

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -473,7 +473,7 @@ describe('MultiQueryModeContent', function () {
           query: expect.objectContaining({
             dataset: 'spans',
             field: [],
-            interval: '12h',
+            interval: '3h',
             orderby: undefined,
             project: ['2'],
             query: '!transaction.span_id:00',
@@ -524,7 +524,7 @@ describe('MultiQueryModeContent', function () {
             dataset: 'spans',
             excludeOther: 0,
             field: ['span.op', 'count(span.duration)'],
-            interval: '12h',
+            interval: '3h',
             orderby: '-count_span_duration',
             project: ['2'],
             query: '!transaction.span_id:00',
@@ -663,9 +663,9 @@ describe('MultiQueryModeContent', function () {
 
     const section = screen.getByTestId('section-visualization-0');
     expect(
-      await within(section).findByRole('button', {name: '12 hours'})
+      await within(section).findByRole('button', {name: '3 hours'})
     ).toBeInTheDocument();
-    await userEvent.click(within(section).getByRole('button', {name: '12 hours'}));
+    await userEvent.click(within(section).getByRole('button', {name: '3 hours'}));
     await userEvent.click(within(section).getByRole('option', {name: '30 minutes'}));
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/traces/compare',


### PR DESCRIPTION
This removes the 1d option from the chart intervals in explore when using 7d periods.