### PR TITLE
feat(auto_source): Increase granularity to better handle country TLDs

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -18,7 +18,7 @@ from sentry.models.repository import Repository
 from sentry.utils import metrics
 from sentry.utils.event_frames import EventFrame, try_munge_frame_path
 
-from .constants import METRIC_PREFIX, STACK_ROOT_MAX_LEVEL
+from .constants import METRIC_PREFIX, SECOND_LEVEL_TLDS, STACK_ROOT_MAX_LEVEL
 from .integration_utils import InstallationNotFoundError, get_installation
 from .utils.platform import PlatformConfig
 
@@ -594,15 +594,21 @@ def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
     # Gets rid of the class name
     parts = module.rsplit(".", 1)[0].split(".")
     dirpath = "/".join(parts)
+    # a.Bar, Bar.kt -> stack_root: a/, file_path:  a/Bar.kt
+    granularity = 1
 
-    if len(parts) >= STACK_ROOT_MAX_LEVEL:
+    if len(parts) > 1:
         # com.example.foo.bar.Baz$InnerClass, Baz.kt ->
         #    stack_root: com/example/
         #    file_path:  com/example/foo/bar/Baz.kt
-        stack_root = "/".join(parts[:STACK_ROOT_MAX_LEVEL])
-    else:
-        # a.Bar, Bar.kt -> stack_root: a/, file_path:  a/Bar.kt
-        stack_root = parts[0] + "/"
+        granularity = STACK_ROOT_MAX_LEVEL - 1
 
+        if parts[1] in SECOND_LEVEL_TLDS:
+            # uk.co.example.foo.bar.Baz$InnerClass, Baz.kt ->
+            #    stack_root: uk/co/example/
+            #    file_path:  uk/co/example/foo/bar/Baz.kt
+            granularity = STACK_ROOT_MAX_LEVEL
+
+    stack_root = "/".join(parts[:granularity]) + "/"
     file_path = f"{dirpath}/{abs_path}"
     return stack_root, file_path

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -585,7 +585,7 @@ def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
         # Split the module at the first '$' character and take the part before it
         # If there's no '$', use the entire module
         file_path = module.split("$", 1)[0] if "$" in module else module
-        stack_root = module.rsplit(".", 1)[0].replace(".", "/")
+        stack_root = module.rsplit(".", 1)[0].replace(".", "/") + "/"
         return stack_root, file_path.replace(".", "/")
 
     if "." not in module:

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -6,7 +6,11 @@ from typing import Any
 METRIC_PREFIX = "auto_source_code_config"
 DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
 SUPPORTED_INTEGRATIONS = ["github"]
-STACK_ROOT_MAX_LEVEL = 2
+STACK_ROOT_MAX_LEVEL = 3
+# Stacktrace roots that match one of these will have three levels of granularity
+# com.au, co.uk, org.uk, gov.uk, net.uk, edu.uk, ct.uk
+# This list does not have to be exhaustive as the fallback is two levels of granularity
+SECOND_LEVEL_TLDS = ("com", "co", "org", "gov", "net", "edu")
 
 # Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces

--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -6,7 +6,7 @@ from sentry.issues.auto_source_code_config.utils.platform import PlatformConfig
 from sentry.models.project import Project
 from sentry.utils import metrics
 
-from .constants import DERIVED_ENHANCEMENTS_OPTION_KEY, METRIC_PREFIX, STACK_ROOT_MAX_LEVEL
+from .constants import DERIVED_ENHANCEMENTS_OPTION_KEY, METRIC_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,7 @@ def generate_rule_for_code_mapping(code_mapping: CodeMapping) -> str:
         raise ValueError("Stacktrace root is empty")
 
     parts = stacktrace_root.rstrip("/").split("/")
-
-    # We only want the first two parts
-    module = ".".join(parts[:STACK_ROOT_MAX_LEVEL])
+    module = ".".join(parts)
 
     if module == "":
         raise ValueError("Module is empty")
@@ -59,5 +57,6 @@ def generate_rule_for_code_mapping(code_mapping: CodeMapping) -> str:
     # a/ -> a.**
     # x/y/ -> x.y.**
     # com/example/foo/bar/ -> com.example.**
-    # uk/co/example/foo/bar/ -> uk.co.**
+    # We add an extra level of granularity
+    # uk/co/example/foo/bar/ -> uk.co.example.**
     return f"stack.module:{module}.** +app"

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -152,25 +152,25 @@ class TestFrameInfo:
         [
             pytest.param(
                 {"module": "foo.bar.Baz$handle$1", "abs_path": "baz.java"},
-                "foo/bar",
+                "foo/bar/",
                 "foo/bar/baz.java",
                 id="dollar_symbol_in_module",
             ),
             pytest.param(
                 {"module": "foo.bar.Baz", "abs_path": "baz.extra.java"},
-                "foo/bar",
+                "foo/bar/",
                 "foo/bar/baz.extra.java",
                 id="two_dots_in_abs_path",
             ),
             pytest.param(
                 {"module": "foo.bar.Baz", "abs_path": "no_extension"},
-                "foo/bar",
+                "foo/bar/",
                 "foo/bar/Baz",  # The path does not use the abs_path
                 id="invalid_abs_path_no_extension",
             ),
             pytest.param(
                 {"module": "foo.bar.Baz", "abs_path": "foo$bar"},
-                "foo/bar",
+                "foo/bar/",
                 "foo/bar/Baz",  # The path does not use the abs_path
                 id="invalid_abs_path_dollar_sign",
             ),


### PR DESCRIPTION
It increases the granularity to three levels instead of two for these cases:
```
<country_specific>.co.** +app
<country_specific>.com.** +app
<country_specific>.edu.** +app
<country_specific>.gov.** +app
<country_specific>.net.** +app
<country_specific>.org.** +app
```

Note: In Java, the package names are normally a domain reversed (e.g. `https://example.co.uk` -> `uk.co.example.path.to.source.code`)