### PR TITLE
feat(codecov): Add useDisablePointerEvents hook

### DIFF
--- a/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.spec.tsx
+++ b/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.spec.tsx
@@ -1,0 +1,80 @@
+import {useRef} from 'react';
+
+// Because of the way that userEvent works, we're unable to use it for these tests, and
+// require the use of fireEvent instead.
+import {fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useDisablePointerEvents} from 'sentry/components/codecov/virtualRenderers/useDisablePointerEvents';
+
+window.requestAnimationFrame = cb => {
+  cb(1);
+  return 1;
+};
+window.cancelAnimationFrame = () => {};
+
+function TestComponent() {
+  const elementRef = useRef<HTMLDivElement>(null);
+  useDisablePointerEvents(elementRef);
+
+  return <div ref={elementRef} data-test-id="virtual-file-renderer" />;
+}
+
+describe('useDisablePointerEvents', () => {
+  describe('toggling pointer events', () => {
+    let requestAnimationFrameSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+    let cancelAnimationFrameSpy: jest.SpyInstance<void, [number]>;
+    let dateNowSpy: jest.SpyInstance<number>;
+
+    beforeEach(() => {
+      requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
+      cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+      dateNowSpy = jest.spyOn(Date, 'now');
+    });
+
+    afterEach(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+      dateNowSpy.mockRestore();
+      jest.clearAllMocks();
+    });
+
+    it('disables pointer events on scroll and resets after timeout', async () => {
+      dateNowSpy.mockImplementationOnce(() => 1000).mockImplementationOnce(() => 2000);
+      requestAnimationFrameSpy.mockImplementation((cb: any) => {
+        setTimeout(() => {
+          cb();
+        }, 50);
+        return 1;
+      });
+
+      render(<TestComponent />);
+
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      const codeRenderer = screen.getByTestId('virtual-file-renderer');
+      await waitFor(() => expect(codeRenderer).toHaveStyle('pointer-events: none'));
+      await waitFor(() => expect(codeRenderer).toHaveStyle('pointer-events: auto'));
+    });
+
+    it('calls cancelAnimationFrame', async () => {
+      dateNowSpy.mockImplementationOnce(() => 1000).mockImplementationOnce(() => 2000);
+      requestAnimationFrameSpy.mockImplementation((cb: any) => {
+        setTimeout(() => {
+          cb();
+        }, 50);
+        return 1;
+      });
+
+      const {container} = render(<TestComponent />);
+
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      // eslint-disable-next-line testing-library/no-container
+      container.remove();
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      await waitFor(() => expect(cancelAnimationFrameSpy).toHaveBeenCalled());
+    });
+  });
+});

--- a/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
+++ b/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
@@ -21,7 +21,7 @@ export const useDisablePointerEvents = (
     const onScroll = (_event: Event) => {
       /**
        * We want to disable pointer events on the ref while scrolling because as the user
-       * is scrolling the page, the browser needs to also check to see if the user if the
+       * is scrolling the page, the browser needs to also check to see if the user or the
        * pointer is over any interactive elements (like the line number indicators)
        * during the repaint. By disabling these events, we can reduce the amount of work
        * the browser needs to do during the repaint, as it does not need to check these

--- a/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
+++ b/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
@@ -1,0 +1,55 @@
+import {useLayoutEffect, useRef} from 'react';
+
+import {requestAnimationTimeout} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
+
+export const useDisablePointerEvents = (
+  elementRef: React.RefObject<HTMLElement | null>
+) => {
+  // this ref is actually used to store the ID of the requestAnimationFrame hence Raf instead of Ref
+  const pointerEventsRaf = useRef<{id: number} | null>(null);
+
+  useLayoutEffect(() => {
+    const onScroll = (_event: Event) => {
+      /**
+       * We want to disable pointer events on the virtual file renderer while
+       * scrolling because as the user is scrolling the page, the browser needs
+       * to also check to see if the user if the pointer is over any
+       * interactive elements (like the line number indicators) during the
+       * repaint. By disabling these events, we can reduce the amount of work
+       * the browser needs to do during the repaint, as it does not need to
+       * check these events.
+       */
+      if (!pointerEventsRaf.current && elementRef.current) {
+        elementRef.current.style.pointerEvents = 'none';
+      }
+
+      /**
+       * If there is a requestAnimationFrame already scheduled, we cancel it
+       * and schedule a new one. This is to prevent the pointer events from
+       * being re-enabled while the user is still scrolling.
+       */
+      if (pointerEventsRaf.current) {
+        window.cancelAnimationFrame(pointerEventsRaf.current.id);
+      }
+
+      /**
+       * We then re-enable pointer events after the scroll event has finished so
+       * the user can continue interacting with the line number indicators.
+       */
+      pointerEventsRaf.current = requestAnimationTimeout(() => {
+        if (elementRef.current) {
+          elementRef.current.style.pointerEvents = 'auto';
+          pointerEventsRaf.current = null;
+        }
+      }, 50);
+    };
+
+    if (elementRef) {
+      window.addEventListener('scroll', onScroll, {passive: true});
+    }
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, [elementRef]);
+};

