### PR TITLE
insights: use text colors for loading

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
@@ -1,2 +1,2 @@
 export const LOADING_PLACEHOLDER = '\u2014';
-export const DEEMPHASIS_COLOR_NAME = 'gray300';
+export const DEEMPHASIS_COLOR_NAME = 'subText';


### PR DESCRIPTION
use subText instead of gray color name.