### PR TITLE
feat(issue-views): Add star/unstar functionality to issue views list

### DIFF
--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -28,6 +28,7 @@ type SavedEntityTableProps = {
   isError: boolean;
   isLoading: boolean;
   className?: string;
+  'data-test-id'?: string;
   pageSize?: number;
 };
 
@@ -56,9 +57,10 @@ export function SavedEntityTable({
   isLoading,
   emptyMessage,
   pageSize = 20,
+  'data-test-id': dataTestId,
 }: SavedEntityTableProps) {
   return (
-    <StyledPanelTable className={className}>
+    <StyledPanelTable className={className} data-test-id={dataTestId}>
       {header}
       {isError && <LoadingError />}
       {isLoading && <LoadingSkeleton pageSize={pageSize} />}

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -498,6 +498,7 @@ export function IssueViewsStateProvider({
                 projects: tab.projects,
                 environments: tab.environments,
                 timeFilters: tab.timeFilters,
+                starred: true,
               })),
           });
         }

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -141,4 +141,29 @@ describe('IssueViewsList', function () {
       );
     });
   });
+
+  it('handles errors when starring views', async function () {
+    const mockStarredEndpoint = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/2/starred/',
+      method: 'POST',
+      statusCode: 500,
+    });
+
+    render(<IssueViewsList />, {organization});
+
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+
+    const tableOthers = screen.getByTestId('table-others');
+
+    // First 'others' view should be unstarred
+    const othersView = within(tableOthers).getByTestId('table-others-row-0');
+    const othersViewStarButton = within(othersView).getByRole('button', {name: 'Star'});
+
+    // Starring should result in a button that is not starred
+    await userEvent.click(othersViewStarButton);
+    await waitFor(() => {
+      expect(mockStarredEndpoint).toHaveBeenCalled();
+    });
+    expect(screen.getByRole('button', {name: 'Star'})).toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -1,7 +1,13 @@
 import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import IssueViewsList from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsList';
@@ -28,6 +34,7 @@ describe('IssueViewsList', function () {
             end: null,
             utc: null,
           },
+          starred: true,
         }),
       ],
     });
@@ -48,6 +55,7 @@ describe('IssueViewsList', function () {
             end: null,
             utc: null,
           },
+          starred: false,
         }),
       ],
     });
