### PR TITLE
fix(insights): Adjust height & margin of Issue based charts on Insights > Session Health

### DIFF
--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -147,6 +147,7 @@ const FooterIssues = styled('div')`
 const GroupWrapper = styled(GroupSummary)`
   border-top: 1px solid ${p => p.theme.border};
   padding: ${space(1)} ${space(0.5)} ${space(1.5)} ${space(0.5)};
+  margin-inline: ${space(1)};
 
   &:first-child {
     border-top: none;

--- a/static/app/views/insights/sessions/utils/sessions.tsx
+++ b/static/app/views/insights/sessions/utils/sessions.tsx
@@ -15,4 +15,4 @@ export const getCountStatusSeries = (
     'count_unique(user)'
   ] ?? [];
 
-export const SESSION_HEALTH_CHART_HEIGHT = 400;
+export const SESSION_HEALTH_CHART_HEIGHT = 322;


### PR DESCRIPTION
Before the border between the Issues in the list (two items) was too short. Now it's running almost across the whole width, even at the left and right.

**Before**
![SCR-20250408-lydu](https://github.com/user-attachments/assets/298477e5-077c-4842-82a0-6d198c081772)


**After**
![SCR-20250408-macv](https://github.com/user-attachments/assets/ea1fefa4-f65a-44e6-bfc2-60d7c695e6bf)


I also adjusted the overall height to account for their only being 2 items in the list instead of three. Should've done that as part of https://github.com/getsentry/sentry/pull/89062 but missed adding the file.
