### PR TITLE
fix(issue-alerts) Don't cast percentage frequency to int

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -943,7 +943,6 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         # We do not have sessions for non-error issue types
         for group in generic_issue_ids:
             batch_percents[group] = 0
-
         return batch_percents
 
     def passes_activity_frequency(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -190,7 +190,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return current_value > value
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: dict[datetime, int]
+        self, activity: ConditionActivity, buckets: dict[datetime, int | float]
     ) -> bool:
         interval, value = self._get_options()
         if not (interval and value is not None):
@@ -221,7 +221,9 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def get_preview_aggregate(self) -> tuple[str, str]:
         raise NotImplementedError
 
-    def query(self, event: GroupEvent, start: datetime, end: datetime, environment_id: int) -> int:
+    def query(
+        self, event: GroupEvent, start: datetime, end: datetime, environment_id: int
+    ) -> int | float:
         """
         Queries Snuba for a unique condition for a single group.
         """
@@ -229,7 +231,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
     def query_hook(
         self, event: GroupEvent, start: datetime, end: datetime, environment_id: int
-    ) -> int:
+    ) -> int | float:
         """
         Abstract method that specifies how to query Snuba for a single group
         depending on the condition. Must be implemented by subclasses.
@@ -238,7 +240,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
     def batch_query(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
+    ) -> dict[int, int | float]:
         """
         Queries Snuba for a unique condition for multiple groups.
         """
@@ -246,7 +248,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
+    ) -> dict[int, int | float]:
         """
         Abstract method that specifies how to query Snuba for multiple groups
         depending on the condition. Must be implemented by subclasses.
@@ -279,7 +281,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         event: GroupEvent,
         environment_id: int,
         comparison_type: str,
-    ) -> int:
+    ) -> int | float:
         current_time = timezone.now()
         start, end = self.get_query_window(end=current_time, duration=duration)
         with self.disable_consistent_snuba_mode(duration):
@@ -302,7 +304,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         environment_id: int,
         current_time: datetime,
         comparison_interval: timedelta | None,
