### PR TITLE
perf(tags): query GroupTags with a default time range

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from rest_framework.request import Request
@@ -53,7 +54,7 @@ class GroupTagsEndpoint(GroupEndpoint):
         start, end = get_date_range_from_params(request.GET, optional=True)
         if start is None or end is None:
             start = group.first_seen
-            end = group.last_seen
+            end = max(group.last_seen, group.first_seen + timedelta(seconds=1))
 
         tag_keys = backend.get_group_tag_keys_and_top_values(
             group,

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -12,6 +12,7 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_date_range_from_params
 from sentry.search.utils import DEVICE_CLASS
 
 if TYPE_CHECKING:
@@ -48,6 +49,11 @@ class GroupTagsEndpoint(GroupEndpoint):
                 value_limit = 10
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
+
+        start, end = get_date_range_from_params(request.GET, optional=True)
+        if start is None or end is None:
+            start = group.first_seen
+            end = group.last_seen
 
         tag_keys = backend.get_group_tag_keys_and_top_values(
             group,

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -62,6 +62,8 @@ class GroupTagsEndpoint(GroupEndpoint):
             keys=keys,
             value_limit=value_limit,
             tenant_ids={"organization_id": group.project.organization_id},
+            start=start,
+            end=end,
         )
 
         data = serialize(tag_keys, request.user)


### PR DESCRIPTION
Accept datetime params on this endpoint and default to first/last seen if they're not provided.