### PR TITLE
ref(uptime): Bump sentry-kafka-schemas

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.21.0
-sentry-kafka-schemas>=1.1.6
+sentry-kafka-schemas>=1.2.0
 sentry-ophio==1.0.0
 sentry-protos==0.1.69
 sentry-redis-tools>=0.5.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-devenv==1.16.0
 sentry-forked-django-stubs==5.1.3.post2
 sentry-forked-djangorestframework-stubs==3.15.3.post1
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.1.6
+sentry-kafka-schemas==1.2.0
 sentry-ophio==1.0.0
 sentry-protos==0.1.69
 sentry-redis-tools==0.5.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.21.0
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.1.6
+sentry-kafka-schemas==1.2.0
 sentry-ophio==1.0.0
 sentry-protos==0.1.69
 sentry-redis-tools==0.5.0


### PR DESCRIPTION
Removes the uptime-configs topic, this bump isn't strictly required, but
may as well do it just for sanity