### PR TITLE
feat(span-alerts): Make best effort request for alert details chart

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -61,6 +61,7 @@ import {getChangeStatus} from 'sentry/views/alerts/utils/getChangeStatus';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useMetricEventStats} from 'sentry/views/issueDetails/metricIssues/useMetricEventStats';
 import {useMetricSessionStats} from 'sentry/views/issueDetails/metricIssues/useMetricSessionStats';
 
@@ -459,6 +460,11 @@ export default function MetricChart({
       rule,
       timePeriod,
       referrer: 'api.alerts.alert-rule-chart',
+      samplingMode:
+        organization.features.includes('visibility-explore-progressive-loading') &&
+        rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
+          ? SAMPLING_MODE.BEST_EFFORT
+          : undefined,
     },
     {enabled: !shouldUseSessionsStats}
   );

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -18,6 +18,10 @@ import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {getMetricDatasetQueryExtras} from 'sentry/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
+import type {
+  SamplingMode,
+  SpansRPCQueryExtras,
+} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 interface MetricEventStatsParams {
   project: Project;
@@ -39,6 +43,7 @@ export interface EventRequestQueryParams {
   project?: number[];
   query?: string;
   referrer?: string;
+  samplingMode?: SamplingMode;
   start?: string;
   statsPeriod?: string;
   team?: string | string[];
@@ -51,7 +56,13 @@ export interface EventRequestQueryParams {
 }
 
 export function useMetricEventStats(
-  {project, rule, timePeriod, referrer}: MetricEventStatsParams,
+  {
+    project,
+    rule,
+    timePeriod,
+    referrer,
+    samplingMode,
+  }: MetricEventStatsParams & SpansRPCQueryExtras,
   options: Partial<UseApiQueryOptions<EventsStats>> = {}
 ) {
   const organization = useOrganization();
@@ -92,6 +103,7 @@ export function useMetricEventStats(
       yAxis: aggregate,
       useRpc: dataset === Dataset.EVENTS_ANALYTICS_PLATFORM ? '1' : undefined,
       referrer,
+      sampling: samplingMode,
       ...queryExtras,
     }).filter(([, value]) => typeof value !== 'undefined')
   );


### PR DESCRIPTION
Pass along the `BEST_EFFORT` enum for the metrics chart request for EAP charts on the alert details page (i.e. after an alert's been saved)