### PR TITLE
fix(alerts): Don't group on time

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -171,7 +171,7 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
         assert rule.project_id == project.id, "Rule must belong to Project"
 
     tenant_ids = {"organization_id": project.organization_id}
-    event_counts = tsdb.backend.get_sums(
+    event_counts = tsdb.backend.get_timeseries_sums(
         TSDBModel.group,
         group_ids,
         start,

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
-from typing import NamedTuple, TypeAlias
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple, TypeAlias
 
 from sentry import tsdb
 from sentry.digests.types import Notification, Record, RecordWithRuleObjects
@@ -22,7 +22,7 @@ Digest: TypeAlias = dict[Rule, dict[Group, list[RecordWithRuleObjects]]]
 class DigestInfo(NamedTuple):
     digest: Digest
     event_counts: dict[int, int]
-    user_counts: dict[int, int]
+    user_counts: Mapping[int, int]
 
 
 def split_key(
@@ -113,7 +113,7 @@ def _group_records(
 
 
 def _sort_digest(
-    digest: Digest, event_counts: dict[int, int], user_counts: dict[int, int]
+    digest: Digest, event_counts: dict[int, int], user_counts: Mapping[Any, int]
 ) -> Digest:
     # sort inner groups dict by (event_count, user_count) descending
     for key, rule_groups in digest.items():
@@ -142,7 +142,7 @@ def _build_digest_impl(
     groups: dict[int, Group],
     rules: dict[int, Rule],
     event_counts: dict[int, int],
-    user_counts: dict[int, int],
+    user_counts: Mapping[Any, int],
 ) -> Digest:
     # sans-io implementation details
     bound_records = _bind_records(records, groups, rules)

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -118,7 +118,7 @@ class GroupSnooze(Model):
         end = timezone.now()
         start = end - timedelta(minutes=self.window)
 
-        rate = tsdb.backend.get_sums(
+        rate = tsdb.backend.get_timeseries_sums(
             model=get_issue_tsdb_group_model(self.group.issue_category),
             keys=[self.group_id],
             start=start,

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -351,22 +351,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         referrer_suffix: str,
         group_on_time: bool = True,
     ) -> Mapping[int, int]:
-        result: Mapping[int, int] = {}
-        # if tsdb_function == tsdb.get_sums:
-        #     result = tsdb_function(
-        #         model=model,
-        #         keys=keys,
-        #         start=start,
-        #         end=end,
-        #         environment_id=environment_id,
-        #         use_cache=True,
-        #         jitter_value=group_id,
-        #         tenant_ids={"organization_id": organization_id},
-        #         referrer_suffix=referrer_suffix,
-        #         group_on_time=group_on_time,
-        #     )
-        # else:
-        result = tsdb_function(
+        result: Mapping[int, int] = tsdb_function(
             model=model,
             keys=keys,
             start=start,

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -235,7 +235,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = False,
+        # group_on_time: bool = False,
     ) -> int | float:
         """
         Abstract method that specifies how to query Snuba for a single group
@@ -438,7 +438,6 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = False,
     ) -> int:
         sums: Mapping[int, int] = self.get_snuba_query_result(
             tsdb_function=self.tsdb.get_sums,
@@ -450,7 +449,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
             end=end,
             environment_id=environment_id,
             referrer_suffix="alert_event_frequency",
-            group_on_time=group_on_time,
+            group_on_time=False,
         )
         return sums[event.group_id]
 
@@ -514,7 +513,6 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = False,
     ) -> int:
         totals: Mapping[int, int] = self.get_snuba_query_result(
             tsdb_function=self.tsdb.get_distinct_counts_totals,
@@ -526,7 +524,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
             end=end,
             environment_id=environment_id,
             referrer_suffix="alert_event_uniq_user_frequency",
-            group_on_time=group_on_time,
+            group_on_time=False,
         )
         return totals[event.group_id]
 
@@ -590,7 +588,6 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = False,
     ) -> int:
         assert self.rule
         if not features.has(
@@ -625,7 +622,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
             environment_id=environment_id,
             referrer_suffix="batch_alert_event_uniq_user_frequency",
             conditions=conditions,
-            group_on_time=group_on_time,
+            group_on_time=False,
         )
         return total[event.group.id]
 
@@ -926,7 +923,6 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = True,
     ) -> float:
         project_id = event.project_id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
@@ -944,7 +940,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="alert_event_frequency_percent",
-                group_on_time=group_on_time,
+                group_on_time=True,
             )[event.group_id]
 
             if issue_count > avg_sessions_in_interval:

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -374,7 +374,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         end: datetime,
         environment_id: int,
         referrer_suffix: str,
-        group_on_time: bool = True,
+        group_on_time: bool = False,
     ) -> dict[int, int]:
         batch_totals: dict[int, int] = defaultdict(int)
         group_id = group_ids[0]

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -482,7 +482,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_frequency",
-                group_on_time=False,
+                group_on_time=group_on_time,
             )
             batch_sums.update(error_sums)
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -235,7 +235,6 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         start: datetime,
         end: datetime,
         environment_id: int,
-        # group_on_time: bool = False,
     ) -> int | float:
         """
         Abstract method that specifies how to query Snuba for a single group

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -551,7 +551,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = True,
+        group_on_time: bool = False,
     ) -> dict[int, int | float]:
         batch_totals: dict[int, int | float] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -348,7 +348,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         end: datetime,
         environment_id: int,
         referrer_suffix: str,
-        group_on_time: bool = True,
+        group_on_time: bool = False,
     ) -> Mapping[int, int]:
         result: Mapping[int, int] = tsdb_function(
             model=model,
@@ -458,7 +458,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         start: datetime,
         end: datetime,
         environment_id: int,
-        group_on_time: bool = True,
+        group_on_time: bool = False,
     ) -> dict[int, int | float]:
         batch_sums: dict[int, int | float] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
@@ -939,7 +939,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="alert_event_frequency_percent",
-                group_on_time=True,
+                group_on_time=False,
             )[event.group_id]
 
             if issue_count > avg_sessions_in_interval:

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -346,8 +346,9 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         referrer_suffix: str,
         group_on_time: bool = True,
     ) -> Mapping[int, int]:
+        result: Mapping[int, int] = {}
         if tsdb_function == tsdb.get_sums:
-            result: Mapping[int, int] = tsdb_function(
+            result = tsdb_function(
                 model=model,
                 keys=keys,
                 start=start,
@@ -360,7 +361,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
                 group_on_time=group_on_time,
             )
         else:
-            result: Mapping[int, int] = tsdb_function(
+            result = tsdb_function(
                 model=model,
                 keys=keys,
                 start=start,
@@ -685,7 +686,6 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_uniq_user_frequency",
                 conditions=conditions,
-                group_on_time=group_on_time,
             )
             batch_totals.update(error_totals)
 
@@ -700,7 +700,6 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_uniq_user_frequency",
                 conditions=conditions,
-                group_on_time=group_on_time,
             )
             batch_totals.update(error_totals)
 
@@ -721,6 +720,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
         end: datetime,
         environment_id: int,
         referrer_suffix: str,
+        group_on_time: bool = True,
         conditions: list[tuple[str, str, str | list[str]]] | None = None,
     ) -> Mapping[int, int]:
         result: Mapping[int, int] = tsdb_function(
@@ -747,6 +747,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
         end: datetime,
         environment_id: int,
         referrer_suffix: str,
+        group_on_time: bool = True,
         conditions: list[tuple[str, str, str | list[str]]] | None = None,
     ) -> dict[int, int]:
         batch_totals: dict[int, int] = defaultdict(int)

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -248,7 +248,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         """
         Queries Snuba for a unique condition for multiple groups.
         """
-        return self.batch_query_hook(group_ids, start, end, environment_id, True)
+        return self.batch_query_hook(group_ids, start, end, environment_id, False)
 
     def batch_query_hook(
         self,

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -68,7 +68,7 @@ def get_events_24h() -> int:
     end = timezone.now()
     sum_events = 0
     for organization_id in organization_ids:
-        events_per_org_24h = tsdb.backend.get_sums(
+        events_per_org_24h = tsdb.backend.get_timeseries_sums(
             model=TSDBModel.organization_total_received,
             keys=[organization_id],
             start=end - timedelta(hours=24),

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -450,7 +450,7 @@ class BaseTSDB(Service):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = True,
-    ) -> dict[int, int]:
+    ) -> dict[int, int] | dict[int, list[tuple[int, int]]]:
         range_set = self.get_range(
             model,
             keys,

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -423,7 +423,7 @@ class BaseTSDB(Service):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
-    ) -> dict[TSDBKey, list[tuple[int, int]]]:
+    ) -> Mapping[TSDBKey, list[tuple[int, int]]]:
         """
         To get a range of data for group ID=[1, 2, 3]:
 
@@ -439,7 +439,7 @@ class BaseTSDB(Service):
     def get_sums(
         self,
         model: TSDBModel,
-        keys: list[int],
+        keys: Sequence[TSDBKey],
         start: datetime,
         end: datetime,
         rollup: int | None = None,
@@ -450,8 +450,8 @@ class BaseTSDB(Service):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = True,
-    ) -> dict[int, int] | dict[int, list[tuple[int, int]]]:
-        range_set = self.get_range(
+    ) -> Mapping[TSDBKey, int] | Mapping[TSDBKey, list[tuple[int, int]]]:
+        range_set: Mapping[TSDBKey, list[tuple[int, int]]] = self.get_range(
             model,
             keys,
             start,
@@ -468,7 +468,9 @@ class BaseTSDB(Service):
         if not group_on_time:
             return range_set
 
-        sum_set = {key: sum(p for _, p in points) for (key, points) in range_set.items()}
+        sum_set: Mapping[TSDBKey, int] = {
+            key: sum(p for _, p in points) for (key, points) in range_set.items()
+        }
         return sum_set
 
     def _add_jitter_to_series(

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -422,6 +422,7 @@ class BaseTSDB(Service):
         jitter_value: int | None = None,
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
+        group_on_time: bool = True,
     ) -> dict[TSDBKey, list[tuple[int, int]]]:
         """
         To get a range of data for group ID=[1, 2, 3]:
@@ -448,6 +449,7 @@ class BaseTSDB(Service):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
+        group_on_time: bool = True,
     ) -> dict[int, int]:
         range_set = self.get_range(
             model,
@@ -461,7 +463,11 @@ class BaseTSDB(Service):
             tenant_ids=tenant_ids,
             referrer_suffix=referrer_suffix,
             conditions=conditions,
+            group_on_time=group_on_time,
         )
+        if not group_on_time:
+            return range_set
+
         sum_set = {key: sum(p for _, p in points) for (key, points) in range_set.items()}
         return sum_set
 

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -590,7 +590,7 @@ class BaseTSDB(Service):
     def get_distinct_counts_totals(
         self,
         model: TSDBModel,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start: datetime,
         end: datetime | None = None,
         rollup: int | None = None,
@@ -601,7 +601,7 @@ class BaseTSDB(Service):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, Any]:
+    ) -> Mapping[TSDBKey, int]:
         """
         Count distinct items during a time range with optional conditions
         """

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -424,7 +424,7 @@ class BaseTSDB(Service):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
-    ) -> Mapping[TSDBKey, list[tuple[int, int]]]:
+    ) -> dict[TSDBKey, list[tuple[int, int]]]:
         """
         To get a range of data for group ID=[1, 2, 3]:
 
@@ -451,8 +451,8 @@ class BaseTSDB(Service):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = True,
-    ) -> Mapping[int, list[tuple[int, int]]]:
-        range_set: Mapping[TSDBKey, list[tuple[int, int]]] = self.get_range(
+    ) -> dict[TSDBKey, int]:
+        range_set = self.get_range(
             model,
             keys,
             start,
@@ -465,10 +465,26 @@ class BaseTSDB(Service):
             referrer_suffix=referrer_suffix,
             conditions=conditions,
         )
-        sum_set: Mapping[TSDBKey, int] = {
-            key: sum(p for _, p in points) for (key, points) in range_set.items()
-        }
+        sum_set = {key: sum(p for _, p in points) for (key, points) in range_set.items()}
         return sum_set
+
+    def get_sums_data(
+        self,
+        model: TSDBModel,
+        keys: Sequence[TSDBKey],
+        start: datetime,
+        end: datetime,
+        rollup: int | None = None,
+        environment_ids: Sequence[int] | None = None,
+        conditions=None,
+        use_cache: bool = False,
+        jitter_value: int | None = None,
+        tenant_ids: dict[str, str | int] | None = None,
+        referrer_suffix: str | None = None,
+        group_on_time: bool = True,
+    ) -> Mapping[TSDBKey, int]:
+
+        raise NotImplementedError
 
     def get_sums(
         self,
@@ -491,7 +507,7 @@ class BaseTSDB(Service):
             start,
             end,
             rollup,
-            [environment_id],
+            [environment_id] if environment_id is not None else None,
             group_on_time=group_on_time,
             conditions=conditions,
             use_cache=use_cache,

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -554,6 +554,7 @@ class BaseTSDB(Service):
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
+        group_on_time: bool = False,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range with optional conditions

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -74,6 +74,7 @@ class DummyTSDB(BaseTSDB):
         tenant_ids=None,
         referrer_suffix=None,
         conditions=None,
+        group_on_time: bool = False,
     ):
         self.validate_arguments([model], [environment_id])
         return {k: 0 for k in keys}

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -38,6 +38,7 @@ class DummyTSDB(BaseTSDB):
         jitter_value: int | None = None,
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
+        group_on_time: bool = True,
     ) -> dict[TSDBKey, list[tuple[int, int]]]:
         self.validate_arguments([model], _environment_ids(environment_ids))
         _, series = self.get_optimal_rollup_series(start, end, rollup)

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -64,7 +64,7 @@ class DummyTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start,
         end=None,
         rollup=None,

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -322,6 +322,7 @@ class RedisTSDB(BaseTSDB):
         jitter_value: int | None = None,
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
+        group_on_time: bool = True,
     ) -> dict[TSDBKey, list[tuple[int, int]]]:
         """
         To get a range of data for group ID=[1, 2, 3]:

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -539,6 +539,7 @@ class RedisTSDB(BaseTSDB):
         tenant_ids: dict[str, int | str] | None = None,
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
+        group_on_time: bool = False,
     ) -> dict[int, Any]:
         """
         Count distinct items during a time range.

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -529,7 +529,7 @@ class RedisTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model: TSDBModel,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start: datetime,
         end: datetime | None = None,
         rollup: int | None = None,
@@ -540,7 +540,7 @@ class RedisTSDB(BaseTSDB):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, Any]:
+    ) -> Mapping[TSDBKey, int]:
         """
         Count distinct items during a time range.
         """

--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -28,6 +28,7 @@ method_specifications = {
     # method: (type, function(callargs) -> set[model])
     "get_range": (READ, single_model_argument),
     "get_sums": (READ, single_model_argument),
+    "get_timeseries_sums": (READ, single_model_argument),
     "get_distinct_counts_series": (READ, single_model_argument),
     "get_distinct_counts_totals": (READ, single_model_argument),
     "get_frequency_series": (READ, single_model_argument),

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -791,6 +791,7 @@ class SnubaTSDB(BaseTSDB):
         tenant_ids=None,
         referrer_suffix=None,
         conditions=None,
+        group_on_time: bool = True,
     ):
         return self.get_data(
             model,
@@ -805,6 +806,7 @@ class SnubaTSDB(BaseTSDB):
             tenant_ids=tenant_ids,
             referrer_suffix=referrer_suffix,
             conditions=conditions,
+            group_on_time=group_on_time,
         )
 
     def get_frequency_series(

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -759,15 +759,24 @@ class SnubaTSDB(BaseTSDB):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
-    ) -> Mapping[TSDBKey, list[tuple[int, int]]]:
-        result = self.get_sums_data(
+    ) -> dict[TSDBKey, list[tuple[int, int]]]:
+        model_query_settings = self.model_query_settings.get(model)
+        assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
+
+        if model_query_settings.dataset == Dataset.Outcomes:
+            aggregate_function = "sum"
+        else:
+            aggregate_function = "count()"
+
+        result = self.get_data(
             model,
             keys,
             start,
             end,
             rollup,
             environment_ids,
-            group_on_time=group_on_time,
+            aggregation=aggregate_function,
+            group_on_time=True,
             conditions=conditions,
             use_cache=use_cache,
             jitter_value=jitter_value,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -819,7 +819,7 @@ class SnubaTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start,
         end=None,
         rollup=None,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -791,7 +791,7 @@ class SnubaTSDB(BaseTSDB):
         tenant_ids=None,
         referrer_suffix=None,
         conditions=None,
-        group_on_time: bool = True,
+        group_on_time: bool = False,
     ):
         return self.get_data(
             model,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -705,6 +705,16 @@ class SnubaTSDB(BaseTSDB):
                     else:
                         self.unnest(val, aggregated_as)
 
+    def get_aggregate_function(self, model) -> str:
+        model_query_settings = self.model_query_settings.get(model)
+        assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
+
+        if model_query_settings.dataset == Dataset.Outcomes:
+            aggregate_function = "sum"
+        else:
+            aggregate_function = "count()"
+        return aggregate_function
+
     def get_sums_data(
         self,
         model: TSDBModel,
@@ -720,14 +730,6 @@ class SnubaTSDB(BaseTSDB):
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
     ) -> Mapping[TSDBKey, int]:
-        model_query_settings = self.model_query_settings.get(model)
-        assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
-
-        if model_query_settings.dataset == Dataset.Outcomes:
-            aggregate_function = "sum"
-        else:
-            aggregate_function = "count()"
-
         result: Mapping[TSDBKey, int] = self.get_data(
             model,
             keys,
@@ -735,7 +737,7 @@ class SnubaTSDB(BaseTSDB):
             end,
             rollup,
             environment_ids,
-            aggregation=aggregate_function,
+            aggregation=self.get_aggregate_function(model),
             group_on_time=group_on_time,
             conditions=conditions,
             use_cache=use_cache,
@@ -760,14 +762,6 @@ class SnubaTSDB(BaseTSDB):
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
     ) -> dict[TSDBKey, list[tuple[int, int]]]:
-        model_query_settings = self.model_query_settings.get(model)
-        assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
-
-        if model_query_settings.dataset == Dataset.Outcomes:
-            aggregate_function = "sum"
-        else:
-            aggregate_function = "count()"
-
         result = self.get_data(
             model,
             keys,
@@ -775,7 +769,7 @@ class SnubaTSDB(BaseTSDB):
             end,
             rollup,
             environment_ids,
-            aggregation=aggregate_function,
+            aggregation=self.get_aggregate_function(model),
             group_on_time=True,
             conditions=conditions,
             use_cache=use_cache,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -792,7 +792,7 @@ class SnubaTSDB(BaseTSDB):
     def get_distinct_counts_series(
         self,
         model,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start,
         end=None,
         rollup=None,
@@ -830,7 +830,7 @@ class SnubaTSDB(BaseTSDB):
         referrer_suffix=None,
         conditions=None,
         group_on_time: bool = False,
-    ):
+    ) -> Mapping[TSDBKey, int]:
         return self.get_data(
             model,
             keys,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -719,7 +719,7 @@ class SnubaTSDB(BaseTSDB):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
-    ) -> dict[TSDBKey, list[tuple[int, int]]]:
+    ) -> Mapping[TSDBKey, list[tuple[int, int]]]:
         model_query_settings = self.model_query_settings.get(model)
         assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
 

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -49,8 +49,8 @@ class TSDBFunction(Protocol):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
-        group_on_time: bool = True,
-    ) -> Mapping[int, int]: ...
+        group_on_time: bool = False,
+    ) -> dict[int, int]: ...
 
 
 class InvalidFilter(Exception):

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -25,7 +25,7 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
 )
 from sentry.rules.match import MatchType
-from sentry.tsdb.base import SnubaCondition, TSDBModel
+from sentry.tsdb.base import SnubaCondition, TSDBKey, TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
 from sentry.utils.snuba import options_override
@@ -39,7 +39,7 @@ class TSDBFunction(Protocol):
     def __call__(
         self,
         model: TSDBModel,
-        keys: list[int],
+        keys: list[TSDBKey],
         start: datetime,
         end: datetime,
         rollup: int | None = None,
@@ -50,7 +50,7 @@ class TSDBFunction(Protocol):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, int]: ...
+    ) -> Mapping[TSDBKey, int]: ...
 
 
 class InvalidFilter(Exception):
@@ -104,7 +104,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
     ) -> Mapping[int, int]:
-        result = tsdb_function(
+        result: Mapping[int, int] = tsdb_function(
             model=model,
             keys=keys,
             start=start,

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -400,7 +400,7 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
                     environment_id=environment_id,
                     referrer_suffix="batch_alert_event_uniq_user_frequency",
                     filters=filters,
-                    group_on_time=True,
+                    group_on_time=False,
                 )
             except InvalidFilter:
                 # Filter is not supported for this issue type

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1186,7 +1186,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert event.group is not None
 
         def query(model: TSDBModel, key: int, **kwargs: Any) -> int:
-            return tsdb.backend.get_sums(
+            return tsdb.backend.get_timeseries_sums(
                 model,
                 [key],
                 event.datetime,
@@ -2251,7 +2251,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         assert event.group is None
         assert (
-            tsdb.backend.get_sums(
+            tsdb.backend.get_timeseries_sums(
                 TSDBModel.project,
                 [self.project.id],
                 event.datetime,

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -132,13 +132,17 @@ class RedisTSDBTest(TestCase):
             ],
         }
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
+        sum_results = self.db.get_timeseries_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
         assert sum_results == {1: 9, 2: 4}
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=1)
+        sum_results = self.db.get_timeseries_sums(
+            TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=1
+        )
         assert sum_results == {1: 4, 2: 3}
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=0)
+        sum_results = self.db.get_timeseries_sums(
+            TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=0
+        )
         assert sum_results == {1: 0, 2: 0}
 
         self.db.merge(TSDBModel.project, 1, [2], now, environment_ids=[0, 1, 2])
@@ -174,15 +178,17 @@ class RedisTSDBTest(TestCase):
             2: [(timestamp(dts[i]), 0) for i in range(0, 4)],
         }
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
+        sum_results = self.db.get_timeseries_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
         assert sum_results == {1: 13, 2: 0}
 
         self.db.delete([TSDBModel.project], [1, 2], dts[0], dts[-1], environment_ids=[0, 1, 2])
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
+        sum_results = self.db.get_timeseries_sums(TSDBModel.project, [1, 2], dts[0], dts[-1])
         assert sum_results == {1: 0, 2: 0}
 
-        sum_results = self.db.get_sums(TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=1)
+        sum_results = self.db.get_timeseries_sums(
+            TSDBModel.project, [1, 2], dts[0], dts[-1], environment_id=1
+        )
         assert sum_results == {1: 0, 2: 0}
 
     def test_count_distinct(self):

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -180,8 +180,8 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             assert group_id
             return group_id
 
-        group_1_id = _store_events("group-1")
-        group_2_id = _store_events("group-2", offset=False)
+        group_1_id = _store_events("group-hb")
+        group_2_id = _store_events("group-pb", offset=False)
 
         condition_inst = self.get_rule(
             data={"interval": "1w", "value": 1},
@@ -213,8 +213,8 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             group_on_time=False,
         )
         assert batch_query == {
-            group_1_id: 5,
-            group_2_id: 5,
+            group_1_id: 4,
+            group_2_id: 4,
         }
 
     def test_get_error_and_generic_group_ids(self):

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -193,8 +193,10 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             environment_id=None,
             group_on_time=True,
         )
-        assert batch_query[group_1_id] < 5
-        assert batch_query[group_2_id] < 5
+        assert batch_query == {
+            group_1_id: 2,
+            group_2_id: 1,
+        }
 
         # data is not missing when we do not group on time
         batch_query = condition_inst.batch_query_hook(

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -171,6 +171,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
                 )
                 hours += 1
                 group_id = event.group_id
+            assert group_id
             return group_id
 
         group_1_id = _store_events("group-1", 1)

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -193,10 +193,8 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             environment_id=None,
             group_on_time=True,
         )
-        assert batch_query == {
-            group_1_id: 5,
-            group_2_id: 5,
-        }
+        assert batch_query[group_1_id] < 5
+        assert batch_query[group_2_id] < 5
 
         # data is not missing when we do not group on time
         batch_query = condition_inst.batch_query_hook(


### PR DESCRIPTION
Issue alerts that have "slow" conditions over a large time period (1 day, 1 week, 1 month) can hit the 10,000 limit we have for results when there are a lot of group to process as we return timestamped data per group (e.g. group id 1 has data for 12:01, 12:02, 12:03, and so on and that's multiplied by the number of groups we're querying) and we'll drop the remaining data past the limit which results in lower numbers than we'd expect. This can cause alerts to not fire as the data we're receiving isn't accurate.

To fix this we'll disable `group_on_time` and instead of receiving all the timestamp data that we add up later, we'll simply receive the sum without the timestamps.

I renamed `get_sums` to `get_timeseries_sums` and replaced the usages that rely on the timeseries data with that. The places that use `get_sums` now expect to receive the aggregate data in a simple dictionary `{group_id: count}`.