### PR TITLE
feat(billing): Add profile hours to subscription overview usage chart

### DIFF
--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
@@ -664,7 +664,9 @@ describe('getCategoryOptions', () => {
     });
 
     result.forEach(option => {
-      expect(subscription.planDetails.checkoutCategories).toContain(option.value);
+      const inCheckoutCategories = subscription.planDetails.checkoutCategories.includes(option.value);
+      const inOnDemandCategories = subscription.planDetails.onDemandCategories.includes(option.value);
+      expect(inCheckoutCategories || inOnDemandCategories).toBe(true);
     });
   });
 

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
@@ -664,8 +664,12 @@ describe('getCategoryOptions', () => {
     });
 
     result.forEach(option => {
-      const inCheckoutCategories = subscription.planDetails.checkoutCategories.includes(option.value);
-      const inOnDemandCategories = subscription.planDetails.onDemandCategories.includes(option.value);
+      const inCheckoutCategories = subscription.planDetails.checkoutCategories.includes(
+        option.value
+      );
+      const inOnDemandCategories = subscription.planDetails.onDemandCategories.includes(
+        option.value
+      );
       expect(inCheckoutCategories || inOnDemandCategories).toBe(true);
     });
   });

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -77,7 +77,8 @@ export function getCategoryOptions({
 }): CategoryOption[] {
   return USAGE_CHART_OPTIONS_DATACATEGORY.filter(
     opt =>
-      plan.checkoutCategories.includes(opt.value as DataCategory) &&
+      (plan.checkoutCategories.includes(opt.value as DataCategory) ||
+        plan.onDemandCategories.includes(opt.value as DataCategory)) &&
       (opt.value === DataCategory.SPANS_INDEXED ? hadCustomDynamicSampling : true)
   );
 }


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/17167


UI profile hours:

<img width="1183" alt="Screenshot 2025-04-09 at 6 38 14 PM" src="https://github.com/user-attachments/assets/f539ccee-44c5-42c4-bb40-dcb1778102a4" />

<img width="1189" alt="Screenshot 2025-04-09 at 6 38 07 PM" src="https://github.com/user-attachments/assets/d85c1a1f-7596-4892-b9de-7ae469b63411" />

Continuous profiling:

<img width="1200" alt="Screenshot 2025-04-09 at 6 38 25 PM" src="https://github.com/user-attachments/assets/ea005c47-100d-4652-b7a0-1768758fcac5" />
<img width="1185" alt="Screenshot 2025-04-09 at 6 38 20 PM" src="https://github.com/user-attachments/assets/fc314ace-2346-45c3-b429-a50877b16401" />
