### PR TITLE
feat(codemappings): F#, VB, PowerShell to mappings as C#

### DIFF
--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -15,7 +15,7 @@ SECOND_LEVEL_TLDS = ("com", "co", "org", "gov", "net", "edu")
 # Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces
 PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
-    "csharp": {"extensions": ["cs"]},
+    "csharp": {"extensions": ["cs","fs","vb"]},
     "go": {"extensions": ["go"]},
     "java": {
         # e.g. com.foo.bar.Baz$handle$1, Baz.kt -> com/foo/bar/Baz.kt

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -15,7 +15,8 @@ SECOND_LEVEL_TLDS = ("com", "co", "org", "gov", "net", "edu")
 # Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces
 PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
-    "csharp": {"extensions": ["cs", "fs", "vb"]},
+    # C#, F#, VB, PowerShell, C# Script, F# Script
+    "csharp": {"extensions": ["cs", "fs", "vb", "ps1", "csx", "fsx"]},
     "go": {"extensions": ["go"]},
     "java": {
         # e.g. com.foo.bar.Baz$handle$1, Baz.kt -> com/foo/bar/Baz.kt

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -15,7 +15,7 @@ SECOND_LEVEL_TLDS = ("com", "co", "org", "gov", "net", "edu")
 # Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces
 PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
-    "csharp": {"extensions": ["cs","fs","vb"]},
+    "csharp": {"extensions": ["cs", "fs", "vb"]},
     "go": {"extensions": ["go"]},
     "java": {
         # e.g. com.foo.bar.Baz$handle$1, Baz.kt -> com/foo/bar/Baz.kt


### PR DESCRIPTION
Noticed .NET (we refer to it as C# internally) has no mappings to other major .NET languages outside of C#

Affects events from:
* https://github.com/getsentry/sentry-dotnet
* https://github.com/getsentry/sentry-xamarin
* https://github.com/getsentry/sentry-unity
* https://github.com/getsentry/sentry-powershell