### PR TITLE
feat(trace-tree): Add `prefetch` prefix to span descriptions for prefetch spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.spec.tsx.snap
@@ -169,6 +169,25 @@ trace root
 "
 `;
 
+exports[`TraceTree printTraceTreeNode adds prefetch prefix to spans with http.request.prefetch attribute 1`] = `
+"
+trace root
+  transaction - transaction.op
+    http - (prefetch) GET /api/users
+    http - GET /api/users
+    transaction - transaction.op
+"
+`;
+
+exports[`TraceTree printTraceTreeNode handles falsy prefetch attribute 1`] = `
+"
+trace root
+  transaction - transaction.op
+    http - GET /api/users
+    transaction - transaction.op
+"
+`;
+
 exports[`TraceTree zoom maintains the span tree when parent is zoomed in 1`] = `
 "
 trace root

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1844,13 +1844,7 @@ describe('TraceTree', () => {
         makeEventTransaction()
       );
 
-      const serialized = tree.build().serialize();
-
-      // Check that the prefetch span has the prefix
-      expect(serialized).toContain('http - (prefetch) GET /api/users');
-
-      // Check that the regular span doesn't have the prefix
-      expect(serialized).toContain('http - GET /api/users');
+      expect(tree.build().serialize()).toMatchSnapshot();
     });
 
     it('handles falsy prefetch attribute', () => {
@@ -1870,11 +1864,7 @@ describe('TraceTree', () => {
         makeEventTransaction()
       );
 
-      const serialized = tree.build().serialize();
-
-      // Check that the span with prefetch = false doesn't have the prefix
-      expect(serialized).toContain('http - GET /api/users');
-      expect(serialized).not.toContain('http - (prefetch) GET /api/users');
+      expect(tree.build().serialize()).toMatchSnapshot();
     });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -2164,6 +2164,7 @@ function printTraceTreeNode(
       padding +
       (t.value.op || 'unknown span') +
       ' - ' +
+      getNodeDescriptionPrefix(t) +
       (t.value.description || 'unknown description') +
       (isEAPTransactionNode(t) ? ` (eap-transaction)` : '')
     );
@@ -2314,4 +2315,13 @@ function getRelatedPerformanceIssuesFromTransaction(
   }
 
   return occurences;
+}
+
+export function getNodeDescriptionPrefix(
+  node: TraceTreeNode<TraceTree.EAPSpan> | TraceTreeNode<TraceTree.Span>
+) {
+  // Check if span has http.request.prefetch attribute and add prefix if it does
+  const isPrefetch =
+    isSpanNode(node) && node.value.data && !!node.value.data['http.request.prefetch'];
+  return isPrefetch ? '(prefetch) ' : '';
 }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {getNodeDescriptionPrefix} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {
   makeTraceNodeBarColor,
@@ -80,6 +81,7 @@ export function TraceSpanRow(
             </React.Fragment>
           )}
           <span className="TraceDescription" title={props.node.value.description}>
+            {getNodeDescriptionPrefix(props.node)}
             {props.node.value.description
               ? props.node.value.description.length > 100
                 ? props.node.value.description.slice(0, 100).trim() + '\u2026'


### PR DESCRIPTION
![Screenshot 2025-04-14 at 13 55 26](https://github.com/user-attachments/assets/2798dbb5-ba1f-41e6-9d28-834e3fce0e29)

Adds a `(prefetch) ` prefix to the descriptions.