### PR TITLE
fix(perf-issues): Use parameterized URL for similarities on N+1 API Calls

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -6,7 +6,7 @@ import re
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 from sentry import options
@@ -292,7 +292,17 @@ def fingerprint_resource_span(span: Span):
     return hashlib.sha1(stripped_url.encode("utf-8")).hexdigest()
 
 
-def parameterize_url(url: str) -> str:
+class ParameterizedUrl(TypedDict):
+    url: str
+    path_params: list[str]  # e.g. ["123", "abc123de-1024-4321-abcd-1234567890ab"]
+    query_params: dict[str, list[str]]  # e.g. {"limit": "50", "offset": "100"}
+
+
+def parameterize_url_with_result(url: str) -> ParameterizedUrl:
+    """
+    Given a URL, return the URL with parsed path and query parameters replaced with '*',
+    a list of the path parameters, and a dict of the query parameters.
+    """
     parsed_url = urlparse(str(url))
 
     protocol_fragments = []
@@ -305,15 +315,18 @@ def parameterize_url(url: str) -> str:
         host_fragments.append(str(fragment))
 
     path_fragments = []
+    path_params = []
     for fragment in parsed_url.path.split("/"):
-        if PARAMETERIZED_URL_REGEX.search(fragment):
+        path_param = PARAMETERIZED_URL_REGEX.search(fragment)
+        if path_param:
             path_fragments.append("*")
+            path_params.append(path_param.group())
         else:
             path_fragments.append(str(fragment))
 
     query = parse_qs(parsed_url.query)
 
-    return "".join(
+    parameterized_url = "".join(
         [
             "".join(protocol_fragments),
             ".".join(host_fragments),
@@ -322,6 +335,16 @@ def parameterize_url(url: str) -> str:
             "&".join(sorted([f"{key}=*" for key in query.keys()])),
         ]
     ).rstrip("?")
+
+    return ParameterizedUrl(
+        url=parameterized_url,
+        path_params=path_params,
+        query_params=query,
+    )
+
+
+def parameterize_url(url: str) -> str:
+    return parameterize_url_with_result(url).get("url", "")
 
 
 def fingerprint_http_spans(spans: list[Span]) -> str:

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import os
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import Any
 from urllib.parse import parse_qs, urlparse
-
-from django.utils.encoding import force_bytes
 
 from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -51,7 +48,6 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         # TODO: Only store the span IDs and timestamps instead of entire span objects
         self.stored_problems: PerformanceProblemsMap = {}
         self.spans: list[Span] = []
-        self.span_hashes: dict[str, str | None] = {}
 
     def visit_span(self, span: Span) -> None:
         if not NPlusOneAPICallsDetector.is_span_eligible(span):
@@ -60,8 +56,6 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         op = span.get("op", None)
         if op not in self.settings.get("allowed_span_ops", []):
             return
-
-        self.span_hashes[span["span_id"]] = get_span_hash(span)
 
         previous_span = self.spans[-1] if len(self.spans) > 0 else None
 
@@ -250,61 +244,10 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
     def _spans_are_similar(self, span_a: Span, span_b: Span) -> bool:
         return (
-            self.span_hashes[span_a["span_id"]] == self.span_hashes[span_b["span_id"]]
+            parameterize_url(get_url_from_span(span_a))
+            == parameterize_url(get_url_from_span(span_b))
             and span_a["parent_span_id"] == span_b["parent_span_id"]
         )
-
-
-HTTP_METHODS = {
-    "GET",
-    "HEAD",
-    "POST",
-    "PUT",
-    "DELETE",
-    "CONNECT",
-    "OPTIONS",
-    "TRACE",
-    "PATCH",
-}
-
-
-def get_span_hash(span: Span) -> str | None:
-    if span.get("op") != "http.client":
-        return span.get("hash")
-
-    parts = remove_http_client_query_string_strategy(span)
-    if not parts:
-        return None
-
-    hash = hashlib.md5()
-    for part in parts:
-        hash.update(force_bytes(part, errors="replace"))
-
-    return hash.hexdigest()[:16]
-
-
-def remove_http_client_query_string_strategy(span: Span) -> Sequence[str] | None:
-    """
-    This is an inline version of the `http.client` parameterization code in
-    `"default:2022-10-27"`, the default span grouping strategy at time of
-    writing. It's inlined here to insulate this detector from changes in the
-    strategy, which are coming soon.
-    """
-
-    # Check the description is of the form `<HTTP METHOD> <URL>`
-    description = span.get("description") or ""
-    parts = description.split(" ", 1)
-    if len(parts) != 2:
-        return None
-
-    # Ensure that this is a valid http method
-    method, url_str = parts
-    method = method.upper()
-    if method not in HTTP_METHODS:
-        return None
-
-    url = urlparse(url_str)
-    return [method, url.scheme, url.netloc, url.path]
 
 
 def without_query_params(url: str) -> str:

--- a/src/sentry/utils/performance_issues/performance_problem.py
+++ b/src/sentry/utils/performance_issues/performance_problem.py
@@ -22,7 +22,7 @@ class PerformanceProblem:
     # We can't make it required until we stop loading these from nodestore via EventPerformanceProblem,
     # since there's legacy data in there that won't have these fields.
     # So until we disable transaction based perf issues we'll need to keep this optional.
-    evidence_data: Mapping[str, Any] | None
+    evidence_data: dict[str, Any] | None
     # User-friendly evidence to be displayed directly
     evidence_display: Sequence[IssueEvidence]
 


### PR DESCRIPTION

Sanity check here, but I believe these parameterized URLs are already being used for fingerprinting, but they are not being used for checking similarity. Instead we are checking hashes from `span_hashes` which is generated from a pinned function which does not attempt to parameterize, meaning the hash of `/posts/1/comments/` is not going to match `/posts/2/comments/`.

Rather than hashing the URLs, we can compare them directly after parameterization, in order to increase how often we can fingerprint. Added tests for this new behaviour and adjusted some previous ones.

As per the recommendation, I think I'm going to have this shadow for a while before actually implementing this to ensure we don't cause any fingerprint explosions.

This will allow for N+1 API calls to trigger when we process a transaction that does something like:

```js
for (let i = 0; i < 20; i++) { 
  await fetch(`https://example.com/posts/${i}/`)
}
```
rather than just for query params like:
```js
for (let i = 0; i < 20; i++) { 
  await fetch(`https://example.com/posts/?id=${i}`)
}
```
