### PR TITLE
feat(ACI): Set up deletions for Incident model

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -98,6 +98,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
         AlertRuleTrigger,
         AlertRuleTriggerAction,
     )
+    from sentry.incidents.models.incident import Incident
     from sentry.integrations.models.organization_integration import OrganizationIntegration
     from sentry.integrations.models.repository_project_path_config import (
         RepositoryProjectPathConfig,
@@ -152,6 +153,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(models.GroupShare, BulkModelDeletionTask)
     manager.register(models.GroupSnooze, BulkModelDeletionTask)
     manager.register(models.GroupSubscription, BulkModelDeletionTask)
+    manager.register(Incident, defaults.IncidentDeletionTask)
     manager.register(monitor_models.Monitor, defaults.MonitorDeletionTask)
     manager.register(monitor_models.MonitorEnvironment, defaults.MonitorEnvironmentDeletionTask)
     manager.register(models.Organization, defaults.OrganizationDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -11,6 +11,7 @@ from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
 from .grouphash import *  # noqa: F401,F403
 from .grouphistory import *  # noqa: F401,F403
+from .incident import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/incident.py
+++ b/src/sentry/deletions/defaults/incident.py
@@ -8,7 +8,7 @@ class IncidentDeletionTask(ModelDeletionTask[Incident]):
         from sentry.incidents.models.incident import IncidentProject
         from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 
-        model_relations = [
+        model_relations: list[BaseRelation] = [
             ModelRelation(IncidentProject, {"incident": instance}),
         ]
 

--- a/src/sentry/deletions/defaults/incident.py
+++ b/src/sentry/deletions/defaults/incident.py
@@ -1,0 +1,13 @@
+from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.incidents.models.incident import Incident
+
+
+class IncidentDeletionTask(ModelDeletionTask[Incident]):
+    def get_child_relations(self, instance: Incident) -> list[BaseRelation]:
+        from sentry.incidents.models.incident import IncidentProject
+        from sentry.workflow_engine.models import IncidentGroupOpenPeriod
+
+        return [
+            ModelRelation(IncidentGroupOpenPeriod, {"incident_id": instance.id}),
+            ModelRelation(IncidentProject, {"incident": instance}),
+        ]

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -12,11 +12,17 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleSensitivity,
     AlertRuleTrigger,
 )
-from sentry.incidents.models.incident import Incident
+from sentry.incidents.models.incident import Incident, IncidentProject
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.workflow_engine.models import AlertRuleDetector, AlertRuleWorkflow
+from sentry.workflow_engine.models import (
+    AlertRuleDetector,
+    AlertRuleWorkflow,
+    IncidentGroupOpenPeriod,
+)
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -33,6 +39,17 @@ class DeleteAlertRuleTest(BaseWorkflowTest, HybridCloudTestMixin):
             projects=[self.project],
             alert_rule=alert_rule,
         )
+        one_minute = before_now(minutes=1).isoformat()
+        event = self.store_event(
+            data={"timestamp": one_minute, "fingerprint": ["group1"]}, project_id=self.project.id
+        )
+        group = event.group
+        group_open_period = GroupOpenPeriod.objects.create(
+            project=self.project, group=group, user_id=self.user.id
+        )
+        IncidentGroupOpenPeriod.objects.create(
+            incident_id=incident.id, group_open_period=group_open_period
+        )
 
         detector = self.create_detector()
         workflow = self.create_workflow()
@@ -48,6 +65,10 @@ class DeleteAlertRuleTest(BaseWorkflowTest, HybridCloudTestMixin):
         assert not AlertRule.objects.filter(id=alert_rule.id).exists()
         assert not AlertRuleTrigger.objects.filter(id=alert_rule_trigger.id).exists()
         assert not Incident.objects.filter(id=incident.id).exists()
+        assert not IncidentProject.objects.filter(incident=incident, project=self.project).exists()
+        assert not IncidentGroupOpenPeriod.objects.filter(
+            incident_id=incident.id, group_open_period=group_open_period
+        ).exists()
         assert not AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
         assert not AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).exists()
 

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -69,6 +69,9 @@ class DeleteAlertRuleTest(BaseWorkflowTest, HybridCloudTestMixin):
         assert not IncidentGroupOpenPeriod.objects.filter(
             incident_id=incident.id, group_open_period=group_open_period
         ).exists()
