### PR TITLE
ref(uptime): Remove usage of sentry_kafka_schemas.schema_types.uptime_configs_v1

### DIFF
--- a/src/sentry/uptime/config_producer.py
+++ b/src/sentry/uptime/config_producer.py
@@ -8,11 +8,11 @@ from django.conf import settings
 from redis import StrictRedis
 from rediscluster import RedisCluster
 from sentry_kafka_schemas.codecs import Codec
-from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.subscriptions.regions import get_region_config
+from sentry.uptime.types import CheckConfig
 from sentry.utils import redis
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Count, Q
 from django.db.models.functions import Now
-from sentry_kafka_schemas.schema_types.uptime_configs_v1 import REGIONSCHEDULEMODE_ROUND_ROBIN
 
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
@@ -288,7 +287,7 @@ def load_regions_for_uptime_subscription(
 
 
 class UptimeRegionScheduleMode(enum.StrEnum):
-    ROUND_ROBIN = REGIONSCHEDULEMODE_ROUND_ROBIN
+    ROUND_ROBIN = "round_robin"
 
 
 @data_source_type_registry.register(DATA_SOURCE_UPTIME_SUBSCRIPTION)

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from uuid import uuid4
 
 from django.utils import timezone
-from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
@@ -20,6 +19,7 @@ from sentry.uptime.models import (
     UptimeSubscription,
     UptimeSubscriptionRegion,
 )
+from sentry.uptime.types import CheckConfig
 from sentry.utils import metrics
 from sentry.utils.query import RangeQuerySetWrapper
 

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum
+from typing import Literal, Required, TypedDict
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckStatus, CheckStatusReasonType
 
@@ -9,6 +11,84 @@ DATA_SOURCE_UPTIME_SUBSCRIPTION = "uptime_subscription"
 The workflow engine DataSource type used for registering handlers and fetching
 the uptime sbuscription data source.
 """
+
+
+RegionScheduleMode = Literal["round_robin"]
+"""
+Defines how we'll schedule checks based on other active regions.
+"""
+
+CheckInterval = Literal[60, 300, 600, 1200, 1800, 3600]
+"""
+The interval between each check run in seconds.
+"""
+
+RequestHeader = tuple[str, str]
+"""
+An individual header, consisting of a name and value as a tuple.
+"""
+
+RequestMethod = Literal["GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
+"""
+The HTTP method to use for the request.
+"""
+
+
+class CheckConfig(TypedDict, total=False):
+    """
+    A message containing the configuration for a check to scheduled and
+    executed by the uptime-checker.
+    """
+
+    subscription_id: Required[str]
+    """
+    UUID of the subscription that this check config represents.
+    """
+
+    interval_seconds: Required[CheckInterval]
+    """
+    The interval between each check run in seconds.
+    """
+
+    timeout_ms: Required[int | float]
+    """
+    The total time we will allow to make the request in milliseconds.
+    """
+
+    url: Required[str]
+    """
+    The actual HTTP URL to check.
+    """
+
+    request_method: RequestMethod
+    """
+    The HTTP method to use for the request.
+    """
+
+    request_headers: Sequence[RequestHeader]
+    """
+    Additional HTTP headers to send with the request.
+    """
+
+    request_body: str
+    """
+    Additional HTTP headers to send with the request.
+    """
+
+    trace_sampling: bool
+    """
+    Whether to allow for sampled trace spans for the request.
+    """
+
+    active_regions: Sequence[str]
+    """
+    A list of region slugs the uptime check is configured to run in.
+    """
+
+    region_schedule_mode: "RegionScheduleMode"
+    """
+    Defines how we'll schedule checks based on other active regions.
+    """
 
 
 class IncidentStatus(IntEnum):


### PR DESCRIPTION
We'll be removing this topic from sentry_kafka_schemas since we no loner
use it and it's existence will confuse us.