### PR TITLE
feat(explore): Add turbo mode feature flag for internal testing

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -470,6 +470,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:visibility-explore-progressive-loading", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable skipping preflight for EAP charts/tables, to be used in conjunction with visibility-explore-progressive-loading
     manager.add("organizations:visibility-explore-skip-preflight", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable turbo mode for EAP charts/tables, to be used in conjunction with visibility-explore-progressive-loading and visibility-explore-skip-preflight
+    manager.add("organizations:visibility-explore-turbo-mode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable explore multi query page
     manager.add("organizations:explore-multi-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled unresolved issue webhook for organization


### PR DESCRIPTION
We want to be able to toggle to the preflight data, so add a feature flag for me to add UI for specific users.