### PR TITLE
fix(emails): OrganizationInviteRequest preview

### DIFF
--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -63,7 +63,8 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
                 inviter = None
             if inviter:
                 context["inviter_name"] = inviter.get_salutation_name()
-            context["inviter_name"] = inviter_name
+            else:
+                context["inviter_name"] = inviter_name
         return context
 
     def get_message_actions(

--- a/src/sentry/web/frontend/debug/debug_organization_invite_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_invite_request.py
@@ -2,7 +2,7 @@ from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 
 from sentry.models.organization import Organization
-from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import InviteRequestNotification
 from sentry.users.models.user import User
 
@@ -12,12 +12,18 @@ from .mail import render_preview_email_for_notification
 class DebugOrganizationInviteRequestEmailView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         org = Organization(id=1, slug="default", name="Default")
-        requester = User(name="Rick Swan")
+        requester = User(name="Rick Swan", id=2, email="rick@gmail.com")
+        OrganizationMember(user_id=requester.id, organization=org, email="james@gmail.com")
         pending_member = OrganizationMember(
-            email="test@gmail.com", organization=org, inviter_id=requester.id
+            email="new_member@gmail.com",
+            organization=org,
+            inviter_id=requester.id,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
         )
-        recipient = User(name="James Bond")
-        recipient_member = OrganizationMember(user_id=recipient.id, organization=org)
+        recipient = User(name="James Bond", id=3, email="james@gmail.com")
+        recipient_member = OrganizationMember(
+            user_id=recipient.id, organization=org, email="james@gmail.com"
+        )
 
         notification = InviteRequestNotification(pending_member, requester)
 

--- a/src/sentry/web/frontend/debug/debug_organization_join_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_join_request.py
@@ -12,16 +12,16 @@ from .mail import render_preview_email_for_notification
 class DebugOrganizationJoinRequestEmailView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         org = Organization(id=1, slug="default", name="Default")
-        user_to_join = User(name="Rick Swan")
+        user_to_join = User(name="Rick Swan", id=2)
         pending_member = OrganizationMember(
             email="test@gmail.com",
             organization=org,
             user_id=user_to_join.id,
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
-        recipient = User(name="James Bond")
-        recipient_member = OrganizationMember(user_id=recipient.id, organization=org)
 
+        recipient = User(name="James Bond", id=3)
+        recipient_member = OrganizationMember(user_id=recipient.id, organization=org)
         notification = JoinRequestNotification(pending_member, user_to_join)
 
         # hack to avoid a query


### PR DESCRIPTION
This preview was broken for 2 reasons. Invite object was not complete and also inviter name is overwritten by "". The latter can happen in product too and not just the preview problem.

before:
<img width="561" alt="Screenshot 2025-04-09 at 5 42 00 PM" src="https://github.com/user-attachments/assets/a901042d-a9a4-47ff-9e4d-288bf5ea4a7b" />


after:
<img width="551" alt="Screenshot 2025-04-09 at 5 38 53 PM" src="https://github.com/user-attachments/assets/e48b39d2-5d35-4b60-8ebe-f3ffa3298695" />


Note that preview is still broken because "User1" is coming from db. There's no easy way to fix it but this broken status is much better than the previous broken status.
