### PR TITLE
fix(aci milestone 3): separate flag for processing metric issue workflows

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -476,6 +476,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable workflow processing for metric issues
+    manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow engine for issue alerts
     manager.add("organizations:workflow-engine-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logging to debug workflow engine process workflows

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -937,10 +937,11 @@ def process_workflow_engine(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
+    org = job["event"].project.organization
     # TODO: only fire one system. to test, fire from both systems and observe metrics
     if not features.has(
-        "organizations:workflow-engine-process-workflows", job["event"].project.organization
-    ):
+        "organizations:workflow-engine-process-workflows", org
+    ) and not features.has("organizations:workflow-engine-process-metric-issue-workflows", org):
         return
 
     from sentry.workflow_engine.processors.workflow import process_workflows

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -939,9 +939,38 @@ def process_workflow_engine(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
     # TODO: only fire one system. to test, fire from both systems and observe metrics
-    if not features.has(
-        "organizations:workflow-engine-process-workflows", org
-    ) and not features.has("organizations:workflow-engine-process-metric-issue-workflows", org):
+    if not features.has("organizations:workflow-engine-process-workflows", org):
+        return
+
+    from sentry.workflow_engine.processors.workflow import process_workflows
+
+    # PostProcessJob event is optional, WorkflowEventData event is required
+    if "event" not in job:
+        logger.error("Missing event to create WorkflowEventData", extra={"job": job})
+        return
+
+    try:
+        workflow_event_data = WorkflowEventData(
+            event=job["event"],
+            group_state=job.get("group_state"),
+            has_reappeared=job.get("has_reappeared"),
+            has_escalated=job.get("has_escalated"),
+        )
+    except Exception:
+        logger.exception("Could not create WorkflowEventData", extra={"job": job})
+        return
+
+    with sentry_sdk.start_span(op="tasks.post_process_group.workflow_engine.process_workflow"):
+        process_workflows(workflow_event_data)
+
+
+def process_workflow_engine_metric_issues(job: PostProcessJob) -> None:
+    if job["is_reprocessed"]:
+        return
+
+    org = job["event"].project.organization
+    # TODO: only fire one system. to test, fire from both systems and observe metrics
+    if not features.has("organizations:workflow-engine-process-metric-issue-workflows", org):
         return
 
     from sentry.workflow_engine.processors.workflow import process_workflows
@@ -1543,7 +1572,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         feedback_filter_decorator(process_rules),
     ],
     GroupCategory.METRIC_ALERT: [
-        process_workflow_engine,
+        process_workflow_engine_metric_issues,
     ],
 }
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -184,6 +184,16 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
 
     Finally, each of the triggered workflows will have their actions evaluated and executed.
     """
+    # TODO: only fire one system. to test, fire from both systems and observe metrics
+    if event_data.event.occurrence is None and not features.has(
+        "organizations:workflow-engine-process-workflows", event_data.event.project.organization
+    ):
+        return set()
+    if event_data.event.group.occurrence is not None and not features.has(
+        "organizations:workflow-engine-process-metric-issue-workflows",
+        event_data.event.project.organization,
+    ):
+        return set()
     # Check to see if the GroupEvent has an issue occurrence
     try:
         detector = get_detector_by_event(event_data)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -189,7 +189,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         "organizations:workflow-engine-process-workflows", event_data.event.project.organization
     ):
         return set()
-    if event_data.event.group.occurrence is not None and not features.has(
+    if event_data.event.occurrence is not None and not features.has(
         "organizations:workflow-engine-process-metric-issue-workflows",
         event_data.event.project.organization,
     ):

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -184,16 +184,6 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
 
     Finally, each of the triggered workflows will have their actions evaluated and executed.
     """
-    # TODO: only fire one system. to test, fire from both systems and observe metrics
-    if event_data.event.occurrence is None and not features.has(
-        "organizations:workflow-engine-process-workflows", event_data.event.project.organization
-    ):
-        return set()
-    if event_data.event.occurrence is not None and not features.has(
-        "organizations:workflow-engine-process-metric-issue-workflows",
-        event_data.event.project.organization,
-    ):
-        return set()
     # Check to see if the GroupEvent has an issue occurrence
     try:
         detector = get_detector_by_event(event_data)

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -128,7 +128,7 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
     @with_feature("organizations:workflow-engine-metric-alert-processing")
-    @with_feature("organizations:workflow-engine-process-workflows")
+    @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     def test_workflow_engine__workflows(self):
         """
         This test ensures that the workflow engine is correctly hooked up to tasks/post_process.py.


### PR DESCRIPTION
Gating processing of both metric issues and errors with one flag was causing problems if an org was flagged into metric detectors but not error detectors (or vice versa). Add a separate flag for metric issues. 