### PR TITLE
feat(shared-views): create separate starred endpoint

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchviewstarred.py
+++ b/src/sentry/api/serializers/models/groupsearchviewstarred.py
@@ -1,0 +1,42 @@
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.groupsearchview import (
+    GroupSearchViewSerializer,
+    GroupSearchViewSerializerResponse,
+)
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.savedsearch import SORT_LITERALS
+
+
+class GroupSearchViewStarredSerializerResponse(GroupSearchViewSerializerResponse):
+    id: str
+    name: str
+    query: str
+    querySort: SORT_LITERALS
+    projects: list[int]
+    environments: list[str]
+    timeFilters: dict
+    lastVisited: str | None
+    dateCreated: str
+    dateUpdated: str
+
+
+@register(GroupSearchViewStarred)
+class GroupSearchViewStarredSerializer(Serializer):
+    def __init__(self, *args, **kwargs):
+        self.has_global_views = kwargs.pop("has_global_views", None)
+        self.default_project = kwargs.pop("default_project", None)
+        self.organization = kwargs.pop("organization", None)
+        super().__init__(*args, **kwargs)
+
+    def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewStarredSerializerResponse:
+        serialized_view: GroupSearchViewSerializerResponse = serialize(
+            obj.group_search_view,
+            user,
+            serializer=GroupSearchViewSerializer(
+                has_global_views=self.has_global_views,
+                default_project=self.default_project,
+                organization=self.organization,
+            ),
+        )
+
+        return serialized_view

--- a/src/sentry/api/serializers/models/groupsearchviewstarred.py
+++ b/src/sentry/api/serializers/models/groupsearchviewstarred.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.groupsearchview import (
     GroupSearchViewSerializer,
@@ -7,7 +9,7 @@ from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SORT_LITERALS
 
 
-class GroupSearchViewStarredSerializerResponse(GroupSearchViewSerializerResponse):
+class GroupSearchViewStarredSerializerResponse(TypedDict):
     id: str
     name: str
     query: str

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -193,8 +193,9 @@ from sentry.issues.endpoints import (
     OrganizationGroupIndexEndpoint,
     OrganizationGroupIndexStatsEndpoint,
     OrganizationGroupSearchViewDetailsEndpoint,
+    OrganizationGroupSearchViewDetailsStarredEndpoint,
     OrganizationGroupSearchViewsEndpoint,
-    OrganizationGroupSearchViewStarredEndpoint,
+    OrganizationGroupSearchViewsStarredEndpoint,
     OrganizationGroupSearchViewVisitEndpoint,
     OrganizationIssuesCountEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
@@ -1833,6 +1834,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-group-search-views",
     ),
     re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/starred/$",
+        OrganizationGroupSearchViewsStarredEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-views-starred",
+    ),
+    re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/$",
         OrganizationGroupSearchViewDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-details",
