### PR TITLE
feat(autofix): Add progress bar

### DIFF
--- a/static/app/components/events/autofix/autofixProgressBar.tsx
+++ b/static/app/components/events/autofix/autofixProgressBar.tsx
@@ -117,7 +117,7 @@ const ProgressBarHoverContent = styled('div')<{hasData: boolean}>`
   align-items: center;
   justify-content: space-between;
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding: 0 ${space(1.5)};
+  padding: 0 ${space(3)};
   opacity: 0;
   transition: ${p => (p.hasData ? 'opacity 0.2s ease-in-out' : 'none')};
   background: ${p => p.theme.background}

--- a/static/app/components/events/autofix/autofixProgressBar.tsx
+++ b/static/app/components/events/autofix/autofixProgressBar.tsx
@@ -117,7 +117,7 @@ const ProgressBarHoverContent = styled('div')<{hasData: boolean}>`
   align-items: center;
   justify-content: space-between;
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding: 0 ${space(1)};
+  padding: 0 ${space(1.5)};
   opacity: 0;
   transition: ${p => (p.hasData ? 'opacity 0.2s ease-in-out' : 'none')};
   background: ${p => p.theme.background}

--- a/static/app/components/events/autofix/autofixProgressBar.tsx
+++ b/static/app/components/events/autofix/autofixProgressBar.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {SeerLoadingIcon, SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+import type {AutofixData} from './types';
+import {AutofixStatus} from './types';
+import {getAutofixProgressPercentage} from './utils';
+
+interface AutofixProgressBarProps {
+  autofixData?: AutofixData;
+}
+
+function AutofixProgressBar({autofixData}: AutofixProgressBarProps) {
+  const [progress, setProgress] = useState<number>(0);
+
+  useEffect(() => {
+    // Calculate progress percentage using the utility function
+    setProgress(getAutofixProgressPercentage(autofixData));
+  }, [autofixData]);
+
+  return (
+    <ProgressBarContainer hasData={!!autofixData}>
+      <ProgressBarWrapper>
+        <ProgressBarTrack>
+          <ProgressBarFill style={{width: `${progress}%`}} />
+        </ProgressBarTrack>
+      </ProgressBarWrapper>
+      <ProgressBarHoverContent hasData={!!autofixData}>
+        {autofixData && (
+          <React.Fragment>
+            <LeftContent>
+              <IconContainer>
+                {autofixData.status === AutofixStatus.PROCESSING ? (
+                  <SeerLoadingIcon size="md" />
+                ) : autofixData.status === AutofixStatus.NEED_MORE_INFORMATION ||
+                  autofixData.status === AutofixStatus.WAITING_FOR_USER_RESPONSE ? (
+                  <SeerWaitingIcon size="md" />
+                ) : null}
+              </IconContainer>
+              <ProgressText>
+                {autofixData.status === AutofixStatus.COMPLETED
+                  ? t('Complete.')
+                  : autofixData.status === AutofixStatus.ERROR
+                    ? t('Something broke.')
+                    : autofixData.status === AutofixStatus.PROCESSING
+                      ? progress <= 33
+                        ? t(
+                            "Autofix is hard at work on the root cause. Feel free to leave - it\'ll continue in the background."
+                          )
+                        : progress <= 67
+                          ? t(
+                              "Autofix is hard at work on the solution. Feel free to leave - it\'ll continue in the background."
+                            )
+                          : t(
+                              "Autofix is hard at work on the code changes. Feel free to leave - it\'ll continue in the background."
+                            )
+                      : autofixData.status === AutofixStatus.NEED_MORE_INFORMATION ||
+                          autofixData.status === AutofixStatus.WAITING_FOR_USER_RESPONSE
+                        ? t('Standing by. All work so far is saved.')
+                        : t('Initializing...')}
+              </ProgressText>
+            </LeftContent>
+            <ProgressPercentage>{`${progress}%`}</ProgressPercentage>
+          </React.Fragment>
+        )}
+      </ProgressBarHoverContent>
+    </ProgressBarContainer>
+  );
+}
+
+const ProgressBarContainer = styled('div')<{hasData: boolean}>`
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 2px;
+  transition: ${p => (p.hasData ? 'height 0.2s ease-in-out' : 'none')};
+
+  ${p =>
+    p.hasData &&
+    `&:hover {
+      height: 30px;
+    }`}
+`;
+
+const ProgressBarWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const ProgressBarTrack = styled('div')`
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  background-color: ${p => p.theme.border};
+`;
+
+const ProgressBarFill = styled('div')`
+  height: 100%;
+  background-color: ${p => p.theme.pink200};
+  transition: width 1s ease-in-out;
+`;
+
+const ProgressBarHoverContent = styled('div')<{hasData: boolean}>`
+  position: absolute;
+  top: 2px;
+  left: 0;
+  width: 100%;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: ${p => p.theme.dropShadowMedium};
+  padding: 0 ${space(1)};
+  opacity: 0;
+  transition: ${p => (p.hasData ? 'opacity 0.2s ease-in-out' : 'none')};
+  background: ${p => p.theme.background}
+    linear-gradient(to right, ${p => p.theme.background}, ${p => p.theme.pink400}20);
+
+  ${p =>
+    p.hasData &&
+    `
+    ${ProgressBarContainer}:hover & {
+      opacity: 1;
+    }`}
+`;
+
+const ProgressText = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.pink400};
+`;
+
+const ProgressPercentage = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.pink400};
+`;
+
+const IconContainer = styled('div')`
+  margin-top: ${space(0.25)};
+  margin-right: ${space(0.5)};
+`;
+
+const LeftContent = styled('div')`
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.pink400};
+`;
+
+export {AutofixProgressBar};

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -131,3 +131,126 @@ export const getCodeChangesIsLoading = (autofixData: AutofixData) => {
 export const isSupportedAutofixProvider = (provider: string) => {
   return provider.toLowerCase().includes('github');
 };
+
+/**
+ * Calculates the progress percentage for the autofix process based on steps.
+ * Progress percentages:
+ * - 0%: haven't started
+ * - 0-32%: root cause processing (increases by 2% per iteration)
+ * - 33%: root cause present
+ * - 33-66%: solution processing (increases by 2% per iteration)
+ * - 67%: solution present
+ * - 67-99%: coding / planning (increases by 2% per iteration)
+ * - 100%: code changes present
+ */
+export function getAutofixProgressPercentage(autofixData?: AutofixData): number {
+  if (!autofixData) {
+    return 0;
+  }
+
+  // Find key steps if they exist
+  const steps = autofixData.steps ?? [];
+  const rootCauseStep = steps.find(
+    step => step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS
+  );
+  const solutionStep = steps.find(step => step.type === AutofixStepType.SOLUTION);
+  const changesStep = steps.find(step => step.type === AutofixStepType.CHANGES);
+
+  // Find potential processing steps (assuming default type and specific keys)
+  const rootCauseProcessingStep = steps.find(
+    step =>
+      step.key === 'root_cause_analysis_processing' &&
+      step.type === AutofixStepType.DEFAULT
+  );
+  const solutionProcessingStep = steps.find(
+    step => step.key === 'solution_processing' && step.type === AutofixStepType.DEFAULT
+  );
+  const planStep = steps.find(
+    step => step.key === 'plan' && step.type === AutofixStepType.DEFAULT
+  );
+
+  // Code changes complete
+  if (changesStep && changesStep.status === AutofixStatus.COMPLETED) {
+    return 100;
+  }
+  // Coding / Planning in progress
+  if (planStep && planStep.status === AutofixStatus.PROCESSING) {
+    const basePercentage = 67;
+    const maxPercentage = 99;
+    const progressCount = planStep.progress?.length || 0;
+    const calculatedPercentage = basePercentage + progressCount * 2;
+    return Math.min(calculatedPercentage, maxPercentage);
+  }
+
+  // Solution present
+  if (
+    solutionStep &&
+    (solutionStep.status === AutofixStatus.COMPLETED || solutionStep.solution_selected)
+  ) {
+    return 67;
+  }
+  // Solution processing
+  if (
+    solutionProcessingStep &&
+    solutionProcessingStep.status === AutofixStatus.PROCESSING
+  ) {
+    const basePercentage = 33;
+    const maxPercentage = 66;
+    const progressCount = solutionProcessingStep.progress?.length || 0;
+    const calculatedPercentage = basePercentage + progressCount * 2;
+    return Math.min(calculatedPercentage, maxPercentage);
+  }
+  // Fallback for solution processing if key step missing
+  if (
+    solutionStep &&
+    solutionStep.status === AutofixStatus.PROCESSING &&
+    !solutionProcessingStep
+  ) {
+    const basePercentage = 33;
+    const maxPercentage = 66;
+    const progressCount = solutionStep.progress?.length || 0;
+    const calculatedPercentage = basePercentage + progressCount * 2;
+    return Math.min(calculatedPercentage, maxPercentage);
+  }
+  // Root cause present
+  if (
+    rootCauseStep &&
+    (rootCauseStep.status === AutofixStatus.COMPLETED || rootCauseStep.selection)
+  ) {
+    return 33;
+  }
+  // Root cause processing
+  if (
+    rootCauseProcessingStep &&
+    rootCauseProcessingStep.status === AutofixStatus.PROCESSING
+  ) {
+    const basePercentage = 0;
+    const maxPercentage = 32;
+    const progressCount = rootCauseProcessingStep.progress?.length || 0;
+    const calculatedPercentage = basePercentage + progressCount * 2;
+    return progressCount > 0
+      ? Math.min(Math.max(calculatedPercentage, 1), maxPercentage)
+      : 0;
+  }
+
+  // No steps match specific phases, use overall status as fallback
+  switch (autofixData.status) {
+    case AutofixStatus.PROCESSING:
+      return 1; // Assume just started processing if no specific steps
+    case AutofixStatus.COMPLETED:
+      return 100;
+    case AutofixStatus.NEED_MORE_INFORMATION:
+    case AutofixStatus.WAITING_FOR_USER_RESPONSE:
+      if (rootCauseStep && !rootCauseStep.selection) {
+        return 33;
+      }
+      if (solutionStep && !solutionStep.solution_selected) {
+        return 67;
+      }
+      return 50;
+    case AutofixStatus.ERROR:
+    case AutofixStatus.CANCELLED:
+    default:
+      return 0;
+  }
+}

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -343,13 +343,14 @@ const CardTitleSpacer = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${space(0.75)};
 `;
 
 const CardTitleText = styled('p')`
   margin: 0;
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightBold};
+  margin-top: 1px;
 `;
 
 const CardTitleIcon = styled('div')`

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -215,14 +215,7 @@ function AutofixSummary({
             }
 
             return (
-              <InsightCardButton
-                key={card.id}
-                onClick={card.onClick}
-                role="button"
-                initial="initial"
-                animate={card.isLoading ? 'animate' : 'initial'}
-                variants={pulseAnimation}
-              >
+              <InsightCardButton key={card.id} onClick={card.onClick} role="button">
                 <InsightCard>
                   <CardTitle preview={card.isLoading}>
                     <CardTitleSpacer>
@@ -243,7 +236,13 @@ function AutofixSummary({
                   </CardTitle>
                   <CardContent>
                     {card.isLoading ? (
-                      <Placeholder height="1.5rem" />
+                      <motion.div
+                        initial="initial"
+                        animate="animate"
+                        variants={pulseAnimation}
+                      >
+                        <Placeholder height="1.5rem" />
+                      </motion.div>
                     ) : (
                       <React.Fragment>
                         {card.insightElement}
@@ -284,12 +283,6 @@ const Content = styled('div')`
   position: relative;
 `;
 
-const InsightGrid = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1.5)};
-`;
-
 const InsightCardButton = styled(motion.div)<React.HTMLAttributes<HTMLDivElement>>`
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
@@ -311,6 +304,24 @@ const InsightCardButton = styled(motion.div)<React.HTMLAttributes<HTMLDivElement
   }
 `;
 
+const InsightGrid = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1.5)};
+  position: relative;
+
+  &:before {
+    content: '';
+    position: absolute;
+    left: ${space(3)};
+    top: ${space(4)};
+    bottom: ${space(2)};
+    width: 1px;
+    background: ${p => p.theme.border};
+    z-index: 0;
+  }
+`;
+
 const InsightCard = styled('div')`
   display: flex;
   flex-direction: column;
@@ -323,7 +334,7 @@ const CardTitle = styled('div')<{preview?: boolean}>`
   align-items: center;
   gap: ${space(1)};
   color: ${p => p.theme.subText};
-  padding: ${space(1)} ${space(1)} ${space(1)} ${space(1.5)};
+  padding: ${space(0.5)} ${space(0.5)} ${space(0.5)} ${space(1)};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   justify-content: space-between;
 `;
@@ -350,7 +361,7 @@ const CardTitleIcon = styled('div')`
 const CardContent = styled('div')`
   overflow-wrap: break-word;
   word-break: break-word;
-  padding: ${space(1.5)};
+  padding: ${space(1)};
   text-align: left;
   flex: 1;
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import starImage from 'sentry-images/spot/banner-star.svg';
 
 import Feature from 'sentry/components/acl/feature';
-import {SeerIcon, SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
+import {SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
@@ -13,6 +13,7 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
+import {AutofixProgressBar} from 'sentry/components/events/autofix/autofixProgressBar';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import AutofixPreferenceDropdown from 'sentry/components/events/autofix/preferences/autofixPreferenceDropdown';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
@@ -192,7 +193,6 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
       </SeerDrawerHeader>
       <SeerDrawerNavigator>
         <Header>
-          <SeerIcon size="lg" />
           {t('Autofix')}
           <StyledFeatureBadge
             type="beta"
@@ -231,14 +231,9 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         )}
       </SeerDrawerNavigator>
 
-      {!aiConfig.isAutofixSetupLoading && !aiConfig.needsGenAIConsent && (
-        <SeerNotices
-          groupId={group.id}
-          hasGithubIntegration={aiConfig.hasGithubIntegration}
-          project={project}
-        />
+      {!aiConfig.isAutofixSetupLoading && !aiConfig.needsGenAIConsent && autofixData && (
+        <AutofixProgressBar autofixData={autofixData} />
       )}
-
       <SeerDrawerBody ref={scrollContainerRef} onScroll={handleScroll}>
         {aiConfig.isAutofixSetupLoading ? (
           <div data-test-id="ai-setup-loading-indicator">
@@ -248,6 +243,11 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
           <AiSetupDataConsent groupId={group.id} />
         ) : (
           <Fragment>
+            <SeerNotices
+              groupId={group.id}
+              hasGithubIntegration={aiConfig.hasGithubIntegration}
+              project={project}
+            />
             {aiConfig.hasSummary && (
               <StyledCard>
                 <GroupSummary group={group} event={event} project={project} />
@@ -434,7 +434,7 @@ const StyledFeatureBadge = styled(FeatureBadge)`
 const SeerDrawerContainer = styled('div')`
   height: 100%;
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto auto 1fr;
   position: relative;
 `;
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -119,8 +119,8 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     notices.push(<GithubIntegrationSetupCard key="github-setup" />);
   } else if (
     repos.length === 0 &&
-    !preference?.repositories &&
-    !codeMappingRepos &&
+    !preference?.repositories?.length &&
+    !codeMappingRepos?.length &&
     !isLoadingPreferences
   ) {
     notices.push(<SelectReposCard key="repo-selection" />);
@@ -188,11 +188,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     return null;
   }
 
-  return (
-    <StickyNoticesContainer>
-      <NoticesContainer>{notices}</NoticesContainer>
-    </StickyNoticesContainer>
-  );
+  return <NoticesContainer>{notices}</NoticesContainer>;
 }
 
 const NoticesContainer = styled('div')`
@@ -201,17 +197,6 @@ const NoticesContainer = styled('div')`
   gap: ${space(2)};
   align-items: stretch;
   margin-bottom: ${space(2)};
-`;
-
-const StickyNoticesContainer = styled('div')`
-  position: sticky;
-  top: 0;
-  background: ${p => p.theme.background};
-  padding-top: ${space(2)};
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
-  box-shadow: ${p => p.theme.dropShadowMedium};
 `;
 
 const IntegrationCard = styled('div')`


### PR DESCRIPTION
Sorry for tacking on a few things:
- Adds a progress bar for the run
- Restyles the sidebar cards to take less space and be a bit closer to Vu's design
- Fix bug in when we showing a notice card
- Unsticky them (I changed my mind lol)
- Remove icon from header

<img width="1021" alt="Screenshot 2025-04-11 at 9 15 05 AM" src="https://github.com/user-attachments/assets/e1512700-3440-473a-a2f1-c262e56d2201" />
<img width="560" alt="Screenshot 2025-04-10 at 8 23 15 PM" src="https://github.com/user-attachments/assets/4fd1ccb6-73ad-46e6-af58-0b41805b9fa7" />
<img width="324" alt="Screenshot 2025-04-11 at 9 28 57 AM" src="https://github.com/user-attachments/assets/85dbcc21-3cc9-4b09-9c80-745f3f110101" />