@@ -72,5 +80,65 @@ describe('IssueViewsList', function () {
     expect(screen.getByText(textWithMarkupMatcher('bar is baz'))).toBeInTheDocument();
     expect(screen.getByText('My Projects')).toBeInTheDocument();
     expect(screen.getByText('All')).toBeInTheDocument();
+  });
+
+  it('can unstar views', async function () {
+    const mockStarredEndpoint = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/1/starred/',
+      method: 'POST',
+    });
+
+    render(<IssueViewsList />, {organization});
+
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+
+    const tableMe = screen.getByTestId('table-me');
+
+    // First view should be starred
+    const myView = within(tableMe).getByTestId('table-me-row-0');
+    const myViewStarButton = within(myView).getByRole('button', {name: 'Unstar'});
+
+    // Can unstar the view
+    await userEvent.click(myViewStarButton);
+    await within(myView).findByRole('button', {name: 'Star'});
+
+    await waitFor(() => {
+      expect(mockStarredEndpoint).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {starred: false},
+        })
+      );
+    });
+  });
+
+  it('can star views', async function () {
+    const mockStarredEndpoint = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/2/starred/',
+      method: 'POST',
+    });
+
+    render(<IssueViewsList />, {organization});
+
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+
+    const tableOthers = screen.getByTestId('table-others');
+
+    // First 'others' view should be unstarred
+    const othersView = within(tableOthers).getByTestId('table-others-row-0');
+    const othersViewStarButton = within(othersView).getByRole('button', {name: 'Star'});
+
+    // Can star the view
+    await userEvent.click(othersViewStarButton);
+    await within(othersView).findByRole('button', {name: 'Unstar'});
+
+    await waitFor(() => {
+      expect(mockStarredEndpoint).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {starred: true},
+        })
+      );
+    });
   });
 });

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -164,6 +164,8 @@ describe('IssueViewsList', function () {
     await waitFor(() => {
       expect(mockStarredEndpoint).toHaveBeenCalled();
     });
-    expect(screen.getByRole('button', {name: 'Star'})).toBeInTheDocument();
+    expect(
+      await within(othersView).findByRole('button', {name: 'Star'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -68,6 +68,7 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
     createdBy,
     limit,
     cursor,
+    sort,
   });
 
   const {mutate: mutateViewStarred} = useUpdateGroupSearchViewStarred({

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -50,33 +50,27 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
     cursor,
   });
 
+  const tableQueryKey = makeFetchGroupSearchViewsKey({
+    orgSlug: organization.slug,
+    createdBy,
+    limit,
+    cursor,
+  });
+
   const {mutate: mutateViewStarred} = useUpdateGroupSearchViewStarred({
     onMutate: variables => {
-      setApiQueryData<GroupSearchView[]>(
-        queryClient,
-        makeFetchGroupSearchViewsKey({
-          orgSlug: organization.slug,
-          createdBy,
-          limit,
-          cursor,
-        }),
-        data => {
-          return data?.map(view =>
-            view.id === variables.id ? {...view, starred: variables.starred} : view
-          );
-        }
-      );
+      setApiQueryData<GroupSearchView[]>(queryClient, tableQueryKey, data => {
+        return data?.map(view =>
+          view.id === variables.id ? {...view, starred: variables.starred} : view
+        );
+      });
     },
     onError: (_error, variables) => {
-      setApiQueryData<GroupSearchView[]>(
-        queryClient,
-        makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
-        data => {
-          return data?.map(view =>
-            view.id === variables.id ? {...view, starred: !variables.starred} : view
-          );
-        }
-      );
+      setApiQueryData<GroupSearchView[]>(queryClient, tableQueryKey, data => {
+        return data?.map(view =>
+          view.id === variables.id ? {...view, starred: !variables.starred} : view
+        );
+      });
     },
   });
 

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -6,16 +6,25 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type IssueViewsTableProps = {
+  handleStarView: (view: GroupSearchView) => void;
   isError: boolean;
   isPending: boolean;
+  type: string;
   views: GroupSearchView[];
 };
 
-export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProps) {
+export function IssueViewsTable({
+  views,
+  isPending,
+  isError,
+  handleStarView,
+  type,
+}: IssueViewsTableProps) {
   const organization = useOrganization();
 
   return (
     <SavedEntityTableWithColumns
+      data-test-id={`table-${type}`}
       header={
         <SavedEntityTable.Header>
           <SavedEntityTable.HeaderCell key="star" />
@@ -42,9 +51,18 @@ export function IssueViewsTable({views, isPending, isError}: IssueViewsTableProp
       emptyMessage={t('No saved views found')}
     >
       {views.map((view, index) => (
-        <SavedEntityTable.Row key={view.id} isFirst={index === 0}>
+        <SavedEntityTable.Row
+          key={view.id}
+          isFirst={index === 0}
+          data-test-id={`table-${type}-row-${index}`}
+        >
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellStar isStarred onClick={() => {}} />
+            <SavedEntityTable.CellStar
+              isStarred={view.starred}
+              onClick={() => {
+                handleStarView(view);
+              }}
+            />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
             <SavedEntityTable.CellName

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -39,6 +39,7 @@ describe('IssueViewsHeader', () => {
       },
       visibility: GroupSearchViewVisibility.OWNER,
       lastVisited: null,
+      starred: false,
     },
     {
       id: '2',
@@ -55,6 +56,7 @@ describe('IssueViewsHeader', () => {
       },
       visibility: GroupSearchViewVisibility.ORGANIZATION,
       lastVisited: null,
+      starred: false,
     },
     {
       id: '3',
@@ -71,6 +73,7 @@ describe('IssueViewsHeader', () => {
       },
       visibility: GroupSearchViewVisibility.ORGANIZATION,
       lastVisited: null,
+      starred: false,
     },
   ];
 

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
@@ -43,10 +43,11 @@ export const useUpdateGroupSearchViewStarred = (
       );
       options.onError?.(error, variables, context);
     },
-    onSettled: () => {
+    onSettled: (...args) => {
       queryClient.invalidateQueries({
         queryKey: makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
       });
+      options.onSettled?.(...args);
     },
   });
 };

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
@@ -1,0 +1,52 @@
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+type UpdateGroupSearchViewStarredVariables = {
+  id: string | number;
+  starred: boolean;
+  view: GroupSearchView;
+};
+
+export const useUpdateGroupSearchViewStarred = (
+  options: Omit<
+    UseMutationOptions<null, RequestError, UpdateGroupSearchViewStarredVariables>,
+    'mutationFn'
+  > = {}
+) => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
+
+  return useMutation<null, RequestError, UpdateGroupSearchViewStarredVariables>({
+    ...options,
+    mutationFn: ({id, starred}: UpdateGroupSearchViewStarredVariables) =>
+      api.requestPromise(
+        `/organizations/${organization.slug}/group-search-views/${id}/starred/`,
+        {
+          method: 'POST',
+          data: {starred},
+        }
+      ),
+    onError: (error, variables, context) => {
+      addErrorMessage(
+        variables.starred ? t('Failed to star view') : t('Failed to unstar view')
+      );
+      options.onError?.(error, variables, context);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
+      });
+    },
+  });
+};

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -34,6 +34,7 @@ export type GroupSearchView = {
   projects: number[];
   query: string;
   querySort: IssueSortOptions;
+  starred: boolean;
   timeFilters: PageFilters['datetime'];
   visibility: GroupSearchViewVisibility;
 };

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -59,6 +59,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
             projects: defaultProject,
             environments: DEFAULT_ENVIRONMENTS,
             timeFilters: DEFAULT_TIME_FILTERS,
+            starred: true,
           },
         ],
         orgSlug: organization.slug,

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -134,6 +134,7 @@ export function IssueViewNavItems({
                 projects: tab.projects,
                 environments: tab.environments,
                 timeFilters: tab.timeFilters,
+                starred: true,
               })),
           });
         }
