### PR TITLE
fix(rpc): Capture rpc errors

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -378,6 +378,7 @@ def handle_query_errors() -> Generator[None]:
         if isinstance(arg, TimeoutError):
             sentry_sdk.set_tag("query.error_reason", "Timeout")
             raise ParseError(detail=TIMEOUT_RPC_ERROR_MESSAGE)
+        sentry_sdk.capture_exception(error)
         raise APIException(detail=message)
     except SnubaError as error:
         message = "Internal error. Please try again."


### PR DESCRIPTION
- We weren't capturing rpc errors so if snuba errored in these situations there wasn't any sentry error being made