### PR TITLE
feat(auto_source): Make derived enhancments section read-only

### DIFF
--- a/static/app/views/settings/projectIssueGrouping/index.spec.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.spec.tsx
@@ -87,5 +87,8 @@ describe('projectIssueGrouping', () => {
 
     // Verify the section is visible for superuser
     expect(screen.getByText(/Derived Grouping Enhancements/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {name: /Derived Grouping Enhancements/})
+    ).toBeDisabled();
   });
 });

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -108,6 +108,7 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
             {...jsonFormProps}
             title={t('Derived Grouping Enhancements')}
             fields={[fields.derivedGroupingEnhancements]}
+            disabled
           />
         )}
       </Form>


### PR DESCRIPTION
In #88475 we added the modal but never made it read-only. The screenshot shows you can't edit the section.
![image](https://github.com/user-attachments/assets/3332ac9d-53f4-46d2-8b96-d85fbdc5f02f)
