### PR TITLE
ref(shared-views): Enable starred ordering endpoint for custom views users

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -35,7 +35,9 @@ class OrganizationGroupSearchViewStarredOrderEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
     def put(self, request: Request, organization: Organization) -> Response:
-        if not features.has("organizations:issue-view-sharing", organization, actor=request.user):
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         serializer = GroupSearchViewStarredOrderSerializer(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
@@ -67,7 +67,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
                 position=idx,
             )
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_simple_reordering(self):
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id])
 
@@ -91,7 +91,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[2].group_search_view_id == self.views[1].id
         assert starred_views[2].position == 2
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_same_order_reordering(self):
         original_order = [self.views[0].id, self.views[1].id, self.views[2].id]
 
@@ -115,7 +115,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[2].group_search_view_id == self.views[2].id
         assert starred_views[2].position == 2
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def reordering_with_shared_views(self):
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id, self.shared_view.id])
 
@@ -142,7 +142,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[3].group_search_view_id == self.views[1].id
         assert starred_views[3].position == 3
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_empty_starred_list(self):
         response = self.client.put(self.url, data={"view_ids": []}, format="json")
 
@@ -153,7 +153,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
             user_id=self.user.id,
         ).exists()
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_fewer_views_than_starred_views(self):
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id])
 
@@ -163,7 +163,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
 
         assert response.status_code == 400
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_more_views_than_starred_views(self):
         self.star_views([self.views[0].id, self.views[1].id])
 
@@ -175,7 +175,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
 
         assert response.status_code == 400
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_duplicate_view_ids(self):
         view_ids = [self.views[0].id, self.views[1].id, self.views[1].id]
 
@@ -208,7 +208,7 @@ class OrganizationGroupSearchViewStarredOrderTransactionTest(TransactionTestCase
             query_sort="date",
         )
 
-    @with_feature("organizations:issue-view-sharing")
+    @with_feature("organizations:issue-stream-custom-views")
     def test_nonexistent_view_id(self):
         non_existent_id = 373737
         view_ids = [self.view.id, non_existent_id]


### PR DESCRIPTION
A small subset of users are now using this endpoint, we need to enable it. 