### PR TITLE
ref(perf): Display duration breakdown as line chart

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -4,7 +4,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
@@ -113,7 +113,7 @@ function useDurationBreakdownVisualization({
 
   const timeSeries = eapSeriesDataToTimeSeries(spanSeriesData);
 
-  const plottables = timeSeries.map(series => new Area(series));
+  const plottables = timeSeries.map(series => new Line(series));
 
   return <TimeSeriesWidgetVisualization plottables={plottables} />;
 }


### PR DESCRIPTION
For the new transaction summary, changes the duration breakdown chart from an area chart to line chart. This is because area charts should be used only when each series is meant to be interpreted as individual components of a total. However, we are plotting percentiles here and so they're separate values that don't add up as a total. 

![image](https://github.com/user-attachments/assets/e5414c23-59cd-46d8-9051-f6cd5a9d263f)
