### PR TITLE
chore(uptime): Move UptimeDomainCheckFailure to uptime/grouptype.py take 3

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -642,34 +642,6 @@ class FeedbackGroup(GroupType):
 
 
 @dataclass(frozen=True)
-class UptimeDomainCheckFailure(GroupType):
-    type_id = 7001
-    slug = "uptime_domain_failure"
-    description = "Uptime Domain Monitor Failure"
-    category = GroupCategory.UPTIME.value
-    creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
-    default_priority = PriorityLevel.HIGH
-    enable_auto_resolve = False
-    enable_escalation_detection = False
-    detector_config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "A representation of an uptime alert",
-        "type": "object",
-        "required": ["mode", "environment"],
-        "properties": {
-            "mode": {
-                "type": ["integer"],
-                # TODO: Enable this when we can move this grouptype out of this file
-                # "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
-            },
-            "environment": {"type": ["string"]},
-        },
-        "additionalProperties": False,
-    }
-    use_flagpole_for_all_features = True
-
-
-@dataclass(frozen=True)
 class MetricIssuePOC(GroupType):
     type_id = 8002
     slug = "metric_issue_poc"

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry.issues import grouptype
+from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.ratelimits.sliding_windows import Quota
+from sentry.types.group import PriorityLevel
+
+
+@dataclass(frozen=True)
+class UptimeDomainCheckFailure(GroupType):
+    type_id = 7001
+    slug = "uptime_domain_failure"
+    description = "Uptime Domain Monitor Failure"
+    category = GroupCategory.UPTIME.value
+    creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    detector_config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A representation of an uptime alert",
+        "type": "object",
+        "required": ["mode", "environment"],
+        "properties": {
+            "mode": {
+                "type": ["integer"],
+                # TODO: Enable this when we can move this grouptype out of this file
+                # "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+            },
+            "environment": {"type": ["string"]},
+        },
+        "additionalProperties": False,
+    }
+    use_flagpole_for_all_features = True
+
+
+# XXX: Temporary hack to work around pickling issues
+grouptype.UptimeDomainCheckFailure = UptimeDomainCheckFailure  # type: ignore[attr-defined]

--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -5,11 +5,11 @@ from datetime import datetime, timezone
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
 
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import ProjectUptimeSubscription
 
 

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -12,7 +12,6 @@ from sentry.integrations.repository.notification_action import NotificationActio
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.service import ActionDataError, RuleDataError, SlackService
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.models.activity import Activity
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -24,6 +23,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.workflow_engine.models import Action
 
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -23,7 +23,6 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
 from sentry.conf.types import kafka_definition
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import DataCategory, ObjectStatus
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.models.group import Group, GroupStatus
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.datetime import freeze_time
@@ -37,6 +36,7 @@ from sentry.uptime.consumers.results_consumer import (
 )
 from sentry.uptime.detectors.ranking import _get_cluster
 from sentry.uptime.detectors.tasks import is_failed_url
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -8,13 +8,13 @@ from pytest import raises
 
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import DataCategory, ObjectStatus
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.models.group import Group, GroupStatus
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.issue_platform import create_issue_platform_occurrence
 from sentry.uptime.models import (
     ProjectUptimeSubscription,

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -1,8 +1,8 @@
 import pytest
 from jsonschema import ValidationError
 
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.testutils.cases import TestCase
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import ProjectUptimeSubscriptionMode
 
 

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -4,12 +4,12 @@ from hashlib import md5
 from itertools import cycle
 from unittest.mock import patch
 
-from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType
 from sentry.models.group import Group, GroupStatus
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.issue_platform import (
     build_event_data_for_occurrence,
     build_occurrence_from_result,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -8,10 +8,10 @@ from sentry.issues.grouptype import (
     GroupTypeRegistry,
     MonitorIncidentType,
     PerformanceSlowDBQueryGroupType,
-    UptimeDomainCheckFailure,
 )
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, DetectorHandler
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel


### PR DESCRIPTION
We want to keep grouptypes in the module that is related to them, so just moving this out.

The first time caused pickling problems last time, so importing the model in its old location to prevent issues.

The second time, moving the model broke the old option based feature handlers. We've moved them to flagpole now.

<!-- Describe your PR here. -->