### PR TITLE
feat(taskworker) Improve tracing for taskworker

### DIFF
--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -148,12 +148,10 @@ class TaskNamespace:
             name=activation.taskname,
             origin="taskworker",
         ) as span:
+            # TODO(taskworker) add monitor headers
+            span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, activation.namespace)
             span.set_data(SPANDATA.MESSAGING_MESSAGE_ID, activation.id)
-            span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, topic.value)
             span.set_data(SPANDATA.MESSAGING_SYSTEM, "taskworker")
-            span.set_data(
-                SPANDATA.MESSAGING_MESSAGE_RETRY_COUNT, activation.retry_state.max_attempts
-            )
 
             produce_future = self._producer(topic).produce(
                 ArroyoTopic(name=topic.value),

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -6,11 +6,13 @@ from collections.abc import Callable
 from concurrent import futures
 from typing import Any
 
+import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import BrokerValue
 from arroyo.types import Topic as ArroyoTopic
 from django.conf import settings
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
+from sentry_sdk.consts import OP, SPANDATA
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.taskworker.constants import DEFAULT_PROCESSING_DEADLINE
@@ -140,10 +142,24 @@ class TaskNamespace:
 
     def send_task(self, activation: TaskActivation, wait_for_delivery: bool = False) -> None:
         topic = self.router.route_namespace(self.name)
-        produce_future = self._producer(topic).produce(
-            ArroyoTopic(name=topic.value),
-            KafkaPayload(key=None, value=activation.SerializeToString(), headers=[]),
-        )
+
+        with sentry_sdk.start_span(
+            op=OP.QUEUE_PUBLISH,
+            name=activation.taskname,
+            origin="taskworker",
+        ) as span:
+            span.set_data(SPANDATA.MESSAGING_MESSAGE_ID, activation.id)
+            span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, topic.value)
+            span.set_data(SPANDATA.MESSAGING_SYSTEM, "taskworker")
+            span.set_data(
+                SPANDATA.MESSAGING_MESSAGE_RETRY_COUNT, activation.retry_state.max_attempts
+            )
+
+            produce_future = self._producer(topic).produce(
+                ArroyoTopic(name=topic.value),
+                KafkaPayload(key=None, value=activation.SerializeToString(), headers=[]),
+            )
+
         # We know this type is futures.Future, but cannot assert so,
         # because it is also mock.Mock in tests.
         produce_future.add_done_callback(  # type:ignore[attr-defined]


### PR DESCRIPTION
Implement the tracing span for queue.publish which is necessary to have taskworker show up in the performance insights queues module for both the producing and consuming side. I've made each namespace a 'destination' as we generally don't want to expose topic names to application teams.

I will include monitor checkins for scheduled tasks in a separate pull request.