### PR TITLE
fix(dashboards-eap): Extrapolation message in widget builder

### DIFF
--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -130,6 +130,10 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
   const config = SpansConfig;
   const organization = useOrganization();
 
+  const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
+  const [isSampled, setIsSampled] = useState<boolean | null>(null);
+
   // The best effort response props are stored to render after the preflight
   const [bestEffortChildrenProps, setBestEffortChildrenProps] =
     useState<GenericWidgetQueriesChildrenProps | null>(null);
@@ -137,6 +141,10 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
   const afterFetchSeriesData = (result: SeriesResult) => {
     const {seriesConfidence, seriesSampleCount, seriesIsSampled} =
       getConfidenceInformation(result);
+
+    setConfidence(seriesConfidence);
+    setSampleCount(seriesSampleCount);
+    setIsSampled(seriesIsSampled);
 
     onDataFetched?.({
       confidence: seriesConfidence,
@@ -170,6 +178,9 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
               children({
                 ...(bestEffortChildrenProps ?? preflightProps),
                 loading: preflightProps.loading,
+                confidence,
+                sampleCount,
+                isSampled,
               })
             ) : (
               <GenericWidgetQueries<SeriesResult, TableResult>
@@ -186,6 +197,9 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
                 onDataFetched={results => {
                   setBestEffortChildrenProps({
                     ...results,
+                    confidence,
+                    sampleCount,
+                    isSampled,
                     loading: false,
                     isProgressivelyLoading: false,
                   });
@@ -199,9 +213,17 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
                       loading: true,
                       isProgressivelyLoading:
                         !preflightProps.errorMessage && !bestEffortProps.errorMessage,
+                      confidence,
+                      sampleCount,
+                      isSampled,
                     });
                   }
-                  return children(bestEffortProps);
+                  return children({
+                    ...bestEffortProps,
+                    confidence,
+                    sampleCount,
+                    isSampled,
+                  });
                 }}
               </GenericWidgetQueries>
             )}


### PR DESCRIPTION
With the introduction of the progressive loading, I forgot to carry over the extrapolation warning related state, which we use to render the extrapolation message in the preview. I added the state back and passed it along any of the return statements to ensure it's provided as render props.

onDataFetched handles the state for the widget viewer context, the widget queries component passes along data for the preview to render