### PR TITLE
fix(query-builder): Center loading indicator

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -71,7 +71,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
       <SectionedOverlay ref={popoverRef}>
         {isLoading && hiddenOptions.size >= totalOptions ? (
           <LoadingWrapper>
-            <LoadingIndicator mini />
+            <LoadingIndicator size={24} />
           </LoadingWrapper>
         ) : (
           <Fragment>


### PR DESCRIPTION
for some reason the .mini class only has a height and so flex center isn't centered.

before
<img width="339" alt="image" src="https://github.com/user-attachments/assets/aa23c0b7-50b0-420e-925b-ebcd7ec4d08f" />


after

<img width="315" alt="image" src="https://github.com/user-attachments/assets/f1a38987-d568-498b-a997-948a0d382e19" />
