### PR TITLE
:wrench: chore(aci): don't change exception type when error is raised in noa

### DIFF
--- a/src/sentry/notifications/notification_action/exceptions.py
+++ b/src/sentry/notifications/notification_action/exceptions.py
@@ -1,2 +1,0 @@
-class NotificationHandlerException(Exception):
-    pass

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/issue_alert_registry_handler.py
@@ -1,7 +1,6 @@
 import logging
 
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.notifications.notification_action.exceptions import NotificationHandlerException
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
     issue_alert_handler_registry,
@@ -28,9 +27,9 @@ class IssueAlertRegistryHandler(LegacyRegistryHandler):
                 extra={"action_id": action.id},
             )
             raise
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Error invoking issue alert handler",
                 extra={"action_id": action.id},
             )
-            raise NotificationHandlerException(e)
+            raise

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -4,7 +4,6 @@ from sentry.issues.grouptype import MetricIssuePOC
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.notifications.notification_action.exceptions import NotificationHandlerException
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
     metric_alert_handler_registry,
@@ -31,12 +30,12 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
                 extra={"action_id": action.id},
             )
             raise
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Error invoking metric alert handler",
                 extra={"action_id": action.id},
             )
-            raise NotificationHandlerException(e)
+            raise
 
     @staticmethod
     def target(action: Action) -> OrganizationMember | Team | str | None:

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from sentry.notifications.notification_action.exceptions import NotificationHandlerException
 from sentry.notifications.notification_action.group_type_notification_registry.handlers.issue_alert_registry_handler import (
     IssueAlertRegistryHandler,
 )
@@ -36,28 +35,6 @@ class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
                 self.event_data, self.action, self.detector
             )
 
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get"
-    )
-    @mock.patch(
-        "sentry.notifications.notification_action.group_type_notification_registry.handlers.issue_alert_registry_handler.logger"
-    )
-    def test_handle_workflow_action_general_exception(self, mock_logger, mock_registry_get):
-        """Test that handle_workflow_action wraps general exceptions in NotificationHandlerException"""
-        mock_handler = mock.Mock()
-        mock_handler.invoke_legacy_registry.side_effect = Exception("Something went wrong")
-        mock_registry_get.return_value = mock_handler
-
-        with pytest.raises(NotificationHandlerException):
-            IssueAlertRegistryHandler.handle_workflow_action(
-                self.event_data, self.action, self.detector
-            )
-
-        mock_logger.exception.assert_called_once_with(
-            "Error invoking issue alert handler",
-            extra={"action_id": self.action.id},
-        )
-
 
 class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
     def setUp(self):
@@ -79,25 +56,3 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
             MetricAlertRegistryHandler.handle_workflow_action(
                 self.event_data, self.action, self.detector
             )
-
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
-    )
-    @mock.patch(
-        "sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler.logger"
-    )
-    def test_handle_workflow_action_general_exception(self, mock_logger, mock_registry_get):
-        """Test that handle_workflow_action wraps general exceptions in NotificationHandlerException"""
-        mock_handler = mock.Mock()
-        mock_handler.invoke_legacy_registry.side_effect = Exception("Something went wrong")
-        mock_registry_get.return_value = mock_handler
-
-        with pytest.raises(NotificationHandlerException):
-            MetricAlertRegistryHandler.handle_workflow_action(
-                self.event_data, self.action, self.detector
-            )
-
-        mock_logger.exception.assert_called_once_with(
-            "Error invoking metric alert handler",
-            extra={"action_id": self.action.id},
-        )


### PR DESCRIPTION
we don't want to change the exception type when an error is raised in the noa since it will break the logic which sends the integration exceptions to frontend to make debugging setting up notifications easier