### PR TITLE
fix(aci milestone 3): make dual processing logs more informative

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -436,7 +436,11 @@ class SubscriptionProcessor:
                 logger.info(
                     "dual processing results for alert rule %s",
                     self.alert_rule.id,
-                    extra={"results": results},
+                    extra={
+                        "results": results,
+                        "num_results": len(results),
+                        "value": aggregation_value,
+                    },
                 )
 
         has_anomaly_detection = features.has(


### PR DESCRIPTION
Allow filtering for non-empty results + add aggregation value to logs