### PR TITLE
feat(flags): add an internal-only suspicion score under flag distributions

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -31,8 +31,8 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import useLegacyEventSuspectFlags from 'sentry/views/issueDetails/streamline/hooks/featureFlags/useLegacyEventSuspectFlags';
 import {useOrganizationFlagLog} from 'sentry/views/issueDetails/streamline/hooks/featureFlags/useOrganizationFlagLog';
-import useSuspectFlags from 'sentry/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlags';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
@@ -114,7 +114,7 @@ export function EventFeatureFlagList({
     suspectFlags,
     isError: isSuspectError,
     isPending: isSuspectPending,
-  } = useSuspectFlags({
+  } = useLegacyEventSuspectFlags({
     organization,
     firstSeen: group.firstSeen,
     rawFlagData,

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.spec.tsx
@@ -19,6 +19,11 @@ describe('GroupFeatureFlagsDrawerContent', function () {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/1/suspect/flags/`,
+      body: [],
+    });
+
     ProjectsStore.init();
     ProjectsStore.loadInitialData([
       ProjectFixture({platform: 'javascript', hasFlags: false}),

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -67,9 +67,13 @@ export default function FlagDrawerContent({
     return searchedTags;
   }, [data, search, tagValues]);
 
-  // Suspect flag scoring
+  // Suspect flag scoring. This a rudimentary INTERNAL-ONLY display for testing our scoring algorithms.
   const organization = useOrganization();
   const {selection} = usePageFilters();
+
+  const showScores = organization.features.includes(
+    'organizations:suspect-scores-sandbox-ui'
+  );
 
   const {data: suspectScores} = useSuspectFlagScores({
     organization,
@@ -77,6 +81,7 @@ export default function FlagDrawerContent({
     environment: environments.length ? environments : undefined,
     start: selection.datetime.start?.toString(),
     end: selection.datetime.end?.toString(),
+    enabled: showScores,
   });
 
   const suspectScoresMap = useMemo(() => {
@@ -117,7 +122,9 @@ export default function FlagDrawerContent({
           <FlagDetailsLink tag={tag} key={tag.key}>
             <TagDistribution tag={tag} key={tag.key} />
           </FlagDetailsLink>
-          {`Suspicion Score: ${suspectScoresMap[tag.key] ?? 'unknown'}`}
+          {showScores && (
+            <div>{`Suspicion Score: ${suspectScoresMap[tag.key] ?? 'unknown'}`}</div>
+          )}
         </div>
       ))}
     </Container>

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -10,13 +10,13 @@ import useProjects from 'sentry/utils/useProjects';
 import FlagDetailsLink from 'sentry/views/issueDetails/groupFeatureFlags/flagDetailsLink';
 import FlagDrawerCTA from 'sentry/views/issueDetails/groupFeatureFlags/flagDrawerCTA';
 import useGroupFeatureFlags from 'sentry/views/issueDetails/groupFeatureFlags/useGroupFeatureFlags';
+import {useGroupSuspectFlagScores} from 'sentry/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores';
 import {TagDistribution} from 'sentry/views/issueDetails/groupTags/tagDistribution';
 import {
   Container,
   StyledEmptyStateWarning,
 } from 'sentry/views/issueDetails/groupTags/tagDrawerContent';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
-import {useSuspectFlagScores} from 'sentry/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores';
 
 /**
  * Ordering for flags in the drawer.
@@ -72,8 +72,8 @@ export default function FlagDrawerContent({
     'organizations:suspect-scores-sandbox-ui'
   );
 
-  const {data: suspectScores} = useSuspectFlagScores({
-    group,
+  const {data: suspectScores} = useGroupSuspectFlagScores({
+    groupId: group.id,
     environment: environments.length ? environments : undefined,
     enabled: showScores,
   });

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -78,8 +78,8 @@ export default function FlagDrawerContent({
 
   const organization = useOrganization();
   const scoresEnabled =
-    organization.features.includes('organizations:suspect-scores-sandbox-ui') &&
-    organization.features.includes('organizations:feature-flag-suspect-flags');
+    organization.features.includes('suspect-scores-sandbox-ui') &&
+    organization.features.includes('feature-flag-suspect-flags');
 
   const {data: suspectScores} = useGroupSuspectFlagScores({
     groupId: group.id,

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -77,9 +77,9 @@ export default function FlagDrawerContent({
   );
 
   const organization = useOrganization();
-  const scoresEnabled = organization.features.includes(
-    'organizations:suspect-scores-sandbox-ui'
-  );
+  const scoresEnabled =
+    organization.features.includes('organizations:suspect-scores-sandbox-ui') &&
+    organization.features.includes('organizations:feature-flag-suspect-flags');
 
   const {data: suspectScores} = useGroupSuspectFlagScores({
     groupId: group.id,

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -6,7 +6,6 @@ import {featureFlagOnboardingPlatforms} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import FlagDetailsLink from 'sentry/views/issueDetails/groupFeatureFlags/flagDetailsLink';
 import FlagDrawerCTA from 'sentry/views/issueDetails/groupFeatureFlags/flagDrawerCTA';
@@ -69,18 +68,13 @@ export default function FlagDrawerContent({
 
   // Suspect flag scoring. This a rudimentary INTERNAL-ONLY display for testing our scoring algorithms.
   const organization = useOrganization();
-  const {selection} = usePageFilters();
-
   const showScores = organization.features.includes(
     'organizations:suspect-scores-sandbox-ui'
   );
 
   const {data: suspectScores} = useSuspectFlagScores({
-    organization,
-    issue_id: group.id,
+    group,
     environment: environments.length ? environments : undefined,
-    start: selection.datetime.start?.toString(),
-    end: selection.datetime.end?.toString(),
     enabled: showScores,
   });
 

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -1,26 +1,27 @@
-import type {Group} from 'sentry/types/group';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {SuspectFlagScore} from 'sentry/views/issueDetails/streamline/featureFlagUtils';
 
 /**
  * Query all feature flags and their scores for a given issue. Defaults to page filters for datetime and environment params.
  */
-export function useSuspectFlagScores({
-  group,
+export function useGroupSuspectFlagScores({
+  groupId,
   environment,
   statsPeriod,
   start,
   end,
   enabled = true,
 }: {
-  group: Group;
+  groupId: string;
   enabled?: boolean;
   end?: string;
   environment?: string[] | string;
   start?: string;
   statsPeriod?: string;
 }) {
+  const organization = useOrganization();
   const {selection} = usePageFilters();
   const query = {
     environment: environment ?? selection.environments,
@@ -30,10 +31,7 @@ export function useSuspectFlagScores({
   };
 
   return useApiQuery<SuspectFlagScoresResponse>(
-    [
-      `/organizations/${group.project.organization.slug}/issues/${group.id}/suspect/flags/`,
-      {query},
-    ],
+    [`/organizations/${organization.slug}/issues/${groupId}/suspect/flags/`, {query}],
     {
       staleTime: 30000,
       enabled,

--- a/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
+++ b/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
@@ -15,6 +15,11 @@ export type RawFlag = {
 
 export type RawFlagData = {data: RawFlag[]};
 
+export type SuspectFlagScore = {
+  flag: string;
+  score: number;
+};
+
 type FlagSeriesDatapoint = {
   // flag action
   label: {formatter: () => string};

--- a/static/app/views/issueDetails/streamline/hooks/featureFlags/useLegacyEventSuspectFlags.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/featureFlags/useLegacyEventSuspectFlags.tsx
@@ -13,7 +13,13 @@ import {
   type RawFlagData,
 } from 'sentry/views/issueDetails/streamline/featureFlagUtils';
 
-export default function useSuspectFlags({
+/**
+ * Legacy suspect flags implementation.
+ *
+ * Returns up to 3 recently changed flags from the intersection of A) the flags on one EVENT (rawFlagData) and
+ * B) organization audit logs (queried from /logs/).
+ */
+export default function useLegacyEventSuspectFlags({
   organization,
   firstSeen,
   rawFlagData,

--- a/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
@@ -10,10 +10,10 @@ export function useSuspectFlagScores({
   start,
   end,
 }: {
-  issue_id: number;
+  issue_id: string;
   organization: Organization;
   end?: string;
-  environment?: string;
+  environment?: string[] | string;
   start?: string;
   statsPeriod?: string;
 }) {

--- a/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
@@ -1,33 +1,39 @@
-import type {Organization} from 'sentry/types/organization';
+import type {Group} from 'sentry/types/group';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import type {SuspectFlagScore} from 'sentry/views/issueDetails/streamline/featureFlagUtils';
 
+/**
+ * Query all feature flags and their scores for a given issue. Defaults to page filters for datetime and environment params.
+ */
 export function useSuspectFlagScores({
-  organization,
-  issue_id,
+  group,
   environment,
   statsPeriod,
   start,
   end,
   enabled = true,
 }: {
-  issue_id: string;
-  organization: Organization;
+  group: Group;
   enabled?: boolean;
   end?: string;
   environment?: string[] | string;
   start?: string;
   statsPeriod?: string;
 }) {
+  const {selection} = usePageFilters();
   const query = {
-    environment,
-    statsPeriod,
-    start,
-    end,
+    environment: environment ?? selection.environments,
+    statsPeriod: statsPeriod ?? selection.datetime.period,
+    start: start ?? selection.datetime.start?.toString(),
+    end: end ?? selection.datetime.end?.toString(),
   };
 
   return useApiQuery<SuspectFlagScoresResponse>(
-    [`/organizations/${organization.slug}/issues/${issue_id}/suspect/flags/`, {query}],
+    [
+      `/organizations/${group.project.organization.slug}/issues/${group.id}/suspect/flags/`,
+      {query},
+    ],
     {
       staleTime: 30000,
       enabled,

--- a/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
@@ -1,0 +1,37 @@
+import type {Organization} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {SuspectFlagScore} from 'sentry/views/issueDetails/streamline/featureFlagUtils';
+
+export function useSuspectFlagScores({
+  organization,
+  issue_id,
+  environment,
+  statsPeriod,
+  start,
+  end,
+}: {
+  issue_id: number;
+  organization: Organization;
+  end?: string;
+  environment?: string;
+  start?: string;
+  statsPeriod?: string;
+}) {
+  const query = {
+    environment,
+    statsPeriod,
+    start,
+    end,
+  };
+
+  return useApiQuery<SuspectFlagScoresResponse>(
+    [`/organizations/${organization.slug}/issues/${issue_id}/suspect/flags/`, {query}],
+    {
+      staleTime: 0,
+    }
+  );
+}
+
+type SuspectFlagScoresResponse = {
+  data: SuspectFlagScore[];
+};

--- a/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/featureFlags/useSuspectFlagScores.tsx
@@ -9,9 +9,11 @@ export function useSuspectFlagScores({
   statsPeriod,
   start,
   end,
+  enabled = true,
 }: {
   issue_id: string;
   organization: Organization;
+  enabled?: boolean;
   end?: string;
   environment?: string[] | string;
   start?: string;
@@ -27,7 +29,8 @@ export function useSuspectFlagScores({
   return useApiQuery<SuspectFlagScoresResponse>(
     [`/organizations/${organization.slug}/issues/${issue_id}/suspect/flags/`, {query}],
     {
-      staleTime: 0,
+      staleTime: 30000,
+      enabled,
     }
   );
 }


### PR DESCRIPTION
Use for internal experiments w/the [new suspect flags endpoint](https://github.com/getsentry/sentry/pull/88674) on prod data. Includes a local storage toggle to hide it (default hidden).

![Screenshot 2025-04-07 at 2 19 16 PM](https://github.com/user-attachments/assets/68b47f1d-9c55-42e6-910e-27cd487ec3f8)