### PR TITLE
ref(shared-views): Rewire reordering event handler to use new endpoint

### DIFF
--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
@@ -5,7 +5,6 @@ import {
   getApiQueryData,
   setApiQueryData,
   useMutation,
-  type UseMutationOptions,
   useQueryClient,
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -18,23 +17,17 @@ type UpdateGroupSearchViewStarredOrderVariables = {
   viewIds: number[];
 };
 
-export const useUpdateGroupSearchViewStarredOrder = (
-  options: Omit<
-    UseMutationOptions<void, RequestError, UpdateGroupSearchViewStarredOrderVariables>,
-    'mutationFn'
-  > = {}
-) => {
+export const useUpdateGroupSearchViewStarredOrder = () => {
   const api = useApi();
   const queryClient = useQueryClient();
 
   return useMutation<void, RequestError, UpdateGroupSearchViewStarredOrderVariables>({
-    ...options,
     mutationFn: ({orgSlug, viewIds}: UpdateGroupSearchViewStarredOrderVariables) =>
       api.requestPromise(`/organizations/${orgSlug}/group-search-views/starred/order/`, {
         method: 'PUT',
         data: {view_ids: viewIds},
       }),
-    onSuccess: (_, parameters, context) => {
+    onSuccess: (_, parameters) => {
       // Reorder the existing views in the cache
       const groupSearchViews = getApiQueryData<GroupSearchView[]>(
         queryClient,
@@ -52,11 +45,9 @@ export const useUpdateGroupSearchViewStarredOrder = (
         makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
         newViewsOrder
       );
-      options.onSuccess?.(_, parameters, context);
     },
-    onError: (error, variables, context) => {
+    onError: () => {
       addErrorMessage(t('Failed to update starred views order'));
-      options.onError?.(error, variables, context);
     },
   });
 };

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
@@ -1,0 +1,62 @@
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {
+  getApiQueryData,
+  setApiQueryData,
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+type UpdateGroupSearchViewStarredOrderVariables = {
+  orgSlug: string;
+  viewIds: number[];
+};
+
+export const useUpdateGroupSearchViewStarredOrder = (
+  options: Omit<
+    UseMutationOptions<void, RequestError, UpdateGroupSearchViewStarredOrderVariables>,
+    'mutationFn'
+  > = {}
+) => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, RequestError, UpdateGroupSearchViewStarredOrderVariables>({
+    ...options,
+    mutationFn: ({orgSlug, viewIds}: UpdateGroupSearchViewStarredOrderVariables) =>
+      api.requestPromise(`/organizations/${orgSlug}/group-search-views/starred/order/`, {
+        method: 'PUT',
+        data: {view_ids: viewIds},
+      }),
+    onSuccess: (_, parameters, context) => {
+      // Reorder the existing views in the cache
+      const groupSearchViews = getApiQueryData<GroupSearchView[]>(
+        queryClient,
+        makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug})
+      );
+      if (!groupSearchViews) {
+        return;
+      }
+      const newViewsOrder = parameters.viewIds
+        .map(id => groupSearchViews.find(view => parseInt(view.id, 10) === id))
+        .filter(defined);
+
+      setApiQueryData<GroupSearchView[]>(
+        queryClient,
+        makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
+        newViewsOrder
+      );
+      options.onSuccess?.(_, parameters, context);
+    },
+    onError: (error, variables, context) => {
+      addErrorMessage(t('Failed to update starred views order'));
+      options.onError?.(error, variables, context);
+    },
+  });
+};


### PR DESCRIPTION
Creates the frontend hook that calls the new `PUT` `/group-search-views/starred/order/` endpoint to reorder views, rather than using the now deprecated `PUT` `/group-search-views/` endpoint, like before. 

Rewires the onReorderComplete hook to call the new endpoint instead. 