### PR TITLE
sdkcd: ignore Flutter functions `handleDrawFrame` and `handleBeginFrame`

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -355,10 +355,14 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),
-            # getCurrentStackTrace is always part of the stacktrace when the SDK captures the stacktrace,
-            # and would cause false positives. Therefore, we ignore it.
             sdk_crash_ignore_functions_matchers={
+                # getCurrentStackTrace is always part of the stacktrace when the SDK captures the stacktrace,
+                # and would cause false positives. Therefore, we ignore it.
                 "getCurrentStackTrace",
+                # We override the handleDrawFrame and handleBeginFrame methods in the Flutter SDK to instrument frame tracking.
+                # These methods are part of the Flutter engine and lead to false positives.
+                "handleDrawFrame",
+                "handleBeginFrame",
             },
         )
         configs.append(dart_config)

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -355,7 +355,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),
-            sdk_crash_ignore_functions_matchers=
+            sdk_crash_ignore_functions_matchers={
                 # getCurrentStackTrace is always part of the stacktrace when the SDK captures the stacktrace,
                 # and would cause false positives. Therefore, we ignore it.
                 "getCurrentStackTrace",
@@ -365,7 +365,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 # However every custom implementation is try/catch guarded so no exception can be thrown.
                 "SentryWidgetsBindingMixin.handleDrawFrame",
                 "SentryWidgetsBindingMixin.handleBeginFrame",
-            ,
+            },
         )
         configs.append(dart_config)
 

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -355,15 +355,17 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),
-            sdk_crash_ignore_functions_matchers={
+            sdk_crash_ignore_functions_matchers=
                 # getCurrentStackTrace is always part of the stacktrace when the SDK captures the stacktrace,
                 # and would cause false positives. Therefore, we ignore it.
                 "getCurrentStackTrace",
-                # We override the handleDrawFrame and handleBeginFrame methods in the Flutter SDK to instrument frame tracking.
-                # These methods are part of the Flutter engine and lead to false positives.
-                "handleDrawFrame",
-                "handleBeginFrame",
-            },
+                # Ignore handleDrawFrame and handleBeginFrame to avoid false positives.
+                # In the Sentry Flutter SDK, we override the handleDrawFrame and handleBeginFrame methods,
+                # add our custom implementation on top to instrument frame tracking and then forward the calls to Flutter.
+                # However every custom implementation is try/catch guarded so no exception can be thrown.
+                "**handleDrawFrame",
+                "**handleBeginFrame",
+            ,
         )
         configs.append(dart_config)
 

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -363,8 +363,8 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 # In the Sentry Flutter SDK, we override the handleDrawFrame and handleBeginFrame methods,
                 # add our custom implementation on top to instrument frame tracking and then forward the calls to Flutter.
                 # However every custom implementation is try/catch guarded so no exception can be thrown.
-                "**handleDrawFrame",
-                "**handleBeginFrame",
+                "SentryWidgetsBindingMixin.handleDrawFrame",
+                "SentryWidgetsBindingMixin.handleBeginFrame",
             ,
         )
         configs.append(dart_config)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -224,3 +224,47 @@ def test_too_low_min_sdk_version_not_detected(
     )
 
     assert mock_sdk_crash_reporter.report.call_count == 0
+
+@decorators
+def test_ignore_handle_draw_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="handleDrawFrame")
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@decorators
+def test_ignore_handle_begin_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="SentryWidgetsBindingMixin.handleBeginFrame")
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@decorators
+def test_ignore_handle_draw_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="SentryWidgetsBindingMixin.handleDrawFrame")
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 0

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -225,6 +225,7 @@ def test_too_low_min_sdk_version_not_detected(
 
     assert mock_sdk_crash_reporter.report.call_count == 0
 
+
 @decorators
 def test_ignore_handle_begin_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
     event_data = get_crash_event(sdk_function="SentryWidgetsBindingMixin.handleBeginFrame")

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -226,21 +226,6 @@ def test_too_low_min_sdk_version_not_detected(
     assert mock_sdk_crash_reporter.report.call_count == 0
 
 @decorators
-def test_ignore_handle_draw_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
-    event_data = get_crash_event(sdk_function="handleDrawFrame")
-    event = store_event(data=event_data)
-
-    configs[1].organization_allowlist = [event.project.organization_id]
-
-    sdk_crash_detection.detect_sdk_crash(
-        event=event,
-        configs=configs,
-    )
-
-    assert mock_sdk_crash_reporter.report.call_count == 0
-
-
-@decorators
 def test_ignore_handle_begin_frame(mock_sdk_crash_reporter, mock_random, store_event, configs):
     event_data = get_crash_event(sdk_function="SentryWidgetsBindingMixin.handleBeginFrame")
     event = store_event(data=event_data)


### PR DESCRIPTION
SDKCD will falsely report `handleDrawFrame` and `handleBeginFrame` as SDK crashes although they are not.