### PR TITLE
chore(ourlogs): Sort by precise timestamp

### DIFF
--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -51,14 +51,15 @@ def query(
     query_source: QuerySource | None = None,
     debug: bool = False,
 ) -> EventsResponse:
+    precise_timestamp = "tags[sentry.timestamp_precise,number]"
     if orderby == ["-timestamp"]:
-        orderby = ["-timestamp", "-sentry.timestamp_precise"]
-        if "sentry.timestamp_precise" not in selected_columns:
-            selected_columns.append("sentry.timestamp_precise")
+        orderby = ["-timestamp", f"-{precise_timestamp}"]
+        if precise_timestamp not in selected_columns:
+            selected_columns.append(precise_timestamp)
     if orderby == ["timestamp"]:
-        orderby = ["timestamp", "sentry.timestamp_precise"]
-        if "sentry.timestamp_precise" not in selected_columns:
-            selected_columns.append("sentry.timestamp_precise")
+        orderby = ["timestamp", precise_timestamp]
+        if precise_timestamp not in selected_columns:
+            selected_columns.append(precise_timestamp)
     return run_table_query(
         query_string=query or "",
         selected_columns=selected_columns,

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -51,6 +51,14 @@ def query(
     query_source: QuerySource | None = None,
     debug: bool = False,
 ) -> EventsResponse:
+    if orderby == ["-timestamp"]:
+        orderby = ["-timestamp", "-sentry.timestamp_precise"]
+        if "sentry.timestamp_precise" not in selected_columns:
+            selected_columns.append("sentry.timestamp_precise")
+    if orderby == ["timestamp"]:
+        orderby = ["timestamp", "sentry.timestamp_precise"]
+        if "sentry.timestamp_precise" not in selected_columns:
+            selected_columns.append("sentry.timestamp_precise")
     return run_table_query(
         query_string=query or "",
         selected_columns=selected_columns,

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -55,12 +55,16 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
     def test_timestamp_order(self):
         logs = [
             self.create_ourlog(
-                {"body": "bar"},
+                {"body": "foo"},
                 timestamp=self.ten_mins_ago,
             ),
             self.create_ourlog(
-                {"body": "foo"},
-                timestamp=self.nine_mins_ago,
+                {"body": "bar"},
+                timestamp=self.ten_mins_ago + timedelta(microseconds=1),
+            ),
+            self.create_ourlog(
+                {"body": "baz"},
+                timestamp=self.ten_mins_ago + timedelta(microseconds=2),
             ),
         ]
         self.store_ourlogs(logs)
@@ -77,7 +81,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         meta = response.data["meta"]
-        assert len(data) == 2
+        assert len(data) == len(logs)
 
         for log, source in zip(data, logs):
             assert log["log.body"] == source["body"]

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -85,6 +85,8 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
 
         for log, source in zip(data, logs):
             assert log["log.body"] == source["body"]
+            assert "tags[sentry.timestamp_precise,number]" in log
+            assert "timestamp" in log
             ts = datetime.fromisoformat(log["timestamp"])
             assert ts.tzinfo == timezone.utc
             timestamp_from_nanos = source["timestamp_nanos"] / 1_000_000_000


### PR DESCRIPTION
Sort first by imprecise timestamp, then by precise timestamp. Logs with sub-second accuracy will now properly be ordered.