### PR TITLE
chore(laravel): Remove unused laravel user option

### DIFF
--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -39,14 +39,6 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 TIMEZONE_CHOICES = get_timezone_choices()
 
 
-def validate_prefers_specialized_project_overview(value: dict[str, bool] | None) -> None:
-    invalid_entries = [key for key, value_ in (value or {}).items() if not isinstance(value_, bool)]
-    if len(invalid_entries) > 0:
-        raise ValidationError(
-            f"The enabled values {', '.join(invalid_entries)} should be booleans."
-        )
-
-
 def validate_quick_start_display(value: dict[str, int] | None) -> None:
     if value is not None:
         for display_value in value.values():
@@ -87,12 +79,6 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
         required=False,
     )
     prefersIssueDetailsStreamlinedUI = serializers.BooleanField(required=False)
-    prefersSpecializedProjectOverview = serializers.JSONField(
-        required=False,
-        allow_null=True,
-        validators=[validate_prefers_specialized_project_overview],
-        help_text="Tracks whether the user prefers the new specialized project overview experience (dict of project ids to booleans)",
-    )
     prefersStackedNavigation = serializers.BooleanField(required=False)
     prefersChonkUI = serializers.BooleanField(required=False)
 
@@ -270,7 +256,6 @@ class UserDetailsEndpoint(UserEndpoint):
             "defaultIssueEvent": "default_issue_event",
             "clock24Hours": "clock_24_hours",
             "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
-            "prefersSpecializedProjectOverview": "prefers_specialized_project_overview",
             "prefersStackedNavigation": "prefers_stacked_navigation",
             "prefersChonkUI": "prefers_chonk_ui",
             "quickStartDisplay": "quick_start_display",

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -265,7 +265,7 @@ class UserDetailsEndpoint(UserEndpoint):
 
         for key in key_map:
             if key in options_result:
-                if key in ("quickStartDisplay", "prefersSpecializedProjectOverview"):
+                if key == "quickStartDisplay":
                     current_value = UserOption.objects.get_value(
                         user=user, key=key_map.get(key, key)
                     )

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -66,7 +66,6 @@ class _UserOptions(TypedDict):
     timezone: str
     clock24Hours: bool
     prefersIssueDetailsStreamlinedUI: bool | None
-    prefersSpecializedProjectOverview: dict[str, bool]
     prefersStackedNavigation: bool
     prefersChonkUI: bool
     quickStartDisplay: dict[str, int]

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -202,9 +202,6 @@ class UserSerializer(Serializer):
                 "prefersIssueDetailsStreamlinedUI": options.get(
                     "prefers_issue_details_streamlined_ui"
                 ),
-                "prefersSpecializedProjectOverview": options.get(
-                    "prefers_specialized_project_overview", {}
-                ),
                 "prefersStackedNavigation": options.get("prefers_stacked_navigation", False),
                 "prefersChonkUI": options.get("prefers_chonk_ui", False),
                 "quickStartDisplay": options.get("quick_start_display") or {},

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -165,8 +165,6 @@ class UserOption(Model):
         - unused
      - prefers_issue_details_streamlined_ui
         - Whether the user prefers the new issue details experience (boolean)
-     - prefers_specialized_project_overview
-        - Whether the user prefers the new specialized project overview experience (dict of project ids to booleans)
      - prefers_stacked_navigation
         - Whether the user prefers the new stacked navigation experience (boolean)
      - prefers_chonk_ui

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -145,12 +145,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert UserOption.objects.get_value(user=self.user, key="prefers_stacked_navigation")
         assert UserOption.objects.get_value(user=self.user, key="prefers_chonk_ui")
         assert (
-            UserOption.objects.get_value(
-                user=self.user, key="prefers_specialized_project_overview"
-            ).get("2")
-            is True
-        )
-        assert (
             UserOption.objects.get_value(user=self.user, key="quick_start_display").get(
                 str(self.organization.id)
             )
@@ -220,42 +214,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
 
         assert user.email == "c@example.com"
         assert user.username == "c@example.com"
-
-    def test_saving_specialized_project_overview_option(self):
-        self.get_success_response(
-            "me",
-            options={"prefersSpecializedProjectOverview": {"1": False, "2": False}},
-        )
-
-        options = UserOption.objects.get_value(
-            user=self.user, key="prefers_specialized_project_overview"
-        )
-        assert options.get("1") is False
-        assert options.get("2") is False
-
-        # Test updating project 1 to True
-        self.get_success_response(
-            "me",
-            options={"prefersSpecializedProjectOverview": {"1": True}},
-        )
-        options = UserOption.objects.get_value(
-            user=self.user, key="prefers_specialized_project_overview"
-        )
-        assert options.get("1") is True
-        # Project 2 should not be affected
-        assert options.get("2") is False
-
-        # Enabled value is not a boolean
-        self.get_error_response(
-            "me",
-            options={"prefersSpecializedProjectOverview": {"1": "True"}},
-            status_code=400,
-        )
-        self.get_error_response(
-            "me",
-            options={"prefersSpecializedProjectOverview": {"1": 1}},
-            status_code=400,
-        )
 
     def test_saving_quick_start_display_option(self):
         org1_id = str(self.organization.id)

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -119,7 +119,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
                 "clock24Hours": True,
                 "extra": True,
                 "prefersIssueDetailsStreamlinedUI": True,
-                "prefersSpecializedProjectOverview": {"2": True},
                 "prefersStackedNavigation": True,
                 "prefersChonkUI": True,
                 "quickStartDisplay": {self.organization.id: 1},


### PR DESCRIPTION
Remove `prefers_specialized_project_overview` since it is no longer used anywhere, and it was removed from the FE usage in this PR: https://github.com/getsentry/sentry/pull/89469

Part of [TET-295: Run a job to clear framework opt-out](https://linear.app/getsentry/issue/TET-295/run-a-job-to-clear-framework-opt-out)