### PR TITLE
✨  feat(aci): update send test notification to invoke noa

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -5,16 +5,25 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import DummyRuleSerializer
 from sentry.eventstore.models import GroupEvent
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.utils.samples import create_sample_event
+from sentry.workflow_engine.migration_helpers.rule_action import (
+    translate_rule_data_actions_to_notification_actions,
+)
+from sentry.workflow_engine.models import Detector, Workflow
+from sentry.workflow_engine.types import WorkflowEventData
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
@@ -65,6 +74,13 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             project, platform=project.platform, default="javascript", tagged=True
         )
 
+        if features.has(
+            "organizations:workflow-engine-test-notifications", project.organization
+        ) and features.has(
+            "organizations:workflow-engine-issue-alert-dual-write", project.organization
+        ):
+            return self.execute_future_on_test_event_workflow_engine(test_event, rule)
+
         return self.execute_future_on_test_event(test_event, rule)
 
     def execute_future_on_test_event(
@@ -112,6 +128,80 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         status = None
         data = None
         # Presence of "actions" here means we have exceptions to surface to the user
+        if len(action_exceptions) > 0:
+            status = 400
+            data = {"actions": action_exceptions}
+
+        return Response(status=status, data=data)
+
+    def execute_future_on_test_event_workflow_engine(
+        self,
+        test_event: GroupEvent,
+        rule: Rule,
+    ) -> Response:
+        """
+        Invoke the workflow_engine to send a test notification.
+        This method will lookup the corresponding workflow for a given rule then invoke the notification action.
+        """
+        action_exceptions = []
+        actions = rule.data.get("actions", [])
+
+        workflow = Workflow(
+            id=-1,
+            name="Test Workflow",
+            organization=rule.project.organization,
+        )
+
+        detector = Detector(
+            id=-1,
+            project=rule.project,
+            name=rule.label,
+            enabled=True,
+            type=ErrorGroupType.slug,
+        )
+
+        event_data = WorkflowEventData(
+            event=test_event,
+            workflow_id=workflow.id,
+        )
+
+        for action_blob in actions:
+            try:
+                action = translate_rule_data_actions_to_notification_actions(
+                    [action_blob], skip_failures=False
+                )[0]
+                action.id = -1
+            except Exception as e:
+                action_exceptions.append(str(e))
+                sentry_sdk.capture_exception(e)
+                continue
+
+            try:
+                action.trigger(
+                    event_data=event_data,
+                    detector=detector,
+                )
+            except Exception as exc:
+                if isinstance(exc, IntegrationFormError):
+                    logger.warning(
+                        "%s.test_alert.integration_error", action.type, extra={"exc": exc}
+                    )
+
+                    # IntegrationFormErrors should be safe to propagate via the API
+                    action_exceptions.append(str(exc))
+                else:
+                    # If we encounter some unexpected exception, we probably
+                    # don't want to continue executing more callbacks.
+                    logger.warning("%s.test_alert.unexpected_exception", action.type, exc_info=True)
+                    error_id = sentry_sdk.capture_exception(exc)
+                    action_exceptions.append(
+                        f"An unexpected error occurred. Error ID: '{error_id}'"
+                    )
+
+                break
+
+        status = None
+        data = None
         if len(action_exceptions) > 0:
             status = 400
             data = {"actions": action_exceptions}

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -482,6 +482,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-trigger-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logs to debug metric alert dual processing
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable sending test notifications from the workflow_engine
+    manager.add("organizations:workflow-engine-test-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -136,13 +136,13 @@ class BaseIssueAlertHandler(ABC):
         if not features.has(
             "organizations:workflow-engine-ui-links", detector.project.organization
         ):
+            if job.workflow_id is None:
+                raise ValueError("Workflow ID is required when triggering an action")
+
             # If test event, just set the legacy rule id to -1
             if job.workflow_id == -1:
                 data["actions"][0]["legacy_rule_id"] = -1
             else:
-                if job.workflow_id is None:
-                    raise ValueError("Workflow ID is required when triggering an action")
-
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(
                     workflow_id=job.workflow_id,
                 )

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -136,17 +136,21 @@ class BaseIssueAlertHandler(ABC):
         if not features.has(
             "organizations:workflow-engine-ui-links", detector.project.organization
         ):
-            if job.workflow_id is None:
-                raise ValueError("Workflow ID is required when triggering an action")
+            # If test event, just set the legacy rule id to -1
+            if job.workflow_id == -1:
+                data["actions"][0]["legacy_rule_id"] = -1
+            else:
+                if job.workflow_id is None:
+                    raise ValueError("Workflow ID is required when triggering an action")
 
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(
-                workflow_id=job.workflow_id,
-            )
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(
+                    workflow_id=job.workflow_id,
+                )
 
-            if alert_rule_workflow.rule_id is None:
-                raise ValueError("Rule not found when querying for AlertRuleWorkflow")
+                if alert_rule_workflow.rule_id is None:
+                    raise ValueError("Rule not found when querying for AlertRuleWorkflow")
 
-            data["actions"][0]["legacy_rule_id"] = alert_rule_workflow.rule_id
+                data["actions"][0]["legacy_rule_id"] = alert_rule_workflow.rule_id
 
         # In the new UI, we need this for to build the link to the new rule in the notification action
         else:
@@ -197,6 +201,23 @@ class BaseIssueAlertHandler(ABC):
             for callback, future in futures:
                 safe_execute(callback, job.event, future)
 
+    @staticmethod
+    def send_test_notification(
+        job: WorkflowEventData,
+        futures: Collection[
+            tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
+        ],
+    ) -> None:
+        """
+        This method will execute the futures.
+        Based off of process_rules in post_process.py
+        """
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.execute_futures"
+        ):
+            for callback, future in futures:
+                callback(job.event, future)
+
     @classmethod
     def invoke_legacy_registry(
         cls,
@@ -225,7 +246,11 @@ class BaseIssueAlertHandler(ABC):
             futures = cls.get_rule_futures(job, rule, notification_uuid)
 
             # Execute the futures
-            cls.execute_futures(job, futures)
+            # If the rule id is -1, we are sending a test notification
+            if rule.id == -1:
+                cls.send_test_notification(job, futures)
+            else:
+                cls.execute_futures(job, futures)
 
 
 class TicketingIssueAlertHandler(BaseIssueAlertHandler):

--- a/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
@@ -1,0 +1,37 @@
+import logging
+
+import sentry_sdk
+
+from sentry.shared_integrations.exceptions import IntegrationFormError
+from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.types import WorkflowEventData
+
+logger = logging.getLogger(__name__)
+
+
+def test_fire_action(
+    action: Action, event_data: WorkflowEventData, detector: Detector
+) -> list[str]:
+    """
+    This function will fire an action and return a list of exceptions that occurred.
+    """
+    action_exceptions = []
+    try:
+        action.trigger(
+            event_data=event_data,
+            detector=detector,
+        )
+    except Exception as exc:
+        if isinstance(exc, IntegrationFormError):
+            logger.warning("%s.test_alert.integration_error", action.type, extra={"exc": exc})
+
+            # IntegrationFormErrors should be safe to propagate via the API
+            action_exceptions.append(str(exc))
+        else:
+            # If we encounter some unexpected exception, we probably
+            # don't want to continue executing more callbacks.
+            logger.warning("%s.test_alert.unexpected_exception", action.type, exc_info=True)
+            error_id = sentry_sdk.capture_exception(exc)
+            action_exceptions.append(f"An unexpected error occurred. Error ID: '{error_id}'")
+
+    return action_exceptions

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -5,12 +5,21 @@ import sentry_sdk
 from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
+from sentry.notifications.notification_action.group_type_notification_registry import (
+    IssueAlertRegistryHandler,
+)
+from sentry.notifications.notification_action.issue_alert_registry import (
+    PagerDutyIssueAlertHandler,
+    PluginIssueAlertHandler,
+)
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import apply_feature_flag_on_cls
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -102,6 +111,161 @@ class ProjectRuleActionsEndpointTest(APITestCase):
     @mock.patch.object(JiraIntegration, "create_issue")
     @mock.patch.object(sentry_sdk, "capture_exception")
     def test_sample_event_raises_exceptions(self, mock_sdk_capture, mock_create_issue):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
+
+        form_errors = {"broken": "something went wrong"}
+        mock_create_issue.side_effect = IntegrationFormError(form_errors)
+        mock_sdk_capture.return_value = "abc-1234"
+        action_data = [
+            {
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": {
+                    "fake_field": "fake_value",
+                },
+            }
+        ]
+
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        assert response.status_code == 400
+        assert mock_create_issue.call_count == 1
+        assert response.data == {"actions": [str(form_errors)]}
+
+        mock_create_issue.side_effect = Exception("Something went wrong")
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        actions = response.data.get("actions")
+        assert actions is not None
+        assert actions == ["An unexpected error occurred. Error ID: 'abc-1234'"]
+
+    def test_no_events(self):
+        response = self.get_response(self.organization.slug, self.project.slug)
+        assert response.status_code == 400
+
+
+@apply_feature_flag_on_cls("organizations:workflow-engine-test-notifications")
+@apply_feature_flag_on_cls("organizations:workflow-engine-issue-alert-dual-write")
+class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest):
+    endpoint = "sentry-api-0-project-rule-actions"
+    method = "POST"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.workflow = self.create_workflow()
+
+    def setup_pd_service(self) -> PagerDutyServiceDict:
+        service_info = {
+            "type": "service",
+            "integration_key": "PND123",
+            "service_name": "Sentry Service",
+        }
+        _integration, org_integration = self.create_provider_integration_for(
+            provider="pagerduty",
+            name="Example PagerDuty",
+            external_id="example-pd",
+            metadata={"services": [service_info]},
+            organization=self.organization,
+            user=self.user,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return add_service(
+                org_integration,
+                service_name=service_info["service_name"],
+                integration_key=service_info["integration_key"],
+            )
+
+    @mock.patch.object(NotifyEventAction, "after")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
+        return_value=PluginIssueAlertHandler,
+    )
+    def test_actions(self, mock_get_handler, action):
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+            }
+        ]
+
+        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
+        assert action.called
+
+    @mock.patch.object(PagerDutyClient, "send_trigger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
+        return_value=IssueAlertRegistryHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
+        return_value=PagerDutyIssueAlertHandler,
+    )
+    def test_name_action_default(
+        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_send_trigger
+    ):
+        """
+        Tests that label will be used as 'Test Alert' if not present. Uses PagerDuty since those
+        notifications will differ based on the name of the alert.
+        """
+        service_info = self.setup_pd_service()
+        action_data = [
+            {
+                "account": service_info["integration_id"],
+                "service": service_info["id"],
+                "severity": "info",
+                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
+            }
+        ]
+        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
+
+        assert mock_send_trigger.call_count == 1
+        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
+        assert pagerduty_data["payload"]["summary"].startswith("[Test Alert]:")
+
+    @mock.patch.object(PagerDutyClient, "send_trigger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
+        return_value=IssueAlertRegistryHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
+        return_value=PagerDutyIssueAlertHandler,
+    )
+    def test_name_action_with_custom_name(
+        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_send_trigger
+    ):
+        """
+        Tests that custom names can be provided to the test notification. Uses PagerDuty since those
+        notifications will differ based on the name of the alert.
+        """
+        service_info = self.setup_pd_service()
+        action_data = [
+            {
+                "account": service_info["integration_id"],
+                "service": service_info["id"],
+                "severity": "info",
+                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
+            }
+        ]
+        custom_alert_name = "Check #feed-issues"
+
+        self.get_success_response(
+            self.organization.slug, self.project.slug, actions=action_data, name=custom_alert_name
+        )
+        assert mock_send_trigger.call_count == 1
+        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
+        assert pagerduty_data["payload"]["summary"].startswith(f"[{custom_alert_name}]:")
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    @mock.patch.object(sentry_sdk, "capture_exception")
+    def test_sample_event_raises_exceptions_workflow_engine(
+        self, mock_sdk_capture, mock_create_issue
+    ):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.jira_integration = self.create_provider_integration(
                 provider="jira", name="Jira", external_id="jira:1"

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -150,7 +150,6 @@ class ProjectRuleActionsEndpointTest(APITestCase):
 
 
 @apply_feature_flag_on_cls("organizations:workflow-engine-test-notifications")
-@apply_feature_flag_on_cls("organizations:workflow-engine-issue-alert-dual-write")
 class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest):
     endpoint = "sentry-api-0-project-rule-actions"
     method = "POST"

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -195,6 +195,18 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
         assert action.called
 
+    def test_unknown_action_returns_400(self):
+        action_data = [
+            {
+                "id": "sentry.rules.actions.fake_action.FakeAction",
+            }
+        ]
+
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        assert response.status_code == 400
+
     @mock.patch.object(PagerDutyClient, "send_trigger")
     @mock.patch(
         "sentry.notifications.notification_action.registry.group_type_notification_registry.get",


### PR DESCRIPTION
this pr updated the send test notification API to invoke the NOA. 

this pr introduces a method that we can reuse in the future when we build the new endpoint for send test notifications in the new UI.