### PR TITLE
ref(flags): iterate on sus flags sandbox UI

### DIFF
--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {Button} from 'sentry/components/core/button';
 import LoadingError from 'sentry/components/loadingError';
@@ -20,14 +20,6 @@ import {
 } from 'sentry/views/issueDetails/groupTags/tagDrawerContent';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
-/**
- * Ordering for flags in the drawer.
- */
-function getSortedTags(tags: GroupTag[]) {
-  // Alphabetical by key.
-  return tags.toSorted((t1, t2) => t1.key.localeCompare(t2.key));
-}
-
 const SHOW_SCORES_LOCAL_STORAGE_KEY = 'flag-drawer-show-suspicion-scores';
 
 export default function FlagDrawerContent({
@@ -39,7 +31,7 @@ export default function FlagDrawerContent({
   group: Group;
   search: string;
 }) {
-  // Flags use the same endpoint and response format as tags, so we reuse TagDistribution, tag types, and "tag" in variable names.
+  // Fetch data. Flags use the same endpoint and response type as tags, so we reuse some "tags" naming.
   const {
     data = [],
     isPending,
@@ -59,18 +51,7 @@ export default function FlagDrawerContent({
     [data]
   );
 
-  const displayTags = useMemo(() => {
-    const sortedTags = getSortedTags(data);
-    const searchedTags = sortedTags.filter(
-      tag =>
-        tag.key.includes(search) ||
-        tag.name.includes(search) ||
-        tagValues[tag.key]?.toLowerCase().includes(search.toLowerCase())
-    );
-    return searchedTags;
-  }, [data, search, tagValues]);
-
-  // Suspect flag scoring. This a rudimentary INTERNAL-ONLY display for testing our scoring algorithms.
+  // Suspect flag scores. This is a rudimentary INTERNAL-ONLY feature for testing our scoring algorithms.
   const [showScores, setShowScores] = useLocalStorageState(
     SHOW_SCORES_LOCAL_STORAGE_KEY,
     '0'
@@ -92,6 +73,32 @@ export default function FlagDrawerContent({
       suspectScores?.data?.map(score => [score.flag, score.score]) ?? []
     );
   }, [suspectScores]);
+
+  // Sort and filter results.
+  const sortTags = useCallback(
+    (tags: GroupTag[]) => {
+      if (scoresEnabled && showScores === '1') {
+        // Descending by score.
+        return tags.toSorted(
+          (t1, t2) => (suspectScoresMap[t2.key] ?? 0) - (suspectScoresMap[t1.key] ?? 0)
+        );
+      }
+      // Alphabetical by key.
+      return tags.toSorted((t1, t2) => t1.key.localeCompare(t2.key));
+    },
+    [scoresEnabled, showScores, suspectScoresMap]
+  );
+
+  const displayTags = useMemo(() => {
+    const sortedTags = sortTags(data);
+    const searchedTags = sortedTags.filter(
+      tag =>
+        tag.key.includes(search) ||
+        tag.name.includes(search) ||
+        tagValues[tag.key]?.toLowerCase().includes(search.toLowerCase())
+    );
+    return searchedTags;
+  }, [data, search, sortTags, tagValues]);
 
   // CTA logic
   const {projects} = useProjects();

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -70,9 +70,23 @@ export default function FlagDrawerContent({
 
   const suspectScoresMap = useMemo(() => {
     return Object.fromEntries(
-      suspectScores?.data?.map(score => [score.flag, score.score]) ?? []
+      suspectScores?.data?.map(score => [score.flag, score]) ?? []
     );
   }, [suspectScores]);
+
+  const getSuspectDisplay = useCallback(
+    (flag: string) => {
+      const scoreObj = suspectScoresMap[flag];
+      return (
+        <div>
+          {`Suspicion Score: ${scoreObj?.score.toString() ?? '_'}`}
+          <br />
+          {`Baseline Percent: ${scoreObj?.baseline_percent ? `${scoreObj.baseline_percent * 100}%` : '_'}`}
+        </div>
+      );
+    },
+    [suspectScoresMap]
+  );
 
   // Sort and filter results.
   const sortTags = useCallback(
@@ -80,7 +94,9 @@ export default function FlagDrawerContent({
       if (scoresEnabled && showScores === '1') {
         // Descending by score.
         return tags.toSorted(
-          (t1, t2) => (suspectScoresMap[t2.key] ?? 0) - (suspectScoresMap[t1.key] ?? 0)
+          (t1, t2) =>
+            (suspectScoresMap[t2.key]?.score ?? 0) -
+            (suspectScoresMap[t1.key]?.score ?? 0)
         );
       }
       // Alphabetical by key.
@@ -133,9 +149,7 @@ export default function FlagDrawerContent({
             <FlagDetailsLink tag={tag} key={tag.key}>
               <TagDistribution tag={tag} key={tag.key} />
             </FlagDetailsLink>
-            {scoresEnabled && showScores === '1' && (
-              <div>{`Suspicion Score: ${suspectScoresMap[tag.key] ?? 'unknown'}`}</div>
-            )}
+            {scoresEnabled && showScores === '1' && getSuspectDisplay(tag.key)}
           </div>
         ))}
       </Container>

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -1,7 +1,16 @@
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {SuspectFlagScore} from 'sentry/views/issueDetails/streamline/featureFlagUtils';
+
+type SuspectFlagScore = {
+  baseline_percent: number;
+  flag: string;
+  score: number;
+};
+
+type SuspectFlagScoresResponse = {
+  data: SuspectFlagScore[];
+};
 
 /**
  * Query all feature flags and their scores for a given issue. Defaults to page filters for datetime and environment params.
@@ -38,7 +47,3 @@ export function useGroupSuspectFlagScores({
     }
   );
 }
-
-type SuspectFlagScoresResponse = {
-  data: SuspectFlagScore[];
-};

--- a/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
+++ b/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
@@ -15,11 +15,6 @@ export type RawFlag = {
 
 export type RawFlagData = {data: RawFlag[]};
 
-export type SuspectFlagScore = {
-  flag: string;
-  score: number;
-};
-
 type FlagSeriesDatapoint = {
   // flag action
   label: {formatter: () => string};


### PR DESCRIPTION
Follow-up on https://github.com/getsentry/sentry/pull/89067/files

1. Sorts by descending suspicion score (KL divergence) when showing them.
2. Displays a "Baseline Percent" representing % events in the project where the flag=true. This is useful to compare with the issue flag distribution.

To declutter, `unknown` has been replaced with '_'. Still investigating why the score algorithms are excluding some flags.