### PR TITLE
ref(insights): clarify which releases are shown in mobile charts

### DIFF
--- a/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionsChart.tsx
@@ -25,7 +25,7 @@ export default function CrashFreeSessionsChart() {
       )}
       height={SESSION_HEALTH_CHART_HEIGHT}
       description={tct(
-        'The percent of sessions terminating without a crash. See [link:session status].',
+        'The percent of sessions terminating without a crash. See [link:session status]. The 5 most adopted releases are shown.',
         {
           link: (
             <ExternalLink href="https://docs.sentry.io/product/releases/health/#session-status" />

--- a/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
+++ b/static/app/views/insights/sessions/charts/releaseNewIssuesChart.tsx
@@ -30,7 +30,9 @@ export default function ReleaseNewIssuesChart({project}: {project: Project}) {
       )}
       project={project}
       series={series}
-      description={t('New issue counts over time, grouped by release.')}
+      description={t(
+        `New issue counts over time, grouped by release. The 5 most recent releases are shown, and the rest are grouped into 'other'.`
+      )}
       isPending={isPending}
       error={error}
       legendSelection={{

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -5,7 +5,7 @@ import {getSessionsInterval} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
+import useSessionProjectTotal from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useCrashFreeSessions() {
@@ -44,7 +44,7 @@ export default function useCrashFreeSessions() {
     {staleTime: 0}
   );
 
-  const projectTotal = useSessionAdoptionRate();
+  const projectTotal = useSessionProjectTotal();
 
   if (isPending || !sessionData) {
     return {
@@ -108,7 +108,7 @@ export default function useCrashFreeSessions() {
     }
   });
 
-  // Get top 5 releases
+  // Get top 5 releases based on highest adoption rate (most sessions out of the project total)
   const topReleases = Array.from(releaseAdoptionMap.entries())
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5)


### PR DESCRIPTION
add information about which 5 releases are shown. some charts had this in the tooltip already