### PR TITLE
🔧 chore: log all exceptions and invoke issue alert registry correctly

### DIFF
--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,7 +1,9 @@
 import logging
 
-from sentry.notifications.notification_action.registry import group_type_notification_registry
-from sentry.notifications.notification_action.types import BaseIssueAlertHandler
+from sentry.notifications.notification_action.registry import (
+    group_type_notification_registry,
+    issue_alert_handler_registry,
+)
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.types import WorkflowEventData
@@ -21,6 +23,13 @@ def execute_via_group_type_registry(
             detector.type,
             extra={"detector_id": detector.id, "action_id": action.id},
         )
+        raise
+    except Exception:
+        logger.exception(
+            "Error executing via group type registry",
+            extra={"detector_id": detector.id, "action_id": action.id},
+        )
+        raise
 
 
 def execute_via_issue_alert_handler(
@@ -30,4 +39,19 @@ def execute_via_issue_alert_handler(
     This exists so that all ticketing actions can use the same handler as issue alerts since that's the only way we can
     ensure that the same thread is used for the notification action.
     """
-    BaseIssueAlertHandler.invoke_legacy_registry(job, action, detector)
+    try:
+        handler = issue_alert_handler_registry.get(action.type)
+        handler.invoke_legacy_registry(job, action, detector)
+    except NoRegistrationExistsError:
+        logger.exception(
+            "No notification handler found for action type: %s",
+            action.type,
+            extra={"action_id": action.id, "detector_id": detector.id},
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "Error executing via issue alert handler",
+            extra={"action_id": action.id, "detector_id": detector.id},
+        )
+        raise

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import MetricIssuePOC
 from sentry.utils.registry import NoRegistrationExistsError
@@ -20,7 +22,8 @@ class TestNotificationActionHandler(BaseWorkflowTest):
     def test_execute_without_group_type(self):
         """Test that execute does nothing when detector has no group_type"""
         self.detector.type = ""
-        self.action.trigger(self.event_data, self.detector)
+        with pytest.raises(NoRegistrationExistsError):
+            self.action.trigger(self.event_data, self.detector)
         # Test passes if no exception is raised
 
     @mock.patch(
@@ -66,7 +69,8 @@ class TestNotificationActionHandler(BaseWorkflowTest):
     @mock.patch("sentry.notifications.notification_action.utils.logger")
     def test_execute_unknown_group_type(self, mock_logger, mock_registry_get):
         """Test that execute does nothing when detector has no group_type"""
-        self.action.trigger(self.event_data, self.detector)
+        with pytest.raises(NoRegistrationExistsError):
+            self.action.trigger(self.event_data, self.detector)
 
         mock_logger.exception.assert_called_once_with(
             "No notification handler found for detector type: %s",


### PR DESCRIPTION
capturing all exception types and actually using the issue alert registry when calling `execute_via_issue_alert_handler`