### PR TITLE
fix(laravel-insights): dont deeplink caches on free plan

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -171,7 +171,7 @@ export function CachesWidget({query}: {query?: string}) {
             <div>
               <Link
                 to={
-                  organization.features.includes('caches')
+                  organization.features.includes('insights-addon-modules')
                     ? `/insights/backend/caches?project=${item['project.id']}&transaction=${item.transaction}`
                     : `/insights/backend/caches`
                 }

--- a/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/backend/laravel/cachesWidget.tsx
@@ -170,7 +170,11 @@ export function CachesWidget({query}: {query?: string}) {
             </div>
             <div>
               <Link
-                to={`/insights/backend/caches?project=${item['project.id']}&transaction=${item.transaction}`}
+                to={
+                  organization.features.includes('caches')
+                    ? `/insights/backend/caches?project=${item['project.id']}&transaction=${item.transaction}`
+                    : `/insights/backend/caches`
+                }
               >
                 {item.transaction}
               </Link>


### PR DESCRIPTION
- free plans don't have insights for caches, therefore we shouldn't deep link, as this would show half-baked data and circumvent access controls