### PR TITLE
fix(flags): remove export button from flag drawer details

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -333,6 +333,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/flags/                                              @getsentry/replay-backend
 /tests/sentry/flags/                                            @getsentry/replay-backend
 /static/app/components/events/featureFlags/                     @getsentry/replay-frontend
+/static/app/views/issueDetails/groupDistributionsDrawer.tsx     @getsentry/replay-frontend
 /static/app/views/issueDetails/groupFeatureFlags/               @getsentry/replay-frontend
 /static/app/views/issueDetails/groupTags/                       @getsentry/replay-frontend
 /static/app/views/issueDetails/streamline/hooks/featureFlags/   @getsentry/replay-frontend

--- a/static/app/views/issueDetails/groupDistributionsDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributionsDrawer.tsx
@@ -103,83 +103,84 @@ export function GroupDistributionsDrawer({
   const [search, setSearch] = useState('');
   const {tab, setTab} = useDrawerTab({enabled: includeFeatureFlagsTab});
 
-  const headerActions = tagKey ? (
-    <DropdownMenu
-      size="xs"
-      trigger={triggerProps => (
-        <Button
-          {...triggerProps}
-          borderless
-          size="xs"
-          aria-label={t('Export options')}
-          icon={<IconDownload />}
-        />
-      )}
-      items={[
-        {
-          key: 'export-page',
-          label: t('Export Page to CSV'),
-          // TODO(issues): Dropdown menu doesn't support hrefs yet
-          onAction: () => {
-            window.open(
-              `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
-              '_blank'
-            );
+  const headerActions =
+    tagKey && tab === DrawerTab.TAGS ? (
+      <DropdownMenu
+        size="xs"
+        trigger={triggerProps => (
+          <Button
+            {...triggerProps}
+            borderless
+            size="xs"
+            aria-label={t('Export options')}
+            icon={<IconDownload />}
+          />
+        )}
+        items={[
+          {
+            key: 'export-page',
+            label: t('Export Page to CSV'),
+            // TODO(issues): Dropdown menu doesn't support hrefs yet
+            onAction: () => {
+              window.open(
+                `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+                '_blank'
+              );
+            },
           },
-        },
-        {
-          key: 'export-all',
-          label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
-          onAction: () => {
-            handleDataExport();
-            setIsExportDisabled(true);
+          {
+            key: 'export-all',
+            label: isExportDisabled ? t('Export in progress...') : t('Export All to CSV'),
+            onAction: () => {
+              handleDataExport();
+              setIsExportDisabled(true);
+            },
+            disabled: isExportDisabled,
           },
-          disabled: isExportDisabled,
-        },
-      ]}
-    />
-  ) : (
-    <ButtonBar gap={1}>
-      <InputGroup>
-        <SearchInput
-          size="xs"
-          value={search}
-          onChange={e => {
-            setSearch(e.target.value);
-            trackAnalytics('tags.drawer.action', {
-              control: 'search',
-              organization,
-            });
-          }}
-          aria-label={
-            includeFeatureFlagsTab
-              ? t('Search All Tags & Feature Flags')
-              : t('Search All Tags')
-          }
-        />
-        <InputGroup.TrailingItems disablePointerEvents>
-          <IconSearch size="xs" />
-        </InputGroup.TrailingItems>
-      </InputGroup>
-      {includeFeatureFlagsTab && (
-        <SegmentedControl
-          size="xs"
-          value={tab}
-          onChange={newTab => {
-            setTab(newTab as DrawerTab);
-            setSearch('');
-          }}
-        >
-          <SegmentedControl.Item key={DrawerTab.TAGS}>
-            {t('All Tags')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key={DrawerTab.FEATURE_FLAGS}>
-            {t('All Feature Flags')}
-          </SegmentedControl.Item>
-        </SegmentedControl>
-      )}
-    </ButtonBar>
-  );
+        ]}
+      />
+    ) : tagKey && tab === DrawerTab.FEATURE_FLAGS ? null : (
+      <ButtonBar gap={1}>
+        <InputGroup>
+          <SearchInput
+            size="xs"
+            value={search}
+            onChange={e => {
+              setSearch(e.target.value);
+              trackAnalytics('tags.drawer.action', {
+                control: 'search',
+                organization,
+              });
+            }}
+            aria-label={
+              includeFeatureFlagsTab
+                ? t('Search All Tags & Feature Flags')
+                : t('Search All Tags')
+            }
+          />
+          <InputGroup.TrailingItems disablePointerEvents>
+            <IconSearch size="xs" />
+          </InputGroup.TrailingItems>
+        </InputGroup>
+        {includeFeatureFlagsTab && (
+          <SegmentedControl
+            size="xs"
+            value={tab}
+            onChange={newTab => {
+              setTab(newTab as DrawerTab);
+              setSearch('');
+            }}
+          >
+            <SegmentedControl.Item key={DrawerTab.TAGS}>
+              {t('All Tags')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key={DrawerTab.FEATURE_FLAGS}>
+              {t('All Feature Flags')}
+            </SegmentedControl.Item>
+          </SegmentedControl>
+        )}
+      </ButtonBar>
+    );
 
   return (
     <EventDrawerContainer ref={drawerRef}>


### PR DESCRIPTION
These action and download links aren't valid for flags

Before (broken link):
![Screenshot 2025-04-09 at 12 17 54 PM](https://github.com/user-attachments/assets/4700c0ff-f164-45dc-b50c-70ee29a1bb9c)

After:
![Screenshot 2025-04-09 at 12 16 11 PM](https://github.com/user-attachments/assets/f0322b45-ea38-4e48-aafa-51a818b530e8)

