### PR TITLE
admin: drop deprecated usage of DropdownActions

### DIFF
--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -1,4 +1,8 @@
+import styled from '@emotion/styled';
+
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
+import {IconNot} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
 
 import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
 
@@ -31,7 +35,12 @@ function mapActionsToCompactSelect(
       }
       return {
         value: action.key,
-        label: action.name,
+        label: (
+          <div>
+            {action.name}
+            <StyledIconNot size="xs" />
+          </div>
+        ),
         details: action.help,
         disabled: action.disabled,
         tooltip: action.disabled ? action.disabledReason : undefined,
@@ -76,3 +85,9 @@ function DropdownActions({actions, label}: Props) {
 }
 
 export default DropdownActions;
+
+const StyledIconNot = styled(IconNot)`
+  color: ${p => p.theme.red200};
+  margin-left: ${space(0.5)};
+  transform: translateY(2px);
+`;

--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -1,37 +1,6 @@
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
-
-import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
-import DropdownButton from 'sentry/components/dropdownButton';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconNot} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
+import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 
 import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
-
-const ActionName = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
-`;
-
-const ActionLabel = styled('div')<{isDisabled: boolean}>`
-  width: 350px;
-  ${p =>
-    p.isDisabled &&
-    css`
-      color: ${p.theme.subText};
-      svg {
-        color: ${p.theme.red200};
-      }
-    `}
-`;
-
-const HelpText = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
-  line-height: 1.2;
-`;
 
 type Props = {
   actions: Array<{
@@ -48,20 +17,31 @@ type Props = {
   label?: string;
 };
 
+/**
+ * Map actions to a format that can be used by the CompactSelect component. This exists
+ * because this used a component with a different signature, and I
+ */
+function mapActionsToCompactSelect(
+  actions: Props['actions']
+): Array<SelectOption<string>> {
+  return actions.map(action => ({
+    value: action.key,
+    label: action.name,
+    details: action.help,
+    disabled: action.disabled,
+    tooltip: action.disabled ? action.disabledReason : undefined,
+    help: action.help,
+  }));
+}
+
 function DropdownActions({actions, label}: Props) {
   return (
-    <DropdownAutoComplete
-      alignMenu="right"
-      searchPlaceholder="Filter actions"
-      noResultsMessage="No actions match your filter"
-      onSelect={({value}) => {
-        const action = actions.find(a => a.key === value);
-
-        if (action === undefined) {
-          return;
-        }
-
-        if (action.disabled) {
+    <CompactSelect
+      searchable
+      options={mapActionsToCompactSelect(actions)}
+      onChange={option => {
+        const action = actions.find(a => a.key === option.value);
+        if (!action || action.disabled) {
           return;
         }
 
@@ -83,40 +63,8 @@ function DropdownActions({actions, label}: Props) {
           onConfirm: action.onAction,
         });
       }}
-      items={actions
-        .filter(action => action.visible !== false)
-        .map(action => {
-          const actionLabel = (
-            <ActionLabel
-              data-test-id={`action-${action.key}`}
-              isDisabled={!!action.disabled}
-              aria-disabled={!!action.disabled}
-            >
-              <ActionName>
-                {action.name}
-                {action.disabled && (
-                  <Tooltip skipWrapper title={action.disabledReason}>
-                    <IconNot size="xs" data-test-id="icon-not" />
-                  </Tooltip>
-                )}
-              </ActionName>
-              {action.help && <HelpText>{action.help}</HelpText>}
-            </ActionLabel>
-          );
-
-          return {
-            value: action.key,
-            searchKey: action.name,
-            label: actionLabel,
-          };
-        })}
-    >
-      {({isOpen}) => (
-        <DropdownButton data-test-id="detail-actions" size="sm" isOpen={isOpen}>
-          {label}
-        </DropdownButton>
-      )}
-    </DropdownAutoComplete>
+      triggerLabel={label}
+    />
   );
 }
 

--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -24,14 +24,21 @@ type Props = {
 function mapActionsToCompactSelect(
   actions: Props['actions']
 ): Array<SelectOption<string>> {
-  return actions.map(action => ({
-    value: action.key,
-    label: action.name,
-    details: action.help,
-    disabled: action.disabled,
-    tooltip: action.disabled ? action.disabledReason : undefined,
-    help: action.help,
-  }));
+  return actions
+    .map(action => {
+      if (action.visible === false) {
+        return null;
+      }
+      return {
+        value: action.key,
+        label: action.name,
+        details: action.help,
+        disabled: action.disabled,
+        tooltip: action.disabled ? action.disabledReason : undefined,
+        help: action.help,
+      };
+    })
+    .filter(Boolean) as Array<SelectOption<string>>;
 }
 
 function DropdownActions({actions, label}: Props) {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1137,7 +1137,7 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
     expect(screen.getByText('Start Trial')).toBeInTheDocument();
@@ -1171,7 +1171,7 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
     await userEvent.click(screen.getByText('Convert to Sponsored'));
@@ -1218,16 +1218,16 @@ describe('Customer Details', function () {
       await screen.findByRole('heading', {name: 'Customers'});
 
       await userEvent.click(
-        screen.getAllByRole('button', {name: 'Customers Actions'})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
-      expect(screen.getByTestId('action-changeSoftCap')).toHaveAttribute(
+      expect(screen.getByTestId('changeSoftCap')).toHaveAttribute(
         'aria-disabled',
         'true'
       );
 
       await userEvent.hover(
-        within(screen.getByTestId('action-changeSoftCap')).getByTestId('icon-not')
+        within(screen.getByTestId('changeSoftCap')).getByTestId('terminateContract')
       );
 
       expect(
@@ -1256,7 +1256,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Add Legacy Soft Cap')).toBeInTheDocument();
@@ -1316,7 +1316,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Add Legacy Soft Cap'));
@@ -1365,7 +1365,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Remove Legacy Soft Cap'));
@@ -1421,7 +1421,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Disable Overage Notification')).toBeInTheDocument();
@@ -1452,7 +1452,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Enable Overage Notification')).toBeInTheDocument();
@@ -1489,7 +1489,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Disable Overage Notification'));
@@ -1541,7 +1541,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -1587,7 +1587,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Clear Pending Changes')).toBeInTheDocument();
@@ -1613,7 +1613,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.queryByText('Clear Pending Changes')).not.toBeInTheDocument();
@@ -1643,7 +1643,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Allow Trial')).toBeInTheDocument();
@@ -1669,7 +1669,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.queryByText('Allow Trial')).not.toBeInTheDocument();
@@ -1695,7 +1695,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.queryByText('Allow Trial')).not.toBeInTheDocument();
@@ -1727,7 +1727,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -1773,7 +1773,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Allow Grace Period')).toBeInTheDocument();
@@ -1799,16 +1799,13 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-allowGrace')).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
+      expect(screen.getByTestId('allowGrace')).toHaveAttribute('aria-disabled', 'true');
 
       await userEvent.hover(
-        within(screen.getByTestId('action-allowGrace')).getByTestId('icon-not')
+        within(screen.getByTestId('allowGrace')).getByTestId('terminateContract')
       );
 
       expect(
@@ -1842,7 +1839,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -1894,16 +1891,16 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-terminateContract')).toHaveAttribute(
+      expect(screen.getByTestId('terminateContract')).toHaveAttribute(
         'aria-disabled',
         'true'
       );
 
       await userEvent.hover(
-        within(screen.getByTestId('action-terminateContract')).getByTestId('icon-not')
+        within(screen.getByTestId('terminateContract')).getByText('Terminate Contract')
       );
 
       expect(
@@ -1941,10 +1938,10 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-terminateContract')).toHaveAttribute(
+      expect(screen.getByTestId('terminateContract')).toHaveAttribute(
         'aria-disabled',
         'false'
       );
@@ -1986,7 +1983,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Terminate Contract'));
@@ -2035,7 +2032,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2100,7 +2097,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2181,7 +2178,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2261,7 +2258,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2338,7 +2335,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2381,7 +2378,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2458,7 +2455,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2510,7 +2507,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Cancel Subscription')).toBeInTheDocument();
@@ -2540,7 +2537,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Cancel Subscription'));
@@ -2619,12 +2616,9 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
-      expect(screen.getByTestId('action-changePlan')).toHaveAttribute(
-        'aria-disabled',
-        'false'
-      );
+      expect(screen.getByTestId('changePlan')).toHaveAttribute('aria-disabled', 'false');
     });
 
     it('is enabled for deactivated partner account', async function () {
@@ -2674,12 +2668,9 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
-      expect(screen.getByTestId('action-changePlan')).toHaveAttribute(
-        'aria-disabled',
-        'false'
-      );
+      expect(screen.getByTestId('changePlan')).toHaveAttribute('aria-disabled', 'false');
     });
 
     it('is disabled for active, non-XX partner account', async function () {
@@ -2717,13 +2708,10 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-changePlan')).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
+      expect(screen.getByTestId('changePlan')).toHaveAttribute('aria-disabled', 'true');
     });
   });
 
@@ -2756,7 +2744,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -2798,10 +2786,10 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-endTrialEarly')).toHaveAttribute(
+      expect(screen.getByTestId('endTrialEarly')).toHaveAttribute(
         'aria-disabled',
         'true'
       );
@@ -2851,7 +2839,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Disable On Demand Billing')).toBeInTheDocument();
@@ -2890,7 +2878,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByText('Enable On Demand Billing')).toBeInTheDocument();
@@ -2929,7 +2917,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.queryByText('Enable On Demand Billing')).not.toBeInTheDocument();
@@ -2973,7 +2961,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -3033,7 +3021,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -3083,7 +3071,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Convert to Sponsored'));
@@ -3153,7 +3141,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       await userEvent.click(screen.getByText('Convert to Sponsored'));
@@ -3206,10 +3194,10 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
-      expect(screen.getByTestId('action-convertToSponsored')).toHaveAttribute(
+      expect(screen.getByTestId('convertToSponsored')).toHaveAttribute(
         'aria-disabled',
         'true'
       );
@@ -3240,10 +3228,10 @@ describe('Customer Details', function () {
         await userEvent.click(
           screen.getAllByRole('button', {
             name: 'Customers Actions',
-          })[1]!
+          })[0]!
         );
 
-        await userEvent.click(screen.getByTestId(`action-gift-${dataCategory}`));
+        await userEvent.click(screen.getByTestId(`gift-${dataCategory}`));
 
         expect(
           await screen.findByText(
@@ -3278,7 +3266,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       const freeEventsKey = FREE_EVENTS_KEYS[DataCategory.ERRORS];
@@ -3288,7 +3276,7 @@ describe('Customer Details', function () {
         body: {...organization, [freeEventsKey]: 26000},
       });
 
-      await userEvent.click(screen.getByTestId(`action-gift-${DataCategory.ERRORS}`));
+      await userEvent.click(screen.getByTestId(`gift-${DataCategory.ERRORS}`));
 
       expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
@@ -3338,7 +3326,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       const freeEventsKey = FREE_EVENTS_KEYS[DataCategory.TRANSACTIONS];
@@ -3348,9 +3336,7 @@ describe('Customer Details', function () {
         body: {...organization, [freeEventsKey]: 26000},
       });
 
-      await userEvent.click(
-        screen.getByTestId(`action-gift-${DataCategory.TRANSACTIONS}`)
-      );
+      await userEvent.click(screen.getByTestId(`gift-${DataCategory.TRANSACTIONS}`));
 
       expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
@@ -3402,7 +3388,7 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
     const freeEventsKey = FREE_EVENTS_KEYS[DataCategory.REPLAYS];
@@ -3412,7 +3398,7 @@ describe('Customer Details', function () {
       body: {...organization, [freeEventsKey]: 50},
     });
 
-    await userEvent.click(screen.getByTestId(`action-gift-${DataCategory.REPLAYS}`));
+    await userEvent.click(screen.getByTestId(`gift-${DataCategory.REPLAYS}`));
 
     expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
@@ -3463,7 +3449,7 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
     const freeEventsKey = FREE_EVENTS_KEYS[DataCategory.SPANS];
@@ -3473,7 +3459,7 @@ describe('Customer Details', function () {
       body: {...organization, [freeEventsKey]: 50},
     });
 
-    await userEvent.click(screen.getByTestId(`action-gift-${DataCategory.SPANS}`));
+    await userEvent.click(screen.getByTestId(`gift-${DataCategory.SPANS}`));
 
     expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
@@ -3522,10 +3508,10 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
-    const item = screen.getByTestId(`action-gift-${DataCategory.SPANS_INDEXED}`);
+    const item = screen.getByTestId(`gift-${DataCategory.SPANS_INDEXED}`);
     expect(item).toBeInTheDocument();
     expect(item).toHaveAttribute('aria-disabled', 'true');
   });
@@ -3552,10 +3538,10 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
-    const item = screen.getByTestId(`action-gift-${DataCategory.SPANS_INDEXED}`);
+    const item = screen.getByTestId(`gift-${DataCategory.SPANS_INDEXED}`);
     expect(item).toBeInTheDocument();
     expect(item).toHaveAttribute('aria-disabled', 'true');
   });
@@ -3583,7 +3569,7 @@ describe('Customer Details', function () {
     await userEvent.click(
       screen.getAllByRole('button', {
         name: 'Customers Actions',
-      })[1]!
+      })[0]!
     );
 
     const freeEventsKey = FREE_EVENTS_KEYS[DataCategory.MONITOR_SEATS];
@@ -3593,9 +3579,7 @@ describe('Customer Details', function () {
       body: {...organization, [freeEventsKey]: 50},
     });
 
-    await userEvent.click(
-      screen.getByTestId(`action-gift-${DataCategory.MONITOR_SEATS}`)
-    );
+    await userEvent.click(screen.getByTestId(`gift-${DataCategory.MONITOR_SEATS}`));
 
     expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
@@ -3652,7 +3636,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(
@@ -3682,7 +3666,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.getByRole('button', {name: 'Oct 24, 2018'})).toBeInTheDocument();
@@ -3718,7 +3702,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       expect(screen.queryByText('Suspend Account')).not.toBeInTheDocument();
@@ -3750,7 +3734,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -3798,7 +3782,7 @@ describe('Customer Details', function () {
       await userEvent.click(
         screen.getAllByRole('button', {
           name: 'Customers Actions',
-        })[1]!
+        })[0]!
       );
 
       renderGlobalModal();
@@ -3857,7 +3841,7 @@ describe('Customer Details', function () {
       await screen.findByRole('heading', {name: 'Customers'});
 
       await userEvent.click(
-        screen.getAllByRole('button', {name: /customers actions/i})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
       expect(screen.getByText('Gift to reserved budget')).toBeInTheDocument();
@@ -3885,7 +3869,7 @@ describe('Customer Details', function () {
       await screen.findByRole('heading', {name: 'Customers'});
 
       await userEvent.click(
-        screen.getAllByRole('button', {name: /customers actions/i})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
       expect(screen.queryByText('Gift to reserved budget')).not.toBeInTheDocument();
@@ -3921,7 +3905,7 @@ describe('Customer Details', function () {
 
       // Open actions dropdown and click gift budget action
       await userEvent.click(
-        screen.getAllByRole('button', {name: /customers actions/i})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
       await userEvent.click(screen.getByText('Gift to reserved budget'));
 
@@ -3986,7 +3970,7 @@ describe('Customer Details', function () {
 
       // Open the actions dropdown
       await userEvent.click(
-        screen.getAllByRole('button', {name: /customers actions/i})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
       // The delete option should be present
@@ -4016,7 +4000,7 @@ describe('Customer Details', function () {
 
       // Open the actions dropdown
       await userEvent.click(
-        screen.getAllByRole('button', {name: /customers actions/i})[1]!
+        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
       );
 
       // The delete option should not be present


### PR DESCRIPTION
Just remap props so they can be used by the select component - we don't really care about the type in admin, as long as this is no longer using the deprecated component