### PR TITLE
ref(insights): Remove `useRef` mocks from tests

### DIFF
--- a/static/app/views/insights/common/components/chart.spec.tsx
+++ b/static/app/views/insights/common/components/chart.spec.tsx
@@ -8,28 +8,13 @@ import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 jest.mock('sentry/components/charts/baseChart', () => {
   return jest.fn().mockImplementation(() => <div />);
 });
-jest.mock('react', () => {
-  return {
-    ...jest.requireActual('react'),
-    useRef: jest.fn(),
-  };
-});
-// XXX: Mocking useRef throws an error for AnimatePrecense, so it must be mocked as well
-jest.mock('framer-motion', () => {
-  return {
-    ...jest.requireActual('framer-motion'),
-    AnimatePresence: jest.fn().mockImplementation(({children}) => <div>{children}</div>),
-  };
-});
 
 describe('Chart', function () {
   test('it shows an error panel if an error prop is supplied', function () {
     const parsingError = new Error('Could not parse chart data');
 
     render(
-      <Chart error={parsingError} data={[]} loading={false} type={ChartType.LINE} />,
-      // Mocked useRef breaks router
-      {enableRouterMocks: false}
+      <Chart error={parsingError} data={[]} loading={false} type={ChartType.LINE} />
     );
 
     expect(screen.getByTestId('chart-error-panel')).toBeInTheDocument();
@@ -57,10 +42,7 @@ describe('Chart', function () {
         }),
       },
     ];
-    render(<Chart data={mockedSeries} loading={false} type={ChartType.LINE} />, {
-      // Mocked useRef breaks router
-      enableRouterMocks: false,
-    });
+    render(<Chart data={mockedSeries} loading={false} type={ChartType.LINE} />);
     expect(jest.mocked(BaseChart).mock.calls[0]![0].series?.[0]).toHaveProperty(
       'markLine'
     );

--- a/static/app/views/insights/common/components/chart.spec.tsx
+++ b/static/app/views/insights/common/components/chart.spec.tsx
@@ -14,7 +14,8 @@ describe('Chart', function () {
     const parsingError = new Error('Could not parse chart data');
 
     render(
-      <Chart error={parsingError} data={[]} loading={false} type={ChartType.LINE} />
+      <Chart error={parsingError} data={[]} loading={false} type={ChartType.LINE} />,
+      {enableRouterMocks: false}
     );
 
     expect(screen.getByTestId('chart-error-panel')).toBeInTheDocument();
@@ -42,7 +43,9 @@ describe('Chart', function () {
         }),
       },
     ];
-    render(<Chart data={mockedSeries} loading={false} type={ChartType.LINE} />);
+    render(<Chart data={mockedSeries} loading={false} type={ChartType.LINE} />, {
+      enableRouterMocks: false,
+    });
     expect(jest.mocked(BaseChart).mock.calls[0]![0].series?.[0]).toHaveProperty(
       'markLine'
     );


### PR DESCRIPTION
Not sure why `useRef` needed to be mocked, but we probably should not need to mock React at all
