### PR TITLE
feat(perf): Disable unimplemented Transaction Summary charts

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -19,7 +19,7 @@ export enum EAPWidgetType {
 
 const WIDGET_OPTIONS: Record<
   EAPWidgetType,
-  {description: string; title: string; spanCategoryTitle?: string}
+  {description: string; title: string; disabled?: boolean; spanCategoryTitle?: string}
 > = {
   [EAPWidgetType.DURATION_BREAKDOWN]: {
     title: t('Duration Breakdown'),
@@ -27,6 +27,7 @@ const WIDGET_OPTIONS: Record<
     description: t(
       'Duration Breakdown reflects transaction durations by percentile over time.'
     ),
+    disabled: false,
   },
   [EAPWidgetType.DURATION_PERCENTILES]: {
     title: t('Duration Percentiles'),
@@ -34,6 +35,7 @@ const WIDGET_OPTIONS: Record<
     description: t(
       `Compare the duration at each percentile. Compare with Latency Histogram to see transaction volume at duration intervals.`
     ),
+    disabled: false,
   },
   [EAPWidgetType.DURATION_DISTRIBUTION]: {
     title: t('Duration Distribution'),
@@ -41,16 +43,19 @@ const WIDGET_OPTIONS: Record<
     description: t(
       'Duration Distribution reflects the volume of transactions per median duration.'
     ),
+    disabled: true,
   },
   [EAPWidgetType.TRENDS]: {
     title: t('Trends'),
     description: t('Trends shows the smoothed value of an aggregate over time.'),
+    disabled: true,
   },
   [EAPWidgetType.WEB_VITALS]: {
     title: t('Web Vitals'),
     description: t(
       'Web Vitals Breakdown reflects the 75th percentile of web vitals over time.'
     ),
+    disabled: true,
   },
 };
 
@@ -83,6 +88,7 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
     return Object.entries(WIDGET_OPTIONS).map(([key, value]) => ({
       label: value.title,
       value: key,
+      disabled: value.disabled,
     }));
   }, []);
 


### PR DESCRIPTION
Disables the selector options for the new charts that are not currently implemented in EAP

![image](https://github.com/user-attachments/assets/1682ba0e-e371-48e5-b000-b2453c112e6a)
