### PR TITLE
chore(rollbacks): Remove options for GroupRelease model

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2803,14 +2803,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch for GroupRelease.get_or_create refactor
-register(
-    "grouprelease.new_get_or_create.rollout",
-    default=0.0,
-    type=Float,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Killswitch for Postgres query timeout error handling
 register(
     "api.postgres-query-timeout-error-handling.enabled",


### PR DESCRIPTION
The code that was using this option is now refactored, this can now safely be removed