### PR TITLE
ref(shared-views): Use queryclient cache instead of state, rewire with new endpoints

### DIFF
--- a/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
@@ -7,17 +7,10 @@ import {
   decodeList,
   decodeScalar,
 } from 'sentry/utils/queryString';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import type {IssueViewParams} from 'sentry/views/issueList/issueViews/issueViews';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
-export function createIssueViewFromUrl({
-  query,
-}: {
-  query: Query;
-}): Pick<
-  GroupSearchView,
-  'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
-> {
+export function createIssueViewFromUrl({query}: {query: Query}): IssueViewParams {
   return {
     query: typeof query.query === 'string' ? query.query : '',
     querySort:

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -21,9 +21,9 @@ import {
   useFetchGroupSearchViews,
 } from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {
-  type GroupSearchView,
   GroupSearchViewCreatedBy,
   GroupSearchViewSort,
+  type StarredGroupSearchView,
 } from 'sentry/views/issueList/types';
 
 type IssueViewSectionProps = {
@@ -73,14 +73,14 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
 
   const {mutate: mutateViewStarred} = useUpdateGroupSearchViewStarred({
     onMutate: variables => {
-      setApiQueryData<GroupSearchView[]>(queryClient, tableQueryKey, data => {
+      setApiQueryData<StarredGroupSearchView[]>(queryClient, tableQueryKey, data => {
         return data?.map(view =>
           view.id === variables.id ? {...view, starred: variables.starred} : view
         );
       });
     },
     onError: (_error, variables) => {
-      setApiQueryData<GroupSearchView[]>(queryClient, tableQueryKey, data => {
+      setApiQueryData<StarredGroupSearchView[]>(queryClient, tableQueryKey, data => {
         return data?.map(view =>
           view.id === variables.id ? {...view, starred: !variables.starred} : view
         );

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -106,12 +106,6 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
           makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug}),
           data => data?.filter(view => view.id !== variables.id)
         );
-      } else {
-        setApiQueryData<StarredGroupSearchView[]>(
-          queryClient,
-          makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug}),
-          data => [...(data ?? []), variables.view]
-        );
       }
     },
   });

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -81,7 +81,7 @@ export function IssueViewsTable({
             <SavedEntityTable.CellQuery query={view.query} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTimeSince date={view.lastVisited ?? null} />
+            <SavedEntityTable.CellTimeSince date={view.lastVisited} />
           </SavedEntityTable.Cell>
         </SavedEntityTable.Row>
       ))}

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -81,7 +81,7 @@ export function IssueViewsTable({
             <SavedEntityTable.CellQuery query={view.query} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTimeSince date={view.lastVisited} />
+            <SavedEntityTable.CellTimeSince date={view.lastVisited ?? null} />
           </SavedEntityTable.Cell>
         </SavedEntityTable.Row>
       ))}

--- a/static/app/views/issueList/issueViews/useIssueViewUnsavedChanges.tsx
+++ b/static/app/views/issueList/issueViews/useIssueViewUnsavedChanges.tsx
@@ -24,5 +24,12 @@ export function useIssueViewUnsavedChanges() {
 
   return {
     hasUnsavedChanges,
+    changedParams: {
+      query: !isEqual(currentViewData.query, viewFromUrl.query),
+      querySort: !isEqual(currentViewData.querySort, viewFromUrl.querySort),
+      projects: !isEqual(currentViewData.projects, viewFromUrl.projects),
+      environments: !isEqual(currentViewData.environments, viewFromUrl.environments),
+      timeFilters: !isEqual(currentViewData.timeFilters, viewFromUrl.timeFilters),
+    },
   };
 }

--- a/static/app/views/issueList/mutations/useCreateGroupSearchView.tsx
+++ b/static/app/views/issueList/mutations/useCreateGroupSearchView.tsx
@@ -7,8 +7,8 @@ import {
 } from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
+import type {GroupSearchView, StarredGroupSearchView} from 'sentry/views/issueList/types';
 
 interface CreateGroupSearchViewData
   extends Partial<
@@ -36,9 +36,9 @@ export function useCreateGroupSearchView(
     ...options,
     onSuccess: (data, variables, context) => {
       if (variables.starred) {
-        setApiQueryData<GroupSearchView[]>(
+        setApiQueryData<StarredGroupSearchView[]>(
           queryClient,
-          makeFetchGroupSearchViewsKey({
+          makeFetchStarredGroupSearchViewsKey({
             orgSlug: organization.slug,
           }),
           existingViews => [...(existingViews ?? []), data]

--- a/static/app/views/issueList/mutations/useDeleteGroupSearchView.tsx
+++ b/static/app/views/issueList/mutations/useDeleteGroupSearchView.tsx
@@ -36,12 +36,13 @@ export const useDeleteGroupSearchView = (
         }
       ),
     onSuccess: (data, parameters, context) => {
-      // Update the specific view cache
-      setApiQueryData<GroupSearchView>(
-        queryClient,
-        makeFetchGroupSearchViewKey({orgSlug: organization.slug, id: parameters.id}),
-        undefined
-      );
+      // Invalidate the view in cache
+      queryClient.invalidateQueries({
+        queryKey: makeFetchGroupSearchViewKey({
+          orgSlug: organization.slug,
+          id: parameters.id,
+        }),
+      });
 
       // Update any matching starred views in cache
       setApiQueryData<StarredGroupSearchView[]>(

--- a/static/app/views/issueList/mutations/useDeleteGroupSearchView.tsx
+++ b/static/app/views/issueList/mutations/useDeleteGroupSearchView.tsx
@@ -22,7 +22,7 @@ export const useDeleteGroupSearchView = (
     'mutationFn'
   > = {}
 ) => {
-  const api = useApi();
+  const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
   const organization = useOrganization();
 

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarred.tsx
@@ -8,7 +8,7 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewStarredVariables = {
@@ -45,7 +45,7 @@ export const useUpdateGroupSearchViewStarred = (
     },
     onSettled: (...args) => {
       queryClient.invalidateQueries({
-        queryKey: makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
+        queryKey: makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug}),
       });
       options.onSettled?.(...args);
     },

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
@@ -10,7 +10,8 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
+import type {GroupSearchView, StarredGroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewStarredOrderVariables = {
   orgSlug: string;
@@ -40,9 +41,9 @@ export const useUpdateGroupSearchViewStarredOrder = () => {
         .map(id => groupSearchViews.find(view => parseInt(view.id, 10) === id))
         .filter(defined);
 
-      setApiQueryData<GroupSearchView[]>(
+      setApiQueryData<StarredGroupSearchView[]>(
         queryClient,
-        makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
+        makeFetchStarredGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
         newViewsOrder
       );
     },

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -8,9 +8,10 @@ import {
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
-import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import type {
   GroupSearchView,
+  StarredGroupSearchView,
   UpdateGroupSearchViewPayload,
 } from 'sentry/views/issueList/types';
 
@@ -36,9 +37,9 @@ export const useUpdateGroupSearchViews = (
         data: {views: groupSearchViews},
       }),
     onSuccess: (groupSearchViews, parameters, context) => {
-      setApiQueryData<GroupSearchView[]>(
+      setApiQueryData<StarredGroupSearchView[]>(
         queryClient,
-        makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
+        makeFetchStarredGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
         groupSearchViews // Update the cache with the new groupSearchViews
       );
       options.onSuccess?.(groupSearchViews, parameters, context);

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -29,12 +29,12 @@ export enum GroupSearchViewCreatedBy {
 export type StarredGroupSearchView = {
   environments: string[];
   id: string;
+  lastVisited: string | null;
   name: string;
   projects: number[];
   query: string;
   querySort: IssueSortOptions;
   timeFilters: PageFilters['datetime'];
-  lastVisited?: string;
 };
 
 export type GroupSearchView = StarredGroupSearchView & {

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -29,12 +29,12 @@ export enum GroupSearchViewCreatedBy {
 export type StarredGroupSearchView = {
   environments: string[];
   id: string;
-  lastVisited: string | null;
   name: string;
   projects: number[];
   query: string;
   querySort: IssueSortOptions;
   timeFilters: PageFilters['datetime'];
+  lastVisited?: string;
 };
 
 export type GroupSearchView = StarredGroupSearchView & {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,14 +14,14 @@ import {
   DEFAULT_ENVIRONMENTS,
   DEFAULT_TIME_FILTERS,
 } from 'sentry/views/issueList/issueViews/issueViews';
-import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
 import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {useNavContext} from 'sentry/views/nav/context';
 import useDefaultProject from 'sentry/views/nav/secondary/sections/issues/issueViews/useDefaultProject';
 import type {NavLayout} from 'sentry/views/nav/types';
 
-export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
+export function IssueViewAddViewButton() {
   const navigate = useNavigate();
   const organization = useOrganization();
 
@@ -33,35 +34,31 @@ export function IssueViewAddViewButton({baseUrl}: {baseUrl: string}) {
     orgSlug: organization.slug,
   });
 
-  const {mutate: updateViews} = useUpdateGroupSearchViews({
-    onSuccess: data => {
-      if (data?.length) {
-        navigate(
-          normalizeUrl({
-            pathname: `${baseUrl}/views/${data.at(-1)!.id}/`,
-          })
-        );
-        setIsLoading(false);
-      }
+  const {mutate: createIssueView} = useCreateGroupSearchView({
+    onSuccess: (data, variables) => {
+      setIsLoading(false);
+      navigate(
+        normalizeUrl(`/organizations/${organization.slug}/issues/views/${data.id}/`)
+      );
+
+      trackAnalytics('issue_views.created', {
+        organization,
+        starred: variables.starred ?? false,
+      });
     },
   });
 
   const handleOnAddView = () => {
     if (starredGroupSearchViews) {
       setIsLoading(true);
-      updateViews({
-        groupSearchViews: [
-          ...starredGroupSearchViews,
-          {
-            name: 'New View',
-            query: 'is:unresolved',
-            querySort: IssueSortOptions.DATE,
-            projects: defaultProject,
-            environments: DEFAULT_ENVIRONMENTS,
-            timeFilters: DEFAULT_TIME_FILTERS,
-          },
-        ],
-        orgSlug: organization.slug,
+      createIssueView({
+        name: 'New View',
+        query: 'is:unresolved',
+        querySort: IssueSortOptions.DATE,
+        projects: defaultProject,
+        environments: DEFAULT_ENVIRONMENTS,
+        timeFilters: DEFAULT_TIME_FILTERS,
+        starred: true,
       });
     }
   };

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
@@ -24,6 +24,13 @@ describe('IssueViewNavEditableTitle', () => {
       method: 'PUT',
       body: mockGroupSearchView,
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/group-search-views/starred/`,
+      method: 'GET',
+      body: {
+        views: [convertGSVtoIssueView(mockGroupSearchView)],
+      },
+    });
   });
 
   it('renders the label correctly', () => {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
@@ -7,11 +7,9 @@ import {convertGSVtoIssueView} from 'sentry/views/nav/secondary/sections/issues/
 import IssueViewNavEditableTitle from './issueViewNavEditableTitle';
 
 describe('IssueViewNavEditableTitle', () => {
-  const mockOnChange = jest.fn();
   const mockSetIsEditing = jest.fn();
   const mockGroupSearchView = GroupSearchViewFixture();
   const defaultProps = {
-    onChange: mockOnChange,
     isEditing: false,
     setIsEditing: mockSetIsEditing,
     isDragging: false,
@@ -21,16 +19,21 @@ describe('IssueViewNavEditableTitle', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/group-search-views/${mockGroupSearchView.id}/`,
+      method: 'PUT',
+      body: mockGroupSearchView,
+    });
   });
 
   it('renders the label correctly', () => {
     render(<IssueViewNavEditableTitle {...defaultProps} />);
-    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Test View')).toBeInTheDocument();
   });
 
   it('enters edit mode on double click', async () => {
     render(<IssueViewNavEditableTitle {...defaultProps} />);
-    const element = screen.getByText('Test Label');
+    const element = screen.getByText('Test View');
     await userEvent.dblClick(element);
     expect(mockSetIsEditing).toHaveBeenCalledWith(true);
   });
@@ -39,7 +42,7 @@ describe('IssueViewNavEditableTitle', () => {
     render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
     const input = screen.getByRole('textbox');
     expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('Test Label');
+    expect(input).toHaveValue('Test View');
   });
 
   describe('keyboard interactions', () => {
@@ -49,7 +52,6 @@ describe('IssueViewNavEditableTitle', () => {
       await userEvent.clear(input);
       await userEvent.type(input, 'New Label{enter}');
 
-      expect(mockOnChange).toHaveBeenCalledWith('New Label');
       expect(mockSetIsEditing).toHaveBeenCalledWith(false);
     });
 
@@ -59,7 +61,6 @@ describe('IssueViewNavEditableTitle', () => {
       await userEvent.clear(input);
       await userEvent.type(input, 'New Label{escape}');
 
-      expect(mockOnChange).not.toHaveBeenCalled();
       expect(mockSetIsEditing).toHaveBeenCalledWith(false);
     });
 
@@ -69,7 +70,6 @@ describe('IssueViewNavEditableTitle', () => {
       await userEvent.clear(input);
       await userEvent.tab();
 
-      expect(mockOnChange).not.toHaveBeenCalled();
       expect(mockSetIsEditing).toHaveBeenCalledWith(false);
     });
 
@@ -78,8 +78,6 @@ describe('IssueViewNavEditableTitle', () => {
       const input = screen.getByRole('textbox');
       await userEvent.clear(input);
       await userEvent.type(input, '  New Label  {enter}');
-
-      expect(mockOnChange).toHaveBeenCalledWith('New Label');
     });
   });
 });

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.spec.tsx
@@ -1,17 +1,22 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {convertGSVtoIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 import IssueViewNavEditableTitle from './issueViewNavEditableTitle';
 
 describe('IssueViewNavEditableTitle', () => {
   const mockOnChange = jest.fn();
   const mockSetIsEditing = jest.fn();
+  const mockGroupSearchView = GroupSearchViewFixture();
   const defaultProps = {
-    label: 'Test Label',
     onChange: mockOnChange,
     isEditing: false,
-    isSelected: false,
     setIsEditing: mockSetIsEditing,
     isDragging: false,
+    isActive: false,
+    view: convertGSVtoIssueView(mockGroupSearchView),
   };
 
   beforeEach(() => {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.tsx
@@ -5,37 +5,52 @@ import {motion} from 'framer-motion';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 import {Tooltip} from 'sentry/components/tooltip';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
+import type {NavIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
+import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 interface IssueViewNavEditableTitleProps {
+  isActive: boolean;
   isDragging: boolean;
   isEditing: boolean;
-  isSelected: boolean;
-  label: string;
-  onChange: (newLabel: string) => void;
   setIsEditing: (isEditing: boolean) => void;
+  view: NavIssueView;
 }
 
 function IssueViewNavEditableTitle({
-  label,
-  onChange,
+  view,
+  isActive,
   isEditing,
-  isSelected,
   setIsEditing,
   isDragging,
 }: IssueViewNavEditableTitleProps) {
-  const [inputValue, setInputValue] = useState(label);
+  const organization = useOrganization();
+  const [inputValue, setInputValue] = useState(view.label);
+
+  const {starredViews, setStarredIssueViews} = useStarredIssueViews();
+
+  const {mutate: updateIssueView} = useUpdateGroupSearchView({
+    onSuccess: () => {
+      trackAnalytics('issue_views.renamed_view', {
+        leftNav: true,
+        organization: organization.slug,
+      });
+    },
+  });
 
   useEffect(() => {
-    setInputValue(label);
-  }, [label]);
+    setInputValue(view.label);
+  }, [view.label]);
 
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const isEmpty = !inputValue.trim();
 
   const memoizedStyles = useMemo(() => {
-    return {fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal};
-  }, [isSelected, theme.fontWeightBold, theme.fontWeightNormal]);
+    return {fontWeight: isActive ? theme.fontWeightBold : theme.fontWeightNormal};
+  }, [isActive, theme.fontWeightBold, theme.fontWeightNormal]);
 
   const handleOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
     e.stopPropagation();
@@ -46,13 +61,16 @@ function IssueViewNavEditableTitle({
     }
 
     if (isEmpty) {
-      setInputValue(label);
+      setInputValue(view.label);
       setIsEditing(false);
       return;
     }
-    if (trimmedInputValue !== label) {
-      onChange(trimmedInputValue);
+    if (trimmedInputValue !== view.label) {
+      setStarredIssueViews(
+        starredViews.map(v => (v.id === view.id ? {...v, name: trimmedInputValue} : v))
+      );
       setInputValue(trimmedInputValue);
+      updateIssueView({...view, name: trimmedInputValue});
     }
     setIsEditing(false);
   };
@@ -62,7 +80,7 @@ function IssueViewNavEditableTitle({
       inputRef.current?.blur();
     }
     if (e.key === 'Escape') {
-      setInputValue(label.trim());
+      setInputValue(view.label.trim());
       setIsEditing(false);
     }
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === ' ') {
@@ -87,7 +105,7 @@ function IssueViewNavEditableTitle({
 
   return (
     <Tooltip
-      title={label}
+      title={inputValue}
       disabled={isEditing || isDragging}
       showOnlyOnOverflow
       skipWrapper
@@ -120,20 +138,20 @@ function IssueViewNavEditableTitle({
           <UnselectedTabTitle
             onDoubleClick={() => setIsEditing(true)}
             onPointerDown={e => {
-              if (isSelected) {
+              if (isActive) {
                 e.stopPropagation();
                 e.preventDefault();
               }
             }}
             onMouseDown={e => {
-              if (isSelected) {
+              if (isActive) {
                 e.stopPropagation();
                 e.preventDefault();
               }
             }}
-            isSelected={isSelected}
+            isActive={isActive}
           >
-            {label}
+            {inputValue}
           </UnselectedTabTitle>
         )}
       </motion.div>
@@ -143,9 +161,9 @@ function IssueViewNavEditableTitle({
 
 export default IssueViewNavEditableTitle;
 
-const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
+const UnselectedTabTitle = styled('div')<{isActive: boolean}>`
   height: 20px;
-  max-width: ${p => (p.isSelected ? '325px' : '310px')};
+  max-width: ${p => (p.isActive ? '325px' : '310px')};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle.tsx
@@ -9,7 +9,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
 import type {NavIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
-import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 interface IssueViewNavEditableTitleProps {
   isActive: boolean;
@@ -28,8 +27,6 @@ function IssueViewNavEditableTitle({
 }: IssueViewNavEditableTitleProps) {
   const organization = useOrganization();
   const [inputValue, setInputValue] = useState(view.label);
-
-  const {starredViews, setStarredIssueViews} = useStarredIssueViews();
 
   const {mutate: updateIssueView} = useUpdateGroupSearchView({
     onSuccess: () => {
@@ -66,9 +63,6 @@ function IssueViewNavEditableTitle({
       return;
     }
     if (trimmedInputValue !== view.label) {
-      setStarredIssueViews(
-        starredViews.map(v => (v.id === view.id ? {...v, name: trimmedInputValue} : v))
-      );
       setInputValue(trimmedInputValue);
       updateIssueView({...view, name: trimmedInputValue});
     }

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.spec.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.spec.tsx
@@ -24,13 +24,10 @@ describe('IssueViewNavEllipsisMenu', () => {
     isCommitted: true,
     key: 'test-view',
     label: 'Test View',
+    lastVisited: null,
   };
 
   const defaultProps: IssueViewNavEllipsisMenuProps = {
-    baseUrl: '/organizations/sentry/issues',
-    onDeleteView: jest.fn(),
-    onDuplicateView: jest.fn(),
-    onUpdateView: jest.fn(),
     setIsEditing: jest.fn(),
     view: mockView,
     isLastView: false,
@@ -68,15 +65,23 @@ describe('IssueViewNavEllipsisMenu', () => {
   });
 
   it('shows save and discard options when there are unsaved changes', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/group-search-views/${mockView.id}/`,
+      method: 'GET',
+      body: mockView,
+    });
     const user = userEvent.setup();
-    const viewWithChanges = {
-      ...mockView,
-      unsavedChanges: {
-        query: 'is:resolved',
-      },
-    };
 
-    render(<IssueViewNavEllipsisMenu {...defaultProps} view={viewWithChanges} />);
+    render(<IssueViewNavEllipsisMenu {...defaultProps} view={mockView} />, {
+      enableRouterMocks: false,
+      initialRouterConfig: {
+        route: '/organizations/:orgId/issues/views/:viewId/',
+        location: {
+          pathname: `/organizations/sentry/issues/views/${mockView.id}/`,
+          query: {query: 'is:resolved'},
+        },
+      },
+    });
 
     await user.click(screen.getByRole('button'));
 

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
@@ -1,26 +1,30 @@
 import styled from '@emotion/styled';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IconEllipsis, IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
+import {useParams} from 'sentry/utils/useParams';
+import {createIssueViewFromUrl} from 'sentry/views/issueList/issueViews/createIssueViewFromUrl';
+import {useIssueViewUnsavedChanges} from 'sentry/views/issueList/issueViews/useIssueViewUnsavedChanges';
+import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
+import {useDeleteGroupSearchView} from 'sentry/views/issueList/mutations/useDeleteGroupSearchView';
+import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
+import type {NavIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
 
 export interface IssueViewNavEllipsisMenuProps {
-  baseUrl: string;
+  // TODO(msun): Allow deleting last view once horizontal tab views are deleted
   isLastView: boolean;
-  onDeleteView: () => void;
-  onDuplicateView: () => void;
-  onUpdateView: (view: IssueView) => void;
   setIsEditing: (isEditing: boolean) => void;
-  view: IssueView;
+  view: NavIssueView;
   sectionRef?: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -28,47 +32,49 @@ export function IssueViewNavEllipsisMenu({
   sectionRef,
   setIsEditing,
   view,
-  onDeleteView,
-  onDuplicateView,
-  onUpdateView,
-  baseUrl,
   isLastView,
 }: IssueViewNavEllipsisMenuProps) {
   const navigate = useNavigate();
   const organization = useOrganization();
+  const location = useLocation();
+  const {viewId} = useParams<{viewId: string}>();
+  const isSelected = viewId === view.id;
 
-  const handleSaveChanges = () => {
-    const updatedView = {
-      ...view,
-      query: view.unsavedChanges?.query ?? view.query,
-      querySort: view.unsavedChanges?.querySort ?? view.querySort,
-      projects: view.unsavedChanges?.projects ?? view.projects,
-      environments: view.unsavedChanges?.environments ?? view.environments,
-      timeFilters: view.unsavedChanges?.timeFilters ?? view.timeFilters,
-      unsavedChanges: undefined,
-    };
-    onUpdateView(updatedView);
-    navigate(constructViewLink(baseUrl, updatedView));
+  const {mutate: updateIssueView} = useUpdateGroupSearchView({
+    onSuccess: () => {
+      trackAnalytics('issue_views.saved_changes', {
+        leftNav: true,
+        organization: organization.slug,
+      });
+    },
+  });
 
-    trackAnalytics('issue_views.saved_changes', {
-      leftNav: true,
-      organization: organization.slug,
-    });
-  };
+  const {mutate: deleteIssueView} = useDeleteGroupSearchView({
+    onSuccess: () => {
+      trackAnalytics('issue_views.deleted_view', {
+        leftNav: true,
+        organization: organization.slug,
+      });
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to delete view'));
+    },
+  });
 
-  const handleDiscardChanges = () => {
-    const updatedView = {
-      ...view,
-      unsavedChanges: undefined,
-    };
-    onUpdateView(updatedView);
-    navigate(constructViewLink(baseUrl, updatedView));
+  const {mutate: createIssueView} = useCreateGroupSearchView({
+    onSuccess: data => {
+      navigate(
+        normalizeUrl(`/organizations/${organization.slug}/issues/views/${data.id}/`)
+      );
+      trackAnalytics('issue_views.duplicated_view', {
+        leftNav: true,
+        organization,
+      });
+    },
+  });
 
-    trackAnalytics('issue_views.discarded_changes', {
-      leftNav: true,
-      organization: organization.slug,
-    });
-  };
+  const currentViewParams = createIssueViewFromUrl({query: location.query});
+  const {hasUnsavedChanges} = useIssueViewUnsavedChanges();
 
   return (
     <DropdownMenu
@@ -99,15 +105,26 @@ export function IssueViewNavEllipsisMenu({
               key: 'save-changes',
               label: t('Save Changes'),
               priority: 'primary',
-              onAction: handleSaveChanges,
+              onAction: () =>
+                updateIssueView({
+                  id: view.id,
+                  name: view.label,
+                  ...currentViewParams,
+                }),
             },
             {
               key: 'discard-changes',
               label: t('Discard Changes'),
-              onAction: handleDiscardChanges,
+              onAction: () => {
+                navigate(
+                  normalizeUrl(
+                    `/organizations/${organization.slug}/issues/views/${view.id}/`
+                  )
+                );
+              },
             },
           ],
-          hidden: !view.unsavedChanges,
+          hidden: !isSelected || !hasUnsavedChanges,
         },
         {
           key: 'default',
@@ -120,13 +137,22 @@ export function IssueViewNavEllipsisMenu({
             {
               key: 'duplicate-tab',
               label: t('Duplicate'),
-              onAction: onDuplicateView,
+              onAction: () =>
+                createIssueView({
+                  name: `${view.label} (Copy)`,
+                  query: view.query,
+                  querySort: view.querySort,
+                  projects: view.projects,
+                  environments: view.environments,
+                  timeFilters: view.timeFilters,
+                }),
             },
             {
               key: 'delete-tab',
               label: t('Delete'),
               priority: 'danger',
-              onAction: onDeleteView,
+              // TODO(msun): Optimistically render deletion and handle error
+              onAction: () => deleteIssueView({id: view.id}),
               disabled: isLastView,
             },
           ],
@@ -167,21 +193,6 @@ function FeedbackFooter() {
     </SectionedOverlayFooter>
   );
 }
-
-const constructViewLink = (baseUrl: string, view: IssueView) => {
-  return normalizeUrl({
-    pathname: `${baseUrl}/views/${view.id}/`,
-    query: {
-      query: view.unsavedChanges?.query ?? view.query,
-      sort: view.unsavedChanges?.querySort ?? view.querySort,
-      project: view.unsavedChanges?.projects ?? view.projects,
-      environment: view.unsavedChanges?.environments ?? view.environments,
-      ...normalizeDateTimeParams(view.unsavedChanges?.timeFilters ?? view.timeFilters),
-      cursor: undefined,
-      page: undefined,
-    },
-  });
-};
 
 const TriggerWrapper = styled(Button)`
   display: flex;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu.tsx
@@ -50,11 +50,15 @@ export function IssueViewNavEllipsisMenu({
   });
 
   const {mutate: deleteIssueView} = useDeleteGroupSearchView({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       trackAnalytics('issue_views.deleted_view', {
         leftNav: true,
         organization: organization.slug,
       });
+
+      if (variables.id === viewId) {
+        navigate(normalizeUrl(`/organizations/${organization.slug}/issues/`));
+      }
     },
     onError: () => {
       addErrorMessage(t('Failed to delete view'));
@@ -145,6 +149,7 @@ export function IssueViewNavEllipsisMenu({
                   projects: view.projects,
                   environments: view.environments,
                   timeFilters: view.timeFilters,
+                  starred: true,
                 }),
             },
             {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -31,16 +31,15 @@ export interface IssueViewNavItemContentProps {
    * Whether the item is active.
    */
   isActive: boolean;
-  //
-  // Whether an item is being dragged.
-  //
+  /**
+   * Whether an item is being dragged.
+   */
   isDragging: string | null;
   /**
    * Whether the item is the last view in the list.
    * This will be removed once view sharing/starring is implemented.
    */
   isLastView: boolean;
-
   /**
    * A callback function that is called when the user has completed a reorder.
    */

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -1,11 +1,8 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import {motion, Reorder, useDragControls} from 'framer-motion';
-import type {Location} from 'history';
-import isEqual from 'lodash/isEqual';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -17,18 +14,16 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import type {
-  IssueView,
-  IssueViewParams,
-} from 'sentry/views/issueList/issueViews/issueViews';
-import {normalizeProjectsEnvironments} from 'sentry/views/issueList/issueViewsHeader';
-import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {useIssueViewUnsavedChanges} from 'sentry/views/issueList/issueViews/useIssueViewUnsavedChanges';
 import {useNavContext} from 'sentry/views/nav/context';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import IssueViewNavEditableTitle from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavEditableTitle';
 import {IssueViewNavEllipsisMenu} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavEllipsisMenu';
-import {constructViewLink} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
+import {
+  constructViewLink,
+  type NavIssueView,
+} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount';
 
 export interface IssueViewNavItemContentProps {
@@ -36,31 +31,20 @@ export interface IssueViewNavItemContentProps {
    * Whether the item is active.
    */
   isActive: boolean;
-  /**
-   * Whether an item is being dragged.
-   */
+  //
+  // Whether an item is being dragged.
+  //
   isDragging: string | null;
   /**
    * Whether the item is the last view in the list.
    * This will be removed once view sharing/starring is implemented.
    */
   isLastView: boolean;
-  /**
-   * A callback function that's fired when the user clicks "Delete" on the view.
-   */
-  onDeleteView: () => void;
-  /**
-   * A callback function that's fired when the user clicks "Duplicate" on the view.
-   */
-  onDuplicateView: () => void;
+
   /**
    * A callback function that is called when the user has completed a reorder.
    */
   onReorderComplete: () => void;
-  /**
-   * A callback function that updates the view with new params.
-   */
-  onUpdateView: (updatedView: IssueView) => void;
   /**
    * A callback function that updates the isDragging state.
    */
@@ -68,7 +52,7 @@ export interface IssueViewNavItemContentProps {
   /**
    * The issue view to display
    */
-  view: IssueView;
+  view: NavIssueView;
   /**
    * Ref to the body of the section that contains the reorderable items.
    * This is used as the portal container for the ellipsis menu, and as
@@ -81,9 +65,6 @@ export function IssueViewNavItemContent({
   view,
   sectionRef,
   isActive,
-  onUpdateView,
-  onDeleteView,
-  onDuplicateView,
   onReorderComplete,
   isLastView,
   isDragging,
@@ -97,6 +78,7 @@ export function IssueViewNavItemContent({
 
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
+  const {hasUnsavedChanges, changedParams} = useIssueViewUnsavedChanges();
 
   const {projects} = useProjects();
 
@@ -106,22 +88,9 @@ export function IssueViewNavItemContent({
         navigate(constructViewLink(baseUrl, view), {replace: true});
         return;
       }
-      const unsavedChanges = hasUnsavedChanges(view, location.query);
-
-      if (unsavedChanges && !isEqual(unsavedChanges, view.unsavedChanges)) {
-        onUpdateView({
-          ...view,
-          unsavedChanges,
-        });
-      } else if (!unsavedChanges && view.unsavedChanges) {
-        onUpdateView({
-          ...view,
-          unsavedChanges: undefined,
-        });
-      }
     }
     return;
-  }, [view, isActive, location.query, navigate, baseUrl, onUpdateView]);
+  }, [view, isActive, location.query, navigate, baseUrl]);
 
   const projectPlatforms = projects
     .filter(p => view.projects.map(String).includes(p.id))
@@ -194,15 +163,11 @@ export function IssueViewNavItemContent({
               e.preventDefault();
             }}
           >
-            <IssueViewNavQueryCount view={view} />
+            <IssueViewNavQueryCount view={view} isActive={isActive} />
             <IssueViewNavEllipsisMenu
               isLastView={isLastView}
               setIsEditing={setIsEditing}
               view={view}
-              onUpdateView={onUpdateView}
-              onDeleteView={onDeleteView}
-              onDuplicateView={onDuplicateView}
-              baseUrl={baseUrl}
               sectionRef={sectionRef}
             />
           </TrailingItemsWrapper>
@@ -223,22 +188,15 @@ export function IssueViewNavItemContent({
         analyticsItemName="issues_view_starred"
       >
         <IssueViewNavEditableTitle
-          label={view.label}
+          view={view}
           isEditing={isEditing}
-          isSelected={isActive}
-          onChange={value => {
-            onUpdateView({...view, label: value});
-            trackAnalytics('issue_views.renamed_view', {
-              leftNav: true,
-              organization: organization.slug,
-            });
-          }}
           setIsEditing={setIsEditing}
           isDragging={!!isDragging}
+          isActive={isActive}
         />
-        {view.unsavedChanges && (
+        {isActive && hasUnsavedChanges && changedParams && (
           <Tooltip
-            title={constructUnsavedTooltipTitle(view.unsavedChanges)}
+            title={constructUnsavedTooltipTitle(changedParams)}
             position="top"
             skipWrapper
           >
@@ -262,98 +220,25 @@ const READABLE_PARAM_MAPPING = {
   timeFilters: t('time range'),
 };
 
-const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewParams>) => {
-  const changedParams = Object.keys(unsavedChanges)
-    .filter(k => unsavedChanges[k as keyof IssueViewParams] !== undefined)
-    .map(k => READABLE_PARAM_MAPPING[k as keyof IssueViewParams]);
+const constructUnsavedTooltipTitle = (changedParams: {
+  environments: boolean;
+  projects: boolean;
+  query: boolean;
+  querySort: boolean;
+  timeFilters: boolean;
+}) => {
+  const changedParamsArray = Object.keys(changedParams)
+    .filter(k => changedParams[k as keyof typeof changedParams])
+    .map(k => READABLE_PARAM_MAPPING[k as keyof typeof READABLE_PARAM_MAPPING]);
 
   return (
     <Fragment>
       {t(
         "This view's %s filters are not saved.",
-        <BoldTooltipText>{oxfordizeArray(changedParams)}</BoldTooltipText>
+        <BoldTooltipText>{oxfordizeArray(changedParamsArray)}</BoldTooltipText>
       )}
     </Fragment>
   );
-};
-
-// TODO(msun): Once nuqs supports native array query params, we can use that here and replace this absurd function
-const hasUnsavedChanges = (
-  view: IssueView,
-  queryParams: Location['query']
-): false | Partial<IssueViewParams> => {
-  const {
-    query: originalQuery,
-    querySort: originalSort,
-    projects: originalProjects,
-    environments: originalEnvironments,
-    timeFilters: originalTimeFilters,
-  } = view;
-  const {
-    query: queryQuery,
-    sort: querySort,
-    project,
-    environment,
-    start,
-    end,
-    statsPeriod,
-    utc,
-  } = queryParams;
-
-  const queryTimeFilters =
-    start || end || statsPeriod || utc
-      ? {
-          start: statsPeriod ? null : (start?.toString() ?? null),
-          end: statsPeriod ? null : (end?.toString() ?? null),
-          period: statsPeriod?.toString() ?? null,
-          utc: statsPeriod ? null : utc?.toString() === 'true',
-        }
-      : undefined;
-
-  const {queryEnvs, queryProjects} = normalizeProjectsEnvironments(
-    project ?? [],
-    environment ?? []
-  );
-
-  const issueSortOption = Object.values(IssueSortOptions).includes(
-    querySort?.toString() as IssueSortOptions
-  )
-    ? (querySort as IssueSortOptions)
-    : undefined;
-
-  const newUnsavedChanges: Partial<IssueViewParams> = {
-    query:
-      queryQuery !== null &&
-      queryQuery !== undefined &&
-      queryQuery.toString() !== originalQuery
-        ? queryQuery.toString()
-        : undefined,
-    querySort:
-      querySort && issueSortOption !== originalSort ? issueSortOption : undefined,
-    projects: isEqual(queryProjects?.sort(), originalProjects.sort())
-      ? undefined
-      : queryProjects,
-    environments: isEqual(queryEnvs?.sort(), originalEnvironments.sort())
-      ? undefined
-      : queryEnvs,
-    timeFilters:
-      queryTimeFilters &&
-      !isEqual(
-        normalizeDateTimeParams(originalTimeFilters),
-        normalizeDateTimeParams(queryTimeFilters)
-      )
-        ? queryTimeFilters
-        : undefined,
-  };
-
-  const hasNoChanges = Object.values(newUnsavedChanges).every(
-    value => value === undefined
-  );
-  if (hasNoChanges) {
-    return false;
-  }
-
-  return newUnsavedChanges;
 };
 
 // Reorder.Item does handle lifting an item being dragged above other items out of the box,

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -1,150 +1,44 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {Reorder} from 'framer-motion';
 import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
-import {generateTempViewId} from 'sentry/views/issueList/issueViews/issueViews';
-import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import type {IssueViewParams} from 'sentry/views/issueList/issueViews/issueViews';
 import {useUpdateGroupSearchViewStarredOrder} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder';
-import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import {
-  type GroupSearchView,
-  GroupSearchViewVisibility,
-} from 'sentry/views/issueList/types';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewAddViewButton} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton';
 import {IssueViewNavItemContent} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent';
+import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 interface IssueViewNavItemsProps {
   baseUrl: string;
-  loadedViews: IssueView[];
   sectionRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export function IssueViewNavItems({
-  loadedViews,
-  sectionRef,
-  baseUrl,
-}: IssueViewNavItemsProps) {
+export interface NavIssueView extends IssueViewParams {
+  id: string;
+  label: string;
+  lastVisited: string | null;
+}
+
+export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps) {
   const organization = useOrganization();
-  const navigate = useNavigate();
-  const location = useLocation();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
 
-  const queryParams = location.query;
+  const {starredViews: views, setStarredIssueViews: setViews} = useStarredIssueViews();
 
-  /**
-   * TODO(msun): Revisit whether we can use the useApiQuery's cache as the
-   * source of truth for the view state, rather than a separate state
-   */
-  const [views, setViews] = useState<IssueView[]>(loadedViews);
   const [isDragging, setIsDragging] = useState<string | null>(null);
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (loadedViews.length !== views.length) {
-      setViews(loadedViews);
-    }
-  }, [loadedViews, views, setViews]);
-
-  const replaceWithPersistentViewIds = useCallback(
-    (responseViews: GroupSearchView[]) => {
-      const newlyCreatedViews = responseViews.filter(
-        view => !views.some(tab => tab.id === view.id)
-      );
-      if (newlyCreatedViews.length > 0) {
-        const assignedIds = new Set();
-
-        const currentView = views.find(tab => tab.id === viewId);
-        const updatedViews = views.map(tab => {
-          if (tab.id && tab.id[0] === '_') {
-            const matchingView = newlyCreatedViews.find(
-              view =>
-                view.id &&
-                !assignedIds.has(view.id) &&
-                tab.query === view.query &&
-                tab.querySort === view.querySort &&
-                tab.label === view.name
-            );
-            if (matchingView?.id) {
-              assignedIds.add(matchingView.id);
-              return {...tab, id: matchingView.id, key: matchingView.id};
-            }
-          }
-          return tab;
-        });
-        setViews(updatedViews);
-
-        if (viewId?.startsWith('_') && currentView) {
-          const matchingView = newlyCreatedViews.find(
-            view =>
-              view.id &&
-              currentView.query === view.query &&
-              currentView.querySort === view.querySort
-          );
-          if (matchingView?.id) {
-            navigate(
-              normalizeUrl({
-                pathname: `${baseUrl}/views/${matchingView.id}/`,
-                query: queryParams,
-              }),
-              {replace: true}
-            );
-          }
-        }
-      }
-      return;
-    },
-    [baseUrl, navigate, queryParams, viewId, views]
-  );
-
-  const {mutate: updateViews} = useUpdateGroupSearchViews({
-    onSuccess: replaceWithPersistentViewIds,
-  });
 
   const {mutate: updateStarredViewsOrder} = useUpdateGroupSearchViewStarredOrder();
 
-  const debounceUpdateViews = useMemo(
-    () =>
-      debounce((newTabs: IssueView[]) => {
-        if (newTabs) {
-          updateViews({
-            orgSlug: organization.slug,
-            groupSearchViews: newTabs
-              .filter(tab => tab.isCommitted)
-              .map(tab => ({
-                // Do not send over an ID if it's a temporary or default tab so that
-                // the backend will save these and generate permanent Ids for them
-                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
-                  ? {id: tab.id}
-                  : {}),
-                name: tab.label,
-                query: tab.query,
-                querySort: tab.querySort,
-                projects: tab.projects,
-                environments: tab.environments,
-                timeFilters: tab.timeFilters,
-                starred: true,
-              })),
-          });
-        }
-      }, 500),
-    [organization.slug, updateViews]
-  );
-
   const debounceUpdateStarredViewsOrder = useMemo(
     () =>
-      debounce((newViews: IssueView[]) => {
+      debounce((newViews: NavIssueView[]) => {
         updateStarredViewsOrder({
           orgSlug: organization.slug,
           viewIds: newViews
@@ -164,114 +58,10 @@ export function IssueViewNavItems({
     });
   }, [debounceUpdateStarredViewsOrder, organization.slug, views]);
 
-  const handleUpdateView = useCallback(
-    (view: IssueView, updatedView: IssueView) => {
-      const newViews = views.map(v => {
-        if (v.id === view.id) {
-          return updatedView;
-        }
-        return v;
-      });
-      debounceUpdateViews(newViews);
-      setViews(newViews);
-
-      trackAnalytics('issue_views.updated_view', {
-        leftNav: true,
-        organization: organization.slug,
-      });
-    },
-    [debounceUpdateViews, views, organization.slug]
-  );
-
-  const handleDeleteView = useCallback(
-    (view: IssueView) => {
-      const newViews = views.filter(v => v.id !== view.id);
-      setViews(newViews);
-      debounceUpdateViews(newViews);
-      // Only redirect if the deleted view is the active view
-      if (view.id === viewId) {
-        const newUrl =
-          newViews.length > 0 ? constructViewLink(baseUrl, newViews[0]!) : `${baseUrl}/`;
-        navigate(newUrl);
-      }
-
-      trackAnalytics('issue_views.deleted_view', {
-        leftNav: true,
-        organization: organization.slug,
-      });
-      setApiQueryData<GroupSearchView[]>(
-        queryClient,
-        makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
-        newViews.map(v => ({
-          ...v,
-          isAllProjects: isEqual(v.projects, [-1]),
-          name: v.label,
-          lastVisited: null,
-          visibility: GroupSearchViewVisibility.ORGANIZATION,
-          starred: true,
-        }))
-      );
-    },
-    [
-      views,
-      debounceUpdateViews,
-      viewId,
-      baseUrl,
-      navigate,
-      organization.slug,
-      queryClient,
-    ]
-  );
-
-  const handleDuplicateView = useCallback(
-    (view: IssueView) => {
-      const idx = views.findIndex(v => v.id === view.id);
-      if (idx !== -1) {
-        const newViewId = generateTempViewId();
-        const duplicatedView = {
-          ...views[idx]!,
-          id: newViewId,
-          label: `${views[idx]!.label} (Copy)`,
-        };
-        const newViews = [
-          ...views.slice(0, idx + 1),
-          duplicatedView,
-          ...views.slice(idx + 1),
-        ];
-        setViews(newViews);
-        debounceUpdateViews(newViews);
-        if (view.id === viewId) {
-          navigate(constructViewLink(baseUrl, duplicatedView));
-        }
-        setApiQueryData<GroupSearchView[]>(
-          queryClient,
-          makeFetchGroupSearchViewsKey({orgSlug: organization.slug}),
-          newViews.map(v => ({
-            ...v,
-            isAllProjects: isEqual(v.projects, [-1]),
-            name: v.label,
-            lastVisited: null,
-            visibility: GroupSearchViewVisibility.ORGANIZATION,
-            starred: true,
-          }))
-        );
-      }
-    },
-    [
-      views,
-      viewId,
-      baseUrl,
-      navigate,
-      debounceUpdateViews,
-      organization.slug,
-      queryClient,
-    ]
-  );
-
   return (
     <SecondaryNav.Section
       title={t('Starred Views')}
-      trailingItems={<IssueViewAddViewButton baseUrl={baseUrl} />}
+      trailingItems={<IssueViewAddViewButton />}
     >
       <Reorder.Group
         as="div"
@@ -288,9 +78,6 @@ export function IssueViewNavItems({
             sectionRef={sectionRef}
             isActive={view.id === viewId}
             onReorderComplete={handleReorderComplete}
-            onUpdateView={updatedView => handleUpdateView(view, updatedView)}
-            onDeleteView={() => handleDeleteView(view)}
-            onDuplicateView={() => handleDuplicateView(view)}
             isLastView={views.length === 1}
             isDragging={isDragging}
             setIsDragging={setIsDragging}
@@ -306,15 +93,15 @@ export function IssueViewNavItems({
   );
 }
 
-export const constructViewLink = (baseUrl: string, view: IssueView) => {
+export const constructViewLink = (baseUrl: string, view: NavIssueView) => {
   return normalizeUrl({
     pathname: `${baseUrl}/views/${view.id}/`,
     query: {
-      query: view.unsavedChanges?.query ?? view.query,
-      sort: view.unsavedChanges?.querySort ?? view.querySort,
-      project: view.unsavedChanges?.projects ?? view.projects,
-      environment: view.unsavedChanges?.environments ?? view.environments,
-      ...normalizeDateTimeParams(view.unsavedChanges?.timeFilters ?? view.timeFilters),
+      query: view.query,
+      sort: view.querySort,
+      project: view.projects,
+      environment: view.environments,
+      ...normalizeDateTimeParams(view.timeFilters),
       cursor: undefined,
       page: undefined,
     },

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -23,7 +23,7 @@ interface IssueViewNavItemsProps {
 export interface NavIssueView extends IssueViewParams {
   id: string;
   label: string;
-  lastVisited: string | null;
+  lastVisited?: string;
 }
 
 export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps) {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -23,7 +23,7 @@ interface IssueViewNavItemsProps {
 export interface NavIssueView extends IssueViewParams {
   id: string;
   label: string;
-  lastVisited?: string;
+  lastVisited: string | null;
 }
 
 export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps) {

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.spec.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.spec.tsx
@@ -6,7 +6,7 @@ import {IssueViewNavQueryCount} from 'sentry/views/nav/secondary/sections/issues
 describe('IssueViewNavQueryCount', () => {
   const mockView = {
     id: '1',
-    name: 'Test View',
+    label: 'Test View',
     query: 'is:unresolved',
     querySort: IssueSortOptions.DATE,
     environments: ['37'],
@@ -17,9 +17,7 @@ describe('IssueViewNavQueryCount', () => {
       end: null,
       utc: null,
     },
-    isCommitted: true,
-    key: 'test-view',
-    label: 'Test View',
+    lastVisited: null,
   };
 
   beforeEach(() => {
@@ -35,7 +33,7 @@ describe('IssueViewNavQueryCount', () => {
       },
     });
 
-    render(<IssueViewNavQueryCount view={mockView} />);
+    render(<IssueViewNavQueryCount view={mockView} isActive />);
 
     expect(await screen.findByText('71')).toBeInTheDocument();
   });
@@ -49,7 +47,7 @@ describe('IssueViewNavQueryCount', () => {
       },
     });
 
-    render(<IssueViewNavQueryCount view={mockView} />);
+    render(<IssueViewNavQueryCount view={mockView} isActive />);
 
     expect(await screen.findByText('99+')).toBeInTheDocument();
   });

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount.tsx
@@ -5,9 +5,11 @@ import {motion} from 'framer-motion';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
+import {createIssueViewFromUrl} from 'sentry/views/issueList/issueViews/createIssueViewFromUrl';
 import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
+import type {NavIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
 
 const TAB_MAX_COUNT = 99;
 
@@ -29,12 +31,16 @@ const constructCountTimeFrame = (
 };
 
 interface IssueViewNavQueryCountProps {
-  view: IssueView;
+  isActive: boolean;
+  view: NavIssueView;
 }
 
-export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {
+export function IssueViewNavQueryCount({view, isActive}: IssueViewNavQueryCountProps) {
   const organization = useOrganization();
   const theme = useTheme();
+  const location = useLocation();
+
+  const queryIssueViewParams = createIssueViewFromUrl({query: location.query});
 
   const {
     data: queryCount,
@@ -43,10 +49,12 @@ export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {
     isError,
   } = useFetchIssueCounts({
     orgSlug: organization.slug,
-    query: [view.unsavedChanges?.query ?? view.query],
-    project: view.unsavedChanges?.projects ?? view.projects,
-    environment: view.unsavedChanges?.environments ?? view.environments,
-    ...constructCountTimeFrame(view.unsavedChanges?.timeFilters ?? view.timeFilters),
+    query: [isActive ? queryIssueViewParams.query : view.query],
+    project: isActive ? queryIssueViewParams.projects : view.projects,
+    environment: isActive ? queryIssueViewParams.environments : view.environments,
+    ...constructCountTimeFrame(
+      isActive ? queryIssueViewParams.timeFilters : view.timeFilters
+    ),
   });
 
   // The endpoint's response type looks like this: { <query1>: <count>, <query2>: <count> }
@@ -59,9 +67,7 @@ export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {
       : undefined;
   const count = isError
     ? 0
-    : (queryCount?.[view.unsavedChanges?.query ?? view.query] ??
-      queryCount?.[defaultQuery ?? ''] ??
-      0);
+    : (queryCount?.[view.query] ?? queryCount?.[defaultQuery ?? ''] ?? 0);
 
   return (
     <QueryCountBubble

--- a/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
@@ -31,7 +31,7 @@ export function useStarredIssueViews() {
   return {starredViews, setStarredIssueViews};
 }
 
-const convertGSVtoIssueView = (gsv: StarredGroupSearchView): NavIssueView => {
+export const convertGSVtoIssueView = (gsv: StarredGroupSearchView): NavIssueView => {
   return {
     id: gsv.id,
     label: gsv.name,

--- a/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
@@ -1,0 +1,58 @@
+import {useCallback} from 'react';
+
+import {getApiQueryData, setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
+import type {StarredGroupSearchView} from 'sentry/views/issueList/types';
+import type {NavIssueView} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
+
+export function useStarredIssueViews() {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  const groupSearchViews = getApiQueryData<StarredGroupSearchView[]>(
+    queryClient,
+    makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug})
+  );
+
+  const starredViews = groupSearchViews?.map(convertGSVtoIssueView) ?? [];
+
+  const setStarredIssueViews = useCallback(
+    (newViews: NavIssueView[]) => {
+      setApiQueryData<StarredGroupSearchView[]>(
+        queryClient,
+        makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug}),
+        newViews.map(convertIssueViewToGSV)
+      );
+    },
+    [queryClient, organization.slug]
+  );
+
+  return {starredViews, setStarredIssueViews};
+}
+
+const convertGSVtoIssueView = (gsv: StarredGroupSearchView): NavIssueView => {
+  return {
+    id: gsv.id,
+    label: gsv.name,
+    query: gsv.query,
+    querySort: gsv.querySort,
+    environments: gsv.environments,
+    timeFilters: gsv.timeFilters,
+    projects: gsv.projects,
+    lastVisited: gsv.lastVisited,
+  };
+};
+
+export const convertIssueViewToGSV = (view: NavIssueView): StarredGroupSearchView => {
+  return {
+    id: view.id,
+    name: view.label,
+    query: view.query,
+    querySort: view.querySort,
+    projects: view.projects,
+    environments: view.environments,
+    timeFilters: view.timeFilters,
+    lastVisited: view.lastVisited,
+  };
+};

--- a/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
@@ -1,6 +1,6 @@
 import {useCallback} from 'react';
 
-import {getApiQueryData, setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import type {StarredGroupSearchView} from 'sentry/views/issueList/types';
@@ -10,9 +10,9 @@ export function useStarredIssueViews() {
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  const groupSearchViews = getApiQueryData<StarredGroupSearchView[]>(
-    queryClient,
-    makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug})
+  const {data: groupSearchViews} = useApiQuery<StarredGroupSearchView[]>(
+    makeFetchStarredGroupSearchViewsKey({orgSlug: organization.slug}),
+    {notifyOnChangeProps: ['data'], staleTime: 0}
   );
 
   const starredViews = groupSearchViews?.map(convertGSVtoIssueView) ?? [];

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -4,7 +4,6 @@ import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -39,38 +38,7 @@ export function IssuesSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         {starredGroupSearchViews && (
-          <IssueViewNavItems
-            loadedViews={starredGroupSearchViews.map(
-              (
-                {
-                  id,
-                  name,
-                  query: viewQuery,
-                  querySort: viewQuerySort,
-                  environments: viewEnvironments,
-                  projects: viewProjects,
-                  timeFilters: viewTimeFilters,
-                },
-                index
-              ): IssueView => {
-                const tabId = id ?? `default${index.toString()}`;
-
-                return {
-                  id: tabId,
-                  key: tabId,
-                  label: name,
-                  query: viewQuery,
-                  querySort: viewQuerySort,
-                  environments: viewEnvironments,
-                  projects: viewProjects,
-                  timeFilters: viewTimeFilters,
-                  isCommitted: true,
-                };
-              }
-            )}
-            sectionRef={sectionRef}
-            baseUrl={baseUrl}
-          />
+          <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
         )}
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>


### PR DESCRIPTION
This PR makes a couple of major refactors to the new Issue Views Navigation component family in preparation for the launch of shared views. The same refactors have **not** been applied to the legacy issue views component since it will be completely deleted with the release of issue view sharing. 

Here's a high level overview of the changes: 
* **QueryClient cache is now the single source of truth for starred views state:** Previously, I used a react useState that consumed the views from the QueryClient cache, which was essentially a middleman that provided 0 value. 
* **All entrypoints to `PUT` `/group-search-views/` have been rewired:** All issue view mutations in the new nav have been rewired to use the new CRUD endpoints created. 
* **Unsaved Changes no longer persist across navigation:** Clicking away from your view with unsaved changes will now discard those changes automatically. This saves us from a lot of state management and complexity. 


Unfortunately, these refactors were a bit tricky to implement by themselves without destroying or degrading functionality (this has active users), hence why the size of this PR is quite large. I have tried to comprehensively annotate my changes in the diff, happy to elaborate more on any the changes. 


Some bonus style changes: 

* Each component's mutation logic is significantly more localized. Previously, the root issue views component passed down a single bulk-mutate function to all of its children (because its debounced and updates react state). Now, each component self-contains its own mutation logic, rather than consuming it from its parent. This means significantly less prop drilling, and significantly more balanced components (in terms of LOC/component) 




