### PR TITLE
feat(trace summary): Call seer endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -11,6 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.trace_summary import get_trace_summary
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -36,15 +37,24 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
 
     def post(self, request: Request, organization: Organization) -> Response:
 
-        if not features.has("organizations:single-trace-summary", organization, actor=request.user):
+        if not features.has(
+            "organizations:single-trace-summary", organization, actor=request.user
+        ) and not features.has(
+            "organizations:trace-spans-format:", organization, actor=request.user
+        ):
             return Response({"detail": "Feature flag not enabled"}, status=400)
 
-        data = orjson.loads(request.body) if request.body else {}
+        data: dict = orjson.loads(request.body) if request.body else {}
         trace_id = data.get("trace_id", None)
-        trace_tree = data.get("trace_tree", [])
-
         if not trace_id:
             return Response({"detail": "Missing trace_id parameter"}, status=400)
+
+        try:
+            trace_endpoint = OrganizationTraceEndpoint()
+            trace_response = trace_endpoint.get(request, organization, trace_id)
+            trace_tree = trace_response.data
+        except Exception as e:
+            return Response({"detail": f"Error fetching trace: {str(e)}"}, status=400)
 
         if not trace_tree:
             return Response({"detail": "Missing trace_tree data"}, status=400)

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -41,10 +41,17 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
 
         data = orjson.loads(request.body) if request.body else {}
         trace_id = data.get("trace_id", None)
+        trace_tree = data.get("trace_tree", [])
+
+        if not trace_id:
+            return Response({"detail": "Missing trace_id parameter"}, status=400)
+
+        if not trace_tree:
+            return Response({"detail": "Missing trace_tree data"}, status=400)
 
         summary_data, status_code = get_trace_summary(
             traceSlug=trace_id,
-            traceTree=request.trace_tree,
+            traceTree=trace_tree,
             organization=organization,
             user=request.user,
         )

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -45,6 +45,7 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
 
         data: dict = orjson.loads(request.body) if request.body else {}
         trace_id = data.get("traceSlug", None)
+        only_transaction = data.get("onlyTransaction", False)
         if not trace_id:
             return Response({"detail": "Missing traceSlug parameter"}, status=400)
 
@@ -66,5 +67,6 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
             traceTree=trace_tree,
             organization=organization,
             user=request.user,
+            onlyTransaction=only_transaction,
         )
         return Response(summary_data, status=status_code)

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -53,7 +53,8 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
         try:
             trace_endpoint = OrganizationTraceEndpoint()
             trace_response = trace_endpoint.get(request, organization, trace_id)
-            trace_tree = trace_response.data
+            if hasattr(trace_response, "data"):
+                trace_tree = trace_response.data
         except Exception:
             return Response({"detail": "Error fetching trace"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -49,10 +49,12 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
         if not trace_id:
             return Response({"detail": "Missing trace_id parameter"}, status=400)
 
+        trace_tree = []
         try:
             trace_endpoint = OrganizationTraceEndpoint()
             trace_response = trace_endpoint.get(request, organization, trace_id)
-            trace_tree = trace_response.data
+            if hasattr(trace_response, "data"):
+                trace_tree = trace_response.data
         except Exception as e:
             return Response({"detail": f"Error fetching trace: {str(e)}"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.seer.trace_summary import get_trace_summary
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    # Keeping same rate limits as GroupAISummary endpoint for now
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=60),
+            RateLimitCategory.USER: RateLimit(limit=10, window=60),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=30, window=60),
+        }
+    }
+
+    def post(self, request: Request, organization: Organization) -> Response:
+
+        if not features.has("organizations:single-trace-summary", organization, actor=request.user):
+            return Response({"detail": "Feature flag not enabled"}, status=400)
+
+        data = orjson.loads(request.body) if request.body else {}
+        trace_id = data.get("trace_id", None)
+
+        summary_data, status_code = get_trace_summary(
+            traceSlug=trace_id,
+            traceTree=request.trace_tree,
+            organization=organization,
+            user=request.user,
+        )
+
+        return Response(summary_data, status=status_code)

--- a/src/sentry/api/endpoints/organization_trace_summary.py
+++ b/src/sentry/api/endpoints/organization_trace_summary.py
@@ -50,12 +50,10 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
             return Response({"detail": "Missing traceSlug parameter"}, status=400)
 
         # Get the trace tree
