### PR TITLE
chore(issue-details): Don't show tour if modal dismissed

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -104,7 +104,18 @@ export function NewIssueExperienceButton() {
             }}
           />
         ),
-        {modalCss: IssueDetailsTourModalCss}
+        {
+          modalCss: IssueDetailsTourModalCss,
+          onClose: reason => {
+            if (reason) {
+              mutateAssistant({
+                guide: ISSUE_DETAILS_TOUR_GUIDE_KEY,
+                status: 'dismissed',
+              });
+              endTour();
+            }
+          },
+        }
       );
     }
   }, [isPromoVisible, mutateAssistant, organization, endTour, startTour]);


### PR DESCRIPTION
Now we will mark the tour as dismissed even if they don't click one of the buttons and just exit the modal 