### PR TITLE
fix(alerts): Update function name for latest adopted release filter 

### DIFF
--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -49,11 +49,11 @@ class LatestAdoptedReleaseForm(forms.Form):
         return environment
 
 
-def get_first_last_release_for_env(
+def get_first_last_release_for_event(
     event: GroupEvent, release_age_type: str, order_type: LatestReleaseOrders
 ) -> Release | None:
     """
-    Fetches the first/last release for the group associated with this group
+    Fetches the first/last release for the group associated with this group event
     """
     group = event.group
     cache_key = get_first_last_release_for_group_cache_key(group.id, release_age_type, order_type)
@@ -133,7 +133,7 @@ class LatestAdoptedReleaseFilter(EventFilter):
         if not latest_project_release:
             return False
 
-        release = get_first_last_release_for_env(event, release_age_type, order_type)
+        release = get_first_last_release_for_event(event, release_age_type, order_type)
         if not release:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -4,7 +4,7 @@ from sentry.models.environment import Environment
 from sentry.models.release import follows_semver_versioning_scheme
 from sentry.rules.age import AgeComparisonType, ModelAgeType
 from sentry.rules.filters.latest_adopted_release_filter import (
-    get_first_last_release_for_env,
+    get_first_last_release_for_event,
     is_newer_release,
 )
 from sentry.search.utils import LatestReleaseOrders
@@ -56,7 +56,7 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
         if not latest_project_release:
             return False
 
-        release = get_first_last_release_for_env(event, release_age_type, order_type)
+        release = get_first_last_release_for_event(event, release_age_type, order_type)
         if not release:
             return False
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -253,10 +253,12 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch(
-        "sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.get_first_last_release_for_env",
+        "sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.get_first_last_release_for_event",
         return_value=None,
     )
-    def test_first_last_release_for_env_does_not_exist(self, mock_get_first_last_release_for_env):
+    def test_first_last_release_for_event_does_not_exist(
+        self, mock_get_first_last_release_for_event
+    ):
         self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch(


### PR DESCRIPTION
function was called `get_first_last_release_for_env` but it doesn't look at the environment, it looks at the release for the event's issue. 