### PR TITLE
fix(flags): fix missing scores and baselines in sandbox UI

### DIFF
--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.tsx
@@ -81,7 +81,7 @@ export default function FlagDrawerContent({
         <div>
           {`Suspicion Score: ${scoreObj?.score.toString() ?? '_'}`}
           <br />
-          {`Baseline Percent: ${scoreObj?.baseline_percent ? `${scoreObj.baseline_percent * 100}%` : '_'}`}
+          {`Baseline Percent: ${scoreObj?.baseline_percent === undefined ? '_' : `${scoreObj.baseline_percent * 100}%`}`}
         </div>
       );
     },

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -33,12 +33,12 @@ export function useGroupSuspectFlagScores({
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const query = Object.fromEntries(
-    [
-      ['environment', environment ?? selection.environments],
-      ['statsPeriod', statsPeriod],
-      ['start', start],
-      ['end', end],
-    ].filter(([_, value]) => !!value)
+    Object.entries({
+      environment: environment ?? selection.environments,
+      statsPeriod,
+      start,
+      end,
+    }).filter(([_, value]) => !!value)
   );
 
   return useApiQuery<SuspectFlagScoresResponse>(

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -38,7 +38,7 @@ export function useGroupSuspectFlagScores({
       statsPeriod,
       start,
       end,
-    }).filter(Boolean)
+    }).filter(([_, value]) => !!value)
   );
 
   return useApiQuery<SuspectFlagScoresResponse>(

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -13,7 +13,7 @@ type SuspectFlagScoresResponse = {
 };
 
 /**
- * Query all feature flags and their scores for a given issue. Defaults to page filters for datetime and environment params.
+ * Query all feature flags and their scores for a given issue. Defaults to page filters if environment is not provided.
  */
 export function useGroupSuspectFlagScores({
   groupId,
@@ -32,12 +32,14 @@ export function useGroupSuspectFlagScores({
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const query = {
-    environment: environment ?? selection.environments,
-    statsPeriod: statsPeriod ?? selection.datetime.period,
-    start: start ?? selection.datetime.start?.toString(),
-    end: end ?? selection.datetime.end?.toString(),
-  };
+  const query = Object.fromEntries(
+    [
+      ['environment', environment ?? selection.environments],
+      ['statsPeriod', statsPeriod],
+      ['start', start],
+      ['end', end],
+    ].filter(([_, value]) => !!value)
+  );
 
   return useApiQuery<SuspectFlagScoresResponse>(
     [`/organizations/${organization.slug}/issues/${groupId}/suspect/flags/`, {query}],

--- a/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/useGroupSuspectFlagScores.tsx
@@ -38,7 +38,7 @@ export function useGroupSuspectFlagScores({
       statsPeriod,
       start,
       end,
-    }).filter(([_, value]) => !!value)
+    }).filter(Boolean)
   );
 
   return useApiQuery<SuspectFlagScoresResponse>(


### PR DESCRIPTION
We shouldn't inherit the time range from URL params since these are persisted from issues stream. Like with `useGroupFeatureFlags`, we'll defer to the backend for the time range (whole issue lifetime).

