### PR TITLE
fix(insights): adjust session interval in query

### DIFF
--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -1,14 +1,19 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {percent} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useCrashFreeSessions() {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -30,6 +35,7 @@ export default function useCrashFreeSessions() {
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['session.status', 'release'],
         },

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -1,12 +1,17 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useErrorFreeSessions() {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -28,6 +33,7 @@ export default function useErrorFreeSessions() {
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['session.status'],
         },

--- a/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
@@ -1,11 +1,16 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 export default function useReleaseSessionCounts() {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -27,6 +32,7 @@ export default function useReleaseSessionCounts() {
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['release'],
           per_page: 5,

--- a/static/app/views/insights/sessions/queries/useReleaseSessionPercentage.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseSessionPercentage.tsx
@@ -1,11 +1,16 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 export default function useReleaseSessionPercentage() {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -27,6 +32,7 @@ export default function useReleaseSessionPercentage() {
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['release'],
           per_page: 5,

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -1,12 +1,17 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useSessionHealthBreakdown({type}: {type: 'count' | 'rate'}) {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -28,6 +33,7 @@ export default function useSessionHealthBreakdown({type}: {type: 'count' | 'rate
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['session.status'],
         },

--- a/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
@@ -1,11 +1,16 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 export default function useSessionProjectTotal() {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -27,6 +32,7 @@ export default function useSessionProjectTotal() {
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['sum(session)'],
           groupBy: ['project'],
         },

--- a/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
@@ -1,12 +1,17 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {getCountStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useUserHealthBreakdown({type}: {type: 'count' | 'rate'}) {
   const location = useLocation();
   const organization = useOrganization();
+  const {
+    selection: {datetime},
+  } = usePageFilters();
 
   const locationQuery = {
     ...location,
@@ -28,6 +33,7 @@ export default function useUserHealthBreakdown({type}: {type: 'count' | 'rate'})
       {
         query: {
           ...locationQuery.query,
+          interval: getSessionsInterval(datetime),
           field: ['count_unique(user)'],
           groupBy: ['session.status'],
         },


### PR DESCRIPTION
adjust the interval in the `/sessions/` api query, so that we can query for 90d

<img width="1200" alt="SCR-20250407-ojwq" src="https://github.com/user-attachments/assets/80d0e902-8a9b-4f6f-abb8-9aee288958af" />
