### PR TITLE
ref(flags): update suspect flags to return baseline_percent

### DIFF
--- a/src/sentry/flags/docs/api.md
+++ b/src/sentry/flags/docs/api.md
@@ -223,24 +223,26 @@ Retrieve a collection of confidence scores for all feature flags associated with
 
 **Attributes**
 
-| Column                | Type   | Description                                                           |
-| --------------------- | ------ | --------------------------------------------------------------------- |
-| flag                  | object | Object containing score data for a flag. Key is the name of the flag. |
-| flag.score            | number | A suspicion score from 0 to infinity.                                 |
-| flag.baseline_percent | number | Percentage of events in the same project with the flag enabled.       |
+| Column           | Type   | Description                                                     |
+| ---------------- | ------ | --------------------------------------------------------------- |
+| flag             | string | The name of the flag.                                           |
+| score            | number | A suspicion score from 0 to infinity.                           |
+| baseline_percent | number | Percentage of events in the same project with the flag enabled. |
 
 - Response 200
 
   ```json
   {
     "data": [
-      "hello": {
+      {
+        "flag": "hello",
         "score": 5.83,
-        "baseline_percent": 0.33,
+        "baseline_percent": 0.33
       },
-      "world": {
+      {
+        "flag": "world",
         "score": 0.0021,
-        "baseline_percent": 0.491,
+        "baseline_percent": 0.491
       }
     ]
   }

--- a/src/sentry/flags/docs/api.md
+++ b/src/sentry/flags/docs/api.md
@@ -223,23 +223,24 @@ Retrieve a collection of confidence scores for all feature flags associated with
 
 **Attributes**
 
-| Column | Type   | Description                           |
-| ------ | ------ | ------------------------------------- |
-| flag   | string | The name of the flag.                 |
-| score  | number | A suspicion score from 0 to infinity. |
+| Column                | Type   | Description                                                           |
+| --------------------- | ------ | --------------------------------------------------------------------- |
+| flag                  | object | Object containing score data for a flag. Key is the name of the flag. |
+| flag.score            | number | A suspicion score from 0 to infinity.                                 |
+| flag.baseline_percent | number | Percentage of events in the same project with the flag enabled.       |
 
 - Response 200
 
   ```json
   {
     "data": [
-      {
-        "flag": "hello",
-        "score": 5.83
+      "hello": {
+        "score": 5.83,
+        "baseline_percent": 0.33,
       },
-      {
-        "flag": "world",
-        "score": 0.0021
+      "world": {
+        "score": 0.0021,
+        "baseline_percent": 0.491,
       }
     ]
   }

--- a/src/sentry/issues/endpoints/organization_group_suspect_flags.py
+++ b/src/sentry/issues/endpoints/organization_group_suspect_flags.py
@@ -43,8 +43,8 @@ class OrganizationGroupSuspectFlagsEndpoint(GroupEndpoint, EnvironmentMixin):
         return Response(
             {
                 "data": [
-                    {"flag": flag, "score": score}
-                    for flag, score in get_suspect_flag_scores(
+                    {"flag": flag, "score": score, "baseline_percent": baseline_percent}
+                    for flag, score, baseline_percent in get_suspect_flag_scores(
                         organization_id,
                         project_id,
                         start,

--- a/src/sentry/issues/suspect_flags.py
+++ b/src/sentry/issues/suspect_flags.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 from typing import NamedTuple
 
@@ -42,11 +43,11 @@ def get_suspect_flag_scores(
         total_b=outliers_count,
     )
 
-    baseline_percent_dict = {
-        key: (count / baseline_count if baseline_count else 0.0)
-        for key, value, count in baseline
-        if value == "true"
-    }
+    baseline_percent_dict = defaultdict(int)
+    if baseline_count:
+        for key, value, count in baseline:
+            if value == "true":
+                baseline_percent_dict[key] = count / baseline_count
 
     return [
         Score(key=key, score=score, baseline_percent=baseline_percent_dict[key])

--- a/src/sentry/issues/suspect_flags.py
+++ b/src/sentry/issues/suspect_flags.py
@@ -36,14 +36,14 @@ def get_suspect_flag_scores(
     outliers_count = query_error_counts(org_id, project_id, start, end, envs, group_id=group_id)
     baseline_count = query_error_counts(org_id, project_id, start, end, envs, group_id=None)
 
-    score_dict = keyed_kl_score(
+    keyed_scores = keyed_kl_score(
         a=baseline,
         b=outliers,
         total_a=baseline_count,
         total_b=outliers_count,
     )
 
-    baseline_percent_dict = defaultdict(int)
+    baseline_percent_dict: defaultdict[str, float] = defaultdict(int)
     if baseline_count:
         for key, value, count in baseline:
             if value == "true":
@@ -51,7 +51,7 @@ def get_suspect_flag_scores(
 
     return [
         Score(key=key, score=score, baseline_percent=baseline_percent_dict[key])
-        for key, score in sorted(score_dict.items(), key=lambda x: x[1], reverse=True)
+        for key, score in keyed_scores
     ]
 
 

--- a/src/sentry/issues/suspect_flags.py
+++ b/src/sentry/issues/suspect_flags.py
@@ -1,10 +1,17 @@
 from datetime import datetime
+from typing import NamedTuple
 
 import sentry_sdk
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
-from sentry.seer.workflows.compare import KeyedValueCount, Score, keyed_kl_score
+from sentry.seer.workflows.compare import KeyedValueCount, keyed_kl_score
 from sentry.utils.snuba import raw_snql_query
+
+
+class Score(NamedTuple):
+    key: str
+    score: float
+    baseline_percent: float
 
 
 @sentry_sdk.trace
@@ -18,7 +25,7 @@ def get_suspect_flag_scores(
 ) -> list[Score]:
     """
     Queries the baseline and outliers sets. Computes the KL scores of each and returns a sorted
-    list of key, score values.
+    list of key, score, baseline_percent tuples.
     """
     outliers = query_selection_set(org_id, project_id, start, end, envs, group_id=group_id)
     baseline = query_baseline_set(
@@ -28,12 +35,23 @@ def get_suspect_flag_scores(
     outliers_count = query_error_counts(org_id, project_id, start, end, envs, group_id=group_id)
     baseline_count = query_error_counts(org_id, project_id, start, end, envs, group_id=None)
 
-    return keyed_kl_score(
+    score_dict = keyed_kl_score(
         a=baseline,
         b=outliers,
         total_a=baseline_count,
         total_b=outliers_count,
     )
+
+    baseline_percent_dict = {
+        key: (count / baseline_count if baseline_count else 0.0)
+        for key, value, count in baseline
+        if value == "true"
+    }
+
+    return [
+        Score(key=key, score=score, baseline_percent=baseline_percent_dict[key])
+        for key, score in sorted(score_dict.items(), key=lambda x: x[1], reverse=True)
+    ]
 
 
 @sentry_sdk.trace

--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -34,15 +34,14 @@ def get_suspect_tag_scores(
     outliers_count = query_error_counts(org_id, project_id, start, end, envs, group_id=group_id)
     baseline_count = query_error_counts(org_id, project_id, start, end, envs, group_id=None)
 
-    score_dict = keyed_kl_score(
-        a=baseline,
-        b=outliers,
-        total_a=baseline_count,
-        total_b=outliers_count,
-    )
     return [
         Score(key=key, score=score)
-        for key, score in sorted(score_dict.items(), key=lambda x: x[1], reverse=True)
+        for key, score in keyed_kl_score(
+            a=baseline,
+            b=outliers,
+            total_a=baseline_count,
+            total_b=outliers_count,
+        )
     ]
 
 

--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -1,10 +1,16 @@
 from datetime import datetime
+from typing import NamedTuple
 
 import sentry_sdk
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
-from sentry.seer.workflows.compare import KeyedValueCount, Score, keyed_kl_score
+from sentry.seer.workflows.compare import KeyedValueCount, keyed_kl_score
 from sentry.utils.snuba import raw_snql_query
+
+
+class Score(NamedTuple):
+    key: str
+    score: float
 
 
 @sentry_sdk.trace
@@ -28,12 +34,16 @@ def get_suspect_tag_scores(
     outliers_count = query_error_counts(org_id, project_id, start, end, envs, group_id=group_id)
     baseline_count = query_error_counts(org_id, project_id, start, end, envs, group_id=None)
 
-    return keyed_kl_score(
+    score_dict = keyed_kl_score(
         a=baseline,
         b=outliers,
         total_a=baseline_count,
         total_b=outliers_count,
     )
+    return [
+        Score(key=key, score=score)
+        for key, score in sorted(score_dict.items(), key=lambda x: x[1], reverse=True)
+    ]
 
 
 @sentry_sdk.trace

--- a/src/sentry/seer/workflows/compare.py
+++ b/src/sentry/seer/workflows/compare.py
@@ -93,7 +93,7 @@ def _multi_dimensional_kl_compare_sets(
     baseline: Attributes, outliers: Attributes
 ) -> dict[str, float]:
     """
-    Computes the KL scores of each key in the outlier set.
+    Computes the KL scores of each key in both sets.
     """
     return {
         key: _kl_compare_sets(baseline[key], outliers[key]) for key in outliers if key in baseline

--- a/src/sentry/seer/workflows/compare.py
+++ b/src/sentry/seer/workflows/compare.py
@@ -15,7 +15,7 @@ def keyed_kl_score(
     b: Sequence[KeyedValueCount],
     total_a: int,
     total_b: int,
-) -> dict[str, float]:
+) -> list[tuple[str, float]]:
     """
     KL score a multi-dimensional distribution of values. Returns a list of key, score pairs.
     Duplicates are not tolerated.
@@ -91,13 +91,20 @@ def _add_unseen_value(dist: Distribution, total: int) -> None:
 
 def _multi_dimensional_kl_compare_sets(
     baseline: Attributes, outliers: Attributes
-) -> dict[str, float]:
+) -> list[tuple[str, float]]:
     """
-    Computes the KL scores of each key in both sets.
+    Computes the KL scores of each key in the outlier set and returns a sorted list, in descending
+    order, of key, score values.
     """
-    return {
-        key: _kl_compare_sets(baseline[key], outliers[key]) for key in outliers if key in baseline
-    }
+    return sorted(
+        (
+            (key, _kl_compare_sets(baseline[key], outliers[key]))
+            for key in outliers
+            if key in baseline
+        ),
+        key=lambda k: k[1],
+        reverse=True,
+    )
 
 
 def _kl_compare_sets(a: Distribution, b: Distribution):

--- a/src/sentry/seer/workflows/compare.py
+++ b/src/sentry/seer/workflows/compare.py
@@ -6,8 +6,8 @@ from sentry.seer.math import kl_divergence, laplace_smooth
 Attributes = Mapping[str, dict[str, float]]
 Distribution = dict[str, float]
 KeyedValueCount = tuple[str, str, float]
-Score = tuple[str, float]
 ValueCount = tuple[str, float]
+Score = tuple[str, float]
 
 
 def keyed_kl_score(
@@ -15,7 +15,7 @@ def keyed_kl_score(
     b: Sequence[KeyedValueCount],
     total_a: int,
     total_b: int,
-) -> list[Score]:
+) -> dict[str, float]:
     """
     KL score a multi-dimensional distribution of values. Returns a list of key, score pairs.
     Duplicates are not tolerated.
@@ -89,20 +89,15 @@ def _add_unseen_value(dist: Distribution, total: int) -> None:
         dist[""] = delta
 
 
-def _multi_dimensional_kl_compare_sets(baseline: Attributes, outliers: Attributes) -> list[Score]:
+def _multi_dimensional_kl_compare_sets(
+    baseline: Attributes, outliers: Attributes
+) -> dict[str, float]:
     """
-    Computes the KL scores of each key in the outlier set and returns a sorted list, in descending
-    order, of key, score values.
+    Computes the KL scores of each key in the outlier set.
     """
-    return sorted(
-        (
-            (key, _kl_compare_sets(baseline[key], outliers[key]))
-            for key in outliers
-            if key in baseline
-        ),
-        key=lambda k: k[1],
-        reverse=True,
-    )
+    return {
+        key: _kl_compare_sets(baseline[key], outliers[key]) for key in outliers if key in baseline
+    }
 
 
 def _kl_compare_sets(a: Distribution, b: Distribution):

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
@@ -50,8 +50,8 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.json() == {
             "data": [
-                {"flag": "key", "score": 2.7622287114272543},
-                {"flag": "other", "score": 0.0},
+                {"flag": "key", "score": 2.7622287114272543, "baseline_percent": 0.5},
+                {"flag": "other", "score": 0.0, "baseline_percent": 0.0},
             ]
         }
 

--- a/tests/sentry/issues/test_suspect_flags.py
+++ b/tests/sentry/issues/test_suspect_flags.py
@@ -110,4 +110,4 @@ class SnubaTest(TestCase, SnubaTestCase):
         )
 
         results = get_suspect_flag_scores(1, 1, before, later, envs=[], group_id=1)
-        assert results == [("key", 2.7622287114272543), ("other", 0.0)]
+        assert results == [("key", 2.7622287114272543, 0.5), ("other", 0.0, 0.0)]

--- a/tests/sentry/seer/workflows/test_compare.py
+++ b/tests/sentry/seer/workflows/test_compare.py
@@ -12,30 +12,27 @@ def test_keyed_kl_score():
     ]
     outliers = [("key", "true", 10), ("other", "true", 100), ("other", "false", 500)]
 
-    scores = keyed_kl_score(
+    score_dict = keyed_kl_score(
         baseline,
         outliers,
         total_a=sum(i[2] for i in baseline),
         total_b=sum(i[2] for i in outliers),
     )
-    assert scores[0][0] == "key"
-    assert math.isclose(scores[0][1], 0.297377, rel_tol=1e-3)
-    assert scores[1][0] == "other"
-    assert math.isclose(scores[1][1], 0.007, abs_tol=1e-3)
+    assert math.isclose(score_dict["key"], 0.297377, rel_tol=1e-3)
+    assert math.isclose(score_dict["other"], 0.007, abs_tol=1e-3)
 
     # Assert that without a large unseen value (missing the other key) the suspicion probability
     # is higher.
     baseline = [("key", "true", 10), ("key", "false", 200)]
     outliers = [("key", "true", 10)]
 
-    scores = keyed_kl_score(
+    score_dict = keyed_kl_score(
         baseline,
         outliers,
         total_a=sum(i[2] for i in baseline),
         total_b=sum(i[2] for i in outliers),
     )
-    assert scores[0][0] == "key"
-    assert math.isclose(scores[0][1], 8.58, rel_tol=1e-3)
+    assert math.isclose(score_dict["key"], 8.58, rel_tol=1e-3)
 
 
 def test_kl_score():

--- a/tests/sentry/seer/workflows/test_compare.py
+++ b/tests/sentry/seer/workflows/test_compare.py
@@ -12,27 +12,30 @@ def test_keyed_kl_score():
     ]
     outliers = [("key", "true", 10), ("other", "true", 100), ("other", "false", 500)]
 
-    score_dict = keyed_kl_score(
+    scores = keyed_kl_score(
         baseline,
         outliers,
         total_a=sum(i[2] for i in baseline),
         total_b=sum(i[2] for i in outliers),
     )
-    assert math.isclose(score_dict["key"], 0.297377, rel_tol=1e-3)
-    assert math.isclose(score_dict["other"], 0.007, abs_tol=1e-3)
+    assert scores[0][0] == "key"
+    assert math.isclose(scores[0][1], 0.297377, rel_tol=1e-3)
+    assert scores[1][0] == "other"
+    assert math.isclose(scores[1][1], 0.007, abs_tol=1e-3)
 
     # Assert that without a large unseen value (missing the other key) the suspicion probability
     # is higher.
     baseline = [("key", "true", 10), ("key", "false", 200)]
     outliers = [("key", "true", 10)]
 
-    score_dict = keyed_kl_score(
+    scores = keyed_kl_score(
         baseline,
         outliers,
         total_a=sum(i[2] for i in baseline),
         total_b=sum(i[2] for i in outliers),
     )
-    assert math.isclose(score_dict["key"], 8.58, rel_tol=1e-3)
+    assert scores[0][0] == "key"
+    assert math.isclose(scores[0][1], 8.58, rel_tol=1e-3)
 
 
 def test_kl_score():


### PR DESCRIPTION
Adds a `baseline_percent` field to the suspect flags response, representing the percent of all events that have the flag enabled (in the issue's project).