### PR TITLE
fix(autofix): Fix no repos notice rendering

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -122,6 +122,13 @@ describe('SeerDrawer', () => {
         headline: 'Test headline',
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: null,
+      },
+    });
   });
 
   it('renders consent state if not consented', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -235,6 +235,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         <SeerNotices
           groupId={group.id}
           hasGithubIntegration={aiConfig.hasGithubIntegration}
+          project={project}
         />
       )}
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -5,14 +5,17 @@ import onboardingInstall from 'sentry-images/spot/onboarding-install.svg';
 
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button';
+import {useProjectPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectPreferences';
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Project} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface SeerNoticesProps {
   groupId: string;
+  project: Project;
   hasGithubIntegration?: boolean;
 }
 
@@ -100,15 +103,26 @@ function SelectReposCard() {
   );
 }
 
-export function SeerNotices({groupId, hasGithubIntegration}: SeerNoticesProps) {
+export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNoticesProps) {
   const organization = useOrganization();
   const {repos} = useAutofixRepos(groupId);
+  const {
+    preference,
+    codeMappingRepos,
+    isLoading: isLoadingPreferences,
+  } = useProjectPreferences(project);
+
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
   const notices: React.JSX.Element[] = [];
 
   if (!hasGithubIntegration) {
     notices.push(<GithubIntegrationSetupCard key="github-setup" />);
-  } else if (repos.length === 0) {
+  } else if (
+    repos.length === 0 &&
+    !preference?.repositories &&
+    !codeMappingRepos &&
+    !isLoadingPreferences
+  ) {
     notices.push(<SelectReposCard key="repo-selection" />);
   }
 


### PR DESCRIPTION
Fixed logic for rendering "pick repos" notice so it doesn't show while the run is starting. Add tests to verify.