### PR TITLE
ref(uptime): Remove usage of uptimeAutodetection org/project option

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -62,7 +62,6 @@ from sentry.constants import (
     SCRAPE_JAVASCRIPT_DEFAULT,
     SENSITIVE_FIELDS_DEFAULT,
     TARGET_SAMPLE_RATE_DEFAULT,
-    UPTIME_AUTODETECTION,
     ObjectStatus,
 )
 from sentry.datascrubbing import validate_pii_config_update, validate_pii_selectors
@@ -214,7 +213,6 @@ ORG_OPTIONS = (
         bool,
         METRIC_ALERTS_THREAD_DEFAULT,
     ),
-    ("uptimeAutodetection", "sentry:uptime_autodetection", bool, UPTIME_AUTODETECTION),
     ("targetSampleRate", "sentry:target_sample_rate", float, TARGET_SAMPLE_RATE_DEFAULT),
     ("samplingMode", "sentry:sampling_mode", str, SAMPLING_MODE_DEFAULT),
     ("rollbackEnabled", "sentry:rollback_enabled", bool, ROLLBACK_ENABLED_DEFAULT),
@@ -274,7 +272,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     allowJoinRequests = serializers.BooleanField(required=False)
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
-    uptimeAutodetection = serializers.BooleanField(required=False)
     targetSampleRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     samplingMode = serializers.ChoiceField(choices=DynamicSamplingMode.choices, required=False)
     rollbackEnabled = serializers.BooleanField(required=False)

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -132,7 +132,6 @@ class ProjectMemberSerializer(serializers.Serializer):
         "performanceIssueCreationRate",
         "performanceIssueCreationThroughPlatform",
         "performanceIssueSendToPlatform",
-        "uptimeAutodetection",
         "tempestFetchScreenshots",
         "tempestFetchDumps",
     ]
@@ -227,7 +226,6 @@ E.g. `['release', 'environment']`""",
     performanceIssueCreationRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     performanceIssueCreationThroughPlatform = serializers.BooleanField(required=False)
     performanceIssueSendToPlatform = serializers.BooleanField(required=False)
-    uptimeAutodetection = serializers.BooleanField(required=False)
     tempestFetchScreenshots = serializers.BooleanField(required=False)
     tempestFetchDumps = serializers.BooleanField(required=False)
 
@@ -763,10 +761,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:dynamic_sampling_biases"] = result[
                     "dynamicSamplingBiases"
                 ]
-
-        if result.get("uptimeAutodetection") is not None:
-            if project.update_option("sentry:uptime_autodetection", result["uptimeAutodetection"]):
-                changed_proj_settings["sentry:uptime_autodetection"] = result["uptimeAutodetection"]
 
         if has_elevated_scopes:
             options = result.get("options", {})

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -52,7 +52,6 @@ from sentry.constants import (
     SENSITIVE_FIELDS_DEFAULT,
     STREAMLINE_UI_ONLY,
     TARGET_SAMPLE_RATE_DEFAULT,
-    UPTIME_AUTODETECTION,
     ObjectStatus,
 )
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
@@ -506,7 +505,6 @@ class OnboardingTasksSerializer(Serializer):
 class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResponse, total=False):
     role: Any  # TODO: replace with enum/literal
     orgRole: str
-    uptimeAutodetection: bool
     targetSampleRate: float
     samplingMode: str
     effectiveSampleRate: float
@@ -713,11 +711,6 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ).count(),
             "isDynamicallySampled": is_dynamically_sampled,
         }
-
-        if features.has("organizations:uptime-settings", obj):
-            context["uptimeAutodetection"] = bool(
-                obj.get_option("sentry:uptime_autodetection", UPTIME_AUTODETECTION)
-            )
 
         if has_custom_dynamic_sampling(obj, actor=user):
             context["targetSampleRate"] = float(

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -948,7 +948,6 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     dynamicSamplingBiases: list[dict[str, str | bool]]
     eventProcessing: dict[str, bool]
     symbolSources: str
-    uptimeAutodetection: NotRequired[bool]
     isDynamicallySampled: bool
     tempestFetchScreenshots: NotRequired[bool]
     tempestFetchDumps: NotRequired[bool]
@@ -1101,11 +1100,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "symbolSources": serialized_sources,
             "isDynamicallySampled": sample_rate is not None and sample_rate < 1.0,
         }
-
-        if features.has("organizations:uptime-settings", obj.organization):
-            data["uptimeAutodetection"] = bool(
-                attrs["options"].get("sentry:uptime_autodetection", True)
-            )
 
         if has_tempest_access(obj.organization, user):
             data["tempestFetchScreenshots"] = attrs["options"].get(

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -174,7 +174,6 @@ DETAILED_PROJECT = {
     "secondaryGroupingExpiry": 1687010243,
     "secondaryGroupingConfig": LEGACY_GROUPING_CONFIG,
     "fingerprintingRules": "",
-    "uptimeAutodetection": True,
     "organization": {
         "id": "1",
         "slug": "sentry",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -780,7 +780,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "allowJoinRequests": False,
             "issueAlertsThreadFlag": False,
             "metricAlertsThreadFlag": False,
-            "uptimeAutodetection": False,
             "targetSampleRate": 0.1,
             "samplingMode": "organization",
             "rollbackEnabled": True,
@@ -821,7 +820,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert options.get("sentry:join_requests") is False
         assert options.get("sentry:events_member_admin") is False
 
-        assert options.get("sentry:uptime_autodetection") is False
         assert options.get("sentry:target_sample_rate") == 0.1
         assert options.get("sentry:sampling_mode") == "organization"
         assert options.get("sentry:rollback_enabled") is True
@@ -860,7 +858,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["githubNudgeInvite"]) in log.data["githubNudgeInvite"]
         assert "to {}".format(data["issueAlertsThreadFlag"]) in log.data["issueAlertsThreadFlag"]
         assert "to {}".format(data["metricAlertsThreadFlag"]) in log.data["metricAlertsThreadFlag"]
-        assert "to {}".format(data["uptimeAutodetection"]) in log.data["uptimeAutodetection"]
         assert "to Default Mode" in log.data["samplingMode"]
 
     @responses.activate

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1265,17 +1265,6 @@ class ProjectUpdateTest(APITestCase):
             assert resp.status_code == 200
             assert project.get_option("sentry:symbol_sources", orjson.dumps([source1]).decode())
 
-    @with_feature("organizations:uptime-settings")
-    def test_uptime_settings(self):
-        # test when the value is set to False
-        resp = self.get_success_response(self.org_slug, self.proj_slug, uptimeAutodetection=False)
-        assert self.project.get_option("sentry:uptime_autodetection") is False
-        assert resp.data["uptimeAutodetection"] is False
-        # test when the value is set to True
-        resp = self.get_success_response(self.org_slug, self.proj_slug, uptimeAutodetection=True)
-        assert self.project.get_option("sentry:uptime_autodetection") is True
-        assert resp.data["uptimeAutodetection"] is True
-
     @with_feature({"organizations:dynamic-sampling-custom": False})
     def test_target_sample_rate_without_feature(self):
         self.project.update_option("sentry:target_sample_rate", 1.0)


### PR DESCRIPTION
We never ended up using this, so there's no need to reply with this in
the API