### PR TITLE
chore(issue-platform): Switch `PerformanceRenderBlockingAssetSpanGroupType` to read from flagpole

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -322,6 +322,7 @@ class PerformanceRenderBlockingAssetSpanGroupType(PerformanceGroupTypeDefaults, 
     category = GroupCategory.PERFORMANCE.value
     default_priority = PriorityLevel.LOW
     released = True
+    use_flagpole_for_all_features = True
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This has been updated in options automator, so we can start using it here.

<!-- Describe your PR here. -->