### PR TITLE
feat(onboarding): Mark invite member as complete if member invited

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -43,19 +43,6 @@ class OnboardingTaskStatus:
     SKIPPED = 3
 
 
-# NOTE: data fields for some event types are as follows:
-#
-#   FIRST_EVENT:      { 'platform':  'flask', }
-#   INVITE_MEMBER:    { 'invited_member': user.id, 'teams': [team.id] }
-#   SECOND_PLATFORM:  { 'platform': 'javascript' }
-#
-# NOTE: Currently the `PENDING` status is applicable for the following
-# onboarding tasks:
-#
-#   FIRST_EVENT:     User confirms that sdk has been installed
-#   INVITE_MEMBER:   Until the member has successfully joined org
-
-
 class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"]):
     def record(self, organization_id, task, **kwargs):
         cache_key = f"organizationonboardingtask:{organization_id}:{task}"

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -368,7 +368,7 @@ first_insight_span_received.connect(record_first_insight_span, weak=False)
 
 @member_invited.connect(weak=False, dispatch_uid="onboarding.record_member_invited")
 def record_member_invited(member, user, **kwargs):
-    OrganizationOnboardingTask.objects.update_or_create(
+    OrganizationOnboardingTask.objects.get_or_create(
         organization_id=member.organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         defaults={

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -35,7 +35,6 @@ from sentry.signals import (
     first_transaction_received,
     integration_added,
     member_invited,
-    member_joined,
     project_created,
     transaction_processed,
 )
@@ -369,12 +368,12 @@ first_insight_span_received.connect(record_first_insight_span, weak=False)
 
 @member_invited.connect(weak=False, dispatch_uid="onboarding.record_member_invited")
 def record_member_invited(member, user, **kwargs):
-    OrganizationOnboardingTask.objects.record(
+    OrganizationOnboardingTask.objects.update_or_create(
         organization_id=member.organization_id,
         task=OnboardingTask.INVITE_MEMBER,
-        user_id=user.id if user else None,
-        status=OnboardingTaskStatus.PENDING,
-        data={"invited_member_id": member.id},
+        defaults={
+            "status": OnboardingTaskStatus.COMPLETE,
+        },
     )
 
     analytics.record(
@@ -384,29 +383,6 @@ def record_member_invited(member, user, **kwargs):
         organization_id=member.organization_id,
         referrer=kwargs.get("referrer"),
     )
-
-
-@member_joined.connect(weak=False, dispatch_uid="onboarding.record_member_joined")
-def record_member_joined(organization_id: int, organization_member_id: int, **kwargs):
-    obj, created = OrganizationOnboardingTask.objects.get_or_create(
-        organization_id=organization_id,
-        task=OnboardingTask.INVITE_MEMBER,
-        defaults={
-            "status": OnboardingTaskStatus.COMPLETE,
-            "date_completed": django_timezone.now(),
-            "data": {"invited_member_id": organization_member_id},
-        },
-    )
-    if created:
-        # The task was just created and marked as complete, no need to do anything extra
-        return
-
-    if obj.status != OnboardingTaskStatus.COMPLETE:
-        # The task exists but is not complete, so we need to update it as complete
-        obj.status = OnboardingTaskStatus.COMPLETE
-        obj.date_completed = django_timezone.now()
-        obj.data = {"invited_member_id": organization_member_id}
-        obj.save()
 
 
 def _record_release_received(project, event, **kwargs):

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -1011,7 +1011,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             OrganizationOnboardingTask.objects.get(
                 organization=self.organization,
                 task=OnboardingTask.INVITE_MEMBER,
-                status=OnboardingTaskStatus.PENDING,
+                status=OnboardingTaskStatus.COMPLETE,
             )
             is not None
         )
@@ -1021,27 +1021,6 @@ class OrganizationOnboardingTaskTest(TestCase):
             inviter_user_id=user.id,
             organization_id=self.organization.id,
             referrer=None,
-        )
-
-        # Member accepted the invite
-        member_joined.send(
-            organization_member_id=member.id,
-            organization_id=self.organization.id,
-            user_id=member.user_id,
-            sender=None,
-        )
-        assert (
-            OrganizationOnboardingTask.objects.get(
-                organization=self.organization,
-                task=OnboardingTask.INVITE_MEMBER,
-                status=OnboardingTaskStatus.COMPLETE,
-            )
-            is not None
-        )
-        record_analytics.assert_called_with(
-            "organization.joined",
-            user_id=None,
-            organization_id=self.organization.id,
         )
 
         # Manually update the completionSeen column of existing tasks

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -5,7 +5,6 @@ import pytest
 from django.utils import timezone
 
 from sentry import onboarding_tasks
-from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -14,7 +13,6 @@ from sentry.models.organizationonboardingtask import (
 )
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.organizations.services.organization import organization_service
 from sentry.receivers.rules import DEFAULT_RULE_LABEL
 from sentry.signals import (
     alert_rule_created,
@@ -32,7 +30,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.event import has_event_minified_stack_trace
@@ -304,73 +301,9 @@ class OrganizationOnboardingTaskTest(TestCase):
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
             task=OnboardingTask.INVITE_MEMBER,
-            status=OnboardingTaskStatus.PENDING,
-        )
-        assert task is not None
-
-    def test_member_joined(self):
-        user = self.create_user(email="test@example.org")
-
-        with pytest.raises(OrganizationOnboardingTask.DoesNotExist):
-            OrganizationOnboardingTask.objects.get(
-                organization=self.organization,
-                task=OnboardingTask.INVITE_MEMBER,
-                status=OnboardingTaskStatus.COMPLETE,
-            )
-
-        om = self.create_member(
-            organization=self.organization, teams=[self.team], email="someemail@example.com"
-        )
-        invite = organization_service.get_invite_by_id(
-            organization_member_id=om.id, organization_id=om.organization_id
-        )
-        assert invite is not None
-        helper = ApiInviteHelper(
-            self.make_request(user=user),
-            invite,
-            None,
-        )
-
-        with pytest.raises(OrganizationOnboardingTask.DoesNotExist):
-            OrganizationOnboardingTask.objects.get(
-                organization=self.organization,
-                task=OnboardingTask.INVITE_MEMBER,
-                status=OnboardingTaskStatus.COMPLETE,
-            )
-
-        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
-            helper.accept_invite(user=user)
-
-        task = OrganizationOnboardingTask.objects.get(
-            organization=self.organization,
-            task=OnboardingTask.INVITE_MEMBER,
             status=OnboardingTaskStatus.COMPLETE,
         )
         assert task is not None
-
-        user2 = self.create_user(email="test@example.com")
-        om2 = self.create_member(
-            organization=self.organization, teams=[self.team], email="blah@example.com"
-        )
-        invite = organization_service.get_invite_by_id(
-            organization_member_id=om2.id, organization_id=om2.organization_id
-        )
-        assert invite is not None
-        helper = ApiInviteHelper(
-            self.make_request(user=user2),
-            invite,
-            None,
-        )
-
-        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
-            helper.accept_invite(user=user2)
-
-        task = OrganizationOnboardingTask.objects.get(
-            organization=self.organization,
-            task=OnboardingTask.INVITE_MEMBER,
-            status=OnboardingTaskStatus.COMPLETE,
-        )
-        assert task.data["invited_member_id"] == om.id
 
     def test_alert_added(self):
         alert_rule_created.send(


### PR DESCRIPTION
Previously, when a user invited a member, the "invite_member" onboarding task was initially marked as pending. It would then be updated to complete once the invited user accepted the invitation.

This PR changes that behavior: now, the "invite_member" task is immediately marked as complete upon inviting a member, regardless of whether the invitation is accepted.

Contributes to TET-285