### PR TITLE
ci(eslint): Install no-relative-import-paths and warn when using `../…` in js import statements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ import prettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 import jest from 'eslint-plugin-jest';
 import jestDom from 'eslint-plugin-jest-dom';
+import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 // @ts-expect-error TS(7016): Could not find a declaration file
@@ -363,6 +364,21 @@ export default typescript.config([
       'import/no-named-as-default-member': 'off', // Disabled in favor of typescript-eslint
       'import/no-named-as-default': 'off', // TODO(ryan953): Fix violations and enable this rule
       'import/no-unresolved': 'off', // Disabled in favor of typescript-eslint
+    },
+  },
+  {
+    name: 'plugin/no-relative-import-paths',
+    // https://github.com/MelvinVermeer/eslint-plugin-no-relative-import-paths?tab=readme-ov-file#rule-options
+    plugins: {'no-relative-import-paths': noRelativeImportPaths},
+    rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'warn', // TODO(ryan953): Fix violations and enable this rule,
+        {
+          prefix: 'sentry',
+          rootDir: 'static/app',
+          allowSameFolder: true, // TODO(ryan953): followup and investigate `allowSameFolder`, maybe exceptions for *.spec.tsx files?
+        },
+      ],
     },
   },
   {
@@ -838,6 +854,14 @@ export default typescript.config([
     name: 'files/gsApp',
     files: ['static/gsApp/**/*.{js,mjs,ts,jsx,tsx}'],
     rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'warn', // TODO(ryan953): Fix violations and enable this rule,
+        {
+          prefix: 'getsentry',
+          rootDir: 'static/gsApp',
+          allowSameFolder: true, // TODO(ryan953): followup and investigate `allowSameFolder`, maybe exceptions for *.spec.tsx files?
+        },
+      ],
       'no-restricted-imports': [
         'error',
         {
@@ -866,6 +890,14 @@ export default typescript.config([
     name: 'files/gsAdmin',
     files: ['static/gsAdmin/**/*.{js,mjs,ts,jsx,tsx}'],
     rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'warn', // TODO(ryan953): Fix violations and enable this rule,
+        {
+          prefix: 'admin',
+          rootDir: 'static/gsAdmin',
+          allowSameFolder: true, // TODO(ryan953): followup and investigate `allowSameFolder`, maybe exceptions for *.spec.tsx files?
+        },
+      ],
       'no-restricted-imports': [
         'error',
         {

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-jest-dom": "^5.5.0",
+    "eslint-plugin-no-relative-import-paths": "^1.6.1",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-sentry": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6699,6 +6699,11 @@ eslint-plugin-jest@^28.11.0:
   dependencies:
     "@typescript-eslint/utils" "^6.0.0 || ^7.0.0 || ^8.0.0"
 
+eslint-plugin-no-relative-import-paths@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.6.1.tgz#7d1e8f34694016d6d390c28063bedfa7203e7771"
+  integrity sha512-YZNeOnsOrJcwhFw0X29MXjIzu2P/f5X2BZDPWw1R3VUYBRFxNIh77lyoL/XrMU9ewZNQPcEvAgL/cBOT1P330A==
+
 eslint-plugin-react-hooks@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz#1be0080901e6ac31ce7971beed3d3ec0a423d9e3"


### PR DESCRIPTION
Just the new rule, set to warn. Trying to avoid conflicts and failing CI

https://github.com/MelvinVermeer/eslint-plugin-no-relative-import-paths?tab=readme-ov-file#rule-options