### PR TITLE
:wrench: chore: refactor action migration util to not have unnecessary imports

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -1,11 +1,8 @@
 import logging
 from typing import Any
 
-from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.action import Action
-from sentry.workflow_engine.typings.notification_action import (
-    issue_alert_action_translator_registry,
-)
+from sentry.workflow_engine.typings.notification_action import issue_alert_action_translator_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +35,9 @@ def translate_rule_data_actions_to_notification_actions(
 
         # Fetch the translator class
         try:
-            translator_class = issue_alert_action_translator_registry.get(registry_id)
+            translator_class = issue_alert_action_translator_mapping[registry_id]
             translator = translator_class(action)
-        except NoRegistrationExistsError as e:
+        except KeyError as e:
             logger.exception(
                 "Action translator not found for action",
                 extra={

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -3,15 +3,32 @@ from __future__ import annotations
 import dataclasses
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict
 
-from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
-from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
-from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
-from sentry.utils.registry import Registry
-from sentry.workflow_engine.models.action import Action
+OPSGENIE_DEFAULT_PRIORITY = "P3"
+PAGERDUTY_DEFAULT_SEVERITY = "default"
+
+
+class ActionTarget(IntEnum):
+    SPECIFIC = 0
+    USER = 1
+    TEAM = 2
+    SENTRY_APP = 3
+    ISSUE_OWNERS = 4
+
+
+class ActionTargetType(Enum):
+    ISSUE_OWNERS = "IssueOwners"
+    TEAM = "Team"
+    MEMBER = "Member"
+
+
+class FallthroughChoiceType(Enum):
+    ALL_MEMBERS = "AllMembers"
+    ACTIVE_MEMBERS = "ActiveMembers"
+    NO_ONE = "NoOne"
+
 
 # Keep existing excluded keys constant
 EXCLUDED_ACTION_DATA_KEYS = ["uuid", "id"]
@@ -25,6 +42,27 @@ class SentryAppIdentifier(StrEnum):
     SENTRY_APP_INSTALLATION_UUID = "sentry_app_installation_uuid"
     SENTRY_APP_SLUG = "sentry_app_slug"
     SENTRY_APP_ID = "sentry_app_id"
+
+
+class ActionType(StrEnum):
+    SLACK = "slack"
+    MSTEAMS = "msteams"
+    DISCORD = "discord"
+
+    PAGERDUTY = "pagerduty"
+    OPSGENIE = "opsgenie"
+
+    GITHUB = "github"
+    GITHUB_ENTERPRISE = "github_enterprise"
+    JIRA = "jira"
+    JIRA_SERVER = "jira_server"
+    AZURE_DEVOPS = "azure_devops"
+
+    EMAIL = "email"
+    SENTRY_APP = "sentry_app"
+
+    PLUGIN = "plugin"
+    WEBHOOK = "webhook"
 
 
 @dataclass
@@ -74,66 +112,66 @@ class ActionFieldMapping(TypedDict):
     target_display_key: NotRequired[str]
 
 
-ACTION_FIELD_MAPPINGS: dict[Action.Type, ActionFieldMapping] = {
-    Action.Type.SLACK: ActionFieldMapping(
+ACTION_FIELD_MAPPINGS: dict[str, ActionFieldMapping] = {
+    ActionType.SLACK: ActionFieldMapping(
         id="sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
         integration_id_key="workspace",
         target_identifier_key="channel_id",
         target_display_key="channel",
     ),
-    Action.Type.DISCORD: ActionFieldMapping(
+    ActionType.DISCORD: ActionFieldMapping(
         id="sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
         integration_id_key="server",
         target_identifier_key="channel_id",
     ),
-    Action.Type.MSTEAMS: ActionFieldMapping(
+    ActionType.MSTEAMS: ActionFieldMapping(
         id="sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction",
         integration_id_key="team",
         target_identifier_key="channel_id",
         target_display_key="channel",
     ),
-    Action.Type.PAGERDUTY: ActionFieldMapping(
+    ActionType.PAGERDUTY: ActionFieldMapping(
         id="sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
         integration_id_key="account",
         target_identifier_key="service",
     ),
-    Action.Type.OPSGENIE: ActionFieldMapping(
+    ActionType.OPSGENIE: ActionFieldMapping(
         id="sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
         integration_id_key="account",
         target_identifier_key="team",
     ),
-    Action.Type.GITHUB: ActionFieldMapping(
+    ActionType.GITHUB: ActionFieldMapping(
         id="sentry.integrations.github.notify_action.GitHubCreateTicketAction",
         integration_id_key="integration",
     ),
-    Action.Type.GITHUB_ENTERPRISE: ActionFieldMapping(
+    ActionType.GITHUB_ENTERPRISE: ActionFieldMapping(
         id="sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
         integration_id_key="integration",
     ),
-    Action.Type.AZURE_DEVOPS: ActionFieldMapping(
+    ActionType.AZURE_DEVOPS: ActionFieldMapping(
         id="sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction",
         integration_id_key="integration",
     ),
-    Action.Type.JIRA: ActionFieldMapping(
+    ActionType.JIRA: ActionFieldMapping(
         id="sentry.integrations.jira.notify_action.JiraCreateTicketAction",
         integration_id_key="integration",
     ),
-    Action.Type.JIRA_SERVER: ActionFieldMapping(
+    ActionType.JIRA_SERVER: ActionFieldMapping(
         id="sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
         integration_id_key="integration",
     ),
-    Action.Type.EMAIL: ActionFieldMapping(
+    ActionType.EMAIL: ActionFieldMapping(
         id="sentry.mail.actions.NotifyEmailAction",
         target_identifier_key="targetIdentifier",
     ),
-    Action.Type.PLUGIN: ActionFieldMapping(
+    ActionType.PLUGIN: ActionFieldMapping(
         id="sentry.rules.actions.notify_event.NotifyEventAction",
     ),
-    Action.Type.WEBHOOK: ActionFieldMapping(
+    ActionType.WEBHOOK: ActionFieldMapping(
         id="sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
         target_identifier_key="service",
     ),
-    Action.Type.SENTRY_APP: ActionFieldMapping(
+    ActionType.SENTRY_APP: ActionFieldMapping(
         id="sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
         target_identifier_key="sentryAppInstallationUuid",
     ),
@@ -143,7 +181,7 @@ ACTION_FIELD_MAPPINGS: dict[Action.Type, ActionFieldMapping] = {
 class BaseActionTranslator(ABC):
     @property
     @abstractmethod
-    def action_type(self) -> Action.Type:
+    def action_type(self) -> ActionType:
         pass
 
     # Represents the mapping of a target field to a source field {target_field: FieldMapping}
@@ -165,7 +203,7 @@ class BaseActionTranslator(ABC):
 
     @property
     @abstractmethod
-    def target_type(self) -> ActionTarget | None:
+    def target_type(self) -> int | None:
         """Return the target type for this action"""
         pass
 
@@ -198,9 +236,9 @@ class BaseActionTranslator(ABC):
         base_config = {
             "target_identifier": self.target_identifier,
             "target_display": self.target_display,
-            "target_type": self.target_type.value if self.target_type is not None else None,
+            "target_type": self.target_type if self.target_type is not None else None,
         }
-        if self.action_type == Action.Type.SENTRY_APP:
+        if self.action_type == ActionType.SENTRY_APP:
             base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
 
         return base_config
@@ -244,96 +282,87 @@ class BaseActionTranslator(ABC):
             return {k: v for k, v in self.action.items() if k not in excluded_keys}
 
 
-issue_alert_action_translator_registry = Registry[type[BaseActionTranslator]](
-    enable_reverse_lookup=False
-)
-
-
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.SLACK]["id"])
 class SlackActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.SLACK
+    def action_type(self) -> ActionType:
+        return ActionType.SLACK
 
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.SLACK][
+            ACTION_FIELD_MAPPINGS[ActionType.SLACK][
                 ActionFieldMappingKeys.INTEGRATION_ID_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.SLACK][
+            ACTION_FIELD_MAPPINGS[ActionType.SLACK][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.SLACK][
+            ACTION_FIELD_MAPPINGS[ActionType.SLACK][
                 ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value
             ],
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
     @property
     def blob_type(self) -> type[DataBlob]:
         return SlackDataBlob
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.DISCORD]["id"])
 class DiscordActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.DISCORD
+    def action_type(self) -> ActionType:
+        return ActionType.DISCORD
 
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.DISCORD][
+            ACTION_FIELD_MAPPINGS[ActionType.DISCORD][
                 ActionFieldMappingKeys.INTEGRATION_ID_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.DISCORD][
+            ACTION_FIELD_MAPPINGS[ActionType.DISCORD][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ],
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
     @property
     def blob_type(self) -> type[DataBlob]:
         return DiscordDataBlob
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.MSTEAMS]["id"])
 class MSTeamsActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.MSTEAMS
+    def action_type(self) -> ActionType:
+        return ActionType.MSTEAMS
 
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.MSTEAMS][
+            ACTION_FIELD_MAPPINGS[ActionType.MSTEAMS][
                 ActionFieldMappingKeys.INTEGRATION_ID_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.MSTEAMS][
+            ACTION_FIELD_MAPPINGS[ActionType.MSTEAMS][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.MSTEAMS][
+            ACTION_FIELD_MAPPINGS[ActionType.MSTEAMS][
                 ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value
             ],
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.PAGERDUTY]["id"])
 class PagerDutyActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.PAGERDUTY
+    def action_type(self) -> ActionType:
+        return ActionType.PAGERDUTY
 
     field_mappings = {
         "priority": FieldMapping(
@@ -344,28 +373,27 @@ class PagerDutyActionTranslator(BaseActionTranslator):
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.PAGERDUTY][
+            ACTION_FIELD_MAPPINGS[ActionType.PAGERDUTY][
                 ActionFieldMappingKeys.INTEGRATION_ID_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.PAGERDUTY][
+            ACTION_FIELD_MAPPINGS[ActionType.PAGERDUTY][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ],
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
     @property
     def blob_type(self) -> type[DataBlob]:
         return OnCallDataBlob
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.OPSGENIE]["id"])
 class OpsgenieActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.OPSGENIE
+    def action_type(self) -> ActionType:
+        return ActionType.OPSGENIE
 
     field_mappings = {
         "priority": FieldMapping(
@@ -376,17 +404,17 @@ class OpsgenieActionTranslator(BaseActionTranslator):
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.OPSGENIE][
+            ACTION_FIELD_MAPPINGS[ActionType.OPSGENIE][
                 ActionFieldMappingKeys.INTEGRATION_ID_KEY.value
             ],
-            ACTION_FIELD_MAPPINGS[Action.Type.OPSGENIE][
+            ACTION_FIELD_MAPPINGS[ActionType.OPSGENIE][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ],
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
     @property
     def blob_type(self) -> type[DataBlob]:
@@ -428,8 +456,8 @@ class TicketActionTranslator(BaseActionTranslator, TicketingActionDataBlobHelper
         return self.action.get("integration")
 
     @property
-    def target_type(self) -> ActionTarget:
-        return ActionTarget.SPECIFIC
+    def target_type(self) -> int:
+        return ActionTarget.SPECIFIC.value
 
     @property
     def blob_type(self) -> type[DataBlob]:
@@ -450,70 +478,58 @@ class TicketActionTranslator(BaseActionTranslator, TicketingActionDataBlobHelper
         return data
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.GITHUB]["id"])
 class GithubActionTranslator(TicketActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.GITHUB
+    def action_type(self) -> ActionType:
+        return ActionType.GITHUB
 
 
-@issue_alert_action_translator_registry.register(
-    ACTION_FIELD_MAPPINGS[Action.Type.GITHUB_ENTERPRISE]["id"]
-)
 class GithubEnterpriseActionTranslator(TicketActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.GITHUB_ENTERPRISE
+    def action_type(self) -> ActionType:
+        return ActionType.GITHUB_ENTERPRISE
 
 
-@issue_alert_action_translator_registry.register(
-    ACTION_FIELD_MAPPINGS[Action.Type.AZURE_DEVOPS]["id"]
-)
 class AzureDevopsActionTranslator(TicketActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.AZURE_DEVOPS
+    def action_type(self) -> ActionType:
+        return ActionType.AZURE_DEVOPS
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.JIRA]["id"])
 class JiraActionTranslatorBase(TicketActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.JIRA
+    def action_type(self) -> ActionType:
+        return ActionType.JIRA
 
 
-@issue_alert_action_translator_registry.register(
-    ACTION_FIELD_MAPPINGS[Action.Type.JIRA_SERVER]["id"]
-)
 class JiraServerActionTranslatorBase(TicketActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.JIRA_SERVER
+    def action_type(self) -> ActionType:
+        return ActionType.JIRA_SERVER
 
 
 class EmailActionHelper(ABC):
     target_type_mapping = {
-        ActionTarget.USER: ActionTargetType.MEMBER.value,
-        ActionTarget.TEAM: ActionTargetType.TEAM.value,
-        ActionTarget.ISSUE_OWNERS: ActionTargetType.ISSUE_OWNERS.value,
+        ActionTarget.USER.value: ActionTargetType.MEMBER.value,
+        ActionTarget.TEAM.value: ActionTargetType.TEAM.value,
+        ActionTarget.ISSUE_OWNERS.value: ActionTargetType.ISSUE_OWNERS.value,
     }
 
     reverse_target_type_mapping = {v: k for k, v in target_type_mapping.items()}
 
     @staticmethod
-    def get_target_type_object(target_type: str) -> ActionTarget:
+    def get_target_type_object(target_type: str) -> int:
         return EmailActionHelper.reverse_target_type_mapping[target_type]
 
     @staticmethod
-    def get_target_type_string(target_type: ActionTarget) -> str:
+    def get_target_type_string(target_type: int) -> str:
         return EmailActionHelper.target_type_mapping[target_type]
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.EMAIL]["id"])
 class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.EMAIL
+    def action_type(self) -> ActionType:
+        return ActionType.EMAIL
 
     @property
     def required_fields(self) -> list[str]:
@@ -522,7 +538,7 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
         ]
 
     @property
-    def target_type(self) -> ActionTarget:
+    def target_type(self) -> int:
         # If the targetType is Member, then set the target_type to User,
         # if the targetType is Team, then set the target_type to Team,
         # otherwise return None (this would be for IssueOwners (suggested assignees))
@@ -538,7 +554,7 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
         if target_type in [ActionTargetType.MEMBER.value, ActionTargetType.TEAM.value]:
             return str(
                 self.action.get(
-                    ACTION_FIELD_MAPPINGS[Action.Type.EMAIL][
+                    ACTION_FIELD_MAPPINGS[ActionType.EMAIL][
                         ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
                     ]
                 )
@@ -571,11 +587,10 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
         return {}
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.PLUGIN]["id"])
 class PluginActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.PLUGIN
+    def action_type(self) -> ActionType:
+        return ActionType.PLUGIN
 
     @property
     def required_fields(self) -> list[str]:
@@ -590,44 +605,40 @@ class PluginActionTranslator(BaseActionTranslator):
         return None
 
 
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.WEBHOOK]["id"])
 class WebhookActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.WEBHOOK
+    def action_type(self) -> ActionType:
+        return ActionType.WEBHOOK
 
     @property
-    def target_type(self) -> ActionTarget | None:
+    def target_type(self) -> int | None:
         return None
 
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.WEBHOOK][
+            ACTION_FIELD_MAPPINGS[ActionType.WEBHOOK][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ]
         ]
 
 
-@issue_alert_action_translator_registry.register(
-    ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP]["id"]
-)
 class SentryAppActionTranslator(BaseActionTranslator):
     @property
-    def action_type(self) -> Action.Type:
-        return Action.Type.SENTRY_APP
+    def action_type(self) -> ActionType:
+        return ActionType.SENTRY_APP
 
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP][
+            ACTION_FIELD_MAPPINGS[ActionType.SENTRY_APP][
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ]
         ]
 
     @property
-    def target_type(self) -> ActionTarget | None:
-        return ActionTarget.SENTRY_APP
+    def target_type(self) -> int | None:
+        return ActionTarget.SENTRY_APP.value
 
     def get_sanitized_data(self) -> dict[str, Any]:
         data = SentryAppDataBlob()
@@ -731,3 +742,21 @@ class EmailDataBlob(DataBlob):
     """
 
     fallthroughType: str = ""
+
+
+issue_alert_action_translator_mapping: dict[str, type[BaseActionTranslator]] = {
+    ACTION_FIELD_MAPPINGS[ActionType.SLACK]["id"]: SlackActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.DISCORD]["id"]: DiscordActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.MSTEAMS]["id"]: MSTeamsActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.PAGERDUTY]["id"]: PagerDutyActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.OPSGENIE]["id"]: OpsgenieActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.GITHUB]["id"]: GithubActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.GITHUB_ENTERPRISE]["id"]: GithubEnterpriseActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.AZURE_DEVOPS]["id"]: AzureDevopsActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.JIRA]["id"]: JiraActionTranslatorBase,
+    ACTION_FIELD_MAPPINGS[ActionType.JIRA_SERVER]["id"]: JiraServerActionTranslatorBase,
+    ACTION_FIELD_MAPPINGS[ActionType.EMAIL]["id"]: EmailActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.PLUGIN]["id"]: PluginActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.WEBHOOK]["id"]: WebhookActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.SENTRY_APP]["id"]: SentryAppActionTranslator,
+}

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -48,7 +48,7 @@ from sentry.workflow_engine.typings.notification_action import (
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
-def pop_keys_from_data_blob(data_blob: dict, action_type: Action.Type) -> dict:
+def pop_keys_from_data_blob(data_blob: dict, action_type: str) -> dict:
     """
     Remove standard action fields from each dictionary in the data blob.
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -24,7 +24,7 @@ from sentry.workflow_engine.typings.notification_action import (
     SentryAppIdentifier,
     TicketDataBlob,
     TicketFieldMappingKeys,
-    issue_alert_action_translator_registry,
+    issue_alert_action_translator_mapping,
 )
 
 
@@ -83,7 +83,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         Asserts that the action data is equivalent to the compare_dict.
         Uses the translator to determine which keys should be excluded from the data blob.
         """
-        translator_class = issue_alert_action_translator_registry.get(compare_dict["id"])
+        translator_class = issue_alert_action_translator_mapping[compare_dict["id"]]
         translator = translator_class(compare_dict)
 
         # Get the keys we need to ignore
@@ -154,7 +154,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         """
         Asserts that the action attributes are equivalent to the compare_dict using the translator.
         """
-        translator_class = issue_alert_action_translator_registry.get(compare_dict["id"])
+        translator_class = issue_alert_action_translator_mapping[compare_dict["id"]]
         translator = translator_class(compare_dict)
 
         # Assert action type matches the translator
@@ -179,7 +179,7 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # Assert target_type matches
         if translator.target_type is not None:
-            assert action.config.get("target_type") == translator.target_type.value
+            assert action.config.get("target_type") == translator.target_type
         else:
             assert action.config.get("target_type") is None
 
@@ -762,7 +762,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         ]
 
         for registry_id, expected_type in test_cases:
-            translator_class = issue_alert_action_translator_registry.get(registry_id)
+            translator_class = issue_alert_action_translator_mapping[registry_id]
             # Create an instance with empty action data
             translator = translator_class({"id": registry_id})
             assert translator.action_type == expected_type, (


### PR DESCRIPTION
so that we can use the action migration util for migrations, i removed most imports by switching to a dictionary from a registry and copy pasting enums.