### PR TITLE
feat(taskworker) Add monitor checkins for scheduled tasks

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -265,8 +265,8 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 
     with managed_bgtasks(role="taskworker-scheduler"):
         runner = ScheduleRunner(taskregistry, run_storage)
-        for _, schedule_data in settings.TASKWORKER_SCHEDULES.items():
-            runner.add(schedule_data)
+        for key, schedule_data in settings.TASKWORKER_SCHEDULES.items():
+            runner.add(key, schedule_data)
 
         runner.log_startup()
         while True:

--- a/src/sentry/taskworker/scheduler/schedules.py
+++ b/src/sentry/taskworker/scheduler/schedules.py
@@ -56,7 +56,7 @@ class TimedeltaSchedule(Schedule):
             raise ValueError("interval must be at least one second")
 
     def monitor_interval(self) -> tuple[int, MonitorConfigScheduleUnit]:
-        time_units = (
+        time_units: tuple[tuple[MonitorConfigScheduleUnit, float], ...] = (
             ("day", 60 * 60 * 24.0),
             ("hour", 60 * 60.0),
             ("minute", 60.0),

--- a/src/sentry/taskworker/scheduler/schedules.py
+++ b/src/sentry/taskworker/scheduler/schedules.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import abc
 import logging
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 from cronsim import CronSim, CronSimError
 from django.utils import timezone
 
 from sentry.conf.types.taskworker import crontab
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import MonitorConfigScheduleUnit
 
 logger = logging.getLogger("taskworker.scheduler")
 
@@ -51,7 +55,7 @@ class TimedeltaSchedule(Schedule):
         if delta.total_seconds() < 0:
             raise ValueError("interval must be at least one second")
 
-    def monitor_interval(self) -> tuple[int, str]:
+    def monitor_interval(self) -> tuple[int, MonitorConfigScheduleUnit]:
         time_units = (
             ("day", 60 * 60 * 24.0),
             ("hour", 60 * 60.0),

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -85,8 +85,8 @@ class Task(Generic[P, R]):
 
     def apply_async(
         self,
-        args: Any = None,
-        kwargs: Any = None,
+        args: list[Any] | None = None,
+        kwargs: Mapping[str, Any] | None = None,
         headers: Mapping[str, Any] | None = None,
         expires: int | datetime.timedelta | None = None,
         **options: Any,
@@ -97,6 +97,10 @@ class Task(Generic[P, R]):
         The provided parameters will be JSON encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka
         """
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
         if settings.TASK_WORKER_ALWAYS_EAGER:
             self._func(*args, **kwargs)
         else:

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -85,8 +85,8 @@ class Task(Generic[P, R]):
 
     def apply_async(
         self,
-        args: list[Any] | None = None,
-        kwargs: Mapping[str, Any] | None = None,
+        args: Any | None = None,
+        kwargs: Any | None = None,
         headers: Mapping[str, Any] | None = None,
         expires: int | datetime.timedelta | None = None,
         **options: Any,

--- a/tests/sentry/taskworker/scheduler/test_schedules.py
+++ b/tests/sentry/taskworker/scheduler/test_schedules.py
@@ -33,6 +33,20 @@ def test_timedeltaschedule_is_due() -> None:
     assert schedule.is_due(six_min_ago)
 
 
+def test_timedeltaschedule_monitor_interval() -> None:
+    schedule = TimedeltaSchedule(timedelta(seconds=10))
+    assert schedule.monitor_interval() == (10, "second")
+
+    schedule = TimedeltaSchedule(timedelta(minutes=5))
+    assert schedule.monitor_interval() == (5, "minute")
+
+    schedule = TimedeltaSchedule(timedelta(minutes=5, seconds=10))
+    assert schedule.monitor_interval() == (5, "minute")
+
+    schedule = TimedeltaSchedule(timedelta(hours=1))
+    assert schedule.monitor_interval() == (1, "hour")
+
+
 @freeze_time("2025-01-24 14:25:00")
 def test_timedeltaschedule_remaining_seconds() -> None:
     now = timezone.now()
@@ -160,3 +174,14 @@ def test_crontabschedule_runtime_after() -> None:
     schedule = CrontabSchedule("test", crontab(minute="*/1"))
     now = timezone.now()
     assert schedule.runtime_after(now) == datetime(2025, 1, 24, 14, 26, 0, tzinfo=UTC)
+
+
+def test_crontabschedule_monitor_value() -> None:
+    schedule = CrontabSchedule("test", crontab(minute="*/5"))
+    assert schedule.monitor_value() == "*/5 * * * *"
+
+    schedule = CrontabSchedule("test", crontab(minute="*/10", hour="*/2"))
+    assert schedule.monitor_value() == "*/10 */2 * * *"
+
+    schedule = CrontabSchedule("test", crontab(minute="*/10", day_of_week="1"))
+    assert schedule.monitor_value() == "*/10 * * * 1"

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -84,10 +84,12 @@ def test_delay_taskrunner_immediate_mode(task_namespace: TaskNamespace) -> None:
     with TaskRunner():
         task.delay("arg", org_id=1)
         task.apply_async(args=["arg2"], kwargs={"org_id": 2})
+        task.apply_async()
 
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert calls[0] == {"args": ("arg",), "kwargs": {"org_id": 1}}
     assert calls[1] == {"args": ("arg2",), "kwargs": {"org_id": 2}}
+    assert calls[2] == {"args": tuple(), "kwargs": {}}
 
 
 def test_should_retry(task_namespace: TaskNamespace) -> None:


### PR DESCRIPTION
Tasks scheduled through taskworkers should have cron checkins included. This gives us production monitoring for all taskworker tasks out of the box.