### PR TITLE
feat(profiling-onboarding): Apple instructions

### DIFF
--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -14,6 +14,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {appleFeedbackOnboarding} from 'sentry/gettingStartedDocs/apple/macos';
 import {t, tct} from 'sentry/locale';
+import {appleProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/apple';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
@@ -49,7 +50,7 @@ const getManualInstallSnippet = (params: Params) => `
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
   params,
   'sentry.cocoa',
-  '8.9.3'
+  '8.49.0'
 )}"),`;
 
 const getConfigurationSnippet = (params: Params) => `
@@ -468,6 +469,7 @@ const docs: Docs<PlatformOptions> = {
   crashReportOnboarding: appleFeedbackOnboarding,
   platformOptions,
   replayOnboarding,
+  profilingOnboarding: appleProfilingOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -10,6 +10,7 @@ import {
   getCrashReportInstallDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
+import {appleProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/apple';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
 type Params = DocsParams;
@@ -339,6 +340,7 @@ const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: appleFeedbackOnboarding,
   crashReportOnboarding: appleFeedbackOnboarding,
+  profilingOnboarding: appleProfilingOnboarding,
 };
 
 export default docs;

--- a/static/app/utils/gettingStartedDocs/apple.tsx
+++ b/static/app/utils/gettingStartedDocs/apple.tsx
@@ -1,0 +1,117 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+const getInstallSnippet = (params: DocsParams) => `
+.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
+  params,
+  'sentry.cocoa',
+  '8.49.0'
+)}"),`;
+
+export const appleProfilingOnboarding: OnboardingConfig = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      description:
+        params.profilingOptions?.defaultProfilingMode === 'continuous'
+          ? tct(
+              'UI Profiling requires a minimum version of [code:8.49.0] of the Sentry SDK.',
+              {
+                code: <code />,
+              }
+            )
+          : undefined,
+      configurations: [
+        {
+          description: tct(
+            'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
+            {
+              alternateMethods: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/install/" />
+              ),
+              addPackage: <strong />,
+            }
+          ),
+        },
+        {
+          language: 'url',
+          code: `https://github.com/getsentry/sentry-cocoa.git`,
+        },
+        {
+          description: (
+            <p>
+              {tct(
+                'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
+                {
+                  packageSwift: <code />,
+                }
+              )}
+            </p>
+          ),
+          language: 'swift',
+          partialLoading: params.sourcePackageRegistries.isLoading,
+          code: getInstallSnippet(params),
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'To configure profiling, assign a closure to [code:SentryOptions.configureProfiling], setting the desired options on the object passed in as parameter.',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'Swift',
+              value: 'swift',
+              language: 'swift',
+              code: `
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "${params.dsn.public}"
+    // Tracing must be enabled for profiling
+    options.tracesSampleRate = 1
+    // Configure the profiler to start profiling when there is an active root span
+    options.configureProfiling = {
+        $0.lifecycle = .trace
+        $0.sessionSampleRate = 1
+    }
+}`,
+            },
+          ],
+          additionalInfo: tct(
+            'For more detailed information on profiling, see the [link:profiling documentation].',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/apple/profiling/`}
+                />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'Verify that profiling is working correctly by simply using your application.'
+      ),
+    },
+  ],
+};


### PR DESCRIPTION
Add instruction for apple platforms.

<img width="522" alt="Screenshot 2025-04-09 at 20 09 02" src="https://github.com/user-attachments/assets/0c89d3be-9b7d-40d7-be71-b6bdd428f577" />

<img width="522" alt="Screenshot 2025-04-09 at 20 12 48" src="https://github.com/user-attachments/assets/4e5b7c96-fd1b-4777-924b-e2d5bd6894b6" />


- closes TET-251