### PR TITLE
ref(shared-views): Swap GET /gsv for GET /gsv/starred

### DIFF
--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -124,7 +124,7 @@ describe('IssueViewsHeader', () => {
     beforeEach(() => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -205,7 +205,7 @@ describe('IssueViewsHeader', () => {
 
     it('creates a default viewId if no id is present in the request views', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [
           {
@@ -249,7 +249,7 @@ describe('IssueViewsHeader', () => {
 
     it('allows you to manually enter a query, even if you only have a default tab', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [
           {
@@ -400,7 +400,7 @@ describe('IssueViewsHeader', () => {
 
     it('updates the unsaved changes indicator for a default tab if the query is different', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [
           {
@@ -461,7 +461,7 @@ describe('IssueViewsHeader', () => {
     beforeEach(() => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -679,7 +679,7 @@ describe('IssueViewsHeader', () => {
     beforeEach(() => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -697,7 +697,7 @@ describe('IssueViewsHeader', () => {
 
     it('should render the correct set of actions for an unchanged tab', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -728,7 +728,7 @@ describe('IssueViewsHeader', () => {
 
     it('should render the correct set of actions for a changed tab', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -760,7 +760,7 @@ describe('IssueViewsHeader', () => {
 
     it('should render the correct set of actions if only a single tab exists', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [getRequestViews[0]],
       });
@@ -1030,7 +1030,7 @@ describe('IssueViewsHeader', () => {
 
     it('should render the correct count for a single view', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [getRequestViews[0]],
       });
@@ -1055,7 +1055,7 @@ describe('IssueViewsHeader', () => {
 
     it('should render the correct count for multiple views', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: getRequestViews,
       });
@@ -1081,7 +1081,7 @@ describe('IssueViewsHeader', () => {
 
     it('should show a max count of 99+ if the count is greater than 99', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [getRequestViews[0]],
       });
@@ -1106,7 +1106,7 @@ describe('IssueViewsHeader', () => {
 
     it('should show stil show a 0 query count if the count is 0', async () => {
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
+        url: `/organizations/${organization.slug}/group-search-views/starred/`,
         method: 'GET',
         body: [getRequestViews[0]],
       });

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -34,7 +34,7 @@ import {
   TEMPORARY_TAB_KEY,
 } from 'sentry/views/issueList/issueViews/issueViews';
 import {IssueViewTab} from 'sentry/views/issueList/issueViews/issueViewTab';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
 import {IssueSortOptions} from './utils';
@@ -64,7 +64,7 @@ function IssueViewsIssueListHeader({
 
   const {newViewActive} = useContext(NewTabContext);
 
-  const {data: groupSearchViews} = useFetchGroupSearchViews({
+  const {data: starredGroupSearchViews} = useFetchStarredGroupSearchViews({
     orgSlug: organization.slug,
   });
 
@@ -77,7 +77,7 @@ function IssueViewsIssueListHeader({
       noActionWrap
       // No viewId in the URL query means that a temp view is selected, which has a dashed border
       borderStyle={
-        groupSearchViews && !router?.location.query.viewId ? 'dashed' : 'solid'
+        starredGroupSearchViews && !router?.location.query.viewId ? 'dashed' : 'solid'
       }
     >
       <Layout.HeaderContent>
@@ -106,10 +106,10 @@ function IssueViewsIssueListHeader({
         )}
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      {groupSearchViews ? (
+      {starredGroupSearchViews ? (
         <StyledIssueViews
           router={router}
-          initialViews={groupSearchViews.map(
+          initialViews={starredGroupSearchViews.map(
             (
               {
                 id,

--- a/static/app/views/issueList/queries/useFetchStarredGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchStarredGroupSearchViews.tsx
@@ -1,0 +1,25 @@
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {StarredGroupSearchView} from 'sentry/views/issueList/types';
+
+type FetchStarredGroupSearchViewsParameters = {
+  orgSlug: string;
+};
+
+export const makeFetchStarredGroupSearchViewsKey = ({
+  orgSlug,
+}: FetchStarredGroupSearchViewsParameters): ApiQueryKey =>
+  [`/organizations/${orgSlug}/group-search-views/starred/`, {}] as const;
+
+export const useFetchStarredGroupSearchViews = (
+  parameters: FetchStarredGroupSearchViewsParameters,
+  options: Partial<UseApiQueryOptions<StarredGroupSearchView[]>> = {}
+) => {
+  return useApiQuery<StarredGroupSearchView[]>(
+    makeFetchStarredGroupSearchViewsKey(parameters),
+    {
+      staleTime: Infinity,
+      ...options,
+    }
+  );
+};

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -43,7 +43,7 @@ export type GroupSearchView = StarredGroupSearchView & {
 };
 
 export interface UpdateGroupSearchViewPayload
-  extends Omit<GroupSearchView, 'id' | 'lastVisited' | 'visibility'> {
+  extends Omit<GroupSearchView, 'id' | 'lastVisited' | 'visibility' | 'starred'> {
   environments: string[];
   projects: number[];
   timeFilters: PageFilters['datetime'];

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -26,7 +26,7 @@ export enum GroupSearchViewCreatedBy {
   OTHERS = 'others',
 }
 
-export type GroupSearchView = {
+export type StarredGroupSearchView = {
   environments: string[];
   id: string;
   lastVisited: string | null;
@@ -34,8 +34,11 @@ export type GroupSearchView = {
   projects: number[];
   query: string;
   querySort: IssueSortOptions;
-  starred: boolean;
   timeFilters: PageFilters['datetime'];
+};
+
+export type GroupSearchView = StarredGroupSearchView & {
+  starred: boolean;
   visibility: GroupSearchViewVisibility;
 };
 

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -65,7 +65,7 @@ describe('Nav', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/group-search-views/`,
+      url: `/organizations/org-slug/group-search-views/starred/`,
       body: [],
     });
 

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -14,7 +14,7 @@ import {
   DEFAULT_TIME_FILTERS,
 } from 'sentry/views/issueList/issueViews/issueViews';
 import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {useNavContext} from 'sentry/views/nav/context';
 import useDefaultProject from 'sentry/views/nav/secondary/sections/issues/issueViews/useDefaultProject';
@@ -29,7 +29,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
 
   const defaultProject = useDefaultProject();
 
-  const {data: groupSearchViews} = useFetchGroupSearchViews({
+  const {data: starredGroupSearchViews} = useFetchStarredGroupSearchViews({
     orgSlug: organization.slug,
   });
 
@@ -47,11 +47,14 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
   });
 
   const handleOnAddView = () => {
-    if (groupSearchViews) {
+    if (starredGroupSearchViews) {
       setIsLoading(true);
       updateViews({
         groupSearchViews: [
-          ...groupSearchViews,
+          ...starredGroupSearchViews.map(view => ({
+            ...view,
+            starred: true,
+          })),
           {
             name: 'New View',
             query: 'is:unresolved',

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -51,10 +51,7 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
       setIsLoading(true);
       updateViews({
         groupSearchViews: [
-          ...starredGroupSearchViews.map(view => ({
-            ...view,
-            starred: true,
-          })),
+          ...starredGroupSearchViews,
           {
             name: 'New View',
             query: 'is:unresolved',
@@ -62,7 +59,6 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
             projects: defaultProject,
             environments: DEFAULT_ENVIRONMENTS,
             timeFilters: DEFAULT_TIME_FILTERS,
-            starred: true,
           },
         ],
         orgSlug: organization.slug,

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -5,7 +5,7 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewNavItems} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
@@ -15,7 +15,7 @@ export function IssuesSecondaryNav() {
   const organization = useOrganization();
   const sectionRef = useRef<HTMLDivElement>(null);
 
-  const {data: groupSearchViews} = useFetchGroupSearchViews({
+  const {data: starredGroupSearchViews} = useFetchStarredGroupSearchViews({
     orgSlug: organization.slug,
   });
 
@@ -38,9 +38,9 @@ export function IssuesSecondaryNav() {
             {t('Feedback')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        {groupSearchViews && (
+        {starredGroupSearchViews && (
           <IssueViewNavItems
-            loadedViews={groupSearchViews.map(
+            loadedViews={starredGroupSearchViews.map(
               (
                 {
                   id,


### PR DESCRIPTION
For both the old and new issue views UI, swap the request to GET /group-search-views/ to GET /group-search-views/starred (except on the All Views page). 

This will allow us to separate retrieval of vanilla views from starred views on the backend and significantly simplify things. 

depends on #89041 being deployed all backend regions. 