### PR TITLE
fix(eap-spans): spans-samples endpoint should use `transaction.span_id`

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -295,7 +295,7 @@ def get_eap_span_samples(request: Request, snuba_params: SnubaParams, orderby: l
 
     selected_columns = request.GET.getlist("additionalFields", []) + [
         "project",
-        "span.transaction_id",
+        "transaction.span_id",
         column,
         "timestamp",
         "span_id",

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -295,7 +295,7 @@ def get_eap_span_samples(request: Request, snuba_params: SnubaParams, orderby: l
 
     selected_columns = request.GET.getlist("additionalFields", []) + [
         "project",
-        "transaction.id",
+        "span.transaction_id",
         column,
         "timestamp",
         "span_id",


### PR DESCRIPTION
When eap is being used with the `spans-samples` endpoint, we should query for the `transaction.span_id` field instead of `transaction.id`.

This fixes an issue where the the link from insights span samples to the trace view is broken when using eap, because the transaction.id is null