### PR TITLE
test(eap-spans): add tests for http response rate timeseries

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -280,7 +280,7 @@ def http_response_rate(args: ResolvedArguments, settings: ResolverSettings) -> C
         ),
         op=Column.BinaryFormula.OP_DIVIDE,
         right=Column(
-            conditional_aggregation=AttributeConditionalAggregation(
+            aggregation=AttributeAggregation(
                 aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(
                     name="sentry.status_code",

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -177,7 +177,6 @@ def run_timeseries_query(
 
     """Run the query"""
     rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
-
     """Process the results"""
     result = ProcessedTimeseries()
     final_meta: EventsMeta = EventsMeta(fields={})

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1678,6 +1678,60 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         assert data[2][1][0]["count"] == 0.0
         assert response.data["meta"]["dataset"] == self.dataset
 
+    def test_http_response_rate_multiple_series(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "description 1", "sentry_tags": {"status_code": "500"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"description": "description 1", "sentry_tags": {"status_code": "400"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+                self.create_span(
+                    {"description": "description 2", "sentry_tags": {"status_code": "500"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"description": "description 2", "sentry_tags": {"status_code": "500"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"description": "description 2", "sentry_tags": {"status_code": "500"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+                self.create_span(
+                    {"description": "description 2", "sentry_tags": {"status_code": "400"}},
+                    start_ts=self.day_ago + timedelta(minutes=2),
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=4),
+                "interval": "1m",
+                "query": "",
+                "yAxis": ["http_response_rate(5)", "http_response_rate(4)"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["http_response_rate(5)"]["data"][0][1][0]["count"] == 0.0
+        assert data["http_response_rate(5)"]["data"][1][1][0]["count"] == 0.5
+        assert data["http_response_rate(5)"]["data"][2][1][0]["count"] == 0.75
+
+        assert data["http_response_rate(4)"]["data"][0][1][0]["count"] == 0.0
+        assert data["http_response_rate(4)"]["data"][1][1][0]["count"] == 0.5
+        assert (
+            data["http_response_rate(4)"]["data"][2][1][0]["count"] == 0.25
+        )  # why is this returning 0.75 :(
+
     @pytest.mark.xfail(reason="https://github.com/getsentry/eap-planning/issues/237")
     def test_downsampling_single_series(self):
         span = self.create_span(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1772,15 +1772,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         )
         assert response.status_code == 200, response.content
         data = response.data
-        assert data["http_response_rate(5)"]["data"][0][1][0]["count"] == 0.0
-        assert data["http_response_rate(5)"]["data"][1][1][0]["count"] == 0.5
-        assert data["http_response_rate(5)"]["data"][2][1][0]["count"] == 0.75
 
         assert data["http_response_rate(4)"]["data"][0][1][0]["count"] == 0.0
         assert data["http_response_rate(4)"]["data"][1][1][0]["count"] == 0.5
-        assert (
-            data["http_response_rate(4)"]["data"][2][1][0]["count"] == 0.25
-        )  # why is this returning 0.75 :(
+        assert data["http_response_rate(4)"]["data"][2][1][0]["count"] == 0.25
+
+        assert data["http_response_rate(5)"]["data"][0][1][0]["count"] == 0.0
+        assert data["http_response_rate(5)"]["data"][1][1][0]["count"] == 0.5
+        assert data["http_response_rate(5)"]["data"][2][1][0]["count"] == 0.75  # why is this 0.25?
 
     @pytest.mark.xfail(reason="https://github.com/getsentry/eap-planning/issues/237")
     def test_downsampling_single_series(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1678,8 +1678,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         assert data[2][1][0]["count"] == 0.0
         assert response.data["meta"]["dataset"] == self.dataset
 
-    # This passes no problem
-    def test_http_response_rate_multiple_series(self):
+    def test_http_response_rate(self):
         self.store_spans(
             [
                 self.create_span(
@@ -1728,7 +1727,10 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         assert data["data"][1][1][0]["count"] == 0.5
         assert data["data"][2][1][0]["count"] == 0.75
 
-    def test_http_response_rate_multiple_series_fails_for_some_reason(self):
+    @pytest.mark.xfail(
+        reason="raw sql is is not querying for 5xx's, https://github.com/getsentry/eap-planning/issues/242"
+    )
+    def test_http_response_rate_multiple_series(self):
         self.store_spans(
             [
                 self.create_span(
@@ -1779,7 +1781,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
 
         assert data["http_response_rate(5)"]["data"][0][1][0]["count"] == 0.0
         assert data["http_response_rate(5)"]["data"][1][1][0]["count"] == 0.5
-        assert data["http_response_rate(5)"]["data"][2][1][0]["count"] == 0.75  # why is this 0.25?
+        assert data["http_response_rate(5)"]["data"][2][1][0]["count"] == 0.75
 
     @pytest.mark.xfail(reason="https://github.com/getsentry/eap-planning/issues/237")
     def test_downsampling_single_series(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1716,7 +1716,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
                 "end": self.day_ago + timedelta(minutes=4),
                 "interval": "1m",
                 "query": "",
-                "yAxis": ["http_response_rate(4)"],
+                "yAxis": ["http_response_rate(5)"],
                 "project": self.project.id,
                 "dataset": self.dataset,
             },
@@ -1726,7 +1726,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
 
         assert data["data"][0][1][0]["count"] == 0.0
         assert data["data"][1][1][0]["count"] == 0.5
-        assert data["data"][2][1][0]["count"] == 0.25
+        assert data["data"][2][1][0]["count"] == 0.75
 
     def test_http_response_rate_multiple_series_fails_for_some_reason(self):
         self.store_spans(


### PR DESCRIPTION
- First and second case have the same spans
- First test case passes with `http_response_rate(5)`
- Second test case fails with `http_response_rate(4)` and `http_response_rate(5)`. Despite it passing in test case 1

Below is the rpc request and response of the second test case

x failed test case for now, until https://github.com/getsentry/eap-planning/issues/242 is fixed

<details>
<summary>RPC REQUEST</summary> 
<pre><code class="language-json">
api.organization-event-stats.body:
{
  "meta": {
    "organizationId": "4555871906430976",
    "referrer": "api.organization-event-stats",
    "projectIds": [
      "4555871906430978"
    ],
    "startTimestamp": "2025-04-08T10:00:00Z",
    "endTimestamp": "2025-04-08T10:04:00Z",
    "traceItemType": "TRACE_ITEM_TYPE_SPAN",
    "downsampledStorageConfig": {}
  },
  "granularitySecs": "60",
  "expressions": [
    {
      "formula": {
        "op": "OP_DIVIDE",
        "left": {
          "conditionalAggregation": {
            "aggregate": "FUNCTION_COUNT",
            "key": {
              "type": "TYPE_STRING",
              "name": "sentry.status_code"
            },
            "label": "error_request_count",
            "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
            "filter": {
              "comparisonFilter": {
                "key": {
                  "type": "TYPE_STRING",
                  "name": "sentry.status_code"
                },
                "op": "OP_IN",
                "value": {
                  "valStrArray": {
                    "values": [
                      "400",
                      "401",
                      "402",
                      "403",
                      "404",
                      "405",
                      "406",
                      "407",
                      "408",
                      "409",
                      "410",
                      "411",
                      "412",
                      "413",
                      "414",
                      "415",
                      "416",
                      "417",
                      "418",
                      "421",
                      "422",
                      "423",
                      "424",
                      "425",
                      "426",
                      "428",
                      "429",
                      "431",
                      "451"
                    ]
                  }
                }
              }
            }
          }
        },
        "right": {
          "aggregation": {
            "aggregate": "FUNCTION_COUNT",
            "key": {
              "type": "TYPE_STRING",
              "name": "sentry.status_code"
            },
            "label": "total_request_count",
            "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED"
          }
        }
      },
      "label": "http_response_rate(4)"
    },
    {
      "formula": {
        "op": "OP_DIVIDE",
        "left": {
          "conditionalAggregation": {
            "aggregate": "FUNCTION_COUNT",
            "key": {
              "type": "TYPE_STRING",
              "name": "sentry.status_code"
            },
            "label": "error_request_count",
            "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
            "filter": {
              "comparisonFilter": {
                "key": {
                  "type": "TYPE_STRING",
                  "name": "sentry.status_code"
                },
                "op": "OP_IN",
                "value": {
                  "valStrArray": {
                    "values": [
                      "500",
                      "501",
                      "502",
                      "503",
                      "504",
                      "505",
                      "506",
                      "507",
                      "508",
                      "509",
                      "510",
                      "511"
                    ]
                  }
                }
              }
            }
          }
        },
        "right": {
          "aggregation": {
            "aggregate": "FUNCTION_COUNT",
            "key": {
              "type": "TYPE_STRING",
              "name": "sentry.status_code"
            },
            "label": "total_request_count",
            "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED"
          }
        }
      },
      "label": "http_response_rate(5)"
    }
  ]
}
 </code>
</details>

<details>
<summary>RPC RESPONE</summary> 
<pre><code class="language-json">
result_timeseries {
  label: "http_response_rate(5)"
  buckets {
    seconds: 1744106400
  }
  buckets {
    seconds: 1744106460
  }
  buckets {
    seconds: 1744106520
  }
  buckets {
    seconds: 1744106580
  }
  data_points {
  }
  data_points {
    data: 0.5
    data_present: true
  }
  data_points {
    data: 0.25
    data_present: true
  }
  data_points {
  }
}
result_timeseries {
  label: "http_response_rate(4)"
  buckets {
    seconds: 1744106400
  }
  buckets {
    seconds: 1744106460
  }
  buckets {
    seconds: 1744106520
  }
  buckets {
    seconds: 1744106580
  }
  data_points {
  }
  data_points {
    data: 0.5
    data_present: true
  }
  data_points {
    data: 0.25
    data_present: true
  }
  data_points {
  }
}
meta {
  request_id: "2cf37653-b97b-40a4-90a6-447025143a2e"
}
 </code>
</details>