### PR TITLE
feat(explore): Auto switch to aggregates when changing group bys

### DIFF
--- a/static/app/views/explore/contexts/dragNDropContext.tsx
+++ b/static/app/views/explore/contexts/dragNDropContext.tsx
@@ -25,7 +25,7 @@ interface DragNDropContextProps {
     updateColumnAtIndex: (i: number, column: string) => void;
   }) => React.ReactNode;
   columns: string[];
-  setColumns: (columns: string[]) => void;
+  setColumns: (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
 }
 
 export function DragNDropContext({columns, setColumns, children}: DragNDropContextProps) {

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -229,8 +229,12 @@ export function useSetExploreFields() {
 export function useSetExploreGroupBys() {
   const setPageParams = useSetExplorePageParams();
   return useCallback(
-    (groupBys: string[]) => {
-      setPageParams({groupBys});
+    (groupBys: string[], mode?: Mode) => {
+      if (mode) {
+        setPageParams({groupBys, mode});
+      } else {
+        setPageParams({groupBys});
+      }
     },
     [setPageParams]
   );

--- a/static/app/views/explore/hooks/useDragNDropColumns.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.tsx
@@ -9,7 +9,7 @@ export type Column = {
 
 interface UseDragAndDropColumnsProps {
   columns: string[];
-  setColumns: (columns: string[]) => void;
+  setColumns: (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
 }
 
 const extractColumns = (editableColumns: Column[]) => {
@@ -44,7 +44,7 @@ export function useDragNDropColumns({columns, setColumns}: UseDragAndDropColumns
 
       setNextId(nextId + 1); // make sure to increment the id for the next time
 
-      setColumns(extractColumns(newEditableColumns));
+      setColumns(extractColumns(newEditableColumns), 'insert');
 
       return newEditableColumns;
     });
@@ -55,7 +55,7 @@ export function useDragNDropColumns({columns, setColumns}: UseDragAndDropColumns
       const newEditableColumns = [...oldEditableColumns];
       newEditableColumns[i]!.column = column;
 
-      setColumns(extractColumns(newEditableColumns));
+      setColumns(extractColumns(newEditableColumns), 'update');
 
       return newEditableColumns;
     });
@@ -64,7 +64,7 @@ export function useDragNDropColumns({columns, setColumns}: UseDragAndDropColumns
   function deleteColumnAtIndex(i: number) {
     setEditableColumns(oldEditableColumns => {
       if (oldEditableColumns.length === 1) {
-        setColumns(['']);
+        setColumns([''], 'delete');
         return [{id: 1, column: undefined}];
       }
 
@@ -73,7 +73,7 @@ export function useDragNDropColumns({columns, setColumns}: UseDragAndDropColumns
         ...oldEditableColumns.slice(i + 1),
       ];
 
-      setColumns(extractColumns(newEditableColumns));
+      setColumns(extractColumns(newEditableColumns), 'delete');
 
       return newEditableColumns;
     });
@@ -89,7 +89,7 @@ export function useDragNDropColumns({columns, setColumns}: UseDragAndDropColumns
       setEditableColumns(oldEditableColumns => {
         const newEditableColumns = arrayMove(oldEditableColumns, oldIndex, newIndex);
 
-        setColumns(extractColumns(newEditableColumns));
+        setColumns(extractColumns(newEditableColumns), 'reorder');
 
         return newEditableColumns;
       });

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -17,21 +17,24 @@ export function useTopEvents(): number | undefined {
   const groupBys = useExploreGroupBys();
   const mode = useExploreMode();
 
-  const hasChartWithMultipleYaxes = useMemo(() => {
-    return visualizes.some(visualize => visualize.yAxes.length > 1);
-  }, [visualizes]);
-
   const topEvents: number | undefined = useMemo(() => {
+    // We only support top events in aggregates mode for
+    // when there are no multiple y-axes chart and there is at least one group by.
+
     if (mode === Mode.SAMPLES) {
       return undefined;
     }
 
-    // We only support top events for when there are no multiple y-axes chart
-    // and there is at least one group by.
-    return hasChartWithMultipleYaxes || (groupBys.length === 1 && groupBys[0] === '')
-      ? undefined
-      : TOP_EVENTS_LIMIT;
-  }, [hasChartWithMultipleYaxes, groupBys, mode]);
+    if (visualizes.some(visualize => visualize.yAxes.length > 1)) {
+      return undefined;
+    }
+
+    if (groupBys.every(groupBy => groupBy === '')) {
+      return undefined;
+    }
+
+    return TOP_EVENTS_LIMIT;
+  }, [groupBys, mode, visualizes]);
 
   return topEvents;
 }

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -554,6 +554,65 @@ describe('ExploreToolbar', function () {
     expect(within(section).getByLabelText('Remove Column')).toBeDisabled();
   });
 
+  it('switches to aggregates mode when modifying group bys', async function () {
+    let groupBys: any;
+    let mode: any;
+
+    function Component() {
+      groupBys = useExploreGroupBys();
+      mode = useExploreMode();
+      return <ExploreToolbar extras={['tabs']} />;
+    }
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {enableRouterMocks: false}
+    );
+
+    expect(mode).toEqual(Mode.SAMPLES);
+    expect(groupBys).toEqual(['']);
+
+    const section = screen.getByTestId('section-group-by');
+
+    await userEvent.click(within(section).getByRole('button', {name: '\u2014'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.op'}));
+
+    expect(mode).toEqual(Mode.AGGREGATE);
+    expect(groupBys).toEqual(['span.op']);
+  });
+
+  it('switches to aggregates mode when adding group bys', async function () {
+    let groupBys: any;
+    let mode: any;
+
+    function Component() {
+      groupBys = useExploreGroupBys();
+      mode = useExploreMode();
+      return <ExploreToolbar extras={['tabs']} />;
+    }
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {enableRouterMocks: false}
+    );
+
+    expect(mode).toEqual(Mode.SAMPLES);
+    expect(groupBys).toEqual(['']);
+
+    const section = screen.getByTestId('section-group-by');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'Add Group'}));
+
+    expect(mode).toEqual(Mode.AGGREGATE);
+    expect(groupBys).toEqual(['', '']);
+  });
+
   it('allows changing sort by', async function () {
     let sortBys: any;
     function Component() {

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -38,7 +38,9 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
     <Container width={width}>
       {!extras?.includes('tabs') && <ToolbarMode mode={mode} setMode={setMode} />}
       <ToolbarVisualize equationSupport={extras?.includes('equations')} />
-      {(extras?.includes('tabs') || mode === Mode.AGGREGATE) && <ToolbarGroupBy />}
+      {(extras?.includes('tabs') || mode === Mode.AGGREGATE) && (
+        <ToolbarGroupBy autoSwitchToAggregates={extras?.includes('tabs') || false} />
+      )}
       <ToolbarSortBy
         fields={fields}
         groupBys={groupBys}


### PR DESCRIPTION
When adding a group by or changing a group by, we auto put the user in aggregates mode for ease of use.