### PR TITLE
fix(aci): don't cast percentage frequency to int in delayed workflow processing

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -233,14 +233,17 @@ def create_latest_adopted_release_data_condition(
 
 
 def create_base_event_frequency_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup, count_type: Condition, percent_type: Condition
+    value: int | float,
+    data: dict[str, Any],
+    dcg: DataConditionGroup,
+    count_type: Condition,
+    percent_type: Condition,
 ) -> DataConditionKwargs:
     comparison_type = data.get(
         "comparisonType", ComparisonType.COUNT
     )  # this is camelCase, age comparison is snake_case
     comparison_type = ComparisonType(comparison_type)
 
-    value = int(data["value"])
     value = max(value, 0)  # force to 0 if negative
     comparison = {
         "interval": data["interval"],
@@ -264,7 +267,9 @@ def create_base_event_frequency_data_condition(
 def create_event_frequency_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
+    value = int(data["value"])
     return create_base_event_frequency_data_condition(
+        value=value,
         data=data,
         dcg=dcg,
         count_type=Condition.EVENT_FREQUENCY_COUNT,
@@ -275,7 +280,9 @@ def create_event_frequency_data_condition(
 def create_event_unique_user_frequency_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
+    value = int(data["value"])
     return create_base_event_frequency_data_condition(
+        value=value,
         data=data,
         dcg=dcg,
         count_type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
@@ -286,29 +293,13 @@ def create_event_unique_user_frequency_data_condition(
 def create_percent_sessions_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
-    comparison_type = data.get(
-        "comparisonType", ComparisonType.COUNT
-    )  # this is camelCase, age comparison is snake_case
-    comparison_type = ComparisonType(comparison_type)
-
     value = float(data["value"])
-    value = max(value, 0)  # force to 0 if negative
-    comparison = {
-        "interval": data["interval"],
-        "value": value,
-    }
-
-    if comparison_type == ComparisonType.COUNT:
-        type = Condition.PERCENT_SESSIONS_COUNT
-    else:
-        type = Condition.PERCENT_SESSIONS_PERCENT
-        comparison["comparison_interval"] = data["comparisonInterval"]
-
-    return DataConditionKwargs(
-        type=type,
-        comparison=comparison,
-        condition_result=True,
-        condition_group=dcg,
+    return create_base_event_frequency_data_condition(
+        value=value,
+        data=data,
+        dcg=dcg,
+        count_type=Condition.PERCENT_SESSIONS_COUNT,
+        percent_type=Condition.PERCENT_SESSIONS_PERCENT,
     )
 
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -240,7 +240,8 @@ def create_base_event_frequency_data_condition(
     )  # this is camelCase, age comparison is snake_case
     comparison_type = ComparisonType(comparison_type)
 
-    value = max(int(data["value"]), 0)  # force to 0 if negative
+    value = int(data["value"])
+    value = max(value, 0)  # force to 0 if negative
     comparison = {
         "interval": data["interval"],
         "value": value,
@@ -285,11 +286,29 @@ def create_event_unique_user_frequency_data_condition(
 def create_percent_sessions_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
-    return create_base_event_frequency_data_condition(
-        data=data,
-        dcg=dcg,
-        count_type=Condition.PERCENT_SESSIONS_COUNT,
-        percent_type=Condition.PERCENT_SESSIONS_PERCENT,
+    comparison_type = data.get(
+        "comparisonType", ComparisonType.COUNT
+    )  # this is camelCase, age comparison is snake_case
+    comparison_type = ComparisonType(comparison_type)
+
+    value = float(data["value"])
+    value = max(value, 0)  # force to 0 if negative
+    comparison = {
+        "interval": data["interval"],
+        "value": value,
+    }
+
+    if comparison_type == ComparisonType.COUNT:
+        type = Condition.PERCENT_SESSIONS_COUNT
+    else:
+        type = Condition.PERCENT_SESSIONS_PERCENT
+        comparison["comparison_interval"] = data["comparisonInterval"]
+
+    return DataConditionKwargs(
+        type=type,
+        comparison=comparison,
+        condition_result=True,
+        condition_group=dcg,
     )
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -446,8 +446,8 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
 
     def test_dual_write_count__value_floor(self):
         # forces negative to zero for migration
-        self.payload["value"] = -1
-        self._test_dual_write_count(0)
+        self.payload["value"] = 0  # expected
+        self._test_dual_write_count(-1)
 
     def _test_dual_write_percent(self, value):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})
@@ -473,8 +473,8 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
 
     def test_dual_write_count__percent_floor(self):
         # forces negative to zero for migration
-        self.payload["value"] = -1
-        self._test_dual_write_percent(0)
+        self.payload["value"] = 0  # expected
+        self._test_dual_write_percent(-1)
 
     def test_dual_write__invalid(self):
         with pytest.raises(KeyError):

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -25,7 +25,7 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.condition = Condition.EVENT_FREQUENCY_COUNT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "1h",
             "id": EventFrequencyCondition.id,
             "value": 50,
@@ -74,14 +74,14 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         results = [dc.comparison["value"] - 1]
         self.assert_slow_condition_does_not_pass(dc, results)
 
-    def _test_dual_write(self, value: int):
+    def _test_dual_write(self, value):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {
             "interval": self.payload["interval"],
-            "value": value,
+            "value": self.payload["value"],
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
@@ -93,22 +93,21 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         assert dc.type == self.condition
         assert dc.comparison == {
             "interval": self.payload["interval"],
-            "value": value,
+            "value": self.payload["value"],
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
     def test_dual_write_count(self):
-        self._test_dual_write(int(self.payload["value"]))
+        self._test_dual_write(self.payload["value"])
 
     def test_dual_write_count__string_value(self):
-        self.payload["value"] = str(self.payload["value"])
-        self._test_dual_write(int(self.payload["value"]))
+        self._test_dual_write(str(self.payload["value"]))
 
     def test_dual_write__value_floor(self):
         # forces negative to zero for migration
-        self.payload["value"] = -1
-        self._test_dual_write(0)
+        self.payload["value"] = 0  # expected value
+        self._test_dual_write(-1)
 
     def test_json_schema(self):
         with pytest.raises(ValidationError):
@@ -161,7 +160,7 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
 class TestEventFrequencyPercentCondition(ConditionTestCase):
     def setUp(self):
         self.condition = Condition.EVENT_FREQUENCY_PERCENT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "1h",
             "id": EventFrequencyCondition.id,
             "value": 50,
@@ -218,30 +217,29 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         results = [10, 10]
         self.assert_slow_condition_does_not_pass(dc, results)
 
-    def _test_dual_write(self, value: int):
+    def _test_dual_write(self, value):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {
             "interval": self.payload["interval"],
-            "value": value,
+            "value": self.payload["value"],
             "comparison_interval": self.payload["comparisonInterval"],
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
     def test_dual_write_percent(self):
-        self._test_dual_write(int(self.payload["value"]))
+        self._test_dual_write(self.payload["value"])
 
     def test_dual_write_percent__string_value(self):
-        self.payload["value"] = str(self.payload["value"])
-        self._test_dual_write(int(self.payload["value"]))
+        self._test_dual_write(str(self.payload["value"]))
 
     def test_dual_write__value_floor(self):
         # forces negative to zero for migration
-        self.payload["value"] = -1
-        self._test_dual_write(0)
+        self.payload["value"] = 0  # expected value
+        self._test_dual_write(-1)
 
     def test_json_schema(self):
         with pytest.raises(ValidationError):
@@ -318,7 +316,7 @@ class TestEventUniqueUserFrequencyCountCondition(TestEventFrequencyCountConditio
     def setUp(self):
         super().setUp()
         self.condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "1h",
             "id": EventUniqueUserFrequencyCondition.id,
             "value": 50,
@@ -330,7 +328,7 @@ class TestEventUniqueUserFrequencyPercentCondition(TestEventFrequencyPercentCond
     def setUp(self):
         super().setUp()
         self.condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "1h",
             "id": EventUniqueUserFrequencyCondition.id,
             "value": 50,
@@ -343,10 +341,10 @@ class TestPercentSessionsCountCondition(TestEventFrequencyCountCondition):
     def setUp(self):
         super().setUp()
         self.condition = Condition.PERCENT_SESSIONS_COUNT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "30m",  # only percent sessions allows 30m
             "id": EventFrequencyPercentCondition.id,
-            "value": 17,
+            "value": 17.2,
             "comparisonType": ComparisonType.COUNT,
         }
         self.intervals = PERCENT_INTERVALS
@@ -363,10 +361,10 @@ class TestPercentSessionsPercentCondition(TestEventFrequencyPercentCondition):
     def setUp(self):
         super().setUp()
         self.condition = Condition.PERCENT_SESSIONS_PERCENT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "30m",  # only percent sessions allows 30m
             "id": EventFrequencyPercentCondition.id,
-            "value": 17,
+            "value": 17.2,
             "comparisonType": ComparisonType.PERCENT,
             "comparisonInterval": "1d",
         }
@@ -385,7 +383,7 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
     def setUp(self):
         super().setUp()
         self.condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
-        self.payload: dict[str, int | str] = {
+        self.payload: dict[str, str | int | float] = {
             "interval": "1h",
             "id": EventUniqueUserFrequencyConditionWithConditions.id,
             "value": 50,
@@ -426,7 +424,7 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
         ]
         self.dcg = self.create_data_condition_group()
 
-    def _test_dual_write_count(self, value: int):
+    def _test_dual_write_count(self, value):
         dc = create_event_unique_user_frequency_condition_with_conditions(
             self.payload, self.dcg, self.conditions
         )
@@ -434,25 +432,24 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
         assert dc.type == self.condition
         assert dc.comparison == {
             "interval": self.payload["interval"],
-            "value": value,
+            "value": self.payload["value"],
             "filters": self.expected_filters,
         }
         assert dc.condition_result is True
         assert dc.condition_group == self.dcg
 
     def test_dual_write_count(self):
-        self._test_dual_write_count(int(self.payload["value"]))
+        self._test_dual_write_count(self.payload["value"])
 
     def test_dual_write_count__string_value(self):
-        self.payload["value"] = str(self.payload["value"])
-        self._test_dual_write_count(int(self.payload["value"]))
+        self._test_dual_write_count(str(self.payload["value"]))
 
     def test_dual_write_count__value_floor(self):
         # forces negative to zero for migration
         self.payload["value"] = -1
         self._test_dual_write_count(0)
 
-    def _test_dual_write_percent(self, value: int):
+    def _test_dual_write_percent(self, value):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})
         dc = create_event_unique_user_frequency_condition_with_conditions(
             self.payload, self.dcg, self.conditions
@@ -461,7 +458,7 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
         assert dc.type == Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
         assert dc.comparison == {
             "interval": self.payload["interval"],
-            "value": value,
+            "value": self.payload["value"],
             "comparison_interval": self.payload["comparisonInterval"],
             "filters": self.expected_filters,
         }
@@ -469,11 +466,10 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
         assert dc.condition_group == self.dcg
 
     def test_dual_write_percent(self):
-        self._test_dual_write_percent(int(self.payload["value"]))
+        self._test_dual_write_percent(self.payload["value"])
 
     def test_dual_write_percent__string_value(self):
-        self.payload["value"] = str(self.payload["value"])
-        self._test_dual_write_percent(int(self.payload["value"]))
+        self._test_dual_write_percent(str(self.payload["value"]))
 
     def test_dual_write_count__percent_floor(self):
         # forces negative to zero for migration

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -528,7 +528,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         self.data_condition_groups = self.workflow1_dcgs + self.workflow2_dcgs + [self.detector_dcg]
         self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
         self.workflows_to_envs = {self.workflow1.id: self.environment.id, self.workflow2.id: None}
-        self.condition_group_results = {
+        self.condition_group_results: dict[UniqueConditionQuery, dict[int, int | float]] = {
             UniqueConditionQuery(
                 handler=EventFrequencyQueryHandler,
                 interval="1h",

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -20,6 +20,7 @@ from sentry.utils import json
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
     EventFrequencyQueryHandler,
     EventUniqueUserFrequencyQueryHandler,
+    QueryResult,
 )
 from sentry.workflow_engine.models import (
     Action,
@@ -528,7 +529,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         self.data_condition_groups = self.workflow1_dcgs + self.workflow2_dcgs + [self.detector_dcg]
         self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
         self.workflows_to_envs = {self.workflow1.id: self.environment.id, self.workflow2.id: None}
-        self.condition_group_results: dict[UniqueConditionQuery, dict[int, int | float]] = {
+        self.condition_group_results: dict[UniqueConditionQuery, QueryResult] = {
             UniqueConditionQuery(
                 handler=EventFrequencyQueryHandler,
                 interval="1h",


### PR DESCRIPTION
Workflow engine version of https://github.com/getsentry/sentry/pull/89194

Also fixes to allow storing non-integers as the comparison value.