### PR TITLE
fix(nav): Show correct nav on account settings

### DIFF
--- a/static/app/views/nav/useActiveNavGroup.spec.tsx
+++ b/static/app/views/nav/useActiveNavGroup.spec.tsx
@@ -58,6 +58,7 @@ describe('useActiveNavGroup', function () {
       [PrimaryNavGroup.DASHBOARDS, '/organizations/org-slug/dashboard/foo/'],
       [PrimaryNavGroup.INSIGHTS, '/organizations/org-slug/insights/foo/'],
       [PrimaryNavGroup.SETTINGS, '/organizations/org-slug/settings/foo/'],
+      [PrimaryNavGroup.SETTINGS, '/settings/account/details/'],
       [PrimaryNavGroup.CODECOV, '/organizations/org-slug/codecov/foo/'],
     ])('correctly matches %s nav group', async function (navGroup, path) {
       mockUsingCustomerDomain.mockReturnValue(false);

--- a/static/app/views/nav/useActiveNavGroup.tsx
+++ b/static/app/views/nav/useActiveNavGroup.tsx
@@ -11,7 +11,10 @@ const getPrimaryRoutePath = (path: string): string | undefined => {
     return path.match(CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX)?.[1];
   }
 
-  return path.match(NON_CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX)?.[1];
+  return (
+    path.match(NON_CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX)?.[1] ??
+    path.match(CUSTOMER_DOMAIN_PRIMARY_PATH_REGEX)?.[1]
+  );
 };
 
 export function useActiveNavGroup(): PrimaryNavGroup {


### PR DESCRIPTION
When on account details there is no customer domain (`sentry.io/settings/account/`), so we need to deal with the case that there is no `/organizations/<orgslug>`.