### PR TITLE
feat(codecov): Add useIsOverflowing hook

### DIFF
--- a/static/app/components/codecov/virtualRenderers/useIsOverflowing.spec.tsx
+++ b/static/app/components/codecov/virtualRenderers/useIsOverflowing.spec.tsx
@@ -1,0 +1,70 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useIsOverflowing} from './useIsOverflowing';
+
+const mocks = {scrollWidth: 0, clientWidth: 0};
+
+class ResizeObserverMock {
+  callback = (_x: any) => null;
+
+  constructor(callback: any) {
+    this.callback = callback;
+  }
+
+  observe() {
+    this.callback([
+      {
+        contentRect: {width: 100},
+        target: {
+          scrollWidth: mocks.scrollWidth,
+          clientWidth: mocks.clientWidth,
+          getBoundingClientRect: () => ({top: 100}),
+        },
+      },
+    ]);
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+}
+global.window.ResizeObserver = ResizeObserverMock;
+
+describe('useIsOverflowing', () => {
+  describe('ref is null', () => {
+    it('returns false if the ref is null', () => {
+      const {result} = renderHook(() => useIsOverflowing({current: null}));
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe('ref is set', () => {
+    describe('not overflowing', () => {
+      beforeEach(() => {
+        mocks.scrollWidth = 100;
+        mocks.clientWidth = 100;
+      });
+
+      it('returns false', () => {
+        // @ts-expect-error - testing ref not being null
+        const {result} = renderHook(() => useIsOverflowing({current: {}}));
+        expect(result.current).toBe(false);
+      });
+    });
+
+    describe('overflowing', () => {
+      beforeEach(() => {
+        mocks.scrollWidth = 200;
+        mocks.clientWidth = 100;
+      });
+
+      it('returns true', () => {
+        // @ts-expect-error - testing ref not being null
+        const {result} = renderHook(() => useIsOverflowing({current: {}}));
+        expect(result.current).toBe(true);
+      });
+    });
+  });
+});

--- a/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
+++ b/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
@@ -1,0 +1,35 @@
+import {useEffect, useState} from 'react';
+
+// this hook returns whether the element is overflowing by using a resize
+// observer on the element
+export const useIsOverflowing = (ref: React.RefObject<HTMLDivElement | null>) => {
+  // keep track of whether the element is overflowing
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    // if the ref is not available, return
+    if (!ref.current) {
+      return undefined;
+    }
+
+    // create a resize observer to watch for changes in the element's size
+    const resizeObserver = new ResizeObserver(entries => {
+      const entry = entries?.[0];
+      if (entry) {
+        // if the element is overflowing, set the state
+        setIsOverflowing(entry.target.scrollWidth > entry.target.clientWidth);
+      }
+    });
+
+    // observe the element
+    resizeObserver.observe(ref.current);
+
+    return () => {
+      // disconnect the resize observer
+      resizeObserver.disconnect();
+    };
+  }, [ref]);
+
+  // return whether the element is overflowing
+  return isOverflowing;
+};

--- a/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
+++ b/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
@@ -7,33 +7,26 @@ import {useEffect, useState} from 'react';
  * @returns Whether the element is overflowing
  */
 export const useIsOverflowing = (ref: React.RefObject<HTMLDivElement | null>) => {
-  // keep track of whether the element is overflowing
   const [isOverflowing, setIsOverflowing] = useState(false);
 
   useEffect(() => {
-    // if the ref is not available, return
     if (!ref.current) {
       return undefined;
     }
 
-    // create a resize observer to watch for changes in the element's size
     const resizeObserver = new ResizeObserver(entries => {
       const entry = entries?.[0];
       if (entry) {
-        // if the element is overflowing, set the state
         setIsOverflowing(entry.target.scrollWidth > entry.target.clientWidth);
       }
     });
 
-    // observe the element
     resizeObserver.observe(ref.current);
 
     return () => {
-      // disconnect the resize observer
       resizeObserver.disconnect();
     };
   }, [ref]);
 
-  // return whether the element is overflowing
   return isOverflowing;
 };

--- a/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
+++ b/static/app/components/codecov/virtualRenderers/useIsOverflowing.ts
@@ -1,7 +1,11 @@
 import {useEffect, useState} from 'react';
 
-// this hook returns whether the element is overflowing by using a resize
-// observer on the element
+/**
+ * This hook returns a boolean value indicating whether the element is overflowing.
+ * It uses a resize observer to watch for changes in the element's size.
+ * @param ref - The ref of the element to observe
+ * @returns Whether the element is overflowing
+ */
 export const useIsOverflowing = (ref: React.RefObject<HTMLDivElement | null>) => {
   // keep track of whether the element is overflowing
   const [isOverflowing, setIsOverflowing] = useState(false);


### PR DESCRIPTION
This PR adds in a new hook `useIsOverflowing`, which returns whether the element is overflowing by using a resize observer on the element.

This hook is being added for upcoming use in upcoming the virtual diff/file renderers.