### PR TITLE
ref(insights): Improve `useSpanSamples` hooks

### DIFF
--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -19,7 +19,11 @@ import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSampl
 import {useSpanSamples} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {AverageValueMarkLine} from 'sentry/views/insights/common/utils/averageValueMarkLine';
 import {useSampleScatterPlotSeries} from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
-import type {SpanMetricsQueryFilters, SubregionCode} from 'sentry/views/insights/types';
+import type {
+  SpanIndexedProperty,
+  SpanMetricsQueryFilters,
+  SubregionCode,
+} from 'sentry/views/insights/types';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
@@ -27,7 +31,7 @@ const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 type Props = {
   groupId: string;
   transactionName: string;
-  additionalFields?: string[];
+  additionalFields?: SpanIndexedProperty[];
   additionalFilters?: Record<string, string>;
   highlightedSpanId?: string;
   onClickSample?: (sample: SpanSample) => void;
@@ -112,7 +116,7 @@ function DurationChart({
   const avg = spanMetrics?.[`avg(${SPAN_SELF_TIME})`] || 0;
 
   const {
-    data: spans,
+    data: spanSamplesData,
     isPending: areSpanSamplesLoading,
     isRefetching: areSpanSamplesRefetching,
   } = useSpanSamples({
@@ -123,6 +127,8 @@ function DurationChart({
     spanSearch,
     additionalFields,
   });
+
+  const spans = spanSamplesData?.data ?? [];
 
   const baselineAvgSeries: Series = {
     seriesName: 'Average',

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -27,6 +27,7 @@ import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   ModuleName,
   SpanIndexedField,
+  type SpanIndexedProperty,
   SpanMetricsField,
 } from 'sentry/views/insights/types';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
@@ -108,7 +109,7 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
 
   let columnOrder = DEFAULT_COLUMN_ORDER;
 
-  const additionalFields: SpanIndexedField[] = [
+  const additionalFields: SpanIndexedProperty[] = [
     SpanIndexedField.TRACE,
     SpanIndexedField.TRANSACTION_ID,
   ];

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -17,6 +17,7 @@ import {useSpanSamples} from 'sentry/views/insights/common/queries/useSpanSample
 import {useTransactions} from 'sentry/views/insights/common/queries/useTransactions';
 import type {
   ModuleName,
+  SpanIndexedProperty,
   SpanMetricsQueryFilters,
   SubregionCode,
 } from 'sentry/views/insights/types';
@@ -31,7 +32,7 @@ type Props = {
   groupId: string;
   moduleName: ModuleName;
   transactionName: string;
-  additionalFields?: string[];
+  additionalFields?: SpanIndexedProperty[];
   additionalFilters?: Record<string, string>;
   columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
@@ -95,9 +96,9 @@ function SampleTable({
   const {setPageError} = usePageAlert();
 
   const {
-    data: spans,
+    data: spanSamplesData,
     isFetching: isFetchingSamples,
-    isEnabled: isSamplesEnabled,
+    isPending: isPendingSamples,
     error: sampleError,
     refetch,
   } = useSpanSamples({
@@ -109,6 +110,8 @@ function SampleTable({
     spanSearch,
     additionalFields,
   });
+
+  const spans = spanSamplesData?.data ?? [];
 
   const {
     data: transactions,
@@ -151,7 +154,7 @@ function SampleTable({
   const isLoading =
     isFetchingSpanMetrics ||
     isFetchingSamples ||
-    !isSamplesEnabled ||
+    isPendingSamples ||
     (!areNoSamples && isFetchingTransactions && !isTransactionsEnabled);
 
   if (sampleError || transactionError) {

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -226,7 +226,7 @@ export function HTTPSamplesPanel() {
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.self_time)`]]);
 
   const {
-    data: durationSamplesData,
+    data: spanSamplesData,
     isFetching: isDurationSamplesDataFetching,
     error: durationSamplesDataError,
     refetch: refetchDurationSpanSamples,
@@ -243,6 +243,8 @@ export function HTTPSamplesPanel() {
     enabled: isPanelOpen && query.panel === 'duration' && durationAxisMax > 0,
     referrer: Referrer.SAMPLES_PANEL_DURATION_SAMPLES,
   });
+
+  const durationSamplesData = spanSamplesData?.data ?? [];
 
   const {
     data: responseCodeSamplesData,

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -93,6 +93,16 @@ describe('useSpanSamples', () => {
             'span.id': '3aab8a77fe231',
           },
         ],
+        meta: {
+          fields: {
+            'transaction.id': 'string',
+            'span.id': 'string',
+          },
+          units: {
+            'transaction.id': null,
+            'span.id': null,
+          },
+        },
       },
     });
 
@@ -138,17 +148,30 @@ describe('useSpanSamples', () => {
           firstBound: 300,
           secondBound: 600,
           upperBound: 900,
+          sort: '-timestamp',
           utc: false,
         },
       })
     );
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
-    expect(result.current.data).toEqual([
-      {
-        'transaction.id': '7663aab8a',
-        'span.id': '3aab8a77fe231',
+    expect(result.current.data).toEqual({
+      data: [
+        {
+          'transaction.id': '7663aab8a',
+          'span.id': '3aab8a77fe231',
+        },
+      ],
+      meta: {
+        fields: {
+          'transaction.id': 'string',
+          'span.id': 'string',
+        },
+        units: {
+          'transaction.id': null,
+          'span.id': null,
+        },
       },
-    ]);
+    });
   });
 });

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -178,7 +178,7 @@ export function MessageSpanSamplesPanel() {
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.duration)`]]);
 
   const {
-    data: durationSamplesData,
+    data: spanSamplesData,
     isFetching: isDurationSamplesDataFetching,
     error: durationSamplesDataError,
     refetch: refetchDurationSpanSamples,
@@ -199,6 +199,8 @@ export function MessageSpanSamplesPanel() {
       SpanIndexedField.SPAN_DURATION,
     ],
   });
+
+  const durationSamplesData = spanSamplesData?.data ?? [];
 
   const sampledSpanDataSeries = useSampleScatterPlotSeries(
     durationSamplesData,


### PR DESCRIPTION
There are two `useSpanSamples` hooks. One from the HTTP panel, and one "generic" one, used for Queries, Assets, Mobile, etc. The second "generic" one is more fancy, since it calculates its own bounds. I'm going to combine the two hooks soon to eliminate the duplication, but this is a first step to unblock some other work.

- add types to `additionalFields`. This also improves type safety of the responses
- align the parameters passed to `useApiQuery` from the two hooks. They used to have different stale time and behaviour for some reason
- have both the `useSpanSamples` hooks return data _and_ meta. Without meta, I can't plot these samples on new charts, so this unlocks that behaviour
- remove manual sorting from the hook. One of the hooks manually sorted the samples by duration. This is not necessary as of https://github.com/getsentry/sentry/pull/89230 (so, I need to wait for that PR before I deploy this)

