### PR TITLE
feat(sourcemaps) - Allow Querying 'symbolicated_in_app' in issues and discover

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1685,6 +1685,7 @@ default_config = SearchConfig(
         "error.main_thread",
         "stack.in_app",
         "is_application",
+        "symbolicated_in_app",
         TEAM_KEY_TRANSACTION_ALIAS,
     },
 )

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -812,3 +812,12 @@ class Columns(Enum):
         issue_platform_name=None,
         alias="num_processing_errors",
     )
+
+    SYMBOLICATED_IN_APP = Column(
+        group_name="events.symbolicated_in_app",
+        event_name="symbolicated_in_app",
+        transaction_name=None,
+        discover_name="symbolicated_in_app",
+        issue_platform_name=None,
+        alias="symbolicated_in_app",
+    )

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -89,6 +89,7 @@ ERROR_ONLY_FIELDS = [
     "stack.package",
     "stack.resource",
     "stack.stack_level",
+    "symbolicated_in_app",
 ]
 
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -65,7 +65,9 @@ SEEN_COLUMN = "timestamp"
 # all values for a given tag/column
 BLACKLISTED_COLUMNS = frozenset(["project_id"])
 
-BOOLEAN_KEYS = frozenset(["error.handled", "error.unhandled", "error.main_thread", "stack.in_app"])
+BOOLEAN_KEYS = frozenset(
+    ["error.handled", "error.unhandled", "error.main_thread", "stack.in_app", "symbolicated_in_app"]
+)
 
 FUZZY_NUMERIC_KEYS = frozenset(
     ["stack.colno", "stack.lineno", "stack.stack_level", "transaction.duration"]

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1420,6 +1420,7 @@ export const defaultConfig: SearchConfig = {
     'error.unhandled',
     'stack.in_app',
     'team_key_transaction',
+    'symbolicated_in_app',
   ]),
   sizeKeys: new Set([]),
   disallowedLogicalOperators: new Set(),

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -951,3 +951,53 @@ class DiscoverQueryBuilderTest(TestCase):
                 )
             ],
         )
+
+    def test_symbolicated_in_app_parameter(self):
+        query = DiscoverQueryBuilder(
+            Dataset.Discover,
+            self.params,
+            query="symbolicated_in_app:True",
+            selected_columns=["symbolicated_in_app"],
+        )
+
+        self.assertCountEqual(
+            query.where,
+            [
+                Condition(Column("symbolicated_in_app"), Op.EQ, 1),
+                *self.default_conditions,
+            ],
+        )
+        query.get_snql_query().validate()
+
+        query = DiscoverQueryBuilder(
+            Dataset.Discover,
+            self.params,
+            query="symbolicated_in_app:False",
+            selected_columns=["symbolicated_in_app"],
+        )
+
+        self.assertCountEqual(
+            query.where,
+            [
+                Condition(Column("symbolicated_in_app"), Op.EQ, 0),
+                *self.default_conditions,
+            ],
+        )
+        query.get_snql_query().validate()
+
+        # Test !has: filter for checking NULL values
+        query = DiscoverQueryBuilder(
+            Dataset.Discover,
+            self.params,
+            query="!has:symbolicated_in_app",
+            selected_columns=["symbolicated_in_app"],
+        )
+
+        self.assertCountEqual(
+            query.where,
+            [
+                Condition(Function("isNull", [Column("symbolicated_in_app")]), Op.EQ, 1),
+                *self.default_conditions,
+            ],
+        )
+        query.get_snql_query().validate()


### PR DESCRIPTION
New field was already added in previous commits, this now exposes it to be queryable in both issues and discover, while still not making it visibile in autocomplete to allow testing it out with select customers