### PR TITLE
feat(taskworker): Append processing pool name to metrics and logs

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -308,6 +308,11 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     help="The number of tasks to process before choosing a new broker instance. Requires num-brokers > 1",
     default=taskworker_constants.DEFAULT_REBALANCE_AFTER,
 )
+@click.option(
+    "--processing-pool-name",
+    help="The name of the processing pool being used",
+    default="unknown",
+)
 @log_options()
 @configuration
 def taskworker(**options: Any) -> None:
@@ -329,7 +334,7 @@ def run_taskworker(
     child_tasks_queue_maxsize: int,
     result_queue_maxsize: int,
     rebalance_after: int,
-    processing_pool_name: str = "unknown",
+    processing_pool_name: str,
     **options: Any,
 ) -> None:
     """

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -329,6 +329,7 @@ def run_taskworker(
     child_tasks_queue_maxsize: int,
     result_queue_maxsize: int,
     rebalance_after: int,
+    processing_pool_name: str = "unknown",
     **options: Any,
 ) -> None:
     """
@@ -346,6 +347,7 @@ def run_taskworker(
             child_tasks_queue_maxsize=child_tasks_queue_maxsize,
             result_queue_maxsize=result_queue_maxsize,
             rebalance_after=rebalance_after,
+            processing_pool_name=processing_pool_name,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -411,7 +411,7 @@ class TaskWorker:
         self._gettask_backoff_seconds = 0
         self._setstatus_backoff_seconds = 0
 
-        self._processing_pool_name = processing_pool_name | "unknown"
+        self._processing_pool_name: str = processing_pool_name or "unknown"
 
     def __del__(self) -> None:
         self.shutdown()

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -107,6 +107,7 @@ def child_worker(
     processed_tasks: queue.Queue[ProcessingResult],
     shutdown_event: Event,
     max_task_count: int | None,
+    processing_pool_name: str,
 ) -> None:
     for module in settings.TASKWORKER_IMPORTS:
         __import__(module)
@@ -149,6 +150,7 @@ def child_worker(
             metrics.incr(
                 "taskworker.worker.processing_deadline_exceeded",
                 tags={
+                    "processing_pool": processing_pool_name,
                     "namespace": current.namespace,
                     "taskname": current.taskname,
                 },
@@ -160,7 +162,7 @@ def child_worker(
         if max_task_count and processed_task_count >= max_task_count:
             metrics.incr(
                 "taskworker.worker.max_task_count_reached",
-                tags={"count": processed_task_count},
+                tags={"count": processed_task_count, "processing_pool": processing_pool_name},
             )
             logger.info("taskworker.max_task_count_reached", extra={"count": processed_task_count})
             break
@@ -172,14 +174,21 @@ def child_worker(
         try:
             activation = child_tasks.get(timeout=1.0)
         except queue.Empty:
-            metrics.incr("taskworker.worker.child_task_queue_empty")
+            metrics.incr(
+                "taskworker.worker.child_task_queue_empty",
+                tags={"processing_pool": processing_pool_name},
+            )
             continue
 
         task_func = _get_known_task(activation)
         if not task_func:
             metrics.incr(
                 "taskworker.worker.unknown_task",
-                tags={"namespace": activation.namespace, "taskname": activation.taskname},
+                tags={
+                    "namespace": activation.namespace,
+                    "taskname": activation.taskname,
+                    "processing_pool": processing_pool_name,
+                },
             )
             processed_tasks.put(
                 ProcessingResult(task_id=activation.id, status=TASK_ACTIVATION_STATUS_FAILURE)
@@ -190,11 +199,21 @@ def child_worker(
             key = get_at_most_once_key(activation.namespace, activation.taskname, activation.id)
             if cache.add(key, "1", timeout=AT_MOST_ONCE_TIMEOUT):  # The key didn't exist
                 metrics.incr(
-                    "taskworker.task.at_most_once.executed", tags={"taskname": activation.taskname}
+                    "taskworker.task.at_most_once.executed",
+                    tags={
+                        "namespace": activation.namespace,
+                        "taskname": activation.taskname,
+                        "processing_pool": processing_pool_name,
+                    },
                 )
             else:
                 metrics.incr(
-                    "taskworker.worker.at_most_once.skipped", tags={"taskname": activation.taskname}
+                    "taskworker.worker.at_most_once.skipped",
+                    tags={
+                        "namespace": activation.namespace,
+                        "taskname": activation.taskname,
+                        "processing_pool": processing_pool_name,
+                    },
                 )
                 continue
 
@@ -209,7 +228,14 @@ def child_worker(
             next_state = TASK_ACTIVATION_STATUS_COMPLETE
         except Exception as err:
             if task_func.should_retry(activation.retry_state, err):
-                logger.info("taskworker.task.retry", extra={"taskname": activation.taskname})
+                logger.info(
+                    "taskworker.task.retry",
+                    extra={
+                        "namespace": activation.namespace,
+                        "taskname": activation.taskname,
+                        "processing_pool": processing_pool_name,
+                    },
+                )
                 next_state = TASK_ACTIVATION_STATUS_RETRY
 
             if next_state != TASK_ACTIVATION_STATUS_RETRY:
@@ -220,10 +246,21 @@ def child_worker(
 
         # Get completion time before pushing to queue, so we can measure queue append time
         execution_complete_time = time.time()
-        with metrics.timer("taskworker.worker.processed_tasks.put.duration"):
+        with metrics.timer(
+            "taskworker.worker.processed_tasks.put.duration",
+            tags={
+                "processing_pool": processing_pool_name,
+            },
+        ):
             processed_tasks.put(ProcessingResult(task_id=activation.id, status=next_state))
 
-        record_task_execution(activation, next_state, execution_start_time, execution_complete_time)
+        record_task_execution(
+            activation,
+            next_state,
+            execution_start_time,
+            execution_complete_time,
+            processing_pool_name,
+        )
 
 
 def _execute_activation(task_func: Task[Any, Any], activation: TaskActivation) -> None:
@@ -273,6 +310,7 @@ def record_task_execution(
     status: TaskActivationStatus.ValueType,
     start_time: float,
     completion_time: float,
+    processing_pool_name: str,
 ) -> None:
     task_added_time = activation.received_at.ToDatetime().timestamp()
     execution_duration = completion_time - start_time
@@ -292,17 +330,26 @@ def record_task_execution(
         tags={
             "namespace": activation.namespace,
             "status": status,
+            "processing_pool": processing_pool_name,
         },
     )
     metrics.distribution(
         "taskworker.worker.execution_duration",
         execution_duration,
-        tags={"namespace": activation.namespace, "taskname": activation.taskname},
+        tags={
+            "namespace": activation.namespace,
+            "taskname": activation.taskname,
+            "processing_pool": processing_pool_name,
+        },
     )
     metrics.distribution(
         "taskworker.worker.execution_latency",
         execution_latency,
-        tags={"namespace": activation.namespace, "taskname": activation.taskname},
+        tags={
+            "namespace": activation.namespace,
+            "taskname": activation.taskname,
+            "processing_pool": processing_pool_name,
+        },
     )
 
     if (
@@ -342,6 +389,7 @@ class TaskWorker:
         child_tasks_queue_maxsize: int = DEFAULT_WORKER_QUEUE_SIZE,
         result_queue_maxsize: int = DEFAULT_WORKER_QUEUE_SIZE,
         rebalance_after: int = DEFAULT_REBALANCE_AFTER,
+        processing_pool_name: str | None = None,
         **options: dict[str, Any],
     ) -> None:
         self.options = options
@@ -362,6 +410,8 @@ class TaskWorker:
 
         self._gettask_backoff_seconds = 0
         self._setstatus_backoff_seconds = 0
+
+        self._processing_pool_name = processing_pool_name | "unknown"
 
     def __del__(self) -> None:
         self.shutdown()
@@ -431,11 +481,14 @@ class TaskWorker:
                 start_time = time.monotonic()
                 self._child_tasks.put(task)
                 metrics.distribution(
-                    "taskworker.worker.child_task.put.duration", time.monotonic() - start_time
+                    "taskworker.worker.child_task.put.duration",
+                    time.monotonic() - start_time,
+                    tags={"processing_pool": self._processing_pool_name},
                 )
             except queue.Full:
                 logger.warning(
-                    "taskworker.add_task.child_task_queue_full", extra={"task_id": task.id}
+                    "taskworker.add_task.child_task_queue_full",
+                    extra={"task_id": task.id, "processing_pool": self._processing_pool_name},
                 )
             return True
         else:
@@ -461,7 +514,10 @@ class TaskWorker:
                         result = self._processed_tasks.get(timeout=1.0)
                         executor.submit(self._send_result, result)
                     except queue.Empty:
-                        metrics.incr("taskworker.worker.result_thread.queue_empty")
+                        metrics.incr(
+                            "taskworker.worker.result_thread.queue_empty",
+                            tags={"processing_pool": self._processing_pool_name},
+                        )
                         continue
 
         self._result_thread = threading.Thread(target=result_thread)
@@ -477,7 +533,9 @@ class TaskWorker:
         task_received = self._task_receive_timing.pop(result.task_id, None)
         if task_received is not None:
             metrics.distribution(
-                "taskworker.worker.complete_duration", time.monotonic() - task_received
+                "taskworker.worker.complete_duration",
+                time.monotonic() - task_received,
+                tags={"processing_pool": self._processing_pool_name},
             )
 
         if fetch:
@@ -493,7 +551,10 @@ class TaskWorker:
                 except queue.Full:
                     logger.warning(
                         "taskworker.send_result.child_task_queue_full",
-                        extra={"task_id": next_task.id},
+                        extra={
+                            "task_id": next_task.id,
+                            "processing_pool": self._processing_pool_name,
+                        },
                     )
             return True
 
@@ -508,7 +569,11 @@ class TaskWorker:
         """
         logger.debug(
             "taskworker.workers._send_result",
-            extra={"task_id": result.task_id, "next": fetch_next is not None},
+            extra={
+                "task_id": result.task_id,
+                "next": fetch_next is not None,
+                "processing_pool": self._processing_pool_name,
+            },
         )
         # Use the shutdown_event as a sleep mechanism
         self._shutdown_event.wait(self._setstatus_backoff_seconds)
@@ -542,11 +607,15 @@ class TaskWorker:
                     self._processed_tasks,
                     self._shutdown_event,
                     self._max_child_task_count,
+                    self._processing_pool_name,
                 ),
             )
             process.start()
             active_children.append(process)
-            logger.info("taskworker.spawn_child", extra={"pid": process.pid})
+            logger.info(
+                "taskworker.spawn_child",
+                extra={"pid": process.pid, "processing_pool": self._processing_pool_name},
+            )
 
         self._children = active_children
 
@@ -556,14 +625,23 @@ class TaskWorker:
         try:
             activation = self.client.get_task(self._namespace)
         except grpc.RpcError as e:
-            logger.info("taskworker.fetch_task.failed", extra={"error": e})
+            logger.info(
+                "taskworker.fetch_task.failed",
+                extra={"error": e, "processing_pool": self._processing_pool_name},
+            )
 
             self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 1, 10)
             return None
 
         if not activation:
-            metrics.incr("taskworker.worker.fetch_task.not_found")
-            logger.debug("taskworker.fetch_task.not_found")
+            metrics.incr(
+                "taskworker.worker.fetch_task.not_found",
+                tags={"processing_pool": self._processing_pool_name},
+            )
+            logger.debug(
+                "taskworker.fetch_task.not_found",
+                extra={"processing_pool": self._processing_pool_name},
+            )
 
             self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 1, 10)
             return None

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -260,7 +260,7 @@ def test_child_worker_complete(mock_capture_checkin) -> None:
     shutdown = Event()
 
     todo.put(SIMPLE_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get()
@@ -276,7 +276,7 @@ def test_child_worker_retry_task() -> None:
     shutdown = Event()
 
     todo.put(RETRY_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get()
@@ -291,7 +291,7 @@ def test_child_worker_failure_task() -> None:
     shutdown = Event()
 
     todo.put(FAIL_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get()
@@ -307,7 +307,7 @@ def test_child_worker_shutdown() -> None:
     shutdown.set()
 
     todo.put(SIMPLE_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     # When shutdown has been set, the child should not process more tasks.
     assert todo.qsize() == 1
@@ -322,7 +322,7 @@ def test_child_worker_unknown_task() -> None:
 
     todo.put(UNDEFINED_TASK)
     todo.put(SIMPLE_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     result = processed.get()
     assert result.task_id == UNDEFINED_TASK.id
@@ -342,7 +342,7 @@ def test_child_worker_at_most_once() -> None:
     todo.put(AT_MOST_ONCE_TASK)
     todo.put(AT_MOST_ONCE_TASK)
     todo.put(SIMPLE_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=2)
+    child_worker(todo, processed, shutdown, max_task_count=2, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get(block=False)
@@ -362,7 +362,7 @@ def test_child_worker_record_checkin(mock_capture_checkin: mock.Mock) -> None:
     shutdown = Event()
 
     todo.put(SCHEDULED_TASK)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get()
@@ -395,7 +395,7 @@ def test_child_worker_terminate_task(mock_exit: mock.Mock, mock_capture: mock.Mo
     )
 
     todo.put(sleepy)
-    child_worker(todo, processed, shutdown, max_task_count=1)
+    child_worker(todo, processed, shutdown, max_task_count=1, processing_pool_name="test")
 
     assert todo.empty()
     result = processed.get(block=False)


### PR DESCRIPTION
This value can be used during debugging to narrow down which worker pool was having certain issues.