@@ -206,7 +207,8 @@ export function IssueViewNavItems({
           isAllProjects: isEqual(v.projects, [-1]),
           name: v.label,
           lastVisited: null,
-          visibility: GroupSearchViewVisibility.OWNER,
+          visibility: GroupSearchViewVisibility.ORGANIZATION,
+          starred: true,
         }))
       );
     },
@@ -249,7 +251,8 @@ export function IssueViewNavItems({
             isAllProjects: isEqual(v.projects, [-1]),
             name: v.label,
             lastVisited: null,
-            visibility: GroupSearchViewVisibility.OWNER,
+            visibility: GroupSearchViewVisibility.ORGANIZATION,
+            starred: true,
           }))
         );
       }

--- a/tests/js/fixtures/groupSearchView.ts
+++ b/tests/js/fixtures/groupSearchView.ts
@@ -17,6 +17,7 @@ export function GroupSearchViewFixture(params: Partial<GroupSearchView> = {}): G
     },
     lastVisited: null,
     visibility: GroupSearchViewVisibility.ORGANIZATION,
+    starred: false,
     ...params,
   };
 }


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/89111

View 3e815f4894fe24d87ea7b3ef35b12c9f19f364c8 for diff in this PR

Still dependent on `issue-view-sharing` flag

- Adds `starred` boolean to GroupSearchView type, which is already returned in the response but not typed
- Adds hook for starring/unstarring a view
- Uses the hook in the issue views list