### PR TITLE
fix(insights): sort not working http landing page

### DIFF
--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -51,7 +51,7 @@ export function HTTPLandingPage() {
   });
 
   const sort =
-    decodeSorts(location.query?.[QueryParameterNames.DOMAINS_SORT]).find(isAValidSort) ??
+    decodeSorts(query?.[QueryParameterNames.DOMAINS_SORT]).find(isAValidSort) ??
     DEFAULT_SORT;
   const cursor = decodeScalar(location.query?.[QueryParameterNames.DOMAINS_CURSOR]);
 

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -49,8 +49,10 @@ export function HTTPLandingPage() {
       [QueryParameterNames.DOMAINS_SORT]: decodeScalar,
     },
   });
+
   const sort =
-    decodeSorts(QueryParameterNames.DOMAINS_SORT).find(isAValidSort) ?? DEFAULT_SORT;
+    decodeSorts(location.query?.[QueryParameterNames.DOMAINS_SORT]).find(isAValidSort) ??
+    DEFAULT_SORT;
   const cursor = decodeScalar(location.query?.[QueryParameterNames.DOMAINS_CURSOR]);
 
   const chartFilters = useHttpLandingChartFilter();


### PR DESCRIPTION
This broke in https://github.com/getsentry/sentry/issues/89325

We should be passing in `location.query.domainsSort` into decodeSorts and not the string `domainsSort`!
Also added a test case to ensure sort always works off the query param