### PR TITLE
feat(issues): Add readable name to "device" tag search

### DIFF
--- a/static/app/components/deprecatedSmartSearchBar/utils.spec.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/utils.spec.tsx
@@ -69,7 +69,7 @@ describe('getTagItemsFromKeys()', function () {
         title: 'device',
         value: 'device:',
         kind: FieldKind.FIELD,
-        documentation: '-',
+        documentation: 'The device that the event was seen on',
       },
       {
         title: 'someTag',

--- a/static/app/components/deviceName.tsx
+++ b/static/app/components/deviceName.tsx
@@ -16,7 +16,7 @@ export function deviceNameMapper(model: string | undefined): string | null {
   const [identifier, ...rest] = model.split(' ');
 
   const modelName = iOSDeviceMapping[identifier!];
-  return modelName === undefined ? model : `${modelName} ${rest.join(' ')}`;
+  return modelName === undefined ? model : `${modelName} ${rest.join(' ')}`.trim();
 }
 
 interface DeviceNameProps {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -71,6 +71,12 @@ const FILTER_KEYS: TagCollection = {
     name: 'timesSeen',
     kind: FieldKind.FIELD,
   },
+  device: {
+    key: 'device',
+    name: 'Device',
+    kind: FieldKind.FIELD,
+    predefined: false,
+  },
   custom_tag_name: {
     key: 'custom_tag_name',
     name: 'Custom_Tag_Name',
@@ -2707,6 +2713,30 @@ describe('SearchQueryBuilder', function () {
 
         expect(await screen.findByText('is on or after')).toBeInTheDocument();
         expect(screen.getByText('Oct 17, 2:00 PM UTC')).toBeInTheDocument();
+      });
+    });
+
+    describe('device', function () {
+      it('displays the readable name', async function () {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            getTagValues={() => Promise.resolve(['iPhone14,5', 'iPhone15,4'])}
+            initialQuery="device:"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: device'})
+        );
+        await screen.findByRole('option', {name: 'iPhone14,5'});
+
+        expect(await screen.findByText('iPhone 13')).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('option', {name: 'iPhone14,5'}));
+
+        expect(
+          screen.getByRole('row', {name: 'device:"iPhone14,5"'})
+        ).toBeInTheDocument();
       });
     });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -71,7 +71,7 @@ const FILTER_KEYS: TagCollection = {
     name: 'timesSeen',
     kind: FieldKind.FIELD,
   },
-  device: {
+  [FieldKey.DEVICE]: {
     key: 'device',
     name: 'Device',
     kind: FieldKind.FIELD,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -55,7 +55,7 @@ import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
-import {type FieldDefinition, FieldValueType} from 'sentry/utils/fields';
+import {type FieldDefinition, FieldKey, FieldValueType} from 'sentry/utils/fields';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {keepPreviousData, useQuery} from 'sentry/utils/queryClient';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
@@ -387,7 +387,7 @@ function useFilterSuggestions({
         value,
         description:
           // When the key is device, we can help users by displaying the readable name
-          key?.key === 'device' ? (
+          key?.key === FieldKey.DEVICE ? (
             <DeviceName value={value}>
               {/* Prevent the same value from being displayed twice */}
               {name => (name === value ? null : name)}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -12,6 +12,7 @@ import {
   type SearchGroup,
   type SearchItem,
 } from 'sentry/components/deprecatedSmartSearchBar/types';
+import {DeviceName} from 'sentry/components/deviceName';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {
   type CustomComboboxMenu,
@@ -377,10 +378,26 @@ function useFilterSuggestions({
   );
 
   const suggestionGroups: SuggestionSection[] = useMemo(() => {
-    return shouldFetchValues
-      ? [{sectionText: '', suggestions: data?.map(value => ({value})) ?? []}]
-      : (predefinedValues ?? []);
-  }, [data, predefinedValues, shouldFetchValues]);
+    if (!shouldFetchValues) {
+      return predefinedValues ?? [];
+    }
+
+    const suggestions = data?.map(value => {
+      return {
+        value,
+        description:
+          // When the key is device, we can help users by displaying the readable name
+          key?.key === 'device' ? (
+            <DeviceName value={value}>
+              {/* Prevent the same value from being displayed twice */}
+              {name => (name === value ? null : name)}
+            </DeviceName>
+          ) : undefined,
+      };
+    });
+
+    return [{sectionText: '', suggestions: suggestions ?? []}];
+  }, [data, predefinedValues, shouldFetchValues, key?.key]);
 
   // Grouped sections for rendering purposes
   const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -26,6 +26,7 @@ export enum FieldKey {
   BOOKMARKS = 'bookmarks',
   BROWSER_NAME = 'browser.name',
   CULPRIT = 'culprit',
+  DEVICE = 'device',
   DEVICE_ARCH = 'device.arch',
   DEVICE_BATTERY_LEVEL = 'device.battery_level',
   DEVICE_BRAND = 'device.brand',
@@ -1298,6 +1299,11 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   },
   [FieldKey.BROWSER_NAME]: {
     desc: t('Name of the browser'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.DEVICE]: {
+    desc: t('The device that the event was seen on'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },


### PR DESCRIPTION
Adds a description on device tags of the user friendly device name. Part of #68258

I can see an argument for having the description always there but i tried to deduplicate the description.

<img width="488" alt="image" src="https://github.com/user-attachments/assets/1c54a398-97e3-4988-bedf-7e4d0ab64250" />
