### PR TITLE
fix(ourlogs): Fix default timestamp ordering after field persist changes

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -87,7 +87,7 @@ export function LogsPageParamsProvider({
     : getLogFieldsFromLocation(location);
   const sortBys = isTableEditingFrozen
     ? [logsTimestampDescendingSortBy]
-    : getLogSortBysFromLocation(location, fields);
+    : getLogSortBysFromLocation(location);
   const projectIds = isOnEmbeddedView
     ? (limitToProjectIds ?? [-1])
     : decodeProjects(location);

--- a/static/app/views/explore/contexts/logs/sortBys.tsx
+++ b/static/app/views/explore/contexts/logs/sortBys.tsx
@@ -3,30 +3,27 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 const LOGS_SORT_BYS_KEY = 'logsSortBys';
 
 export const logsTimestampDescendingSortBy: Sort = {
-  field: 'timestamp',
+  field: OurLogKnownFieldKey.TIMESTAMP,
   kind: 'desc' as const,
 };
 
-function defaultLogSortBys(fields: string[]): Sort[] {
-  if (fields.includes('timestamp')) {
-    return [logsTimestampDescendingSortBy];
-  }
-
-  return [];
+function defaultLogSortBys(): Sort[] {
+  return [logsTimestampDescendingSortBy];
 }
 
-export function getLogSortBysFromLocation(location: Location, fields: string[]): Sort[] {
+export function getLogSortBysFromLocation(location: Location): Sort[] {
   const sortBys = decodeSorts(location.query[LOGS_SORT_BYS_KEY]);
 
   if (sortBys.length > 0) {
     return sortBys;
   }
 
-  return defaultLogSortBys(fields);
+  return defaultLogSortBys();
 }
 
 export function updateLocationWithLogSortBys(

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -22,6 +22,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.TRACE_ID,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
   OurLogKnownFieldKey.SEVERITY_TEXT,
+  OurLogKnownFieldKey.TIMESTAMP,
 ];
 
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [


### PR DESCRIPTION
### Summary
After we persisted to fields with the column editor, we're no longer including default fields thus the default sortby function didn't work.

Fixes LOGS-25

