### PR TITLE
feat(taskworker): Enable the options sync on the taskworker scheduler

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1454,7 +1454,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
 TASKWORKER_SCHEDULES: ScheduleConfigMap = {
     "sync_options_trial": {
         "schedule": timedelta(minutes=5),
-        "task": "sentry.tasks.options.sync_options",
+        "task": "options:sentry.tasks.options.sync_options",
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1451,7 +1451,12 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
 )
 
 # Schedules for taskworker tasks to be spawned on.
-TASKWORKER_SCHEDULES: ScheduleConfigMap = {}
+TASKWORKER_SCHEDULES: ScheduleConfigMap = {
+    "sync_options_trial": {
+        "schedule": timedelta(minutes=5),
+        "task": "sentry.tasks.options.sync_options",
+    },
+}
 
 # Sentry logs to two major places: stdout, and its internal project.
 # To disable logging to the internal project, add a logger whose only


### PR DESCRIPTION
This will run as a duplicate to the options sync that runs on celery, so will not break the options
sync.