### PR TITLE
feat(explore): Explore All Queries page design

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -114,6 +114,12 @@ type GridEditableProps<DataRow, ColumnKey> = {
   onRowMouseOut?: (row: DataRow, key: number, event: React.MouseEvent) => void;
   onRowMouseOver?: (row: DataRow, key: number, event: React.MouseEvent) => void;
 
+  /**
+   * Whether columns in the grid can be resized.
+   *
+   * @default true
+   */
+  resizable?: boolean;
   scrollable?: boolean;
   stickyHeader?: boolean;
   /**
@@ -314,7 +320,15 @@ class GridEditable<
   }
 
   renderGridHead() {
-    const {error, isLoading, columnOrder, grid, data, stickyHeader} = this.props;
+    const {
+      error,
+      isLoading,
+      columnOrder,
+      grid,
+      data,
+      stickyHeader,
+      resizable = true,
+    } = this.props;
 
     // Ensure that the last column cannot be removed
     const numColumn = columnOrder.length;
@@ -342,7 +356,7 @@ class GridEditable<
               sticky={stickyHeader}
             >
               {grid.renderHeadCell ? grid.renderHeadCell(column, i) : column.name}
-              {i !== numColumn - 1 && (
+              {i !== numColumn - 1 && resizable && (
                 <GridResizer
                   dataRows={!error && !isLoading && data ? data.length : 0}
                   onMouseDown={e => this.onResizeMouseDown(e, i)}

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -54,7 +54,6 @@ describe('SavedQueriesTable', () => {
     expect(screen.getByText('Projects')).toBeInTheDocument();
     expect(screen.getByText('Query')).toBeInTheDocument();
     expect(screen.getByText('Owner')).toBeInTheDocument();
-    expect(screen.getByText('Access')).toBeInTheDocument();
     expect(screen.getByText('Last Viewed')).toBeInTheDocument();
     await screen.findByText('Query Name');
   });

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -17,9 +17,11 @@ import GridEditable, {
   type GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import {GridHeadCellStatic} from 'sentry/components/gridEditable/styles';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link from 'sentry/components/links/link';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import TimeSince from 'sentry/components/timeSince';
 import {IconEllipsis, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -176,9 +178,7 @@ export function SavedQueriesTable({
     if (col.key === 'lastVisited') {
       return (
         <LastColumnWrapper>
-          <span>
-            {row.lastVisited ? new Date(row.lastVisited).toDateString() : NO_VALUE}
-          </span>
+          <span>{row.lastVisited ? <TimeSince date={row.lastVisited} /> : NO_VALUE}</span>
           <span>
             <DropdownMenu
               items={[
@@ -307,6 +307,7 @@ export function SavedQueriesTable({
           columnSortBy={[]}
           bodyStyle={{overflow: 'visible', zIndex: 'unset'}}
           minimumColWidth={30}
+          resizable={false}
         />
       </StyledStreamlineGridEditable>
       <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
@@ -351,6 +352,10 @@ const StyledStreamlineGridEditable = styled(StreamlineGridEditable)`
   ${GridHeadCellStatic}:first-child {
     height: auto;
     padding-left: ${space(1.5)};
+  }
+
+  tr:hover > ${InteractionStateLayer} {
+    opacity: 0.06;
   }
 `;
 

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -46,9 +46,9 @@ const NO_VALUE = ' \u2014 ';
 
 const ORDER: Array<GridColumnOrder<keyof SavedQuery>> = [
   {key: 'name', width: 250, name: t('Name')},
-  {key: 'projects', width: 80, name: t('Projects')},
+  {key: 'projects', width: 85, name: t('Projects')},
   {key: 'query', width: 500, name: t('Query')},
-  {key: 'createdBy', width: 80, name: t('Owner')},
+  {key: 'createdBy', width: 70, name: t('Owner')},
   {key: 'lastVisited', width: 120, name: t('Last Viewed')},
 ];
 


### PR DESCRIPTION
This update includes a number of design changes for the Explore All Queries page and tables:
- Updates GridEditable to accept a `resizable` prop. Updates the All Queries tables to be not `resizable`.
- Updates table rows to highlight on hover.
- Updates Last Viewed column to have relative dates.
- Updates column widths to always match between Owned and Shared tables
- Drops access column
- Aligns all columns to the left
- Updates to use `ProjectAvatar` instead of `ProjectIcon` to better match design

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/9f3d7fcb-9ff8-457e-900b-509c8f554e31" />