@@ -1844,7 +1850,7 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/starred/$",
-        OrganizationGroupSearchViewStarredEndpoint.as_view(),
+        OrganizationGroupSearchViewDetailsStarredEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-starred",
     ),
     re_path(

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -16,9 +16,12 @@ from .organization_eventid import EventIdLookupEndpoint
 from .organization_group_index import OrganizationGroupIndexEndpoint
 from .organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
 from .organization_group_search_view_details import OrganizationGroupSearchViewDetailsEndpoint
-from .organization_group_search_view_starred import OrganizationGroupSearchViewStarredEndpoint
+from .organization_group_search_view_details_starred import (
+    OrganizationGroupSearchViewDetailsStarredEndpoint,
+)
 from .organization_group_search_view_visit import OrganizationGroupSearchViewVisitEndpoint
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
+from .organization_group_search_views_starred import OrganizationGroupSearchViewsStarredEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
 from .organization_searches import OrganizationSearchesEndpoint
@@ -54,8 +57,9 @@ __all__ = (
     "OrganizationGroupIndexStatsEndpoint",
     "OrganizationGroupSearchViewsEndpoint",
     "OrganizationGroupSearchViewDetailsEndpoint",
-    "OrganizationGroupSearchViewStarredEndpoint",
+    "OrganizationGroupSearchViewDetailsStarredEndpoint",
     "OrganizationGroupSearchViewVisitEndpoint",
+    "OrganizationGroupSearchViewsStarredEndpoint",
     "OrganizationIssuesCountEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
@@ -29,7 +29,7 @@ class MemberPermission(OrganizationPermission):
 
 
 @region_silo_endpoint
-class OrganizationGroupSearchViewStarredEndpoint(OrganizationEndpoint):
+class OrganizationGroupSearchViewDetailsStarredEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -1,0 +1,108 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.paginator import SequencePaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.groupsearchviewstarred import GroupSearchViewStarredSerializer
+from sentry.models.groupsearchview import DEFAULT_VIEWS
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.team import Team
+from sentry.users.models.user import User
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Retrieve a list of starred views for the current organization member.
+        """
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        has_global_views = features.has("organizations:global-views", organization)
+
+        default_project = None
+        if not has_global_views:
+            default_project = pick_default_project(organization, request.user)
+            if default_project is None:
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"detail": "You do not have access to any projects."},
+                )
+
+        starred_views = GroupSearchViewStarred.objects.filter(
+            organization=organization, user_id=request.user.id
+        )
+
+        # TODO(msun): Remove when tabbed views are deprecated
+        if not starred_views.exists():
+            return self.paginate(
+                request=request,
+                paginator=SequencePaginator(
+                    [
+                        (
+                            idx,
+                            {
+                                **view,
+                                "projects": (
+                                    []
+                                    if has_global_views
+                                    else [pick_default_project(organization, request.user)]
+                                ),
+                            },
+                        )
+                        for idx, view in enumerate(DEFAULT_VIEWS)
+                    ]
+                ),
+                on_results=lambda results: serialize(results, request.user),
+            )
+
+        return self.paginate(
+            request=request,
+            queryset=starred_views,
+            order_by="position",
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                serializer=GroupSearchViewStarredSerializer(
+                    has_global_views=has_global_views,
+                    default_project=default_project,
+                    organization=organization,
+                ),
+            ),
+        )
+
+
+def pick_default_project(org: Organization, user: User | AnonymousUser) -> int | None:
+    user_teams = Team.objects.get_for_user(organization=org, user=user)
+    user_team_ids = [team.id for team in user_teams]
+    default_user_project = (
+        Project.objects.get_for_team_ids(user_team_ids)
+        .order_by("slug")
+        .values_list("id", flat=True)
+        .first()
+    )
+    return default_user_project

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details_starred.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
-class OrganizationGroupSearchViewStarredEndpointTest(APITestCase):
+class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-group-search-view-starred"
     method = "post"
 
@@ -25,11 +25,8 @@ class OrganizationGroupSearchViewStarredEndpointTest(APITestCase):
         )
 
     def create_view(self, user_id=None, visibility=None, starred=False):
-        if user_id is None:
-            user_id = self.user.id
-
-        if visibility is None:
-            visibility = GroupSearchViewVisibility.ORGANIZATION
+        user_id = user_id or self.user.id
+        visibility = visibility or GroupSearchViewVisibility.OWNER
 
         view = GroupSearchView.objects.create(
             name="Test View",

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.users.models.user import User
+
+
+class OrganizationGroupSearchViewsStarredEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-views-starred"
+    method = "get"
+
+    def create_view(
+        self,
+        user: User,
+        name: str = "Test View",
+        starred: bool = False,
+        last_visited: datetime | None = None,
+    ) -> GroupSearchView:
+        view = GroupSearchView.objects.create(
+            name=name,
+            organization=self.organization,
+            user_id=user.id,
+            query="is:unresolved",
+            query_sort="date",
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
+        )
+
+        if starred:
+            GroupSearchViewStarred.objects.insert_starred_view(
+                user_id=user.id,
+                organization=self.organization,
+                view=view,
+            )
+        if last_visited:
+            GroupSearchViewLastVisited.objects.create(
+                user_id=user.id,
+                organization=self.organization,
+                group_search_view=view,
+                last_visited=last_visited,
+            )
+        return view
+
+    def star_view(self, user: User, view: GroupSearchView):
+        GroupSearchViewStarred.objects.insert_starred_view(
+            user_id=user.id,
+            organization=self.organization,
+            view=view,
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_simple_case(self):
+        self.login_as(user=self.user)
+        view_1 = self.create_view(user=self.user, name="Starred View 1", starred=True)
+        view_2 = self.create_view(user=self.user, name="Starred View 2", starred=True)
+        view_3 = self.create_view(user=self.user, name="Starred View 3", starred=True)
+        # These views should not appear in the response
+        self.create_view(user=self.user, name="Unstarred View 1", starred=False)
+        self.create_view(user=self.user, name="Unstarred View 2", starred=False)
+        self.create_view(user=self.user, name="Unstarred View 3", starred=False)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 3
+        assert response.data[0]["id"] == str(view_1.id)
+        assert response.data[1]["id"] == str(view_2.id)
+        assert response.data[2]["id"] == str(view_3.id)
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_views_starred_by_many_users(self):
+        user_1 = self.user
+        user_2 = self.create_user()
+        self.create_member(user=user_2, organization=self.organization)
+        user_3 = self.create_user()
+        self.create_member(user=user_3, organization=self.organization)
+
+        u1_view_1 = self.create_view(user=user_1, name="Starred View 1", starred=True)
+        u1_view_2 = self.create_view(user=user_1, name="Starred View 2", starred=True)
+        u1_view_3 = self.create_view(user=user_1, name="Starred View 3", starred=True)
+
+        # User 2 stars their own view, and view_1 and view_2
+        u2_view = self.create_view(user=user_2, name="User 2 View", starred=True)
+        self.star_view(user=user_2, view=u1_view_1)
+        self.star_view(user=user_2, view=u1_view_2)
+
+        # User 3 star view_1
+        self.star_view(user=user_3, view=u1_view_1)
+
+        self.login_as(user=user_1)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 3
+        assert response.data[0]["id"] == str(u1_view_1.id)
+        assert response.data[1]["id"] == str(u1_view_2.id)
+        assert response.data[2]["id"] == str(u1_view_3.id)
+
+        self.login_as(user=user_2)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 3
+        assert response.data[0]["id"] == str(u2_view.id)
+        assert response.data[1]["id"] == str(u1_view_1.id)
+        assert response.data[2]["id"] == str(u1_view_2.id)
+
+        self.login_as(user=user_3)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(u1_view_1.id)


### PR DESCRIPTION
This endpoint is necessary now because the `GET` `/group-search-views/`  endpoint now returns all sorts of extra data to support the "All Views" page (e.g. starred, popularity, user). 

This new endpoint now supports getting just a user's starred views, ordered by position. I will remove the duplicate logic from the old GET endpoint after refactoring the frontend to use this. 