### PR TITLE
feat(insights): Rename Errored Sessions chart to Unhealthy Sessions

### DIFF
--- a/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
@@ -21,7 +21,7 @@ export default function UnhealthySessionsChart() {
       )}
       height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
-        'The percent of sessions terminating without a single error occurring. See [link:session status].',
+        'The percent of sessions ending normally and no errors occurred during its lifetime. See [link:session status].',
         {
           link: (
             <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />

--- a/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
@@ -6,7 +6,7 @@ import useErroredSessions from 'sentry/views/insights/sessions/queries/useErrore
 import {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
 import {SESSION_HEALTH_CHART_HEIGHT} from 'sentry/views/insights/sessions/utils/sessions';
 
-export default function ErroredSessionsChart() {
+export default function UnhealthySessionsChart() {
   const {series, isPending, error} = useErroredSessions();
 
   const aliases = {
@@ -15,9 +15,9 @@ export default function ErroredSessionsChart() {
 
   return (
     <InsightsLineChartWidget
-      title={CHART_TITLES.ErroredSessionsChart}
+      title={CHART_TITLES.UnhealthySessionsChart}
       interactiveTitle={() => (
-        <ChartSelectionTitle title={CHART_TITLES.ErroredSessionsChart} />
+        <ChartSelectionTitle title={CHART_TITLES.UnhealthySessionsChart} />
       )}
       height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(

--- a/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/unhealthySessionsChart.tsx
@@ -21,7 +21,7 @@ export default function UnhealthySessionsChart() {
       )}
       height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
-        'The percent of sessions ending normally and no errors occurred during its lifetime. See [link:session status].',
+        'The percent of sessions ending normally, with no errors occurring during its lifetime. See [link:session status].',
         {
           link: (
             <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />

--- a/static/app/views/insights/sessions/components/chartMap.tsx
+++ b/static/app/views/insights/sessions/components/chartMap.tsx
@@ -3,13 +3,13 @@ import type {ReactElement} from 'react';
 import type {Project} from 'sentry/types/project';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import CrashFreeSessionsChart from 'sentry/views/insights/sessions/charts/crashFreeSessionsChart';
-import ErroredSessionsChart from 'sentry/views/insights/sessions/charts/erroredSessionsChart';
 import NewAndResolvedIssueChart from 'sentry/views/insights/sessions/charts/newAndResolvedIssueChart';
 import ReleaseNewIssuesChart from 'sentry/views/insights/sessions/charts/releaseNewIssuesChart';
 import ReleaseSessionCountChart from 'sentry/views/insights/sessions/charts/releaseSessionCountChart';
 import ReleaseSessionPercentageChart from 'sentry/views/insights/sessions/charts/releaseSessionPercentageChart';
 import SessionHealthCountChart from 'sentry/views/insights/sessions/charts/sessionHealthCountChart';
 import SessionHealthRateChart from 'sentry/views/insights/sessions/charts/sessionHealthRateChart';
+import UnhealthySessionsChart from 'sentry/views/insights/sessions/charts/unhealthySessionsChart';
 import UserHealthCountChart from 'sentry/views/insights/sessions/charts/userHealthCountChart';
 import UserHealthRateChart from 'sentry/views/insights/sessions/charts/userHealthRateChart';
 import type {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
@@ -19,7 +19,7 @@ export const CHART_MAP: Record<
   (props: {project: Project}) => ReactElement
 > = {
   CrashFreeSessionsChart,
-  ErroredSessionsChart,
+  UnhealthySessionsChart,
   NewAndResolvedIssueChart,
   ReleaseNewIssuesChart,
   ReleaseSessionCountChart,
@@ -32,7 +32,8 @@ export const CHART_MAP: Record<
 
 export const CHART_RENAMES: Record<string, keyof typeof CHART_TITLES> = {
   // Map from the old name to the new
-  ErrorFreeSessionsChart: 'ErroredSessionsChart',
+  ErrorFreeSessionsChart: 'UnhealthySessionsChart',
+  ErroredSessionsChart: 'UnhealthySessionsChart',
 };
 
 export const PAGE_CHART_OPTIONS: Record<
@@ -42,7 +43,7 @@ export const PAGE_CHART_OPTIONS: Record<
   frontend: [
     // ORDER MATTERS HERE
     // The order things are listed is the order rendered
-    'ErroredSessionsChart',
+    'UnhealthySessionsChart',
     'NewAndResolvedIssueChart',
     'SessionHealthCountChart',
     'SessionHealthRateChart',
@@ -72,7 +73,7 @@ export const DEFAULT_LAYOUTS: Record<
   frontend: [
     // ORDER MATTERS HERE
     // The order represents the default chart layout for Frontend > Session Health
-    'ErroredSessionsChart',
+    'UnhealthySessionsChart',
     'UserHealthRateChart',
     'SessionHealthRateChart',
     'SessionHealthCountChart',

--- a/static/app/views/insights/sessions/settings.ts
+++ b/static/app/views/insights/sessions/settings.ts
@@ -12,7 +12,7 @@ export const MODULE_VISIBLE_FEATURES = ['insights-session-health-tab-ui'];
 
 export const CHART_TITLES = {
   CrashFreeSessionsChart: t('Crash Free Sessions'),
-  ErroredSessionsChart: t('Errored Sessions'),
+  ErroredSessionsChart: t('Unheathly Sessions'),
   NewAndResolvedIssueChart: t('Issues'),
   ReleaseNewIssuesChart: t('New Issues by Release'),
   ReleaseSessionCountChart: t('Total Sessions by Release'),

--- a/static/app/views/insights/sessions/settings.ts
+++ b/static/app/views/insights/sessions/settings.ts
@@ -12,7 +12,7 @@ export const MODULE_VISIBLE_FEATURES = ['insights-session-health-tab-ui'];
 
 export const CHART_TITLES = {
   CrashFreeSessionsChart: t('Crash Free Sessions'),
-  ErroredSessionsChart: t('Unhealthy Sessions'),
+  UnhealthySessionsChart: t('Unhealthy Sessions'),
   NewAndResolvedIssueChart: t('Issues'),
   ReleaseNewIssuesChart: t('New Issues by Release'),
   ReleaseSessionCountChart: t('Total Sessions by Release'),

--- a/static/app/views/insights/sessions/settings.ts
+++ b/static/app/views/insights/sessions/settings.ts
@@ -12,7 +12,7 @@ export const MODULE_VISIBLE_FEATURES = ['insights-session-health-tab-ui'];
 
 export const CHART_TITLES = {
   CrashFreeSessionsChart: t('Crash Free Sessions'),
-  ErroredSessionsChart: t('Unheathly Sessions'),
+  ErroredSessionsChart: t('Unhealthy Sessions'),
   NewAndResolvedIssueChart: t('Issues'),
   ReleaseNewIssuesChart: t('New Issues by Release'),
   ReleaseSessionCountChart: t('Total Sessions by Release'),


### PR DESCRIPTION
Followup to a comment here: https://github.com/getsentry/sentry/pull/89315/files#r2038106208

