### PR TITLE
feat(eap): add `span.name` field alias

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -90,6 +90,12 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="span.name",
+            internal_name="sentry.op",
+            search_type="string",
+            secondary_alias=True,
+        ),
+        ResolvedAttribute(
             public_alias="span.category",
             internal_name="sentry.category",
             search_type="string",


### PR DESCRIPTION
Sentry's new span schema is aligning with OTel, introducing `name` as the top level field by which a span's operation is identified. This effectively replaces `op` in Sentry's current data model.

Add `span.name` as a secondary alias for the underlying `sentry.op` field.

I considered trying to put this field behind a feature flag, but the blast radius is pretty large since this field is currently a constant that is transformed into several other constants, all of which would have to become dynamic. Adding it as a secondary alias means it shouldn't yet show up anywhere unless a user explicity tries to use it. We might start conditionally using it in the frontend behind a feature flag.

Eventually, `span.op` will become the secondary alias, for backwards compatibility.