### PR TITLE
ref(eap): Change list of supported widgets in Txn Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -11,8 +11,6 @@ import {useWidgetChartVisualization} from 'sentry/views/performance/transactionS
 export enum EAPWidgetType {
   DURATION_BREAKDOWN = 'duration_breakdown',
   DURATION_PERCENTILES = 'duration_percentiles',
-  DURATION_DISTRIBUTION = 'duration_distribution',
-  TRENDS = 'trends',
   WEB_VITALS = 'web_vitals',
 }
 
@@ -36,19 +34,17 @@ const WIDGET_OPTIONS: Record<
     ),
     disabled: false,
   },
-  [EAPWidgetType.DURATION_DISTRIBUTION]: {
-    title: t('Duration Distribution'),
-    spanCategoryTitle: t('Span Category Distribution'),
-    description: t(
-      'Duration Distribution reflects the volume of transactions per median duration.'
-    ),
-    disabled: true,
-  },
-  [EAPWidgetType.TRENDS]: {
-    title: t('Trends'),
-    description: t('Trends shows the smoothed value of an aggregate over time.'),
-    disabled: true,
-  },
+  // TODO: Histograms are not supported in EAP yet and will be added Post-GA.
+  // We can re-enable this once the feature is released.
+
+  // [EAPWidgetType.DURATION_DISTRIBUTION]: {
+  //   title: t('Duration Distribution'),
+  //   spanCategoryTitle: t('Span Category Distribution'),
+  //   description: t(
+  //     'Duration Distribution reflects the volume of transactions per median duration.'
+  //   ),
+  //   disabled: true,
+  // },
   [EAPWidgetType.WEB_VITALS]: {
     title: t('Web Vitals'),
     description: t(


### PR DESCRIPTION
Duration Distribution and Trends will not work on the EAP dataset at the moment. Duration Distribution requires a histogram implementation on EAP which will likely be investigated Post-GA, and Trends is being deprecated. This PR simply updates the list of supported charts in the transaction summary page for EAP