-    ) -> dict[int, int]:
+    ) -> dict[int, int | float]:
         """
         Make a batch query for multiple groups. The return value is a dictionary
         of group_id to the result for that group.
@@ -434,8 +436,8 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
-        batch_sums: dict[int, int] = defaultdict(int)
+    ) -> dict[int, int | float]:
+        batch_sums: dict[int, int | float] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
@@ -497,8 +499,8 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
 
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
-        batch_totals: dict[int, int] = defaultdict(int)
+    ) -> dict[int, int | float]:
+        batch_totals: dict[int, int | float] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
@@ -583,7 +585,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
 
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
+    ) -> dict[int, int | float]:
         logger = logging.getLogger(
             "sentry.rules.event_frequency.EventUniqueUserFrequencyConditionWithConditions"
         )
@@ -609,7 +611,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
             raise NotImplementedError(
                 "EventUniqueUserFrequencyConditionWithConditions does not support filter_match == any"
             )
-        batch_totals: dict[int, int] = defaultdict(int)
+        batch_totals: dict[int, int | float] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
@@ -723,7 +725,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
 
     @staticmethod
     def convert_rule_condition_to_snuba_condition(
-        condition: dict[str, Any]
+        condition: dict[str, Any],
     ) -> tuple[str, str, str | list[str]] | None:
         if condition["id"] != "sentry.rules.filters.tagged_event.TaggedEventFilter":
             return None
@@ -863,7 +865,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
 
     def query_hook(
         self, event: GroupEvent, start: datetime, end: datetime, environment_id: int
-    ) -> int:
+    ) -> float:
         project_id = event.project_id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         avg_sessions_in_interval = self.get_session_interval(
@@ -892,14 +894,14 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                         "avg_sessions_in_interval": avg_sessions_in_interval,
                     },
                 )
-            percent: int = int(100 * round(issue_count / avg_sessions_in_interval, 4))
+            percent: float = 100 * round(issue_count / avg_sessions_in_interval, 4)
             return percent
 
         return 0
 
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
+    ) -> dict[int, int | float]:
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
@@ -933,9 +935,9 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             referrer_suffix="batch_alert_event_frequency_percent",
         )
 
-        batch_percents: dict[int, int] = {}
+        batch_percents: dict[int, int | float] = {}
         for group_id, count in error_issue_count.items():
-            percent: int = int(100 * round(count / avg_sessions_in_interval, 4))
+            percent: float = 100 * round(count / avg_sessions_in_interval, 4)
             batch_percents[group_id] = percent
 
         # We do not have sessions for non-error issue types
@@ -945,7 +947,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return batch_percents
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: dict[datetime, int]
+        self, activity: ConditionActivity, buckets: dict[datetime, int | float]
     ) -> bool:
         raise NotImplementedError
 
@@ -953,14 +955,16 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return EventFrequencyPercentForm(self.data)
 
 
-def bucket_count(start: datetime, end: datetime, buckets: dict[datetime, int]) -> int:
+def bucket_count(
+    start: datetime, end: datetime, buckets: dict[datetime, int | float]
+) -> int | float:
     rounded_end = round_to_five_minute(end)
     rounded_start = round_to_five_minute(start)
     count = buckets.get(rounded_end, 0) - buckets.get(rounded_start, 0)
     return count
 
 
-def percent_increase(result: int, comparison_result: int) -> int:
+def percent_increase(result: int | float, comparison_result: int | float) -> int:
     return (
         int(max(0, ((result - comparison_result) / comparison_result * 100)))
         if comparison_result > 0

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -213,7 +213,7 @@ def bulk_fetch_events(event_ids: list[str], project_id: int) -> dict[str, Event]
 
 
 def parse_rulegroup_to_event_data(
-    rulegroup_to_event_data: dict[str, str]
+    rulegroup_to_event_data: dict[str, str],
 ) -> dict[tuple[int, int], dict[str, str]]:
     parsed_rulegroup_to_event_data = {}
     for rule_group, instance_data in rulegroup_to_event_data.items():
@@ -326,7 +326,7 @@ def get_group_to_groupevent(
 
 def get_condition_group_results(
     condition_groups: dict[UniqueConditionQuery, DataAndGroups], project: Project
-) -> dict[UniqueConditionQuery, dict[int, int]] | None:
+) -> dict[UniqueConditionQuery, dict[int, int | float]] | None:
     condition_group_results = {}
     current_time = datetime.now(tz=timezone.utc)
     project_id = project.id
@@ -377,7 +377,7 @@ def get_condition_group_results(
 
 
 def passes_comparison(
-    condition_group_results: dict[UniqueConditionQuery, dict[int, int]],
+    condition_group_results: dict[UniqueConditionQuery, dict[int, int | float]],
     condition_data: EventFrequencyConditionData,
     group_id: int,
     environment_id: int,
@@ -414,7 +414,7 @@ def passes_comparison(
 
 
 def get_rules_to_fire(
-    condition_group_results: dict[UniqueConditionQuery, dict[int, int]],
+    condition_group_results: dict[UniqueConditionQuery, dict[int, int | float]],
     rules_to_slow_conditions: DefaultDict[Rule, list[EventFrequencyConditionData]],
     rules_to_groups: DefaultDict[int, set[int]],
     project_id: int,

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -393,7 +393,7 @@ class GetRulesToFireTest(TestCase):
         self.group1: Group = self.create_group(self.project)
         self.group2: Group = self.create_group(self.project)
 
-        self.condition_group_results: dict[UniqueConditionQuery, dict[int, int]] = {
+        self.condition_group_results: dict[UniqueConditionQuery, dict[int, int | float]] = {
             UniqueConditionQuery(
                 cls_id=TEST_RULE_SLOW_CONDITION["id"],
                 interval=TEST_RULE_SLOW_CONDITION["interval"],

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1146,6 +1146,37 @@ class ApplyDelayedTest(ProcessDelayedAlertConditionsTestBase):
         assert (percent_comparison_rule.id, group5.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
 
+    def test_apply_delayed_event_frequency_percent_condition_fires_on_small_value(self):
+        event_frequency_percent_condition_2 = self.create_event_frequency_condition(
+            interval="1h", id="EventFrequencyPercentCondition", value=0.1
+        )
+
+        self.project_three = self.create_project(organization=self.organization)
+        # 1 event / 600 sessions ~= 0.17%
+        self._make_sessions(600, project=self.project_three)
+
+        percent_comparison_rule = self.create_project_rule(
+            project=self.project_three,
+            condition_data=[event_frequency_percent_condition_2],
+        )
+
+        event5 = self.create_event(self.project_three.id, FROZEN_TIME, "group-6")
+        assert event5.group
+
+        buffer.backend.push_to_sorted_set(
+            key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project_three.id
+        )
+        self.push_to_hash(
+            self.project_three.id, percent_comparison_rule.id, event5.group.id, event5.event_id
+        )
+        apply_delayed(self.project_three.id)
+
+        assert RuleFireHistory.objects.filter(
+            rule__in=[percent_comparison_rule],
+            project=self.project_three,
+        ).exists()
+        self.assert_buffer_cleared(project_id=self.project_three.id)
+
     def test_apply_delayed_event_frequency_percent_comparison_interval(self):
         """
         Test that the event frequency percent condition with a percent


### PR DESCRIPTION
Users can set percentage threshold to values lower than 1%, but casting the calculated
value to int makes it so that anything evaluated as <1% will be evaluated as 0% which causes
certain alerts to not fire. 

More details [here](https://www.notion.so/sentry/Alerts-Percent-of-sessions-affected-by-an-issue-is-more-than-X-in-X-time-1cb8b10e4b5d8036b098c190c5ac6eae).

related to https://github.com/getsentry/sentry/issues/88880