### PR TITLE
feat(uptime): Switch uptime grouptype to use flagpole

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -666,6 +666,7 @@ class UptimeDomainCheckFailure(GroupType):
         },
         "additionalProperties": False,
     }
+    use_flagpole_for_all_features = True
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -79,7 +79,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 datetime.now(),
             )
         )
-        with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()):
             if consumer is None:
                 factory = UptimeResultsStrategyFactory(mode=self.strategy_processing_mode)
                 commit = mock.Mock()

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -690,7 +690,10 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
 
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test_disable_failed(self, mock_disable_seat):
-        with self.tasks(), self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
+        with (
+            self.tasks(),
+            self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()),
+        ):
             proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -119,7 +119,7 @@ class ResolveUptimeIssueTest(UptimeTestCase):
             uptime_subscription=subscription
         )
         result = self.create_uptime_result(subscription.subscription_id)
-        with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()):
             create_issue_platform_occurrence(result, project_subscription)
         hashed_fingerprint = md5(str(project_subscription.id).encode("utf-8")).hexdigest()
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)


### PR DESCRIPTION
We've created the appropriate feature flags in options automator, so now we can switch uptime over to use these flags instead of the option backed flags.

<!-- Describe your PR here. -->