-        trace_tree = []
         try:
             trace_endpoint = OrganizationTraceEndpoint()
-            trace_response = trace_endpoint.get(request, organization, trace_id)
-            if hasattr(trace_response, "data"):
-                trace_tree = trace_response.data
+            snuba_params = trace_endpoint.get_snuba_params(request, organization)
+            trace_tree = trace_endpoint.query_trace_data(snuba_params, trace_id)
         except Exception:
             return Response({"detail": "Error fetching trace"}, status=400)
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -38,6 +38,7 @@ from sentry.api.endpoints.organization_trace_item_attributes import (
     OrganizationTraceItemAttributesEndpoint,
     OrganizationTraceItemAttributeValuesEndpoint,
 )
+from sentry.api.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
 from sentry.api.endpoints.organization_unsubscribe import (
     OrganizationUnsubscribeIssue,
     OrganizationUnsubscribeProject,
@@ -1685,6 +1686,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/trace/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         OrganizationTraceEndpoint.as_view(),
         name="sentry-api-0-organization-trace",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/trace-summary/$",
+        OrganizationTraceSummaryEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-summary",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/measurements-meta/$",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -527,6 +527,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:jira-per-project-statuses", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable using paginated projects endpoint for Jira integration
     manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable single trace summary
+    manager.add("organizations:single-trace-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Relay extracting logs from breadcrumbs for a project.
     manager.add("projects:ourlogs-breadcrumb-extraction", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/models.py
+++ b/src/sentry/seer/models.py
@@ -27,3 +27,11 @@ class SeerRepoDefinition(BaseModel):
     instructions: str | None = None
     base_commit_sha: str | None = None
     provider_raw: str | None = None
+
+
+class SummarizeTraceResponse(BaseModel):
+    trace_id: str
+    summary: str
+    key_observations: str
+    performance_characteristics: str
+    suggested_investigations: str

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -66,7 +66,7 @@ def get_trace_summary(
 def _call_seer(
     trace_id: str,
     trace_content: list[dict],
-    only_transaction: bool = True,
+    only_transaction: bool = False,
 ) -> SummarizeTraceResponse:
 
     path = "/v1/automation/summarize/trace"

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -48,20 +48,16 @@ def get_trace_summary(
         return convert_dict_key_case(cached_summary, snake_to_camel_case), 200
 
     trace_summary = None
-    try:
-        trace_summary = _call_seer(
-            traceSlug,
-            traceTree,
-        )
-    except Exception as e:
-        logger.exception("Error calling Seer: %s", e)
-        return {"detail": "Error calling Seer"}, 500
+    trace_summary = _call_seer(
+        traceSlug,
+        traceTree,
+    )
 
     trace_summary_dict = trace_summary.dict()
 
     cache.set(cache_key, trace_summary_dict, timeout=int(timedelta(days=7).total_seconds()))
 
-    return trace_summary_dict, 200
+    return convert_dict_key_case(trace_summary_dict, snake_to_camel_case), 200
 
 
 def _call_seer(

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from typing import Any
 
 import orjson
 import requests
@@ -23,7 +24,7 @@ def get_trace_summary(
     traceTree: list[dict],
     organization: Organization,
     user: User | RpcUser | AnonymousUser | None = None,
-):
+) -> tuple[dict[str, Any], int]:
     """
     Generate an AI summary for a single trace. Trace must be in the EAP format.
 
@@ -35,7 +36,7 @@ def get_trace_summary(
         user: The user requesting the summary
 
     Returns:
-        A dictionary containing the trace summary.
+        A tuple containing (summary_data, status_code)
     """
     if user is None:
         user = AnonymousUser()
@@ -60,7 +61,7 @@ def get_trace_summary(
 
     cache.set(cache_key, trace_summary_dict, timeout=int(timedelta(days=7).total_seconds()))
 
-    return trace_summary_dict
+    return trace_summary_dict, 200
 
 
 def _call_seer(

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -24,6 +24,7 @@ def get_trace_summary(
     traceTree: list[dict],
     organization: Organization,
     user: User | RpcUser | AnonymousUser | None = None,
+    onlyTransaction: bool = False,
 ) -> tuple[dict[str, Any], int]:
     """
     Generate an AI summary for a single trace. Trace must be in the EAP format.
@@ -47,10 +48,10 @@ def get_trace_summary(
     if cached_summary := cache.get(cache_key):
         return convert_dict_key_case(cached_summary, snake_to_camel_case), 200
 
-    trace_summary = None
     trace_summary = _call_seer(
         traceSlug,
         traceTree,
+        onlyTransaction,
     )
 
     trace_summary_dict = trace_summary.dict()

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -1,0 +1,96 @@
+import logging
+from datetime import timedelta
+from typing import Any
+
+import orjson
+import requests
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+
+from sentry import features
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
+from sentry.models.organization import Organization
+from sentry.seer.models import SummarizeTraceResponse
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+def get_trace_summary(
+    traceSlug: str,
+    rootEvent: Any,  # TODO: Fix type
+    traceTree: list[dict],
+    organization: Organization,
+    user: User | RpcUser | AnonymousUser | None = None,
+):
+    """
+    Generate an AI summary for a single trace.
+
+    Args:
+        traceSlug: The slug of the trace to summarize. Equivalent to the trace ID.
+        rootEvent: The root event of the trace.
+        traceTree: The trace tree for the trace to summarize. List of spans in the EAP format.
+        organization: The organization the trace belongs to.
+        user: The user requesting the summary
+
+    Returns:
+        A dictionary containing the trace ID, trace content, and trace summary
+    """
+    if user is None:
+        user = AnonymousUser()
+    if not features.has("organizations:single-trace-summary", organization, actor=user):
+        return {"detail": "Feature flag not enabled"}, 400
+
+    cache_key = "ai-trace-summary:" + str(traceSlug)
+    if cached_summary := cache.get(cache_key):
+        return convert_dict_key_case(cached_summary, snake_to_camel_case), 200
+
+    trace_summary = _call_seer(
+        traceSlug,
+        rootEvent.startTimestamp,
+        traceTree,
+    )
+
+    trace_summary_dict = trace_summary.dict()
+
+    cache.set(cache_key, trace_summary_dict, timeout=int(timedelta(days=7).total_seconds()))
+
+    return trace_summary_dict
+
+
+def _call_seer(
+    trace_id: str,
+    timestamp: float,
+    trace_content: list[dict],
+    only_transaction: bool = True,
+) -> SummarizeTraceResponse:
+
+    path = "/v1/automation/summarize/trace"
+    body = orjson.dumps(
+        {
+            "trace_id": trace_id,
+            "only_transaction": only_transaction,
+            "trace": {
+                "id": trace_id,
+                "timestamp": timestamp,
+                "trace_content": trace_content,
+            },
+        },
+        option=orjson.OPT_NON_STR_KEYS,
+    )
+
+    response = requests.post(
+        f"{settings.SEER_AUTOFIX_URL}{path}",
+        data=body,
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            **sign_with_seer_secret(body),
+        },
+    )
+
+    response.raise_for_status()
+
+    return SummarizeTraceResponse.validate(response.json())

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def get_trace_summary(
     traceSlug: str,
-    traceTree: list[dict],
+    traceTree: list[Any],
     organization: Organization,
     user: User | RpcUser | AnonymousUser | None = None,
     onlyTransaction: bool = False,
@@ -31,10 +31,10 @@ def get_trace_summary(
 
     Args:
         traceSlug: The slug of the trace to summarize. Equivalent to the trace ID.
-        timestamp: The timestamp of the root event of the trace.
         traceTree: The trace tree for the trace to summarize. List of spans in the EAP format.
         organization: The organization the trace belongs to.
         user: The user requesting the summary
+        onlyTransaction: Whether to only summarize the entire trace or just the transaction spans.
 
     Returns:
         A tuple containing (summary_data, status_code)
@@ -63,7 +63,7 @@ def get_trace_summary(
 
 def _call_seer(
     trace_id: str,
-    trace_content: list[dict],
+    trace_content: list[Any],
     only_transaction: bool = False,
 ) -> SummarizeTraceResponse:
 

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -77,7 +77,7 @@ def _call_seer(
             "only_transaction": only_transaction,
             "trace": {
                 "trace_id": trace_id,
-                "trace_content": trace_content,
+                "trace": trace_content,
             },
         },
         option=orjson.OPT_NON_STR_KEYS,

--- a/tests/sentry/api/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/api/endpoints/test_organization_trace_summary.py
@@ -62,6 +62,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
             traceTree=self.mock_trace_tree,
             organization=self.org,
             user=ANY,
+            onlyTransaction=False,
         )
 
     def test_endpoint_without_trace_slug(self):

--- a/tests/sentry/api/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/api/endpoints/test_organization_trace_summary.py
@@ -1,0 +1,69 @@
+from unittest.mock import ANY, patch
+
+# from django.http import HttpResponse
+from rest_framework.response import Response
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.skips import requires_snuba
+
+# from django.urls import reverse
+
+
+pytestmark = [requires_snuba]
+
+
+@apply_feature_flag_on_cls("organizations:single-trace-summary")
+@apply_feature_flag_on_cls("organizations:trace-spans-format")
+class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+        self.trace_id = "trace123"
+        self.mock_trace_tree = [
+            {"span_id": "span1", "operation_name": "http.request", "duration_ms": 100},
+            {"span_id": "span2", "operation_name": "db.query", "duration_ms": 50},
+        ]
+
+        self.mock_summary_response = {
+            "trace_id": self.trace_id,
+            "summary": "Test summary of the trace",
+            "key_observations": "Test key observations of the trace",
+            "performance_characteristics": "Test performance characteristics of the trace",
+            "suggested_investigations": "Test suggested investigations of the trace",
+        }
+
+        self.url = self._get_url()
+
+    def _get_url(self):
+        return f"/api/0/organizations/{self.org.slug}/trace-summary/"
+
+    @patch("sentry.api.endpoints.organization_trace_summary.get_trace_summary")
+    @patch("sentry.api.endpoints.organization_trace_summary.OrganizationTraceEndpoint")
+    def test_endpoint_calls_get_trace_summary(
+        self, mock_trace_endpoint_class, mock_get_trace_summary
+    ):
+        mock_trace_endpoint_class.return_value.get.return_value = Response(
+            data=self.mock_trace_tree
+        )
+
+        mock_get_trace_summary.return_value = (self.mock_summary_response, 200)
+
+        response = self.client.post(
+            self.url,
+            data={"traceSlug": self.trace_id},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data == self.mock_summary_response
+
+        mock_trace_endpoint_class.assert_called_once()
+        mock_get_trace_summary.assert_called_once_with(
+            traceSlug=self.trace_id,
+            traceTree=self.mock_trace_tree,
+            organization=self.org,
+            user=ANY,
+        )

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -1,5 +1,7 @@
+import datetime
 from unittest.mock import patch
 
+from sentry.api.endpoints.organization_trace import SerializedSpan
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.seer.models import SummarizeTraceResponse
 from sentry.seer.trace_summary import get_trace_summary
@@ -20,8 +22,48 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
 
         self.trace_id = "trace123"
         self.trace_tree = [
-            {"span_id": "span1", "operation_name": "http.request", "duration_ms": 100},
-            {"span_id": "span2", "operation_name": "db.query", "duration_ms": 50},
+            SerializedSpan(
+                description="http.request",
+                event_id="span1",
+                event_type="span",
+                project_id=1,
+                project_slug="test-project",
+                start_timestamp=datetime.datetime(2023, 1, 1, 0, 0, 0),
+                transaction="test_transaction",
+                children=[],
+                errors=[],
+                occurrences=[],
+                duration=100.0,
+                end_timestamp=datetime.datetime(2023, 1, 1, 0, 0, 1),
+                measurements={},
+                op="http.request",
+                parent_span_id=None,
+                profile_id="",
+                profiler_id="",
+                sdk_name="test_sdk",
+                is_transaction=True,
+            ),
+            SerializedSpan(
+                description="db.query",
+                event_id="span2",
+                event_type="span",
+                project_id=1,
+                project_slug="test-project",
+                start_timestamp=datetime.datetime(2023, 1, 1, 0, 0, 0),
+                transaction="test_transaction",
+                children=[],
+                errors=[],
+                occurrences=[],
+                duration=50.0,
+                end_timestamp=datetime.datetime(2023, 1, 1, 0, 0, 1),
+                measurements={},
+                op="db.query",
+                parent_span_id=None,
+                profile_id="",
+                profiler_id="",
+                sdk_name="test_sdk",
+                is_transaction=False,
+            ),
         ]
 
         self.mock_summary_response = SummarizeTraceResponse(
@@ -79,7 +121,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
         )
         mock_has_feature.assert_called_once()
         mock_cache_get.assert_called_once()
-        mock_call_seer.assert_called_once_with(self.trace_id, self.trace_tree)
+        mock_call_seer.assert_called_once_with(self.trace_id, self.trace_tree, False)
         mock_cache_set.assert_called_once()
 
     @patch("sentry.seer.trace_summary._call_seer")

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -1,0 +1,100 @@
+from unittest.mock import patch
+
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
+from sentry.seer.models import SummarizeTraceResponse
+from sentry.seer.trace_summary import get_trace_summary
+from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.skips import requires_snuba
+from sentry.utils.cache import cache
+
+pytestmark = [requires_snuba]
+
+
+@apply_feature_flag_on_cls("organizations:single-trace-summary")
+class TraceSummaryTest(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+
+        self.trace_id = "trace123"
+        self.trace_tree = [
+            {"span_id": "span1", "operation_name": "http.request", "duration_ms": 100},
+            {"span_id": "span2", "operation_name": "db.query", "duration_ms": 50},
+        ]
+
+        self.mock_summary_response = SummarizeTraceResponse(
+            trace_id=self.trace_id,
+            summary="Test summary of the trace",
+            key_observations="There are two spans in this trace",
+            performance_characteristics="This trace has performance issues",
+            suggested_investigations="check out the db.query span",
+        )
+
+        cache.clear()
+
+    def tearDown(self):
+        super().tearDown()
+        cache.delete(f"ai-trace-summary:{self.trace_id}")
+
+    @patch("sentry.features.has")
+    def test_get_trace_summary_feature_flag_disabled(self, mock_has_feature):
+        mock_has_feature.return_value = False
+
+        summary_data, status_code = get_trace_summary(
+            traceSlug=self.trace_id,
+            traceTree=self.trace_tree,
+            organization=self.organization,
+            user=self.user,
+        )
+
+        assert status_code == 400
+        assert summary_data == {"detail": "Feature flag not enabled"}
+        mock_has_feature.assert_called_once_with(
+            "organizations:single-trace-summary", self.organization, actor=self.user
+        )
+
+    @patch("sentry.features.has")
+    @patch("sentry.seer.trace_summary.cache.get")
+    @patch("sentry.seer.trace_summary._call_seer")
+    @patch("sentry.seer.trace_summary.cache.set")
+    def test_get_trace_summary_success(
+        self, mock_cache_set, mock_call_seer, mock_cache_get, mock_has_feature
+    ):
+        mock_has_feature.return_value = True
+        mock_cache_get.return_value = None
+        mock_call_seer.return_value = self.mock_summary_response
+
+        summary_data, status_code = get_trace_summary(
+            traceSlug=self.trace_id,
+            traceTree=self.trace_tree,
+            organization=self.organization,
+            user=self.user,
+        )
+
+        assert status_code == 200
+        assert summary_data == convert_dict_key_case(
+            self.mock_summary_response.dict(), snake_to_camel_case
+        )
+        mock_has_feature.assert_called_once()
+        mock_cache_get.assert_called_once()
+        mock_call_seer.assert_called_once_with(self.trace_id, self.trace_tree)
+        mock_cache_set.assert_called_once()
+
+    @patch("sentry.seer.trace_summary._call_seer")
+    def test_get_trace_summary_cache_hit(self, mock_call_seer):
+        cached_summary = self.mock_summary_response.dict()
+
+        cache.set(f"ai-trace-summary:{self.trace_id}", cached_summary, timeout=60 * 60 * 24 * 7)
+
+        summary_data, status_code = get_trace_summary(
+            traceSlug=self.trace_id,
+            traceTree=self.trace_tree,
+            organization=self.organization,
+            user=self.user,
+        )
+
+        assert status_code == 200
+        assert summary_data == convert_dict_key_case(cached_summary, snake_to_camel_case)
+        mock_call_seer.assert_not_called()


### PR DESCRIPTION
- Calls Seer endpoints for generating a Single Trace Summary
- Feature flagged `organizations:single-trace-sumamry` for Sentry employees only