### PR TITLE
feat(autofix): Show alert with explanation if no code changes

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.spec.tsx
@@ -90,7 +90,9 @@ describe('AutofixChanges', () => {
       />
     );
 
-    expect(screen.getByText('Could not find a fix.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Autofix had trouble applying its code changes.')
+    ).toBeInTheDocument();
   });
 
   it('renders changes with action buttons', () => {

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -224,7 +224,8 @@ export function AutofixChanges({
               <MarkdownAlert
                 dangerouslySetInnerHTML={{
                   __html: marked(
-                    step.termination_reason || t('Autofix had trouble applying its code changes.')
+                    step.termination_reason ||
+                      t('Autofix had trouble applying its code changes.')
                   ),
                 }}
               />

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import ClippedBox from 'sentry/components/clippedBox';
+import {Alert} from 'sentry/components/core/alert';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
@@ -27,7 +28,7 @@ import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {IconCode, IconCopy, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {singleLineRenderer} from 'sentry/utils/marked';
+import marked, {singleLineRenderer} from 'sentry/utils/marked';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
@@ -216,11 +217,23 @@ export function AutofixChanges({
 
   if (!step.changes.length) {
     return (
-      <Content>
-        <PreviewContent>
-          <span>{t('Could not find a fix.')}</span>
-        </PreviewContent>
-      </Content>
+      <AnimatePresence initial={isChangesFirstAppearance}>
+        <AnimationWrapper key="card" {...cardAnimationProps}>
+          <NoChangesPadding>
+            <Alert.Container>
+              <MarkdownAlert
+                dangerouslySetInnerHTML={{
+                  __html: marked(
+                    step.termination_reason
+                      ? step.termination_reason
+                      : t('Autofix had trouble applying its code changes.')
+                  ),
+                }}
+              />
+            </Alert.Container>
+          </NoChangesPadding>
+        </AnimationWrapper>
+      </AnimatePresence>
     );
   }
 
@@ -392,6 +405,18 @@ const RepoChangesHeader = styled('div')`
   display: grid;
   align-items: center;
   grid-template-columns: 1fr auto;
+`;
+
+const MarkdownAlert = styled('div')`
+  border: 1px solid ${p => p.theme.alert.warning.border};
+  background-color: ${p => p.theme.alert.warning.backgroundLight};
+  padding: ${space(2)} ${space(2)} 0 ${space(2)};
+  border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.alert.warning.color};
+`;
+
+const NoChangesPadding = styled('div')`
+  padding: 0 ${space(2)};
 `;
 
 const Separator = styled('hr')`

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -224,9 +224,7 @@ export function AutofixChanges({
               <MarkdownAlert
                 dangerouslySetInnerHTML={{
                   __html: marked(
-                    step.termination_reason
-                      ? step.termination_reason
-                      : t('Autofix had trouble applying its code changes.')
+                    step.termination_reason || t('Autofix had trouble applying its code changes.')
                   ),
                 }}
               />

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -175,6 +175,7 @@ export type AutofixCodebaseChange = {
 export interface AutofixChangesStep extends BaseStep {
   changes: AutofixCodebaseChange[];
   type: AutofixStepType.CHANGES;
+  termination_reason?: string;
 }
 
 export type AutofixRelevantCodeFile = {


### PR DESCRIPTION
Shows an explanation if no code changes appear. 

<img width="695" alt="Screenshot 2025-04-07 at 2 28 09 PM" src="https://github.com/user-attachments/assets/9a83157b-cc13-47db-9823-3efa572e8dbc" />
