### PR TITLE
ref: fix create_or_update handling in organization_pinned_searches

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -66,7 +66,14 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
                 "visibility": GroupSearchViewVisibility.ORGANIZATION,
             },
         )
-        default_view_id = default_view.id if created else default_view
+        if created:
+            default_view_id = default_view.id
+        else:
+            default_view_id = GroupSearchView.objects.get(
+                organization=organization,
+                user_id=request.user.id,
+            ).id
+
         GroupSearchViewStarred.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,


### PR DESCRIPTION
the return value of create_or_update is either (rows_affected, False) or (instance, True) -- but the previous code assumed it was (instance_id, False)!

I'm pretty sure the current code could lead to data loss but I couldn't find any examples of this in redash :shrug: 

found this while researching a test pollution:

```console
$ pytest tests/sentry/api/endpoints/test_organization_pinned_searches.py::CreateOrganizationPinnedSearchTest::test_empty_query tests/sentry/api/endpoints/test_organization_pinned_searches.py::CreateOrganizationPinnedSearchTest::test --show-capture=no
============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-8.1.2, pluggy-1.5.0
django: version: 5.1.7
rootdir: /home/asottile/workspace/sentry
configfile: pyproject.toml
plugins: cov-4.0.0, metadata-3.1.1, rerunfailures-15.0, pytest_sentry-0.3.0, django-4.9.0, time-machine-2.16.0, json-report-1.5.0, xdist-3.0.2, fail-slow-0.3.0, anyio-3.7.1
collected 2 items                                                              

tests/sentry/api/endpoints/test_organization_pinned_searches.py .FE      [100%]

==================================== ERRORS ====================================
_________ ERROR at teardown of CreateOrganizationPinnedSearchTest.test _________
src/sentry/db/postgres/decorators.py:91: in inner
    return func(self, sql, *args, **kwargs)
src/sentry/db/postgres/base.py:85: in execute
    return self.cursor.execute(sql)
E   psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "sentry_groupsearchviewstarred_unique_view_position_per_org_user"
E   DETAIL:  Key (user_id, organization_id, "position")=(3, 4555866867105792, 0) already exists.

During handling of the above exception, another exception occurred:
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:103: in _execute
    return self.cursor.execute(sql)
src/sentry/db/postgres/decorators.py:77: in inner
    raise_the_exception(self.db, e)
src/sentry/db/postgres/decorators.py:75: in inner
    return func(self, *args, **kwargs)
src/sentry/db/postgres/decorators.py:18: in inner
    return func(self, *args, **kwargs)
src/sentry/db/postgres/decorators.py:93: in inner
    raise type(e)(f"{e!r}\nSQL: {sql}").with_traceback(e.__traceback__)
src/sentry/db/postgres/decorators.py:91: in inner
    return func(self, sql, *args, **kwargs)
src/sentry/db/postgres/base.py:85: in execute
    return self.cursor.execute(sql)
E   psycopg2.errors.UniqueViolation: UniqueViolation('duplicate key value violates unique constraint "sentry_groupsearchviewstarred_unique_view_position_per_org_user"\nDETAIL:  Key (user_id, organization_id, "position")=(3, 4555866867105792, 0) already exists.\n')
E   SQL: SET CONSTRAINTS ALL IMMEDIATE

The above exception was the direct cause of the following exception:
.venv/lib/python3.13/site-packages/django/test/testcases.py:372: in _setup_and_call
    self._post_teardown()
src/sentry/testutils/cases.py:396: in _post_teardown
    super()._post_teardown()
.venv/lib/python3.13/site-packages/django/test/testcases.py:1202: in _post_teardown
    self._fixture_teardown()
.venv/lib/python3.13/site-packages/django/test/testcases.py:1455: in _fixture_teardown
    connections[db_name].check_constraints()
.venv/lib/python3.13/site-packages/django/db/backends/postgresql/base.py:482: in check_constraints
    cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:122: in execute
    return super().execute(sql, params)
.venv/lib/python3.13/site-packages/sentry_sdk/utils.py:1809: in runner
    return original_function(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:79: in execute
    return self._execute_with_wrappers(
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:92: in _execute_with_wrappers
    return executor(sql, params, many, context)
src/sentry/testutils/hybrid_cloud.py:133: in __call__
    return execute(*params)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:100: in _execute
    with self.db.wrap_database_errors:
.venv/lib/python3.13/site-packages/django/db/utils.py:91: in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:103: in _execute
    return self.cursor.execute(sql)
src/sentry/db/postgres/decorators.py:77: in inner
    raise_the_exception(self.db, e)
src/sentry/db/postgres/decorators.py:75: in inner
    return func(self, *args, **kwargs)
src/sentry/db/postgres/decorators.py:18: in inner
    return func(self, *args, **kwargs)
src/sentry/db/postgres/decorators.py:93: in inner
    raise type(e)(f"{e!r}\nSQL: {sql}").with_traceback(e.__traceback__)
src/sentry/db/postgres/decorators.py:91: in inner
    return func(self, sql, *args, **kwargs)
src/sentry/db/postgres/base.py:85: in execute
    return self.cursor.execute(sql)
E   django.db.utils.IntegrityError: UniqueViolation('duplicate key value violates unique constraint "sentry_groupsearchviewstarred_unique_view_position_per_org_user"\nDETAIL:  Key (user_id, organization_id, "position")=(3, 4555866867105792, 0) already exists.\n')
E   SQL: SET CONSTRAINTS ALL IMMEDIATE
=================================== FAILURES ===================================
___________________ CreateOrganizationPinnedSearchTest.test ____________________
src/sentry/hybridcloud/models/outbox.py:305: in process
    coalesced.send_signal()
src/sentry/hybridcloud/models/outbox.py:447: in send_signal
    process_control_outbox.send(
.venv/lib/python3.13/site-packages/django/dispatch/dispatcher.py:189: in send
    response = receiver(signal=self, sender=sender, **named)
src/sentry/hybridcloud/outbox/category.py:110: in receiver
    maybe_instance.handle_async_replication(
src/sentry/users/models/user.py:584: in handle_async_replication
    region_caching_service.clear_key(key=get_user.key_from(self.id), region_name=region_name)
src/sentry/hybridcloud/rpc/service.py:354: in remote_method
    return dispatch_remote_call(
src/sentry/hybridcloud/rpc/service.py:476: in dispatch_remote_call
    return remote_silo_call.dispatch(use_test_client)
src/sentry/hybridcloud/rpc/service.py:511: in dispatch
    serial_response = self._send_to_remote_silo(use_test_client)
src/sentry/hybridcloud/rpc/service.py:582: in _send_to_remote_silo
    self._raise_from_response_status_error(response)
src/sentry/hybridcloud/rpc/service.py:605: in _raise_from_response_status_error
    raise self._remote_exception(
E   sentry.hybridcloud.rpc.service.RpcRemoteException: region_caching.clear_key: Error invoking rpc at '/api/0/internal/rpc/region_caching/clear_key/': check error logs for more details

The above exception was the direct cause of the following exception:
tests/sentry/api/endpoints/test_organization_pinned_searches.py:84: in test
    self.login_as(self.user)
src/sentry/testutils/cases.py:322: in login_as
    login(request, user)
.venv/lib/python3.13/site-packages/django/contrib/auth/__init__.py:152: in login
    user_logged_in.send(sender=user.__class__, request=request, user=user)
.venv/lib/python3.13/site-packages/django/dispatch/dispatcher.py:189: in send
    response = receiver(signal=self, sender=sender, **named)
.venv/lib/python3.13/site-packages/django/contrib/auth/models.py:24: in update_last_login
    user.save(update_fields=["last_login"])
src/sentry/silo/base.py:158: in override
    return original_method(*args, **kwargs)
src/sentry/users/models/user.py:224: in save
    with outbox_context(transaction.atomic(using=router.db_for_write(User))):
/usr/lib/python3.13/contextlib.py:148: in __exit__
    next(self.gen)
src/sentry/hybridcloud/models/outbox.py:525: in outbox_context
    with unguarded_write(using=inner.using), enforce_constraints(inner):
/usr/lib/python3.13/contextlib.py:148: in __exit__
    next(self.gen)
src/sentry/db/postgres/transactions.py:114: in enforce_constraints
    with transaction:
src/sentry/testutils/hybrid_cloud.py:229: in new_atomic_exit
    maybe_flush_commit_hooks(connection)
src/sentry/testutils/hybrid_cloud.py:220: in maybe_flush_commit_hooks
    connection.run_and_clear_commit_hooks()
src/sentry/testutils/pytest/stale_database_reads.py:134: in run_and_clear_commit_hooks
    return old_run_and_clear_commit_hooks(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/backends/base/base.py:769: in run_and_clear_commit_hooks
    func()
src/sentry/hybridcloud/models/outbox.py:195: in <lambda>
    transaction.on_commit(lambda: self.drain_shard(), using=router.db_for_write(type(self)))
src/sentry/hybridcloud/models/outbox.py:344: in drain_shard
    processed = shard_row.process(is_synchronous_flush=not flush_all)
src/sentry/hybridcloud/models/outbox.py:307: in process
    raise OutboxFlushError(
E   sentry.hybridcloud.models.outbox.OutboxFlushError: Could not flush shard category=0 (USER_UPDATE)
=========================== short test summary info ============================
FAILED tests/sentry/api/endpoints/test_organization_pinned_searches.py::CreateOrganizationPinnedSearchTest::test - sentry.hybridcloud.models.outbox.OutboxFlushError: Could not flush shard ca...
ERROR tests/sentry/api/endpoints/test_organization_pinned_searches.py::CreateOrganizationPinnedSearchTest::test - django.db.utils.IntegrityError: UniqueViolation('duplicate key value violat...
===================== 1 failed, 1 passed, 1 error in 9.66s =====================
```

it also fixes the test pollution :)

<!-- Describe your PR here. -->