### PR TITLE
ref(shared-views): Remove visibility from PUT endpoint request params

### DIFF
--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 
 from sentry import features
 from sentry.api.serializers.rest_framework import ValidationError
-from sentry.models.groupsearchview import GroupSearchViewVisibility
 from sentry.models.project import Project
 from sentry.models.savedsearch import SORT_LITERALS, SortOptions
 
@@ -67,6 +66,7 @@ class ViewValidator(serializers.Serializer):
 
 
 class GroupSearchViewValidator(serializers.Serializer):
+    # TODO(msun): Remove min_length when tabbed views are removed
     views = serializers.ListField(
         child=ViewValidator(), required=True, min_length=1, max_length=MAX_VIEWS
     )
@@ -77,26 +77,6 @@ class GroupSearchViewValidator(serializers.Serializer):
 
 class GroupSearchViewPostValidator(ViewValidator):
     starred = serializers.BooleanField(required=False)
-
-    def validate(self, data):
-        return super().validate(data)
-
-
-class GroupSearchViewDetailsPutValidator(ViewValidator):
-    visibility = serializers.ChoiceField(
-        required=False, choices=GroupSearchViewVisibility.as_choices()
-    )
-
-    def validate_visibility(self, value):
-        has_share_access = (
-            self.context["access"].has_scope("team:admin")
-            or self.context["access"].has_scope("org:admin")
-            or self.context["access"].has_scope("org:owner")
-        )
-
-        if value == GroupSearchViewVisibility.ORGANIZATION and not has_share_access:
-            raise ValidationError(detail="You do not have permission to share this view")
-        return value
 
     def validate(self, data):
         return super().validate(data)

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -11,7 +11,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
-from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewDetailsPutValidator
+from sentry.api.serializers.rest_framework.groupsearchview import ViewValidator
 from sentry.issues.endpoints.organization_group_search_views import pick_default_project
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
@@ -92,9 +92,9 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         except GroupSearchView.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = GroupSearchViewDetailsPutValidator(
+        serializer = ViewValidator(
             data=request.data,
-            context={"organization": organization, "access": request.access},
+            context={"organization": organization},
         )
 
         if not serializer.is_valid():
@@ -109,8 +109,6 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         view.environments = validated_data["environments"]
         view.time_filters = validated_data["timeFilters"]
         view.projects.set(validated_data["projects"])
-
-        view.visibility = validated_data.get("visibility", view.visibility)
 
         view.save()
 

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -8,7 +8,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 
@@ -25,17 +24,6 @@ class GroupSearchViewStarredOrderSerializer(serializers.Serializer):
     def validate_view_ids(self, view_ids):
         if len(view_ids) != len(set(view_ids)):
             raise serializers.ValidationError("Single view cannot take up multiple positions")
-
-        gsvs = GroupSearchView.objects.filter(
-            organization=self.context["organization"], id__in=view_ids
-        )
-        # This should never happen, but we can check just in case
-        if any(
-            gsv.user_id != self.context["user"].id
-            and gsv.visibility != GroupSearchViewVisibility.ORGANIZATION
-            for gsv in gsvs
-        ):
-            raise serializers.ValidationError("You do not have access to one or more views")
 
         return view_ids
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -4,10 +4,8 @@ from django.utils import timezone
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
-from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.silo import assume_test_silo_mode
 from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
 
 
@@ -400,66 +398,6 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         updated_view = GroupSearchView.objects.get(id=self.view_id)
         assert updated_view.is_all_projects is True
         assert updated_view.projects.count() == 0
-
-    @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_put_with_visibility(self) -> None:
-        # Make the user a team admin to set the view to organization visibility
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.user.update(is_staff=True)
-
-        data = {
-            "name": "Organization View",
-            "query": "is:unresolved",
-            "querySort": "date",
-            "projects": [self.project.id],
-            "environments": [],
-            "timeFilters": {"period": "14d"},
-            "visibility": "organization",
-        }
-
-        response = self.client.put(self.url, data=data)
-        assert response.status_code == 200
-
-        # Verify visibility was updated
-        updated_view = GroupSearchView.objects.get(id=self.view_id)
-        assert updated_view.visibility == "organization"
-
-    @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_put_visibility_without_permission(self) -> None:
-        user_without_permission = self.create_user()
-        self.create_member(organization=self.organization, user=user_without_permission)
-
-        self.login_as(user=user_without_permission)
-
-        member_view = GroupSearchView.objects.create(
-            organization=self.organization,
-            user_id=user_without_permission.id,
-            name="Personal View",
-            query="is:unresolved",
-            query_sort="date",
-            visibility=GroupSearchViewVisibility.ORGANIZATION,
-        )
-
-        data = {
-            "name": "Organization View",
-            "query": "is:unresolved",
-            "querySort": "date",
-            "projects": [self.project.id],
-            "environments": [],
-            "timeFilters": {"period": "14d"},
-            "visibility": "organization",
-        }
-
-        url = reverse(
-            "sentry-api-0-organization-group-search-view-details",
-            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": member_view.id},
-        )
-
-        response = self.client.put(url, data=data)
-        assert response.status_code == 400
-
-        member_view.refresh_from_db()
-        assert member_view.visibility == "owner"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_put_nonexistent_view(self) -> None:

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.utils import timezone
 
-from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.silo.base import SiloMode
@@ -221,6 +221,7 @@ class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
             user_id=self.user_1.id,
             name="User 1's View",
             query="is:unresolved",
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
         GroupSearchViewStarred.objects.create(
             organization=self.organization,
@@ -240,6 +241,7 @@ class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
             user_id=self.user_2.id,
             name="User 2's View",
             query="is:unresolved",
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
 
         GroupSearchViewStarred.objects.create(
@@ -435,6 +437,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
             name="Personal View",
             query="is:unresolved",
             query_sort="date",
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
 
         data = {

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
@@ -54,20 +54,6 @@ class OrganizationGroupSearchViewStarredEndpointTest(APITestCase):
         assert response.status_code == 404
 
     @with_feature("organizations:issue-view-sharing")
-    def test_view_not_accessible(self):
-        other_user = self.create_user()
-        view = self.create_view(user_id=other_user.id)
-
-        response = self.client.post(self.get_url(view.id), data={"starred": True})
-
-        assert response.status_code == 404
-        assert not GroupSearchViewStarred.objects.filter(
-            organization=self.org,
-            user_id=self.user.id,
-            group_search_view=view,
-        ).exists()
-
-    @with_feature("organizations:issue-view-sharing")
     def test_organization_view_accessible(self):
         other_user = self.create_user()
         view = self.create_view(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred.py
@@ -29,7 +29,7 @@ class OrganizationGroupSearchViewStarredEndpointTest(APITestCase):
             user_id = self.user.id
 
         if visibility is None:
-            visibility = GroupSearchViewVisibility.OWNER
+            visibility = GroupSearchViewVisibility.ORGANIZATION
 
         view = GroupSearchView.objects.create(
             name="Test View",

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
@@ -27,7 +27,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
                 user_id=self.user.id,
                 query=f"is:unresolved query:{i}",
                 query_sort="date",
-                visibility=GroupSearchViewVisibility.OWNER,
+                visibility=GroupSearchViewVisibility.ORGANIZATION,
             )
             self.views.append(view)
 
@@ -37,7 +37,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
             user_id=self.user.id,
             query="is:unresolved non_starred",
             query_sort="date",
-            visibility=GroupSearchViewVisibility.OWNER,
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
 
         self.user_2_view = GroupSearchView.objects.create(
@@ -46,7 +46,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
             user_id=self.user_2.id,
             query="is:unresolved user_2",
             query_sort="date",
-            visibility=GroupSearchViewVisibility.OWNER,
+            visibility=GroupSearchViewVisibility.ORGANIZATION,
         )
 
         self.shared_view = GroupSearchView.objects.create(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
@@ -188,19 +188,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
             ]
         }
 
-    @with_feature("organizations:issue-view-sharing")
-    def test_error_on_inaccessible_views(self):
-        view_ids = [self.views[0].id, self.user_2_view.id]
-
-        response = self.client.put(self.url, data={"view_ids": view_ids}, format="json")
-
-        assert response.status_code == 400
-        assert response.data == {
-            "view_ids": [
-                ErrorDetail(string="You do not have access to one or more views", code="invalid")
-            ]
-        }
-
 
 class OrganizationGroupSearchViewStarredOrderTransactionTest(TransactionTestCase):
     endpoint = "sentry-api-0-organization-group-search-view-starred-order"


### PR DESCRIPTION
Removes the optional `visibility` param from the `PUT` `/group-search-views/:viewId` endpoint.

This was necessary before we decided to make views shared by default. Now, there's no need to be able to change visibility since everything is shared. 