### PR TITLE
ref(seer grouping): Improve ingest Seer match deletion

### DIFF
--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -97,11 +97,9 @@ class SeerSimilarIssueData:
         )
 
         if not parent_grouphash:
-            # TODO: Report back to seer that the hash has been deleted.
             raise SimilarHashNotFoundError("Similar hash suggested by Seer does not exist")
 
         if not parent_grouphash.group_id:
-            # TODO: Report back to seer that the hash has been deleted.
             raise SimilarHashMissingGroupError("Similar hash suggested by Seer missing group id")
 
         # TODO: The `Any` casting here isn't great, but Python currently has no way to

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -428,7 +428,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
         mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["not a real hash"])
 
-    @mock.patch("sentry.seer.similarity.similar_issues.delete_seer_grouping_records_by_hash")
     @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
@@ -437,7 +436,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_similarity_request: mock.MagicMock,
         mock_logger: mock.MagicMock,
         mock_metrics_incr: mock.MagicMock,
-        mock_seer_deletion_request: mock.MagicMock,
     ) -> None:
         """
         The seer API can return groups that do not exist if they have been deleted/merged.
@@ -488,6 +486,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         logged_gh_age = mock_logger.warning.call_args.kwargs["extra"]["parent_gh_age_in_sec"]
         assert isinstance(logged_gh_age, float)
         assert logged_gh_age > 0 and logged_gh_age < 1
+
+        # Note that unlike in the missing grouphash test below, we're not testing Seer deletion here
+        # because it only happens conditionally, behavior that's tested in `test_similar_issues.py`
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -1,13 +1,16 @@
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 
+from django.utils import timezone
 from urllib3.exceptions import MaxRetryError, TimeoutError
 from urllib3.response import HTTPResponse
 
 from sentry import options
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.models.grouphash import GroupHash
+from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.seer.similarity.similar_issues import (
     get_similarity_data_from_seer,
     seer_grouping_connection_pool,
@@ -316,3 +319,89 @@ class GetSimilarityDataFromSeerTest(TestCase):
         get_similarity_data_from_seer(self.request_params)
 
         mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["not a real hash"])
+
+    @mock.patch("sentry.seer.similarity.similar_issues.delete_seer_grouping_records_by_hash")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_conditionally_calls_seer_deletion_task_if_parent_hash_missing_group_id(
+        self,
+        mock_seer_similarity_request: MagicMock,
+        mock_seer_deletion_request: MagicMock,
+    ):
+        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        assert existing_grouphash.group_id is None
+
+        # Set the grouphash creation date to yesterday
+        GroupHashMetadata.objects.get_or_create(
+            grouphash=existing_grouphash, date_added=timezone.now() - timedelta(days=1)
+        )
+
+        mock_seer_similarity_request.return_value = self._make_response(
+            {
+                "responses": [
+                    {
+                        "parent_hash": "dogs are great",
+                        "should_group": True,
+                        "stacktrace_distance": 0.01,
+                    }
+                ]
+            }
+        )
+
+        get_similarity_data_from_seer(self.request_params)
+
+        assert mock_seer_deletion_request.delay.call_count == 1
+        mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["dogs are great"])
+
+        # Now do it all over again, but with a hash that's just been created
+
+        newly_created_grouphash = GroupHash.objects.create(
+            hash="adopt, don't shop", project=self.project
+        )
+        assert newly_created_grouphash.group_id is None
+
+        # Set the grouphash creation date to today
+        GroupHashMetadata.objects.get_or_create(
+            grouphash=newly_created_grouphash, date_added=timezone.now()
+        )
+
+        mock_seer_similarity_request.return_value = self._make_response(
+            {
+                "responses": [
+                    {
+                        "parent_hash": "adopt, don't shop",
+                        "should_group": True,
+                        "stacktrace_distance": 0.01,
+                    }
+                ]
+            }
+        )
+
+        get_similarity_data_from_seer(self.request_params)
+
+        # Call count is still 1, because we don't call the deletion task if the group is missing
+        # because of a race condition
+        assert mock_seer_deletion_request.delay.call_count == 1
+
+        # Finally, do it with a grouphash missing metadata, to simulate one which was created before
+        # grouphash metadata was a thing
+
+        very_old_grouphash = GroupHash.objects.create(hash="maisey", project=self.project)
+        assert very_old_grouphash.group_id is None
+        assert very_old_grouphash.metadata is None
+
+        mock_seer_similarity_request.return_value = self._make_response(
+            {
+                "responses": [
+                    {
+                        "parent_hash": "maisey",
+                        "should_group": True,
+                        "stacktrace_distance": 0.01,
+                    }
+                ]
+            }
+        )
+
+        get_similarity_data_from_seer(self.request_params)
+
+        # Call count has increased to 2, because we know the grouphash is old by its lack of metadata
+        assert mock_seer_deletion_request.delay.call_count == 2

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -299,7 +299,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
 
     @mock.patch("sentry.seer.similarity.similar_issues.delete_seer_grouping_records_by_hash")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_calls_seer_deletion_task_if_parent_group_not_found(
+    def test_calls_seer_deletion_task_if_parent_hash_not_found(
         self,
         mock_seer_similarity_request: MagicMock,
         mock_seer_deletion_request: MagicMock,


### PR DESCRIPTION
This makes a few changes to our code handling the deletion of Seer records that's triggered when Seer returns hashes which either a) are missing, or b) exist but have no group id.

The biggest change is that we now refrain from triggering the deletion in the no-group-id case if we determine that the grouphash suggested by Seer has just been created. If that's the case, it means the (seemingly) bad grouphash is just still midstream and hasn't had a group id assigned to it yet. In other words, it's a perfectly good answer which Seer has given us, it's just that it's given it to us a fraction of a second too soon, and we therefore don't want Seer to delete the record. (Our logging has shown that this accounts for virtually all of our no-group-id cases, so we've been regularly deleting records we shouldn't have. Whoops.)

The other changes are small - removing some obsolete TODOs, cleaning up a few related tests, and adding a test for the no-group-id case.