### PR TITLE
ref: convert BatchedOccurence test to TransactionTestCase

### DIFF
--- a/tests/sentry/issues/test_run.py
+++ b/tests/sentry/issues/test_run.py
@@ -19,7 +19,7 @@ from sentry.issues.producer import (
 )
 from sentry.issues.run import OccurrenceStrategyFactory
 from sentry.issues.status_change_message import StatusChangeMessage
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.types.group import PriorityLevel
@@ -159,7 +159,12 @@ class TestOccurrenceConsumer(TestCase, OccurrenceTestMixin):
         mock_logger.exception.assert_called_once_with("failed to process message payload")
 
 
-class TestBatchedOccurrenceConsumer(TestCase, OccurrenceTestMixin, StatusChangeTestMixin):
+# XXX: this is a TransactionTestCase because it creates database objects in a
+# background thread which otherwise do not get cleaned up by django's
+# transaction-based cleanup
+class TestBatchedOccurrenceConsumer(
+    TransactionTestCase, OccurrenceTestMixin, StatusChangeTestMixin
+):
     def build_mock_message(
         self, data: MutableMapping[str, Any] | None, topic: ArroyoTopic | None = None
     ) -> mock.Mock:


### PR DESCRIPTION
fixes this test pollution:

```console
$ pytest tests/sentry/issues/test_run.py::TestBatchedOccurrenceConsumer::test_saves_issue_occurrence tests/sentry/utils/mockdata/test_core.py::TestMockData::test_main_default_setup
============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /home/asottile/workspace/sentry
configfile: pyproject.toml
plugins: cov-4.0.0, metadata-3.1.1, rerunfailures-15.0, pytest_sentry-0.3.0, django-4.9.0, time-machine-2.16.0, json-report-1.5.0, xdist-3.0.2, fail-slow-0.3.0, anyio-3.7.1
collected 2 items                                                              

tests/sentry/issues/test_run.py .                                        [ 50%]
tests/sentry/utils/mockdata/test_core.py F                               [100%]

=================================== FAILURES ===================================
_____________________ TestMockData.test_main_default_setup _____________________
tests/sentry/utils/mockdata/test_core.py:80: in test_main_default_setup
    assert Environment.objects.count() == 6, "Should environments"
E   AssertionError: Should environments
E   assert 7 == 6

<about a thousand lines omitted>
```

<!-- Describe your PR here. -->