### PR TITLE
ref(insights): Make Session Health page responsible for chart height

### DIFF
--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -22,7 +22,6 @@ import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDisco
 import {ModalChartContainer} from 'sentry/views/insights/pages/backend/laravel/styles';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/backend/laravel/widgetVisualizationStates';
 import useRecentIssues from 'sentry/views/insights/sessions/queries/useRecentIssues';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 interface Props extends WidgetTitleProps {
   description: string;
@@ -63,10 +62,7 @@ export default function ChartWithIssues({
 
   if (isLoading) {
     return (
-      <Widget
-        height={SESSION_HEALTH_CHART_HEIGHT}
-        Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
-      />
+      <Widget Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />} />
     );
   }
 
@@ -103,7 +99,6 @@ export default function ChartWithIssues({
   return (
     <Widget
       Title={Title}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       Visualization={visualization}
       Actions={
         <Widget.WidgetToolbar>

--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -5,7 +5,6 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useCrashFreeSessions from 'sentry/views/insights/sessions/queries/useCrashFreeSessions';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function CrashFreeSessionsChart() {
   const {series, releases, isPending, error} = useCrashFreeSessions();
@@ -23,7 +22,6 @@ export default function CrashFreeSessionsChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.CrashFreeSessionsChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'The percent of sessions terminating without a crash. See [link:session status].',
         {
@@ -32,6 +30,7 @@ export default function CrashFreeSessionsChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -4,7 +4,6 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useErrorFreeSessions from 'sentry/views/insights/sessions/queries/useErrorFreeSessions';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function ErrorFreeSessionsChart() {
   const {series, isPending, error} = useErrorFreeSessions();
@@ -19,7 +18,6 @@ export default function ErrorFreeSessionsChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.ErrorFreeSessionsChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'The percent of sessions terminating without a single error occurring. See [link:session status].',
         {
@@ -28,6 +26,7 @@ export default function ErrorFreeSessionsChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionCountChart.tsx
@@ -4,7 +4,6 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useReleaseSessionCounts from 'sentry/views/insights/sessions/queries/useReleaseSessionCounts';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function ReleaseSessionCountChart() {
   const {series, releases, isPending, error} = useReleaseSessionCounts();
@@ -20,10 +19,10 @@ export default function ReleaseSessionCountChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.ReleaseSessionCountChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={t(
         'The total number of sessions per release. The 5 most recent releases are shown.'
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseSessionPercentageChart.tsx
@@ -4,7 +4,6 @@ import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useReleaseSessionPercentage from 'sentry/views/insights/sessions/queries/useReleaseSessionPercentage';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function ReleaseSessionPercentageChart() {
   const {series, releases, isPending, error} = useReleaseSessionPercentage();
@@ -20,10 +19,10 @@ export default function ReleaseSessionPercentageChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.ReleaseSessionPercentageChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={t(
         'The percentage of total sessions that each release accounted for. The 5 most recent releases are shown.'
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthCountChart.tsx
@@ -4,7 +4,6 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function SessionHealthCountChart() {
   const {series, isPending, error} = useSessionHealthBreakdown({type: 'count'});
@@ -22,7 +21,6 @@ export default function SessionHealthCountChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.SessionHealthCountChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'The count of sessions with each health status. See [link:session status].',
         {
@@ -31,6 +29,7 @@ export default function SessionHealthCountChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
@@ -4,7 +4,6 @@ import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function SessionHealthRateChart() {
   const {series, isPending, error} = useSessionHealthBreakdown({type: 'rate'});
@@ -22,7 +21,6 @@ export default function SessionHealthRateChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.SessionHealthRateChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'The percent of sessions with each health status. See [link:session status].',
         {
@@ -31,6 +29,7 @@ export default function SessionHealthRateChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
@@ -4,7 +4,6 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function UserHealthCountChart() {
   const {series, isPending, error} = useUserHealthBreakdown({type: 'count'});
@@ -22,7 +21,6 @@ export default function UserHealthCountChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.UserHealthCountChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'Breakdown of total [linkUsers:users], grouped by [linkStatus:health status].',
         {
@@ -34,6 +32,7 @@ export default function UserHealthCountChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
@@ -4,7 +4,6 @@ import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/i
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
 import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
-import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function UserHealthRateChart() {
   const {series, isPending, error} = useUserHealthBreakdown({type: 'rate'});
@@ -22,7 +21,6 @@ export default function UserHealthRateChart() {
       interactiveTitle={() => (
         <ChartSelectionTitle title={CHART_TITLES.UserHealthRateChart} />
       )}
-      height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
         'The percent of [linkUsers:users] with each [linkStatus:health status].',
         {
@@ -34,6 +32,7 @@ export default function UserHealthRateChart() {
           ),
         }
       )}
+      height="100%"
       aliases={aliases}
       series={series}
       isLoading={isPending}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -23,6 +23,7 @@ import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/fil
 import ReleaseTableSearch from 'sentry/views/insights/sessions/components/releaseTableSearch';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
 import useProjectHasSessions from 'sentry/views/insights/sessions/queries/useProjectHasSessions';
+import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export function SessionsOverview() {
@@ -100,20 +101,30 @@ function ViewSpecificCharts({
       return (
         <Fragment>
           <ModuleLayout.Half>
-            <ChartPlacementSlot view={view} index={0} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={0} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Half>
           <ModuleLayout.Half>
-            <ChartPlacementSlot view={view} index={1} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={1} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Half>
 
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={2} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={2} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={3} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={3} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={4} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={4} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
         </Fragment>
       );
@@ -122,20 +133,30 @@ function ViewSpecificCharts({
       return (
         <Fragment>
           <ModuleLayout.Half>
-            <ChartPlacementSlot view={view} index={0} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={0} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Half>
           <ModuleLayout.Half>
-            <ChartPlacementSlot view={view} index={1} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={1} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Half>
 
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={2} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={2} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={3} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={3} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
           <ModuleLayout.Third>
-            <ChartPlacementSlot view={view} index={4} chartProps={chartProps} />
+            <ChartHeight>
+              <ChartPlacementSlot view={view} index={4} chartProps={chartProps} />
+            </ChartHeight>
           </ModuleLayout.Third>
 
           <ModuleLayout.Full>
@@ -171,4 +192,8 @@ const FilterWrapper = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     grid-template-rows: auto auto;
   }
+`;
+
+const ChartHeight = styled('div')`
+  height: ${SESSION_HEALTH_CHART_HEIGHT};
 `;


### PR DESCRIPTION
The charts themselves shouldn't know about what page they're embedded inside of, or what height to use. The page should control that (or the modal that the charts go inside of). The `<Widget>` height prop alludes to this too saying "Avoid this": 

https://github.com/getsentry/sentry/blob/64cda28248d606d03135162ddbd9ed4d779a7780/static/app/views/dashboards/widgets/widget/widget.tsx#L41-L44


So i've replaced a bunch of `height={SESSION_HEALTH_CHART_HEIGHT}` props with `height="100%"` which makes the charts easier to put into any spot, at a size specific to the spot.

It's is bit unfortunate that `<InsightsTimeSeriesWidget>` had it's own `<ChartContainer>` wrapper which creats some assumptions about height. I tried to extract this out but the Web Vital page had issues so that's not included here. That's why we need to keep specifying the 100% everywhere.. but it should be possible to keep iterating so that's the default.

