### PR TITLE
fix(workflow-engine): stop emitting errors for missing workflow in issue alert dual delete

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -117,10 +117,9 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
     except WorkflowDataConditionGroup.DoesNotExist:
         # OK state because we can recreate the IF DCG but should not happen
         logger.info(
-            "workflow_engine.issue_alert.updated.error",
+            "IF DCG for workflow does not exist, recreating",
             extra={
                 "workflow_id": workflow.id,
-                "error": "WorkflowDataConditionGroup does not exist",
             },
         )
         # if no IF DCG exists, create one

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -191,9 +191,9 @@ def delete_migrated_issue_alert(rule: Rule) -> int | None:
         alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
     except AlertRuleWorkflow.DoesNotExist:
         # OK state, rule may not have been migrated
-        logger.exception(
-            "workflow_engine.issue_alert.deleted.error",
-            extra={"rule_id": rule.id, "error": "AlertRuleWorkflow does not exist"},
+        logger.info(
+            "rule was not dual written or objects were already deleted, returning early",
+            extra={"rule_id": rule.id},
         )
         return None
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -116,7 +116,7 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
         if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
     except WorkflowDataConditionGroup.DoesNotExist:
         # OK state because we can recreate the IF DCG but should not happen
-        logger.exception(
+        logger.info(
             "workflow_engine.issue_alert.updated.error",
             extra={
                 "workflow_id": workflow.id,


### PR DESCRIPTION
replacing `logger.exception` with `logger.info` for OK/expected states