### PR TITLE
feat(perf): Persist selected chart in query param

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
@@ -1,0 +1,55 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+import {EAPChartsWidget} from './eapChartsWidget';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useNavigate');
+jest.mock(
+  'sentry/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization'
+);
+
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+
+describe('EAPChartsWidget', function () {
+  const transactionName = 'test-transaction';
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    mockUseLocation.mockImplementation(() => LocationFixture());
+    mockUseNavigate.mockImplementation(() => mockNavigate);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockClear();
+  });
+
+  it('shows default widget type when no query param is provided', function () {
+    render(<EAPChartsWidget transactionName={transactionName} />);
+
+    // Default widget type should be DURATION_BREAKDOWN
+    expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+  });
+
+  it('shows default widget when invalid query param is provided', function () {
+    mockUseLocation.mockImplementation(() =>
+      LocationFixture({
+        query: {
+          chartDisplay: 'some_widget_that_does_not_exist',
+        },
+        pathname: '/test',
+      })
+    );
+
+    render(<EAPChartsWidget transactionName={transactionName} />);
+
+    // Should fallback to DURATION_BREAKDOWN
+    expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
@@ -1,43 +1,43 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {EAPChartsWidget} from './eapChartsWidget';
 
 jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-jest.mock(
-  'sentry/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization'
-);
 
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
-const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
 
 describe('EAPChartsWidget', function () {
   const transactionName = 'test-transaction';
-  const mockNavigate = jest.fn();
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     mockUseLocation.mockImplementation(() => LocationFixture());
-    mockUseNavigate.mockImplementation(() => mockNavigate);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+      status: 200,
+    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    mockNavigate.mockClear();
+    MockApiClient.clearMockResponses();
   });
 
-  it('shows default widget type when no query param is provided', function () {
+  it('shows default widget type when no query param is provided', async function () {
     render(<EAPChartsWidget transactionName={transactionName} />);
 
-    // Default widget type should be DURATION_BREAKDOWN
-    expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+    });
   });
 
-  it('shows default widget when invalid query param is provided', function () {
+  it('shows default widget when invalid query param is provided', async function () {
     mockUseLocation.mockImplementation(() =>
       LocationFixture({
         query: {
@@ -49,7 +49,8 @@ describe('EAPChartsWidget', function () {
 
     render(<EAPChartsWidget transactionName={transactionName} />);
 
-    // Should fallback to DURATION_BREAKDOWN
-    expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -78,15 +78,15 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const params = useLocationQuery({
+  const {
+    [SpanIndexedField.SPAN_CATEGORY]: spanCategoryUrlParam,
+    [SELECTED_CHART_QUERY_PARAM]: selectedChartUrlParam,
+  } = useLocationQuery({
     fields: {
       [SpanIndexedField.SPAN_CATEGORY]: decodeScalar,
       [SELECTED_CHART_QUERY_PARAM]: decodeScalar,
     },
   });
-
-  const spanCategoryUrlParam = params[SpanIndexedField.SPAN_CATEGORY];
-  const {chartDisplay: selectedChartUrlParam} = params;
 
   const selectedChart = WIDGET_OPTIONS[selectedChartUrlParam as EAPWidgetType]
     ? (selectedChartUrlParam as EAPWidgetType)

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -7,6 +7,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 import {useWidgetChartVisualization} from 'sentry/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization';
 
 export enum EAPWidgetType {
@@ -79,12 +80,12 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
 
   const params = useLocationQuery({
     fields: {
-      'span.category': decodeScalar,
-      chartDisplay: decodeScalar,
+      [SpanIndexedField.SPAN_CATEGORY]: decodeScalar,
+      [SELECTED_CHART_QUERY_PARAM]: decodeScalar,
     },
   });
 
-  const spanCategoryUrlParam = params['span.category'];
+  const spanCategoryUrlParam = params[SpanIndexedField.SPAN_CATEGORY];
   const {chartDisplay: selectedChartUrlParam} = params;
 
   const selectedChart = WIDGET_OPTIONS[selectedChartUrlParam as EAPWidgetType]

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -3,10 +3,10 @@ import {useMemo} from 'react';
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {SpanIndexedField} from 'sentry/views/insights/types';
 import {useWidgetChartVisualization} from 'sentry/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization';
 
 export enum EAPWidgetType {
@@ -77,12 +77,15 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
-  const selectedChartUrlParam = decodeScalar(
-    location.query?.[SELECTED_CHART_QUERY_PARAM]
-  );
+  const params = useLocationQuery({
+    fields: {
+      'span.category': decodeScalar,
+      chartDisplay: decodeScalar,
+    },
+  });
+
+  const spanCategoryUrlParam = params['span.category'];
+  const {chartDisplay: selectedChartUrlParam} = params;
 
   const selectedChart = WIDGET_OPTIONS[selectedChartUrlParam as EAPWidgetType]
     ? (selectedChartUrlParam as EAPWidgetType)

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -114,6 +114,7 @@ export function EAPChartsWidget({transactionName}: EAPChartsWidgetProps) {
     <Widget
       Title={
         <CompactSelect
+          data-test-id="eap-charts-widget-select"
           options={options}
           value={selectedChart}
           onChange={handleChartChange}


### PR DESCRIPTION
Allows the currently selected chart in the new transaction summary to persist by storing it as a URL parameter. This will allow the chart to remain across refreshes and also when clicking into a link with the query param added. 