### PR TITLE
feat(codecov): Add useSyncWrapperWidth hook

### DIFF
--- a/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.spec.ts
+++ b/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.spec.ts
@@ -38,7 +38,7 @@ describe('useSyncWrapperWidth', () => {
         result.current.setWrapperRefState({} as HTMLDivElement);
       });
 
-      expect(result.current.wrapperWidth).toBe(100);
+      expect(result.current.wrapperWidth).toBe('100px');
     });
   });
 });

--- a/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.spec.ts
+++ b/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.spec.ts
@@ -1,0 +1,44 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useSyncWrapperWidth} from './useSyncWrapperWidth';
+
+class ResizeObserverMock {
+  callback = (_x: any) => null;
+
+  constructor(callback: any) {
+    this.callback = callback;
+  }
+
+  observe() {
+    this.callback([{contentRect: {width: 100}}]);
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+}
+global.window.ResizeObserver = ResizeObserverMock;
+
+describe('useSyncWrapperWidth', () => {
+  describe('wrapperRefState is null', () => {
+    it('returns the wrapper width as 100%', () => {
+      const {result} = renderHook(() => useSyncWrapperWidth());
+
+      expect(result.current.wrapperWidth).toBe('100%');
+    });
+  });
+
+  describe('wrapperRefState is set', () => {
+    it('returns the wrapper width from the ResizeObserver entry', () => {
+      const {result} = renderHook(() => useSyncWrapperWidth());
+
+      act(() => {
+        result.current.setWrapperRefState({} as HTMLDivElement);
+      });
+
+      expect(result.current.wrapperWidth).toBe(100);
+    });
+  });
+});

--- a/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
+++ b/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
@@ -1,0 +1,30 @@
+import {useLayoutEffect, useState} from 'react';
+
+export const useSyncWrapperWidth = () => {
+  const [wrapperWidth, setWrapperWidth] = useState<number | '100%'>('100%');
+  const [wrapperRefState, setWrapperRefState] = useState<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!wrapperRefState) {
+      return undefined;
+    }
+
+    const resizeObserver = new ResizeObserver(entries => {
+      const entry = entries?.[0];
+      if (entry) {
+        setWrapperWidth(entry.contentRect.width);
+      }
+    });
+
+    resizeObserver.observe(wrapperRefState);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [wrapperRefState]);
+
+  return {
+    wrapperWidth,
+    setWrapperRefState,
+  };
+};

--- a/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
+++ b/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
@@ -6,7 +6,7 @@ import {useLayoutEffect, useState} from 'react';
  * @returns The width of the wrapper element and setter for the wrapper ref.
  */
 export const useSyncWrapperWidth = () => {
-  const [wrapperWidth, setWrapperWidth] = useState<number | '100%'>('100%');
+  const [wrapperWidth, setWrapperWidth] = useState<`${number}px` | '100%'>('100%');
   const [wrapperRefState, setWrapperRefState] = useState<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
@@ -17,7 +17,7 @@ export const useSyncWrapperWidth = () => {
     const resizeObserver = new ResizeObserver(entries => {
       const entry = entries?.[0];
       if (entry) {
-        setWrapperWidth(entry.contentRect.width);
+        setWrapperWidth(`${entry.contentRect.width}px`);
       }
     });
 

--- a/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
+++ b/static/app/components/codecov/virtualRenderers/useSyncWrapperWidth.ts
@@ -1,5 +1,10 @@
 import {useLayoutEffect, useState} from 'react';
 
+/**
+ * This hook gets the width of the wrapper element and syncs it with the width of the
+ * content.
+ * @returns The width of the wrapper element and setter for the wrapper ref.
+ */
 export const useSyncWrapperWidth = () => {
   const [wrapperWidth, setWrapperWidth] = useState<number | '100%'>('100%');
   const [wrapperRefState, setWrapperRefState] = useState<HTMLDivElement | null>(null);


### PR DESCRIPTION
This PR adds in a `useSyncWrapperWidth` hook that is used to sync widths of elements for the upcoming virtual file/diff renderers.