### PR TITLE
WIP

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -392,6 +392,7 @@ class EventManager:
         )
 
         pre_normalize_type = self._data.get("type")
+        # XXX: We reject main_exception_id here, thus, the SDK cannot set it
         self._data = rust_normalizer.normalize_event(dict(self._data), json_loads=orjson.loads)
 
         # XXX: This is a hack to make generic events work (for now?). I'm not sure whether we should

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -703,7 +703,9 @@ def filter_exceptions_for_exception_groups(
         else:
             # At least one exception is missing mechanism ids, so we can't continue with the filter.
             # Exit early to not waste perf.
-            return exceptions
+            # Reversing it will cause splitting groups :(
+            # We are going to need a project transition to fix this
+            return list(reversed(exceptions))
 
     # This gets the child exceptions for an exception using the exception_id from the mechanism.
     # That data is guaranteed to exist at this point.

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2675,7 +2675,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert sdk7_event.group is not None
         assert sdk7_event.data.get("main_exception_id") is None
 
-        # In SDK 8 we have exception_ids and main_exception_id
+        # In SDK 8 we have exception_ids
         concurrent_exception["mechanism"] = {"type": "chained", "exception_id": 1, "parent_id": 0}
         runtime_exception["mechanism"] = {
             "type": "UncaughtExceptionHandler",
@@ -2695,7 +2695,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         ).save(self.project.id)
         assert sdk8_event.group is not None
         # This is what our customer is seeing
-        assert sdk8_event.group.id != sdk7_event.group.id
+        assert sdk8_event.group.id == sdk7_event.group.id
 
 
 class ReleaseIssueTest(TestCase):


### PR DESCRIPTION
This shows that the incorrect exception ID causes misgrouping.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
