### PR TITLE
feat(issues): Add cache projects feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -66,6 +66,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable GenAI features such as Autofix and Issue Summary
     manager.add("organizations:autofix-seer-preferences", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable caching projects in browser to speed up ui bootstrap time
+    manager.add("organizations:cache-projects-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Chonk UI
     manager.add("organizations:chonk-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Chonk UI Feedback button

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -224,7 +224,9 @@ class _ClientConfig:
         if features.has("system:multi-region"):
             yield "system:multi-region"
         # last_org may not always be available
-        if features.has("organizations:cache-projects-ui", self.last_org, actor=self.user):
+        if self.last_org and features.has(
+            "organizations:cache-projects-ui", self.last_org, actor=self.user
+        ):
             yield "organizations:cache-projects-ui"
         # TODO @athena: remove this feature flag after development is done
         # this is a temporary hack to be able to used flagpole in a case where there's no organization

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -223,6 +223,9 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
+        # last_org may not always be available
+        if features.has("organizations:cache-projects-ui", self.last_org, actor=self.user):
+            yield "organizations:cache-projects-ui"
         # TODO @athena: remove this feature flag after development is done
         # this is a temporary hack to be able to used flagpole in a case where there's no organization
         # availble on the frontend


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/80120 we'd like to make this feature flag available in the config object before the frontend bootstrap process has started. 
