### PR TITLE
perf(warmup): Import the sql compiler during warmup

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -1,3 +1,4 @@
+import django.db.models.sql.compiler  # NOQA
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import override

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 
 modules = [
+    "django.db.models.sql.compiler",
     "sentry.identity.services.identity.impl",
     "sentry.integrations.services.integration.impl",
     "sentry.middleware.integrations.parsers.plugin",


### PR DESCRIPTION
The sql compiler is loaded at run time during the first query and is causing some locking up. Not sure how big of an impact this will have but worth adding.