### PR TITLE
fix(warmup): set correct subdomain on request

### DIFF
--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -20,12 +20,15 @@ from django.core.handlers.wsgi import WSGIHandler
 # Run WSGI handler for the application
 application = WSGIHandler()
 
+
+warmup_host_name = settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS[0] != "*" else "127.0.0.1"
+
 # trigger a warmup of the application
 application(
     {
         "PATH_INFO": reverse("sentry-warmup"),
         "REQUEST_METHOD": "GET",
-        "SERVER_NAME": "127.0.0.1",
+        "SERVER_NAME": warmup_host_name,
         "SERVER_PORT": "9001",
         "wsgi.input": io.BytesIO(),
         "wsgi.url_scheme": "https",

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -42,3 +42,31 @@ def test_wsgi_init():
     subprocess.check_call(
         [sys.executable, "-c", SUBPROCESS_TEST_WGI_WARMUP],
     )
+
+
+SUBPROCESS_TEST_WGI_WARMUP_WITH_SUBDOMAIN = f"""
+import sys
+from django.conf import settings
+from sentry.runner import configure
+configure()
+settings.ALLOWED_HOSTS = [".test.com"]
+
+import sentry.wsgi
+{assert_in_sys_modules}
+import django.urls.resolvers
+from django.conf import settings
+resolver = django.urls.resolvers.get_resolver()
+assert resolver._populated is True
+for lang, _ in settings.LANGUAGES:
+    assert lang in resolver._reverse_dict
+"""
+
+
+def test_wsgi_init_with_subdomain():
+    """
+    In production, we have settings.ALLOWED_HOSTS set, so override it for this test
+    and ensure that the wsgi.py file correctly pre-loads the application it set.
+    """
+    subprocess.check_call(
+        [sys.executable, "-c", SUBPROCESS_TEST_WGI_WARMUP_WITH_SUBDOMAIN],
+    )


### PR DESCRIPTION
we've been trying to figure out why our language warmup code hasn't been working ([profile](https://sentry.sentry.io/explore/profiling/profile/sentry/407f9ad7de474f8b83afce24fbafd7d4/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&fov=23628372%2C15%2C53948248%2C14&frameName=SentryLocaleMiddleware.process_request&query=&sorting=call%20order&tid=136114459358912&view=top%20down)). I noticed in production the `SubdomainMiddleware` is actually rejecting the warmup request. ([link to GCP Log](https://console.cloud.google.com/logs/query;cursorTimestamp=2025-04-10T22:16:21.263953117Z;duration=PT3H;query=labels.%22k8s-pod%2Fservice%22%3D%22getsentry-control%22%0Aresource.labels.pod_name%3D%22getsentry-control-web-rpc-production-89b5f5cd7-h6mx8%22%0A-textPayload%3D~%22closing%20because%22%0Atimestamp%3D%222025-04-10T22:16:20.848716206Z%22%0AinsertId%3D%22p42bh00ozwtb4t3s%22;summaryFields=:true:32:beginning?project=internal-sentry)), so it's not actually running. Locally and in tests, the `setting.ALLOWED_HOSTS` variable is set to `*`, so it always works, but in prod, we actually set it to a value, which causes this request to get rejected. The imports were done outside of the function, which is why they were still having an effect. 

There is no easy way to set `ALLOWED_HOSTS` easily in the `test_wsgi.py` tests, but I confirmed behavior by setting my `ALLOWED_HOSTS` to `["getsentry.net"]` and verifying the test passes locally.


