### PR TITLE
perf(warmup): A few more modules to be imported

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -4,8 +4,13 @@ from django.utils.translation import override
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+import sentry.identity.services.identity.impl  # NOQA
+import sentry.integrations.services.integration.impl  # NOQA
 import sentry.middleware.integrations.parsers.plugin  # NOQA
+import sentry.notifications.services.impl  # NOQA
 import sentry.sentry_apps.services.app.impl  # NOQA
+import sentry.users.services.user.impl  # NOQA
+import sentry.users.services.user_option.impl  # NOQA
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -1,16 +1,28 @@
 import subprocess
 import sys
 
-SUBPROCESS_TEST_WGI_WARMUP = """
+modules = [
+    "sentry.identity.services.identity.impl",
+    "sentry.integrations.services.integration.impl",
+    "sentry.middleware.integrations.parsers.plugin",
+    "sentry.notifications.services.impl",
+    "sentry.sentry_apps.services.app.impl",
+    "sentry.users.services.user.impl",
+    "sentry.users.services.user_option.impl",
+]
+
+assert_not_in_sys_modules = "\n".join(f'assert "{module}" not in sys.modules' for module in modules)
+
+assert_in_sys_modules = "\n".join(f'assert "{module}" in sys.modules' for module in modules)
+
+SUBPROCESS_TEST_WGI_WARMUP = f"""
 import sys
-assert "sentry.conf.urls" not in sys.modules
-assert "sentry.middleware.integrations.parsers.plugin" not in sys.modules
-assert "sentry.sentry_apps.services.app.impl" not in sys.modules
+
+{assert_not_in_sys_modules}
 
 import sentry.wsgi
-assert "sentry.conf.urls" in sys.modules
-assert "sentry.middleware.integrations.parsers.plugin" in sys.modules
-assert "sentry.sentry_apps.services.app.impl" in sys.modules
+
+{assert_in_sys_modules}
 
 import django.urls.resolvers
 from django.conf import settings


### PR DESCRIPTION
Found a few more profiles where it's importing modules at run time.

![image](https://github.com/user-attachments/assets/73f5ee3d-8c36-4288-a0a9-fbe16c3db3fb)

https://sentry.sentry.io/profiling/profile/sentry/f3fe9c7874894d7782e581cd52068ff2/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&frameName=IntegrationService.get_local_implementation&query=&sorting=call%20order&tid=137461340554944&view=top%20down https://sentry.sentry.io/profiling/profile/sentry/6344012c67314bd1a8de4256ab00c57f/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&frameName=UserService.get_local_implementation&query=&sorting=call%20order&tid=133401909156736&view=top%20down https://sentry.sentry.io/profiling/profile/sentry/c02ee97758a1451aa86c8aa1cf1402ed/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&fov=17832316%2C90%2C13153812%2C35&frameName=NotificationsService.get_local_implementation&query=&sorting=call%20order&tid=139976389940928&view=top%20down https://sentry.sentry.io/profiling/profile/sentry/d33ccad0549d476b8f3d5c935de607ea/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&frameName=IdentityService.get_local_implementation&query=&sorting=call%20order&tid=136062139623104&view=top%20down https://sentry.sentry.io/profiling/profile/sentry/e2588548231a46048a26f184c0bcee32/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&frameName=UserOptionService.get_local_implementation&query=&sorting=call%20order&tid=135279792879296&view=top%20down

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
