### PR TITLE
feat(replay): Clarify in search typeahead that viewed_by_me and seen_by_me are aliases

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2256,7 +2256,9 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.SEEN_BY_ME]: {
-    desc: t('Whether you have seen this replay before (true/false)'),
+    desc: t(
+      'Whether you have seen this replay before. Alias of viewed_by_me. (true/false)'
+    ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
@@ -2271,7 +2273,7 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.VIEWED_BY_ME]: {
-    desc: t('Whether you have seen this replay before (true/false)'),
+    desc: t('Whether you have seen this replay before. Alias of seen_by_me (true/false)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },


### PR DESCRIPTION
The bit that connects them together is here: 
https://github.com/getsentry/sentry/blob/master/src/sentry/replays/usecases/query/__init__.py#L56

Better descriptions should reduce user confusion.