### PR TITLE
Add profiles filestore config and storage utility

### DIFF
--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -86,6 +86,10 @@ filestore.options:
 filestore.relocation-backend: 'filesystem'
 filestore.relocation-options:
   location: '/tmp/sentry-relocation-files'
+filestore.profiles-backend: 'filesystem'
+filestore.profiles-options:
+  location: '/tmp/sentry-profiles'
+  allow_overwrite: true
 
 # NOTE: See docs/filestore for instructions on configuring the shell environment
 #       with authentication credentials for Google Cloud.
@@ -95,6 +99,9 @@ filestore.relocation-options:
 # filestore.relocation-backend: 'gcs'
 # filestore.relocation-options:
 #   bucket_name: 'gcs-relocation-bucket-name'
+# filestore.profiles-backend: 'gcs'
+# filestore.profiles-options:
+#   bucket_name: 'gcs-profiles-bucket-name'
 
 # filestore.backend: 's3'
 # filestore.options:
@@ -106,3 +113,8 @@ filestore.relocation-options:
 #   access_key: 'AKIXXXXXX'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-relocation-bucket-name'
+# filestore.profiles-backend: 's3'
+# filestore.profiles-options:
+#   access_key: 'AKIXXXXXX'
+#   secret_key: 'XXXXXXX'
+#   bucket_name: 's3-profiles-bucket-name'

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -108,6 +108,21 @@ def get_relocation_storage(config=None) -> Storage:
     return storage(**relocation)
 
 
+def get_profiles_storage(config=None) -> Storage:
+    from sentry import options as options_store
+
+    backend = options_store.get("filestore.profiles-backend")
+    relocation = options_store.get("filestore.profiles-options")
+
+    try:
+        backend = settings.SENTRY_FILESTORE_ALIASES[backend]
+    except KeyError:
+        pass
+
+    storage = import_string(backend)
+    return storage(**relocation)
+
+
 def clear_cached_files(cache_path):
     try:
         cache_folders = os.listdir(cache_path)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -346,6 +346,12 @@ register(
     default={"location": "/tmp/sentry-relocation-files"},
     flags=FLAG_NOSTORE,
 )
+register("filestore.profiles-backend", default="filesystem", flags=FLAG_NOSTORE)
+register(
+    "filestore.profiles-options",
+    default={"location": "/tmp/sentry-profiles", "allow_overwrite": True},
+    flags=FLAG_NOSTORE,
+)
 
 # Filestore for control silo
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -548,6 +548,8 @@ def apply_legacy_settings(settings: Any) -> None:
         ("SENTRY_FILESTORE_OPTIONS", "filestore.options"),
         ("SENTRY_RELOCATION_BACKEND", "filestore.relocation-backend"),
         ("SENTRY_RELOCATION_OPTIONS", "filestore.relocation-options"),
+        ("SENTRY_PROFILES_BACKEND", "filestore.profiles-backend"),
+        ("SENTRY_PROFILES_OPTIONS", "filestore.profiles-options"),
         ("GOOGLE_CLIENT_ID", "auth-google.client-id"),
         ("GOOGLE_CLIENT_SECRET", "auth-google.client-secret"),
     ):


### PR DESCRIPTION
Since we're moving some of the logic from the `vroom` service to `Sentry` we'll now need to be able to store profiles directly from the latter through _filestore_.

Profiles, are stored into an separate store/bucket from other sentry files, hence we'll need a bespoke one for profiles.

 Two new properties have been added to the _filestore_ config:
 
1. `filestore.profiles-backend`
2. `filestore.profiles-options`

These two, mirror the existing ones `filestore.backend` and `filestore.options`.


A new storage getter called `get_profiles_storage` is created to provide access to this bespoke bucket in the same manner we use get_storage to directly access the main bucket today.


This is loosely based on similar work that was done as part of the following [PR](https://github.com/getsentry/sentry/compare/viglia/feat/add-profiles-storage?expand=1) (_filestore_ for _relocations_).