### PR TITLE
feat(insights): ensure eap toggle persists between tab changes

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -91,7 +91,10 @@ export function DomainViewHeader({
   const tabValue =
     hideDefaultTabs && tabs?.value ? tabs.value : (selectedModule ?? OVERVIEW_PAGE_TITLE);
 
-  const globalQuery = extractSelectionParameters(location?.query);
+  const globalQuery = {
+    ...extractSelectionParameters(location?.query),
+    useEap: location.query.useEap,
+  };
 
   const tabList: TabListItemProps[] = [
     ...(hasOverviewPage

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -93,7 +93,7 @@ export function DomainViewHeader({
 
   const globalQuery = {
     ...extractSelectionParameters(location?.query),
-    useEap: location.query.useEap,
+    useEap: location.query?.useEap,
   };
 
   const tabList: TabListItemProps[] = [

--- a/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
@@ -3,6 +3,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {
@@ -26,7 +27,7 @@ export function useQueuesByDestinationQuery({
 }: Props) {
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.DESTINATIONS_CURSOR]);
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
 
   const timeSpentField: SpanMetricsProperty = useEap
     ? 'time_spent_percentage(span.duration)'

--- a/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
@@ -3,6 +3,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {
@@ -25,7 +26,7 @@ export function useQueuesByTransactionQuery({
   referrer,
 }: Props) {
   const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.TRANSACTIONS_CURSOR]);
 
   const mutableSearch = new MutableSearch(DEFAULT_QUERY_FILTER);

--- a/static/app/views/insights/queues/queries/useQueuesMetricsQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesMetricsQuery.tsx
@@ -1,6 +1,6 @@
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/queues/settings';
 import type {SpanMetricsProperty} from 'sentry/views/insights/types';
@@ -19,8 +19,7 @@ export function useQueuesMetricsQuery({
   referrer,
 }: Props) {
   const mutableSearch = new MutableSearch(DEFAULT_QUERY_FILTER);
-  const location = useLocation();
-  const useEap = location.query?.useEap === '1';
+  const useEap = useInsightsEap();
   if (destination) {
     mutableSearch.addFilterValue('messaging.destination.name', destination);
   }


### PR DESCRIPTION
1. Ensure `useEap` query param persists between tab changes between modules
2. Update several missing `useInsightsEap` calls