### PR TITLE
test(ui): Remove test cleanup calls, deprecate export

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -7,7 +7,6 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
-  cleanup,
   render,
   renderGlobalModal,
   screen,
@@ -731,8 +730,7 @@ describe('OrganizationMemberDetail', function () {
           organization,
           router: {params: {memberId: testMember.id}},
         });
-        cleanup();
-        render(<OrganizationMemberDetail />, {
+        const {unmount} = render(<OrganizationMemberDetail />, {
           router,
           organization,
         });
@@ -750,6 +748,7 @@ describe('OrganizationMemberDetail', function () {
         // Dropdown cannot be opened
         await selectEvent.openMenu(teamRoleSelect);
         expect(screen.queryAllByText('...')).toHaveLength(0);
+        unmount();
       }
 
       for (const role of [admin, manager, owner]) {

--- a/static/gsApp/views/amCheckout/legacyPlanToggle.spec.tsx
+++ b/static/gsApp/views/amCheckout/legacyPlanToggle.spec.tsx
@@ -2,12 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {PlanMigrationFixture} from 'getsentry-test/fixtures/planMigration';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {
-  cleanup,
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {CohortId} from 'getsentry/types';
@@ -17,16 +12,12 @@ describe('LegacyPlanToggle', function () {
   const organization = OrganizationFixture();
 
   beforeEach(function () {
+    SubscriptionStore.set(organization.slug, {});
+    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/plan-migrations/?applied=0`,
       body: [],
     });
-  });
-
-  afterEach(function () {
-    cleanup();
-    SubscriptionStore.set(organization.slug, {});
-    MockApiClient.clearMockResponses();
   });
 
   describe('AMCheckout', function () {

--- a/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
@@ -2,13 +2,7 @@ import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {InvoiceFixture} from 'getsentry-test/fixtures/invoice';
-import {
-  cleanup,
-  render,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ModalBody} from 'sentry/components/globalModal/components';
 
@@ -65,8 +59,6 @@ describe('InvoiceDetails > Payment Form', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     SubscriptionStore.set(organization.slug, {});
-    // This should happen automatically, but isn't.
-    cleanup();
   });
 
   const modalDummy = ({children}: {children?: ReactNode}) => <div>{children}</div>;

--- a/static/gsApp/views/spendAllocations/index.spec.tsx
+++ b/static/gsApp/views/spendAllocations/index.spec.tsx
@@ -7,7 +7,6 @@ import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
-  cleanup,
   render,
   renderGlobalModal,
   screen,
@@ -48,9 +47,6 @@ describe('SpendAllocations feature enable flow', () => {
       statusCode: 403,
       match: [MockApiClient.matchQuery({timestamp: dateTs})],
     });
-  });
-  afterEach(() => {
-    cleanup();
   });
 
   it('renders enable button for owners/billing in an org that has not enabled spend allocations', async () => {

--- a/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.spec.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {cleanup, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {DataCategoryExact} from 'sentry/types/core';
@@ -37,10 +37,6 @@ describe('SpikeProtectionHistoryTable', () => {
       body: [],
       statusCode: 200,
     });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   it('renders an empty state when no spikes are provided', async () => {

--- a/static/gsApp/views/spikeProtection/spikeProtectionProjects.spec.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionProjects.spec.tsx
@@ -4,7 +4,6 @@ import {ProjectFixture} from 'getsentry-test/fixtures/project';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
-  cleanup,
   render,
   renderGlobalModal,
   screen,
@@ -119,9 +118,6 @@ describe('project renders and toggles', () => {
       ],
       statusCode: 200,
     });
-  });
-  afterEach(() => {
-    cleanup();
   });
 
   async function validateComponents(project: Project, isEnabled: boolean) {

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -431,6 +431,12 @@ instrumentUserEvent();
 // eslint-disable-next-line no-restricted-imports, import/export
 export * from '@testing-library/react';
 
+/**
+ * @deprecated Cleanup is called for you between each test.
+ * If you are getting act errors in afterEach, try moving them to beforeEach.
+ */
+const cleanup = rtl.cleanup;
+
 export {
   // eslint-disable-next-line import/export
   render,
@@ -440,4 +446,6 @@ export {
   fireEvent,
   waitForDrawerToHide,
   makeAllTheProviders,
+  // eslint-disable-next-line import/export
+  cleanup,
 };


### PR DESCRIPTION
I think getsentry test environment might not have been setup correctly at some point so they're all from getsentry.
