### PR TITLE
fix(workflow_engine): Always validate config for detectors

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -35,6 +35,7 @@ from sentry.eventstore.models import Event
 from sentry.hybridcloud.models.outbox import RegionOutbox, outbox_context
 from sentry.hybridcloud.models.webhookpayload import WebhookPayload
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
+from sentry.incidents.grouptype import MetricAlertFire
 from sentry.incidents.logic import (
     create_alert_rule,
     create_alert_rule_trigger,
@@ -319,6 +320,10 @@ DEFAULT_EVENT_DATA = {
     },
     "tags": [],
     "platform": "python",
+}
+
+default_detector_config_data = {
+    MetricAlertFire.slug: {"threshold_period": 1, "detection_type": "static"}
 }
 
 
@@ -2181,7 +2186,7 @@ class Factories:
         if name is None:
             name = petname.generate(2, " ", letters=10).title()
         if config is None:
-            config = {}
+            config = default_detector_config_data.get(kwargs["type"], {})
 
         return Detector.objects.create(
             name=name,

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -26,6 +26,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         help_text="Name of the uptime monitor",
     )
     detector_type = serializers.CharField()
+    config = serializers.JSONField(default={})
 
     def validate_detector_type(self, value: str) -> type[GroupType]:
         detector_type = grouptype.registry.get_by_slug(value)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -131,5 +131,4 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
         raise ValidationError("Detector config must be a dictionary")
 
     config_schema = group_type.detector_config_schema
-    if instance.config:
-        instance.validate_config(config_schema)
+    instance.validate_config(config_schema)

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -8,6 +8,7 @@ from sentry.incidents.metric_alert_detector import (
     MetricAlertComparisonConditionValidator,
     MetricAlertsDetectorValidator,
 )
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
@@ -128,6 +129,10 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
                         "conditionGroupId": self.data_condition_group.id,
                     },
                 ],
+            },
+            "config": {
+                "threshold_period": 1,
+                "detection_type": AlertRuleDetectionType.STATIC.value,
             },
         }
 

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricAlertFire
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import (
@@ -80,6 +81,10 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
                         "conditionGroupId": self.data_condition_group.id,
                     }
                 ],
+            },
+            "config": {
+                "threshold_period": 1,
+                "detection_type": AlertRuleDetectionType.STATIC.value,
             },
         }
 

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -8,6 +8,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import default_detector_config_data
 from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import data_source_type_registry
@@ -30,7 +31,7 @@ class TestDetectorSerializer(TestCase):
             "dateUpdated": detector.date_updated,
             "dataSources": None,
             "conditionGroup": None,
-            "config": {},
+            "config": default_detector_config_data[MetricAlertFire.slug],
         }
 
     def test_serialize_full(self):
@@ -130,7 +131,7 @@ class TestDetectorSerializer(TestCase):
                     }
                 ],
             },
-            "config": {},
+            "config": default_detector_config_data[MetricAlertFire.slug],
         }
 
     def test_serialize_bulk(self):

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -103,7 +103,6 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 class MockDetectorValidator(BaseDetectorTypeValidator):
     data_source = MockDataSourceValidator()
     condition_group = MockConditionGroupValidator()
-    # config = JSONField()
 
 
 # TODO - see if we can refactor and mock the grouptype / grouptype.registry

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -103,6 +103,7 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 class MockDetectorValidator(BaseDetectorTypeValidator):
     data_source = MockDataSourceValidator()
     condition_group = MockConditionGroupValidator()
+    # config = JSONField()
 
 
 # TODO - see if we can refactor and mock the grouptype / grouptype.registry

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -118,21 +118,23 @@ class TestMetricAlertFireDetectorConfig(JSONConfigBaseTest, APITestCase):
         )
 
     def test_empty_config(self):
-        self.create_detector(
-            name=self.metric_alert.name,
-            project_id=self.project.id,
-            type="test_metric_alert_fire",
-            owner_user_id=self.metric_alert.user_id,
-            config={},
-        )
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.metric_alert.name,
+                project_id=self.project.id,
+                type="test_metric_alert_fire",
+                owner_user_id=self.metric_alert.user_id,
+                config={},
+            )
 
     def test_no_config(self):
-        self.create_detector(
-            name=self.metric_alert.name,
-            project_id=self.project.id,
-            type="test_metric_alert_fire",
-            owner_user_id=self.metric_alert.user_id,
-        )
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.metric_alert.name,
+                project_id=self.project.id,
+                type="test_metric_alert_fire",
+                owner_user_id=self.metric_alert.user_id,
+            )
 
     def test_incorrect_config(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION
We have required fields in detector configs, but if the config is null or empty we skip validation. This changes the behaviour and fixes related tests
