### PR TITLE
nit(aci): create DataCondition with condition_group_id

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -14,7 +14,7 @@ class DataConditionKwargs:
     type: str
     comparison: Any
     condition_result: bool
-    condition_group: DataConditionGroup
+    condition_group_id: int
 
 
 def create_every_event_data_condition(
@@ -24,7 +24,7 @@ def create_every_event_data_condition(
         type=Condition.EVERY_EVENT,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -35,7 +35,7 @@ def create_reappeared_event_data_condition(
         type=Condition.REAPPEARED_EVENT,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -46,7 +46,7 @@ def create_regression_event_data_condition(
         type=Condition.REGRESSION_EVENT,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -57,7 +57,7 @@ def create_existing_high_priority_issue_data_condition(
         type=Condition.EXISTING_HIGH_PRIORITY_ISSUE,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -74,7 +74,7 @@ def create_event_attribute_data_condition(
         type=Condition.EVENT_ATTRIBUTE,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -85,7 +85,7 @@ def create_first_seen_event_data_condition(
         type=Condition.FIRST_SEEN_EVENT,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -96,7 +96,7 @@ def create_new_high_priority_issue_data_condition(
         type=Condition.NEW_HIGH_PRIORITY_ISSUE,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -109,7 +109,7 @@ def create_level_data_condition(
         type=Condition.LEVEL,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -127,7 +127,7 @@ def create_tagged_event_data_condition(
         type=Condition.TAGGED_EVENT,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -155,7 +155,7 @@ def create_age_comparison_data_condition(
         type=Condition.AGE_COMPARISON,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -171,7 +171,7 @@ def create_assigned_to_data_condition(
         type=Condition.ASSIGNED_TO,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -186,7 +186,7 @@ def create_issue_category_data_condition(
         type=Condition.ISSUE_CATEGORY,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -201,7 +201,7 @@ def create_issue_occurrences_data_condition(
         type=Condition.ISSUE_OCCURRENCES,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -212,7 +212,7 @@ def create_latest_release_data_condition(
         type=Condition.LATEST_RELEASE,
         comparison=True,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -228,7 +228,7 @@ def create_latest_adopted_release_data_condition(
         type=Condition.LATEST_ADOPTED_RELEASE,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -256,7 +256,7 @@ def create_base_event_frequency_data_condition(
         type=type,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 
@@ -340,7 +340,7 @@ def create_event_unique_user_frequency_condition_with_conditions(
         type=type,
         comparison=comparison,
         condition_result=True,
-        condition_group=dcg,
+        condition_group_id=dcg.id,
     )
 
 


### PR DESCRIPTION
In the migration, for some reason it errors out when creating a `DataCondition` with the `condition_group` directly, but using the id works.