### PR TITLE
ref(consumers): Quantized rebalancing for all consumers

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -14,7 +14,6 @@ from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
 from arroyo.processing.strategies import ProcessingStrategyFactory
 from arroyo.types import Commit, FilteredPayload, Message, Partition
 
-from sentry import options
 from sentry.sentry_metrics.configuration import (
     MetricsIngestConfiguration,
     initialize_subprocess_state,
@@ -28,7 +27,6 @@ from sentry.sentry_metrics.consumers.indexer.routing_producer import (
 )
 from sentry.sentry_metrics.consumers.indexer.slicing_router import SlicingRouter
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
-from sentry.utils.kafka import delay_kafka_rebalance
 
 logger = logging.getLogger(__name__)
 
@@ -150,14 +148,6 @@ class MetricsConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             # import time
             initializer=functools.partial(initialize_subprocess_state, self.config),
         )
-
-        if use_case is UseCaseKey.PERFORMANCE and options.get(
-            "sentry-metrics.synchronize-kafka-rebalances"
-        ):
-            configured_delay = options.get("sentry-metrics.synchronized-rebalance-delay")
-            logger.info("Started delay in topic subscription step")
-            delay_kafka_rebalance(configured_delay)
-            logger.info("Finished delay in topic subscription step")
 
     def create_with_partitions(
         self,

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -3,8 +3,6 @@ import signal
 import time
 from threading import Thread
 
-from sentry import options
-
 logger = logging.getLogger(__name__)
 
 
@@ -21,24 +19,27 @@ def delay_kafka_rebalance(configured_delay: int) -> None:
     """
 
     time_elapsed_in_slot = int(time.time()) % configured_delay
+    sleep_secs = configured_delay - time_elapsed_in_slot
 
-    time.sleep(configured_delay - time_elapsed_in_slot)
+    logger.info("Sleeping for %s seconds to quantize rebalancing", sleep_secs)
+    time.sleep(sleep_secs)
 
 
-def delay_shutdown(consumer_name, processor) -> None:
-    if consumer_name == "ingest-generic-metrics" and options.get(
-        "sentry-metrics.synchronize-kafka-rebalances"
-    ):
-        configured_delay = options.get("sentry-metrics.synchronized-rebalance-delay")
-        logger.info("Started delay in consumer shutdown step")
-        delay_kafka_rebalance(configured_delay)
-        logger.info("Finished delay in consumer shutdown step")
+def delay_shutdown(processor, quantized_rebalance_delay_secs) -> None:
+    if quantized_rebalance_delay_secs:
+        delay_kafka_rebalance(quantized_rebalance_delay_secs)
+
     processor.signal_shutdown()
 
 
-def run_processor_with_signals(processor, consumer_name: str | None = None):
+def run_processor_with_signals(processor, quantized_rebalance_delay_secs: int | None = None):
+    if quantized_rebalance_delay_secs:
+        # delay startup for quantization
+        delay_kafka_rebalance(quantized_rebalance_delay_secs)
+
     def handler(signum, frame):
-        t = Thread(target=delay_shutdown, args=(consumer_name, processor))
+        # delay shutdown for quantization
+        t = Thread(target=delay_shutdown, args=(processor, quantized_rebalance_delay_secs))
         t.start()
 
     signal.signal(signal.SIGINT, handler)


### PR DESCRIPTION
The metrics indexer currently is the only consumer supporting quantized
rebalancing. Meanwhile in Snuba we support it generically, which is how
it's supposed to work IMO. Pull quantized rebalancing into the consumers
CLI so we can use it in spans buffer.
