### PR TITLE
🔍 nit: add on-call execute methods

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/opsgenie_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/opsgenie_handler.py
@@ -1,10 +1,11 @@
 from sentry.integrations.opsgenie.utils import OPSGENIE_CUSTOM_PRIORITIES
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import ONCALL_ACTION_CONFIG_SCHEMA
-from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler
+from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.OPSGENIE)
@@ -25,3 +26,11 @@ class OpsgenieActionHandler(IntegrationActionHandler):
             "additionalProperties": False,
         },
     }
+
+    @staticmethod
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector)

--- a/src/sentry/workflow_engine/handlers/action/notification/pagerduty_handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/pagerduty_handler.py
@@ -1,10 +1,11 @@
 from sentry.integrations.pagerduty.client import PagerdutySeverity
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.handlers.action.notification.base import IntegrationActionHandler
 from sentry.workflow_engine.handlers.action.notification.common import ONCALL_ACTION_CONFIG_SCHEMA
-from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler
+from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.PAGERDUTY)
@@ -25,3 +26,11 @@ class PagerdutyActionHandler(IntegrationActionHandler):
             "additionalProperties": False,
         },
     }
+
+    @staticmethod
+    def execute(
+        job: WorkflowEventData,
+        action: Action,
+        detector: Detector,
+    ) -> None:
+        execute_via_group_type_registry(job, action, detector)


### PR DESCRIPTION
realized i never defined execute methods for opsgenie and pagerduty when i split all the handlers up