### PR TITLE
fix(quota alert): various fixes + more analytics

### DIFF
--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -13,6 +13,10 @@ import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 
 describe('PrimaryNavigationQuotaExceeded', function () {
   const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({
+    organization,
+    plan: 'am3_business',
+  });
   let promptMock: jest.Mock;
   let requestUpgradeMock: jest.Mock;
   let customerPutMock: jest.Mock;
@@ -20,13 +24,11 @@ describe('PrimaryNavigationQuotaExceeded', function () {
   beforeEach(() => {
     organization.access = [];
     MockApiClient.clearMockResponses();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_business',
-    });
     subscription.categories.errors!.usageExceeded = true;
     subscription.categories.replays!.usageExceeded = true;
     subscription.categories.spans!.usageExceeded = true;
+    subscription.categories.monitorSeats!.usageExceeded = true;
+    subscription.categories.profileDuration!.usageExceeded = true;
     SubscriptionStore.set(organization.slug, subscription);
     ConfigStore.set(
       'user',
@@ -91,12 +93,34 @@ describe('PrimaryNavigationQuotaExceeded', function () {
     // open the alert
     await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
     expect(await screen.findByText('Quota Exceeded')).toBeInTheDocument();
+    // doesn't show categories with <1 reserved tier and no PAYG
     expect(
       screen.getByText(
         /You’ve run out of errors, replays, and spans for this billing cycle./
       )
     ).toBeInTheDocument();
+    expect(screen.queryByText(/cron monitors/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/continuous profile hours/)).not.toBeInTheDocument();
     expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('should render PAYG categories when there is PAYG', async function () {
+    subscription.onDemandMaxSpend = 100;
+    SubscriptionStore.set(organization.slug, subscription);
+    render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+    // open the alert
+    await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
+    expect(await screen.findByText('Quota Exceeded')).toBeInTheDocument();
+    // doesn't show categories with <1 reserved tier and no PAYG
+    expect(
+      screen.getByText(
+        /You’ve run out of errors, replays, spans, cron monitors, and continuous profile hours for this billing cycle./
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+
+    subscription.onDemandMaxSpend = 0;
   });
 
   it('should update prompts when checkbox is toggled', async function () {

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -112,7 +112,6 @@ describe('PrimaryNavigationQuotaExceeded', function () {
     // open the alert
     await userEvent.click(await screen.findByRole('button', {name: 'Billing Status'}));
     expect(await screen.findByText('Quota Exceeded')).toBeInTheDocument();
-    // doesn't show categories with <1 reserved tier and no PAYG
     expect(
       screen.getByText(
         /You’ve run out of errors, replays, spans, cron monitors, and continuous profile hours for this billing cycle./

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -119,7 +119,18 @@ describe('PrimaryNavigationQuotaExceeded', function () {
     ).toBeInTheDocument();
     expect(screen.getByRole('checkbox')).not.toBeChecked();
 
+    // reset
     subscription.onDemandMaxSpend = 0;
+  });
+
+  it('should not render for managed orgs', function () {
+    subscription.canSelfServe = false;
+    SubscriptionStore.set(organization.slug, subscription);
+    render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+    expect(screen.queryByText('Quota Exceeded')).not.toBeInTheDocument();
+
+    // reset
+    subscription.canSelfServe = true;
   });
 
   it('should update prompts when checkbox is toggled', async function () {

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -127,6 +127,9 @@ describe('PrimaryNavigationQuotaExceeded', function () {
     subscription.canSelfServe = false;
     SubscriptionStore.set(organization.slug, subscription);
     render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+    expect(
+      screen.queryByRole('button', {name: 'Billing Status'})
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('Quota Exceeded')).not.toBeInTheDocument();
 
     // reset

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -121,6 +121,12 @@ function PrimaryNavigationQuotaExceeded({
     )
     .reduce((acc, [category, currentHistory]) => {
       if (currentHistory.usageExceeded) {
+        if (
+          subscription.onDemandMaxSpend === 0 &&
+          (!currentHistory.reserved || currentHistory.reserved <= 1)
+        ) {
+          return acc;
+        }
         acc.push(category);
       }
       return acc;

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -159,6 +159,7 @@ function PrimaryNavigationQuotaExceeded({
   const shouldShow =
     prefersStackedNav &&
     exceededCategories.length > 0 &&
+    subscription.canSelfServe &&
     !subscription.hasOverageNotificationsDisabled;
   if (!shouldShow || isLoading || isError) {
     return null;

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -26,6 +26,7 @@ import withSubscription from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/billing';
 import {listDisplayNames, sortCategoriesWithKeys} from 'getsentry/utils/dataCategory';
+import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
 const ANIMATE_PROPS: MotionProps = {
   animate: {
@@ -51,7 +52,15 @@ function QuotaExceededContent({
 }: {
   exceededCategories: string[];
   isDismissed: boolean;
-  onCheck: (checked: boolean) => void;
+  onCheck: ({
+    checked,
+    eventTypes,
+    isManual,
+  }: {
+    checked: boolean;
+    eventTypes: EventType[];
+    isManual?: boolean;
+  }) => void;
   organization: Organization;
   subscription: Subscription;
 }) {
@@ -89,14 +98,14 @@ function QuotaExceededContent({
             notificationType="overage_critical"
             referrer={`overage-alert-${eventTypes.join('-')}`}
             source="nav-quota-overage"
-            handleRequestSent={() => onCheck(true)}
+            handleRequestSent={() => onCheck({checked: true, eventTypes})}
           />
           <DismissContainer>
             <Checkbox
               name="dismiss"
               checked={isDismissed}
               onChange={e => {
-                onCheck(e.target.checked);
+                onCheck({checked: e.target.checked, eventTypes, isManual: true});
               }}
             />
             <CheckboxLabel>{t("Don't annoy me again")}</CheckboxLabel>
@@ -165,7 +174,15 @@ function PrimaryNavigationQuotaExceeded({
     return null;
   }
 
-  const onCheckboxChange = (checked: boolean) => {
+  const onCheckboxChange = ({
+    checked,
+    eventTypes,
+    isManual = false,
+  }: {
+    checked: boolean;
+    eventTypes: EventType[];
+    isManual?: boolean;
+  }) => {
     promptsToCheck.forEach(prompt => {
       if (checked) {
         snoozePrompt(prompt);
@@ -173,6 +190,18 @@ function PrimaryNavigationQuotaExceeded({
         showPrompt(prompt);
       }
     });
+    if (isManual) {
+      const analyticsEvent = checked
+        ? 'quota_alert.clicked_snooze'
+        : 'quota_alert.clicked_unsnooze';
+      trackGetsentryAnalytics(analyticsEvent, {
+        organization,
+        subscription,
+        event_types: eventTypes?.sort().join(','),
+        is_warning: false,
+        source: 'nav-quota-overage',
+      });
+    }
   };
 
   const hasSnoozedAllPrompts = () => {

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -125,6 +125,8 @@ function PrimaryNavigationQuotaExceeded({
           subscription.onDemandMaxSpend === 0 &&
           (!currentHistory.reserved || currentHistory.reserved <= 1)
         ) {
+          // don't show any categories without additional reserved volumes
+          // if there is no PAYG
           return acc;
         }
         acc.push(category);

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -6,7 +6,7 @@ import type {EventType} from 'getsentry/components/addEventsCTA';
 import type {CheckoutType, Subscription} from 'getsentry/types';
 
 type HasSub = {subscription: Subscription};
-type QuotaAlert = {event_types: string; is_warning: boolean} & HasSub;
+type QuotaAlert = {event_types: string; is_warning: boolean; source?: string} & HasSub;
 type UpsellProvider = {
   action: string;
   can_trial: boolean;
@@ -178,6 +178,7 @@ type GetsentryEventParameters = {
   'quota_alert.clicked_link': QuotaAlert & {clicked_event: EventType};
   'quota_alert.clicked_see_usage': QuotaAlert;
   'quota_alert.clicked_snooze': QuotaAlert;
+  'quota_alert.clicked_unsnooze': QuotaAlert;
   'quota_alert.shown': QuotaAlert;
   'replay.list_page.manage_sub': UpdateProps;
   'replay.list_page.open_modal': UpdateProps & {
@@ -250,6 +251,7 @@ const getsentryEventMap: Record<GetsentryEventKey, string> = {
   'growth.codecov_promotion_opened': 'Growth: Codecov Promotion Opened',
   'quota_alert.shown': 'Quota Alert: Shown',
   'quota_alert.clicked_snooze': 'Quota Alert: Clicked Snooze',
+  'quota_alert.clicked_unsnooze': 'Quota Alert: Clicked Unsnooze',
   'product_trial.clicked_snooze': 'Quota Alert: Clicked Snooze',
   'quota_alert.clicked_link': 'Quota Alert: Clicked Link',
   'quota_alert.clicked_see_usage': 'Quota Alert: Clicked See Usage',


### PR DESCRIPTION
- Don't show any categories that have reserved volume <= 1 if there is no PAYG that can be used (includes crons, uptime, profiling)
- Don't show to customers who can't self-serve
- Add analytics for snoozing and unsnoozing