### PR TITLE
ref(onboarding): Remove not needed onboarding code

### DIFF
--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -38,13 +38,6 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-const mockUpdateOnboardingTasks = jest.fn();
-jest.mock('sentry/actionCreators/onboardingTasks', () => ({
-  useUpdateOnboardingTasks: () => ({
-    mutate: mockUpdateOnboardingTasks,
-  }),
-}));
-
 describe('ProjectAlertsCreate', function () {
   beforeEach(function () {
     TeamStore.init();
@@ -363,8 +356,6 @@ describe('ProjectAlertsCreate', function () {
           })
         );
         expect(metric.startSpan).toHaveBeenCalledWith({name: 'saveAlertRule'});
-
-        expect(mockUpdateOnboardingTasks).toHaveBeenCalledTimes(1);
 
         await waitFor(() => {
           expect(wrapper.router.push).toHaveBeenCalledWith(

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -1,15 +1,12 @@
 import {Fragment, useEffect, useRef} from 'react';
 
-import {useUpdateOnboardingTasks} from 'sentry/actionCreators/onboardingTasks';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import {OnboardingTaskKey} from 'sentry/types/onboarding';
 import type {Member, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {isDemoModeActive} from 'sentry/utils/demoMode';
 import EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
@@ -65,7 +62,6 @@ function Create(props: Props) {
 
   const sessionId = useRef(uniqueId());
   const navigate = useNavigate();
-  const updateOnboardingTasks = useUpdateOnboardingTasks();
 
   const isDuplicateRule = createFromDuplicate === 'true' && duplicateRuleId;
 
@@ -176,14 +172,6 @@ function Create(props: Props) {
                 {...props}
                 userTeamIds={teams.map(({id}) => id)}
                 members={members}
-                onSaveSuccess={() => {
-                  if (isDemoModeActive()) {
-                    return;
-                  }
-                  updateOnboardingTasks.mutate([
-                    {task: OnboardingTaskKey.ALERT_RULE, status: 'complete'},
-                  ]);
-                }}
               />
             ) : (
               hasMetricAlerts &&

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -143,10 +143,6 @@ type Props = {
   userTeamIds: string[];
   loadingProjects?: boolean;
   onChangeTitle?: (data: string) => void;
-  /**
-   * A callback triggered when the rule is saved successfully
-   */
-  onSaveSuccess?: () => void;
 } & RouteComponentProps<RouteParams>;
 
 type State = DeprecatedAsyncComponent['state'] & {
@@ -456,9 +452,8 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
   };
 
   handleRuleSuccess = (isNew: boolean, rule: IssueAlertRule) => {
-    const {organization, router, onSaveSuccess} = this.props;
+    const {organization, router} = this.props;
     const {project} = this.state;
-    onSaveSuccess?.();
 
     metric.endSpan({name: 'saveAlertRule'});
 


### PR DESCRIPTION
We do not need this code, because we are already marking the 'alert_rule' as 'complete' in the backend via receivers. see https://github.com/getsentry/sentry/blob/3044aee12e5323b55723e8c952762dce2e5d0fef/src/sentry/receivers/onboarding.py#L561