### PR TITLE
theme: prefer theme.border vs direct gray

### DIFF
--- a/static/app/components/carousel.tsx
+++ b/static/app/components/carousel.tsx
@@ -103,7 +103,7 @@ const StyledArrowButton = styled(Button)<{direction: string}>`
   height: 36px;
   width: 36px;
   border-radius: 50%;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   padding: 0;
   margin: auto;
   background-color: ${p => p.theme.background};

--- a/static/app/components/core/checkbox/index.tsx
+++ b/static/app/components/core/checkbox/index.tsx
@@ -107,7 +107,7 @@ const NativeHiddenCheckbox = withChonk(
     & + * {
       box-shadow: ${p => p.theme.dropShadowMedium} inset;
       color: ${p => p.theme.textColor};
-      border: 1px solid ${p => p.theme.gray200};
+      border: 1px solid ${p => p.theme.border};
 
       svg {
         stroke: ${p => p.theme.white};

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1906,7 +1906,7 @@ const MonoBlock = styled('code')`
   padding: ${space(0.25)} ${space(0.5)};
   color: ${p => p.theme.gray400};
   background: ${p => p.theme.gray100};
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-weight: ${p => p.theme.fontWeightNormal};

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -117,7 +117,7 @@ export const RadioItem = styled('label', {shouldForwardProp})<{
   cursor: ${p => (p.disabled ? 'default' : 'pointer')};
   outline: none;
   font-weight: ${p => p.theme.fontWeightNormal};
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   margin: 0;
 
   &[aria-checked='true'] {

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -356,7 +356,7 @@ const TopFrameworkIcon = styled(PlatformIcon, {
   position: absolute;
   top: 50%;
   left: 50%;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
 `;
 
 const TopFrameworksImageWrapper = styled('div')`

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -277,7 +277,7 @@ const StyledSearchBar = styled(SearchBar)`
 
 const StyledPlatformIcon = styled(PlatformIcon)`
   margin: ${space(2)};
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 `;
 

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -67,7 +67,7 @@ function AddIntegrationRow({onClick}: Props) {
 const RowWrapper = styled('div')`
   display: flex;
   border-radius: 4px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   justify-content: space-between;
   align-items: center;
   padding: ${space(3)} ${space(4)};

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -123,7 +123,7 @@ const Flex = styled('div')`
 const PerformanceScoreLabelContainer = styled('div')`
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
   min-width: 320px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   display: flex;
   align-items: center;

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -349,7 +349,7 @@ const PerformanceScoreRingTooltip = styled('div')<{x: number; y: number}>`
   position: absolute;
   background: ${p => p.theme.backgroundElevated};
   border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   transform: translate3d(${p => p.x - 100}px, ${p => p.y - 74}px, 0px);
   padding: ${space(1)} ${space(2)};
   width: 200px;

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -245,7 +245,7 @@ const MeterBarContainer = styled('div')<{clickable?: boolean}>`
 `;
 
 const MeterBarBody = styled('div')`
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   border-bottom: none;
   padding: ${space(1)} 0 ${space(0.5)} 0;

--- a/static/app/views/insights/mobile/screens/components/vitalCard.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalCard.tsx
@@ -56,7 +56,7 @@ const MeterBarContainer = styled('div')<{clickable?: boolean}>`
 `;
 
 const MeterBarBody = styled('div')`
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   border-bottom: none;
   padding: ${space(1)} 0 ${space(0.5)} 0;

--- a/static/app/views/issueList/issueViews/issueViewEllipsisMenu.tsx
+++ b/static/app/views/issueList/issueViews/issueViewEllipsisMenu.tsx
@@ -103,7 +103,7 @@ const UnsavedChangesIndicator = styled('div')`
 const ButtonWrapper = styled('div')`
   width: 18px;
   height: 16px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: 4px;
 `;
 

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -108,7 +108,7 @@ const QueryCountBubble = styled(motion.span)`
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   color: ${p => p.theme.subText};
   margin-left: 0;
 `;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
@@ -188,7 +188,7 @@ const TriggerWrapper = styled(Button)`
   position: relative;
   width: 24px;
   height: 20px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   align-items: center;
   justify-content: center;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.tsx
@@ -102,7 +102,7 @@ const QueryCountBubble = styled(motion.span)`
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   color: ${p => p.theme.subText};
   margin-left: 0;
   font-weight: ${p => p.theme.fontWeightBold};

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -165,7 +165,7 @@ const ActionItem = styled(motion.div)`
   padding: ${space(2)};
   margin-bottom: ${space(2)};
   justify-content: space-around;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     display: grid;
     grid-template-columns: 125px auto 125px;

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -140,7 +140,7 @@ const VitalPillValue = styled('div')`
 
   height: 100%;
   padding: 0 ${space(0.5)};
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   border-left: none;
   border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
 

--- a/static/gsApp/hooks/integrationFeatures.tsx
+++ b/static/gsApp/hooks/integrationFeatures.tsx
@@ -279,7 +279,7 @@ const IntegrationFeatureGroup = styled((p: GroupProps) => {
 })`
   overflow: hidden;
   border-radius: 4px;
-  border: 1px solid ${p => p.theme.gray200};
+  border: 1px solid ${p => p.theme.border};
   margin-bottom: ${space(2)};
 `;
 


### PR DESCRIPTION
These used to be the same in the old theme, but that is no longer the case in chonk. We should prefer the semantic version instead of referencing the colors directly