### PR TITLE
performance: use native tag component

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/performanceBadge.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceBadge.tsx
@@ -1,10 +1,4 @@
-import styled from '@emotion/styled';
-
-import {space} from 'sentry/styles/space';
-import {
-  makePerformanceScoreColors,
-  type PerformanceScore,
-} from 'sentry/views/insights/browser/webVitals/utils/performanceScoreColors';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {
   scoreToStatus,
   STATUS_TEXT,
@@ -17,20 +11,8 @@ type Props = {
 export function PerformanceBadge({score}: Props) {
   const status = scoreToStatus(score);
   return (
-    <Badge status={status}>
+    <Tag type={status === 'good' ? 'success' : status === 'bad' ? 'error' : 'warning'}>
       {STATUS_TEXT[status]} {score}
-    </Badge>
+    </Tag>
   );
 }
-
-export const Badge = styled('div')<{status: PerformanceScore}>`
-  white-space: nowrap;
-  border-radius: 12px;
-  color: ${p => makePerformanceScoreColors(p.theme)[p.status].normal};
-  background-color: ${p => makePerformanceScoreColors(p.theme)[p.status].light};
-  border: solid 1px ${p => makePerformanceScoreColors(p.theme)[p.status].light};
-  font-size: ${p => p.theme.fontSizeExtraSmall};
-  padding: 0 ${space(1)};
-  display: inline-block;
-  height: 17px;
-`;

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -13,10 +13,7 @@ import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {formatTimeSeriesResultsToChartData} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart';
 import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
-import {
-  Badge,
-  PerformanceBadge,
-} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
+import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
 import {useProjectWebVitalsScoresTimeseriesQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
 import {useTransactionWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery';
@@ -126,9 +123,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
                 }
                 isHoverable
               >
-                <PerformanceBadgeWrapper>
-                  <PerformanceBadge score={listItem.totalScore} />
-                </PerformanceBadgeWrapper>
+                <PerformanceBadge score={listItem.totalScore} />
               </Tooltip>
             )}
             {isProjectScoresLoading ? (
@@ -252,11 +247,5 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
   &,
   .loading-message {
     margin: 0;
-  }
-`;
-
-const PerformanceBadgeWrapper = styled('span')`
-  ${Badge} {
-    text-decoration: underline dotted;
   }
 `;


### PR DESCRIPTION
Before
![CleanShot 2025-04-14 at 10 16 06@2x](https://github.com/user-attachments/assets/34023010-110a-4206-a1ff-ebc6d7d18917)
![CleanShot 2025-04-14 at 10 15 49@2x](https://github.com/user-attachments/assets/7c239671-0205-455a-a9cd-77633a2a2967)

After
![CleanShot 2025-04-14 at 10 16 02@2x](https://github.com/user-attachments/assets/39218f00-e27c-4949-bb4c-3af22d49381d)
![CleanShot 2025-04-14 at 10 15 57@2x](https://github.com/user-attachments/assets/6a31af96-b41a-4b26-bb59-68e5c1aa6474)
