### PR TITLE
chore(lint): Remove `locale` from a test file

### DIFF
--- a/static/app/components/similarSpectrum.spec.tsx
+++ b/static/app/components/similarSpectrum.spec.tsx
@@ -2,19 +2,10 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import SimilarSpectrum from 'sentry/components/similarSpectrum';
 
-import {t} from '../locale';
-
 describe('SimilarSpectrum', function () {
-  beforeEach(function () {});
-
-  afterEach(function () {});
-
   it('renders', function () {
     render(
-      <SimilarSpectrum
-        highSpectrumLabel={t('Similar')}
-        lowSpectrumLabel={t('Not Similar')}
-      />
+      <SimilarSpectrum highSpectrumLabel={'Similar'} lowSpectrumLabel={'Not Similar'} />
     );
   });
 });


### PR DESCRIPTION
There's a lint rule complaining about this.