### PR TITLE
feat(eap): Add subheading for sidebar failure rate widget

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -150,6 +150,7 @@ export const SPAN_FUNCTIONS = [
   'cache_hit_rate',
   'cache_miss_rate',
   'sum',
+  'failure_rate',
 ] as const;
 
 type BreakpointCondition = 'less' | 'greater';

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Tag} from 'sentry/components/core/badge/tag';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import toPercent from 'sentry/utils/number/toPercent';
+import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -78,10 +78,9 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
       return null;
     }
 
-    const failureRateText = toPercent(failureRateValue[0]?.['failure_rate()'] ?? 0);
     return (
       <Tag key="failure-rate-value" type="error">
-        {failureRateText}
+        {formatPercentage(failureRateValue[0]?.['failure_rate()'] ?? 0)}
       </Tag>
     );
   };
@@ -101,7 +100,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
 
   return (
     <Widget
-      Title={t('Failure Rate')}
+      Title={<SideBarWidgetTitle>{t('Failure Rate')}</SideBarWidgetTitle>}
       TitleBadges={getFailureRateBadge()}
       Actions={
         <Widget.WidgetToolbar>
@@ -112,6 +111,11 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
         </Widget.WidgetToolbar>
       }
       Visualization={<TimeSeriesWidgetVisualization plottables={plottables} />}
+      height={200}
     />
   );
 }
+
+const SideBarWidgetTitle = styled('div')`
+  font-weight: ${p => p.theme.fontWeightBold};
+`;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -73,29 +73,36 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     true
   );
 
+  const getFailureRateBadge = () => {
+    if (isFailureRateValuePending || isFailureRateValueError) {
+      return null;
+    }
+
+    const failureRateText = toPercent(failureRateValue[0]?.['failure_rate()'] ?? 0);
+    return (
+      <Tag key="failure-rate-value" type="error">
+        {failureRateText}
+      </Tag>
+    );
+  };
+
   if (isFailureRateSeriesPending || isFailureRateSeriesError) {
     return (
       <Widget
         Title={t('Failure Rate')}
+        TitleBadges={getFailureRateBadge()}
         Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
       />
     );
   }
 
-  const failureRateText = toPercent(failureRateValue[0]?.['failure_rate()'] ?? 0);
-
   const timeSeries = eapSeriesDataToTimeSeries(failureRateSeriesData);
   const plottables = timeSeries.map(series => new Line(series, {color: theme.red300}));
+
   return (
     <Widget
       Title={t('Failure Rate')}
-      TitleBadges={
-        (!isFailureRateValuePending || !isFailureRateValueError) && (
-          <Tag key="failure-rate-value" type="error">
-            {failureRateText}
-          </Tag>
-        )
-      }
+      TitleBadges={getFailureRateBadge()}
       Actions={
         <Widget.WidgetToolbar>
           <Widget.WidgetDescription


### PR DESCRIPTION
In the transaction summary, fetches the overall failure rate for the currently selected time period and displays it as a badge in the heading.


![image](https://github.com/user-attachments/assets/bec90305-41d0-4afd-a762-c7d7c589552f)
