### PR TITLE
feat(explore): Update get explore queries to return starred position and add sort by most starred option

### DIFF
--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -34,6 +34,7 @@ class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
     lastVisited: str
     createdBy: UserSerializerResponse
     starred: bool
+    position: int | None
 
 
 @register(ExploreSavedQuery)
@@ -41,12 +42,12 @@ class ExploreSavedQueryModelSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         result: DefaultDict[str, dict] = defaultdict(lambda: {"created_by": {}})
 
-        starred_query_ids = set(
+        starred_queries = dict(
             ExploreSavedQueryStarred.objects.filter(
                 explore_saved_query__in=item_list,
                 user_id=user.id,
                 organization=item_list[0].organization if item_list else None,
-            ).values_list("explore_saved_query_id", flat=True)
+            ).values_list("explore_saved_query_id", "position")
         )
 
         service_serialized = user_service.serialize_many(
@@ -65,7 +66,13 @@ class ExploreSavedQueryModelSerializer(Serializer):
             result[explore_saved_query]["created_by"] = serialized_users.get(
                 str(explore_saved_query.created_by_id)
             )
-            result[explore_saved_query]["starred"] = explore_saved_query.id in starred_query_ids
+            result[explore_saved_query]["starred"] = explore_saved_query.id in starred_queries
+            if explore_saved_query.id in starred_queries:
+                result[explore_saved_query]["starred"] = True
+                result[explore_saved_query]["position"] = starred_queries[explore_saved_query.id]
+            else:
+                result[explore_saved_query]["starred"] = False
+                result[explore_saved_query]["position"] = None
 
         return result
 
@@ -89,6 +96,7 @@ class ExploreSavedQueryModelSerializer(Serializer):
             "lastVisited": obj.last_visited,
             "createdBy": attrs.get("created_by"),
             "starred": attrs.get("starred"),
+            "position": attrs.get("position"),
         }
 
         for key in query_keys:

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -66,7 +66,6 @@ class ExploreSavedQueryModelSerializer(Serializer):
             result[explore_saved_query]["created_by"] = serialized_users.get(
                 str(explore_saved_query.created_by_id)
             )
-            result[explore_saved_query]["starred"] = explore_saved_query.id in starred_queries
             if explore_saved_query.id in starred_queries:
                 result[explore_saved_query]["starred"] = True
                 result[explore_saved_query]["position"] = starred_queries[explore_saved_query.id]

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -128,6 +128,15 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
                     queryset = queryset.annotate(starred_count=Count("exploresavedquerystarred"))
                     order_by.append("-starred_count")
 
+                elif sort_by == "starred":
+                    order_by.append(
+                        Case(
+                            When(exploresavedquerystarred__isnull=False, then=0),
+                            default=1,
+                            output_field=IntegerField(),
+                        ),
+                    )
+
         if len(order_by) == 0:
             order_by.append("lower_name")
 

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -90,49 +90,50 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
                 else:
                     queryset = queryset.none()
 
-        sort_by = request.query_params.get("sortBy")
-        if sort_by and sort_by.startswith("-"):
-            sort_by, desc = sort_by[1:], True
-        else:
-            desc = False
+        order_by: list[Case | str] = []
 
-        if sort_by == "name":
-            order_by: list[Case | str] = [
-                "-lower_name" if desc else "lower_name",
-                "-date_added",
-            ]
+        sort_by_list = request.query_params.getlist("sortBy")
+        if sort_by_list and len(sort_by_list) > 0:
+            for sort_by in sort_by_list:
+                if sort_by.startswith("-"):
+                    sort_by, desc = sort_by[1:], True
+                else:
+                    desc = False
 
-        elif sort_by == "dateAdded":
-            order_by = ["-date_added" if desc else "date_added"]
+                if sort_by == "name":
+                    order_by.append("-lower_name" if desc else "lower_name")
 
-        elif sort_by == "dateUpdated":
-            order_by = ["-date_updated" if desc else "date_updated"]
+                elif sort_by == "dateAdded":
+                    order_by.append("-date_added" if desc else "date_added")
 
-        elif sort_by == "mostPopular":
-            order_by = [
-                "visits" if desc else "-visits",
-                "-date_updated",
-            ]
+                elif sort_by == "dateUpdated":
+                    order_by.append("-date_updated" if desc else "date_updated")
 
-        elif sort_by == "recentlyViewed":
-            order_by = ["last_visited" if desc else "-last_visited"]
+                elif sort_by == "mostPopular":
+                    order_by.append("visits" if desc else "-visits")
 
-        elif sort_by == "myqueries":
-            order_by = [
-                Case(
-                    When(created_by_id=request.user.id, then=-1),
-                    default="created_by_id",
-                    output_field=IntegerField(),
-                ),
-                "-date_added",
-            ]
+                elif sort_by == "recentlyViewed":
+                    order_by.append("last_visited" if desc else "-last_visited")
 
-        elif sort_by == "mostStarred":
-            queryset = queryset.annotate(starred_count=Count("exploresavedquerystarred"))
-            order_by = ["-starred_count", "-date_added"]
+                elif sort_by == "myqueries":
+                    order_by.append(
+                        Case(
+                            When(created_by_id=request.user.id, then=-1),
+                            default="created_by_id",
+                            output_field=IntegerField(),
+                        ),
+                    )
 
-        else:
-            order_by = ["lower_name"]
+                elif sort_by == "mostStarred":
+                    queryset = queryset.annotate(starred_count=Count("exploresavedquerystarred"))
+                    order_by.append("-starred_count")
+
+        if len(order_by) == 0:
+            order_by.append("lower_name")
+
+        #  Finally we always at least secondarily sort by dateAdded
+        if "dateAdded" not in sort_by_list and "-dateAdded" not in sort_by_list:
+            order_by.append("-date_added")
 
         exclude = request.query_params.get("exclude")
         if exclude == "shared":
