### PR TITLE
fix(widget-builder): Applying a grouping should always add a limit

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1530,6 +1530,53 @@ describe('useWidgetBuilderState', () => {
         {field: 'crash_free_rate(session)', kind: 'desc'},
       ]);
     });
+
+    it('always assigns a limit when there is a y-axis', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            yAxis: ['count()', 'count_unique(user)'],
+            fields: ['event.type'],
+            displayType: DisplayType.LINE,
+            dataset: WidgetType.ERRORS,
+            limit: '5',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.limit).toBe(5);
+
+      // Changing the dataset will unset the limit
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.TRANSACTIONS,
+        });
+      });
+
+      expect(result.current.state.limit).toBeUndefined();
+
+      // Changing the dataset back and applying a grouping should set a limit
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.ERRORS,
+        });
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_FIELDS,
+          payload: [{field: 'event.type', kind: FieldValueKind.FIELD}],
+        });
+      });
+
+      expect(result.current.state.limit).toBe(5);
+    });
   });
 
   describe('yAxis', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -458,7 +458,7 @@ function useWidgetBuilderState(): {
             ]);
           }
 
-          if ((yAxis?.length ?? 0) > 0 && !defined(limit)) {
+          if (action.payload.length > 0 && (yAxis?.length ?? 0) > 0 && !defined(limit)) {
             setLimit(
               Math.min(
                 DEFAULT_RESULTS_LIMIT,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -457,6 +457,15 @@ function useWidgetBuilderState(): {
               },
             ]);
           }
+
+          if ((yAxis?.length ?? 0) > 0 && !defined(limit)) {
+            setLimit(
+              Math.min(
+                DEFAULT_RESULTS_LIMIT,
+                getResultsLimit(query?.length ?? 1, yAxis?.length ?? 0)
+              )
+            );
+          }
           break;
         }
         case BuilderStateAction.SET_Y_AXIS:


### PR DESCRIPTION
Switching datasets was wiping out the limit, and adding a grouping wasn't reinstating the limit by default, so update the hook to add the default.

The code in the diff is added to the `SET_FIELDS` action