### PR TITLE
feat(issues): Add total user/event counts to serializer 

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -147,6 +147,7 @@ class SeenStats(TypedDict):
     first_seen: datetime | None
     last_seen: datetime | None
     user_count: int
+    total_user_count: int
 
 
 def is_seen_stats(o: object) -> TypeGuard[SeenStats]:
@@ -740,6 +741,7 @@ class GroupSerializerBase(Serializer, ABC):
 
     @staticmethod
     def _convert_seen_stats(attrs: SeenStats):
+
         return {
             "count": str(attrs["times_seen"]),
             "userCount": attrs["user_count"],
@@ -813,7 +815,13 @@ class GroupSerializer(GroupSerializerBase):
             environment = self.environment_func()
         except Environment.DoesNotExist:
             return {
-                item: {"times_seen": 0, "first_seen": None, "last_seen": None, "user_count": 0}
+                item: {
+                    "times_seen": 0,
+                    "first_seen": None,
+                    "last_seen": None,
+                    "user_count": 0,
+                    "total_user_count": 0,
+                }
                 for item in issue_list
             }
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -147,7 +147,7 @@ class SeenStats(TypedDict):
     first_seen: datetime | None
     last_seen: datetime | None
     user_count: int
-    total_user_count: int
+    total_user_count: int | None
 
 
 def is_seen_stats(o: object) -> TypeGuard[SeenStats]:
@@ -747,7 +747,7 @@ class GroupSerializerBase(Serializer, ABC):
             "userCount": attrs["user_count"],
             "firstSeen": attrs["first_seen"],
             "lastSeen": attrs["last_seen"],
-            "totalUserCount": attrs["total_user_count"],
+            "totalUserCount": attrs["total_user_count"] if "total_user_count" in attrs else None,
         }
 
 
@@ -820,7 +820,6 @@ class GroupSerializer(GroupSerializerBase):
                     "first_seen": None,
                     "last_seen": None,
                     "user_count": 0,
-                    "total_user_count": 0,
                 }
                 for item in issue_list
             }

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -55,7 +55,7 @@ OPEN_PERIOD_LIMIT = 50
 
 def get_group_global_count(group: Group) -> str:
     fetch_buffered_group_stats(group)
-    return str(group.times_seen_with_pending)
+    return group.times_seen_with_pending
 
 
 @region_silo_endpoint
@@ -270,7 +270,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     "pluginContexts": self._get_context_plugins(request, group),
                     "userReportCount": user_reports.count(),
                     "stats": {"24h": hourly_stats, "30d": daily_stats},
-                    "count": get_group_global_count(group),
+                    "totalCount": get_group_global_count(group),
                 }
             )
 


### PR DESCRIPTION
we have some disjointed behavior regards filters + stats right now for issues. we calculate stats based on env filters, but in our `group_details.py` endpoint, we overwrite the event count for a non-filtered value. this has led to confusion over the numbers. 

this pr adds total user and total events numbers and relabels them so it is more clear which data you have. 