### PR TITLE
fix: Cache the project.organization attribute in ingest consumer

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -18,6 +18,7 @@ from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, is_
 from sentry.ingest.types import ConsumerType
 from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.killswitches import killswitch_matches_context
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.signals import event_accepted
 from sentry.tasks.store import preprocess_event, save_event_feedback, save_event_transaction
@@ -228,6 +229,9 @@ def process_event(
         except Exception:
             pass
 
+        project.set_cached_field_value(
+            "organization", Organization.objects.get_from_cache(id=project.organization_id)
+        )
         if data.get("type") == "transaction":
             if no_celery_mode:
                 with sentry_sdk.start_span(op="ingest_consumer.process_transaction_no_celery"):


### PR DESCRIPTION
<!-- Describe your PR here. -->

The `project.organizaion` attribute access generates unnecessary `organization` queries. Since it is in hot path the volume is substantial. This PR pre-cache the attribute so that all subsequent access won't hit the database.
