### PR TITLE
fix(ourlogs): Hide disallowed attributes from keys

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -29,7 +29,7 @@ from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.search.eap.utils import translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
@@ -161,7 +161,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 [
                     as_attribute_key(attribute.name, serialized["attribute_type"], trace_item_type)
                     for attribute in rpc_response.attributes
-                    if attribute.name
+                    if attribute.name and can_expose_attribute(attribute.name, trace_item_type)
                 ],
             ],
             max_limit=max_attributes,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -131,6 +131,10 @@ def translate_internal_to_public_alias(
     return mapping.get(internal_alias)
 
 
+def can_expose_attribute(attribute: str, item_type: SupportedTraceItemType) -> bool:
+    return attribute not in PRIVATE_ATTRIBUTES.get(item_type, {})
+
+
 def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:
     if meta.tier in {
         DownsampledStorageMeta.SELECTED_TIER_1,

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -131,6 +131,26 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
         keys = {item["key"] for item in response.data}
         assert keys == {"severity_text", "message", "project"}
 
+    def test_disallowed_attributes(self):
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "sentry.item_type": {"string_value": "value1"},  # Disallowed
+                    "sentry.item_type2": {"string_value": "value2"},  # Allowed
+                },
+            ),
+        ]
+
+        self.store_ourlogs(logs)
+
+        response = self.do_request()
+
+        assert response.status_code == 200, response.content
+        keys = {item["key"] for item in response.data}
+        assert keys == {"severity_text", "message", "project", "sentry.item_type2"}
+
 
 class OrganizationTraceItemAttributeValuesEndpointTest(OrganizationEventsEndpointTestBase):
     viewname = "sentry-api-0-organization-trace-item-attribute-values"


### PR DESCRIPTION
We were still emitting  etc. which we shouldn't, since we don't accept it sent via values.

Fixes SENTRY-3RXG
