### PR TITLE
fix(warmup): add plugin import to warmup

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
+from sentry.middleware.integrations.parsers.plugin import PluginRequestParser  # noqa
 from sentry.ratelimits.config import RateLimitConfig
 
 

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -4,9 +4,11 @@ import sys
 SUBPROCESS_TEST_WGI_WARMUP = """
 import sys
 assert "sentry.conf.urls" not in sys.modules
+assert "sentry.middleware.integrations.parsers.plugin" not in sys.modules
 
 import sentry.wsgi
 assert "sentry.conf.urls" in sys.modules
+assert "sentry.middleware.integrations.parsers.plugin" in sys.modules
 
 import django.urls.resolvers
 from django.conf import settings


### PR DESCRIPTION
#inc-1109.

We notice from profiles that we spend a lot of time on this import. let's import it during warmup. Tested locally and takes 10ms, also added assertion to test_warmup and confirmed that our current warmup process wasn't importing this.

Can see flame chart for suspected impact:
https://sentry.sentry.io/insights/backend/summary/profiles/?end=2025-04-06T03%3A59%3A59&project=1&query=http.method%3APOST%20transaction.op%3Ahttp.server&start=2025-04-04T04%3A00%3A00&transaction=%2Fapi%2F0%2Finternal%2Frpc%2F%7Bservice_name%7D%2F%7Bmethod_name%7D%2F