### PR TITLE
fix(releases): fix overflow of long package names & moving finalize button

### DIFF
--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -75,41 +75,46 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
               dateReleased ? (
                 <DateTime date={dateReleased} seconds={false} />
               ) : (
-                <Tooltip
-                  title={t(
-                    'Set release date to %s',
-                    moment
-                      .tz(
-                        release.firstEvent ?? release.dateCreated,
-                        options?.timezone ?? ''
-                      )
-                      .format(
-                        options?.clock24Hours
-                          ? 'MMMM D, YYYY HH:mm z'
-                          : 'MMMM D, YYYY h:mm A z'
-                      )
-                  )}
-                >
-                  <Button
-                    size="xs"
-                    style={{marginRight: '-8px'}}
-                    onClick={() => {
-                      finalizeRelease.mutate([release], {
-                        onSettled() {
-                          window.location.reload();
-                        },
-                      });
-                    }}
+                <ButtonContainer>
+                  <Tooltip
+                    title={t(
+                      'Set release date to %s',
+                      moment
+                        .tz(
+                          release.firstEvent ?? release.dateCreated,
+                          options?.timezone ?? ''
+                        )
+                        .format(
+                          options?.clock24Hours
+                            ? 'MMMM D, YYYY HH:mm z'
+                            : 'MMMM D, YYYY h:mm A z'
+                        )
+                    )}
                   >
-                    {t('Finalize')}
-                  </Button>
-                </Tooltip>
+                    <Button
+                      size="xs"
+                      onClick={() => {
+                        finalizeRelease.mutate([release], {
+                          onSettled() {
+                            window.location.reload();
+                          },
+                        });
+                      }}
+                    >
+                      {t('Finalize')}
+                    </Button>
+                  </Tooltip>
+                </ButtonContainer>
               )
             }
           />
           <KeyValueTableRow
             keyName={t('Version')}
-            value={<Version version={version} anchor={false} />}
+            value={
+              <StyledTextOverflow ellipsisDirection="left">
+                <Version version={version} anchor={false} />
+              </StyledTextOverflow>
+            }
           />
           <KeyValueTableRow
             keyName={t('Semver')}
@@ -159,6 +164,19 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
 const StyledTextOverflow = styled(TextOverflow)`
   line-height: inherit;
   text-align: right;
+`;
+
+const ButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  min-width: 0;
+  position: relative;
+  width: 100%;
+
+  & > * {
+    position: absolute;
+    right: 0;
+  }
 `;
 
 export default ProjectReleaseDetails;

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -145,10 +145,10 @@ function ReleaseCard({
         </ReleaseInfoHeader>
         <ReleaseInfoSubheader>
           <ReleaseInfoSubheaderUpper>
-            <div>
+            <PackageContainer>
               <PackageName>
                 {versionInfo?.package && (
-                  <TextOverflow ellipsisDirection="left">
+                  <TextOverflow ellipsisDirection="right">
                     {versionInfo.package}
                   </TextOverflow>
                 )}
@@ -156,7 +156,7 @@ function ReleaseCard({
               <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
               {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
               &nbsp;
-            </div>
+            </PackageContainer>
             <FinalizeWrapper>
               {release.dateReleased ? (
                 <Tooltip
@@ -346,6 +346,14 @@ const FinalizeWrapper = styled('div')`
   flex-direction: row;
   align-items: flex-end;
   flex: initial;
+  position: relative;
+  width: 80px;
+  margin-left: auto;
+
+  & > * {
+    position: absolute;
+    right: 0;
+  }
 `;
 
 export const PackageName = styled('div')`
@@ -354,6 +362,14 @@ export const PackageName = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+  max-width: 100%;
+`;
+
+const PackageContainer = styled('div')`
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+  margin-right: ${space(1)};
 `;
 
 const ReleaseProjects = styled('div')`


### PR DESCRIPTION
- Package name is truncated using ellipsis, and the full package name is now visible via hover on the version, which shows a tooltip with {package}@{version}

Before: 
<img width="1245" alt="Screenshot 2025-04-10 at 14 48 47" src="https://github.com/user-attachments/assets/51a26b6b-0cc0-4ebb-986c-e68a4f5de0fb" />

After: 
<img width="1430" alt="Screenshot 2025-04-10 at 14 48 52" src="https://github.com/user-attachments/assets/0882b54a-5161-4e00-b2b4-3cd3dea82b2e" />
