### PR TITLE
chore(aci milestone 3): logs for metric alert dual processing

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -480,6 +480,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable firing actions for workflow engine issue alerts
     manager.add("organizations:workflow-engine-trigger-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable logs to debug metric alert dual processing
+    manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -428,7 +428,16 @@ class SubscriptionProcessor:
             data_packet = DataPacket[MetricDetectorUpdate](
                 source_id=str(self.subscription.id), packet=packet
             )
-            process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+            results = process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+            if features.has(
+                "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                self.alert_rule.organization,
+            ):
+                logger.info(
+                    "dual processing results for alert rule %s",
+                    self.alert_rule.id,
+                    extra={"results": results},
+                )
 
         has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization


### PR DESCRIPTION
After enabling metric issues, we still aren't processing workflows. Add some logs to verify detector processing output.