### PR TITLE
feat(profiling-onboarding): python

### DIFF
--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -169,7 +170,7 @@ web.run_app(app)
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding(),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -11,6 +11,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -177,6 +178,7 @@ const docs: Docs = {
   onboarding,
 
   crashReportOnboarding: crashReportOnboardingPython,
+  profilingOnboarding: getPythonProfilingOnboarding(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -11,9 +11,9 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -161,7 +162,7 @@ run(app, host='localhost', port=8000)
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[bottle]'}),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -13,10 +13,10 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -13,6 +13,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -201,7 +202,7 @@ def init_sentry(**_kwargs):
 
 const docs: Docs = {
   onboarding,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[celery]'}),
   crashReportOnboarding: crashReportOnboardingPython,
 };
 

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -8,6 +8,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -133,7 +134,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[chalice]'}),
   crashReportOnboarding: crashReportOnboardingPython,
 };
 

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -8,9 +8,9 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -176,7 +177,7 @@ const performanceOnboarding: OnboardingConfig = {
             {code: <code />}
           ),
           code: `
-import sentry-sdk
+import sentry_sdk
 
 sentry_sdk.init(
   dsn: "${params.dsn.public}",
@@ -222,7 +223,7 @@ sentry_sdk.init(
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[django]'}),
   performanceOnboarding,
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -161,7 +162,7 @@ app.add_route('/', HelloWorldResource())
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[falcon]'}),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -16,6 +16,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -171,7 +172,7 @@ async def trigger_error():
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[fastapi]'}),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -16,9 +16,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -16,9 +16,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -16,6 +16,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -230,7 +231,7 @@ sentry_sdk.init(
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[flask]'}),
   performanceOnboarding,
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -13,10 +13,10 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -13,6 +13,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -168,6 +169,7 @@ const docs: Docs = {
   onboarding,
 
   crashReportOnboarding: crashReportOnboardingPython,
+  profilingOnboarding: getPythonProfilingOnboarding(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -12,9 +12,9 @@ import {
 import {
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -12,6 +12,7 @@ import {
 import {
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -113,6 +114,7 @@ const docs: Docs = {
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
+  profilingOnboarding: getPythonProfilingOnboarding(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -135,7 +135,8 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))`,
   },
 };
 
-const getInstallSnippet = (basePackage: string, minimumVersion: string) =>
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
+const getProfilingInstallSnippet = (basePackage: string, minimumVersion: string) =>
   `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
 
 const getSdkSetupSnippet = (params: Params) => `
@@ -216,7 +217,7 @@ const onboarding: OnboardingConfig = {
                 )
               : undefined,
           language: 'bash',
-          code: getInstallSnippet('sentry_sdk', '1.18.0'),
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -435,7 +436,7 @@ export const getPythonProfilingOnboarding = ({
       configurations: [
         {
           language: 'bash',
-          code: getInstallSnippet(basePackage, '1.18.0'),
+          code: getProfilingInstallSnippet(basePackage, '1.18.0'),
         },
       ],
     },
@@ -443,33 +444,13 @@ export const getPythonProfilingOnboarding = ({
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Set up the [code:nodeProfilingIntegration] in your [code:Sentry.init()] call.',
-        {
-          code: <code />,
-        }
+      description: t(
+        "Import and initialize the Sentry SDK early in your application's setup:"
       ),
       configurations: [
         {
           language: 'python',
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: getSdkSetupSnippet(params),
-            },
-          ],
-          additionalInfo: tct(
-            'If you need more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://docs.sentry.io/platforms/javascript/guides/node/profiling/node-profiling/#enabling-manual-lifecycle-profiling`}
-                />
-              ),
-            }
-          ),
+          code: getSdkSetupSnippet(params),
         },
         {
           description: tct(
@@ -484,8 +465,13 @@ export const getPythonProfilingOnboarding = ({
           ),
         },
       ],
+      additionalInfo: params.isProfilingSelected &&
+        params.profilingOptions?.defaultProfilingMode === 'continuous' && (
+          <AlternativeConfiguration />
+        ),
     },
   ],
