### PR TITLE
fix(onboarding): Release registry not passed to doc functions

### DIFF
--- a/static/app/components/performanceOnboarding/sidebar.spec.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.spec.tsx
@@ -75,6 +75,11 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdks/`,
+      method: 'GET',
+    });
+
     const statusPageData: StatuspageIncident[] = [];
     jest
       .spyOn(incidentsHook, 'useServiceIncidents')

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -13,6 +13,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {shouldShowPerformanceTasks} from 'sentry/components/onboardingWizard/filterSupportedTasks';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
@@ -269,6 +270,10 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     projSlug: currentProject.slug,
     productType: 'performance',
   });
+
+  const {isPending: isLoadingRegistry, data: registryData} =
+    useSourcePackageRegistries(organization);
+
   const performanceDocs = docs?.performanceOnboarding;
 
   if (isLoading) {
@@ -332,8 +337,8 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     isProfilingSelected: false,
     isReplaySelected: false,
     sourcePackageRegistries: {
-      isLoading: false,
-      data: undefined,
+      isLoading: isLoadingRegistry,
+      data: registryData,
     },
     platformOptions: [ProductSolution.PERFORMANCE_MONITORING],
     newOrg: false,

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -13,6 +13,7 @@ import {
   type DocsParams,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {TaskSidebar} from 'sentry/components/sidebar/taskSidebar';
 import type {CommonSidebarProps} from 'sentry/components/sidebar/types';
@@ -281,11 +282,17 @@ interface ProfilingOnboardingContentProps {
 
 function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
   const api = useApi();
+  const organization = useOrganization();
+
   const {isLoading, isError, dsn, docs, refetch, projectKeyId} = useLoadGettingStarted({
     orgSlug: props.organization.slug,
     projSlug: props.projectSlug,
     platform: props.platform,
   });
+
+  const {isPending: isLoadingRegistry, data: registryData} =
+    useSourcePackageRegistries(organization);
+
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
 
   if (isLoading) {
@@ -347,8 +354,8 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     isProfilingSelected: true,
     isReplaySelected: false,
     sourcePackageRegistries: {
-      isLoading: false,
-      data: undefined,
+      isLoading: isLoadingRegistry,
+      data: registryData,
     },
     platformOptions: PROFILING_ONBOARDING_STEPS,
     newOrg: false,

--- a/static/app/views/onboarding/integrationSetup.tsx
+++ b/static/app/views/onboarding/integrationSetup.tsx
@@ -12,6 +12,7 @@ import type {
   BasePlatformOptions,
   DocsParams,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {
   PlatformOptionsControl,
@@ -80,6 +81,9 @@ function IntegrationSetup({project, integrationSlug, platform}: Props) {
     projSlug: project.slug,
     platform,
   });
+
+  const {isPending: isLoadingRegistry, data: registryData} =
+    useSourcePackageRegistries(organization);
 
   const selectedPlatformOptions = useUrlPlatformOptions(docsConfig?.platformOptions);
 
@@ -234,8 +238,8 @@ function IntegrationSetup({project, integrationSlug, platform}: Props) {
     isSelfHosted,
     platformOptions: selectedPlatformOptions,
     sourcePackageRegistries: {
-      isLoading: false,
-      data: undefined,
+      isLoading: isLoadingRegistry,
+      data: registryData,
     },
     urlPrefix,
   };

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -35,6 +35,7 @@ import {
   type DocsParams,
   ProductSolution,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import LegacyOnboardingPanel from 'sentry/components/onboardingPanel';
 import Panel from 'sentry/components/panels/panel';
@@ -494,6 +495,9 @@ export function Onboarding({organization, project}: OnboardingProps) {
     productType: 'performance',
   });
 
+  const {isPending: isLoadingRegistry, data: registryData} =
+    useSourcePackageRegistries(organization);
+
   const doesNotSupportPerformance = project.platform
     ? withoutPerformanceSupport.has(project.platform)
     : false;
@@ -599,8 +603,8 @@ export function Onboarding({organization, project}: OnboardingProps) {
     isProfilingSelected: false,
     isReplaySelected: false,
     sourcePackageRegistries: {
-      isLoading: false,
-      data: undefined,
+      isLoading: isLoadingRegistry,
+      data: registryData,
     },
     platformOptions: [ProductSolution.PERFORMANCE_MONITORING],
     newOrg: false,


### PR DESCRIPTION
Pass the release registry to every doc function to ensure updated version numbers to be rendered.