### PR TITLE
fix(aci/ui2): update priority colors

### DIFF
--- a/static/app/components/badge/iconCellSignal.tsx
+++ b/static/app/components/badge/iconCellSignal.tsx
@@ -7,9 +7,9 @@ interface Props extends SVGIconProps {
 }
 function IconCellSignal({ref, bars = 3, ...props}: Props) {
   const theme = useTheme();
-  const firstBarColor = bars > 0 ? theme.gray300 : theme.gray200;
-  const secondBarColor = bars > 1 ? theme.gray300 : theme.gray200;
-  const thirdBarColor = bars > 2 ? theme.gray300 : theme.gray200;
+  const firstBarColor = bars > 0 ? theme.subText : theme.gray200;
+  const secondBarColor = bars > 1 ? theme.subText : theme.gray200;
+  const thirdBarColor = bars > 2 ? theme.subText : theme.gray200;
 
   return (
     <SvgIcon {...props} ref={ref} kind={'path'}>

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -102,6 +102,7 @@ const Text = styled('div')`
   /* @TODO(jonasbadalic): Some occurrences pass other things than strings into the children prop. */
   display: flex;
   align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/forms/fields/numberField.tsx
+++ b/static/app/components/forms/fields/numberField.tsx
@@ -104,6 +104,6 @@ const HiddenValue = styled('span')`
   visibility: hidden;
 `;
 const Suffix = styled('span')`
-  color: ${p => p.theme.formPlaceholder};
+  color: ${p => p.theme.subText};
   margin-left: ${space(0.5)};
 `;

--- a/static/app/components/workflowEngine/form/section.tsx
+++ b/static/app/components/workflowEngine/form/section.tsx
@@ -23,7 +23,7 @@ export function FormSection({title, description, children}: FormSectionProps) {
 }
 
 const Container = styled('section')`
-  background: ${p => p.theme.surface300};
+  background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(1.5)} ${space(2)} ${space(1)} ${space(2)};


### PR DESCRIPTION
Bit of an ACI/UI2 crossover, fixing some color contrast issues in the priority control ACI component when the UI2 theme is applied

| Before | After |
|--------|--------|
| <img width="417" alt="Screenshot 2025-04-09 at 4 06 03 PM" src="https://github.com/user-attachments/assets/3eb5406a-0869-4586-b968-087d764c2226" /> | <img width="429" alt="Screenshot 2025-04-09 at 4 05 39 PM" src="https://github.com/user-attachments/assets/9f5bbfd0-2769-407c-8acc-ab43a59e8677" /> |