### PR TITLE
fix(insights): `useSamplesDrawer` blocks releases drawer from opening

### DIFF
--- a/static/app/views/insights/common/utils/useSamplesDrawer.tsx
+++ b/static/app/views/insights/common/utils/useSamplesDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -96,13 +96,19 @@ export function useSamplesDrawer({
   const shouldDrawerOpen = requiredParams.every(paramName =>
     Boolean(location.query[paramName])
   );
+  const previousShouldDrawerOpen = useRef(shouldDrawerOpen);
 
   useEffect(() => {
     if (shouldDrawerOpen) {
       openSamplesDrawer();
-    } else {
+    } else if (previousShouldDrawerOpen.current) {
+      // Only close if drawer was previously open due to URL params. This
+      // should stop the case where a different drawer was open and this hook
+      // closes it because params don't match
       closeDrawer();
     }
+
+    previousShouldDrawerOpen.current = shouldDrawerOpen;
   }, [shouldDrawerOpen, openSamplesDrawer, closeDrawer]);
 }
 

--- a/static/app/views/insights/common/utils/useSamplesDrawer.tsx
+++ b/static/app/views/insights/common/utils/useSamplesDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -96,19 +96,10 @@ export function useSamplesDrawer({
   const shouldDrawerOpen = requiredParams.every(paramName =>
     Boolean(location.query[paramName])
   );
-  const previousShouldDrawerOpen = useRef(shouldDrawerOpen);
-
   useEffect(() => {
     if (shouldDrawerOpen) {
       openSamplesDrawer();
-    } else if (previousShouldDrawerOpen.current) {
-      // Only close if drawer was previously open due to URL params. This
-      // should stop the case where a different drawer was open and this hook
-      // closes it because params don't match
-      closeDrawer();
     }
-
-    previousShouldDrawerOpen.current = shouldDrawerOpen;
   }, [shouldDrawerOpen, openSamplesDrawer, closeDrawer]);
 }
 


### PR DESCRIPTION
This fixes `useSamplesDrawer` from immediately closing the releases drawer when it is opened. Previously this hook would always close the global drawer, regardless of drawer contents, if it does not detect its required URL params. Now we add a check to see if it was previously opened due to URL params, otherwise we dont need to close it since we know it means something else caused it to open.
