### PR TITLE
ref(workflow_engine): Cleanup some of the Data Source Metrics

### DIFF
--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -1,5 +1,4 @@
 import logging
-from collections import Counter
 
 import sentry_sdk
 from django.db.models import Prefetch
@@ -39,13 +38,11 @@ def process_data_sources(
             data_packet_tuple = (packet, detectors)
             result.append(data_packet_tuple)
 
-            detector_metrics = Counter(detector.type for detector in detectors)
-            for detector_type, count in detector_metrics.items():
-                metrics.incr(
-                    "workflow_engine.process_data_sources.detectors",
-                    count,
-                    tags={"query_type": query_type},
-                )
+            metrics.incr(
+                "workflow_engine.process_data_sources.detectors",
+                len(detectors),
+                tags={"query_type": query_type},
+            )
         else:
             logger.warning(
                 "No detectors found",

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -11,6 +11,7 @@ logger = logging.getLogger("sentry.workflow_engine.process_data_source")
 
 
 # TODO - @saponifi3d - change the text choices to an enum
+# TODO - @saponifi3d - make query_type optional override, otherwise infer from the data packet.
 def process_data_sources(
     data_packets: list[DataPacket], query_type: str
 ) -> list[tuple[DataPacket, list[Detector]]]:

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -43,7 +43,7 @@ def process_data_sources(
                 metrics.incr(
                     "workflow_engine.process_data_sources.detectors",
                     count,
-                    tags={"detector_type": detector_type},
+                    tags={"query_type": query_type},
                 )
         else:
             logger.warning(

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -45,12 +45,6 @@ def process_data_sources(
                     count,
                     tags={"detector_type": detector_type},
                 )
-
-            metrics.incr(
-                "workflow_engine.process_data_sources.detectors",
-                len(detectors),
-                tags={"detector_type": detectors[0].type},
-            )
         else:
             logger.warning(
                 "No detectors found",

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -110,14 +110,14 @@ class TestProcessDataSources(BaseWorkflowTest):
                 "workflow_engine.process_data_sources", tags={"query_type": "test"}
             )
 
-    def test_metrics_are_sent_for_detector_types(self):
+    def test_metrics_are_sent_for_data_types(self):
         with mock.patch("sentry.utils.metrics.incr") as mock_incr:
             process_data_sources(self.data_packets, "test")
 
             mock_incr.assert_any_call(
                 "workflow_engine.process_data_sources.detectors",
                 1,
-                tags={"detector_type": self.detector_one.type},
+                tags={"query_type": "test"},
             )
 
     def test_metrics_are_sent_for_no_detectors(self):
@@ -139,5 +139,5 @@ class TestProcessDataSources(BaseWorkflowTest):
             mock_incr.assert_any_call(
                 "workflow_engine.process_data_sources.detectors",
                 2,
-                tags={"detector_type": self.detector_one.type},
+                tags={"query_type": "test"},
             )


### PR DESCRIPTION
# Description
Started to make the [workflow_engine dashboard](https://app.datadoghq.com/dashboard/ccd-cnh-4c7/workflow-engine?fromUser=false&fullscreen_end_ts=1744245597280&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1743640797280&fullscreen_widget=7253675568753455&refresh_mode=sliding&from_ts=1743637744161&to_ts=1744242544161&live=true) and found that the data source metrics looked off.

i think this is why the metrics were off, and i didn't find the detector_type info particularly useful - i kept wanting to compare the different data source types (so updated to that as well)