### PR TITLE
fix(issue-views): Fix add view loading state in new nav

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -90,7 +90,11 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
 }
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  margin: 0 !important;
+  && {
+    margin: 0;
+    height: 14px;
+    width: 14px;
+  }
 `;
 
 const AddViewButton = styled(Button)<{layout: NavLayout}>`


### PR DESCRIPTION
This may have regressed in https://github.com/getsentry/sentry/pull/88738 ?

The global CSS is annoying, setting the width/height with high specificity is the only way I can see how to fix this.

Before:

![CleanShot 2025-04-08 at 11 43 41](https://github.com/user-attachments/assets/e5cb8baa-e6cc-4be3-987a-5fe4b6a52eef)

After:

![CleanShot 2025-04-08 at 11 44 38](https://github.com/user-attachments/assets/c5282d06-1755-48af-a17b-6b04b1a57232)
