### PR TITLE
chore(ourlogs): Start moving the timeseries events_stats logic around

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -22,6 +22,7 @@ from sentry.snuba import (
     functions,
     metrics_enhanced_performance,
     metrics_performance,
+    ourlogs,
     spans_eap,
     spans_indexed,
     spans_metrics,
@@ -282,7 +283,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         use_rpc = request.GET.get("useRpc", "0") == "1" and dataset == spans_eap
         sampling_mode = request.GET.get("sampling")
         transform_alias_to_input_format = (
-            request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
+            request.GET.get("transformAliasToInputFormat") == "1" or use_rpc or dataset == ourlogs
         )
         sentry_sdk.set_tag("performance.use_rpc", use_rpc)
 

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -23,13 +23,12 @@ from sentry.search.events.builder.metrics import AlertMetricsQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_tag_values
-from sentry.snuba import spans_rpc
+from sentry.snuba import rpc_dataset_common, spans_rpc
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.referrer import Referrer
-from sentry.snuba.spans_rpc import get_timeseries_query
 from sentry.utils import metrics
 
 # TODO: If we want to support security events here we'll need a way to
@@ -276,7 +275,7 @@ class PerformanceSpansEAPRpcEntitySubscription(BaseEntitySubscription):
         )
         search_resolver = spans_rpc.get_resolver(snuba_params, SearchResolverConfig())
 
-        rpc_request, _, _ = get_timeseries_query(
+        rpc_request, _, _ = rpc_dataset_common.get_timeseries_query(
             search_resolver=search_resolver,
             params=snuba_params,
             query_string=query,

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -23,6 +23,7 @@ from sentry.search.events.builder.metrics import AlertMetricsQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_tag_values
+from sentry.snuba import spans_rpc
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
@@ -273,14 +274,15 @@ class PerformanceSpansEAPRpcEntitySubscription(BaseEntitySubscription):
             end=now,
             granularity_secs=self.time_window,
         )
+        search_resolver = spans_rpc.get_resolver(snuba_params, SearchResolverConfig())
 
         rpc_request, _, _ = get_timeseries_query(
+            search_resolver=search_resolver,
             params=snuba_params,
             query_string=query,
             y_axes=[self.aggregate],
             groupby=[],
             referrer=referrer,
-            config=SearchResolverConfig(),
             sampling_mode=None,
         )
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -23,8 +23,7 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.constants import MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
-from sentry.search.eap.utils import handle_downsample_meta
-from sentry.search.eap.utils import transform_binary_formula_to_expression
+from sentry.search.eap.utils import handle_downsample_meta, transform_binary_formula_to_expression
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
 from sentry.utils import json, snuba_rpc

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -1,26 +1,71 @@
 import logging
+from dataclasses import dataclass, field
 
 import sentry_sdk
 from google.protobuf.json_format import MessageToJson
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression,
+    TimeSeries,
+    TimeSeriesRequest,
+)
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceItemTableRequest
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, TraceItemFilter
 
+from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.columns import (
     ResolvedAggregate,
     ResolvedAttribute,
     ResolvedConditionalAggregate,
     ResolvedFormula,
 )
+from sentry.search.eap.constants import MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
 from sentry.search.eap.utils import handle_downsample_meta
