### PR TITLE
fix(insights): surface error response json detail if it exists

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
@@ -1,5 +1,2 @@
-import {t} from 'sentry/locale';
-
 export const LOADING_PLACEHOLDER = '\u2014';
-export const NO_DATA_PLACEHOLDER = t('No Data');
 export const DEEMPHASIS_COLOR_NAME = 'gray300';

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -60,9 +60,12 @@ export type TabularData<TFields extends string = string> = {
 };
 
 export type ErrorProp = Error | string;
+export interface ErrorPropWithResponseJSON extends Error {
+  responseJSON?: {detail: string};
+}
 
 export interface StateProps {
-  error?: ErrorProp;
+  error?: ErrorProp | ErrorPropWithResponseJSON;
   isLoading?: boolean;
   onRetry?: () => void;
 }

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -79,9 +79,9 @@ function WidgetLayout(props: Widget) {
       {props.Visualization && (
         <VisualizationWrapper noPadding={props.noVisualizationPadding}>
           <ErrorBoundary
-            customComponent={({error}) => (
-              <WidgetError error={error?.message ?? undefined} />
-            )}
+            customComponent={({error}) => {
+              return <WidgetError error={error ?? undefined} />;
+            }}
           >
             {props.Visualization}
           </ErrorBoundary>

--- a/static/app/views/dashboards/widgets/widget/widgetError.tsx
+++ b/static/app/views/dashboards/widgets/widget/widgetError.tsx
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled';
 
 import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DEEMPHASIS_COLOR_NAME} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
-import type {StateProps} from 'sentry/views/dashboards/widgets/common/types';
+import type {
+  ErrorPropWithResponseJSON,
+  StateProps,
+} from 'sentry/views/dashboards/widgets/common/types';
 
 import {X_GUTTER, Y_GUTTER} from '../common/settings';
 
@@ -15,7 +19,13 @@ export function WidgetError({error}: WidgetErrorProps) {
   return (
     <Panel>
       <NonShrinkingWarningIcon color={DEEMPHASIS_COLOR_NAME} size="md" />
-      <ErrorText>{error?.toString()}</ErrorText>
+      <ErrorText>
+        {typeof error === 'string'
+          ? error
+          : ((error as ErrorPropWithResponseJSON)?.responseJSON?.detail.toString() ??
+            error?.message ??
+            t('Error loading data.'))}
+      </ErrorText>
     </Panel>
   );
 }


### PR DESCRIPTION
when an error occurs rendering the widget, rather than surface the 400/bad request error string, surface the response JSON if it exists.

before:

<img width="1190" alt="SCR-20250407-oaax" src="https://github.com/user-attachments/assets/c857a895-53e6-48f2-8939-81778cd427a6" />

after:




<img width="1189" alt="SCR-20250407-oaqj" src="https://github.com/user-attachments/assets/85e5b316-4b98-41a8-8e11-954ca8655f6b" />
