### PR TITLE
fix(profiling-onboarding): Add tracesSampleRate to manual lifecycle

### DIFF
--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -259,19 +259,20 @@ Sentry.init({
     nodeProfilingIntegration(),
   ],${
     params.profilingOptions?.defaultProfilingMode === 'continuous'
-      ? `${
-          profilingLifecycle === 'trace'
-            ? `
+      ? profilingLifecycle === 'trace'
+        ? `
   // Tracing must be enabled for profiling to work
   tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profileSessionSampleRate: 1.0,
   // Trace lifecycle automatically enables profiling during active traces
   profileLifecycle: 'trace',`
-            : `
+        : `
+  // Tracing is not required for profiling to work
+  // but for the best experience we recommend enabling it
+  tracesSampleRate: 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profileSessionSampleRate: 1.0,`
-        }`
       : `
   // Tracing must be enabled for profiling to work
   tracesSampleRate: 1.0,

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -84,24 +84,28 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="${params.dsn.public}",${
       params.profilingOptions?.defaultProfilingMode === 'continuous'
-        ? `
-    # Set profile_session_sample_rate to 1.0 to profile 100%
-    # of profile sessions.
-    profile_session_sample_rate=1.0,${
-      traceLifecycle === 'trace'
-        ? `
+        ? traceLifecycle === 'trace'
+          ? `
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for tracing.
-    traces_sample_rate=1.0
+    traces_sample_rate=1.0,
+    # Set profile_session_sample_rate to 1.0 to profile 100%
+    # of profile sessions.
+    profile_session_sample_rate=1.0,
     # Set profile_lifecycle to "trace" to automatically
     # run the profiler on when there is an active transaction
-    profile_lifecycle="trace",`
-        : ''
-    }`
+    profile_lifecycle="trace"`
+          : `
+    # Tracing is not required for profiling to work
+    # but for the best experience we recommend enabling it
+    traces_sample_rate=1.0,
+    # Set profile_session_sample_rate to 1.0 to profile 100%
+    # of profile sessions.
+    profile_session_sample_rate=1.0`
         : `
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for tracing.
-    traces_sample_rate=1.0
+    traces_sample_rate=1.0,
     # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.


### PR DESCRIPTION
We want to recommend setting `tracesSampleRate` in the snippets even though it is not required when using manual lifecycle.