### PR TITLE
fix(explore): Fix Explore starred items buggy animation when page scrolls

### DIFF
--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -47,7 +47,7 @@ export function SavedQueriesTable({
   const location = useLocation();
   const navigate = useNavigate();
   const cursor = decodeScalar(location.query[cursorKey]);
-  const {data, isLoading, pageLinks, isFetched} = useGetSavedQueries({
+  const {data, isLoading, pageLinks, isFetched, isError} = useGetSavedQueries({
     sortBy: ['starred', sort],
     exclude: mode === 'owned' ? 'shared' : mode === 'shared' ? 'owned' : undefined, // Inverse because this is an exclusion
     perPage,
@@ -130,6 +130,7 @@ export function SavedQueriesTable({
   return (
     <span>
       <SavedEntityTableWithColumns
+        pageSize={perPage}
         isLoading={isLoading}
         header={
           <SavedEntityTable.Header>
@@ -155,9 +156,9 @@ export function SavedQueriesTable({
             <SavedEntityTable.HeaderCell key="actions" />
           </SavedEntityTable.Header>
         }
-        emptyMessage={undefined}
-        isEmpty={false}
-        isError={false}
+        isEmpty={filteredData.length === 0}
+        isError={isError}
+        emptyMessage={t('No saved queries found')}
       >
         {filteredData.map((query, index) => (
           <SavedEntityTable.Row

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
@@ -41,6 +41,8 @@ export function ExploreSavedQueryNavItems({queries}: Props) {
 
   const reorderStarredSavedQueries = useReorderStarredSavedQueries();
 
+  const [isDragging, setIsDragging] = useState<number | null>(null);
+
   return (
     <Reorder.Group
       as="div"
@@ -55,9 +57,29 @@ export function ExploreSavedQueryNavItems({queries}: Props) {
     >
       {savedQueries?.map(query => (
         <StyledReorderItem
+          grabbing={isDragging === query.id}
+          as="div"
+          dragConstraints={sectionRef}
+          dragElastic={0.03}
+          dragTransition={{bounceStiffness: 400, bounceDamping: 40}}
+          // This style is a hack to fix a framer-motion bug that causes views to
+          // jump from the bottom of the nav bar to their correct positions
+          // upon scrolling down on the page and triggering a page navigation.
+          // See: https://github.com/motiondivision/motion/issues/2006
+          style={{
+            ...(isDragging
+              ? {}
+              : {
+                  originY: '0px',
+                }),
+          }}
           key={query.id}
           value={query}
+          onDragStart={() => {
+            setIsDragging(query.id);
+          }}
           onDragEnd={() => {
+            setIsDragging(null);
             reorderStarredSavedQueries(savedQueries);
           }}
         >
@@ -106,9 +128,11 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
   width: 100%;
 `;
 
-const StyledReorderItem = styled(Reorder.Item)`
+const StyledReorderItem = styled(Reorder.Item, {
+  shouldForwardProp: prop => prop !== 'grabbing',
+})<{grabbing: boolean}>`
   position: relative;
-  background-color: transparent;
+  background-color: ${p => (p.grabbing ? p.theme.translucentSurface200 : 'transparent')};
   border-radius: ${p => p.theme.borderRadius};
   list-style: none;
   display: flex;


### PR DESCRIPTION
Fixes an issue with Explore starred queries and buggy animations any time the ui triggers a scroll.
Also fills out missing props in the explore saved queries table