### PR TITLE
fix(policy): Allow members to see Legal & Compliance page

### DIFF
--- a/static/gsApp/views/legalAndCompliance/policyRow.spec.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {PoliciesFixture} from 'getsentry-test/fixtures/policies';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -67,5 +69,54 @@ describe('PolicyRow', function () {
     expect(screen.getByText(/Updated on/i)).toBeInTheDocument();
     expect(screen.queryByText(/New version available/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Review'})).toBeInTheDocument();
+  });
+
+  it('allows org members to view policies', function () {
+    const policy = policies['soc-2-bridge-letter']!;
+    const modifiedOrganization = OrganizationFixture({
+      access: [],
+    });
+
+    render(
+      <PolicyRow
+        key="soc-2-bridge-letter"
+        policies={policies}
+        policy={policy}
+        showUpdated
+        subscription={subscription}
+        onAccept={() => {}}
+      />,
+      {organization: modifiedOrganization}
+    );
+
+    expect(screen.getByText(policy.name)).toBeInTheDocument();
+    expect(screen.queryByText(/signed/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Updated on/i)).toBeInTheDocument();
+    expect(screen.queryByText(/New version available/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Review'})).toBeInTheDocument();
+  });
+  it('allows those with org write to accept policies', function () {
+    const policy = policies['soc-2-bridge-letter']!;
+    const modifiedOrganization = OrganizationFixture({
+      access: ['org:write'],
+    });
+
+    render(
+      <PolicyRow
+        key="soc-2-bridge-letter"
+        policies={policies}
+        policy={policy}
+        showUpdated
+        subscription={subscription}
+        onAccept={() => {}}
+      />,
+      {organization: modifiedOrganization}
+    );
+
+    expect(screen.getByText(policy.name)).toBeInTheDocument();
+    expect(screen.queryByText(/signed/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Updated on/i)).toBeInTheDocument();
+    expect(screen.queryByText(/New version available/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Review and Accept'})).toBeInTheDocument();
   });
 });

--- a/static/gsApp/views/legalAndCompliance/policyRow.spec.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.spec.tsx
@@ -98,7 +98,7 @@ describe('PolicyRow', function () {
   it('allows those with org write to accept policies', function () {
     const policy = policies['soc-2-bridge-letter']!;
     const modifiedOrganization = OrganizationFixture({
-      access: ['org:write'],
+      access: ['org:billing'],
     });
 
     render(

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -219,7 +219,9 @@ export function PolicyRow({
                   ? t("Superusers can't consent to policies")
                   : hasBillingAccess
                     ? undefined
-                    : t("You don't have access to accept policies.")
+                    : t(
+                        "You don't have access to manage billing and subscription details."
+                      )
               }
             >
               {t('Review and Accept')}

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -219,9 +219,7 @@ export function PolicyRow({
                   ? t("Superusers can't consent to policies")
                   : hasBillingAccess
                     ? undefined
-                    : t(
-                        "You don't have access to manage billing and subscription details."
-                      )
+                    : t("You don't have access to accept policies.")
               }
             >
               {t('Review and Accept')}

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -45,7 +45,7 @@ export function PolicyRow({
   const user = ConfigStore.get('user');
   const companyName = subscription?.companyName ?? organization.name;
   const activeSuperUser = isActiveSuperuser();
-  const hasBillingAccess = organization.access.includes('org:billing');
+  const canAcceptPolicies = organization.access.includes('org:write');
 
   const policyUrl = policy.url ? safeURL(policy.url) : null;
   // userCurrentVersion filters version select dropdown to only the current version + latest version
@@ -207,20 +207,19 @@ export function PolicyRow({
             </LinkButton>
           ) : policy.hasSignature &&
             policy.slug !== 'privacy' &&
-            policy.slug !== 'terms' ? (
+            policy.slug !== 'terms' &&
+            canAcceptPolicies ? (
             <Button
               size="sm"
               priority="primary"
               onClick={showModal}
-              disabled={activeSuperUser || !hasBillingAccess}
+              disabled={activeSuperUser || !canAcceptPolicies}
               title={
                 activeSuperUser
                   ? t("Superusers can't consent to policies")
-                  : hasBillingAccess
+                  : canAcceptPolicies
                     ? undefined
-                    : t(
-                        "You don't have access to manage billing and subscription details."
-                      )
+                    : t("You don't have access to accept policies.")
               }
             >
               {t('Review and Accept')}

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -45,7 +45,7 @@ export function PolicyRow({
   const user = ConfigStore.get('user');
   const companyName = subscription?.companyName ?? organization.name;
   const activeSuperUser = isActiveSuperuser();
-  const canAcceptPolicies = organization.access.includes('org:write');
+  const hasBillingAccess = organization.access.includes('org:billing');
 
   const policyUrl = policy.url ? safeURL(policy.url) : null;
   // userCurrentVersion filters version select dropdown to only the current version + latest version
@@ -208,16 +208,16 @@ export function PolicyRow({
           ) : policy.hasSignature &&
             policy.slug !== 'privacy' &&
             policy.slug !== 'terms' &&
-            canAcceptPolicies ? (
+            hasBillingAccess ? (
             <Button
               size="sm"
               priority="primary"
               onClick={showModal}
-              disabled={activeSuperUser || !canAcceptPolicies}
+              disabled={activeSuperUser || !hasBillingAccess}
               title={
                 activeSuperUser
                   ? t("Superusers can't consent to policies")
-                  : canAcceptPolicies
+                  : hasBillingAccess
                     ? undefined
                     : t("You don't have access to accept policies.")
               }

--- a/tests/js/getsentry-test/fixtures/policies.ts
+++ b/tests/js/getsentry-test/fixtures/policies.ts
@@ -63,5 +63,29 @@ export function PoliciesFixture(): Record<string, Policy> {
       parent: '',
       standalone: true,
     },
+    nda: {
+      name: 'Non Disclosure Agreement',
+      url: 'https://sentry.io/legal/privacy/2.0.0/',
+      consent: null,
+      version: '1.0.0',
+      updatedAt: '2025-04-07T20:58:09.012253Z',
+      slug: 'nda',
+      active: true,
+      hasSignature: true,
+      parent: null,
+      standalone: false,
+    },
+    "soc-2-bridge-letter": {
+      name: 'SOC2 Bridge Letter',
+      url: 'https://sentry.io/legal/privacy/2.0.0/',
+      consent: null,
+      version: '1.0.0',
+      updatedAt: '2025-04-07T20:59:09.012253Z',
+      slug: "soc-2-bridge-letter",
+      active: true,
+      hasSignature: true,
+      parent: 'nda',
+      standalone: true,
+    }
   };
 }


### PR DESCRIPTION
Addresses: https://linear.app/getsentry/issue/TRI-92/allow-members-to-see-legal-and-compliance-page

Changes
- Members who don't have access to org:billing can now view all policies 

POV for user with member role:
![image](https://github.com/user-attachments/assets/5807e882-d8e4-42c0-b891-e0dc8a06a62d)

POV for user with owner role: 
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/7b2a0507-fc78-43e8-8c8c-dc17f050fd12" />

POV for superuser:
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/15669ed1-5178-4371-a7cf-7613270a2339" />
