### PR TITLE
test(insights): Remove console.error mock, fix issues table

### DIFF
--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -11,7 +11,7 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import {IconWrapper} from 'sentry/components/sidebarSection';
 import GroupChart from 'sentry/components/stream/groupChart';
 import {IconUser} from 'sentry/icons';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -30,7 +30,7 @@ function Issue({data}: {data: Group}) {
   const organization = useOrganization();
 
   return (
-    <StyledPanelItem as="tr">
+    <StyledPanelItem>
       <IssueSummaryWrapper>
         <IssueSummary data={data} organization={organization} />
         <EventOrGroupExtraDetails data={data} />
@@ -64,14 +64,10 @@ function Issue({data}: {data: Group}) {
 
 function IssueListHeader({issues}: {issues?: Group[]}) {
   return (
-    <StyledPanelHeader as="tr">
+    <StyledPanelHeader>
       <IssueHeading>
-        {tct(`[count] [text]`, {
-          count: issues?.length ?? 0,
-          text: tn('Related Issue', 'Related Issues', issues?.length ?? 0),
-        })}
+        {tn('%s Related Issue', '%s Related Issues', issues?.length ?? 0)}
       </IssueHeading>
-
       <GraphHeading>{t('Graph')}</GraphHeading>
       <EventsHeading>{t('Events')}</EventsHeading>
       <UsersHeading>{t('Users')}</UsersHeading>
@@ -98,9 +94,7 @@ function useInsightIssues(
       `/organizations/${organization.slug}/issues/`,
       {
         query: {
-          expand: ['inbox', 'owners'],
           query,
-          shortIdLookup: 1,
           // hack: set an arbitrary large upper limit so that the api response likely contains the exact message,
           // even though we only search for the first 200 characters of the message
           limit: 100,
@@ -148,12 +142,13 @@ export default function InsightIssuesList({
   );
 }
 
-const Heading = styled('th')`
+const Heading = styled('h6')`
   display: flex;
   align-self: center;
   margin: 0 ${space(2)};
   width: 60px;
   color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const IssueHeading = styled(Heading)`
@@ -210,7 +205,7 @@ const StyledIconWrapper = styled(IconWrapper)`
   margin: 0;
 `;
 
-const IssueSummaryWrapper = styled('td')`
+const IssueSummaryWrapper = styled('div')`
   overflow: hidden;
   flex: 1;
   width: 66.66%;
@@ -220,7 +215,7 @@ const IssueSummaryWrapper = styled('td')`
   }
 `;
 
-const ColumnWrapper = styled('td')`
+const ColumnWrapper = styled('div')`
   display: flex;
   justify-content: flex-end;
   align-self: center;
@@ -246,7 +241,7 @@ const AssineeWrapper = styled(ColumnWrapper)`
   }
 `;
 
-const ChartWrapper = styled('td')`
+const ChartWrapper = styled('div')`
   width: 200px;
   align-self: center;
 
@@ -263,5 +258,4 @@ const PrimaryCount = styled(Count)`
 const StyledPanelItem = styled(PanelItem)`
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
-  height: 84px;
 `;

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -64,11 +64,6 @@ describe('DatabaseSpanSummaryPage', function () {
   });
 
   it('renders', async function () {
-    // Ignore known issue with jsdom used by jest when parsing nested CSS syntax (@container). See:
-    // - https://github.com/jsdom/jsdom/issues/3236
-    // - https://github.com/jsdom/jsdom/issues/2005
-    jest.spyOn(console, 'error').mockImplementation();
-
     const eventsRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
@@ -87,10 +82,24 @@ describe('DatabaseSpanSummaryPage', function () {
       method: 'GET',
       body: {
         'epm()': {
-          data: [],
+          data: [
+            [1672531200, [{count: 5}]],
+            [1672542000, [{count: 10}]],
+            [1672552800, [{count: 15}]],
+          ],
+          order: 0,
+          start: 1672531200,
+          end: 1672552800,
         },
         'avg(span.self_time)': {
-          data: [],
+          data: [
+            [1672531200, [{count: 100}]],
+            [1672542000, [{count: 150}]],
+            [1672552800, [{count: 200}]],
+          ],
+          order: 1,
+          start: 1672531200,
+          end: 1672552800,
         },
       },
     });
@@ -316,9 +325,7 @@ describe('DatabaseSpanSummaryPage', function () {
           query:
             'issue.type:[performance_slow_db_query,performance_n_plus_one_db_queries] message:"SELECT * FROM users"',
           environment: [],
-          expand: ['inbox', 'owners'],
           limit: 100,
-          shortIdLookup: 1,
           project: [],
           statsPeriod: '10d',
         },
@@ -354,21 +361,21 @@ describe('DatabaseSpanSummaryPage', function () {
     expect(screen.getByRole('columnheader', {name: 'Avg Duration'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Time Spent'})).toBeInTheDocument();
 
-    expect(screen.getByRole('cell', {name: 'GET /api/users'})).toBeInTheDocument();
+    expect(screen.getByText('GET /api/users')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'GET /api/users'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/insights/backend/database/spans/span/1756baf8fd19c116?statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A25%3A0'
     );
-    expect(screen.getByRole('cell', {name: '17.9/s'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '204.50ms'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '2.95min'})).toBeInTheDocument();
+    expect(screen.getByText('17.9/s')).toBeInTheDocument();
+    expect(screen.getByText('204.50ms')).toBeInTheDocument();
+    expect(screen.getByText('2.95min')).toBeInTheDocument();
 
     expect(await screen.findByText('1 Related Issue')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Graph'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Events'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Users'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Assignee'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '327k'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '35k'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Graph'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Events'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Users'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Assignee'})).toBeInTheDocument();
+    expect(screen.getByText('327k')).toBeInTheDocument();
+    expect(screen.getByText('35k')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The console.error mock is hiding the errors from using tr and td elements inside a div instead of a table and missing api requests.

Remove "expand" and shortIdLookup which are not needed here.

before
![Screenshot 2025-04-09 at 12 50 32 PM](https://github.com/user-attachments/assets/2faa27c7-0485-48e6-bedb-5945f7c6c840)

after
![Screenshot 2025-04-09 at 12 50 35 PM](https://github.com/user-attachments/assets/a817fd69-fda4-4d72-928e-250d4e3ed5ab)

