### PR TITLE
fix(taskworker) Reject nested structures in activation headers

### DIFF
--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -137,6 +137,18 @@ class Task(Generic[P, R]):
             "baggage": sentry_sdk.get_baggage() or "",
             **headers,
         }
+        # Monitor config is patched in by the sentry_sdk
+        # however, taskworkers do not support the nested object,
+        # nor do they use it when creating checkins.
+        if "sentry-monitor-config" in headers:
+            del headers["sentry-monitor-config"]
+
+        for key, value in headers.items():
+            if not isinstance(value, (str, bytes, int, bool, float)):
+                raise ValueError(
+                    "Only scalar header values are supported. "
+                    f"The `{key}` header value is of type {type(value)}"
+                )
 
         return TaskActivation(
             id=uuid4().hex,

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -270,9 +270,9 @@ def test_create_activation_headers_monitor_config_treatment(task_namespace: Task
     }
     activation = with_parameters.create_activation(["one", 22], {"org_id": 99}, headers)
 
-    headers = activation.headers
-    assert headers
-    assert headers["key"] == "value"
-    assert "sentry-monitor-config" not in headers
-    assert "sentry-monitor-slug" in headers
-    assert "sentry-monitor-check-in-id" in headers
+    result = activation.headers
+    assert result
+    assert result["key"] == "value"
+    assert "sentry-monitor-config" not in result
+    assert "sentry-monitor-slug" in result
+    assert "sentry-monitor-check-in-id" in result

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -235,3 +235,44 @@ def test_create_activation_headers(task_namespace: TaskNamespace) -> None:
     assert headers["sentry-trace"]
     assert "baggage" in headers
     assert headers["key"] == "value"
+
+
+def test_create_activation_headers_nested(task_namespace: TaskNamespace) -> None:
+    @task_namespace.register(name="test.parameters")
+    def with_parameters(one: str, two: int, org_id: int) -> None:
+        raise NotImplementedError
+
+    headers = {
+        "key": "value",
+        "nested": {
+            "name": "sentry",
+        },
+    }
+    with pytest.raises(ValueError) as err:
+        with_parameters.create_activation(["one", 22], {"org_id": 99}, headers)
+    assert "Only scalar header values are supported" in str(err)
+    assert "The `nested` header value is of type <class 'dict'>" in str(err)
+
+
+def test_create_activation_headers_monitor_config_treatment(task_namespace: TaskNamespace) -> None:
+    @task_namespace.register(name="test.parameters")
+    def with_parameters(one: str, two: int, org_id: int) -> None:
+        raise NotImplementedError
+
+    headers = {
+        "key": "value",
+        "sentry-monitor-config": {
+            "schedule": {"type": "crontab", "value": "*/15 * * * *"},
+            "timezone": "UTC",
+        },
+        "sentry-monitor-slug": "delete-stuff",
+        "sentry-monitor-check-in-id": "abc123",
+    }
+    activation = with_parameters.create_activation(["one", 22], {"org_id": 99}, headers)
+
+    headers = activation.headers
+    assert headers
+    assert headers["key"] == "value"
+    assert "sentry-monitor-config" not in headers
+    assert "sentry-monitor-slug" in headers
+    assert "sentry-monitor-check-in-id" in headers


### PR DESCRIPTION
Add special casing for the sentry_sdk structured headers for monitors, and reject all over nested data structures.

Refs SENTRY-FOR-SENTRY-AJW
