### PR TITLE
fix(aci): Fix bugs when setting open periods for regressions

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1705,7 +1705,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
                 }
             )
 
-        activity = Activity.objects.create_group_activity(
+        Activity.objects.create_group_activity(
             group,
             ActivityType.SET_REGRESSION,
             data=activity_data,
@@ -1719,7 +1719,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             GroupOpenPeriod.objects.create(
                 group=group,
                 project_id=group.project_id,
-                date_started=activity.datetime,
+                date_started=event.datetime,
                 date_ended=None,
             )
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1705,7 +1705,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
                 }
             )
 
-        Activity.objects.create_group_activity(
+        activity = Activity.objects.create_group_activity(
             group,
             ActivityType.SET_REGRESSION,
             data=activity_data,
@@ -1719,7 +1719,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             GroupOpenPeriod.objects.create(
                 group=group,
                 project_id=group.project_id,
-                date_started=event.datetime,
+                date_started=activity.datetime,
                 date_ended=None,
             )
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1234,7 +1234,7 @@ def update_group_open_period(
             )
 
         open_period.update(
-            date_ended=activity.datetime,
+            date_ended=group.resolved_at if group.resolved_at else activity.datetime,
             resolution_activity=activity,
             user_id=activity.user_id if activity else None,
         )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1233,8 +1233,9 @@ def update_group_open_period(
                 .first()
             )
 
+        end_time = group.resolved_at or (activity.datetime if activity else None)
         open_period.update(
-            date_ended=group.resolved_at if group.resolved_at else activity.datetime,
+            date_ended=end_time,
             resolution_activity=activity,
             user_id=activity.user_id if activity else None,
         )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1224,6 +1224,10 @@ def update_group_open_period(
 
     if new_status == GroupStatus.RESOLVED:
         if activity is None:
+            logger.warning(
+                "Missing activity for group resolution, querying for it",
+                extra={"group_id": group.id},
+            )
             activity = (
                 Activity.objects.filter(
                     group=group,
@@ -1240,4 +1244,4 @@ def update_group_open_period(
             user_id=activity.user_id if activity else None,
         )
     elif new_status == GroupStatus.UNRESOLVED and should_reopen_open_period:
-        open_period.update(date_ended=None, resolution_activity=None)
+        open_period.update(date_ended=None, resolution_activity=None, user_id=None)


### PR DESCRIPTION
Regressions were failing to update open periods for platform issues that aren't handled through `event_manager`. This PR fixes that by generalizing the `update_group_open_period` logic which should be called by the issue platform's status_change endpoint. 

FIXES SENTRY-3RYH