### PR TITLE
ref(shared-views): Do not delete views on member deletion

### DIFF
--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -1,15 +1,9 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
-from sentry.models.groupsearchview import GroupSearchView
+from sentry.deletions.base import BaseRelation, ModelDeletionTask
 from sentry.models.organizationmember import OrganizationMember
 
 
 class OrganizationMemberDeletionTask(ModelDeletionTask[OrganizationMember]):
     def get_child_relations(self, instance: OrganizationMember) -> list[BaseRelation]:
-        relations: list[BaseRelation] = [
-            ModelRelation(
-                GroupSearchView,
-                {"user_id": instance.user_id, "organization_id": instance.organization_id},
-            )
-        ]
+        relations: list[BaseRelation] = []
 
         return relations

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -1,5 +1,4 @@
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
-from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organizationmember import OrganizationMember
 from sentry.testutils.cases import APITestCase, TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
@@ -10,53 +9,9 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
         organization = self.create_organization(name="test")
         user = self.create_user()
         member = self.create_member(organization=organization, user=user)
-        custom_view = GroupSearchView.objects.create(
-            organization=organization,
-            user_id=user.id,
-            name="Custom View",
-            query="is:unresolved",
-            query_sort="date",
-        )
-
         self.ScheduledDeletion.schedule(instance=member, days=0)
 
         with self.tasks():
             run_scheduled_deletions()
 
         assert not OrganizationMember.objects.filter(id=member.id).exists()
-        assert not GroupSearchView.objects.filter(id=custom_view.id).exists()
-
-    def test_only_org_specific_views_deleted(self):
-        # If a member is removed from an organization, only their custom views in that organization should be deleted.
-        org_one = self.create_organization(name="test1")
-        org_two = self.create_organization(name="test2")
-        user = self.create_user()
-        member_one = self.create_member(organization=org_one, user=user)
-        member_two = self.create_member(organization=org_two, user=user)
-
-        custom_view_one = GroupSearchView.objects.create(
-            organization=org_one,
-            user_id=user.id,
-            name="Custom View",
-            query="is:unresolved",
-            query_sort="date",
-        )
-
-        custom_view_two = GroupSearchView.objects.create(
-            organization=org_two,
-            user_id=user.id,
-            name="Custom View",
-            query="is:unresolved",
-            query_sort="date",
-        )
-
-        self.ScheduledDeletion.schedule(instance=member_one, days=0)
-
-        with self.tasks():
-            run_scheduled_deletions()
-
-        assert not OrganizationMember.objects.filter(id=member_one.id).exists()
-        assert not GroupSearchView.objects.filter(id=custom_view_one.id).exists()
-
-        assert OrganizationMember.objects.filter(id=member_two.id).exists()
-        assert GroupSearchView.objects.filter(id=custom_view_two.id).exists()


### PR DESCRIPTION
We no longer want to "cascade" delete groupsearchviews upon member deletion now that shared views are a thing. We want a member's views to persist that way people that starred the view can still use them. 

In the future, we may want to add a staleness check + deletion task so we avoid stale views piling up in the DB for forever. 