### PR TITLE
ref(flags): remove statsPeriod in flag details query

### DIFF
--- a/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -36,17 +36,6 @@ export function FlagDetailsDrawerContent() {
 
   const sortArrow = <IconArrow color="gray300" size="xs" direction="down" />;
 
-  const flagQuery = useMemo(() => {
-    return {
-      flag: tagKey,
-      per_page: 50,
-      queryReferrer: 'featureFlagDetailsDrawer',
-      statsPeriod: '90d',
-      sort: '-created_at',
-      cursor: location.query.flagDrawerCursor,
-    };
-  }, [tagKey, location.query.flagDrawerCursor]);
-
   const {
     data: flagLog,
     isPending,
@@ -54,7 +43,13 @@ export function FlagDetailsDrawerContent() {
     getResponseHeader,
   } = useOrganizationFlagLog({
     organization,
-    query: flagQuery,
+    query: {
+      flag: tagKey,
+      per_page: 50,
+      queryReferrer: 'featureFlagDetailsDrawer',
+      sort: '-created_at',
+      cursor: location.query.flagDrawerCursor,
+    },
   });
   const pageLinks = getResponseHeader?.('Link') ?? null;
 

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
@@ -45,7 +45,7 @@ export function FlagDetailsDrawerContent() {
     organization,
     query: {
       flag: tagKey,
-      per_page: 15,
+      per_page: 50,
       queryReferrer: 'featureFlagDetailsDrawer',
       sort: '-created_at',
       cursor: location.query.flagDrawerCursor,

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDetailsDrawerContent.tsx
@@ -45,7 +45,7 @@ export function FlagDetailsDrawerContent() {
     organization,
     query: {
       flag: tagKey,
-      per_page: 50,
+      per_page: 15,
       queryReferrer: 'featureFlagDetailsDrawer',
       sort: '-created_at',
       cursor: location.query.flagDrawerCursor,

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
@@ -51,7 +51,7 @@ export function OrganizationFeatureFlagsAuditLogTable({
   });
   const query = useMemo(() => {
     const filteredFields = Object.fromEntries(
-      Object.entries(locationQuery).filter(([_key, val]) => val !== '')
+      Object.entries(locationQuery).filter(([_key, val]) => !!val)
     );
     return {
       ...filteredFields,

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
@@ -51,7 +51,7 @@ export function OrganizationFeatureFlagsAuditLogTable({
   });
   const query = useMemo(() => {
     const filteredFields = Object.fromEntries(
-      Object.entries(locationQuery).filter(([_key, val]) => !!val)
+      Object.entries(locationQuery).filter(([_key, val]) => val !== '')
     );
     return {
       ...filteredFields,


### PR DESCRIPTION
The backend uses statsPeriod to clamp date range - imo we don't need this since we're already paginating. 