### PR TITLE
chore(issue-platform): Set `PerformanceHTTPOverheadGroupType` to be fully released.

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -425,6 +425,7 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
     noise_config = NoiseConfig(ignore_limit=20)
     category = GroupCategory.PERFORMANCE.value
     default_priority = PriorityLevel.LOW
+    released = True
 
 
 # experimental

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -11,12 +11,12 @@ from sentry.issues.grouptype import (
     GroupTypeRegistry,
     NoiseConfig,
     PerformanceGroupTypeDefaults,
-    PerformanceHTTPOverheadGroupType,
     ProfileJSONDecodeType,
     get_group_type_by_slug,
     get_group_types_by_category,
 )
 from sentry.testutils.cases import TestCase
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 
 
 class BaseGroupTypeTest(TestCase):
@@ -159,14 +159,14 @@ class GroupTypeReleasedTest(BaseGroupTypeTest):
 class GroupRegistryTest(BaseGroupTypeTest):
     def test_get_visible(self) -> None:
         registry = GroupTypeRegistry()
-        registry.add(PerformanceHTTPOverheadGroupType)
+        registry.add(UptimeDomainCheckFailure)
         registry.add(ProfileJSONDecodeType)
         assert registry.get_visible(self.organization) == []
-        with self.feature(PerformanceHTTPOverheadGroupType.build_visible_feature_name()):
-            assert registry.get_visible(self.organization) == [PerformanceHTTPOverheadGroupType]
+        with self.feature(UptimeDomainCheckFailure.build_visible_flagpole_feature_name()):
+            assert registry.get_visible(self.organization) == [UptimeDomainCheckFailure]
         registry.add(ErrorGroupType)
-        with self.feature(PerformanceHTTPOverheadGroupType.build_visible_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_visible_flagpole_feature_name()):
             assert set(registry.get_visible(self.organization)) == {
-                PerformanceHTTPOverheadGroupType,
+                UptimeDomainCheckFailure,
                 ErrorGroupType,
             }


### PR DESCRIPTION
This no longer needs to use feature flags since it's full released. Confirmed with perf team

<!-- Describe your PR here. -->