### PR TITLE
fix(vscode): Remove unused imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,8 @@
     "editor.tabSize": 4,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      "source.organizeImports": "explicit",
+      "source.unusedImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },


### PR DESCRIPTION
In python, hitting ctrl+s will now automatically remove unused imports. 