### PR TITLE
chore: Bump Arroyo version to 2.20.10

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ requests>=2.32.3
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
-sentry-arroyo>=2.20.8
+sentry-arroyo>=2.20.9
 sentry-kafka-schemas>=1.1.4
 sentry-ophio==1.0.0
 sentry-protos>=0.1.66

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ requests>=2.32.3
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
-sentry-arroyo>=2.20.9
+sentry-arroyo>=2.20.10
 sentry-kafka-schemas>=1.1.6
 sentry-ophio==1.0.0
 sentry-protos>=0.1.66

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
 selenium==4.16.0
-sentry-arroyo==2.20.9
+sentry-arroyo==2.20.10
 sentry-cli==2.16.0
 sentry-covdefaults-disable-branch-coverage==1.0.2
 sentry-devenv==1.16.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
 selenium==4.16.0
-sentry-arroyo==2.20.8
+sentry-arroyo==2.20.9
 sentry-cli==2.16.0
 sentry-covdefaults-disable-branch-coverage==1.0.2
 sentry-devenv==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rfc3986-validator==0.1.1
 rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
-sentry-arroyo==2.20.8
+sentry-arroyo==2.20.9
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.4
 sentry-ophio==1.0.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rfc3986-validator==0.1.1
 rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
-sentry-arroyo==2.20.9
+sentry-arroyo==2.20.10
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.1.6
 sentry-ophio==1.0.0


### PR DESCRIPTION
Utilize new fixes that are pushed to Arroyo
