### PR TITLE
ref(shared-views): Remove starred view logic from get /groupsearchviews/ endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -10,7 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.api.paginator import ChainPaginator, OffsetPaginator, SequencePaginator
+from sentry.api.paginator import ChainPaginator, OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
 from sentry.api.serializers.rest_framework.groupsearchview import (
@@ -18,7 +18,7 @@ from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidator,
     GroupSearchViewValidatorResponse,
 )
-from sentry.models.groupsearchview import DEFAULT_VIEWS, GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -83,35 +83,6 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        query = GroupSearchView.objects.filter(
-            organization=organization, user_id=request.user.id
-        ).prefetch_related("projects")
-
-        # Return only the default view(s) if user has no custom views yet
-        # TODO(msun): Delete this logic once left-nav views have been fully rolled out.
-        if not query.exists() and not serializer.validated_data.get("createdBy"):
-            return self.paginate(
-                request=request,
-                paginator=SequencePaginator(
-                    [
-                        (
-                            idx,
-                            {
-                                **view,
-                                "projects": (
-                                    []
-                                    if has_global_views
-                                    else [pick_default_project(organization, request.user)]
-                                ),
-                                "starred": False,
-                            },
-                        )
-                        for idx, view in enumerate(DEFAULT_VIEWS)
-                    ]
-                ),
-                on_results=lambda results: serialize(results, request.user),
-            )
-
         starred_view_ids = GroupSearchViewStarred.objects.filter(
             organization=organization, user_id=request.user.id
         ).values_list("group_search_view_id", flat=True)
@@ -125,79 +96,58 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                     data={"detail": "You do not have access to any projects."},
                 )
 
-        createdBy = serializer.validated_data.get("createdBy")
+        createdBy = serializer.validated_data.get("createdBy", "me")
         sort = SORT_MAP[serializer.validated_data.get("sort", "-visited")]
-        if createdBy:
-            if createdBy == "me":
-                starred_query = (
-                    GroupSearchView.objects.filter(
-                        organization=organization,
-                        user_id=request.user.id,
-                        id__in=starred_view_ids,
-                    )
-                    .prefetch_related("projects")
-                    .annotate(popularity=Count("groupsearchviewstarred"))
-                    .order_by(sort)
-                )
-                non_starred_query = (
-                    GroupSearchView.objects.filter(
-                        organization=organization,
-                        user_id=request.user.id,
-                    )
-                    .exclude(id__in=starred_view_ids)
-                    .prefetch_related("projects")
-                    .annotate(popularity=Count("groupsearchviewstarred"))
-                    .order_by(sort)
-                )
-            elif createdBy == "others":
-                starred_query = (
-                    GroupSearchView.objects.filter(
-                        organization=organization,
-                        visibility=GroupSearchViewVisibility.ORGANIZATION,
-                        id__in=starred_view_ids,
-                    )
-                    .exclude(user_id=request.user.id)
-                    .prefetch_related("projects")
-                    .annotate(popularity=Count("groupsearchviewstarred"))
-                    .order_by(sort)
-                )
-                non_starred_query = (
-                    GroupSearchView.objects.filter(
-                        organization=organization,
-                        visibility=GroupSearchViewVisibility.ORGANIZATION,
-                    )
-                    .exclude(user_id=request.user.id)
-                    .exclude(id__in=starred_view_ids)
-                    .prefetch_related("projects")
-                    .annotate(popularity=Count("groupsearchviewstarred"))
-                    .order_by(sort)
-                )
 
-            return self.paginate(
-                request=request,
-                sources=[starred_query, non_starred_query],
-                paginator_cls=ChainPaginator,
-                on_results=lambda x: serialize(
-                    x,
-                    request.user,
-                    serializer=GroupSearchViewSerializer(
-                        has_global_views=has_global_views,
-                        default_project=default_project,
-                        organization=organization,
-                    ),
-                ),
+        if createdBy == "me":
+            starred_query = (
+                GroupSearchView.objects.filter(
+                    organization=organization,
+                    user_id=request.user.id,
+                    id__in=starred_view_ids,
+                )
+                .prefetch_related("projects")
+                .annotate(popularity=Count("groupsearchviewstarred"))
+                .order_by(sort)
             )
-
-        user_starred_views = (
-            GroupSearchView.objects.filter(id__in=starred_view_ids)
-            .prefetch_related("projects")
-            .order_by("groupsearchviewstarred__position")
-        )
+            non_starred_query = (
+                GroupSearchView.objects.filter(
+                    organization=organization,
+                    user_id=request.user.id,
+                )
+                .exclude(id__in=starred_view_ids)
+                .prefetch_related("projects")
+                .annotate(popularity=Count("groupsearchviewstarred"))
+                .order_by(sort)
+            )
+        elif createdBy == "others":
+            starred_query = (
+                GroupSearchView.objects.filter(
+                    organization=organization,
+                    visibility=GroupSearchViewVisibility.ORGANIZATION,
+                    id__in=starred_view_ids,
+                )
+                .exclude(user_id=request.user.id)
+                .prefetch_related("projects")
+                .annotate(popularity=Count("groupsearchviewstarred"))
+                .order_by(sort)
+            )
+            non_starred_query = (
+                GroupSearchView.objects.filter(
+                    organization=organization,
+                    visibility=GroupSearchViewVisibility.ORGANIZATION,
+                )
+                .exclude(user_id=request.user.id)
+                .exclude(id__in=starred_view_ids)
+                .prefetch_related("projects")
+                .annotate(popularity=Count("groupsearchviewstarred"))
+                .order_by(sort)
+            )
 
         return self.paginate(
             request=request,
-            queryset=user_starred_views,
-            paginator_cls=OffsetPaginator,
+            sources=[starred_query, non_starred_query],
+            paginator_cls=ChainPaginator,
             on_results=lambda x: serialize(
                 x,
                 request.user,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
@@ -4,19 +4,18 @@ from django.utils import timezone
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
-from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
+from tests.sentry.issues.endpoints.test_organization_group_search_views import (
+    GroupSearchViewAPITestCase,
+)
 
 
-class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
+class OrganizationGroupSearchViewVisitTest(GroupSearchViewAPITestCase):
     endpoint = "sentry-api-0-organization-group-search-view-visit"
     method = "post"
 
     def setUp(self) -> None:
         self.login_as(user=self.user)
-        self.base_data = self.create_base_data()
-
-        # Get the first view's ID for testing
-        self.view = self.base_data["user_one_views"][0]
+        self.view = self.create_view(self.user)
 
         self.url = reverse(
             "sentry-api-0-organization-group-search-view-visit",
@@ -89,8 +88,11 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_update_view_from_another_user(self) -> None:
+        user_two = self.create_user()
+        self.create_member(organization=self.organization, user=user_two)
+
         # Get a view ID from user_two
-        view = self.base_data["user_two_views"][0]
+        view = self.create_view(user_two)
         url = reverse(
             "sentry-api-0-organization-group-search-view-visit",
             kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view.id},


### PR DESCRIPTION
depends on #89235 being deployed

This PR refactors the `GET` `/group-search-views/` endpoint. Previously, it used to return a user's starred views if no query params were provided. That logic has now been removed in this PR, and it has been relocated  to `GET` `/group-search-views/starred` to reduce overloading of this endpoint. 