### PR TITLE
fix(api): correct permissions needed for debug symbols endpoint

### DIFF
--- a/api-docs/paths/projects/dsyms.json
+++ b/api-docs/paths/projects/dsyms.json
@@ -158,7 +158,7 @@
     },
     "security": [
       {
-        "auth_token": ["project:write"]
+        "auth_token": ["project:admin", "project:releases"]
       }
     ]
   }


### PR DESCRIPTION
- Make this line up with the permissions class used in the endpoint: https://github.com/getsentry/sentry/blob/df38cddd45ae2e4ad700f9a40acefe7f223ba80b/src/sentry/api/bases/project.py#L77