### PR TITLE
feat(insights): Add a "View All" button to Insights chartWithIssues

### DIFF
--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Flex} from 'sentry/components/container/flex';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
@@ -115,7 +116,16 @@ export default function ChartWithIssues({
             icon={<IconExpand />}
             onClick={() => {
               openInsightChartModal({
-                title,
+                title: (
+                  <Flex justify="space-between">
+                    {title}
+                    {hasData && recentIssues?.length ? (
+                      <LinkButton size="xs" to={{pathname: `/issues/`}}>
+                        {t('View All')}
+                      </LinkButton>
+                    ) : null}
+                  </Flex>
+                ),
                 children: (
                   <Fragment>
                     <ModalChartContainer>
@@ -131,9 +141,11 @@ export default function ChartWithIssues({
               });
             }}
           />
-          <LinkButton size="xs" to={{pathname: `/issues/`}}>
-            {t('View All')}
-          </LinkButton>
+          {hasData && recentIssues?.length ? (
+            <LinkButton size="xs" to={{pathname: `/issues/`}}>
+              {t('View All')}
+            </LinkButton>
+          ) : null}
         </Widget.WidgetToolbar>
       }
       noFooterPadding

--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/core/button';
+import {Button, LinkButton} from 'sentry/components/core/button';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import Panel from 'sentry/components/panels/panel';
@@ -131,6 +131,9 @@ export default function ChartWithIssues({
               });
             }}
           />
+          <LinkButton size="xs" to={{pathname: `/issues/`}}>
+            {t('View All')}
+          </LinkButton>
         </Widget.WidgetToolbar>
       }
       noFooterPadding


### PR DESCRIPTION
New button "View All" that appears when hovering ontop of the Issue based charts on Insights.

| Insight the Insights Page | Full Mode in a modal |
| --- | --- |
| ![SCR-20250408-lydu](https://github.com/user-attachments/assets/b11eae38-946d-4608-a848-6fefab6adcb3) | ![SCR-20250408-myio](https://github.com/user-attachments/assets/242177bc-50f8-4ae6-a9fb-9552c5af8cc7) |
