### PR TITLE
ref: remove unnecessary double copy for log statement

### DIFF
--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -119,8 +119,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if request.GET.get("useReranking"):
             similar_issues_params["use_reranking"] = request.GET["useReranking"] == "true"
 
-        extra: dict[str, Any] = dict(similar_issues_params.copy())
-        logger.info("Similar issues embeddings parameters", extra=extra)
+        logger.info("Similar issues embeddings parameters", extra=similar_issues_params)
 
         results = get_similarity_data_from_seer(similar_issues_params)
 


### PR DESCRIPTION
looks like this was originally copied in 06abdc1cbde8429a72c24e1aa1d38c29213dc3e0 to allow the log parameters to be different

but then the difference was removed in 03cc3cdee634b4f531553282f4fa68ed15510b69

<!-- Describe your PR here. -->