### PR TITLE
fix(emails): OrganizationJoinRequest preview

### DIFF
--- a/src/sentry/web/frontend/debug/debug_organization_join_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_join_request.py
@@ -12,16 +12,16 @@ from .mail import render_preview_email_for_notification
 class DebugOrganizationJoinRequestEmailView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         org = Organization(id=1, slug="default", name="Default")
-        user_to_join = User(name="Rick Swan")
+        user_to_join = User(name="Rick Swan", id=2)
         pending_member = OrganizationMember(
             email="test@gmail.com",
             organization=org,
             user_id=user_to_join.id,
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
-        recipient = User(name="James Bond")
-        recipient_member = OrganizationMember(user_id=recipient.id, organization=org)
 
+        recipient = User(name="James Bond", id=3)
+        recipient_member = OrganizationMember(user_id=recipient.id, organization=org)
         notification = JoinRequestNotification(pending_member, user_to_join)
 
         # hack to avoid a query


### PR DESCRIPTION
OrganizationJoinRequest preview doesn't render because for some reason actor id is none. This fixes the preview:

After:
<img width="560" alt="Screenshot 2025-04-09 at 4 52 30 PM" src="https://github.com/user-attachments/assets/a675cc73-18d1-44aa-80e9-374bfc5bcfd9" />

