### PR TITLE
feat(dashboards-eap): Add loading spinners for best effort requests

### DIFF
--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -36,6 +36,7 @@ function getReferrer(displayType: DisplayType) {
 
 export type OnDataFetchedProps = {
   confidence?: Confidence;
+  isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
   sampleCount?: number;
@@ -81,6 +82,7 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   limit?: number;
   loading?: boolean;
   mepSetting?: MEPState | null;
+  onDataFetchStart?: () => void;
   onDataFetched?: ({
     tableResults,
     timeseriesResults,
@@ -383,7 +385,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
   }
 
   async fetchData() {
-    const {widget} = this.props;
+    const {widget, onDataFetchStart} = this.props;
 
     const queryFetchID = Symbol('queryFetchID');
     this.setState({
@@ -393,6 +395,8 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       errorMessage: undefined,
       queryFetchID,
     });
+
+    onDataFetchStart?.();
 
     try {
       if ([DisplayType.TABLE, DisplayType.BIG_NUMBER].includes(widget.displayType)) {

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,4 +1,4 @@
-import {useContext, useState} from 'react';
+import {useCallback, useContext, useState} from 'react';
 import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
@@ -14,6 +14,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Confidence, Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
@@ -93,6 +94,7 @@ type Props = WithRouterProps & {
 
 type Data = {
   confidence?: Confidence;
+  isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
   sampleCount?: number;
@@ -107,11 +109,15 @@ function WidgetCard(props: Props) {
   const {setData: setWidgetViewerData} = useContext(WidgetViewerContext);
 
   const onDataFetched = (newData: Data) => {
-    if (props.onDataFetched && newData.tableResults) {
-      props.onDataFetched(newData.tableResults);
+    const {isProgressivelyLoading, ...rest} = newData;
+    if (props.onDataFetched && rest.tableResults) {
+      props.onDataFetched(rest.tableResults);
     }
 
-    setData(prevData => ({...prevData, ...newData}));
+    setData(prevData => ({...prevData, ...rest}));
+    if (defined(isProgressivelyLoading)) {
+      setIsProgressivelyLoading(isProgressivelyLoading);
+    }
   };
 
   const {
@@ -160,6 +166,13 @@ function WidgetCard(props: Props) {
   const discoverSplitAlert = useDiscoverSplitAlert({widget, onSetTransactionsDataset});
   const sessionDurationWarning = hasSessionDuration ? SESSION_DURATION_ALERT_TEXT : null;
   const spanTimeRangeWarning = useTimeRangeWarning({widget});
+  const [isProgressivelyLoading, setIsProgressivelyLoading] = useState(false);
+
+  const handleProgressiveLoadingStart = useCallback(() => {
+    if (organization.features.includes('visibility-explore-progressive-loading')) {
+      setIsProgressivelyLoading(true);
+    }
+  }, [organization.features]);
 
   const onFullScreenViewClick = () => {
     if (!isWidgetViewerPath(location.pathname)) {
@@ -250,6 +263,10 @@ function WidgetCard(props: Props) {
           borderless={props.borderless}
           revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
           noVisualizationPadding
+          isProgressivelyLoading={
+            organization.features.includes('visibility-explore-progressive-loading') &&
+            isProgressivelyLoading
+          }
         >
           <WidgetCardChartContainer
             location={location}
@@ -271,6 +288,7 @@ function WidgetCard(props: Props) {
             widgetLegendState={widgetLegendState}
             showConfidenceWarning={showConfidenceWarning}
             minTableColumnWidth={minTableColumnWidth}
+            onDataFetchStart={handleProgressiveLoadingStart}
           />
         </WidgetFrame>
       </VisuallyCompleteWithData>

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -43,6 +43,8 @@ type SpansWidgetQueriesProps = {
   cursor?: string;
   dashboardFilters?: DashboardFilters;
   limit?: number;
+  onBestEffortDataFetched?: () => void;
+  onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
 };
 
@@ -126,6 +128,7 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
   dashboardFilters,
   onDataFetched,
   getConfidenceInformation,
+  onDataFetchStart,
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
   const organization = useOrganization();
@@ -166,6 +169,7 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
         dashboardFilters={dashboardFilters}
         afterFetchSeriesData={afterFetchSeriesData}
         samplingMode={SAMPLING_MODE.PREFLIGHT}
+        onDataFetchStart={onDataFetchStart}
         onDataFetched={() => {
           setBestEffortChildrenProps(null);
         }}
@@ -203,7 +207,7 @@ function SpansWidgetQueriesProgressiveLoadingImpl({
                     loading: false,
                     isProgressivelyLoading: false,
                   });
-                  onDataFetched?.(results);
+                  onDataFetched?.({...results, isProgressivelyLoading: false});
                 }}
               >
                 {bestEffortProps => {

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -40,6 +40,7 @@ type Props = {
   legendOptions?: LegendComponentOption;
   minTableColumnWidth?: string;
   noPadding?: boolean;
+  onDataFetchStart?: () => void;
   onDataFetched?: (results: {
     pageLinks?: string;
     tableResults?: TableDataWithTitle[];
@@ -82,6 +83,7 @@ export function WidgetCardChartContainer({
   widgetLegendState,
   showConfidenceWarning,
   minTableColumnWidth,
+  onDataFetchStart,
 }: Props) {
   const location = useLocation();
 
@@ -101,6 +103,7 @@ export function WidgetCardChartContainer({
       selection={selection}
       onDataFetched={onDataFetched}
       onWidgetSplitDecision={onWidgetSplitDecision}
+      onDataFetchStart={onDataFetchStart}
       tableItemLimit={tableItemLimit}
     >
       {({

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -35,6 +35,7 @@ type Props = {
   selection: PageFilters;
   widget: Widget;
   dashboardFilters?: DashboardFilters;
+  onDataFetchStart?: () => void;
   onDataFetched?: (
     results: Pick<
       Results,
@@ -59,6 +60,7 @@ export function WidgetCardDataLoader({
   tableItemLimit,
   onDataFetched,
   onWidgetSplitDecision,
+  onDataFetchStart,
 }: Props) {
   const api = useApi();
   const organization = useOrganization();
@@ -110,6 +112,7 @@ export function WidgetCardDataLoader({
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
+        onDataFetchStart={onDataFetchStart}
       >
         {props => <Fragment>{children({...props})}</Fragment>}
       </SpansWidgetQueries>

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -7,6 +7,7 @@ import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconExpand, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 
 import type {StateProps} from '../widgets/common/types';
 import {Widget} from '../widgets/widget/widget';
@@ -22,6 +23,7 @@ export interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   badgeProps?: string | string[];
   borderless?: boolean;
   children?: React.ReactNode;
+  isProgressivelyLoading?: boolean;
   noVisualizationPadding?: boolean;
   onFullScreenViewClick?: () => void | Promise<void>;
   revealActions?: 'always' | 'hover';
@@ -81,6 +83,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
       revealActions={
         props.revealTooltip === 'always' ? 'always' : (props.revealActions ?? 'hover')
       }
+      TitleBadges={getProgressiveLoadingIndicator(props.isProgressivelyLoading)}
       Actions={
         <Fragment>
           {props.description && (


### PR DESCRIPTION
Dashboards needs to show a loading spinner in the widget title to indicate that it's fetching more data. To do this I needed ways to indicate that a request cycle is starting and then when the best effort request has completed. I opted to add a callback to set state when the request starts at the level of the widget header, and then when the best effort request completes I pass along an argument that indicates we should set the progressive loading state to false for the header.

<img width="970" alt="Screenshot 2025-04-09 at 2 28 55 PM" src="https://github.com/user-attachments/assets/9dfcf6c6-bcf2-4c51-a554-64661ccd8162" />

⚠️ I recognize there are double loaders now, but I'm going to leave that for another PR to fix if we get feedback