### PR TITLE
chore(issue-platform): Update `MetricIssuePOC` to always read from flagpole instead of the option backed flags

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -629,6 +629,7 @@ class MetricIssuePOC(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
+    use_flagpole_for_all_features = True
 
 
 def should_create_group(

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -12,7 +12,7 @@ from sentry.types.group import GroupSubStatus, PriorityLevel
 from tests.sentry.issues.test_occurrence_consumer import IssueOccurrenceTestBase
 
 
-@apply_feature_flag_on_cls("organizations:metric-issue-poc-ingest")
+@apply_feature_flag_on_cls(MetricIssuePOC.build_ingest_flagpole_feature_name())
 @apply_feature_flag_on_cls("projects:metric-issue-creation")
 class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
     def setUp(self):


### PR DESCRIPTION
Updated these in https://github.com/getsentry/sentry-options-automator/pull/3553, so it's safe to switch over.