### PR TITLE
admin: only show icon if item is disabled

### DIFF
--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -39,7 +39,7 @@ function mapActionsToCompactSelect(
         label: (
           <div>
             {action.name}
-            <StyledIconNot size="xs" />
+            {action.disabled && <StyledIconNot size="xs" />}
           </div>
         ),
         details: action.help,


### PR DESCRIPTION
I missed this when converting from the deprecated dropdown