### PR TITLE
feat(issue-views): Update issue view table styles and create a common component

### DIFF
--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -41,6 +41,12 @@ function LoadingSkeleton({pageSize}: {pageSize: number}) {
   ));
 }
 
+/**
+ * Meant to be used for tables that display saved entities, such as issue views,
+ * saved queries, or dashboards. Exports a number of sub-components for rendering
+ * the table's content such as the name link, projects, query, etc. to keep things
+ * consistent.
+ */
 export function SavedEntityTable({
   children,
   className,
@@ -133,10 +139,11 @@ SavedEntityTable.Cell = styled('div')`
   display: flex;
   align-items: center;
   padding: ${space(1)} ${space(1.5)};
-`;
 
-SavedEntityTable.ButtonCell = styled(SavedEntityTable.Cell)`
-  padding: 0 ${space(0.5)};
+  /* Buttons already provide some padding */
+  &:has(> button:first-child) {
+    padding: 0 ${space(0.5)};
+  }
 `;
 
 SavedEntityTable.CellStar = function CellStar({

--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -1,0 +1,324 @@
+import type {ReactNode} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import Link from 'sentry/components/links/link';
+import LoadingError from 'sentry/components/loadingError';
+import Panel from 'sentry/components/panels/panel';
+import Placeholder from 'sentry/components/placeholder';
+import {ProjectList} from 'sentry/components/projectList';
+import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {getAbsoluteSummary} from 'sentry/components/timeRangeSelector/utils';
+import TimeSince from 'sentry/components/timeSince';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconEllipsis, IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {DateString} from 'sentry/types/core';
+import useProjects from 'sentry/utils/useProjects';
+
+type SavedEntityTableProps = {
+  children: ReactNode;
+  emptyMessage: ReactNode;
+  header: ReactNode;
+  isEmpty: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  className?: string;
+  pageSize?: number;
+};
+
+function LoadingSkeleton({pageSize}: {pageSize: number}) {
+  return Array.from({length: pageSize}, (_, index) => (
+    <SavedEntityTable.Row key={index} isFirst={index === 0} disableHover>
+      <LoadingCell>
+        <Placeholder height="16px" />
+      </LoadingCell>
+    </SavedEntityTable.Row>
+  ));
+}
+
+export function SavedEntityTable({
+  children,
+  className,
+  header,
+  isEmpty,
+  isError,
+  isLoading,
+  emptyMessage,
+  pageSize = 20,
+}: SavedEntityTableProps) {
+  return (
+    <StyledPanelTable className={className}>
+      {header}
+      {isError && <LoadingError />}
+      {isLoading && <LoadingSkeleton pageSize={pageSize} />}
+      {!isError && !isLoading && isEmpty && (
+        <EmptyContainer>
+          <EmptyStateWarning small>{emptyMessage}</EmptyStateWarning>
+        </EmptyContainer>
+      )}
+      {children}
+    </StyledPanelTable>
+  );
+}
+
+SavedEntityTable.Header = styled('div')`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1/-1;
+
+  height: 36px;
+  background-color: ${p => p.theme.backgroundSecondary};
+`;
+
+SavedEntityTable.HeaderCell = styled('div')`
+  display: flex;
+  align-items: center;
+  padding: 0 ${space(1.5)};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  border-width: 0 1px 0 0;
+  border-style: solid;
+  border-image: linear-gradient(
+      to bottom,
+      transparent,
+      transparent 30%,
+      ${p => p.theme.border} 30%,
+      ${p => p.theme.border} 70%,
+      transparent 70%,
+      transparent
+    )
+    1;
+
+  &:last-child,
+  &:empty {
+    border: 0;
+  }
+
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+SavedEntityTable.Row = styled('div')<{isFirst: boolean; disableHover?: boolean}>`
+  display: grid;
+  position: relative;
+  grid-template-columns: subgrid;
+  grid-column: 1/-1;
+  height: 40px;
+
+  ${p =>
+    p.isFirst &&
+    css`
+      border-top: 1px solid ${p.theme.border};
+    `}
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  }
+
+  ${p =>
+    !p.disableHover &&
+    css`
+      &:hover {
+        background-color: ${p.theme.backgroundSecondary};
+      }
+    `}
+`;
+
+SavedEntityTable.Cell = styled('div')`
+  display: flex;
+  align-items: center;
+  padding: ${space(1)} ${space(1.5)};
+`;
+
+SavedEntityTable.ButtonCell = styled(SavedEntityTable.Cell)`
+  padding: 0 ${space(0.5)};
+`;
+
+SavedEntityTable.CellStar = function CellStar({
+  isStarred,
+  onClick,
+}: {
+  isStarred: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      aria-label={isStarred ? t('Unstar') : t('Star')}
+      borderless
+      icon={<IconStar isSolid={isStarred} color={isStarred ? 'yellow300' : 'subText'} />}
+      size="sm"
+      onClick={onClick}
+    />
+  );
+};
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.textColor};
+  text-decoration: underline;
+  text-decoration-color: ${p => p.theme.border};
+  ${p => p.theme.overflowEllipsis};
+`;
+
+SavedEntityTable.CellName = function CellName({
+  children,
+  to,
+}: {
+  children: ReactNode;
+  to: string;
+}) {
+  return <StyledLink to={to}>{children}</StyledLink>;
+};
+
+SavedEntityTable.CellProjects = function CellProjects({
+  projects,
+}: {
+  projects: Array<string | number>;
+}) {
+  const {projects: allProjects} = useProjects();
+
+  const projectSlugs = allProjects
+    .filter(project => projects.includes(parseInt(project.id, 10)))
+    .map(project => project.slug);
+
+  if (projects.length === 0) {
+    return (
+      <SavedEntityTable.CellTextContent>
+        {t('My Projects')}
+      </SavedEntityTable.CellTextContent>
+    );
+  }
+  if (projects.includes(-1)) {
+    return (
+      <SavedEntityTable.CellTextContent>
+        {t('All Projects')}
+      </SavedEntityTable.CellTextContent>
+    );
+  }
+  return <ProjectList projectSlugs={projectSlugs} maxVisibleProjects={5} />;
+};
+
+SavedEntityTable.CellQuery = function CellQuery({query}: {query: string}) {
+  return <FormattedQueryNoWrap query={query} />;
+};
+
+SavedEntityTable.CellActions = function CellActions({
+  items,
+}: {
+  items: DropdownMenuProps['items'];
+}) {
+  return (
+    <DropdownMenu
+      trigger={triggerProps => (
+        <Button
+          {...triggerProps}
+          aria-label={t('More options')}
+          size="sm"
+          borderless
+          icon={<IconEllipsis direction="down" size="sm" />}
+          data-test-id="menu-trigger"
+        />
+      )}
+      items={items}
+      position="bottom-end"
+    />
+  );
+};
+
+SavedEntityTable.CellEnvironments = function CellEnvironments({
+  environments,
+}: {
+  environments: string[];
+}) {
+  const environmentsLabel =
+    environments.length === 0 ? t('All') : environments.join(', ');
+
+  return (
+    <Tooltip title={environmentsLabel}>
+      <SavedEntityTable.CellTextContent>
+        {environmentsLabel}
+      </SavedEntityTable.CellTextContent>
+    </Tooltip>
+  );
+};
+
+SavedEntityTable.CellTimeFilters = function CellTimeFilters({
+  timeFilters,
+}: {
+  timeFilters: {
+    end: DateString | null;
+    period: string | null;
+    start: DateString | null;
+    utc: boolean | null;
+  };
+}) {
+  if (timeFilters.period) {
+    return (
+      <SavedEntityTable.CellTextContent>
+        {timeFilters.period}
+      </SavedEntityTable.CellTextContent>
+    );
+  }
+
+  const dateRangeText = getAbsoluteSummary(
+    timeFilters.start,
+    timeFilters.end,
+    timeFilters.utc
+  );
+
+  return (
+    <Tooltip title={dateRangeText}>
+      <SavedEntityTable.CellTextContent>{dateRangeText}</SavedEntityTable.CellTextContent>
+    </Tooltip>
+  );
+};
+
+SavedEntityTable.CellTimeSince = function CellTimeSince({date}: {date: string | null}) {
+  if (!date) {
+    return '-';
+  }
+  return <TimeSince date={date} unitStyle="short" />;
+};
+
+SavedEntityTable.CellTextContent = function CellTextContent({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <OverflowEllipsis>{children}</OverflowEllipsis>;
+};
+
+const LoadingCell = styled(SavedEntityTable.Cell)`
+  grid-column: 1/-1;
+`;
+
+const StyledPanelTable = styled(Panel)`
+  display: grid;
+  white-space: nowrap;
+  font-size: ${p => p.theme.fontSizeMedium};
+  overflow: auto;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    overflow: hidden;
+  }
+`;
+
+const EmptyContainer = styled('div')`
+  grid-column: 1/-1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const FormattedQueryNoWrap = styled(FormattedQuery)`
+  flex-wrap: nowrap;
+  overflow: hidden;
+`;
+
+const OverflowEllipsis = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+`;

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -21,6 +21,7 @@ import {getFieldDefinition} from 'sentry/utils/fields';
 
 export type FormattedQueryProps = {
   query: string;
+  className?: string;
   fieldDefinitionGetter?: FieldDefinitionGetter;
   filterKeys?: TagCollection;
 };
@@ -87,6 +88,7 @@ function QueryToken({token}: TokenProps) {
  * rendering some filter types such as dates.
  */
 export function FormattedQuery({
+  className,
   query,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
@@ -96,11 +98,11 @@ export function FormattedQuery({
   }, [fieldDefinitionGetter, filterKeys, query]);
 
   if (!parsedQuery) {
-    return <QueryWrapper />;
+    return <QueryWrapper className={className} />;
   }
 
   return (
-    <QueryWrapper aria-label={query}>
+    <QueryWrapper aria-label={query} className={className}>
       {parsedQuery.map((token: any, index: any) => {
         return <QueryToken key={index} token={token} />;
       })}

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -63,7 +63,6 @@ describe('IssueViewsList', function () {
     );
     expect(screen.getByText(textWithMarkupMatcher('foo is bar'))).toBeInTheDocument();
     expect(screen.getByText('env1')).toBeInTheDocument();
-    expect(screen.getByText('7d')).toBeInTheDocument();
 
     expect(await screen.findByText('Bar')).toBeInTheDocument();
     expect(screen.getByText('Bar')).toHaveAttribute(
@@ -73,6 +72,5 @@ describe('IssueViewsList', function () {
     expect(screen.getByText(textWithMarkupMatcher('bar is baz'))).toBeInTheDocument();
     expect(screen.getByText('My Projects')).toBeInTheDocument();
     expect(screen.getByText('All')).toBeInTheDocument();
-    expect(screen.getByText('1d')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -1,0 +1,78 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import IssueViewsList from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsList';
+
+const organization = OrganizationFixture({
+  features: ['issue-view-sharing'],
+});
+
+describe('IssueViewsList', function () {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      match: [MockApiClient.matchQuery({createdBy: 'me'})],
+      body: [
+        GroupSearchViewFixture({
+          id: '1',
+          name: 'Foo',
+          projects: [1],
+          environments: ['env1'],
+          query: 'foo:bar',
+          timeFilters: {
+            period: '7d',
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      match: [MockApiClient.matchQuery({createdBy: 'others'})],
+      body: [
+        GroupSearchViewFixture({
+          id: '2',
+          name: 'Bar',
+          projects: [],
+          environments: [],
+          query: 'bar:baz',
+          timeFilters: {
+            period: '1d',
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }),
+      ],
+    });
+  });
+
+  it('displays views from myself and others', async function () {
+    render(<IssueViewsList />, {organization});
+
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText('Foo')).toHaveAttribute(
+      'href',
+      `/organizations/org-slug/issues/views/1/`
+    );
+    expect(screen.getByText(textWithMarkupMatcher('foo is bar'))).toBeInTheDocument();
+    expect(screen.getByText('env1')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+
+    expect(await screen.findByText('Bar')).toBeInTheDocument();
+    expect(screen.getByText('Bar')).toHaveAttribute(
+      'href',
+      `/organizations/org-slug/issues/views/2/`
+    );
+    expect(screen.getByText(textWithMarkupMatcher('bar is baz'))).toBeInTheDocument();
+    expect(screen.getByText('My Projects')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('1d')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -4,7 +4,6 @@ import {SavedEntityTable} from 'sentry/components/savedEntityTable';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
-import {getSortLabel} from 'sentry/views/issueList/utils';
 
 type IssueViewsTableProps = {
   isError: boolean;
@@ -26,17 +25,11 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
           <SavedEntityTable.HeaderCell key="project">
             {t('Project')}
           </SavedEntityTable.HeaderCell>
-          <SavedEntityTable.HeaderCell key="query">
-            {t('Query')}
-          </SavedEntityTable.HeaderCell>
           <SavedEntityTable.HeaderCell key="envs">
             {t('Envs')}
           </SavedEntityTable.HeaderCell>
-          <SavedEntityTable.HeaderCell key="time">
-            {t('Time')}
-          </SavedEntityTable.HeaderCell>
-          <SavedEntityTable.HeaderCell key="sort">
-            {t('Sort')}
+          <SavedEntityTable.HeaderCell key="query">
+            {t('Query')}
           </SavedEntityTable.HeaderCell>
           <SavedEntityTable.HeaderCell key="last-visited">
             {t('Last Viewed')}
@@ -64,18 +57,10 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
             <SavedEntityTable.CellProjects projects={view.projects} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellQuery query={view.query} />
-          </SavedEntityTable.Cell>
-          <SavedEntityTable.Cell>
             <SavedEntityTable.CellEnvironments environments={view.environments} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTimeFilters timeFilters={view.timeFilters} />
-          </SavedEntityTable.Cell>
-          <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTextContent>
-              {getSortLabel(view.querySort)}
-            </SavedEntityTable.CellTextContent>
+            <SavedEntityTable.CellQuery query={view.query} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
             <SavedEntityTable.CellTimeSince date={view.lastVisited} />
@@ -87,5 +72,7 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
 }
 
 const SavedEntityTableWithColumns = styled(SavedEntityTable)`
-  grid-template-columns: 40px 20% 100px minmax(0, 1fr) 100px 80px 90px auto;
+  grid-template-columns:
+    40px 20% minmax(auto, 120px) minmax(auto, 120px) minmax(0, 1fr)
+    auto;
 `;

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -1,22 +1,10 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import Link from 'sentry/components/links/link';
-import LoadingError from 'sentry/components/loadingError';
-import {PanelTable} from 'sentry/components/panels/panelTable';
-import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
-import {getAbsoluteSummary} from 'sentry/components/timeRangeSelector/utils';
-import TimeSince from 'sentry/components/timeSince';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconLock, IconStar, IconUser} from 'sentry/icons';
+import {SavedEntityTable} from 'sentry/components/savedEntityTable';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {getSortLabel} from 'sentry/views/issueList/utils';
-import {ProjectsRenderer} from 'sentry/views/traces/fieldRenderers';
 
 type IssueViewsTableProps = {
   isError: boolean;
@@ -24,206 +12,80 @@ type IssueViewsTableProps = {
   views: GroupSearchView[];
 };
 
-function StarCellContent({isStarred}: {isStarred: boolean}) {
-  return <IconStar isSolid={isStarred} />;
-}
-
-function ProjectsCellContent({projects}: {projects: GroupSearchView['projects']}) {
-  const {projects: allProjects} = useProjects();
-
-  const projectSlugs = allProjects
-    .filter(project => projects.includes(parseInt(project.id, 10)))
-    .map(project => project.slug);
-
-  if (projects.length === 0) {
-    return t('My Projects');
-  }
-  if (projects.includes(-1)) {
-    return t('All Projects');
-  }
-  return <ProjectsRenderer projectSlugs={projectSlugs} maxVisibleProjects={5} />;
-}
-
-function EnvironmentsCellContent({
-  environments,
-}: {
-  environments: GroupSearchView['environments'];
-}) {
-  const environmentsLabel =
-    environments.length === 0 ? t('All') : environments.join(', ');
-
-  return (
-    <PositionedContent>
-      <Tooltip title={environmentsLabel}>{environmentsLabel}</Tooltip>
-    </PositionedContent>
-  );
-}
-
-function TimeCellContent({timeFilters}: {timeFilters: GroupSearchView['timeFilters']}) {
-  if (timeFilters.period) {
-    return timeFilters.period;
-  }
-
-  return getAbsoluteSummary(timeFilters.start, timeFilters.end, timeFilters.utc);
-}
-
-function SharingCellContent({visibility}: {visibility: GroupSearchView['visibility']}) {
-  if (visibility === 'organization') {
-    return (
-      <Tooltip title={t('Shared with organziation')} skipWrapper>
-        <PositionedContent>
-          <IconUser />
-        </PositionedContent>
-      </Tooltip>
-    );
-  }
-  return (
-    <Tooltip title={t('Private')} skipWrapper>
-      <PositionedContent>
-        <IconLock locked />
-      </PositionedContent>
-    </Tooltip>
-  );
-}
-
-function LastVisitedCellContent({
-  lastVisited,
-}: {
-  lastVisited: GroupSearchView['lastVisited'];
-}) {
-  if (!lastVisited) {
-    return '-';
-  }
-  return <PositionedTimeSince date={lastVisited} unitStyle="short" />;
-}
-
 export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProps) {
   const organization = useOrganization();
 
   return (
-    <StyledPanelTable
-      disableHeaderBorderBottom
-      headers={[
-        '',
-        t('Name'),
-        t('Project'),
-        t('Query'),
-        t('Envs'),
-        t('Time'),
-        t('Sort'),
-        t('Sharing'),
-        'Last Viewed',
-      ]}
+    <SavedEntityTableWithColumns
+      header={
+        <SavedEntityTable.Header>
+          <SavedEntityTable.HeaderCell key="star" />
+          <SavedEntityTable.HeaderCell key="name">
+            {t('Name')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="project">
+            {t('Project')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="query">
+            {t('Query')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="envs">
+            {t('Envs')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="time">
+            {t('Time')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="sort">
+            {t('Sort')}
+          </SavedEntityTable.HeaderCell>
+          <SavedEntityTable.HeaderCell key="last-visited">
+            {t('Last Viewed')}
+          </SavedEntityTable.HeaderCell>
+        </SavedEntityTable.Header>
+      }
       isLoading={isPending}
       isEmpty={views.length === 0}
+      isError={isError}
+      emptyMessage={t('No saved views found')}
     >
-      {isError && <LoadingError />}
       {views.map((view, index) => (
-        <Row key={view.id} isFirst={index === 0}>
-          <RowHoverStateLayer />
-          <StarCell>
-            {/* TODO: Add isStarred when the API is update to include it */}
-            <StarCellContent isStarred />
-          </StarCell>
-          <Cell>
-            <RowLink to={`/organizations/${organization.slug}/issues/views/${view.id}/`}>
+        <SavedEntityTable.Row key={view.id} isFirst={index === 0}>
+          <SavedEntityTable.ButtonCell>
+            <SavedEntityTable.CellStar isStarred onClick={() => {}} />
+          </SavedEntityTable.ButtonCell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellName
+              to={`/organizations/${organization.slug}/issues/views/${view.id}/`}
+            >
               {view.name}
-            </RowLink>
-          </Cell>
-          <Cell>
-            <ProjectsCellContent projects={view.projects} />
-          </Cell>
-          <Cell>
-            <FormattedQuery query={view.query} />
-          </Cell>
-          <Cell>
-            <EnvironmentsCellContent environments={view.environments} />
-          </Cell>
-          <Cell>
-            <TimeCellContent timeFilters={view.timeFilters} />
-          </Cell>
-          <Cell>{getSortLabel(view.querySort)}</Cell>
-          <Cell>
-            <SharingCellContent visibility={view.visibility} />
-          </Cell>
-          <Cell>
-            <LastVisitedCellContent lastVisited={view.lastVisited} />
-          </Cell>
-        </Row>
+            </SavedEntityTable.CellName>
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellProjects projects={view.projects} />
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellQuery query={view.query} />
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellEnvironments environments={view.environments} />
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellTimeFilters timeFilters={view.timeFilters} />
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellTextContent>
+              {getSortLabel(view.querySort)}
+            </SavedEntityTable.CellTextContent>
+          </SavedEntityTable.Cell>
+          <SavedEntityTable.Cell>
+            <SavedEntityTable.CellTimeSince date={view.lastVisited} />
+          </SavedEntityTable.Cell>
+        </SavedEntityTable.Row>
       ))}
-    </StyledPanelTable>
+    </SavedEntityTableWithColumns>
   );
 }
 
-const StyledPanelTable = styled(PanelTable)`
-  white-space: nowrap;
-  font-size: ${p => p.theme.fontSizeMedium};
-  overflow: auto;
-  grid-template-columns: 36px auto auto 1fr auto auto 105px 90px 115px;
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    overflow: hidden;
-  }
-
-  & > * {
-    padding: ${space(1)} ${space(2)};
-  }
-`;
-
-const Row = styled('div')<{isFirst: boolean}>`
-  display: grid;
-  position: relative;
-  grid-template-columns: subgrid;
-  grid-column: 1/-1;
-  padding: 0;
-
-  ${p =>
-    p.isFirst &&
-    css`
-      border-top: 1px solid ${p.theme.border};
-    `}
-
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
-  }
-`;
-
-const Cell = styled('div')`
-  display: flex;
-  align-items: center;
-  padding: ${space(1)} ${space(2)};
-`;
-
-const StarCell = styled(Cell)`
-  padding: 0 0 0 ${space(2)};
-`;
-
-const RowHoverStateLayer = styled(InteractionStateLayer)``;
-
-const RowLink = styled(Link)`
-  color: ${p => p.theme.textColor};
-
-  &:hover {
-    color: ${p => p.theme.textColor};
-    text-decoration: underline;
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-`;
-
-const PositionedTimeSince = styled(TimeSince)`
-  position: relative;
-`;
-
-const PositionedContent = styled('div')`
-  position: relative;
-  display: flex;
-  align-items: center;
+const SavedEntityTableWithColumns = styled(SavedEntityTable)`
+  grid-template-columns: 40px 20% 100px minmax(0, 1fr) 100px 80px 90px auto;
 `;

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -43,9 +43,9 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
     >
       {views.map((view, index) => (
         <SavedEntityTable.Row key={view.id} isFirst={index === 0}>
-          <SavedEntityTable.ButtonCell>
+          <SavedEntityTable.Cell>
             <SavedEntityTable.CellStar isStarred onClick={() => {}} />
-          </SavedEntityTable.ButtonCell>
+          </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
             <SavedEntityTable.CellName
               to={`/organizations/${organization.slug}/issues/views/${view.id}/`}


### PR DESCRIPTION
Adds a new component `SavedEntityTable` which exports a number of cell types in the hopes of keeping the tables for issue views, saved queries, dashboards, etc more consistent. Uses it in the issue views table for now.

Still todo:

- Use this component for saved queries
- Implement starring/unstarring
- Hide columns at small widths

![CleanShot 2025-04-08 at 14 44 22](https://github.com/user-attachments/assets/5f13708a-ec09-4f8d-a310-5800e5740406)