@@ -140,9 +141,9 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         elif exclude == "owned":
             queryset = queryset.exclude(created_by_id=request.user.id)
 
-        starred_queries = request.query_params.get("starred")
+        starred = request.query_params.get("starred")
 
-        if starred_queries == "1":
+        if starred == "1":
             queryset = (
                 queryset.filter(
                     id__in=ExploreSavedQueryStarred.objects.filter(

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -343,6 +343,65 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert response.data[2]["starred"] == 0
         assert response.data[2]["position"] is None
 
+    def test_get_sortby_multiple(self):
+        query = {"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]}
+        model_a = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Query A",
+            query=query,
+            last_visited=before_now(minutes=30),
+        )
+        model_a.set_projects(self.project_ids)
+
+        model_b = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Query B",
+            query=query,
+            last_visited=before_now(minutes=20),
+        )
+        model_b.set_projects(self.project_ids)
+
+        model_c = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Query C",
+            query=query,
+            last_visited=before_now(minutes=10),
+        )
+        model_c.set_projects(self.project_ids)
+
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id,
+            explore_saved_query=model_a,
+            position=1,
+        )
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id,
+            explore_saved_query=model_b,
+            position=2,
+        )
+
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url, data={"sortBy": ["mostStarred", "recentlyViewed"]})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 4
+        assert response.data[0]["name"] == "Query B"
+        assert response.data[0]["starred"] == 1
+        assert response.data[0]["position"] == 2
+        assert response.data[1]["name"] == "Query A"
+        assert response.data[1]["starred"] == 1
+        assert response.data[1]["position"] == 1
+        assert response.data[2]["name"] == "Test query"
+        assert response.data[2]["starred"] == 0
+        assert response.data[2]["position"] is None
+        assert response.data[3]["name"] == "Query C"
+        assert response.data[3]["starred"] == 0
+        assert response.data[3]["position"] is None
+
     def test_post_require_mode(self):
         with self.feature(self.feature_name):
             response = self.client.post(

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -291,7 +291,7 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Starred query"
-        assert response.data[0]["starred"] == 1
+        assert response.data[0]["starred"] is True
         assert response.data[0]["position"] == 1
 
     def test_get_most_starred_queries(self):
@@ -334,13 +334,13 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 3
         assert response.data[0]["name"] == "Most starred query"
-        assert response.data[0]["starred"] == 1
+        assert response.data[0]["starred"] is True
         assert response.data[0]["position"] == 1
         assert response.data[1]["name"] == "Second most starred query"
-        assert response.data[1]["starred"] == 1
+        assert response.data[1]["starred"] is True
         assert response.data[1]["position"] == 2
         assert response.data[2]["name"] == "Test query"
-        assert response.data[2]["starred"] == 0
+        assert response.data[2]["starred"] is False
         assert response.data[2]["position"] is None
 
     def test_get_sortby_multiple(self):
@@ -390,16 +390,16 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 4
         assert response.data[0]["name"] == "Query B"
-        assert response.data[0]["starred"] == 1
+        assert response.data[0]["starred"] is True
         assert response.data[0]["position"] == 2
         assert response.data[1]["name"] == "Query A"
-        assert response.data[1]["starred"] == 1
+        assert response.data[1]["starred"] is True
         assert response.data[1]["position"] == 1
         assert response.data[2]["name"] == "Test query"
-        assert response.data[2]["starred"] == 0
+        assert response.data[2]["starred"] is False
         assert response.data[2]["position"] is None
         assert response.data[3]["name"] == "Query C"
-        assert response.data[3]["starred"] == 0
+        assert response.data[3]["starred"] is False
         assert response.data[3]["position"] is None
 
     def test_post_require_mode(self):

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -386,7 +386,7 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         )
 
         with self.feature(self.feature_name):
-            response = self.client.get(self.url, data={"sortBy": ["mostStarred", "recentlyViewed"]})
+            response = self.client.get(self.url, data={"sortBy": ["starred", "recentlyViewed"]})
         assert response.status_code == 200, response.content
         assert len(response.data) == 4
         assert response.data[0]["name"] == "Query B"

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -292,6 +292,56 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Starred query"
         assert response.data[0]["starred"] == 1
+        assert response.data[0]["position"] == 1
+
+    def test_get_most_starred_queries(self):
+        query = {"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]}
+        model = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Most starred query",
+            query=query,
+        )
+        second_model = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Second most starred query",
+            query=query,
+        )
+        model.set_projects(self.project_ids)
+        second_model.set_projects(self.project_ids)
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id,
+            explore_saved_query=model,
+            position=1,
+        )
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id + 1,
+            explore_saved_query=model,
+            position=1,
+        )
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id,
+            explore_saved_query=second_model,
+            position=2,
+        )
+
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url, data={"sortBy": "mostStarred"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == "Most starred query"
+        assert response.data[0]["starred"] == 1
+        assert response.data[0]["position"] == 1
+        assert response.data[1]["name"] == "Second most starred query"
+        assert response.data[1]["starred"] == 1
+        assert response.data[1]["position"] == 2
+        assert response.data[2]["name"] == "Test query"
+        assert response.data[2]["starred"] == 0
+        assert response.data[2]["position"] is None
 
     def test_post_require_mode(self):
         with self.feature(self.feature_name):


### PR DESCRIPTION
- Updates the `GET` explore saved queries endpoint to also return the starred position of each query (in the serializer). 
- Updates the endpoint to return queries in order of their starred position when `starred_queries` is true.
- Adds a `mostStarred` sort by option that returns queries in order of most starred.
- Updates endpoint sort by query param to be a list, to allow secondary sort selection by the user.


