### PR TITLE
fix(aci milestone 3): placeholder get group key values

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -65,7 +65,7 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
     def get_group_key_values(
         self, data_packet: DataPacket[MetricDetectorUpdate]
     ) -> dict[DetectorGroupKey, int]:
-        return {None: data_packet.packet["values"]["aggregation_value"]}
+        return {None: data_packet.packet["values"]["value"]}
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -66,7 +66,7 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
         self, data_packet: DataPacket[QuerySubscriptionUpdate]
     ) -> dict[DetectorGroupKey, int]:
         # This is for testing purposes, we'll need to update the values inspected.
-        return {None: data_packet.packet["values"]["foo"]}
+        return {None: 17}
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from sentry import features
 from sentry.incidents.metric_alert_detector import MetricAlertsDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
-from sentry.incidents.utils.types import QuerySubscriptionUpdate
+from sentry.incidents.utils.types import MetricDetectorUpdate, QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
@@ -63,10 +63,9 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
         return int(data_packet.packet.get("timestamp", datetime.now(UTC)).timestamp())
 
     def get_group_key_values(
-        self, data_packet: DataPacket[QuerySubscriptionUpdate]
+        self, data_packet: DataPacket[MetricDetectorUpdate]
     ) -> dict[DetectorGroupKey, int]:
-        # This is for testing purposes, we'll need to update the values inspected.
-        return {None: 17}
+        return {None: data_packet.packet["values"]["aggregation_value"]}
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -419,12 +419,12 @@ class SubscriptionProcessor:
             "organizations:workflow-engine-metric-alert-processing",
             self.subscription.project.organization,
         ):
-            packet = {
-                "entity": subscription_update["entity"],
-                "subscription_id": subscription_update["subscription_id"],
-                "values": {"aggregation_value": aggregation_value},
-                "timestamp": self.last_update,
-            }
+            packet = MetricDetectorUpdate(
+                entity=subscription_update.get("entity", ""),
+                subscription_id=subscription_update["subscription_id"],
+                values={"aggregation_value": aggregation_value},
+                timestamp=self.last_update,
+            )
             data_packet = DataPacket[MetricDetectorUpdate](
                 source_id=str(self.subscription.id), packet=packet
             )

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -396,14 +396,7 @@ class SubscriptionProcessor:
             metrics.incr("incidents.alert_rules.skipping_already_processed_update")
             return
 
-        if features.has(
-            "organizations:workflow-engine-metric-alert-processing",
-            self.subscription.project.organization,
-        ):
-            data_packet = DataPacket[QuerySubscriptionUpdate](
-                source_id=str(self.subscription.id), packet=subscription_update
-            )
-            process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        aggregation_value = self.get_aggregation_value(subscription_update, self.alert_rule)
 
         self.last_update = subscription_update["timestamp"]
 
@@ -421,7 +414,20 @@ class SubscriptionProcessor:
                 },
             )
 
-        aggregation_value = self.get_aggregation_value(subscription_update, self.alert_rule)
+        if features.has(
+            "organizations:workflow-engine-metric-alert-processing",
+            self.subscription.project.organization,
+        ):
+            packet = {
+                "entity": subscription_update["entity"],
+                "subscription_id": subscription_update["subscription_id"],
+                "values": {"aggregation_value": aggregation_value},
+                "timestamp": self.last_update,
+            }
+            data_packet = DataPacket[QuerySubscriptionUpdate](
+                source_id=str(self.subscription.id), packet=packet
+            )
+            process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
 
         has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -46,6 +46,7 @@ from sentry.incidents.utils.process_update_helpers import (
 )
 from sentry.incidents.utils.types import (
     DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+    MetricDetectorUpdate,
     QuerySubscriptionUpdate,
 )
 from sentry.models.project import Project
@@ -424,7 +425,7 @@ class SubscriptionProcessor:
                 "values": {"aggregation_value": aggregation_value},
                 "timestamp": self.last_update,
             }
-            data_packet = DataPacket[QuerySubscriptionUpdate](
+            data_packet = DataPacket[MetricDetectorUpdate](
                 source_id=str(self.subscription.id), packet=packet
             )
             process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -422,7 +422,7 @@ class SubscriptionProcessor:
             packet = MetricDetectorUpdate(
                 entity=subscription_update.get("entity", ""),
                 subscription_id=subscription_update["subscription_id"],
-                values={"aggregation_value": aggregation_value},
+                values={"value": aggregation_value},
                 timestamp=self.last_update,
             )
             data_packet = DataPacket[MetricDetectorUpdate](

--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -10,6 +10,13 @@ class QuerySubscriptionUpdate(TypedDict):
     timestamp: datetime
 
 
+class MetricDetectorUpdate(TypedDict):
+    entity: str
+    subscription_id: str
+    values: Any
+    timestamp: datetime
+
+
 class AlertRuleActivationConditionType(Enum):
     RELEASE_CREATION = 0
     DEPLOY_CREATION = 1

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -3845,7 +3845,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         data_packet_list = mock_process_data_packets.call_args_list[0][0][0]
         assert data_packet_list[0].source_id == str(self.sub.id)
-        assert data_packet_list[0].packet["values"] == {"data": [{"some_col_name": 10}]}
+        assert data_packet_list[0].packet["values"] == {"aggregation_value": 10}
 
 
 class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -3845,7 +3845,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         data_packet_list = mock_process_data_packets.call_args_list[0][0][0]
         assert data_packet_list[0].source_id == str(self.sub.id)
-        assert data_packet_list[0].packet["values"] == {"aggregation_value": 10}
+        assert data_packet_list[0].packet["values"] == {"value": 10}
 
 
 class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -137,7 +137,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         """
         subscription_update: QuerySubscriptionUpdate = {
             "subscription_id": "123",
-            "values": {"foo": 1},
+            "values": {"aggregation_value": 1},
             "timestamp": datetime.now(UTC),
             "entity": "test-entity",
         }

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -137,7 +137,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         """
         subscription_update: QuerySubscriptionUpdate = {
             "subscription_id": "123",
-            "values": {"aggregation_value": 1},
+            "values": {"value": 1},
             "timestamp": datetime.now(UTC),
             "entity": "test-entity",
         }


### PR DESCRIPTION
`data_packet.packet["values"]["foo"]` was breaking things when we turned on dual processing. This will be refactored soon, so just replace it with a random integer.