### PR TITLE
chore(autofix): Remove unnecessary fields from get state endpoint response

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -124,7 +124,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             response_state["repositories"] = repositories
 
             # Remove unnecessary or sensitive data to reduce returned payload size
-            for key in ["request", "usage", "signals"]:
+            for key in ["usage", "signals"]:
                 response_state.pop(key, None)
+            if "request" in response_state and "issue" in response_state["request"]:
+                del response_state["request"]["issue"]
 
         return Response({"autofix": response_state})

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -123,4 +123,8 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
             response_state["repositories"] = repositories
 
+            # Remove unnecessary or sensitive data to reduce returned payload size
+            for key in ["request", "usage", "signals"]:
+                response_state.pop(key, None)
+
         return Response({"autofix": response_state})

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -42,7 +42,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is not None
         assert response.data["autofix"]["status"] == "PROCESSING"
-        assert "request" not in response.data["autofix"]
+        assert "issue" not in response.data["autofix"]["request"]
 
         mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -42,6 +42,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is not None
         assert response.data["autofix"]["status"] == "PROCESSING"
+        assert "request" not in response.data["autofix"]
 
         mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
 


### PR DESCRIPTION
Removes`request`, `usage`, and `signals` from returned Autofix state payload in the GET endpoint. This should reduce the payload size significantly while polling. I decided against doing this trimming within Seer because there are some parts within the Sentry backend that require `request` data.