### PR TITLE
nav: chonkify primary navigation

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {Button, ButtonLabel} from 'sentry/components/core/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import Link, {type LinkProps} from 'sentry/components/links/link';
+import Link from 'sentry/components/links/link';
 import {linkStyles} from 'sentry/components/links/styles';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
@@ -193,6 +193,7 @@ const SidebarListItem = styled('li')`
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
 `;
 
 const SeparatorListItem = styled('li')`
@@ -254,7 +255,6 @@ const ChonkNavLinkIconContainer = chonkStyled('span')`
   align-items: center;
   justify-content: center;
   padding: ${space(1)} ${space(1)};
-  margin-bottom: ${space(0.5)};
   border-radius: ${p => p.theme.radius.lg};
 `;
 
@@ -294,38 +294,23 @@ const NavLinkLabel = styled('div')`
 const ChonkNavLink = chonkStyled(Link, {
   shouldForwardProp: prop => prop !== 'isMobile',
 })<{isMobile: boolean}>`
-  width: 100%;
-  position: relative;
   display: flex;
+  position: relative;
+  width: 100%;
   flex-direction: ${p => (p.isMobile ? 'row' : 'column')};
   justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
   align-items: center;
 
   padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : `${space(0.75)} ${space(1.5)}`)};
-  gap: ${p => (p.isMobile ? space(1) : 0)};
 
+  /* On mobile, the buttons are horizontal, so we need a gap between the icon and label */
+  gap: ${p => (p.isMobile ? space(1) : space(0.5))};
+
+  /* Disable default link styles and only apply them to the icon container */
   color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: ${p => p.theme.fontWeightNormal};
-
-  /* Disable default link focus styles */
   outline: none;
   box-shadow: none;
   transition: none;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: ${p => (p.isMobile ? '50%' : '10px')};
-    transform: ${p => (p.isMobile ? 'translateY(-50%)' : 'none')};
-    left: 0px;
-    width: 4px;
-    height: 26px;
-    border-radius: ${p => p.theme.radius.micro};
-    background-color: ${p => p.theme.colors.blue400};
-    transition: opacity 0.1s ease-in-out;
-    opacity: 0;
-  }
 
   &:active,
   &:focus-visible {
@@ -334,10 +319,23 @@ const ChonkNavLink = chonkStyled(Link, {
     color: currentColor;
   }
 
-  &:focus-visible {
-    outline: none;
-    color: currentColor;
+  &::before {
+    content: '';
+    position: absolute;
+    /* We align the active state indicator to the top of the icon container, not to the center of the button */
+    top: ${p => (p.isMobile ? '50%' : '12px')};
+    transform: ${p => (p.isMobile ? 'translateY(-50%)' : 'none')};
+    left: 0px;
+    width: 4px;
+    height: 20px;
+    border-radius: ${p => p.theme.radius.micro};
+    background-color: ${p => p.theme.colors.blue400};
+    transition: opacity 0.1s ease-in-out;
+    opacity: 0;
+  }
 
+  /* Apply focus styles only to the icon container */
+  &:focus-visible {
     ${NavLinkIconContainer} {
       outline: none;
       box-shadow: 0 0 0 2px ${p => p.theme.focusBorder};
@@ -345,37 +343,28 @@ const ChonkNavLink = chonkStyled(Link, {
     }
   }
 
-  &[aria-selected='true'] {
-    &::before {
-      opacity: 1;
-    }
-    color: ${p => p.theme.purple400};
-
-    ${NavLinkIconContainer} {
-      background-color: ${p => p.theme.colors.blue100};
-    }
-  }
-
-  &:hover[aria-selected='true'] {
-    &::before {
-      opacity: 1;
-    }
-    ${NavLinkIconContainer} {
-      background-color: ${p => p.theme.colors.blue100};
-    }
-  }
-
-  &:hover:not([aria-selected='true']) {
+  &:hover {
     color: ${p => p.theme.textColor};
     ${NavLinkIconContainer} {
       background-color: ${p => p.theme.colors.gray100};
     }
   }
-`;
 
