### PR TITLE
fix(explore): Explore Saved Queries respect user id on sort by starred

### DIFF
--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -420,6 +420,12 @@ class ExploreSavedQueriesTest(APITestCase, SnubaTestCase):
             explore_saved_query=model_d,
             position=1,
         )
+        ExploreSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id + 2,
+            explore_saved_query=model_d,
+            position=1,
+        )
 
         with self.feature(self.feature_name):
             response = self.client.get(self.url, data={"sortBy": ["starred", "recentlyViewed"]})


### PR DESCRIPTION
Fixes an issue where sorting by `starred` was still not filtering by user id. This was do the `When` condition causing a join on the queryset. Updates to use `annotate` and `Exists` instead.