### PR TITLE
feat(options): Add a default level of indentation when generating flagpole config

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -187,7 +187,10 @@ class Feature:
         return {self.name: dict_data}
 
     def to_yaml_str(self) -> str:
-        return yaml.dump(self.to_dict())
+        # Add an extra level of indentation by adding a top level dummy config.
+        # This makes it easier to paste the results into options automator
+        dump = yaml.dump({"dummy": self.to_dict()})
+        return "\n".join(dump.split("\n")[1:])
 
     def to_json_str(self) -> str:
         return orjson.dumps(self.to_dict()).decode()


### PR DESCRIPTION
Right now, we don't generate any indentation for our outputted flags. This is a little annoying when copying into options automator, since we need one level of indentation there. It's a bit error prone too, because it's easy to miss if you're just pasting in config.

To work around this, just add a fake default top level key, and strip it out from the output.