### PR TITLE
fix(profiling-onboarding): Display framework gem in install

### DIFF
--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -6,7 +6,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {profilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
+import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -134,7 +134,7 @@ const onboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
-  profilingOnboarding,
+  profilingOnboarding: getRubyProfilingOnboarding(),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -14,7 +14,7 @@ import {
   feedbackOnboardingJsLoader,
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
-import {profilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
+import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -206,7 +206,7 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
-  profilingOnboarding,
+  profilingOnboarding: getRubyProfilingOnboarding({frameworkPackage: 'sentry-rails'}),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/ruby/ruby.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.tsx
@@ -10,7 +10,9 @@ import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
 
-export const profilingOnboarding = {
+export const getRubyProfilingOnboarding = ({
+  frameworkPackage,
+}: {frameworkPackage?: string} = {}) => ({
   install: () => [
     {
       type: StepType.INSTALL,
@@ -24,7 +26,7 @@ export const profilingOnboarding = {
       configurations: [
         {
           description: tct(
-            'First add [code:stackprof] to your [code:Gemfile] and make sure it is loaded before [code:sentry-ruby].',
+            'First add [code:stackprof] to your [code:Gemfile] and make sure it is loaded before the Sentry SDK.',
             {
               code: <code />,
             }
@@ -32,7 +34,12 @@ export const profilingOnboarding = {
           language: 'ruby',
           code: `
 gem 'stackprof'
-gem 'sentry-ruby'`,
+gem 'sentry-ruby'${
+            frameworkPackage
+              ? `
+gem '${frameworkPackage}'`
+              : ''
+          }`,
         },
       ],
     },
@@ -68,7 +75,7 @@ end
     },
   ],
   verify: () => [],
-};
+});
 
 const getInstallSnippet = (params: Params) =>
   `${params.isProfilingSelected ? 'gem "stackprof"\n' : ''}gem "sentry-ruby"`;
@@ -182,7 +189,7 @@ const onboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
-  profilingOnboarding,
+  profilingOnboarding: getRubyProfilingOnboarding(),
 };
 
 export default docs;


### PR DESCRIPTION
Also list the framework specific gem in the install section.

<img width="511" alt="Screenshot 2025-04-10 at 17 25 04" src="https://github.com/user-attachments/assets/0d26ce7e-6cdb-46e2-9500-569a7608a0f0" />