-interface NavLinkProps extends LinkProps {
-  isMobile: boolean;
-}
+  &[aria-selected='true'] {
+    color: ${p => p.theme.purple400};
+
+    &::before { opacity: 1; }
+    ${NavLinkIconContainer} {
+      background-color: ${p => p.theme.colors.blue100};
+    }
+
+    &:hover {
+      ${NavLinkIconContainer} {
+        background-color: ${p => p.theme.colors.blue100};
+      }
+    }
+  }
+`;
 
 const StyledNavLink = styled(Link, {
   shouldForwardProp: prop => prop !== 'isMobile',
@@ -420,29 +409,25 @@ const StyledNavLink = styled(Link, {
     `}
 `;
 
-export const NavLink = styled((p: NavLinkProps) => {
-  const theme = useTheme();
-  if (theme.isChonk) {
-    return <ChonkNavLink {...p} />;
-  }
-  return <StyledNavLink {...p} />;
-})``;
+export const NavLink = withChonk(StyledNavLink, ChonkNavLink);
 
 const ChonkNavButton = styled(Button, {
   shouldForwardProp: prop => prop !== 'isMobile',
 })<{isMobile: boolean}>`
+  display: flex;
+  align-items: center;
+
+  /* On mobile, the buttons are full width and have a gap between the icon and label */
+  justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
   height: ${p => (p.isMobile ? 'auto' : '44px')};
   width: ${p => (p.isMobile ? '100%' : '44px')};
   padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : undefined)};
-  display: flex;
-  align-items: center;
-  justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
-  line-height: 1;
 
