### PR TITLE
ref(tags/flags): exclude flags from button label for unsupported platforms

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -10,7 +10,11 @@ import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
-import {backend, frontend} from 'sentry/data/platformCategories';
+import {
+  backend,
+  featureFlagDrawerPlatforms,
+  frontend,
+} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -159,11 +163,13 @@ function TagPreviewProgressBar({tag, groupId}: {groupId: string; tag: GroupTag})
   );
 }
 
-function IssueTagButton({
+function DistributionsDrawerButton({
   tags,
+  includeFeatureFlags,
   searchQuery,
   isScreenSmall,
 }: {
+  includeFeatureFlags: boolean;
   tags: GroupTag[];
   isScreenSmall?: boolean;
   searchQuery?: string;
@@ -171,13 +177,10 @@ function IssueTagButton({
   const {baseUrl} = useGroupDetailsRoute();
   const location = useLocation();
   const organization = useOrganization();
-  const hasFlagsDistributions = organization.features.includes(
-    'feature-flag-distribution-flyout'
-  );
 
   if (tags.length === 0 || searchQuery || isScreenSmall) {
     return (
-      <VerticalIssueTagsButton
+      <VerticalDistributionsDrawerButton
         aria-label={t('View issue tag distributions')}
         size="xs"
         to={{
@@ -187,19 +190,19 @@ function IssueTagButton({
         replace
         disabled={tags.length === 0}
       >
-        {hasFlagsDistributions
+        {includeFeatureFlags
           ? tct('View[nbsp]All Tags[nbsp]&[nbsp]Flags', {
               nbsp: '\u00A0', // non-breaking space unicode character.
             })
           : tct('View All[nbsp]Tags', {
               nbsp: '\u00A0', // non-breaking space unicode character.
             })}
-      </VerticalIssueTagsButton>
+      </VerticalDistributionsDrawerButton>
     );
   }
 
   return (
-    <IssueTagsLink
+    <DistributionsDrawerLink
       to={{
         pathname: `${baseUrl}${TabPaths[Tab.DISTRIBUTIONS]}`,
         query: location.query,
@@ -208,8 +211,8 @@ function IssueTagButton({
         trackAnalytics('issue_details.issue_tags_click', {organization});
       }}
     >
-      {hasFlagsDistributions ? t('View all tags and feature flags') : t('View all tags')}
-    </IssueTagsLink>
+      {includeFeatureFlags ? t('View all tags and feature flags') : t('View all tags')}
+    </DistributionsDrawerLink>
   );
 }
 
@@ -275,16 +278,21 @@ export default function IssueTagsPreview({
     return uniqueTags.slice(0, 4);
   }, [tags, project.platform, highlightTagKeys]);
 
+  const includeFeatureFlags =
+    featureFlagDrawerPlatforms.includes(project.platform ?? 'other') &&
+    organization.features.includes('feature-flag-distribution-flyout');
+
   if (
     searchQuery ||
     isScreenSmall ||
     (!isPending && !isHighlightPending && tagsToPreview.length === 0)
   ) {
     return (
-      <IssueTagButton
+      <DistributionsDrawerButton
         tags={tagsToPreview}
         searchQuery={searchQuery}
         isScreenSmall={isScreenSmall}
+        includeFeatureFlags={includeFeatureFlags}
       />
     );
   }
@@ -313,7 +321,10 @@ export default function IssueTagsPreview({
             <TagPreviewProgressBar key={tag.key} tag={tag} groupId={groupId} />
           ))}
         </TagsPreview>
-        <IssueTagButton tags={tagsToPreview} />
+        <DistributionsDrawerButton
+          tags={tagsToPreview}
+          includeFeatureFlags={includeFeatureFlags}
+        />
       </IssueTagPreviewSection>
     </Fragment>
   );
@@ -422,7 +433,7 @@ const LegendTitle = styled('div')`
   margin-bottom: ${space(0.75)};
 `;
 
-const IssueTagsLink = styled(Link)`
+const DistributionsDrawerLink = styled(Link)`
   color: ${p => p.theme.purple300};
   align-self: flex-start;
 
@@ -431,7 +442,7 @@ const IssueTagsLink = styled(Link)`
   }
 `;
 
-const VerticalIssueTagsButton = styled(LinkButton)`
+const VerticalDistributionsDrawerButton = styled(LinkButton)`
   display: block;
   flex: 0;
   margin: ${space(1)} ${space(2)} ${space(1)} ${space(1)};


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/88691. Changes the label of this button/link to just "View all tags" if platform is unsupported. We don't show the drawer's segmented control in these platforms so best to avoid confusion
![Screenshot 2025-04-11 at 1 31 48 PM](https://github.com/user-attachments/assets/75930a58-1b53-440b-8288-7baa4a38ff95)

Also renames `IssueTagButton` components to `DistributionsDrawerButton`, now the tags drawer + route is distributions.