+
   verify: () => [
     {
       type: StepType.VERIFY,

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -210,7 +210,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [code:1.18.0] of the [code:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
                   {
                     code: <code />,
                   }
@@ -420,7 +420,7 @@ export const featureFlagOnboarding: OnboardingConfig = {
   nextSteps: () => [],
 };
 export const getPythonProfilingOnboarding = ({
-  basePackage = 'sentry_sdk',
+  basePackage = 'sentry-sdk',
 }: {
   basePackage?: string;
 } = {}): OnboardingConfig => ({
@@ -428,7 +428,7 @@ export const getPythonProfilingOnboarding = ({
     {
       type: StepType.INSTALL,
       description: tct(
-        'To enable profiling, update the Sentry SDK to a compatible version ([code:1.18.0] or higher).',
+        'To enable profiling, update the Sentry SDK to a compatible version ([code:2.24.1] or higher).',
         {
           code: <code />,
         }
@@ -436,7 +436,7 @@ export const getPythonProfilingOnboarding = ({
       configurations: [
         {
           language: 'bash',
-          code: getProfilingInstallSnippet(basePackage, '1.18.0'),
+          code: getProfilingInstallSnippet(basePackage, '2.24.1'),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -13,6 +13,7 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -136,8 +137,6 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))`,
 };
 
 const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
-const getProfilingInstallSnippet = (basePackage: string, minimumVersion?: string) =>
-  `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -172,62 +171,6 @@ sentry_sdk.init(
 )${
   params.isProfilingSelected &&
   params.profilingOptions?.defaultProfilingMode === 'continuous'
-    ? `
-
-def slow_function():
-    import time
-    time.sleep(0.1)
-    return "done"
-
-def fast_function():
-    import time
-    time.sleep(0.05)
-    return "done"
-
-# Manually call start_profiler and stop_profiler
-# to profile the code in between
-sentry_sdk.profiler.start_profiler()
-
-for i in range(0, 10):
-    slow_function()
-    fast_function()
-
-# Calls to stop_profiler are optional - if you don't stop the profiler, it will keep profiling
-# your application until the process exits or stop_profiler is called.
-sentry_sdk.profiler.stop_profiler()`
-    : ''
-}`;
-
-const getProfilingSdkSetupSnippet = (
-  params: Params,
-  traceLifecycle: 'manual' | 'trace'
-) => `
-import sentry_sdk
-
-sentry_sdk.init(
-    dsn="${params.dsn.public}",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for tracing.
-    traces_sample_rate=1.0,
-    ${
-      params.profilingOptions?.defaultProfilingMode === 'continuous'
-        ? `# Set profile_session_sample_rate to 1.0 to profile 100%
-    # of profile sessions.
-    profile_session_sample_rate=1.0,${
-      traceLifecycle === 'trace'
-        ? `
-    # Set profile_lifecycle to "trace" to automatically
-    # run the profiler on when there is an active transaction
-    profile_lifecycle="trace",`
-        : ''
-    }`
-        : `# Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0`
-    }
-)${
-  traceLifecycle === 'manual'
     ? `
 
 def slow_function():
@@ -475,70 +418,6 @@ export const featureFlagOnboarding: OnboardingConfig = {
   verify: () => [],
   nextSteps: () => [],
 };
-export const getPythonProfilingOnboarding = ({
-  basePackage = 'sentry-sdk',
-  traceLifecycle = 'trace',
-}: {
-  basePackage?: string;
-  traceLifecycle?: 'manual' | 'trace';
-} = {}): OnboardingConfig => ({
-  install: () => [
-    {
-      type: StepType.INSTALL,
-      description: tct(
-        'To enable profiling, update the Sentry SDK to a compatible version ([code:2.24.1] or higher).',
-        {
-          code: <code />,
-        }
-      ),
-      configurations: [
-        {
-          language: 'bash',
-          code: getProfilingInstallSnippet(basePackage),
-        },
-      ],
-    },
-  ],
-  configure: (params: Params) => [
-    {
-      type: StepType.CONFIGURE,
-      description: t(
-        "Import and initialize the Sentry SDK early in your application's setup:"
-      ),
-      configurations: [
-        {
-          language: 'python',
-          code: getProfilingSdkSetupSnippet(params, traceLifecycle),
-        },
-        {
-          description: tct(
-            'For more detailed information on profiling, see the [link:profiling documentation].',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://docs.sentry.io/platforms/javascript/guides/node/profiling/node-profiling/`}
-                />
-              ),
-            }
-          ),
-        },
-      ],
-      additionalInfo: params.isProfilingSelected &&
-        params.profilingOptions?.defaultProfilingMode === 'continuous' && (
-          <AlternativeConfiguration />
-        ),
-    },
-  ],
-
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'Verify that profiling is working correctly by simply using your application.'
-      ),
-    },
-  ],
-});
 
 const docs: Docs = {
   onboarding,

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -135,7 +135,8 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))`,
   },
 };
 
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
+const getInstallSnippet = (basePackage: string, minimumVersion: string) =>
+  `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -215,7 +216,7 @@ const onboarding: OnboardingConfig = {
                 )
               : undefined,
           language: 'bash',