--- a/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
+++ b/static/app/components/codecov/virtualRenderers/useDisablePointerEvents.ts
@@ -2,39 +2,47 @@ import {useLayoutEffect, useRef} from 'react';
 
 import {requestAnimationTimeout} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 
+/**
+ * This hook is used to disable pointer events on the ref while scrolling. This is to
+ * prevent the browser from checking for pointer events while the user is scrolling. This
+ * is a performance optimization.
+ * @param elementRef - The ref of the element to disable pointer events on.
+ */
 export const useDisablePointerEvents = (
   elementRef: React.RefObject<HTMLElement | null>
 ) => {
-  // this ref is actually used to store the ID of the requestAnimationFrame hence Raf instead of Ref
+  /**
+   * this ref is actually used to store the ID of the requestAnimationFrame hence Raf
+   * instead of Ref
+   */
   const pointerEventsRaf = useRef<{id: number} | null>(null);
 
   useLayoutEffect(() => {
     const onScroll = (_event: Event) => {
       /**
-       * We want to disable pointer events on the virtual file renderer while
-       * scrolling because as the user is scrolling the page, the browser needs
-       * to also check to see if the user if the pointer is over any
-       * interactive elements (like the line number indicators) during the
-       * repaint. By disabling these events, we can reduce the amount of work
-       * the browser needs to do during the repaint, as it does not need to
-       * check these events.
+       * We want to disable pointer events on the ref while scrolling because as the user
+       * is scrolling the page, the browser needs to also check to see if the user if the
+       * pointer is over any interactive elements (like the line number indicators)
+       * during the repaint. By disabling these events, we can reduce the amount of work
+       * the browser needs to do during the repaint, as it does not need to check these
+       * events.
        */
       if (!pointerEventsRaf.current && elementRef.current) {
         elementRef.current.style.pointerEvents = 'none';
       }
 
       /**
-       * If there is a requestAnimationFrame already scheduled, we cancel it
-       * and schedule a new one. This is to prevent the pointer events from
-       * being re-enabled while the user is still scrolling.
+       * If there is a requestAnimationFrame already scheduled, we cancel it and schedule
+       * a new one. This is to prevent the pointer events from being re-enabled while the
+       * user is still scrolling.
        */
       if (pointerEventsRaf.current) {
         window.cancelAnimationFrame(pointerEventsRaf.current.id);
       }
 
       /**
-       * We then re-enable pointer events after the scroll event has finished so
-       * the user can continue interacting with the line number indicators.
+       * We then re-enable pointer events after the scroll event has finished so the user
+       * can continue interacting with the line number indicators.
        */
       pointerEventsRaf.current = requestAnimationTimeout(() => {
         if (elementRef.current) {


### PR DESCRIPTION
This PR adds in a hook that is going to be used in the upcoming work for the virtual diff/file renderers. 

This hook when used will apply the `pointer-events: none` style imperatively to the passed element ref when the user starts to scroll, and then remove said style after a given amount of time when the user has stopped scrolling.
