### PR TITLE
feat(profiling): Add sdk deprecation banner

### DIFF
--- a/static/app/components/profiling/billing/alerts.tsx
+++ b/static/app/components/profiling/billing/alerts.tsx
@@ -30,3 +30,7 @@ export const ProfilingAM1OrMMXUpgrade = HookOrDefault({
 export const ContinuousProfilingBetaAlertBanner = HookOrDefault({
   hookName: 'component:continuous-profiling-beta-banner',
 });
+
+export const ContinuousProfilingBetaSDKAlertBanner = HookOrDefault({
+  hookName: 'component:continuous-profiling-beta-sdk-banner',
+});

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -107,10 +107,6 @@ type ContinuousProfilingBetaAlertBannerProps = {
   organization: Organization;
 };
 
-type ContinuousProfilingBetaSDKAlertBannerProps = {
-  organization: Organization;
-};
-
 type ProfilingUpgradePlanButtonProps = ButtonProps & {
   children: React.ReactNode;
   fallback: React.ReactNode;
@@ -184,7 +180,7 @@ export type ComponentHooks = {
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;
   'component:continuous-profiling-beta-banner': () => React.ComponentType<ContinuousProfilingBetaAlertBannerProps>;
-  'component:continuous-profiling-beta-sdk-banner': () => React.ComponentType<ContinuousProfilingBetaSDKAlertBannerProps>;
+  'component:continuous-profiling-beta-sdk-banner': () => React.ComponentType;
   'component:crons-list-page-header': () => React.ComponentType<CronsBillingBannerProps>;
   'component:crons-onboarding-panel': () => React.ComponentType<CronsOnboardingPanelProps>;
   'component:dashboards-header': () => React.ComponentType<DashboardHeadersProps>;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -107,6 +107,10 @@ type ContinuousProfilingBetaAlertBannerProps = {
   organization: Organization;
 };
 
+type ContinuousProfilingBetaSDKAlertBannerProps = {
+  organization: Organization;
+};
+
 type ProfilingUpgradePlanButtonProps = ButtonProps & {
   children: React.ReactNode;
   fallback: React.ReactNode;
@@ -180,6 +184,7 @@ export type ComponentHooks = {
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;
   'component:continuous-profiling-beta-banner': () => React.ComponentType<ContinuousProfilingBetaAlertBannerProps>;
+  'component:continuous-profiling-beta-sdk-banner': () => React.ComponentType<ContinuousProfilingBetaSDKAlertBannerProps>;
   'component:crons-list-page-header': () => React.ComponentType<CronsBillingBannerProps>;
   'component:crons-onboarding-panel': () => React.ComponentType<CronsOnboardingPanelProps>;
   'component:dashboards-header': () => React.ComponentType<DashboardHeadersProps>;

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import type {SmartSearchBarProps} from 'sentry/components/deprecatedSmartSearchBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
@@ -98,8 +99,10 @@ export default function ProfilingContent({location}: ProfilingContentProps) {
       >
         <Layout.Page>
           <ProfilingBetaAlertBanner organization={organization} />
-          <ContinuousProfilingBetaAlertBanner organization={organization} />
-          <ContinuousProfilingBetaSDKAlertBanner organization={organization} />
+          <Feature features="continuous-profiling-beta-ui">
+            <ContinuousProfilingBetaAlertBanner organization={organization} />
+            <ContinuousProfilingBetaSDKAlertBanner />
+          </Feature>
           <ProfilingContentPageHeader />
           <LayoutBody>
             <LayoutMain fullWidth>

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -16,6 +16,7 @@ import Pagination from 'sentry/components/pagination';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import {
   ContinuousProfilingBetaAlertBanner,
+  ContinuousProfilingBetaSDKAlertBanner,
   ProfilingBetaAlertBanner,
 } from 'sentry/components/profiling/billing/alerts';
 import {ProfileEventsTable} from 'sentry/components/profiling/profileEventsTable';
@@ -98,6 +99,7 @@ export default function ProfilingContent({location}: ProfilingContentProps) {
         <Layout.Page>
           <ProfilingBetaAlertBanner organization={organization} />
           <ContinuousProfilingBetaAlertBanner organization={organization} />
+          <ContinuousProfilingBetaSDKAlertBanner organization={organization} />
           <ProfilingContentPageHeader />
           <LayoutBody>
             <LayoutMain fullWidth>

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -376,10 +376,7 @@ function ContinuousProfilingBetaAlertBannerInner({
   organization,
   subscription,
 }: ContinuousProfilingBetaAlertBannerInner) {
-  if (
-    !organization.features.includes('continuous-profiling-beta') ||
-    !organization.features.includes('continuous-profiling-beta-ui')
-  ) {
+  if (!organization.features.includes('continuous-profiling-beta')) {
     return null;
   }
 
@@ -416,13 +413,7 @@ export const ContinuousProfilingBetaAlertBanner = withSubscription(
   ContinuousProfilingBetaAlertBannerInner
 );
 
-interface ContinuousProfilingBetaSDKAlertBannerProps {
-  organization: Organization;
-}
-
-export function ContinuousProfilingBetaSDKAlertBanner({
-  organization,
-}: ContinuousProfilingBetaSDKAlertBannerProps) {
+export function ContinuousProfilingBetaSDKAlertBanner() {
   const sdkDeprecationResults = useSDKDeprecations();
 
   const sdkDeprecations = useMemo(() => {
@@ -437,10 +428,6 @@ export function ContinuousProfilingBetaSDKAlertBanner({
   }, [sdkDeprecationResults.data?.data]);
 
   if (sdkDeprecations.size <= 0) {
-    return null;
-  }
-
-  if (!organization.features.includes('continuous-profiling-beta-ui')) {
     return null;
   }
 

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -1,13 +1,17 @@
-import {Fragment, useCallback, useEffect} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
 import type {ButtonProps} from 'sentry/components/core/button';
 import {Button} from 'sentry/components/core/button';
 import {IconClose, IconInfo, IconWarning} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 import {openAM2ProfilingUpsellModal} from 'getsentry/actionCreators/modal';
 import AddEventsCTA, {type EventType} from 'getsentry/components/addEventsCTA';
@@ -412,7 +416,109 @@ export const ContinuousProfilingBetaAlertBanner = withSubscription(
   ContinuousProfilingBetaAlertBannerInner
 );
 
-const StyledAlert = styled(Alert)`
+interface ContinuousProfilingBetaSDKAlertBannerProps {
+  organization: Organization;
+}
+
+export function ContinuousProfilingBetaSDKAlertBanner({
+  organization,
+}: ContinuousProfilingBetaSDKAlertBannerProps) {
+  const sdkDeprecationResults = useSDKDeprecations();
+
+  const sdkDeprecations = useMemo(() => {
+    const sdks: Map<string, SDKDeprecation> = new Map();
+
+    for (const sdk of sdkDeprecationResults.data?.data ?? []) {
+      const key = `${sdk.sdkName}:${sdk.sdkVersion}`;
+      sdks.set(key, sdk);
+    }
+
+    return sdks;
+  }, [sdkDeprecationResults.data?.data]);
+
+  if (sdkDeprecations.size <= 0) {
+    return null;
+  }
+
+  if (!organization.features.includes('continuous-profiling-beta-ui')) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <StyledAlert type="warning" showIcon>
+        {tct(
+          '[bold:Action Needed: Profiling beta period ends May 19, 2025.] Your SDK is out of date. To continue using profiling without interruption, upgrade to the latest version:',
+          {
+            bold: <b />,
+          }
+        )}
+        <SDKDeprecationsContainer>
+          {sdkDeprecations.values().map(sdk => {
+            const key = `${sdk.projectId}-${sdk.sdkName}-${sdk.sdkVersion}`;
+            return (
+              <SDKDeprecationContainer key={key}>
+                <Dot />
+                {tct('[name] minimum version [version]', {
+                  name: <code>{sdk.sdkName}</code>,
+                  version: <code>{sdk.minimumVersion}</code>,
+                })}
+              </SDKDeprecationContainer>
+            );
+          })}
+        </SDKDeprecationsContainer>
+      </StyledAlert>
+    </Alert.Container>
+  );
+}
+
+interface SDKDeprecation {
+  minimumVersion: string;
+  projectId: string;
+  sdkName: string;
+  sdkVersion: string;
+}
+
+function useSDKDeprecations() {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const path = `/organizations/${organization.slug}/sdk-deprecations/`;
+  const options = {
+    query: {
+      project: selection.projects,
+      event_type: 'profile',
+    },
+  };
+
+  return useApiQuery<{data: SDKDeprecation[]}>([path, options], {
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: false,
+  });
+}
+
+const SDKDeprecationsContainer = styled('ul')`
   margin: 0;
+`;
+
+const SDKDeprecationContainer = styled('li')`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const Dot = styled('span')`
+  display: inline-block;
+  margin-right: ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+  width: ${space(0.5)};
+  height: ${space(0.5)};
+  background-color: ${p => p.theme.textColor};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: 0 !important;
   border-radius: 0;
 `;

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -76,6 +76,7 @@ import PrimaryNavigationQuotaExceeded from './components/navBillingStatus';
 import OpenInDiscoverBtn from './components/openInDiscoverBtn';
 import {
   ContinuousProfilingBetaAlertBanner,
+  ContinuousProfilingBetaSDKAlertBanner,
   ProfilingAM1OrMMXUpgrade,
   ProfilingBetaAlertBanner,
   ProfilingUpgradePlanButton,
@@ -215,6 +216,8 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
   'component:codecov-integration-settings-link': () => CodecovSettingsLink,
   'component:continuous-profiling-beta-banner': () => ContinuousProfilingBetaAlertBanner,
+  'component:continuous-profiling-beta-sdk-banner': () =>
+    ContinuousProfilingBetaSDKAlertBanner,
   /**
    * Augment the datetime picker based on plan retention days. Includes upsell interface
    */


### PR DESCRIPTION
Some older sdks are sending profiles chunks that we will deprecate and no longer accept in the near future. This banner shows when the selected project isn't using an up to date sdk.