### PR TITLE
fix(nav): Navigate to correct insights and settings page URLs

### DIFF
--- a/static/app/views/nav/tour/tour.tsx
+++ b/static/app/views/nav/tour/tour.tsx
@@ -161,12 +161,12 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
           break;
         case StackedNavigationTour.INSIGHTS:
           if (activeGroup !== PrimaryNavGroup.INSIGHTS) {
-            navigate(normalizeUrl(`/${prefix}/insights/`), {replace: true});
+            navigate(normalizeUrl(`/${prefix}/insights/frontend/`), {replace: true});
           }
           break;
         case StackedNavigationTour.SETTINGS:
           if (activeGroup !== PrimaryNavGroup.SETTINGS) {
-            navigate(normalizeUrl(`/${prefix}/settings/organization/`), {
+            navigate(normalizeUrl(`/settings/${organization.slug}/`), {
               replace: true,
             });
           }


### PR DESCRIPTION
Settings link follows the fix here, which makes sure that the link is correct even when in non-customer domains: https://github.com/getsentry/sentry/pull/89135