-          code: getInstallSnippet(),
+          code: getInstallSnippet('sentry_sdk', '1.18.0'),
         },
       ],
     },
@@ -417,13 +418,90 @@ export const featureFlagOnboarding: OnboardingConfig = {
   verify: () => [],
   nextSteps: () => [],
 };
+export const getPythonProfilingOnboarding = ({
+  basePackage = 'sentry_sdk',
+}: {
+  basePackage?: string;
+} = {}): OnboardingConfig => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'To enable profiling, update the Sentry SDK to a compatible version ([code:1.18.0] or higher).',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: getInstallSnippet(basePackage, '1.18.0'),
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'Set up the [code:nodeProfilingIntegration] in your [code:Sentry.init()] call.',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: [
+            {
+              label: 'Python',
+              value: 'python',
+              language: 'python',
+              code: getSdkSetupSnippet(params),
+            },
+          ],
+          additionalInfo: tct(
+            'If you need more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/javascript/guides/node/profiling/node-profiling/#enabling-manual-lifecycle-profiling`}
+                />
+              ),
+            }
+          ),
+        },
+        {
+          description: tct(
+            'For more detailed information on profiling, see the [link:profiling documentation].',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/javascript/guides/node/profiling/node-profiling/`}
+                />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'Verify that profiling is working correctly by simply using your application.'
+      ),
+    },
+  ],
+});
 
 const docs: Docs = {
   onboarding,
   performanceOnboarding,
-  profilingOnboarding: onboarding,
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
+  profilingOnboarding: getPythonProfilingOnboarding(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -198,7 +198,10 @@ sentry_sdk.profiler.stop_profiler()`
     : ''
 }`;
 
-const getProfilingSdkSetupSnippet = (params: Params, withExample: boolean) => `
+const getProfilingSdkSetupSnippet = (
+  params: Params,
+  traceLifecycle: 'manual' | 'trace'
+) => `
 import sentry_sdk
 
 sentry_sdk.init(
@@ -210,14 +213,21 @@ sentry_sdk.init(
       params.profilingOptions?.defaultProfilingMode === 'continuous'
         ? `# Set profile_session_sample_rate to 1.0 to profile 100%
     # of profile sessions.
-    profile_session_sample_rate=1.0,`
+    profile_session_sample_rate=1.0,${
+      traceLifecycle === 'trace'
+        ? `
+    # Set profile_lifecycle to "trace" to automatically
+    # run the profiler on when there is an active transaction
+    profile_lifecycle="trace",`
+        : ''
+    }`
         : `# Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`
+    profiles_sample_rate=1.0`
     }
 )${
-  withExample
+  traceLifecycle === 'manual'
     ? `
 
 def slow_function():
@@ -467,10 +477,10 @@ export const featureFlagOnboarding: OnboardingConfig = {
 };
 export const getPythonProfilingOnboarding = ({
   basePackage = 'sentry-sdk',
-  withExample = false,
+  traceLifecycle = 'trace',
 }: {
   basePackage?: string;
-  withExample?: boolean;
+  traceLifecycle?: 'manual' | 'trace';
 } = {}): OnboardingConfig => ({
   install: () => [
     {
@@ -498,7 +508,7 @@ export const getPythonProfilingOnboarding = ({
       configurations: [
         {
           language: 'python',
-          code: getProfilingSdkSetupSnippet(params, withExample),
+          code: getProfilingSdkSetupSnippet(params, traceLifecycle),
         },
         {
           description: tct(
@@ -535,7 +545,7 @@ const docs: Docs = {
   performanceOnboarding,
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
-  profilingOnboarding: getPythonProfilingOnboarding({withExample: true}),
+  profilingOnboarding: getPythonProfilingOnboarding({traceLifecycle: 'manual'}),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -158,7 +159,7 @@ app.run()
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[quart]'}),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -10,9 +10,9 @@ import type {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -10,6 +10,7 @@ import type {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -235,7 +236,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[rq]'}),
   crashReportOnboarding: crashReportOnboardingPython,
 };
 

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -12,9 +12,9 @@ import {
 import {
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -12,6 +12,7 @@ import {
 import {
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -123,6 +124,7 @@ const docs: Docs = {
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
+  profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[sanic]'}),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -11,9 +11,9 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -11,6 +11,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -152,7 +153,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding(),
   crashReportOnboarding: crashReportOnboardingPython,
 };
 

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -158,7 +159,9 @@ app = Starlette(routes=[
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding({
+    basePackage: 'sentry-sdk[starlette]',
+  }),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -14,6 +14,7 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -179,7 +180,7 @@ asyncio.run(main())
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding(),
   crashReportOnboarding: crashReportOnboardingPython,
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -14,9 +14,9 @@ import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
   featureFlagOnboarding,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -11,6 +11,7 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
+  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
@@ -173,7 +174,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  profilingOnboarding: onboarding,
+  profilingOnboarding: getPythonProfilingOnboarding(),
   crashReportOnboarding: crashReportOnboardingPython,
 };
 

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -11,9 +11,9 @@ import {
 import {
   AlternativeConfiguration,
   crashReportOnboardingPython,
-  getPythonProfilingOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -1,0 +1,132 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {AlternativeConfiguration} from 'sentry/gettingStartedDocs/python/python';
+import {t, tct} from 'sentry/locale';
+
+const getProfilingInstallSnippet = (basePackage: string, minimumVersion?: string) =>
+  `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
+import type {
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+export const getPythonProfilingOnboarding = ({
+  basePackage = 'sentry-sdk',
+  traceLifecycle = 'trace',
+}: {
+  basePackage?: string;
+  traceLifecycle?: 'manual' | 'trace';
+} = {}): OnboardingConfig => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'To enable profiling, update the Sentry SDK to a compatible version ([code:2.24.1] or higher).',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: getProfilingInstallSnippet(basePackage),
+        },
+      ],
+    },
+  ],
+  configure: (params: DocsParams) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        "Import and initialize the Sentry SDK early in your application's setup:"
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getProfilingSdkSetupSnippet(params, traceLifecycle),
+        },
+        {
+          description: tct(
+            'For more detailed information on profiling, see the [link:profiling documentation].',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/javascript/guides/node/profiling/node-profiling/`}
+                />
+              ),
+            }
+          ),
+        },
+      ],
+      additionalInfo: params.isProfilingSelected &&
+        params.profilingOptions?.defaultProfilingMode === 'continuous' && (
+          <AlternativeConfiguration />
+        ),
+    },
+  ],
+
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'Verify that profiling is working correctly by simply using your application.'
+      ),
+    },
+  ],
+});
+
+const getProfilingSdkSetupSnippet = (
+  params: DocsParams,
+  traceLifecycle: 'manual' | 'trace'
+) => `
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    ${
+      params.profilingOptions?.defaultProfilingMode === 'continuous'
+        ? `# Set profile_session_sample_rate to 1.0 to profile 100%
+    # of profile sessions.
+    profile_session_sample_rate=1.0,${
+      traceLifecycle === 'trace'
+        ? `
+    # Set profile_lifecycle to "trace" to automatically
+    # run the profiler on when there is an active transaction
+    profile_lifecycle="trace",`
+        : ''
+    }`
+        : `# Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0`
+    }
+)${
+  traceLifecycle === 'manual'
+    ? `
+
+def slow_function():
+    import time
+    time.sleep(0.1)
+    return "done"
+
+def fast_function():
+    import time
+    time.sleep(0.05)
+    return "done"
+
+# Manually call start_profiler and stop_profiler
+# to profile the code in between
+sentry_sdk.profiler.start_profiler()
+
+for i in range(0, 10):
+    slow_function()
+    fast_function()
+
+# Calls to stop_profiler are optional - if you don't stop the profiler, it will keep profiling
+# your application until the process exits or stop_profiler is called.
+sentry_sdk.profiler.stop_profiler()`
+    : ''
+}`;


### PR DESCRIPTION
- add custom, minimal profiling onboarding instructions in utils
- add a new function to generate the install instructions that has a parameter for package extra (e.g. `sentry-sdk` vs `sentry-sdk[django]`) to generate it for profiling instructions
- show an example for profiling only on vanilla python


Vanilla Python: 
![Screenshot 2025-04-08 at 10 47 48](https://github.com/user-attachments/assets/973ccf3f-1200-4a3a-8e39-aca8d0f8ccb9)

Framework: 
![Screenshot 2025-04-08 at 14 04 03](https://github.com/user-attachments/assets/9494128d-3c8e-42b6-b37f-60ab5f020507)