+from sentry.search.eap.utils import transform_binary_formula_to_expression
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.types import EventsMeta, SnubaData
+from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
 from sentry.utils import json, snuba_rpc
 from sentry.utils.snuba import process_value
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
+
+
+@dataclass
+class ProcessedTimeseries:
+    timeseries: SnubaData = field(default_factory=list)
+    confidence: SnubaData = field(default_factory=list)
+    sampling_rate: SnubaData = field(default_factory=list)
+    sample_count: SnubaData = field(default_factory=list)
+
+
+def process_timeseries_list(timeseries_list: list[TimeSeries]) -> ProcessedTimeseries:
+    result = ProcessedTimeseries()
+
+    for timeseries in timeseries_list:
+        label = timeseries.label
+        if result.timeseries:
+            for index, bucket in enumerate(timeseries.buckets):
+                assert result.timeseries[index]["time"] == bucket.seconds
+                assert result.confidence[index]["time"] == bucket.seconds
+                assert result.sampling_rate[index]["time"] == bucket.seconds
+                assert result.sample_count[index]["time"] == bucket.seconds
+        else:
+            for bucket in timeseries.buckets:
+                result.timeseries.append({"time": bucket.seconds})
+                result.confidence.append({"time": bucket.seconds})
+                result.sampling_rate.append({"time": bucket.seconds})
+                result.sample_count.append({"time": bucket.seconds})
+
+        for index, data_point in enumerate(timeseries.data_points):
+            result.timeseries[index][label] = process_value(data_point.data)
+            result.confidence[index][label] = CONFIDENCES.get(data_point.reliability, None)
+            result.sampling_rate[index][label] = data_point.avg_sampling_rate
+            result.sample_count[index][label] = data_point.sample_count
+
+    return result
 
 
 def categorize_column(
@@ -34,6 +79,79 @@ def categorize_column(
         return Column(conditional_aggregation=column.proto_definition, label=column.public_alias)
     else:
         return Column(key=column.proto_definition, label=column.public_alias)
+
+
+def categorize_aggregate(
+    column: ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula,
+) -> Expression:
+    if isinstance(column, ResolvedFormula):
+        # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
+        return Expression(
+            formula=transform_binary_formula_to_expression(column.proto_definition),
+            label=column.public_alias,
+        )
+    if isinstance(column, ResolvedAggregate):
+        return Expression(aggregation=column.proto_definition, label=column.public_alias)
+    if isinstance(column, ResolvedConditionalAggregate):
+        return Expression(
+            conditional_aggregation=column.proto_definition, label=column.public_alias
+        )
+
+
+def get_timeseries_query(
+    search_resolver: SearchResolver,
+    params: SnubaParams,
+    query_string: str,
+    y_axes: list[str],
+    groupby: list[str],
+    referrer: str,
+    sampling_mode: str | None,
+    extra_conditions: TraceItemFilter | None = None,
+) -> tuple[
+    TimeSeriesRequest,
+    list[ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate],
+    list[ResolvedAttribute],
+]:
+    meta = search_resolver.resolve_meta(referrer=referrer, sampling_mode=sampling_mode)
+    query, _, query_contexts = search_resolver.resolve_query(query_string)
+    (functions, _) = search_resolver.resolve_functions(y_axes)
+    (groupbys, _) = search_resolver.resolve_attributes(groupby)
+    if extra_conditions is not None:
+        if query is not None:
+            query = TraceItemFilter(and_filter=AndFilter(filters=[query, extra_conditions]))
+        else:
+            query = extra_conditions
+
+    return (
+        TimeSeriesRequest(
+            meta=meta,
+            filter=query,
+            expressions=[categorize_aggregate(fn) for fn in functions if fn.is_aggregate],
+            group_by=[
+                groupby.proto_definition
+                for groupby in groupbys
+                if isinstance(groupby.proto_definition, AttributeKey)
+            ],
+            granularity_secs=params.timeseries_granularity_secs,
+        ),
+        functions,
+        groupbys,
+    )
+
+
+def validate_granularity(
+    params: SnubaParams,
+) -> None:
+    """The granularity has already been somewhat validated by src/sentry/utils/dates.py:validate_granularity
+    but the RPC adds additional rules on validation so those are checked here"""
+    if params.date_range.total_seconds() / params.timeseries_granularity_secs > MAX_ROLLUP_POINTS:
+        raise InvalidSearchQuery(
+            "Selected interval would create too many buckets for the timeseries"
+        )
+    if params.timeseries_granularity_secs not in VALID_GRANULARITIES:
+        raise InvalidSearchQuery(
+            f"Selected interval is not allowed, allowed intervals are: {sorted(VALID_GRANULARITIES)}"
+        )
 
 
 @sentry_sdk.trace

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,7 +13,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import CONFIDENCES, EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.eap.utils import handle_downsample_meta
 from sentry.search.events.fields import is_function
 from sentry.search.events.types import EventsMeta, SnubaParams
@@ -118,6 +118,7 @@ def run_timeseries_query(
         comp_query_params.start = comp_query_params.start_date - comparison_delta
         comp_query_params.end = comp_query_params.end_date - comparison_delta
 
+        search_resolver = get_resolver(comp_query_params, config)
         comp_rpc_request, aggregates, groupbys = rpc_dataset_common.get_timeseries_query(
             search_resolver,
             comp_query_params,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -1,73 +1,34 @@
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
 from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest
-from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
-    Expression,
-    TimeSeries,
-    TimeSeriesRequest,
-)
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, OrFilter, TraceItemFilter
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.columns import (
-    ResolvedAggregate,
-    ResolvedAttribute,
-    ResolvedConditionalAggregate,
-    ResolvedFormula,
-)
-from sentry.search.eap.constants import DOUBLE, INT, MAX_ROLLUP_POINTS, STRING, VALID_GRANULARITIES
+from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import CONFIDENCES, EAPResponse, SearchResolverConfig
-from sentry.search.eap.utils import handle_downsample_meta, transform_binary_formula_to_expression
+from sentry.search.eap.utils import handle_downsample_meta
 from sentry.search.events.fields import is_function
-from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
+from sentry.search.events.types import EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key, zerofill
 from sentry.utils import snuba_rpc
-from sentry.utils.snuba import SnubaTSResult, process_value
+from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
-
-
-def categorize_aggregate(
-    column: ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula,
-) -> Expression:
-    if isinstance(column, ResolvedFormula):
-        # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
-        return Expression(
-            formula=transform_binary_formula_to_expression(column.proto_definition),
-            label=column.public_alias,
-        )
-    if isinstance(column, ResolvedAggregate):
-        return Expression(aggregation=column.proto_definition, label=column.public_alias)
-    if isinstance(column, ResolvedConditionalAggregate):
-        return Expression(
-            conditional_aggregation=column.proto_definition, label=column.public_alias
-        )
-
-
-@dataclass
-class ProcessedTimeseries:
-    timeseries: SnubaData = field(default_factory=list)
-    confidence: SnubaData = field(default_factory=list)
-    sampling_rate: SnubaData = field(default_factory=list)
-    sample_count: SnubaData = field(default_factory=list)
 
 
 def get_resolver(
     params: SnubaParams,
     config: SearchResolverConfig,
 ) -> SearchResolver:
-
     return SearchResolver(
         params=params,
         config=config,
@@ -102,63 +63,6 @@ def run_table_query(
     )
 
 
-def get_timeseries_query(
-    params: SnubaParams,
-    query_string: str,
-    y_axes: list[str],
-    groupby: list[str],
-    referrer: str,
-    config: SearchResolverConfig,
-    sampling_mode: str | None,
-    extra_conditions: TraceItemFilter | None = None,
-) -> tuple[
-    TimeSeriesRequest,
-    list[ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate],
-    list[ResolvedAttribute],
-]:
-    resolver = get_resolver(params=params, config=config)
-    meta = resolver.resolve_meta(referrer=referrer, sampling_mode=sampling_mode)
-    query, _, query_contexts = resolver.resolve_query(query_string)
-    (functions, _) = resolver.resolve_functions(y_axes)
-    (groupbys, _) = resolver.resolve_attributes(groupby)
-    if extra_conditions is not None:
-        if query is not None:
-            query = TraceItemFilter(and_filter=AndFilter(filters=[query, extra_conditions]))
-        else:
-            query = extra_conditions
-
-    return (
-        TimeSeriesRequest(
-            meta=meta,
-            filter=query,
-            expressions=[categorize_aggregate(fn) for fn in functions if fn.is_aggregate],
-            group_by=[
-                groupby.proto_definition
-                for groupby in groupbys
-                if isinstance(groupby.proto_definition, AttributeKey)
-            ],
-            granularity_secs=params.timeseries_granularity_secs,
-        ),
-        functions,
-        groupbys,
-    )
-
-
-def validate_granularity(
-    params: SnubaParams,
-) -> None:
-    """The granularity has already been somewhat validated by src/sentry/utils/dates.py:validate_granularity
-    but the RPC adds additional rules on validation so those are checked here"""
-    if params.date_range.total_seconds() / params.timeseries_granularity_secs > MAX_ROLLUP_POINTS:
-        raise InvalidSearchQuery(
-            "Selected interval would create too many buckets for the timeseries"
-        )
-    if params.timeseries_granularity_secs not in VALID_GRANULARITIES:
-        raise InvalidSearchQuery(
-            f"Selected interval is not allowed, allowed intervals are: {sorted(VALID_GRANULARITIES)}"
-        )
-
-
 @sentry_sdk.trace
 def run_timeseries_query(
     params: SnubaParams,
@@ -170,15 +74,16 @@ def run_timeseries_query(
     comparison_delta: timedelta | None = None,
 ) -> SnubaTSResult:
     """Make the query"""
-    validate_granularity(params)
-    rpc_request, aggregates, groupbys = get_timeseries_query(
-        params, query_string, y_axes, [], referrer, config, sampling_mode
+    rpc_dataset_common.validate_granularity(params)
+    search_resolver = get_resolver(params, config)
+    rpc_request, aggregates, groupbys = rpc_dataset_common.get_timeseries_query(
+        search_resolver, params, query_string, y_axes, [], referrer, sampling_mode
     )
 
     """Run the query"""
     rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
     """Process the results"""
-    result = ProcessedTimeseries()
+    result = rpc_dataset_common.ProcessedTimeseries()
     final_meta: EventsMeta = EventsMeta(
         fields={}, full_scan=handle_downsample_meta(rpc_response.meta.downsampled_storage_meta)
     )
@@ -186,7 +91,7 @@ def run_timeseries_query(
         final_meta["fields"][resolved_field.public_alias] = resolved_field.search_type
 
     for timeseries in rpc_response.result_timeseries:
-        processed = _process_all_timeseries([timeseries], params, params.granularity_secs)
+        processed = rpc_dataset_common.process_timeseries_list([timeseries])
         if len(result.timeseries) == 0:
             result = processed
         else:
@@ -213,20 +118,20 @@ def run_timeseries_query(
         comp_query_params.start = comp_query_params.start_date - comparison_delta
         comp_query_params.end = comp_query_params.end_date - comparison_delta
 
-        comp_rpc_request, aggregates, groupbys = get_timeseries_query(
+        comp_rpc_request, aggregates, groupbys = rpc_dataset_common.get_timeseries_query(
+            search_resolver,
             comp_query_params,
             query_string,
             y_axes,
             [],
             referrer,
-            config,
             sampling_mode=sampling_mode,
         )
         comp_rpc_response = snuba_rpc.timeseries_rpc([comp_rpc_request])[0]
 
         if comp_rpc_response.result_timeseries:
             timeseries = comp_rpc_response.result_timeseries[0]
-            processed = _process_all_timeseries([timeseries], params, params.granularity_secs)
+            processed = rpc_dataset_common.process_timeseries_list([timeseries])
             for existing, new in zip(result.timeseries, processed.timeseries):
                 existing["comparisonCount"] = new[timeseries.label]
         else:
@@ -300,7 +205,7 @@ def run_top_events_timeseries_query(
     This is because at time of writing, the query construction is very straightforward, if that changes perhaps we can
     change this"""
     """Make a table query first to get what we need to filter by"""
-    validate_granularity(params)
+    rpc_dataset_common.validate_granularity(params)
     search_resolver = get_resolver(params=params, config=config)
     top_events = run_table_query(
         params,
@@ -325,23 +230,23 @@ def run_top_events_timeseries_query(
         search_resolver, top_events, groupby_columns_without_project
     )
     """Make the query"""
-    rpc_request, aggregates, groupbys = get_timeseries_query(
+    rpc_request, aggregates, groupbys = rpc_dataset_common.get_timeseries_query(
+        search_resolver,
         params,
         query_string,
         y_axes,
         groupby_columns_without_project,
         referrer,
-        config,
         sampling_mode=sampling_mode,
         extra_conditions=top_conditions,
     )
-    other_request, other_aggregates, other_groupbys = get_timeseries_query(
+    other_request, other_aggregates, other_groupbys = rpc_dataset_common.get_timeseries_query(
+        search_resolver,
         params,
         query_string,
         y_axes,
         [],  # in the other series, we want eveything in a single group, so the group by
         referrer,
-        config,
         sampling_mode=sampling_mode,
         extra_conditions=other_conditions,
     )
@@ -378,10 +283,8 @@ def run_top_events_timeseries_query(
     for index, row in enumerate(top_events["data"]):
         result_key = create_result_key(row, groupby_columns, {})
         result_groupby = create_groupby_dict(row, groupby_columns, {})
-        result = _process_all_timeseries(
-            map_result_key_to_timeseries[result_key],
-            params,
-            params.granularity_secs,
+        result = rpc_dataset_common.process_timeseries_list(
+            map_result_key_to_timeseries[result_key]
         )
         final_result[result_key] = SnubaTSResult(
             {
@@ -397,10 +300,8 @@ def run_top_events_timeseries_query(
             params.granularity_secs,
         )
     if other_response.result_timeseries:
-        result = _process_all_timeseries(
-            [timeseries for timeseries in other_response.result_timeseries],
-            params,
-            params.granularity_secs,
+        result = rpc_dataset_common.process_timeseries_list(
+            [timeseries for timeseries in other_response.result_timeseries]
         )
         final_result[OTHER_KEY] = SnubaTSResult(
             {
@@ -416,37 +317,6 @@ def run_top_events_timeseries_query(
             params.granularity_secs,
         )
     return final_result
-
-
-def _process_all_timeseries(
-    all_timeseries: list[TimeSeries],
-    params: SnubaParams,
-    order: int | None = None,
-) -> ProcessedTimeseries:
-    result = ProcessedTimeseries()
-
-    for timeseries in all_timeseries:
-        label = timeseries.label
-        if result.timeseries:
-            for index, bucket in enumerate(timeseries.buckets):
-                assert result.timeseries[index]["time"] == bucket.seconds
-                assert result.confidence[index]["time"] == bucket.seconds
-                assert result.sampling_rate[index]["time"] == bucket.seconds
-                assert result.sample_count[index]["time"] == bucket.seconds
-        else:
-            for bucket in timeseries.buckets:
-                result.timeseries.append({"time": bucket.seconds})
-                result.confidence.append({"time": bucket.seconds})
-                result.sampling_rate.append({"time": bucket.seconds})
-                result.sample_count.append({"time": bucket.seconds})
-
-        for index, data_point in enumerate(timeseries.data_points):
-            result.timeseries[index][label] = process_value(data_point.data)
-            result.confidence[index][label] = CONFIDENCES.get(data_point.reliability, None)
-            result.sampling_rate[index][label] = data_point.avg_sampling_rate
-            result.sample_count[index][label] = data_point.sample_count
-
-    return result
 
 
 @sentry_sdk.trace

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -1042,9 +1042,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         assert response.data["meta"]["dataset"] == self.dataset
 
         rows = data[0:6]
-        for test in zip(event_counts, rows):
-            assert test[1][1][0]["count"] == test[0]
-            assert test[1][1][0]["comparisonCount"] == test[0] / 2
+        for expected, actual in zip(event_counts, rows):
+            assert actual[1][0]["count"] == expected
+            assert actual[1][0]["comparisonCount"] == expected / 2
 
     def test_comparison_delta_with_empty_comparison_values(self):
         event_counts = [6, 0, 6, 4, 0, 4]


### PR DESCRIPTION
Logs and spans will share much of the timeseries logic as well as the table logic. Start decoupling.

Essentially no logic changes, refactoring.
