### PR TITLE
fix(tracing): Only show link to replays if there is a replayid

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -69,7 +69,10 @@ function ContextBadges({rootEventResults}: Pick<TitleProps, 'rootEventResults'>)
     return null;
   }
 
-  const replay_id = rootEventResults.data.contexts.replay?.[ReplayContextKey.REPLAY_ID];
+  const replayId = rootEventResults.data.contexts.replay?.[ReplayContextKey.REPLAY_ID];
+  if (!replayId) {
+    return null;
+  }
 
   return (
     <Fragment>
@@ -79,7 +82,7 @@ function ContextBadges({rootEventResults}: Pick<TitleProps, 'rootEventResults'>)
         priority="link"
         icon={<IconPlay size="xs" />}
         to={{
-          pathname: `/explore/replays/${replay_id}`,
+          pathname: `/explore/replays/${replayId}`,
         }}
         replace
         aria-label={t("View this issue's replays")}


### PR DESCRIPTION
**Before**
![SCR-20250410-ngrt](https://github.com/user-attachments/assets/ddc0d044-fba6-4616-a358-cf68e1073c87)

**After**
![SCR-20250410-ngsk](https://github.com/user-attachments/assets/be2c2398-ec0c-467a-8653-b5531461b83a)
