### PR TITLE
fix(issues): Open drawers with navigate, preserve scroll

### DIFF
--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -120,6 +120,10 @@ export interface BaseButtonProps extends CommonButtonProps, ElementProps<ButtonE
   /**
    * @deprecated Use LinkButton instead
    */
+  preventScrollReset?: boolean;
+  /**
+   * @deprecated Use LinkButton instead
+   */
   replace?: boolean;
   /**
    * Similar to `href`, but for internal links within the app.
@@ -153,6 +157,7 @@ interface ToLinkButtonProps extends BaseLinkButtonProps {
    */
   to: string | LocationDescriptor;
   external?: never;
+  preventScrollReset?: boolean;
   replace?: boolean;
 }
 
@@ -203,6 +208,7 @@ function BaseButton({
   size = 'md',
   to,
   replace,
+  preventScrollReset,
   busy,
   href,
   title,
@@ -291,6 +297,7 @@ function BaseButton({
         to={disabled ? undefined : to}
         href={disabled ? undefined : href}
         replace={replace}
+        preventScrollReset={preventScrollReset}
         size={size}
         priority={priority}
         borderless={borderless}

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -8,6 +8,7 @@ import {locationDescriptorToTo} from './reactRouter6Compat/location';
 import {useTestRouteContext} from './useRouteContext';
 
 type NavigateOptions = {
+  preventScrollReset?: boolean;
   replace?: boolean;
   state?: any;
 };

--- a/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
@@ -34,7 +34,7 @@ export function useIssueActivityDrawer({group, project}: UseIssueActivityDrawerP
               filter: undefined,
             },
           },
-          {replace: true}
+          {preventScrollReset: true}
         );
       },
       shouldCloseOnLocationChange: newLocation => {

--- a/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
@@ -35,7 +35,7 @@ export function useMergedIssuesDrawer({
               cursor: undefined,
             },
           },
-          {replace: true}
+          {preventScrollReset: true}
         );
       },
     });

--- a/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
@@ -35,7 +35,7 @@ export function useSimilarIssuesDrawer({
               cursor: undefined,
             },
           },
-          {replace: true}
+          {preventScrollReset: true}
         );
       },
     });

--- a/static/app/views/issueDetails/streamline/sidebar/viewButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/viewButton.tsx
@@ -5,7 +5,7 @@ import {space} from 'sentry/styles/space';
 
 export function ViewButton({children, ...props}: LinkButtonProps) {
   return (
-    <TextButton borderless size="zero" {...props}>
+    <TextButton borderless size="zero" preventScrollReset {...props}>
       {children}
     </TextButton>
   );

--- a/static/app/views/issueDetails/useGroupDistributionsDrawer.tsx
+++ b/static/app/views/issueDetails/useGroupDistributionsDrawer.tsx
@@ -46,7 +46,7 @@ export function useGroupDistributionsDrawer({
                 flagDrawerCursor: undefined,
               },
             },
-            {replace: true}
+            {preventScrollReset: true}
           );
         },
         shouldCloseOnLocationChange: newLocation => {


### PR DESCRIPTION
Fixes an issue where we navigated to /activity/ on open but then replaced it on close which makes it confusing to use the back button because activity does not reopen.

fixes #89368
