### PR TITLE
feat(new-trace): Renaming performance_issues to occurences on TraceTreeNode

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -100,8 +100,8 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
 
   const profileId = props.event.contexts.profile?.profile_id || '';
   const issues = useMemo(() => {
-    return [...props.node.errors, ...props.node.performance_issues];
-  }, [props.node.errors, props.node.performance_issues]);
+    return [...props.node.errors, ...props.node.occurences];
+  }, [props.node.errors, props.node.occurences]);
 
   const {projects} = useProjects();
   const project = projects.find(p => p.id === props.event.projectID);
@@ -300,8 +300,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
   }
 
   function renderSpanErrorMessage() {
-    const hasErrors =
-      props.node.errors.size > 0 || props.node.performance_issues.size > 0;
+    const hasErrors = props.node.errors.size > 0 || props.node.occurences.size > 0;
 
     if (!hasErrors || isGapSpan(props.node.value)) {
       return null;

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -189,7 +189,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
           }
         }
 
-        for (const p of n.performance_issues) {
+        for (const p of n.occurences) {
           if (p.event_id === props.event.eventID) {
             return true;
           }
@@ -205,7 +205,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
             return true;
           }
         }
-        for (const p of n.performance_issues) {
+        for (const p of n.occurences) {
           if (p.event_id === props.event.eventID) {
             return true;
           }
@@ -232,7 +232,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
         if (
           isTraceErrorNode(props.tree.list[start]!) ||
           node.errors.size > 0 ||
-          node.performance_issues.size > 0
+          node.occurences.size > 0
         ) {
           preserveNodes.push(props.tree.list[start]!);
           break;
@@ -244,7 +244,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
         if (
           isTraceErrorNode(props.tree.list[start]!) ||
           node.errors.size > 0 ||
-          node.performance_issues.size > 0
+          node.occurences.size > 0
         ) {
           preserveNodes.push(props.tree.list[start]!);
           break;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1095,7 +1095,7 @@ const TraceStylingWrapper = styled('div')`
         --pattern-odd: #a5752c;
         --pattern-even: ${p => p.theme.yellow300};
       }
-      &.performance_issue {
+      &.occurence {
         --pattern-odd: #063690;
         --pattern-even: ${p => p.theme.blue300};
       }
@@ -1136,7 +1136,7 @@ const TraceStylingWrapper = styled('div')`
         --pattern-odd: #a5752c;
         --pattern-even: ${p => p.theme.yellow300};
       }
-      &.performance_issue {
+      &.occurence {
         --pattern-odd: #063690;
         --pattern-even: ${p => p.theme.blue300};
       }
@@ -1191,7 +1191,7 @@ const TraceStylingWrapper = styled('div')`
     }
     &.error,
     &.fatal,
-    &.performance_issue {
+    &.occurence {
       color: ${p => p.theme.errorText};
       --autogrouped: ${p => p.theme.error};
       --row-children-button-border-color: ${p => p.theme.error};
@@ -1242,8 +1242,8 @@ const TraceStylingWrapper = styled('div')`
       &.fatal {
         background-color: var(--error);
       }
-      &.performance_issue {
-        background-color: var(--performance-issue);
+      &.occurence {
+        background-color: var(--occurence);
       }
       &.default {
         background-color: var(--default);
@@ -1267,7 +1267,7 @@ const TraceStylingWrapper = styled('div')`
 
       &.info,
       &.warning,
-      &.performance_issue,
+      &.occurence,
       &.default,
       &.unknown {
         svg {
@@ -1314,16 +1314,6 @@ const TraceStylingWrapper = styled('div')`
         var(--pattern-odd) 101%
       );
       background-size: 25.5px 17px;
-    }
-
-    .TracePerformanceIssue {
-      position: absolute;
-      top: 0;
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-      background-color: var(--performance-issue);
-      height: 16px;
     }
 
     .TraceRightColumn.Odd {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/parentAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/parentAutogroup.tsx
@@ -20,8 +20,8 @@ export function ParentAutogroupNodeDetails({
 }: TraceTreeNodeDetailsProps<ParentAutogroupNode>) {
   const theme = useTheme();
   const issues = useMemo(() => {
-    return [...node.errors, ...node.performance_issues];
-  }, [node.errors, node.performance_issues]);
+    return [...node.errors, ...node.occurences];
+  }, [node.errors, node.occurences]);
 
   const parentTransaction = TraceTree.ParentTransaction(node);
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/siblingAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/siblingAutogroup.tsx
@@ -20,8 +20,8 @@ export function SiblingAutogroupNodeDetails({
 }: TraceTreeNodeDetailsProps<SiblingAutogroupNode>) {
   const theme = useTheme();
   const issues = useMemo(() => {
-    return [...node.errors, ...node.performance_issues];
-  }, [node.errors, node.performance_issues]);
+    return [...node.errors, ...node.occurences];
+  }, [node.errors, node.occurences]);
 
   const parentTransaction = TraceTree.ParentTransaction(node);
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -19,13 +19,12 @@ import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import type {TracePerformanceIssue} from 'sentry/utils/performance/quickTrace/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {HeaderDivider} from 'sentry/views/issueList/actions';
 import {AssigneeLabel} from 'sentry/views/issueList/actions/headers';
 
-import {isTracePerformanceIssue} from '../../../traceGuards';
+import {isTraceOccurence} from '../../../traceGuards';
 import {TraceIcons} from '../../../traceIcons';
 import type {TraceTree} from '../../../traceModels/traceTree';
 import type {TraceTreeNode} from '../../../traceModels/traceTreeNode';
@@ -102,10 +101,8 @@ function Issue(props: IssueProps) {
     );
   }
 
-  const isPerformanceIssue: boolean = isTracePerformanceIssue(props.issue);
-  const iconClassName: string = isPerformanceIssue
-    ? 'performance_issue'
-    : props.issue.level;
+  const isOccurence: boolean = isTraceOccurence(props.issue);
+  const iconClassName: string = isOccurence ? 'occurence' : props.issue.level;
 
   return isPending ? (
     <StyledLoadingIndicatorWrapper>
@@ -177,10 +174,10 @@ const IconWrapper = styled('div')`
       background-color: var(--error);
     }
   }
-  &.performance_issue {
-    border: 1px solid var(--performance-issue);
+  &.occurence {
+    border: 1px solid var(--occurence);
     ${IconBackground} {
-      background-color: var(--performance-issue);
+      background-color: var(--occurence);
     }
   }
   &.default {
@@ -198,7 +195,7 @@ const IconWrapper = styled('div')`
 
   &.info,
   &.warning,
-  &.performance_issue,
+  &.occurence,
   &.default,
   &.unknown {
     svg {
@@ -312,11 +309,11 @@ export function IssueList({issues, node, organization}: IssueListProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node, node.errors.size]);
 
-  const uniquePerformanceIssues = useMemo(() => {
-    const unique: TracePerformanceIssue[] = [];
+  const uniqueOccurences = useMemo(() => {
+    const unique: TraceTree.TraceOccurence[] = [];
     const seenIssues: Set<number> = new Set();
 
-    for (const issue of node.performance_issues) {
+    for (const issue of node.occurences) {
       if (seenIssues.has(issue.issue_id)) {
         continue;
       }
@@ -327,11 +324,11 @@ export function IssueList({issues, node, organization}: IssueListProps) {
     return unique;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [node, node.performance_issues.size]);
+  }, [node, node.occurences.size]);
 
   const uniqueIssues = useMemo(() => {
-    return [...uniquePerformanceIssues, ...uniqueErrorIssues.sort(sortIssuesByLevel)];
-  }, [uniqueErrorIssues, uniquePerformanceIssues]);
+    return [...uniqueOccurences, ...uniqueErrorIssues.sort(sortIssuesByLevel)];
+  }, [uniqueErrorIssues, uniqueOccurences]);
 
   if (!issues.length) {
     return null;
@@ -343,7 +340,7 @@ export function IssueList({issues, node, organization}: IssueListProps) {
         <IssueListHeader
           node={node}
           errorIssues={uniqueErrorIssues}
-          performanceIssues={uniquePerformanceIssues}
+          occurences={uniqueOccurences}
         />
         {uniqueIssues.slice(0, MAX_DISPLAYED_ISSUES_COUNT).map((issue, index) => (
           <Issue key={index} issue={issue} organization={organization} />
@@ -384,11 +381,11 @@ const IssueLinkWrapper = styled('div')`
 function IssueListHeader({
   node,
   errorIssues,
-  performanceIssues,
+  occurences,
 }: {
   errorIssues: TraceTree.TraceErrorIssue[];
   node: TraceTreeNode<TraceTree.NodeValue>;
-  performanceIssues: TracePerformanceIssue[];
+  occurences: TraceTree.TraceOccurence[];
 }) {
   const [singular, plural] = useMemo((): [string, string] => {
     const label = [t('Issue'), t('Issues')] as [string, string];
@@ -401,35 +398,31 @@ function IssueListHeader({
   }, [errorIssues]);
 
   const issueHeadingContent =
-    errorIssues.length + performanceIssues.length > MAX_DISPLAYED_ISSUES_COUNT
+    errorIssues.length + occurences.length > MAX_DISPLAYED_ISSUES_COUNT
       ? tct(`[count]+  issues, [link]`, {
           count: MAX_DISPLAYED_ISSUES_COUNT,
           link: <StyledIssuesLink node={node}>{t('View All')}</StyledIssuesLink>,
         })
-      : errorIssues.length > 0 && performanceIssues.length === 0
+      : errorIssues.length > 0 && occurences.length === 0
         ? tct('[count] [text]', {
             count: errorIssues.length,
             text: errorIssues.length > 1 ? plural : singular,
           })
-        : performanceIssues.length > 0 && errorIssues.length === 0
+        : occurences.length > 0 && errorIssues.length === 0
           ? tct('[count] [text]', {
-              count: performanceIssues.length,
-              text: tn(
-                'Performance issue',
-                'Performance Issues',
-                performanceIssues.length
-              ),
+              count: occurences.length,
+              text: tn('Performance issue', 'Performance Issues', occurences.length),
             })
           : tct(
               '[errors] [errorsText] and [performance_issues] [performanceIssuesText]',
               {
                 errors: errorIssues.length,
-                performance_issues: performanceIssues.length,
+                performance_issues: occurences.length,
                 errorsText: errorIssues.length > 1 ? plural : singular,
                 performanceIssuesText: tn(
                   'performance issue',
                   'performance issues',
-                  performanceIssues.length
+                  occurences.length
                 ),
               }
             );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -282,8 +282,8 @@ export function SpanNodeDetails({
   const hasNewTraceUi = useHasTraceNewUi();
   const {projects} = useProjects();
   const issues = useMemo(() => {
-    return [...node.errors, ...node.performance_issues];
-  }, [node.errors, node.performance_issues]);
+    return [...node.errors, ...node.occurences];
+  }, [node.errors, node.occurences]);
 
   const project = projects.find(proj => proj.slug === node.event?.projectSlug);
   const profileMeta = getProfileMeta(node.event) || '';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -150,8 +150,8 @@ export function TransactionNodeDetails({
 }: TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.Transaction>>) {
   const {projects} = useProjects();
   const issues = useMemo(() => {
-    return [...node.errors, ...node.performance_issues];
-  }, [node.errors, node.performance_issues]);
+    return [...node.errors, ...node.occurences];
+  }, [node.errors, node.occurences]);
   const {
     data: event,
     isError,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/generalInfo.tsx
@@ -51,15 +51,15 @@ export function GeneralInfo(props: GeneralInfoProps) {
     return unique;
   }, [traceNode]);
 
-  const uniquePerformanceIssues = useMemo(() => {
+  const uniqueOccurences = useMemo(() => {
     if (!traceNode) {
       return [];
     }
 
-    const unique: TraceTree.TracePerformanceIssue[] = [];
+    const unique: TraceTree.TraceOccurence[] = [];
     const seenIssues: Set<number> = new Set();
 
-    for (const issue of traceNode.performance_issues) {
+    for (const issue of traceNode.occurences) {
       if (seenIssues.has(issue.issue_id)) {
         continue;
       }
@@ -70,7 +70,7 @@ export function GeneralInfo(props: GeneralInfoProps) {
     return unique;
   }, [traceNode]);
 
-  const uniqueIssuesCount = uniqueErrorIssues.length + uniquePerformanceIssues.length;
+  const uniqueIssuesCount = uniqueErrorIssues.length + uniqueOccurences.length;
 
   const traceSlug = useMemo(() => {
     return params.traceSlug?.trim() ?? '';
@@ -147,7 +147,7 @@ export function GeneralInfo(props: GeneralInfoProps) {
                   {tn(
                     '%s performance issue',
                     '%s performance issues',
-                    uniquePerformanceIssues.length
+                    uniqueOccurences.length
                   )}
                 </div>
               </Fragment>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
@@ -44,10 +44,10 @@ export function TraceDetails(props: TraceDetailsProps) {
       return [];
     }
 
-    return [...props.node.errors, ...props.node.performance_issues];
+    return [...props.node.errors, ...props.node.occurences];
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.node, props.node?.errors.size, props.node?.performance_issues.size]);
+  }, [props.node, props.node?.errors.size, props.node?.occurences.size]);
 
   if (!props.node) {
     return null;

--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -207,8 +207,8 @@ export function getPageloadTransactionChildCount(
   return count;
 }
 
-export function isTracePerformanceIssue(
+export function isTraceOccurence(
   issue: TraceTree.TraceIssue
-): issue is TraceTree.TracePerformanceIssue {
-  return 'suspect_spans' in issue;
+): issue is TraceTree.TraceOccurence {
+  return 'issue_id' in issue && issue.event_type !== 'error';
 }

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -102,10 +102,10 @@ export function Meta(props: MetaProps) {
       return [];
     }
 
-    const unique: TraceTree.TracePerformanceIssue[] = [];
+    const unique: TraceTree.TraceOccurence[] = [];
     const seenIssues: Set<number> = new Set();
 
-    for (const issue of traceNode.performance_issues) {
+    for (const issue of traceNode.occurences) {
       if (seenIssues.has(issue.issue_id)) {
         continue;
       }

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -62,8 +62,7 @@ function mockSpansResponse(
 
 function hasErrors(n: TraceTreeNode<any>): boolean {
   return (
-    (isTraceErrorNode(n) || n.errors.size > 0 || n.performance_issues.size > 0) &&
-    !isTraceNode(n)
+    (isTraceErrorNode(n) || n.errors.size > 0 || n.occurences.size > 0) && !isTraceNode(n)
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
@@ -78,7 +78,7 @@ export class IssuesTraceTree extends TraceTree {
           }
         }
 
-        for (const p of n.performance_issues) {
+        for (const p of n.occurences) {
           if (p.event_id === eventId) {
             return true;
           }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -252,7 +252,7 @@ describe('TraceTree', () => {
         }),
         traceMetadata
       );
-      expect(tree.root.children[0]!.children[0]!.performance_issues.size).toBe(1);
+      expect(tree.root.children[0]!.children[0]!.occurences.size).toBe(1);
     });
 
     it('adds transaction profile to node', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.spec.tsx
@@ -40,7 +40,7 @@ describe('TraceTreeNode', () => {
       }),
       metadata
     );
-    expect(node.performance_issues.has(issue)).toBe(true);
+    expect(node.occurences.has(issue)).toBe(true);
   });
 
   it('stores error on node', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -69,7 +69,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
 
   // Events associated with the node, these are inferred from the node value.
   errors = new Set<TraceTree.TraceErrorIssue>();
-  performance_issues = new Set<TraceTree.TracePerformanceIssue>();
+  occurences = new Set<TraceTree.TraceOccurence>();
   profiles: TraceTree.Profile[] = [];
 
   space: [number, number] = [0, 0];
@@ -114,7 +114,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
       }
 
       if ('performance_issues' in value && Array.isArray(value.performance_issues)) {
-        value.performance_issues.forEach(issue => this.performance_issues.add(issue));
+        value.performance_issues.forEach(issue => this.occurences.add(issue));
       }
 
       if ('profile_id' in value && typeof value.profile_id === 'string') {
@@ -138,7 +138,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
   }
 
   get hasErrors(): boolean {
-    return this.errors.size > 0 || this.performance_issues.size > 0;
+    return this.errors.size > 0 || this.occurences.size > 0;
   }
 
   private _max_severity: keyof Theme['level'] | undefined;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1693,11 +1693,11 @@ function getIconTimestamps(
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
 
-  if (!node.errors.size && !node.performance_issues.size) {
+  if (!node.errors.size && !node.occurences.size) {
     return [min_icon_timestamp, max_icon_timestamp];
   }
 
-  for (const issue of node.performance_issues) {
+  for (const issue of node.occurences) {
     // Perf issues render icons at the start timestamp
     if (typeof issue.start === 'number') {
       min_icon_timestamp = Math.min(min_icon_timestamp, issue.start * 1e3 - icon_width);

--- a/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
@@ -68,7 +68,7 @@ export function TraceAutogroupedRow(
           virtualized_index={props.virtualized_index}
           color={makeTraceNodeBarColor(props.theme, props.node)}
           node_spaces={props.node.autogroupedSegments}
-          performance_issues={props.node.performance_issues}
+          occurences={props.node.occurences}
           profiles={props.node.profiles}
         />
         <button

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBackgroundPatterns.tsx
@@ -24,17 +24,17 @@ interface BackgroundPatternsProps {
   errors: TraceTreeNode<TraceTree.Transaction>['errors'];
   manager: VirtualizedViewManager;
   node_space: [number, number] | null;
-  performance_issues: TraceTreeNode<TraceTree.Transaction>['performance_issues'];
+  occurences: TraceTreeNode<TraceTree.Transaction>['occurences'];
 }
 
 export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
-  const performance_issues = useMemo(() => {
-    if (!props.performance_issues.size) {
+  const occurences = useMemo(() => {
+    if (!props.occurences.size) {
       return [];
     }
 
-    return [...props.performance_issues];
-  }, [props.performance_issues]);
+    return [...props.occurences];
+  }, [props.occurences]);
 
   const errors = useMemo(() => {
     if (!props.errors.size) {
@@ -47,13 +47,13 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
     return getMaxErrorSeverity(errors);
   }, [errors]);
 
-  if (!props.performance_issues.size && !props.errors.size) {
+  if (!props.occurences.size && !props.errors.size) {
     return null;
   }
 
   // If there is an error, render the error pattern across the entire width.
-  // Else if there is a performance issue, render the performance issue pattern
-  // for the duration of the performance issue. If there is a profile, render
+  // Else if there is an occurence, render the occurence pattern
+  // for the duration of the occurence. If there is a profile, render
   // the profile pattern for entire duration (we do not have profile durations here)
   return (
     <Fragment>
@@ -67,9 +67,9 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
         >
           <div className={`TracePattern ${severity}`} />
         </div>
-      ) : performance_issues.length > 0 ? (
+      ) : occurences.length > 0 ? (
         <Fragment>
-          {performance_issues.map((issue, i) => {
+          {occurences.map((issue, i) => {
             const timestamp = issue.start * 1e3;
             // Clamp the issue timestamp to the span's timestamp
             const left = props.manager.computeRelativeLeftPositionFromOrigin(
@@ -90,7 +90,7 @@ export function TraceBackgroundPatterns(props: BackgroundPatternsProps) {
                   width: (1 - left) * 100 + '%',
                 }}
               >
-                <div className="TracePattern performance_issue" />
+                <div className="TracePattern occurence" />
               </div>
             );
           })}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -18,7 +18,7 @@ import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
 import type {VirtualizedViewManager} from '../traceRenderers/virtualizedViewManager';
 import {TraceBackgroundPatterns} from '../traceRow/traceBackgroundPatterns';
-import {TraceErrorIcons, TracePerformanceIssueIcons} from '../traceRow/traceIcons';
+import {TraceErrorIcons, TraceOccurenceIcons} from '../traceRow/traceIcons';
 
 export function makeTraceNodeBarColor(
   theme: Theme,
@@ -154,7 +154,7 @@ interface TraceBarProps {
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
   node_space: [number, number] | null;
-  performance_issues: TraceTreeNode<TraceTree.Transaction>['performance_issues'];
+  occurences: TraceTreeNode<TraceTree.Transaction>['occurences'];
   profiles: TraceTreeNode<TraceTree.NodeValue>['profiles'];
   virtualized_index: number;
 }
@@ -210,19 +210,19 @@ export function TraceBar(props: TraceBarProps) {
             manager={props.manager}
           />
         ) : null}
-        {props.performance_issues.size > 0 ? (
-          <TracePerformanceIssueIcons
+        {props.occurences.size > 0 ? (
+          <TraceOccurenceIcons
             node_space={props.node_space}
-            performance_issues={props.performance_issues}
+            occurences={props.occurences}
             manager={props.manager}
           />
         ) : null}
-        {props.performance_issues.size > 0 ||
+        {props.occurences.size > 0 ||
         props.errors.size > 0 ||
         props.profiles.length > 0 ? (
           <TraceBackgroundPatterns
             node_space={props.node_space}
-            performance_issues={props.performance_issues}
+            occurences={props.occurences}
             errors={props.errors}
             manager={props.manager}
           />
@@ -242,7 +242,7 @@ interface AutogroupedTraceBarProps {
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
   node_spaces: Array<[number, number]>;
-  performance_issues: TraceTreeNode<TraceTree.Transaction>['performance_issues'];
+  occurences: TraceTreeNode<TraceTree.Transaction>['occurences'];
   profiles: TraceTreeNode<TraceTree.NodeValue>['profiles'];
   virtualized_index: number;
 }
@@ -282,7 +282,7 @@ export function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
         manager={props.manager}
         virtualized_index={props.virtualized_index}
         errors={props.errors}
-        performance_issues={props.performance_issues}
+        occurences={props.occurences}
         profiles={props.profiles}
       />
     );
@@ -322,10 +322,10 @@ export function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
             manager={props.manager}
           />
         ) : null}
-        {props.performance_issues.size > 0 ? (
-          <TracePerformanceIssueIcons
+        {props.occurences.size > 0 ? (
+          <TraceOccurenceIcons
             node_space={props.entire_space}
-            performance_issues={props.performance_issues}
+            occurences={props.occurences}
             manager={props.manager}
           />
         ) : null}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -53,28 +53,28 @@ export function TraceErrorIcons(props: ErrorIconsProps) {
   );
 }
 
-interface TracePerformanceIssueIconsProps {
+interface TraceOccurenceIconsProps {
   manager: VirtualizedViewManager;
   node_space: [number, number] | null;
-  performance_issues: TraceTreeNode<TraceTree.Transaction>['performance_issues'];
+  occurences: TraceTreeNode<TraceTree.Transaction>['occurences'];
 }
 
-export function TracePerformanceIssueIcons(props: TracePerformanceIssueIconsProps) {
-  const performance_issues = useMemo(() => {
-    return [...props.performance_issues];
-  }, [props.performance_issues]);
+export function TraceOccurenceIcons(props: TraceOccurenceIconsProps) {
+  const occurences = useMemo(() => {
+    return [...props.occurences];
+  }, [props.occurences]);
 
-  if (!props.performance_issues.size) {
+  if (!props.occurences.size) {
     return null;
   }
 
   return (
     <Fragment>
-      {performance_issues.map((issue, i) => {
-        const timestamp = issue.timestamp
-          ? issue.timestamp * 1e3
-          : issue.start
-            ? issue.start * 1e3
+      {occurences.map((occurence, i) => {
+        const timestamp = occurence.timestamp
+          ? occurence.timestamp * 1e3
+          : occurence.start
+            ? occurence.start * 1e3
             : props.node_space![0];
         // Clamp the issue timestamp to the span's timestamp
         const left = props.manager.computeRelativeLeftPositionFromOrigin(
@@ -87,12 +87,8 @@ export function TracePerformanceIssueIcons(props: TracePerformanceIssueIconsProp
         );
 
         return (
-          <div
-            key={i}
-            className={`TraceIcon performance_issue`}
-            style={{left: left * 100 + '%'}}
-          >
-            <TraceIcons.Icon event={issue} />
+          <div key={i} className={`TraceIcon occurence`} style={{left: left * 100 + '%'}}>
+            <TraceIcons.Icon event={occurence} />
           </div>
         );
       })}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
@@ -17,7 +17,7 @@ import {
 import {useHasTraceNewUi} from '../useHasTraceNewUi';
 
 const NO_ERRORS = new Set<TraceTree.TraceError>();
-const NO_PERFORMANCE_ISSUES = new Set<TraceTree.TracePerformanceIssue>();
+const NO_OCCURENCES = new Set<TraceTree.TraceOccurence>();
 const NO_PROFILES: any = [];
 
 export function TraceRootRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace>>) {
@@ -89,7 +89,7 @@ export function TraceRootRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace>
               color={makeTraceNodeBarColor(props.theme, props.node)}
               node_space={props.node.space}
               errors={NO_ERRORS}
-              performance_issues={NO_PERFORMANCE_ISSUES}
+              occurences={NO_OCCURENCES}
               profiles={NO_PROFILES}
             />
             <button

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -98,7 +98,7 @@ export function TraceSpanRow(
           color={makeTraceNodeBarColor(props.theme, props.node)}
           node_space={props.node.space}
           errors={props.node.errors}
-          performance_issues={props.node.performance_issues}
+          occurences={props.node.occurences}
           profiles={NO_PROFILES}
         />
         <button

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -94,7 +94,7 @@ export function TraceTransactionRow(
           color={makeTraceNodeBarColor(props.theme, props.node)}
           node_space={props.node.space}
           errors={props.node.errors}
-          performance_issues={props.node.performance_issues}
+          occurences={props.node.occurences}
           profiles={props.node.profiles}
         />
         <button

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -69,9 +69,9 @@ function makeError(overrides: Partial<TraceTree.TraceError> = {}): TraceTree.Tra
   };
 }
 
-function makePerformanceIssue(
-  overrides: Partial<TraceTree.TracePerformanceIssue> = {}
-): TraceTree.TracePerformanceIssue {
+function makeOccurence(
+  overrides: Partial<TraceTree.TraceOccurence> = {}
+): TraceTree.TraceOccurence {
   return {
     event_id: 'event_id',
     project_slug: 'project',
@@ -487,7 +487,7 @@ describe('TraceSearchEvaluator', () => {
       it.each(['issue', 'issues'])('%s (performance issue on transaction)', async key => {
         const tree = makeTree([
           makeTransaction({
-            performance_issues: [makePerformanceIssue()],
+            performance_issues: [makeOccurence()],
           }),
           makeTransaction({errors: []}),
         ]);

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -515,7 +515,7 @@ function resolveValueFromKey(
           }
           case 'issue':
           case 'issues':
-            return node.errors.size > 0 || node.performance_issues.size > 0;
+            return node.errors.size > 0 || node.occurences.size > 0;
           case 'profile':
           case 'profiles':
             return node.profiles.length > 0;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -1017,7 +1017,7 @@ export const TraceGrid = styled('div')<{
   --unknown: ${p => p.theme.gray300};
   --profile: ${p => p.theme.purple300};
   --autogrouped: ${p => p.theme.blue300};
-  --performance-issue: ${p => p.theme.blue300};
+  --occurence: ${p => p.theme.blue300};
   --panel-height: ${DEFAULT_HEIGHT}px;
 
   background-color: ${p => p.theme.background};


### PR DESCRIPTION
This PR does not change any trace view functionality. 

Performance issues are a subset of occurences. This is prep work for adding the occurence event type below, associated to eap spans from the new `/trace/` endpoint that I'll be adding in the next PR: 

```
  type EAPOccurrence = {
    event_id: string;
    event_type: 'occurrence';
    issue_id: number;
    level: Level;
    project_id: number;
    project_slug: string;
    start_timestamp: number;
    transaction: string;
    description?: string;
  };
```
