### PR TITLE
chore(autofix): Sugar coat errors

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -167,6 +167,21 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
       customErrorMessage = t(
         'The robots are having a moment. Our LLM provider is overloaded - please try again soon.'
       );
+    } else if (
+      errorMessage.toLowerCase().includes('prompt') ||
+      errorMessage.toLowerCase().includes('tokens')
+    ) {
+      customErrorMessage = t(
+        "Autofix worked so hard that it couldn't fit all its findings in its own memory. Please try again."
+      );
+    } else if (errorMessage.toLowerCase().includes('iterations')) {
+      customErrorMessage = t(
+        'Autofix was taking a ton of iterations, so we pulled the plug out of fear it might go rogue. Please try again.'
+      );
+    } else if (errorMessage.toLowerCase().includes('timeout')) {
+      customErrorMessage = t(
+        'Autofix was taking way too long, so we pulled the plug to put it out of its misery. Please try again.'
+      );
     } else {
       customErrorMessage = t(
         "Oops, Autofix went kaput. We've dispatched Autofix to fix Autofix. In the meantime, try again?"

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -161,11 +161,27 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
     const errorStep = steps.find(step => step.status === AutofixStatus.ERROR);
     const errorMessage = errorStep?.completedMessage || t('Something went wrong.');
 
+    // sugar coat common errors
+    let customErrorMessage = '';
+    if (errorMessage.toLowerCase().includes('overloaded')) {
+      customErrorMessage = t(
+        'The robots are having a moment. Our LLM provider is overloaded - please try again soon.'
+      );
+    } else {
+      customErrorMessage = t(
+        "Oops, Autofix went kaput. We've dispatched Autofix to fix Autofix. In the meantime, try again?"
+      );
+    }
+
     return (
       <ErrorContainer>
         <StyledArrow direction="down" size="sm" />
         <ErrorMessage>
-          <strong>{t('Something went wrong with Autofix:')}</strong> {errorMessage}
+          {customErrorMessage || (
+            <Fragment>
+              {t('Something went wrong with Autofix:')} {errorMessage}
+            </Fragment>
+          )}
         </ErrorMessage>
       </ErrorContainer>
     );


### PR DESCRIPTION
Adds nice messages, including custom ones for specific errors.

The only known error I put is "overloaded" errors. Are there any others we're aware of?


Here's the generic message if we don't recognize it, so the user doesn't see ugly messages: 

<img width="677" alt="Screenshot 2025-04-08 at 3 02 33 PM" src="https://github.com/user-attachments/assets/9e31a3ff-d99b-44e4-a692-a4872087fb85" />
