### PR TITLE
chore(jira): Add more data to better filter/aggregate outbound status sync logs

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -60,6 +60,14 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
     ).capture() as lifecycle:
         lifecycle.add_extra("sync_task", "sync_status_outbound")
         if installation.should_sync("outbound_status"):
+            lifecycle.add_extras(
+                {
+                    "organization_id": external_issue.organization_id,
+                    "integration_id": integration.id,
+                    "external_issue": external_issue_id,
+                    "status": group.status,
+                }
+            )
             installation.sync_status_outbound(
                 external_issue, group.status == GroupStatus.RESOLVED, group.project_id
             )


### PR DESCRIPTION
Trying to debug this orgs issue: https://linear.app/getsentry/issue/TRI-60/regression-on-sentry-issue-not-triggering-status-sync-to-jira-issue

Currently, I can't filter the SLOs by organization so adding more details to logs