### PR TITLE
fix(onboarding): add install section to tryton onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -69,12 +69,25 @@ def _(app, request, e):
         data = UserError('Custom message', f'{event_id}{e}')
         return app.make_response(request, data)`;
 
+const getInstallSnippet = () => `pip install 'sentry-sdk'`;
+
 const onboarding: OnboardingConfig = {
   introduction: () =>
     tct('The Tryton integration adds support for the [link:Tryton Framework Server].', {
       link: <ExternalLink href="https://www.tryton.org/" />,
     }),
-  install: () => [],
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: t('Install the Sentry Python SDK package:'),
+      configurations: [
+        {
+          language: 'bash',
+          code: getInstallSnippet(),
+        },
+      ],
+    },
+  ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,


### PR DESCRIPTION
- Noticed during the update of Python profiling onboardings that Tryton didn't have an install section. This PR adds one.