### PR TITLE
chore(jira slos): Record APIError as a halt

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -8,6 +8,7 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.models.group import Group, GroupStatus
+from sentry.shared_integrations.exceptions import ApiInvalidRequestError, IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 from sentry.taskworker.config import TaskworkerConfig
@@ -68,9 +69,16 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
                     "status": group.status,
                 }
             )
-            installation.sync_status_outbound(
-                external_issue, group.status == GroupStatus.RESOLVED, group.project_id
-            )
+            try:
+                installation.sync_status_outbound(
+                    external_issue, group.status == GroupStatus.RESOLVED, group.project_id
+                )
+            except ApiInvalidRequestError:
+                raise
+            except IntegrationError as e:
+                lifecycle.record_halt(halt_reason=e)
+                return None
+
             analytics.record(
                 "integration.issue.status.synced",
                 provider=integration.provider,


### PR DESCRIPTION
While digging into `status_sync_outbound` on rotation, I saw our Jira SLOs for `sync_status_outbound` are kinda sus. For this one, we're recording failure in the case where

1. User links a Sentry issue to a Jira ticket
2. User deletes the Jira ticket, but we maintain the link on Sentry's side (this seems like a bug)
3. User updates the Sentry issue, which leads us to reaching out to Jira to update a ghost ticket

Fixes: https://sentry.sentry.io/issues/5681104673/events/latest/?project=1&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20sync_status_outbound%20integration%3Ajira&referrer=latest-event&sort=date&statsPeriod=24h&stream_index=0

I have a [followup](https://github.com/getsentry/sentry/pull/88996) for the `ApiInvalidRequest` errors (which I also think are halt), but I want to wait a bit to collect some more data before classifying that case officially.