### PR TITLE
ref(py): Consistently use `import *` in models

### DIFF
--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -16,7 +16,7 @@ from .avatars import *  # NOQA
 from .broadcast import *  # NOQA
 from .commit import *  # NOQA
 from .commitauthor import *  # NOQA
-from .commitfilechange import CommitFileChange  # noqa
+from .commitfilechange import *  # noqa
 from .counter import *  # NOQA
 from .dashboard import *  # NOQA
 from .dashboard_permissions import *  # NOQA
@@ -69,7 +69,7 @@ from .organization import *  # NOQA
 from .organizationaccessrequest import *  # NOQA
 from .organizationmapping import *  # NOQA
 from .organizationmember import *  # NOQA
-from .organizationmemberinvite import OrganizationMemberInvite  # NOQA
+from .organizationmemberinvite import *  # NOQA
 from .organizationmembermapping import *  # NOQA
 from .organizationmemberteam import *  # NOQA
 from .organizationmemberteamreplica import *  # NOQA
@@ -81,12 +81,12 @@ from .project import *  # NOQA
 from .projectbookmark import *  # NOQA
 from .projectcodeowners import *  # NOQA
 from .projectkey import *  # NOQA
-from .projectownership import ProjectOwnership  # NOQA
+from .projectownership import *  # NOQA
 from .projectplatform import *  # NOQA
 from .projectredirect import *  # NOQA
 from .projectsdk import *  # NOQA
-from .projectteam import ProjectTeam  # noqa
-from .projecttemplate import ProjectTemplate  # noqa
+from .projectteam import *  # NOQA
+from .projecttemplate import *  # NOQA
 from .promptsactivity import *  # NOQA
 from .pullrequest import *  # NOQA
 from .recentsearch import *  # NOQA
@@ -104,8 +104,8 @@ from .repository import *  # NOQA
 from .rollbackorganization import *  # NOQA
 from .rollbackuser import *  # NOQA
 from .rule import *  # NOQA
-from .rulefirehistory import RuleFireHistory  # NOQA
-from .rulesnooze import RuleSnooze  # NOQA
+from .rulefirehistory import *  # NOQA
+from .rulesnooze import *  # NOQA
 from .savedsearch import *  # NOQA
 from .search_common import *  # NOQA
 from .sentryshot import *  # NOQA

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -17,6 +17,9 @@ from sentry.db.models.manager.base import BaseManager
 COMMIT_FILE_CHANGE_TYPES = frozenset(("A", "D", "M"))
 
 
+__all__ = ("CommitFileChange",)
+
+
 class CommitFileChangeManager(BaseManager["CommitFileChange"]):
     def get_count_for_commits(self, commits: Iterable[Any]) -> int:
         return int(self.filter(commit__in=commits).values("filename").distinct().count())

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -18,6 +18,8 @@ from sentry.roles import organization_roles
 
 INVITE_DAYS_VALID = 30
 
+__all__ = ("OrganizationMemberInvite",)
+
 
 class InviteStatus(Enum):
     APPROVED = 0

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from sentry.models.team import Team
     from sentry.users.services.user import RpcUser
 
+__all__ = ("ProjectOwnership",)
+
 logger = logging.getLogger(__name__)
 READ_CACHE_DURATION = 3600
 

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -13,6 +13,8 @@ from sentry.db.models.manager.base import BaseManager
 if TYPE_CHECKING:
     from sentry.models.team import Team
 
+__all__ = ("ProjectTeam",)
+
 
 class ProjectTeamManager(BaseManager["ProjectTeam"]):
     def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> QuerySet["ProjectTeam"]:

--- a/src/sentry/models/projecttemplate.py
+++ b/src/sentry/models/projecttemplate.py
@@ -8,6 +8,8 @@ from sentry.db.models import (
     sane_repr,
 )
 
+__all__ = ("ProjectTemplate",)
+
 
 @region_silo_model
 class ProjectTemplate(DefaultFieldsModelExisting):

--- a/src/sentry/models/rulesnooze.py
+++ b/src/sentry/models/rulesnooze.py
@@ -9,6 +9,8 @@ from sentry.db.models import FlexibleForeignKey, Model, region_silo_model, sane_
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
 
+__all__ = ("RuleSnooze",)
+
 
 class RuleSnoozeManager(BaseManager["RuleSnooze"]):
     def is_snoozed_for_all(self, rule=None, alert_rule=None):


### PR DESCRIPTION
I know we're trying to just straight remove these, but let's at least be
consistent for now so that mypy understands that these models are
available from this module.

Needed for this simplification https://github.com/getsentry/sentry/pull/89440