### PR TITLE
feat(explore): Updates saved query nav to allow reordering

### DIFF
--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -34,6 +34,7 @@ export type SavedQuery = {
   interval: string;
   lastVisited: string;
   name: string;
+  position: number | null;
   projects: number[];
   query: [Query, ...Query[]];
   queryDataset: string;

--- a/static/app/views/explore/hooks/useReorderStarredSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useReorderStarredSavedQueries.tsx
@@ -1,0 +1,31 @@
+import {useCallback} from 'react';
+
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  type SavedQuery,
+  useInvalidateSavedQueries,
+} from 'sentry/views/explore/hooks/useGetSavedQueries';
+
+export function useReorderStarredSavedQueries() {
+  const organization = useOrganization();
+  const api = useApi();
+  const invalidateSavedQueries = useInvalidateSavedQueries();
+  const reorderStarredSavedQueries = useCallback(
+    async (queries: SavedQuery[]) => {
+      await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/starred/order/`,
+        {
+          method: 'PUT',
+          data: {
+            query_ids: queries.map(query => query.id),
+          },
+        }
+      );
+      invalidateSavedQueries();
+    },
+    [api, organization.slug, invalidateSavedQueries]
+  );
+
+  return reorderStarredSavedQueries;
+}

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -36,6 +36,7 @@ interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
   end?: boolean;
   isActive?: boolean;
   leadingItems?: ReactNode;
+  showInteractionStateLayer?: boolean;
   trailingItems?: ReactNode;
 }
 
@@ -104,6 +105,7 @@ SecondaryNav.Item = function SecondaryNavItem({
   isActive: incomingIsActive,
   end = false,
   leadingItems,
+  showInteractionStateLayer = true,
   trailingItems,
   ...linkProps
 }: SecondaryNavItemProps) {
@@ -130,7 +132,9 @@ SecondaryNav.Item = function SecondaryNavItem({
       }}
     >
       {leadingItems}
-      <InteractionStateLayer data-isl hasSelectedBackground={isActive} />
+      {showInteractionStateLayer && (
+        <InteractionStateLayer data-isl hasSelectedBackground={isActive} />
+      )}
       <ItemText>{children}</ItemText>
       {trailingItems}
     </Item>

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.spec.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.spec.tsx
@@ -1,0 +1,45 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {ExploreSavedQueryNavItems} from 'sentry/views/nav/secondary/sections/explore/exploreSavedQueryNavItems';
+
+describe('ExploreSavedQueryNavItems', () => {
+  const queries = [
+    {
+      id: 1,
+      name: 'My Saved Query',
+      query: [
+        {
+          query: '',
+          fields: [],
+          groupby: [],
+          visualize: [],
+        },
+      ],
+      starred: true,
+      position: 1,
+    },
+    {
+      id: 2,
+      name: 'Another Saved Query',
+      query: [
+        {
+          query: '',
+          fields: [],
+          groupby: [],
+          visualize: [],
+        },
+      ],
+      starred: true,
+      position: 2,
+    },
+  ] as unknown as SavedQuery[];
+
+  it('should render a list of starred queries', () => {
+    const sectionRef = {current: null};
+    render(<ExploreSavedQueryNavItems queries={queries} sectionRef={sectionRef} />);
+
+    expect(screen.getByText('My Saved Query')).toBeInTheDocument();
+    expect(screen.getByText('Another Saved Query')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.spec.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.spec.tsx
@@ -36,8 +36,7 @@ describe('ExploreSavedQueryNavItems', () => {
   ] as unknown as SavedQuery[];
 
   it('should render a list of starred queries', () => {
-    const sectionRef = {current: null};
-    render(<ExploreSavedQueryNavItems queries={queries} sectionRef={sectionRef} />);
+    render(<ExploreSavedQueryNavItems queries={queries} />);
 
     expect(screen.getByText('My Saved Query')).toBeInTheDocument();
     expect(screen.getByText('Another Saved Query')).toBeInTheDocument();

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
@@ -1,0 +1,144 @@
+import {useEffect, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {Reorder, useDragControls} from 'framer-motion';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
+import type {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {useReorderStarredSavedQueries} from 'sentry/views/explore/hooks/useReorderStarredSavedQueries';
+import {getExploreUrlFromSavedQueryUrl} from 'sentry/views/explore/utils';
+import ProjectIcon from 'sentry/views/nav/projectIcon';
+import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
+
+type Props = {
+  queries: SavedQuery[];
+  sectionRef: React.RefObject<HTMLDivElement | null>;
+};
+
+export function ExploreSavedQueryNavItems({queries, sectionRef}: Props) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const [savedQueries, setSavedQueries] = useState<SavedQuery[]>(queries);
+
+  // Any time the queries prop changes (e.g. when the user stars or unstars a query),
+  // we need to reset the savedQueries state.
+  useEffect(() => {
+    setSavedQueries(queries);
+  }, [queries]);
+
+  const id = getIdFromLocation(location);
+
+  const controls = useDragControls();
+
+  const {projects} = useProjects();
+
+  const reorderStarredSavedQueries = useReorderStarredSavedQueries();
+
+  return (
+    <Reorder.Group
+      as="div"
+      axis="y"
+      values={savedQueries}
+      onReorder={newOrder => {
+        setSavedQueries(newOrder);
+      }}
+      initial={false}
+      ref={sectionRef}
+      dragControls={controls}
+      onDragEnd={() => {
+        reorderStarredSavedQueries(savedQueries);
+      }}
+    >
+      {savedQueries?.map(query => (
+        <StyledReorderItem key={query.id} value={query}>
+          <GrabHandleWrapper data-test-id={`grab-handle-${query.id}`} data-drag-icon>
+            <StyledIconGrabbable color="gray300" />
+            <StyledProjectIcon
+              projectPlatforms={projects
+                .filter(p => query.projects.map(String).includes(p.id))
+                .map(p => p.platform)
+                .filter(defined)}
+            />
+          </GrabHandleWrapper>
+          <StyledSecondaryNavItem
+            key={query.id}
+            to={getExploreUrlFromSavedQueryUrl({savedQuery: query, organization})}
+            analyticsItemName="explore_starred_item"
+            showInteractionStateLayer={false}
+            isActive={id === query.id.toString()}
+          >
+            {query.name}
+          </StyledSecondaryNavItem>
+          <StyledInteractionStateLayer
+            isPressed={id === query.id.toString()}
+            hasSelectedBackground={id === query.id.toString()}
+          />
+        </StyledReorderItem>
+      ))}
+    </Reorder.Group>
+  );
+}
+
+const StyledProjectIcon = styled(ProjectIcon)`
+  display: flex;
+`;
+
+const StyledIconGrabbable = styled(IconGrabbable)`
+  display: none;
+  width: 18px;
+  cursor: grab;
+`;
+
+const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
+  align-items: center;
+  padding-left: ${space(0.75)};
+  overflow: hidden;
+  width: 100%;
+`;
+
+const StyledReorderItem = styled(Reorder.Item)`
+  position: relative;
+  background-color: transparent;
+  border-radius: ${p => p.theme.borderRadius};
+  list-style: none;
+  display: flex;
+  align-items: center;
+  margin-bottom: ${space(0.25)};
+
+  &:hover {
+    ${StyledProjectIcon} {
+      display: none;
+    }
+    ${StyledIconGrabbable} {
+      display: flex;
+    }
+  }
+`;
+
+const GrabHandleWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  padding: ${space(0.5)} 0 ${space(0.5)} ${space(1)};
+`;
+
+const StyledInteractionStateLayer = styled(InteractionStateLayer)<{
+  hasSelectedBackground: boolean;
+}>`
+  ${p =>
+    p.hasSelectedBackground &&
+    css`
+      color: ${p.theme.purple400};
+      font-weight: ${p.theme.fontWeightBold};
+
+      &:hover {
+        color: ${p.theme.purple400};
+      }
+    `}
+`;

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Reorder, useDragControls} from 'framer-motion';
@@ -19,13 +19,13 @@ import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 
 type Props = {
   queries: SavedQuery[];
-  sectionRef: React.RefObject<HTMLDivElement | null>;
 };
 
-export function ExploreSavedQueryNavItems({queries, sectionRef}: Props) {
+export function ExploreSavedQueryNavItems({queries}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>(queries);
+  const sectionRef = useRef<HTMLDivElement>(null);
 
   // Any time the queries prop changes (e.g. when the user stars or unstars a query),
   // we need to reset the savedQueries state.

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
@@ -52,12 +52,15 @@ export function ExploreSavedQueryNavItems({queries, sectionRef}: Props) {
       initial={false}
       ref={sectionRef}
       dragControls={controls}
-      onDragEnd={() => {
-        reorderStarredSavedQueries(savedQueries);
-      }}
     >
       {savedQueries?.map(query => (
-        <StyledReorderItem key={query.id} value={query}>
+        <StyledReorderItem
+          key={query.id}
+          value={query}
+          onDragEnd={() => {
+            reorderStarredSavedQueries(savedQueries);
+          }}
+        >
           <GrabHandleWrapper data-test-id={`grab-handle-${query.id}`} data-drag-icon>
             <StyledIconGrabbable color="gray300" />
             <StyledProjectIcon

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -1,5 +1,3 @@
-import {useRef} from 'react';
-
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -12,7 +10,6 @@ import {PrimaryNavGroup} from 'sentry/views/nav/types';
 export function ExploreSecondaryNav() {
   const organization = useOrganization();
 
-  const sectionRef = useRef<HTMLDivElement>(null);
   const baseUrl = `/organizations/${organization.slug}/explore`;
 
   const {data: starredQueries} = useGetSavedQueries({
@@ -74,10 +71,7 @@ export function ExploreSecondaryNav() {
         <Feature features="performance-saved-queries">
           <SecondaryNav.Section title={t('Starred Queries')}>
             {starredQueries && starredQueries.length > 0 && (
-              <ExploreSavedQueryNavItems
-                queries={starredQueries}
-                sectionRef={sectionRef}
-              />
+              <ExploreSavedQueryNavItems queries={starredQueries} />
             )}
           </SecondaryNav.Section>
           <SecondaryNav.Section>

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -1,14 +1,18 @@
+import {useRef} from 'react';
+
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGetSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
-import {getExploreUrlFromSavedQueryUrl} from 'sentry/views/explore/utils';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
+import {ExploreSavedQueryNavItems} from 'sentry/views/nav/secondary/sections/explore/exploreSavedQueryNavItems';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function ExploreSecondaryNav() {
   const organization = useOrganization();
+
+  const sectionRef = useRef<HTMLDivElement>(null);
   const baseUrl = `/organizations/${organization.slug}/explore`;
 
   const {data: starredQueries} = useGetSavedQueries({
@@ -69,15 +73,12 @@ export function ExploreSecondaryNav() {
         </SecondaryNav.Section>
         <Feature features="performance-saved-queries">
           <SecondaryNav.Section title={t('Starred Queries')}>
-            {starredQueries?.map(query => (
-              <SecondaryNav.Item
-                key={query.id}
-                to={getExploreUrlFromSavedQueryUrl({savedQuery: query, organization})}
-                analyticsItemName="explore_starred_item"
-              >
-                {query.name}
-              </SecondaryNav.Item>
-            )) ?? null}
+            {starredQueries && starredQueries.length > 0 && (
+              <ExploreSavedQueryNavItems
+                queries={starredQueries}
+                sectionRef={sectionRef}
+              />
+            )}
           </SecondaryNav.Section>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/saved-queries/`}>


### PR DESCRIPTION
Updates the Explore Side Nav to allow drag and drop reordering via `framer-motion`

![image](https://github.com/user-attachments/assets/c8a2d9a6-bdb8-40f3-bca8-ff3f46ee82c9)
