### PR TITLE
fix(nav): Disable prompts query when nothing to check

### DIFF
--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -136,6 +136,9 @@ function PrimaryNavigationQuotaExceeded({
     features: promptsToCheck,
     organization,
     daysToSnooze: -1 * getDaysSinceDate(subscription.onDemandPeriodEnd),
+    options: {
+      enabled: promptsToCheck.length > 0,
+    },
   });
 
   const {


### PR DESCRIPTION
Stops attempts to query for quota exceeded prompts activity when there are no prompts to check (unnecessary 400s)