### PR TITLE
fix(billing): Fix category name for product trial in admin

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -418,7 +418,7 @@ describe('CustomerOverview', function () {
     });
     const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
     expect(productTrialsList).toBeInTheDocument();
-    expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
+    expect(productTrialsList.tagName).toBe('DL');
 
     // Check within the Transactions section (AM1 only has Transactions trial)
     const transactionsTermElement = within(productTrialsList!).getByText('Transactions:');

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -6,7 +6,7 @@ import {
   InvoicedSubscriptionFixture,
   SubscriptionFixture,
 } from 'getsentry-test/fixtures/subscription';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {DataCategory} from 'sentry/types/core';
 
@@ -398,7 +398,9 @@ describe('CustomerOverview', function () {
       organization,
       plan: 'am1_f',
       planTier: PlanTier.AM1,
+      canSelfServe: true,
     });
+    am1_subscription.planDetails.categories = [DataCategory.TRANSACTIONS];
 
     render(
       <CustomerOverview
@@ -409,10 +411,38 @@ describe('CustomerOverview', function () {
     );
 
     expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    expect(screen.getByText('Replays:')).toBeInTheDocument();
+
+    // Find the DetailList containing product trials by finding the heading and its next sibling
+    const productTrialsHeading = screen.getByRole('heading', {
+      name: 'Product Trials',
+    });
+    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    expect(productTrialsList).toBeInTheDocument();
+    expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
+
+    // Check within the Transactions section (AM1 only has Transactions trial)
+    const transactionsTermElement = within(productTrialsList!).getByText('Transactions:');
+    const transactionsDefinition =
+      transactionsTermElement.nextElementSibling as HTMLElement;
+    expect(transactionsDefinition).toBeInTheDocument(); // Ensure we found the dd
+    expect(
+      within(transactionsDefinition).getByRole('button', {name: 'Allow Trial'})
+    ).toBeInTheDocument();
+    expect(
+      within(transactionsDefinition).getByRole('button', {name: 'Start Trial'})
+    ).toBeInTheDocument();
+    expect(
+      within(transactionsDefinition).getByRole('button', {name: 'Stop Trial'})
+    ).toBeInTheDocument();
+
+    // Ensure other trial categories are NOT present
+    expect(within(productTrialsList!).queryByText('Replays:')).not.toBeInTheDocument();
+    expect(within(productTrialsList!).queryByText('Spans:')).not.toBeInTheDocument();
+    expect(
+      within(productTrialsList!).queryByText('Performance Units:')
+    ).not.toBeInTheDocument();
+
     expect(screen.queryByText('Spans:')).not.toBeInTheDocument();
-    expect(screen.queryByText('Performance Units:')).not.toBeInTheDocument();
-    expect(screen.getByText('Transactions:')).toBeInTheDocument();
   });
 
   it('render product trials for am2 account', function () {
@@ -421,7 +451,12 @@ describe('CustomerOverview', function () {
       organization,
       plan: 'am2_f',
       planTier: PlanTier.AM2,
+      canSelfServe: true,
     });
+    am2_subscription.planDetails.categories = [
+      DataCategory.REPLAYS,
+      DataCategory.TRANSACTIONS,
+    ];
 
     render(
       <CustomerOverview
@@ -432,10 +467,47 @@ describe('CustomerOverview', function () {
     );
 
     expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    expect(screen.getByText('Replays:')).toBeInTheDocument();
+
+    // Find the DetailList containing product trials by finding the heading and its next sibling
+    const productTrialsHeading = screen.getByRole('heading', {
+      name: 'Product Trials',
+    });
+    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    expect(productTrialsList).toBeInTheDocument();
+    expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
+
+    // Check within the Replays section
+    const replaysTermElement = within(productTrialsList!).getByText('Replays:');
+    const replaysDefinition = replaysTermElement.nextElementSibling as HTMLElement;
+    expect(replaysDefinition).toBeInTheDocument(); // Ensure we found the dd
+    expect(
+      within(replaysDefinition).getByRole('button', {name: 'Allow Trial'})
+    ).toBeInTheDocument();
+
+    // Check within the Performance Units section
+    const performanceTermElement = within(productTrialsList!).getByText(
+      'Performance Units:'
+    );
+    const performanceDefinition =
+      performanceTermElement.nextElementSibling as HTMLElement;
+    expect(performanceDefinition).toBeInTheDocument(); // Ensure we found the dd
+    expect(
+      within(performanceDefinition).getByRole('button', {name: 'Allow Trial'})
+    ).toBeInTheDocument();
+    expect(
+      within(performanceDefinition).getByRole('button', {name: 'Start Trial'})
+    ).toBeInTheDocument();
+    expect(
+      within(performanceDefinition).getByRole('button', {name: 'Stop Trial'})
+    ).toBeInTheDocument();
+
+    // Ensure other trial categories are NOT present
+    expect(within(productTrialsList!).queryByText('Spans:')).not.toBeInTheDocument();
+    expect(
+      within(productTrialsList!).queryByText('Transactions:')
+    ).not.toBeInTheDocument();
+
     expect(screen.queryByText('Spans:')).not.toBeInTheDocument();
-    expect(screen.getByText('Performance Units:')).toBeInTheDocument();
-    expect(screen.queryByText('Transactions:')).not.toBeInTheDocument();
   });
 
   it('render product trials for am3 account', function () {
@@ -444,7 +516,9 @@ describe('CustomerOverview', function () {
       organization,
       plan: 'am3_f',
       planTier: PlanTier.AM3,
+      canSelfServe: true,
     });
+    am3_subscription.planDetails.categories = [DataCategory.REPLAYS, DataCategory.SPANS];
 
     render(
       <CustomerOverview
@@ -455,10 +529,40 @@ describe('CustomerOverview', function () {
     );
 
     expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    expect(screen.getByText('Replays:')).toBeInTheDocument();
-    expect(screen.getByText('Spans:')).toBeInTheDocument();
+
+    // Find the DetailList containing product trials by finding the heading and its next sibling
+    const productTrialsHeading = screen.getByRole('heading', {
+      name: 'Product Trials',
+    });
+    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    expect(productTrialsList).toBeInTheDocument();
+    expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
+
+    // Check within the Replays section
+    const replaysTermElement = within(productTrialsList!).getByText('Replays:');
+    const replaysDefinition = replaysTermElement.nextElementSibling as HTMLElement;
+    expect(replaysDefinition).toBeInTheDocument(); // Ensure we found the dd
+    expect(
+      within(replaysDefinition).getByRole('button', {name: 'Allow Trial'})
+    ).toBeInTheDocument();
+
+    // Check within the Spans section
+    const spansTermElement = within(productTrialsList!).getByText('Spans:');
+    const spansDefinition = spansTermElement.nextElementSibling as HTMLElement;
+    expect(spansDefinition).toBeInTheDocument(); // Ensure we found the dd
+    expect(
+      within(spansDefinition).getByRole('button', {name: 'Allow Trial'})
+    ).toBeInTheDocument();
+
+    // Ensure other trial categories are NOT present
+    expect(
+      within(productTrialsList!).queryByText('Performance Units:')
+    ).not.toBeInTheDocument();
+    expect(
+      within(productTrialsList!).queryByText('Transactions:')
+    ).not.toBeInTheDocument();
+
     expect(screen.queryByText('Performance Units:')).not.toBeInTheDocument();
-    expect(screen.queryByText('Transactions:')).not.toBeInTheDocument();
   });
 
   it('render dynamic sampling rate for am3 account', function () {

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -416,15 +416,21 @@ describe('CustomerOverview', function () {
     const productTrialsHeading = screen.getByRole('heading', {
       name: 'Product Trials',
     });
-    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    const productTrialsList = productTrialsHeading.nextElementSibling;
     expect(productTrialsList).toBeInTheDocument();
+    // Check if productTrialsList is an HTMLElement before using within
+    if (!productTrialsList || !(productTrialsList instanceof HTMLElement)) {
+      throw new Error('Product trials list not found or not an HTMLElement');
+    }
     expect(productTrialsList.tagName).toBe('DL');
 
     // Check within the Transactions section (AM1 only has Transactions trial)
-    const transactionsTermElement = within(productTrialsList!).getByText('Transactions:');
-    const transactionsDefinition =
-      transactionsTermElement.nextElementSibling as HTMLElement;
+    const transactionsTermElement = within(productTrialsList).getByText('Transactions:');
+    const transactionsDefinition = transactionsTermElement.nextElementSibling;
     expect(transactionsDefinition).toBeInTheDocument(); // Ensure we found the dd
+    if (!transactionsDefinition || !(transactionsDefinition instanceof HTMLElement)) {
+      throw new Error('Transactions definition not found or not an HTMLElement');
+    }
     expect(
       within(transactionsDefinition).getByRole('button', {name: 'Allow Trial'})
     ).toBeInTheDocument();
@@ -436,13 +442,13 @@ describe('CustomerOverview', function () {
     ).toBeInTheDocument();
 
     // Ensure other trial categories are NOT present
-    expect(within(productTrialsList!).queryByText('Replays:')).not.toBeInTheDocument();
-    expect(within(productTrialsList!).queryByText('Spans:')).not.toBeInTheDocument();
+    expect(within(productTrialsList).queryByText('Replays:')).not.toBeInTheDocument();
+    expect(within(productTrialsList).queryByText('Spans:')).not.toBeInTheDocument();
     expect(
-      within(productTrialsList!).queryByText('Performance Units:')
+      within(productTrialsList).queryByText('Performance Units:')
     ).not.toBeInTheDocument();
 
-    expect(screen.queryByText('Spans:')).not.toBeInTheDocument();
+    expect(within(productTrialsList).queryByText('Spans:')).not.toBeInTheDocument();
   });
 
   it('render product trials for am2 account', function () {
@@ -472,25 +478,33 @@ describe('CustomerOverview', function () {
     const productTrialsHeading = screen.getByRole('heading', {
       name: 'Product Trials',
     });
-    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    const productTrialsList = productTrialsHeading.nextElementSibling;
     expect(productTrialsList).toBeInTheDocument();
+    // Check if productTrialsList is an HTMLElement before using within
+    if (!productTrialsList || !(productTrialsList instanceof HTMLElement)) {
+      throw new Error('Product trials list not found or not an HTMLElement');
+    }
     expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
 
     // Check within the Replays section
-    const replaysTermElement = within(productTrialsList!).getByText('Replays:');
-    const replaysDefinition = replaysTermElement.nextElementSibling as HTMLElement;
+    const replaysTermElement = within(productTrialsList).getByText('Replays:');
+    const replaysDefinition = replaysTermElement.nextElementSibling;
     expect(replaysDefinition).toBeInTheDocument(); // Ensure we found the dd
+    if (!replaysDefinition || !(replaysDefinition instanceof HTMLElement)) {
+      throw new Error('Replays definition not found or not an HTMLElement');
+    }
     expect(
       within(replaysDefinition).getByRole('button', {name: 'Allow Trial'})
     ).toBeInTheDocument();
 
     // Check within the Performance Units section
-    const performanceTermElement = within(productTrialsList!).getByText(
-      'Performance Units:'
-    );
-    const performanceDefinition =
-      performanceTermElement.nextElementSibling as HTMLElement;
+    const performanceTermElement =
+      within(productTrialsList).getByText('Performance Units:');
+    const performanceDefinition = performanceTermElement.nextElementSibling;
     expect(performanceDefinition).toBeInTheDocument(); // Ensure we found the dd
+    if (!performanceDefinition || !(performanceDefinition instanceof HTMLElement)) {
+      throw new Error('Performance definition not found or not an HTMLElement');
+    }
     expect(
       within(performanceDefinition).getByRole('button', {name: 'Allow Trial'})
     ).toBeInTheDocument();
@@ -502,12 +516,12 @@ describe('CustomerOverview', function () {
     ).toBeInTheDocument();
 
     // Ensure other trial categories are NOT present
-    expect(within(productTrialsList!).queryByText('Spans:')).not.toBeInTheDocument();
+    expect(within(productTrialsList).queryByText('Spans:')).not.toBeInTheDocument();
     expect(
-      within(productTrialsList!).queryByText('Transactions:')
+      within(productTrialsList).queryByText('Transactions:')
     ).not.toBeInTheDocument();
 
-    expect(screen.queryByText('Spans:')).not.toBeInTheDocument();
+    expect(within(productTrialsList).queryByText('Spans:')).not.toBeInTheDocument();
   });
 
   it('render product trials for am3 account', function () {
@@ -534,35 +548,47 @@ describe('CustomerOverview', function () {
     const productTrialsHeading = screen.getByRole('heading', {
       name: 'Product Trials',
     });
-    const productTrialsList = productTrialsHeading.nextElementSibling as HTMLElement;
+    const productTrialsList = productTrialsHeading.nextElementSibling;
     expect(productTrialsList).toBeInTheDocument();
+    // Check if productTrialsList is an HTMLElement before using within
+    if (!productTrialsList || !(productTrialsList instanceof HTMLElement)) {
+      throw new Error('Product trials list not found or not an HTMLElement');
+    }
     expect(productTrialsList.tagName).toBe('DL'); // Verify it's the correct element type
 
     // Check within the Replays section
-    const replaysTermElement = within(productTrialsList!).getByText('Replays:');
-    const replaysDefinition = replaysTermElement.nextElementSibling as HTMLElement;
+    const replaysTermElement = within(productTrialsList).getByText('Replays:');
+    const replaysDefinition = replaysTermElement.nextElementSibling;
     expect(replaysDefinition).toBeInTheDocument(); // Ensure we found the dd
+    if (!replaysDefinition || !(replaysDefinition instanceof HTMLElement)) {
+      throw new Error('Replays definition not found or not an HTMLElement');
+    }
     expect(
       within(replaysDefinition).getByRole('button', {name: 'Allow Trial'})
     ).toBeInTheDocument();
 
     // Check within the Spans section
-    const spansTermElement = within(productTrialsList!).getByText('Spans:');
-    const spansDefinition = spansTermElement.nextElementSibling as HTMLElement;
+    const spansTermElement = within(productTrialsList).getByText('Spans:');
+    const spansDefinition = spansTermElement.nextElementSibling;
     expect(spansDefinition).toBeInTheDocument(); // Ensure we found the dd
+    if (!spansDefinition || !(spansDefinition instanceof HTMLElement)) {
+      throw new Error('Spans definition not found or not an HTMLElement');
+    }
     expect(
       within(spansDefinition).getByRole('button', {name: 'Allow Trial'})
     ).toBeInTheDocument();
 
     // Ensure other trial categories are NOT present
     expect(
-      within(productTrialsList!).queryByText('Performance Units:')
+      within(productTrialsList).queryByText('Performance Units:')
     ).not.toBeInTheDocument();
     expect(
-      within(productTrialsList!).queryByText('Transactions:')
+      within(productTrialsList).queryByText('Transactions:')
     ).not.toBeInTheDocument();
 
-    expect(screen.queryByText('Performance Units:')).not.toBeInTheDocument();
+    expect(
+      within(productTrialsList).queryByText('Performance Units:')
+    ).not.toBeInTheDocument();
   });
 
   it('render dynamic sampling rate for am3 account', function () {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -651,60 +651,82 @@ function CustomerOverview({customer, onAction, organization}: Props) {
         {productTrialCategories.length > 0 && (
           <Fragment>
             <h6>Product Trials</h6>
-            <DetailList>
+            <ProductTrialsDetailListContainer>
               {productTrialCategories.map(category => {
                 const categoryName = getPlanCategoryName({
                   plan: customer.planDetails,
                   category,
                   title: true,
                 });
+                const upperCategory = upperFirst(category);
+
                 return (
                   <DetailLabel key={category} title={categoryName}>
-                    <Button
-                      priority="link"
-                      onClick={() =>
-                        updateCustomerStatus(
-                          'allowTrial' + upperFirst(category),
-                          'product trial'
-                        )
-                      }
-                    >
-                      {tct('Allow [categoryName] Trial', {categoryName})}
-                    </Button>
-                    {' |'}
-                    <Button
-                      priority="link"
-                      onClick={() =>
-                        updateCustomerStatus(
-                          'startTrial' + upperFirst(category),
-                          'product trial'
-                        )
-                      }
-                    >
-                      {tct('Start [categoryName] Trial', {categoryName})}
-                    </Button>
-                    {' | '}
-                    <Button
-                      priority="link"
-                      onClick={() =>
-                        updateCustomerStatus(
-                          'stopTrial' + upperFirst(category),
-                          'product trial'
-                        )
-                      }
-                    >
-                      {tct('Stop [categoryName] Trial', {categoryName})}
-                    </Button>
+                    <TrialActions>
+                      <Button
+                        size="xs"
+                        onClick={() =>
+                          updateCustomerStatus(
+                            `allowTrial${upperCategory}`,
+                            'product trial'
+                          )
+                        }
+                      >
+                        {tct('Allow Trial', {categoryName})}
+                      </Button>
+                      <Button
+                        size="xs"
+                        onClick={() =>
+                          updateCustomerStatus(
+                            `startTrial${upperCategory}`,
+                            'product trial'
+                          )
+                        }
+                      >
+                        {tct('Start Trial', {categoryName})}
+                      </Button>
+                      <Button
+                        size="xs"
+                        onClick={() =>
+                          updateCustomerStatus(
+                            `stopTrial${upperCategory}`,
+                            'product trial'
+                          )
+                        }
+                      >
+                        {tct('Stop Trial', {categoryName})}
+                      </Button>
+                    </TrialActions>
                   </DetailLabel>
                 );
               })}
-            </DetailList>
+            </ProductTrialsDetailListContainer>
           </Fragment>
         )}
       </div>
     </DetailsContainer>
   );
 }
+
+const TrialActions = styled('div')`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+const ProductTrialsDetailListContainer = styled(DetailList)`
+  dt {
+    justify-self: end;
+    display: flex;
+    align-items: center;
+    min-height: 38px;
+  }
+  dd {
+    display: flex;
+    align-items: center;
+    min-height: 38px;
+  }
+`;
 
 type ThresholdLabelProps = {
   children: React.ReactNode;

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -653,9 +653,11 @@ function CustomerOverview({customer, onAction, organization}: Props) {
             <h6>Product Trials</h6>
             <DetailList>
               {productTrialCategories.map(category => {
-                const categoryName = titleCase(
-                  getPlanCategoryName({plan: customer.planDetails, category})
-                );
+                const categoryName = getPlanCategoryName({
+                  plan: customer.planDetails,
+                  category,
+                  title: true,
+                });
                 return (
                   <DetailLabel key={category} title={categoryName}>
                     <Button

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1140,16 +1140,22 @@ describe('Customer Details', function () {
       })[1]!
     );
 
-    expect(screen.getByText('Start Trial')).toBeInTheDocument();
-    expect(screen.getByText('Convert to Sponsored')).toBeInTheDocument();
-    expect(screen.getByText('Gift errors')).toBeInTheDocument();
-    expect(screen.getByText('Gift transactions')).toBeInTheDocument();
-    expect(screen.getByText('Gift attachments')).toBeInTheDocument();
-    expect(screen.getByText('Change Plan')).toBeInTheDocument();
-    expect(screen.getByText('Start Enterprise Trial')).toBeInTheDocument();
-    expect(screen.getByText('Change Google Domain')).toBeInTheDocument();
-    expect(screen.getByText('Suspend Account')).toBeInTheDocument();
-    expect(screen.getByText('Add Legacy Soft Cap')).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Start Trial/})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: /Convert to Sponsored/})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Gift errors/})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Gift transactions/})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Gift attachments/})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Change Plan/})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: /Start Enterprise Trial/})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: /Change Google Domain/})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Suspend Account/})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /Add Legacy Soft Cap/})).toBeInTheDocument();
   });
 
   it('renders and hides generic confirmation modals', async function () {
@@ -1646,7 +1652,7 @@ describe('Customer Details', function () {
         })[1]!
       );
 
-      expect(screen.getByText('Allow Trial')).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: /Allow Trial/})).toBeInTheDocument();
     });
 
     it('hides Allow Trial in the dropdown when not eligible', async function () {
@@ -1672,7 +1678,7 @@ describe('Customer Details', function () {
         })[1]!
       );
 
-      expect(screen.queryByText('Allow Trial')).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
     });
 
     it('hides Allow Trial in the dropdown when on active trial', async function () {
@@ -1698,7 +1704,7 @@ describe('Customer Details', function () {
         })[1]!
       );
 
-      expect(screen.queryByText('Allow Trial')).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
     });
 
     it('allows an org to trial', async function () {
@@ -1732,7 +1738,7 @@ describe('Customer Details', function () {
 
       renderGlobalModal();
 
-      await userEvent.click(screen.getByText('Allow Trial'));
+      await userEvent.click(screen.getByRole('option', {name: /Allow Trial/}));
 
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
 


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/17168


Fix category names for UI profile hours, and make product trial section in admin look nicer:

### Before

<img width="586" alt="Screenshot 2025-04-09 at 2 41 30 PM" src="https://github.com/user-attachments/assets/739d6ec6-0459-44a0-bf37-dbcf60c4ff32" />

### After

<img width="447" alt="Screenshot 2025-04-09 at 2 39 32 PM" src="https://github.com/user-attachments/assets/9b2b1fc4-b789-4077-b340-1a4c48f25b59" />
