### PR TITLE
fix(laravel-insights): Custom periods being invalid

### DIFF
--- a/static/app/views/insights/pages/backend/laravel/index.tsx
+++ b/static/app/views/insights/pages/backend/laravel/index.tsx
@@ -114,7 +114,10 @@ export function LaravelOverviewPage() {
                   <DatePageFilter
                     maxPickableDays={maxPickableDays}
                     defaultPeriod={defaultPeriod}
-                    relativeOptions={relativeOptions}
+                    relativeOptions={({arbitraryOptions}) => ({
+                      ...arbitraryOptions,
+                      ...relativeOptions,
+                    })}
                   />
                 </PageFilterBar>
                 {!showOnboarding && (


### PR DESCRIPTION
Merge custom time periods into the available relative options.