-  /* Disable interactionstatelayer hover */
   ${ButtonLabel} {
-    gap: ${p => (p.isMobile ? space(1) : 0)};
-    span:first-child {
+    gap: ${space(1)};
+
+    /* Disable interactionstatelayer hover */
+    [data-isl] {
       display: none;
     }
   }
@@ -452,6 +437,7 @@ const StyledNavButton = styled('button', {
   shouldForwardProp: prop => prop !== 'isMobile',
 })<{isMobile: boolean}>`
   border: none;
+  margin: auto;
   position: relative;
   background: transparent;
 
@@ -463,6 +449,7 @@ interface NavButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   isMobile: boolean;
 }
 
+// Use a manual theme switch because the types of Button dont seem to play well with withChonk.
 export const NavButton = styled((p: NavButtonProps) => {
   const theme = useTheme();
   if (theme.isChonk) {
@@ -479,8 +466,8 @@ export const NavButton = styled((p: NavButtonProps) => {
 
 export const SidebarItemUnreadIndicator = styled('span')<{isMobile: boolean}>`
   position: absolute;
-  top: ${p => (p.isMobile ? `8px` : `calc(50% - 5px)`)};
-  left: ${p => (p.isMobile ? '32px' : `calc(50% + 12px)`)};
+  top: ${p => (p.isMobile ? `8px` : `calc(50% - 12px)`)};
+  left: ${p => (p.isMobile ? '32px' : `calc(50% + 14px)`)};
   transform: translate(-50%, -50%);
   display: block;
   text-align: center;

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -297,11 +297,12 @@ const ChonkNavLink = chonkStyled(Link, {
   width: 100%;
   position: relative;
   display: flex;
-  flex-direction: column;
+  flex-direction: ${p => (p.isMobile ? 'row' : 'column')};
+  justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
   align-items: center;
-  justify-content: center;
 
-  padding: ${space(0.75)} ${space(1.5)};
+  padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : `${space(0.75)} ${space(1.5)}`)};
+  gap: ${p => (p.isMobile ? space(1) : 0)};
 
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeMedium};
@@ -315,7 +316,8 @@ const ChonkNavLink = chonkStyled(Link, {
   &::before {
     content: '';
     position: absolute;
-    top: 10px;
+    top: ${p => (p.isMobile ? '50%' : '10px')};
+    transform: ${p => (p.isMobile ? 'translateY(-50%)' : 'none')};
     left: 0px;
     width: 4px;
     height: 26px;
@@ -332,7 +334,6 @@ const ChonkNavLink = chonkStyled(Link, {
     color: currentColor;
   }
 
-  &:focus,
   &:focus-visible {
     outline: none;
     color: currentColor;
@@ -430,12 +431,20 @@ export const NavLink = styled((p: NavLinkProps) => {
 const ChonkNavButton = styled(Button, {
   shouldForwardProp: prop => prop !== 'isMobile',
 })<{isMobile: boolean}>`
-  height: 44px;
-  width: 44px;
+  height: ${p => (p.isMobile ? 'auto' : '44px')};
+  width: ${p => (p.isMobile ? '100%' : '44px')};
+  padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : undefined)};
+  display: flex;
+  align-items: center;
+  justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
+  line-height: 1;
 
   /* Disable interactionstatelayer hover */
-  ${ButtonLabel} span:first-child {
-    display: none;
+  ${ButtonLabel} {
+    gap: ${p => (p.isMobile ? space(1) : 0)};
+    span:first-child {
+      display: none;
+    }
   }
 `;
 
@@ -457,15 +466,21 @@ interface NavButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 export const NavButton = styled((p: NavButtonProps) => {
   const theme = useTheme();
   if (theme.isChonk) {
-    return <ChonkNavButton {...p} aria-label={p['aria-label'] ?? ''} />;
+    return (
+      <ChonkNavButton
+        {...p}
+        aria-label={p['aria-label'] ?? ''}
+        size={p.isMobile ? 'zero' : undefined}
+      />
+    );
   }
   return <StyledNavButton {...p} />;
 })``;
 
-export const SidebarItemUnreadIndicator = styled('span')`
+export const SidebarItemUnreadIndicator = styled('span')<{isMobile: boolean}>`
   position: absolute;
-  top: calc(50% - 12px);
-  left: calc(50% + 12px);
+  top: ${p => (p.isMobile ? `8px` : `calc(50% - 5px)`)};
+  left: ${p => (p.isMobile ? '32px' : `calc(50% + 12px)`)};
   transform: translate(-50%, -50%);
   display: block;
   text-align: center;

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import Hook from 'sentry/components/hook';
@@ -13,11 +11,15 @@ import {
   IconSettings,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {CODECOV_BASE_URL, COVERAGE_BASE_URL} from 'sentry/views/codecov/settings';
 import {useNavContext} from 'sentry/views/nav/context';
-import {SeparatorItem, SidebarLink} from 'sentry/views/nav/primary/components';
+import {
+  SeparatorItem,
+  SidebarFooterWrapper,
+  SidebarLink,
+  SidebarList,
+} from 'sentry/views/nav/primary/components';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {PrimaryNavigationHelp} from 'sentry/views/nav/primary/help';
 import {PrimaryNavigationOnboarding} from 'sentry/views/nav/primary/onboarding';
@@ -28,21 +30,19 @@ import {NavLayout, PrimaryNavGroup} from 'sentry/views/nav/types';
 
 function SidebarBody({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
-  return (
-    <SidebarItemList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarItemList>
-  );
+  return <SidebarList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarList>;
 }
 
 function SidebarFooter({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
   return (
     <SidebarFooterWrapper isMobile={layout === NavLayout.MOBILE}>
-      <SidebarItemList
+      <SidebarList
         isMobile={layout === NavLayout.MOBILE}
         compact={layout === NavLayout.SIDEBAR}
       >
         {children}
-      </SidebarItemList>
+      </SidebarList>
     </SidebarFooterWrapper>
   );
 }
@@ -173,38 +173,3 @@ export function PrimaryNavigationItems() {
     </Fragment>
   );
 }
-
-const SidebarItemList = styled('ul')<{isMobile: boolean; compact?: boolean}>`
-  position: relative;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  padding-top: ${space(1)};
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: ${space(0.5)};
-  width: 100%;
-
-  ${p =>
-    !p.isMobile &&
-    css`
-      align-items: center;
-      gap: ${space(0.5)};
-    `}
-
-  ${p =>
-    p.compact &&
-    css`
-      gap: ${space(0.5)};
-    `}
-`;
-
-const SidebarFooterWrapper = styled('div')<{isMobile: boolean}>`
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  margin-top: auto;
-  margin-bottom: ${p => (p.isMobile ? space(1) : 0)};
-`;

--- a/static/app/views/nav/primary/onboarding.tsx
+++ b/static/app/views/nav/primary/onboarding.tsx
@@ -80,9 +80,7 @@ function OnboardingItem({
           {...overlayTriggerProps}
           isMobile={isMobile}
           aria-label={showLabel ? undefined : label}
-          onMouseEnter={() => {
-            refetch();
-          }}
+          onMouseEnter={refetch}
         >
           <InteractionStateLayer />
           <ProgressRingWrapper isMobile={isMobile}>
@@ -111,7 +109,10 @@ function OnboardingItem({
           </ProgressRingWrapper>
           {showLabel ? label : null}
           {pendingCompletionSeen && (
-            <SidebarItemUnreadIndicator data-test-id="pending-seen-indicator" />
+            <SidebarItemUnreadIndicator
+              data-test-id="pending-seen-indicator"
+              isMobile={isMobile}
+            />
           )}
         </NavButton>
       </SidebarItem>

--- a/static/app/views/nav/primary/serviceIncidents.tsx
+++ b/static/app/views/nav/primary/serviceIncidents.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {StatuspageIncident} from 'sentry/types/system';
 import {useServiceIncidents} from 'sentry/utils/useServiceIncidents';
+import {useNavContext} from 'sentry/views/nav/context';
 import {
   SidebarButton,
   SidebarItemUnreadIndicator,
@@ -15,6 +16,7 @@ import {
   PrimaryButtonOverlay,
   usePrimaryButtonOverlay,
 } from 'sentry/views/nav/primary/primaryButtonOverlay';
+import {NavLayout} from 'sentry/views/nav/types';
 
 function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) {
   const {
@@ -22,6 +24,8 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
     triggerProps: overlayTriggerProps,
     overlayProps,
   } = usePrimaryButtonOverlay();
+
+  const {layout} = useNavContext();
 
   return (
     <Fragment>
@@ -31,7 +35,7 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
         buttonProps={overlayTriggerProps}
       >
         <IconFire />
-        <DangerUnreadIndicator />
+        <DangerUnreadIndicator isMobile={layout === NavLayout.MOBILE} />
       </SidebarButton>
       {isOpen && (
         <PrimaryButtonOverlay overlayProps={overlayProps}>

--- a/static/app/views/nav/primary/whatsNew.tsx
+++ b/static/app/views/nav/primary/whatsNew.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useNavContext} from 'sentry/views/nav/context';
 import {
   SidebarButton,
   SidebarItemUnreadIndicator,
@@ -24,6 +25,7 @@ import {
   PrimaryButtonOverlay,
   usePrimaryButtonOverlay,
 } from 'sentry/views/nav/primary/primaryButtonOverlay';
+import {NavLayout} from 'sentry/views/nav/types';
 
 const MARK_SEEN_DELAY = 1000;
 
@@ -125,6 +127,8 @@ export function PrimaryNavigationWhatsNew() {
     overlayProps,
   } = usePrimaryButtonOverlay();
 
+  const {layout} = useNavContext();
+
   return (
     <Fragment>
       <SidebarButton
@@ -134,7 +138,10 @@ export function PrimaryNavigationWhatsNew() {
       >
         <IconBroadcast />
         {unseenPostIds.length > 0 && (
-          <SidebarItemUnreadIndicator data-test-id="whats-new-unread-indicator" />
+          <SidebarItemUnreadIndicator
+            data-test-id="whats-new-unread-indicator"
+            isMobile={layout === NavLayout.MOBILE}
+          />
         )}
       </SidebarButton>
       {isOpen && (

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -11,6 +11,8 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useNavContext} from 'sentry/views/nav/context';
@@ -211,7 +213,60 @@ const SectionSeparator = styled('hr')`
   border: none;
 `;
 
-const Item = styled(Link)<{layout: NavLayout}>`
+interface ItemProps extends LinkProps {
+  layout: NavLayout;
+}
+
+const ChonkItem = chonkStyled(Link)<ItemProps>`
+  display: flex;
+  gap: ${space(1)};
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  color: ${p => p.theme.textColor};
+  padding: ${p => (p.layout === NavLayout.MOBILE ? `${space(0.75)} ${space(1.5)} ${space(0.75)} 48px` : `${space(0.75)} ${space(1.5)}`)};
+  border-radius: ${p => (p.layout === NavLayout.MOBILE ? '0' : p.theme.radius.lg)};
+
+  /* Disable interaction state layer */
+  > [data-isl] {
+    display: none;
+  }
+
+  /* Renders the active state indicator */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%) translateX(100%);
+    width: 4px;
+    height: 20px;
+    left: -${space(1.5)};
+    border-radius: ${p => p.theme.radius.micro};
+    background-color: ${p => p.theme.colors.blue400};
+    transition: opacity 0.1s ease-in-out;
+    opacity: 0;
+  }
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+    background-color: ${p => p.theme.colors.gray100};
+  }
+
+  &[aria-selected='true'] {
+    color: ${p => p.theme.colors.blue400};
+    background-color: ${p => p.theme.colors.blue100};
+
+    &::before {
+      opacity: 1;
+    }
+    /* Override the default hover styles */
+    &:hover {
+      background-color: ${p => p.theme.colors.blue100};
+    }
+  }
+`;
+
+const StyledNavItem = styled(Link)<ItemProps>`
   position: relative;
   display: flex;
   padding: 4px ${space(1)};
@@ -253,6 +308,8 @@ const Item = styled(Link)<{layout: NavLayout}>`
       border-radius: 0;
     `}
 `;
+
+export const Item = withChonk(StyledNavItem, ChonkItem);
 
 const ItemText = styled('span')`
   ${p => p.theme.overflowEllipsis}

--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -33,8 +33,7 @@ const SecondarySidebarWrapper = styled(NavTourElement)`
   position: relative;
   border-right: 1px solid
     ${p => (p.theme.isChonk ? p.theme.border : p.theme.translucentGray200)};
-  background: ${p =>
-    p.theme.isChonk ? p.theme.backgroundSecondary : p.theme.surface200};
+  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
   width: ${SECONDARY_SIDEBAR_WIDTH}px;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
   height: 100%;

--- a/static/gsApp/components/tryBusinessSidebarItem.tsx
+++ b/static/gsApp/components/tryBusinessSidebarItem.tsx
@@ -7,11 +7,13 @@ import {t} from 'sentry/locale';
 import type {Hooks} from 'sentry/types/hooks';
 import type {Organization} from 'sentry/types/organization';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useNavContext} from 'sentry/views/nav/context';
 import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import {
   SidebarButton,
   SidebarItemUnreadIndicator,
 } from 'sentry/views/nav/primary/components';
+import {NavLayout} from 'sentry/views/nav/types';
 
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import TrialStartedSidebarItem from 'getsentry/components/trialStartedSidebarItem';
@@ -45,6 +47,7 @@ function TryBusinessNavigationItem({
 
   const isNew = !subscription.isTrial && subscription.canTrial;
   const showIsNew = isNew && !tryBusinessSeen;
+  const {layout} = useNavContext();
 
   return (
     <StackedNavTrialStartedSidebarItem {...{organization, subscription}}>
@@ -57,7 +60,9 @@ function TryBusinessNavigationItem({
         analyticsKey="try-business"
       >
         <IconBusiness size="md" />
-        {showIsNew && <SidebarItemUnreadIndicator />}
+        {showIsNew && (
+          <SidebarItemUnreadIndicator isMobile={layout === NavLayout.MOBILE} />
+        )}
       </SidebarButton>
     </StackedNavTrialStartedSidebarItem>
   );


### PR DESCRIPTION
This PR changes the navigation to fit the new chonk style and fixes a minor issues with dot indicator being rendered in the middle of the list for mobile

The indicators not being positioned at the correct place in the current theme
![CleanShot 2025-04-08 at 20 00 45@2x](https://github.com/user-attachments/assets/28ee8d96-ffa1-4ee0-9b71-78b397b586b8)

![CleanShot 2025-04-08 at 20 16 02@2x](https://github.com/user-attachments/assets/1b562a82-aa92-4e8d-953d-d193350f9589)

Mobile 
![CleanShot 2025-04-08 at 20 16 22@2x](https://github.com/user-attachments/assets/220ea6e9-b72e-43ba-a1e6-931d69b2dd0e)

Mobile root
![CleanShot 2025-04-08 at 20 16 28@2x](https://github.com/user-attachments/assets/83670dec-9bb1-41c3-a1bb-1e94719ee5a3)
