### PR TITLE
fix(Jira): Add issue delted webhook code

### DIFF
--- a/src/sentry/integrations/jira/endpoints/descriptor.py
+++ b/src/sentry/integrations/jira/endpoints/descriptor.py
@@ -79,7 +79,12 @@ class JiraDescriptorEndpoint(Endpoint):
                             "event": "jira:issue_updated",
                             "url": reverse("sentry-extensions-jira-issue-updated"),
                             "excludeBody": False,
-                        }
+                        },
+                        {
+                            "event": "jira:issue_deleted",
+                            "url": reverse("sentry-extensions-jira-issue-deleted"),
+                            "excludeBody": False,
+                        },
                     ],
                 },
                 "apiMigrations": {"gdpr": True, "context-qsh": True, "signed-install": True},

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,5 +1,7 @@
 from django.urls import re_path
 
+from sentry.integrations.jira.webhooks.issue_deleted import JiraIssueDeletedWebhook
+
 from .endpoints import JiraDescriptorEndpoint, JiraSearchEndpoint
 from .views import (
     JiraExtensionConfigurationView,
@@ -37,6 +39,11 @@ urlpatterns = [
         r"^issue-updated/$",
         JiraIssueUpdatedWebhook.as_view(),
         name="sentry-extensions-jira-issue-updated",
+    ),
+    re_path(
+        r"^issue-deleted/$",
+        JiraIssueDeletedWebhook.as_view(),
+        name="sentry-extensions-jira-issue-deleted",
     ),
     re_path(
         r"^search/(?P<organization_id_or_slug>[^\/]+)/(?P<integration_id>\d+)/$",

--- a/src/sentry/integrations/jira/webhooks/issue_deleted.py
+++ b/src/sentry/integrations/jira/webhooks/issue_deleted.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+from django.db import router, transaction
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.integrations.jira.webhooks.base import JiraWebhookBase
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
+from sentry.integrations.utils.scope import bind_org_context_from_integration
+from sentry.models.grouplink import GroupLink
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class JiraIssueDeletedWebhook(JiraWebhookBase):
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        token = self.get_token(request)
+        rpc_integration = get_integration_from_jwt(
+            token=token,
+            path=request.path,
+            provider=self.provider,
+            query_params=request.GET,
+            method="POST",
+        )
+        # Integrations and their corresponding RpcIntegrations share the same id,
+        # so we don't need to first convert this to a full Integration object
+        bind_org_context_from_integration(rpc_integration.id, {"webhook": "issue_deleted"})
+        sentry_sdk.set_tag("integration_id", rpc_integration.id)
+
+        data = request.data
+
+        if (external_issue_key := data.get("issue", {}).get("key")) is None:
+            logger.info("jira.missing-issue-key")
+            return self.respond()
+
+        try:
+            # The given Jira issue may not have been linked to a Sentry issue
+            external_issue = ExternalIssue.objects.get(
+                integration_id=rpc_integration.id, key=external_issue_key
+            )
+        except ExternalIssue.DoesNotExist:
+            return self.respond()
+
+        # The jira issue no longer exists so all links should be severed
+        with transaction.atomic(router.db_for_write(GroupLink)):
+            GroupLink.objects.filter(linked_id=external_issue.id).delete()
+            external_issue.delete()
+        return self.respond()


### PR DESCRIPTION
need to add tests :oopsie

Context: When a user deletes a Jira issue that's created or somehow linked to a Sentry issue, we don't delete that link, so when a user updates the Sentry issue, then we'll try and update a ghost issue.

This behavior is happening because we don't actually listen to the` issue-deleted` webhook from Jira. We only listen to `issue-updated`, which is different 🫠 . This PR adds a new webhook endpoint and does the following
1. Get the Jira issue key (e.g ECO-1)
2. Look up the corresponding External Issue object
     - `ExternalIssue` represents a Jira issue that's connected to an `Integration` object
     -  [❓] I'm not sure if Jira supports having 1 Sentry issue be connected to many Jira integrations/orgs. In the UI it looks like this isn't supported but wanna confirm.
3. Look up the corresponding Group Link objects (there can be many)
     - `GroupLink` represents a 'link' between a Sentry issue and some external(3p) object, in this case a Jira issue
4. Delete the GroupLink , I believe we can do this because the Jira issue is being deleted so there's nothing to link to
     - [❓] One concern is that the [group_integration_details](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/group_integration_details.py#L382-L383) endpoint (where I yoinked a lot of logic from), specifies not the delete the GroupLink if there are many connected to the same ExternalIssue. I'm not 100% on what case this comment is referencing, e.g if there are many Sentry issues connected to 1 Jira issue? But I think we just create a new ExternalIssue for each link, so the relationship stays 1:1 (?)
5. Delete the ExternalIssue, Same as above