### PR TITLE
:recycle: ref(aci): update links in issue alert titles

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
@@ -16,12 +16,14 @@ from sentry.integrations.messaging.message_builder import (
     build_footer,
     get_color,
     get_title_link,
+    get_title_link_workflow_engine_ui,
 )
 from sentry.integrations.types import ExternalProviders
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.notifications.base import ProjectNotification
+from sentry.notifications.notifications.rules import get_key_from_rule_data
 
 from ..message_builder.base.component import DiscordComponentCustomIds as CustomIds
 
@@ -55,24 +57,48 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         rule_id = None
         rule_environment_id = None
         if self.rules:
-            rule_id = self.rules[0].id
             rule_environment_id = self.rules[0].environment_id
+            if features.has("organizations:workflow-engine-ui-links", self.group.organization):
+                rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
+            elif features.has(
+                "organizations:workflow-engine-trigger-actions", self.group.organization
+            ):
+                rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
+            else:
+                rule_id = self.rules[0].id
+
+        url = None
+
+        if features.has("organizations:workflow-engine-ui-links", self.group.organization):
+            url = get_title_link_workflow_engine_ui(
+                self.group,
+                self.event,
+                self.link_to_event,
+                self.issue_details,
+                self.notification,
+                ExternalProviders.DISCORD,
+                rule_id,
+                rule_environment_id,
+                notification_uuid=notification_uuid,
+            )
+        else:
+            url = get_title_link(
+                self.group,
+                self.event,
+                self.link_to_event,
+                self.issue_details,
+                self.notification,
+                ExternalProviders.DISCORD,
+                rule_id,
+                rule_environment_id,
+                notification_uuid=notification_uuid,
+            )
 
         embeds = [
             DiscordMessageEmbed(
                 title=build_attachment_title(obj),
                 description=build_attachment_text(self.group, self.event) or None,
-                url=get_title_link(
-                    self.group,
-                    self.event,
-                    self.link_to_event,
-                    self.issue_details,
-                    self.notification,
-                    ExternalProviders.DISCORD,
-                    rule_id,
-                    rule_environment_id,
-                    notification_uuid=notification_uuid,
-                ),
+                url=url,
                 color=LEVEL_TO_COLOR[get_color(event_for_tags, self.notification, self.group)],
                 # We can't embed urls in Discord embed footers.
                 footer=DiscordMessageEmbedFooter(

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -9,7 +9,7 @@ import orjson
 from django.core.exceptions import ObjectDoesNotExist
 from sentry_relay.processing import parse_release
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.constants import LOG_LEVELS
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.identity.services.identity import RpcIdentity, identity_service
@@ -20,6 +20,7 @@ from sentry.integrations.messaging.message_builder import (
     format_actor_option_slack,
     format_actor_options_slack,
     get_title_link,
+    get_title_link_workflow_engine_ui,
 )
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.image_block_builder import ImageBlockBuilder
@@ -52,6 +53,7 @@ from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.notifications.notifications.base import ProjectNotification
+from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
@@ -455,21 +457,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self,
         event_or_group: Event | GroupEvent | Group,
         has_action: bool,
-        rule_id: int | None = None,
-        rule_environment_id: int | None = None,
-        notification_uuid: str | None = None,
+        title_link: str | None = None,
     ) -> SlackBlock:
-        title_link = get_title_link(
-            self.group,
-            self.event,
-            self.link_to_event,
-            self.issue_details,
-            self.notification,
-            ExternalProviders.SLACK,
-            rule_id,
-            rule_environment_id,
-            notification_uuid=notification_uuid,
-        )
         # If using summary, put the body in the headline as well
         headline = None
         if self.issue_summary is not None:
@@ -622,8 +611,14 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         rule_id = None
         rule_environment_id = None
         if self.rules:
-            rule_id = self.rules[0].id
-            rule_environment_id = self.rules[0].environment_id
+            if features.has("organizations:workflow-engine-ui-links", self.group.organization):
+                rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
+            elif features.has(
+                "organizations:workflow-engine-trigger-actions", self.group.organization
+            ):
+                rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
+            else:
+                rule_id = self.rules[0].id
 
         # build up actions text
         if self.actions and self.identity and not action_text:
@@ -631,11 +626,33 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             action_text = get_action_text(self.actions, self.identity)
             has_action = True
 
-        blocks = [
-            self.get_title_block(
-                event_or_group, has_action, rule_id, rule_environment_id, notification_uuid
+        title_link = None
+        if features.has("organizations:workflow-engine-ui-links", self.group.organization):
+            title_link = get_title_link_workflow_engine_ui(
+                self.group,
+                self.event,
+                self.link_to_event,
+                self.issue_details,
+                self.notification,
+                ExternalProviders.SLACK,
+                rule_id,
+                rule_environment_id,
+                notification_uuid=notification_uuid,
             )
-        ]
+        else:
+            title_link = get_title_link(
+                self.group,
+                self.event,
+                self.link_to_event,
+                self.issue_details,
+                self.notification,
+                ExternalProviders.SLACK,
+                rule_id,
+                rule_environment_id,
+                notification_uuid=notification_uuid,
+            )
+
+        blocks = [self.get_title_block(event_or_group, has_action, title_link)]
 
         if culprit_block := self.get_culprit_block(event_or_group):
             blocks.append(culprit_block)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -97,12 +97,18 @@ def build_test_message_blocks(
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
     if rule:
-        title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
+        if legacy_rule_id:
+            title_link += f"&alert_rule_id={legacy_rule_id}&alert_type=issue"
+        else:
+            title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
 
     title_text = f":red_circle: <{title_link}|*{formatted_title}*>"
 
     if rule:
-        block_id = f'{{"issue":{group.id},"rule":{rule.id}}}'
+        if legacy_rule_id:
+            block_id = f'{{"issue":{group.id},"rule":{legacy_rule_id}}}'
+        else:
+            block_id = f'{{"issue":{group.id},"rule":{rule.id}}}'
     else:
         block_id = f'{{"issue":{group.id}}}'
 


### PR DESCRIPTION
this pr updates `get_title_link` method in our notification builder to work with notification action and when the new ui rolls out.

we fetch `legacy_rule_id` if the notification action is invoked
OR
we fetch `workflow_id` if the new ui flag is enabled