### PR TITLE
chore(issue-platform): Clean up issue platform feature flags now that we're using flagpole

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -72,7 +72,6 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
 # like these when we're sending issues as alerts
 @dataclass(frozen=True)
 class MetricAlertFire(GroupType):
-    use_flagpole_for_all_features = True
     type_id = 8001
     slug = "metric_alert_fire"
     description = "Metric alert fired"

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -74,13 +74,7 @@ class GroupTypeRegistry:
         with sentry_sdk.start_span(op="GroupTypeRegistry.get_visible") as span:
             released = [gt for gt in self.all() if gt.released]
             feature_to_grouptype = {
-                (
-                    gt.build_visible_feature_name()
-                    if not gt.use_flagpole_for_all_features
-                    else gt.build_visible_flagpole_feature_name()
-                ): gt
-                for gt in self.all()
-                if not gt.released
+                gt.build_visible_feature_name(): gt for gt in self.all() if not gt.released
             }
             batch_features = features.batch_has(
                 list(feature_to_grouptype.keys()), actor=actor, organization=organization
@@ -182,8 +176,6 @@ class GroupType:
     # Defaults to true to maintain the default workflow notification behavior as it exists for error group types.
     enable_status_change_workflow_notifications: bool = True
     detector_config_schema: ClassVar[dict[str, Any]] = {}
-    # Temporary setting so that we can slowly migrate all perf issues to use flagpole for all feature flags
-    use_flagpole_for_all_features = False
 
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -191,17 +183,8 @@ class GroupType:
 
         if not cls.released:
             features.add(cls.build_visible_feature_name(), OrganizationFeature, True)
-            features.add(cls.build_ingest_feature_name(), OrganizationFeature)
-            features.add(cls.build_post_process_group_feature_name(), OrganizationFeature)
-
-            # XXX: Temporary shim here. We can't use the existing feature flag names, because they're auto defined
-            # as being option backed. So options automator isn't able to validate them and fails. We'll instead
-            # move to new flag names
-            features.add(cls.build_visible_flagpole_feature_name(), OrganizationFeature, True)
-            features.add(cls.build_ingest_flagpole_feature_name(), OrganizationFeature, True)
-            features.add(
-                cls.build_post_process_group_flagpole_feature_name(), OrganizationFeature, True
-            )
+            features.add(cls.build_ingest_feature_name(), OrganizationFeature, True)
+            features.add(cls.build_post_process_group_feature_name(), OrganizationFeature, True)
 
     def __post_init__(self) -> None:
         valid_categories = [category.value for category in GroupCategory]
@@ -213,25 +196,14 @@ class GroupType:
         if cls.released:
             return True
 
-        flag_name = (
-            cls.build_ingest_feature_name()
-            if not cls.use_flagpole_for_all_features
-            else cls.build_ingest_flagpole_feature_name()
-        )
-        return features.has(flag_name, organization)
+        return features.has(cls.build_ingest_feature_name(), organization)
 
     @classmethod
     def allow_post_process_group(cls, organization: Organization) -> bool:
         if cls.released:
             return True
 
-        flag_name = (
-            cls.build_post_process_group_feature_name()
-            if not cls.use_flagpole_for_all_features
-            else cls.build_post_process_group_flagpole_feature_name()
-        )
-
-        return features.has(flag_name, organization)
+        return features.has(cls.build_post_process_group_feature_name(), organization)
 
     @classmethod
     def should_detect_escalation(cls) -> bool:
@@ -245,33 +217,20 @@ class GroupType:
         return cls.slug.replace("_", "-")
 
     @classmethod
-    def build_base_feature_name(cls, prefix: str = "") -> str:
-        return f"organizations:{prefix}{cls.build_feature_name_slug()}"
+    def build_base_feature_name(cls) -> str:
+        return f"organizations:issue-{cls.build_feature_name_slug()}"
 
     @classmethod
     def build_visible_feature_name(cls) -> str:
         return f"{cls.build_base_feature_name()}-visible"
 
     @classmethod
-    def build_visible_flagpole_feature_name(cls) -> str:
-        # We'll rename this too so that all the feature names are consistent
-        return f"{cls.build_base_feature_name("issue-")}-visible"
-
-    @classmethod
     def build_ingest_feature_name(cls) -> str:
         return f"{cls.build_base_feature_name()}-ingest"
 
     @classmethod
-    def build_ingest_flagpole_feature_name(cls) -> str:
-        return f"{cls.build_base_feature_name("issue-")}-ingest"
-
-    @classmethod
     def build_post_process_group_feature_name(cls) -> str:
         return f"{cls.build_base_feature_name()}-post-process-group"
-
-    @classmethod
-    def build_post_process_group_flagpole_feature_name(cls) -> str:
-        return f"{cls.build_base_feature_name("issue-")}-post-process-group"
 
 
 def get_all_group_type_ids() -> set[int]:
@@ -594,7 +553,6 @@ class MetricIssuePOC(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
-    use_flagpole_for_all_features = True
 
 
 def should_create_group(

--- a/src/sentry/runner/commands/createflag.py
+++ b/src/sentry/runner/commands/createflag.py
@@ -204,9 +204,9 @@ def createissueflag(
         click.echo("")
         click.echo("=== GENERATED YAML ===\n")
         for feature_name in [
-            group_type.build_visible_flagpole_feature_name(),
-            group_type.build_ingest_flagpole_feature_name(),
-            group_type.build_post_process_group_flagpole_feature_name(),
+            group_type.build_visible_feature_name(),
+            group_type.build_ingest_feature_name(),
+            group_type.build_post_process_group_feature_name(),
         ]:
 
             feature = Feature(

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
@@ -33,8 +32,3 @@ class UptimeDomainCheckFailure(GroupType):
         },
         "additionalProperties": False,
     }
-    use_flagpole_for_all_features = True
-
-
-# XXX: Temporary hack to work around pickling issues
-grouptype.UptimeDomainCheckFailure = UptimeDomainCheckFailure  # type: ignore[attr-defined]

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -12,7 +12,7 @@ from sentry.types.group import GroupSubStatus, PriorityLevel
 from tests.sentry.issues.test_occurrence_consumer import IssueOccurrenceTestBase
 
 
-@apply_feature_flag_on_cls(MetricIssuePOC.build_ingest_flagpole_feature_name())
+@apply_feature_flag_on_cls(MetricIssuePOC.build_ingest_feature_name())
 @apply_feature_flag_on_cls("projects:metric-issue-creation")
 class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
     def setUp(self):

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -162,10 +162,10 @@ class GroupRegistryTest(BaseGroupTypeTest):
         registry.add(UptimeDomainCheckFailure)
         registry.add(MetricIssuePOC)
         assert registry.get_visible(self.organization) == []
-        with self.feature(UptimeDomainCheckFailure.build_visible_flagpole_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_visible_feature_name()):
             assert registry.get_visible(self.organization) == [UptimeDomainCheckFailure]
         registry.add(ErrorGroupType)
-        with self.feature(UptimeDomainCheckFailure.build_visible_flagpole_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_visible_feature_name()):
             assert set(registry.get_visible(self.organization)) == {
                 UptimeDomainCheckFailure,
                 ErrorGroupType,

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -79,7 +79,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 datetime.now(),
             )
         )
-        with self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
             if consumer is None:
                 factory = UptimeResultsStrategyFactory(mode=self.strategy_processing_mode)
                 commit = mock.Mock()

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -692,7 +692,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
     def test_disable_failed(self, mock_disable_seat):
         with (
             self.tasks(),
-            self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()),
+            self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()),
         ):
             proj_sub = create_project_uptime_subscription(
                 self.project,

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -119,7 +119,7 @@ class ResolveUptimeIssueTest(UptimeTestCase):
             uptime_subscription=subscription
         )
         result = self.create_uptime_result(subscription.subscription_id)
-        with self.feature(UptimeDomainCheckFailure.build_ingest_flagpole_feature_name()):
+        with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
             create_issue_platform_occurrence(result, project_subscription)
         hashed_fingerprint = md5(str(project_subscription.id).encode("utf-8")).hexdigest()
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)


### PR DESCRIPTION
We've migrated all grouptypes to either be released or using flagpole. We can remove all this transition code.

Should be merged after
- https://github.com/getsentry/getsentry/pull/17207
- https://github.com/getsentry/sentry/pull/89446