### PR TITLE
ref(perf): Adjust designs on Transaction Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -1,9 +1,7 @@
 import {useMemo, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -97,25 +95,20 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
   return (
     <Widget
       Title={
-        <WidgetTitleWrapper>
-          <CompactSelect
-            options={options}
-            value={selectedWidget}
-            onChange={option => setSelectedWidget(option.value as EAPWidgetType)}
-            triggerProps={{borderless: true, size: 'md'}}
-          />
+        <CompactSelect
+          options={options}
+          value={selectedWidget}
+          onChange={option => setSelectedWidget(option.value as EAPWidgetType)}
+          triggerProps={{borderless: true, size: 'zero'}}
+        />
+      }
+      Actions={
+        <Widget.WidgetToolbar>
           <Widget.WidgetDescription title={title} description={description} />
-        </WidgetTitleWrapper>
+        </Widget.WidgetToolbar>
       }
       Visualization={visualization}
       revealActions="always"
     />
   );
 }
-
-const WidgetTitleWrapper = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: ${space(1)};
-`;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -95,28 +96,26 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
 
   return (
     <Widget
-      Title={<Widget.WidgetTitle title={title} />}
-      Actions={
-        <Widget.WidgetToolbar>
-          <Widget.WidgetDescription title={title} description={description} />
-        </Widget.WidgetToolbar>
-      }
-      Visualization={visualization}
-      Footer={
-        <FooterContainer>
+      Title={
+        <WidgetTitleWrapper>
           <CompactSelect
             options={options}
             value={selectedWidget}
             onChange={option => setSelectedWidget(option.value as EAPWidgetType)}
+            triggerProps={{borderless: true, size: 'md'}}
           />
-        </FooterContainer>
+          <Widget.WidgetDescription title={title} description={description} />
+        </WidgetTitleWrapper>
       }
+      Visualization={visualization}
+      revealActions="always"
     />
   );
 }
 
-const FooterContainer = styled('div')`
+const WidgetTitleWrapper = styled('div')`
   display: flex;
-  align-items: right;
-  justify-content: right;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -112,6 +112,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
       }
       Visualization={<TimeSeriesWidgetVisualization plottables={plottables} />}
       height={200}
+      borderless
     />
   );
 }


### PR DESCRIPTION
- Remove borders from sidebar charts
- Move the Dropdown options for the chart switcher from the footer to the title

We can clean up the design more in followups, the title dropdown seems a bit messy at the moment

![image](https://github.com/user-attachments/assets/9348d30c-3e7c-4090-9c3c-a7de4be7ab3a)

