### PR TITLE
fix(aci): add locking to Detector.get_or_create in issue alert migrator

### DIFF
--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -10,7 +10,11 @@ from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
+from sentry.utils.locking import UnableToAcquireLock
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import (
+    IssueAlertMigrator,
+    UnableToAcquireLockApiError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,22 +33,26 @@ class ProjectRuleCreator:
     request: Request | None = None
 
     def run(self) -> Rule:
-        with transaction.atomic(router.db_for_write(Rule)):
-            self.rule = self._create_rule()
+        try:
+            with transaction.atomic(router.db_for_write(Rule)):
+                self.rule = self._create_rule()
 
-            if features.has(
-                "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
-            ):
-                # uncaught errors will rollback the transaction
-                workflow = IssueAlertMigrator(
-                    self.rule, self.request.user.id if self.request else None
-                ).run()
-                logger.info(
-                    "workflow_engine.issue_alert.migrated",
-                    extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
-                )
+                if features.has(
+                    "organizations:workflow-engine-issue-alert-dual-write",
+                    self.project.organization,
+                ):
+                    # uncaught errors will rollback the transaction
+                    workflow = IssueAlertMigrator(
+                        self.rule, self.request.user.id if self.request else None
+                    ).run()
+                    logger.info(
+                        "workflow_engine.issue_alert.migrated",
+                        extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
+                    )
+        except UnableToAcquireLock:
+            raise UnableToAcquireLockApiError
 
-            return self.rule
+        return self.rule
 
     def _create_rule(self) -> Rule:
         kwargs = self._get_kwargs()

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -1,6 +1,9 @@
 import logging
 from typing import Any
 
+from rest_framework import status
+
+from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.locks import locks
@@ -35,6 +38,12 @@ from sentry.workflow_engine.models.data_condition import (
 logger = logging.getLogger(__name__)
 
 SKIPPED_CONDITIONS = [Condition.EVERY_EVENT]
+
+
+class UnableToAcquireLockApiError(SentryAPIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "unable_to_acquire_lock"
+    message = "Unable to acquire lock for issue alert migration."
 
 
 class IssueAlertMigrator:
@@ -106,6 +115,7 @@ class IssueAlertMigrator:
                 )
 
                 # Detector is required for migration, migration should fail if unable to acquire lock
+                # UnableToAcquireLock exception should be handled by caller
 
         if not created:
             raise Exception("Issue alert already migrated")

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -4,11 +4,14 @@ import pytest
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
-from sentry.projects.project_rules.creator import ProjectRuleCreator, UnableToAcquireLockApiError
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.actor import Actor
 from sentry.utils.locking import UnableToAcquireLock
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import (
+    UnableToAcquireLockApiError,
+)
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleDetector,

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,9 +1,14 @@
+from unittest.mock import patch
+
+import pytest
+
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
-from sentry.projects.project_rules.creator import ProjectRuleCreator
+from sentry.projects.project_rules.creator import ProjectRuleCreator, UnableToAcquireLockApiError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.actor import Actor
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleDetector,
@@ -140,3 +145,39 @@ class TestProjectRuleCreator(TestCase):
 
         action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
         assert action.type == Action.Type.PLUGIN
+
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    @patch("sentry.projects.project_rules.creator.IssueAlertMigrator.run")
+    def test_dual_create_workflow_engine__cant_acquire_lock(self, mock_run):
+        mock_run.side_effect = UnableToAcquireLock
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            },
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "foo",
+                "match": "is",
+            },
+        ]
+
+        with pytest.raises(UnableToAcquireLockApiError):
+            ProjectRuleCreator(
+                name="New Cool Rule",
+                owner=Actor.from_id(user_id=self.user.id),
+                project=self.project,
+                action_match="any",
+                filter_match="all",
+                conditions=conditions,
+                environment=self.environment.id,
+                actions=[
+                    {
+                        "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                        "name": "Send a notification (for all legacy integrations)",
+                    }
+                ],
+                frequency=5,
+            ).run()

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -5,6 +5,7 @@ from jsonschema.exceptions import ValidationError
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.locks import locks
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_frequency import (
@@ -20,6 +21,7 @@ from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import (
     Action,
@@ -372,6 +374,17 @@ class IssueAlertMigratorTest(TestCase):
         assert DataCondition.objects.all().count() == 1
         dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
         assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
+
+    def test_run__lock(self):
+        lock = locks.get(
+            f"workflow-engine-project-error-detector:{self.project.id}",
+            duration=10,
+            name="workflow_engine_issue_alert",
+        )
+        lock.acquire()
+
+        with pytest.raises(UnableToAcquireLock):
+            IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
     def test_dry_run(self):
         IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()


### PR DESCRIPTION
Fixes SENTRY-3S0W

Apparently it is possible to hit the API quickly enough to cause a race condition in `get_or_create` 🤯 

Return 400 in the API if unable to acquire the lock