+        assert not GroupOpenPeriod.objects.filter(
+            project=self.project, group=group, user_id=self.user.id
+        )
         assert not AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
         assert not AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).exists()
 

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -44,6 +44,7 @@ class DeleteAlertRuleTest(BaseWorkflowTest, HybridCloudTestMixin):
             data={"timestamp": one_minute, "fingerprint": ["group1"]}, project_id=self.project.id
         )
         group = event.group
+        assert group
         group_open_period = GroupOpenPeriod.objects.create(
             project=self.project, group=group, user_id=self.user.id
         )

--- a/tests/sentry/deletions/test_incident.py
+++ b/tests/sentry/deletions/test_incident.py
@@ -28,6 +28,7 @@ class DeleteIncidentTest(BaseWorkflowTest, HybridCloudTestMixin):
             data={"timestamp": one_minute, "fingerprint": ["group1"]}, project_id=self.project.id
         )
         group = event.group
+        assert group
         group_open_period = GroupOpenPeriod.objects.create(
             project=self.project, group=group, user_id=self.user.id
         )

--- a/tests/sentry/deletions/test_incident.py
+++ b/tests/sentry/deletions/test_incident.py
@@ -1,0 +1,47 @@
+from django.utils import timezone
+
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions
+from sentry.incidents.models.incident import Incident, IncidentProject
+from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.workflow_engine.models import IncidentGroupOpenPeriod
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class DeleteIncidentTest(BaseWorkflowTest, HybridCloudTestMixin):
+    def test_simple(self):
+        organization = self.create_organization()
+        alert_rule = self.create_alert_rule(organization=organization)
+        self.create_alert_rule_trigger(alert_rule=alert_rule)
+        incident = self.create_incident(
+            organization,
+            title="Incident #1",
+            date_started=timezone.now(),
+            date_detected=timezone.now(),
+            projects=[self.project],
+            alert_rule=alert_rule,
+        )
+
+        one_minute = before_now(minutes=1).isoformat()
+        event = self.store_event(
+            data={"timestamp": one_minute, "fingerprint": ["group1"]}, project_id=self.project.id
+        )
+        group = event.group
+        group_open_period = GroupOpenPeriod.objects.create(
+            project=self.project, group=group, user_id=self.user.id
+        )
+        IncidentGroupOpenPeriod.objects.create(
+            incident_id=incident.id, group_open_period=group_open_period
+        )
+
+        self.ScheduledDeletion.schedule(instance=incident, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Incident.objects.filter(id=incident.id).exists()
+        assert not IncidentGroupOpenPeriod.objects.filter(
+            incident_id=incident.id, group_open_period=group_open_period
+        ).exists()
+        assert not IncidentProject.objects.filter(incident=incident, project=self.project).exists()

--- a/tests/sentry/deletions/test_incident.py
+++ b/tests/sentry/deletions/test_incident.py
@@ -45,3 +45,6 @@ class DeleteIncidentTest(BaseWorkflowTest, HybridCloudTestMixin):
             incident_id=incident.id, group_open_period=group_open_period
         ).exists()
         assert not IncidentProject.objects.filter(incident=incident, project=self.project).exists()
+        assert not GroupOpenPeriod.objects.filter(
+            project=self.project, group=group, user_id=self.user.id
+        )


### PR DESCRIPTION
When we delete an `Incident` we want to be sure that we're also deleting the corresponding `IncidentGroupOpenPeriod` and the `GroupOpenPeriod`. 