### PR TITLE
fix(autofix): Make mobile experience workable

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -341,6 +341,7 @@ export function AutofixChanges({
                       : null
                   }
                   isAgentComment
+                  blockName={t('Code Changes')}
                 />
               )}
             </AnimatePresence>
@@ -440,6 +441,8 @@ const HeaderWrapper = styled('div')`
   padding-left: ${space(0.5)};
   padding-bottom: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
+  flex-wrap: wrap;
+  gap: ${space(1)};
 `;
 
 const HeaderIconWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
+import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {type Change, diffWords} from 'diff';
 
@@ -263,7 +264,7 @@ function DiffHunkContent({
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, []);
+  }, [overlayRef]);
 
   const lineGroups = useMemo(() => {
     const groups: Array<{end: number; start: number; type: 'change' | DiffLineType}> = [];
@@ -474,7 +475,7 @@ function DiffHunkContent({
       <HunkHeaderEmptySpace />
       <HunkHeader lines={lines} sectionHeader={header} />
       {linesWithChanges.map((line, index) => (
-        <Fragment key={index}>
+        <Fragment key={`${line.diff_line_no}-${index}`}>
           <LineNumber lineType={line.line_type}>{line.source_line_no}</LineNumber>
           <LineNumber lineType={line.line_type}>{line.target_line_no}</LineNumber>
           <DiffContent
@@ -490,7 +491,7 @@ function DiffHunkContent({
           >
             <DiffLineCode line={line} fileName={fileName} />
             {editable && lineGroups.some(group => index === group.start) && (
-              <ButtonGroup>
+              <ButtonGroup data-ignore-autofix-highlight="true">
                 <ActionButton
                   size="xs"
                   icon={<IconEdit size="xs" />}
@@ -509,68 +510,80 @@ function DiffHunkContent({
                 />
               </ButtonGroup>
             )}
-            {editingGroup === index && (
-              <EditOverlay ref={overlayRef} data-ignore-autofix-highlight="true">
-                <OverlayHeader>
-                  <OverlayTitle
-                    dangerouslySetInnerHTML={{
-                      __html: singleLineRenderer(t('Editing `%s`', fileName)),
-                    }}
-                  />
-                </OverlayHeader>
-                <OverlayContent>
-                  <SectionTitle>{getDeletedLineTitle(index)}</SectionTitle>
-                  {linesWithChanges
-                    .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
-                    .some(l => l.line_type === DiffLineType.REMOVED) ? (
-                    <RemovedLines>
-                      {linesWithChanges
-                        .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
-                        .filter(l => l.line_type === DiffLineType.REMOVED)
-                        .map((l, i) => (
-                          <RemovedLine key={i}>{l.value}</RemovedLine>
-                        ))}
-                    </RemovedLines>
-                  ) : (
-                    <NoChangesMessage>
-                      {t('No lines are being deleted.')}
-                    </NoChangesMessage>
-                  )}
-                  <SectionTitle>{getNewLineTitle(index)}</SectionTitle>
-                  <TextAreaWrapper>
-                    <StyledTextArea
-                      value={editedContent}
-                      onChange={handleTextAreaChange}
-                      rows={5}
-                      autosize
-                      placeholder={
-                        editedLines.length === 0 ? t('No lines are being added...') : ''
-                      }
-                    />
-                    <ClearButton
-                      size="xs"
-                      onClick={handleClearChanges}
-                      aria-label={t('Clear changes')}
-                      icon={<IconDelete size="xs" />}
-                      title={t('Clear all new lines')}
-                    />
-                  </TextAreaWrapper>
-                </OverlayContent>
-                <OverlayFooter>
-                  <OverlayButtonGroup>
-                    <Button size="xs" onClick={handleCancelEdit}>
-                      {t('Cancel')}
-                    </Button>
-                    <Button size="xs" priority="primary" onClick={handleSaveEdit}>
-                      {t('Save')}
-                    </Button>
-                  </OverlayButtonGroup>
-                </OverlayFooter>
-              </EditOverlay>
-            )}
           </DiffContent>
         </Fragment>
       ))}
+      {editingGroup !== null &&
+        document.body &&
+        createPortal(
+          <EditOverlay
+            ref={overlayRef}
+            data-ignore-autofix-highlight="true"
+            data-overlay="true"
+          >
+            <OverlayHeader>
+              <OverlayTitle
+                dangerouslySetInnerHTML={{
+                  __html: singleLineRenderer(t('Editing `%s`', fileName)),
+                }}
+              />
+            </OverlayHeader>
+            <OverlayContent>
+              <SectionTitle>{getDeletedLineTitle(editingGroup)}</SectionTitle>
+              {linesWithChanges
+                .slice(
+                  editingGroup,
+                  lineGroups.find(g => g.start === editingGroup)?.end! + 1
+                )
+                .some(l => l.line_type === DiffLineType.REMOVED) ? (
+                <RemovedLines>
+                  {linesWithChanges
+                    .slice(
+                      editingGroup,
+                      lineGroups.find(g => g.start === editingGroup)?.end! + 1
+                    )
+                    .filter(l => l.line_type === DiffLineType.REMOVED)
+                    .map((l, i) => (
+                      <RemovedLine key={i}>{l.value}</RemovedLine>
+                    ))}
+                </RemovedLines>
+              ) : (
+                <NoChangesMessage>{t('No lines are being deleted.')}</NoChangesMessage>
+              )}
+              <SectionTitle>{getNewLineTitle(editingGroup)}</SectionTitle>
+              <TextAreaWrapper>
+                <StyledTextArea
+                  value={editedContent}
+                  onChange={handleTextAreaChange}
+                  rows={5}
+                  autosize
+                  placeholder={
+                    editedLines.length === 0 ? t('No lines are being added...') : ''
+                  }
+                  autoFocus
+                />
+                <ClearButton
+                  size="xs"
+                  onClick={handleClearChanges}
+                  aria-label={t('Clear changes')}
+                  icon={<IconDelete size="xs" />}
+                  title={t('Clear all new lines')}
+                />
+              </TextAreaWrapper>
+            </OverlayContent>
+            <OverlayFooter>
+              <OverlayButtonGroup>
+                <Button size="xs" onClick={handleCancelEdit}>
+                  {t('Cancel')}
+                </Button>
+                <Button size="xs" priority="primary" onClick={handleSaveEdit}>
+                  {t('Save')}
+                </Button>
+              </OverlayButtonGroup>
+            </OverlayFooter>
+          </EditOverlay>,
+          document.body
+        )}
     </Fragment>
   );
 }
@@ -666,6 +679,7 @@ export function AutofixDiff({
               ? previousInsightCount - 1
               : -1
           }
+          displayName={`Diff for ${file.path}`}
         >
           <FileDiff
             file={file}
@@ -735,6 +749,7 @@ const DiffContainer = styled('div')`
   border-top: 1px solid ${p => p.theme.innerBorder};
   display: grid;
   grid-template-columns: auto auto 1fr;
+  overflow-x: auto;
 `;
 
 const HunkHeaderEmptySpace = styled('div')`
@@ -808,7 +823,7 @@ const CodeDiff = styled('span')<{added?: boolean; removed?: boolean}>`
 const ButtonGroup = styled('div')`
   position: absolute;
   top: 0;
-  right: ${space(0.25)};
+  right: ${space(0.5)};
   display: flex;
   z-index: 1;
 `;
@@ -832,16 +847,20 @@ const ActionButton = styled(Button)<{isHovered: boolean}>`
 const EditOverlay = styled('div')`
   position: fixed;
   bottom: ${space(2)};
+  left: 50%;
   right: ${space(2)};
-  left: calc(50% + ${space(2)});
   background: ${p => p.theme.backgroundElevated};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
-  z-index: 1;
+  z-index: ${p => p.theme.zIndex.tooltip};
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - 18rem);
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    left: ${space(2)};
+  }
 `;
 
 const OverlayHeader = styled('div')`

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 import {createPortal} from 'react-dom';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {motion} from 'framer-motion';
@@ -26,6 +27,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
+import useMedia from 'sentry/utils/useMedia';
 import {useUser} from 'sentry/utils/useUser';
 
 import type {CommentThreadMessage} from './types';
@@ -37,6 +39,7 @@ interface Props {
   runId: string;
   selectedText: string;
   stepIndex: number;
+  blockName?: string;
   isAgentComment?: boolean;
 }
 
@@ -123,6 +126,7 @@ function AutofixHighlightPopupContent({
   stepIndex,
   retainInsightCardIndex,
   isAgentComment,
+  blockName,
   isFocused,
 }: Props & {isFocused?: boolean}) {
   const {mutate: submitComment} = useCommentThread({groupId, runId});
@@ -258,7 +262,13 @@ function AutofixHighlightPopupContent({
   return (
     <Container onClick={handleContainerClick} isFocused={isFocused}>
       <Header>
-        <SelectedText>{truncatedText && <span>"{truncatedText}"</span>}</SelectedText>
+        <SelectedText>
+          {blockName ? (
+            <span>{blockName}</span>
+          ) : (
+            truncatedText && <span>"{truncatedText}"</span>
+          )}
+        </SelectedText>
         {allMessages.length > 0 && (
           <ResolveButton
             size="zero"
@@ -364,6 +374,9 @@ function AutofixHighlightPopup(props: Props) {
   const [width, setWidth] = useState<number | undefined>(undefined);
   const [isFocused, setIsFocused] = useState(false);
 
+  const theme = useTheme();
+  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
+
   useLayoutEffect(() => {
     if (!referenceElement || !popupRef.current) {
       return undefined;
@@ -426,6 +439,10 @@ function AutofixHighlightPopup(props: Props) {
   const handleBlur = () => {
     setIsFocused(false);
   };
+
+  if (isSmallScreen) {
+    return null;
+  }
 
   return createPortal(
     <Wrapper

--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -10,6 +10,7 @@ interface AutofixHighlightWrapperProps {
   runId: string;
   stepIndex: number;
   className?: string;
+  displayName?: string;
   isAgentComment?: boolean;
   retainInsightCardIndex?: number | null;
 }
@@ -26,6 +27,7 @@ export function AutofixHighlightWrapper({
   retainInsightCardIndex = null,
   isAgentComment = false,
   className,
+  displayName,
 }: AutofixHighlightWrapperProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const selection = useTextSelection(containerRef);
@@ -46,6 +48,7 @@ export function AutofixHighlightWrapper({
             stepIndex={stepIndex}
             retainInsightCardIndex={retainInsightCardIndex}
             isAgentComment={isAgentComment}
+            blockName={displayName}
           />
         )}
       </AnimatePresence>

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -387,6 +387,7 @@ function AutofixRootCauseDisplay({
                   : null
               }
               isAgentComment
+              blockName={t('Root Cause')}
             />
           )}
         </AnimatePresence>
@@ -477,6 +478,7 @@ const HeaderWrapper = styled('div')`
   padding-bottom: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   gap: ${space(1)};
+  flex-wrap: wrap;
 `;
 
 const IconWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -618,6 +618,7 @@ function AutofixSolutionDisplay({
                   : null
               }
               isAgentComment
+              blockName={t('Solution')}
             />
           )}
         </AnimatePresence>
@@ -707,6 +708,7 @@ const HeaderWrapper = styled('div')`
   padding-left: ${space(0.5)};
   padding-bottom: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
+  flex-wrap: wrap;
   gap: ${space(1)};
 `;
 


### PR DESCRIPTION
- Gives nice names to highlight popup titles for the diffs
- Prevent action buttons from being cut off on mobile
- Disable highlight popup on mobile because it's awkward
- Fix bug in diff editing overlay positioning