### PR TITLE
ref(insights): Make use of `<FeatureBadge>` for new Insight page tabs

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.spec.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.spec.tsx
@@ -118,10 +118,10 @@ describe('DomainViewHeader', function () {
       />,
       {organization}
     );
-    expect(screen.getByRole('tab', {name: 'Mobile Vitals New'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'Mobile Vitals new'})).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'Network Requests'})).toBeInTheDocument();
     expect(
-      screen.queryByRole('tab', {name: 'Network Requests New'})
+      screen.queryByRole('tab', {name: 'Network Requests new'})
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import type {Key} from '@react-types/shared';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
-import {Badge} from 'sentry/components/core/badge';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -13,7 +13,6 @@ import {extractSelectionParameters} from 'sentry/components/organizations/pageFi
 import {TabList} from 'sentry/components/tabs';
 import type {TabListItemProps} from 'sentry/components/tabs/item';
 import {IconBusiness, IconLab} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -201,7 +200,7 @@ function TabLabel({moduleName}: TabLabelProps) {
     return (
       <TabContainer>
         {moduleTitles[moduleName]}
-        {isModuleConsideredNew(moduleName) && <Badge type="new">{t('New')}</Badge>}
+        {isModuleConsideredNew(moduleName) && <FeatureBadge type="new" />}
         {showBusinessIcon && <IconBusiness />}
       </TabContainer>
     );


### PR DESCRIPTION
Using the premade component reduces an import here, and gives us a tooltip for free!
Also we've now got consistent strings to translate, in this case it's lowercase `"new"`.

![SCR-20250408-ombk](https://github.com/user-attachments/assets/10554630-7558-4150-80a0-31b9f2caa010)

---

I realized that the Session Health tab is only out for EA orgs right now, so the "beta" label and tooltip is probably more important. But I think "new" looks better with the "Mobile Vitals (new)" tab in there... and just seems like the better choice.

![SCR-20250408-omxg](https://github.com/user-attachments/assets/762c680d-db03-4479-8178-b2aa40879df3)
