### PR TITLE
fix(profiling-onboarding): Use manual lifecycle for node platform

### DIFF
--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -249,7 +249,9 @@ const docs: Docs = {
   performanceOnboarding,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
-  profilingOnboarding: getNodeProfilingOnboarding(),
+  profilingOnboarding: getNodeProfilingOnboarding({
+    profilingLifecycle: 'manual',
+  }),
 };
 
 export default docs;

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -257,20 +257,24 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
     nodeProfilingIntegration(),
-  ],
-  // Tracing must be enabled for profiling to work
-  tracesSampleRate: 1.0,${
+  ],${
     params.profilingOptions?.defaultProfilingMode === 'continuous'
-      ? `
+      ? `${
+          profilingLifecycle === 'trace'
+            ? `
+  // Tracing must be enabled for profiling to work
+  tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
-  profileSessionSampleRate: 1.0,${
-    profilingLifecycle === 'trace'
-      ? `
+  profileSessionSampleRate: 1.0,
   // Trace lifecycle automatically enables profiling during active traces
   profileLifecycle: 'trace',`
-      : ''
-  }`
+            : `
+  // Set sampling rate for profiling - this is evaluated only once per SDK.init call
+  profileSessionSampleRate: 1.0,`
+        }`
       : `
+  // Tracing must be enabled for profiling to work
+  tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profilesSampleRate: 1.0,`
   }

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -82,23 +82,27 @@ const getProfilingSdkSetupSnippet = (
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for tracing.
-    traces_sample_rate=1.0,
-    ${
+    dsn="${params.dsn.public}",${
       params.profilingOptions?.defaultProfilingMode === 'continuous'
-        ? `# Set profile_session_sample_rate to 1.0 to profile 100%
+        ? `
+    # Set profile_session_sample_rate to 1.0 to profile 100%
     # of profile sessions.
     profile_session_sample_rate=1.0,${
       traceLifecycle === 'trace'
         ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0
     # Set profile_lifecycle to "trace" to automatically
     # run the profiler on when there is an active transaction
     profile_lifecycle="trace",`
         : ''
     }`
-        : `# Set profiles_sample_rate to 1.0 to profile 100%
+        : `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0
+    # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.
     profiles_sample_rate=1.0`


### PR DESCRIPTION
Update node profiling docs to use manual profiling lifecycle.

<img width="503" alt="Screenshot 2025-04-10 at 17 07 32" src="https://github.com/user-attachments/assets/8e4cf60d-e361-42a7-866d-662eefb5f537" />
