### PR TITLE
ref: remove retry on login_as

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -150,7 +150,6 @@ from sentry.utils.auth import SsoSession
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.not_set import NOT_SET, NotSet, default_if_not_set
 from sentry.utils.performance_issues.performance_detection import detect_performance_problems
-from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import _snuba_pool
 
@@ -302,7 +301,6 @@ class BaseTestCase(Fixtures):
 
     # TODO(dcramer): ideally superuser_sso would be False by default, but that would require
     # a lot of tests changing
-    @TimedRetryPolicy.wrap(timeout=5)
     def login_as(
         self,
         user,


### PR DESCRIPTION
on failure it makes the stacktrace a mile long and wastes 5 seconds

looks like this was added in 58b5910c5cf6c07316cd653ed10675008bcc7266 to "fix acceptance tests" however this bit of code doesn't actually go through the browser at all so it's unclear why it was added there

<!-- Describe your PR here. -->