### PR TITLE
perf(warmup): Warm up translation cache

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import override
+from django.utils import translation
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -31,7 +31,17 @@ class WarmupEndpoint(Endpoint):
         # this fixes an issue we were seeing where many languages trying
         # to resolve at once would cause lock contention
         for lang, _ in settings.LANGUAGES:
-            with override(lang):
+            with translation.override(lang):
                 reverse("sentry-warmup")
+
+        # for each possible language we support, warm up the translations
+        # cache for faster access
+        for lang, _ in settings.LANGUAGES:
+            try:
+                language = translation.get_supported_language_variant(lang)
+            except LookupError:
+                pass
+            else:
+                translation.activate(language)
 
         return Response(200)


### PR DESCRIPTION
The SentryLocale middleware applies the translations but the lookup and activation requires disk access. To speed that up, warm up the cache by activating all supported languages.