### PR TITLE
feat(insights): set default sampling mode to `BEST_EFFORT`

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -4,6 +4,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import type {OurLogFieldKey, OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -30,12 +31,16 @@ interface UseDiscoverOptions<Fields> {
   orderby?: string | string[];
   pageFilters?: PageFilters;
   projectIds?: number[];
+  samplingMode?: SamplingMode | 'NONE';
   /**
    * TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
    */
   search?: MutableSearch | string;
   sorts?: Sort[];
 }
+
+// The default sampling mode for eap queries
+export const DEFAULT_SAMPLING_MODE: SamplingMode = 'BEST_EFFORT';
 
 export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
@@ -129,6 +134,7 @@ export const useDiscover = <
     noPagination,
     projectIds,
     orderby,
+    samplingMode = DEFAULT_SAMPLING_MODE,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -151,6 +157,7 @@ export const useDiscover = <
     referrer,
     cursor,
     noPagination,
+    samplingMode: samplingMode === 'NONE' ? undefined : samplingMode,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -137,6 +137,9 @@ export const useDiscover = <
     samplingMode = DEFAULT_SAMPLING_MODE,
   } = options;
 
+  // TODO: remove this check with eap
+  const shouldSetSamplingMode = dataset === DiscoverDatasets.SPANS_EAP_RPC;
+
   const pageFilters = usePageFilters();
 
   const eventView = getEventView(
@@ -157,7 +160,8 @@ export const useDiscover = <
     referrer,
     cursor,
     noPagination,
-    samplingMode: samplingMode === 'NONE' ? undefined : samplingMode,
+    samplingMode:
+      samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -121,6 +121,9 @@ const useDiscoverSeries = <T extends string[]>(
   const location = useLocation();
   const organization = useOrganization();
 
+  // TODO: remove this check with eap
+  const shouldSetSamplingMode = dataset === DiscoverDatasets.SPANS_EAP_RPC;
+
   const eventView = getSeriesEventView(
     search,
     undefined,
@@ -154,7 +157,8 @@ const useDiscoverSeries = <T extends string[]>(
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       transformAliasToInputFormat: options.transformAliasToInputFormat ? '1' : '0',
-      sampling: samplingMode === 'NONE' ? undefined : samplingMode,
+      sampling:
+        samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
     }),
     options: {
       enabled: options.enabled && pageFilters.isReady,

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -11,7 +11,9 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {getSeriesEventView} from 'sentry/views/insights/common/queries/getSeriesEventView';
+import {DEFAULT_SAMPLING_MODE} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   getRetryDelay,
   shouldRetryHandler,
@@ -40,7 +42,9 @@ interface UseMetricsSeriesOptions<Fields> {
   interval?: string;
   overriddenRoute?: string;
   referrer?: string;
-  search?: MutableSearch | string; // TODO: Remove string type and always require MutableSearch
+  samplingMode?: SamplingMode | 'NONE';
+  search?: MutableSearch | string;
+  // TODO: Remove string type and always require MutableSearch
   transformAliasToInputFormat?: boolean;
   yAxis?: Fields;
 }
@@ -106,7 +110,12 @@ const useDiscoverSeries = <T extends string[]>(
   dataset: DiscoverDatasets,
   referrer: string
 ) => {
-  const {search = undefined, yAxis = [], interval = undefined} = options;
+  const {
+    search = undefined,
+    yAxis = [],
+    interval = undefined,
+    samplingMode = DEFAULT_SAMPLING_MODE,
+  } = options;
 
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -145,6 +154,7 @@ const useDiscoverSeries = <T extends string[]>(
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       transformAliasToInputFormat: options.transformAliasToInputFormat ? '1' : '0',
+      sampling: samplingMode === 'NONE' ? undefined : samplingMode,
     }),
     options: {
       enabled: options.enabled && pageFilters.isReady,


### PR DESCRIPTION
BEST_EFFORT will give us the most data without timing out, so it makes sense to use this as the default.