### PR TITLE
feat(releases): Allow `Tabs` in FoldSection to expand `FoldSection`

### DIFF
--- a/static/app/views/releases/drawer/commitsFilesSection.tsx
+++ b/static/app/views/releases/drawer/commitsFilesSection.tsx
@@ -1,3 +1,4 @@
+import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Badge} from 'sentry/components/core/badge';
@@ -48,17 +49,26 @@ export function CommitsFilesSection({
       enabled: !!projectSlug,
     },
   });
+  const [isCollapsed, setCollapsed] = useState(false);
   const isError = repositoriesQuery.isError || releaseReposQuery.isError;
   const isLoading = repositoriesQuery.isPending || releaseReposQuery.isPending;
   const releaseRepos = releaseReposQuery.data;
   const repositories = repositoriesQuery.data;
   const noReleaseReposFound = !releaseRepos?.length;
   const noRepositoryOrgRelatedFound = !repositories?.length;
+  const handleChange = useCallback(() => {
+    setCollapsed(false);
+  }, []);
+  const handleFoldChange = useCallback((collapsed: boolean) => {
+    setCollapsed(collapsed);
+  }, []);
 
   return (
-    <Tabs disabled={isError}>
+    <Tabs disabled={isError} onChange={handleChange}>
       <FoldSection
+        isCollapsed={isCollapsed}
         sectionKey="commits"
+        onChange={handleFoldChange}
         title={
           <TabList hideBorder>
             <TabList.Item key="commits">

--- a/static/app/views/releases/drawer/foldSection.spec.tsx
+++ b/static/app/views/releases/drawer/foldSection.spec.tsx
@@ -1,0 +1,154 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {FoldSection} from './foldSection';
+
+describe('FoldSection', function () {
+  it('renders basic section with title and content', function () {
+    render(
+      <FoldSection title="Test Section" sectionKey="test-section">
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    expect(
+      screen.getByRole('button', {name: /Collapse Test Section Section/})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('can toggle section collapse state', async function () {
+    render(
+      <FoldSection title="Test Section" sectionKey="test-section">
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    // Initially expanded
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    // Click to collapse
+    await userEvent.click(
+      screen.getByRole('button', {name: /Collapse Test Section Section/})
+    );
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+
+    // Click to expand
+    await userEvent.click(
+      screen.getByRole('button', {name: /View Test Section Section/})
+    );
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('respects initialCollapse prop', function () {
+    render(
+      <FoldSection title="Test Section" sectionKey="test-section" initialCollapse>
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+  });
+
+  it('prevents collapsing when preventCollapse is true', async function () {
+    render(
+      <FoldSection title="Test Section" sectionKey="test-section" preventCollapse>
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    const button = screen.getByRole('button', {name: /Test Section Section/});
+    await userEvent.click(button);
+
+    // Content should still be visible
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('renders actions when provided and section is expanded', async function () {
+    const actions = <button>Action Button</button>;
+
+    render(
+      <FoldSection title="Test Section" sectionKey="test-section" actions={actions}>
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    // Actions should be visible when expanded
+    expect(screen.getByRole('button', {name: 'Action Button'})).toBeInTheDocument();
+
+    // Click to collapse
+    await userEvent.click(
+      screen.getByRole('button', {name: /Collapse Test Section Section/})
+    );
+
+    // Actions should not be visible when collapsed
+    expect(screen.queryByRole('button', {name: 'Action Button'})).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when toggling collapse state', async function () {
+    const handleChange = jest.fn();
+
+    render(
+      <FoldSection
+        title="Test Section"
+        sectionKey="test-section"
+        isCollapsed={false}
+        onChange={handleChange}
+      >
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    // Click to collapse
+    await userEvent.click(
+      screen.getByRole('button', {name: /Collapse Test Section Section/})
+    );
+    expect(handleChange).toHaveBeenCalledWith(true);
+
+    // Since it's controlled, nothing actually happens
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    render(
+      <FoldSection
+        title="Test Section"
+        sectionKey="test-section"
+        isCollapsed
+        onChange={handleChange}
+      >
+        <div>Test Content</div>
+      </FoldSection>
+    );
+    // Click to expand
+    await userEvent.click(
+      screen.getByRole('button', {name: /View Test Section Section/})
+    );
+    expect(handleChange).toHaveBeenCalledWith(false);
+
+    // Since it's controlled, nothing actually happens
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('scrolls to section when hash matches sectionKey', async function () {
+    // Mock window.location.hash
+    const originalHash = window.location.hash;
+    window.location.hash = '#test-section';
+
+    const scrollIntoViewMock = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    render(
+      <FoldSection title="Test Section" initialCollapse sectionKey="test-section">
+        <div>Test Content</div>
+      </FoldSection>
+    );
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    // Wait for the setTimeout in the component
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+
+    // Cleanup
+    window.location.hash = originalHash;
+  });
+});

--- a/static/app/views/releases/drawer/foldSection.tsx
+++ b/static/app/views/releases/drawer/foldSection.tsx
@@ -8,7 +8,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-export interface FoldSectionProps {
+interface FoldSectionStatelessProps {
   children: React.ReactNode;
   sectionKey: string;
   /**
@@ -21,13 +21,26 @@ export interface FoldSectionProps {
   actions?: React.ReactNode;
   className?: string;
   /**
-   * Should this section be initially open, gets overridden by user preferences
+   * If this is defined on the initial render, then the component will be
+   * treated as a controlled component, meaning the parent component will need
+   * to handle this component's state. You will likely need to use `onChange`
+   * callback.
    */
-  initialCollapse?: boolean;
+  isCollapsed?: boolean;
   /**
    * Additional margin required to ensure that scrolling to `sectionKey` is correct.
    */
   navScrollMargin?: number;
+  /**
+   * Callback when the collapsed state changes
+   */
+  onChange?: (collapsed: boolean) => void;
+  /**
+   * Callback when scrolled to a collapsed section. If this is a controlled
+   * component, you'll likely want to update state to have "is collapsed" =
+   * false so that the section is expanded when you scroll to it.
+   */
+  onScrollToCollapsedSection?: (element?: HTMLElement) => void;
   /**
    * Disable the ability for the user to collapse the section
    */
@@ -36,24 +49,83 @@ export interface FoldSectionProps {
   style?: CSSProperties;
 }
 
+interface FoldSectionProps extends FoldSectionStatelessProps {
+  /**
+   * Should this section be initially open, gets overridden by user preferences
+   */
+  initialCollapse?: boolean;
+}
+
+export function FoldSection({
+  isCollapsed: isCollapsedProp,
+  onChange,
+  onScrollToCollapsedSection,
+  initialCollapse = false,
+  ...props
+}: FoldSectionProps) {
+  //
+  const isControlled = useRef(isCollapsedProp !== undefined);
+  const [isCollapsedState, setIsCollapsed] = useState(initialCollapse);
+
+  const handleScrollToCollapsedSection = useCallback(
+    (element: HTMLElement | undefined) => {
+      if (isControlled.current) {
+        onScrollToCollapsedSection?.(element);
+      } else {
+        setIsCollapsed(false);
+      }
+    },
+    [onScrollToCollapsedSection, setIsCollapsed]
+  );
+
+  const handleChange = useCallback(
+    (nextCollapsed: boolean) => {
+      if (isControlled.current) {
+        if (typeof onChange !== 'function') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            new Error(
+              'Controlled prop `isCollapsed` used without on `onChange` prop. You likely need an `onChange` so parent component can handle the collapsed state.'
+            )
+          );
+        }
+        onChange?.(nextCollapsed);
+      } else {
+        setIsCollapsed(nextCollapsed);
+      }
+    },
+    [onChange, setIsCollapsed]
+  );
+
+  return (
+    <FoldSectionStateless
+      {...props}
+      isCollapsed={isCollapsedProp ?? isCollapsedState}
+      onChange={handleChange}
+      onScrollToCollapsedSection={handleScrollToCollapsedSection}
+    />
+  );
+}
+
 /**
  * This is a near-duplicate of the component in the
  * steamlined issues view, without localStorage syncing and
  * analytics.
  */
-export function FoldSection({
+function FoldSectionStateless({
   ref,
   children,
   title,
   sectionKey,
   actions,
   className,
+  isCollapsed,
+  onChange,
+  onScrollToCollapsedSection,
   navScrollMargin = 0,
-  initialCollapse = false,
   preventCollapse = false,
-}: FoldSectionProps) {
+}: FoldSectionStatelessProps) {
   const hasAttemptedScroll = useRef(false);
-  const [isCollapsed, setIsCollapsed] = useState(initialCollapse);
 
   const scrollToSection = useCallback(
     (element: HTMLElement | null) => {
@@ -68,7 +140,7 @@ export function FoldSection({
         const [, hash] = window.location.hash.split('#');
         if (hash === sectionKey) {
           if (isCollapsed) {
-            setIsCollapsed(false);
+            onScrollToCollapsedSection?.(element);
           }
 
           // Delay scrollIntoView to allow for layout changes to take place
@@ -76,7 +148,7 @@ export function FoldSection({
         }
       }
     },
-    [sectionKey, navScrollMargin, isCollapsed, setIsCollapsed]
+    [sectionKey, navScrollMargin, isCollapsed, onScrollToCollapsedSection]
   );
 
   // This controls disabling the InteractionStateLayer when hovering over action items. We don't
@@ -87,10 +159,9 @@ export function FoldSection({
     (e: React.MouseEvent) => {
       e.preventDefault(); // Prevent browser summary/details behaviour
       window.getSelection()?.removeAllRanges(); // Prevent text selection on expand
-      setIsCollapsed(!isCollapsed);
-      // onToggleCollapse
+      onChange?.(!isCollapsed);
     },
-    [isCollapsed, setIsCollapsed]
+    [isCollapsed, onChange]
   );
   const labelPrefix = isCollapsed ? t('View') : t('Collapse');
   const labelSuffix = typeof title === 'string' ? title + t(' Section') : t('Section');


### PR DESCRIPTION
Refactors `<FoldSection>` to allow for it to be a controlled component so that we can expand it when a Tab is clicked.
