### PR TITLE
fix(explore): Samples tables do not progressively load unless no data

### DIFF
--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -11,10 +11,7 @@ import {
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
-import {
-  QUERY_MODE,
-  type SpansRPCQueryExtras,
-} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import type {SpansRPCQueryExtras} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useProgressiveQuery} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
@@ -39,7 +36,6 @@ export function useExploreAggregatesTable({
   return useProgressiveQuery<typeof useExploreAggregatesTableImp>({
     queryHookImplementation: useExploreAggregatesTableImp,
     queryHookArgs: {enabled, limit, query},
-    queryMode: QUERY_MODE.SERIAL,
   });
 }
 

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -36,7 +36,7 @@ export function useExploreSpansTable({
   return useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
     queryHookArgs: {enabled, limit, query},
-    queryMode: QUERY_MODE.SERIAL,
+    queryOptions: {queryMode: QUERY_MODE.SERIAL, withholdBestEffort: true},
   });
 }
 

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -15,7 +15,6 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
-  QUERY_MODE,
   type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -43,7 +42,6 @@ export const useExploreTimeseries = ({
   return useProgressiveQuery<typeof useExploreTimeseriesImpl>({
     queryHookImplementation: useExploreTimeseriesImpl,
     queryHookArgs: {query, enabled},
-    queryMode: QUERY_MODE.SERIAL,
   });
 };
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
@@ -10,10 +10,10 @@ import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBy
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {
+  QUERY_MODE,
   type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {QUERY_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {getFieldsForConstructedQuery} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
@@ -37,7 +37,6 @@ export function useMultiQueryTableAggregateMode({
   return useProgressiveQuery({
     queryHookImplementation: useMultiQueryTableAggregateModeImpl,
     queryHookArgs: {groupBys, query, yAxes, sortBys, enabled, queryExtras},
-    queryMode: QUERY_MODE.SERIAL,
   });
 }
 
@@ -102,7 +101,7 @@ export function useMultiQueryTableSampleMode({query, yAxes, sortBys, enabled}: P
   return useProgressiveQuery({
     queryHookImplementation: useMultiQueryTableSampleModeImpl,
     queryHookArgs: {query, yAxes, sortBys, enabled},
-    queryMode: QUERY_MODE.SERIAL,
+    queryOptions: {queryMode: QUERY_MODE.SERIAL, withholdBestEffort: true},
   });
 }
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -8,7 +8,6 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
-  QUERY_MODE,
   type SpansRPCQueryExtras,
   useProgressiveQuery,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -38,7 +37,6 @@ export function useMultiQueryTimeseries({
   return useProgressiveQuery<typeof useMultiQueryTimeseriesImpl>({
     queryHookImplementation: useMultiQueryTimeseriesImpl,
     queryHookArgs: {enabled, index},
-    queryMode: QUERY_MODE.SERIAL,
   });
 }
 

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -221,16 +221,10 @@ function AggregatesTable({
 }
 
 interface SampleTableProps extends MultiQueryTableBaseProps {
-  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
 }
 
-function SpansTable({
-  spansTableResult,
-  query: queryParts,
-  index,
-  isProgressivelyLoading,
-}: SampleTableProps) {
+function SpansTable({spansTableResult, query: queryParts, index}: SampleTableProps) {
   const {result, eventView} = spansTableResult;
   const {fields, sortBys} = queryParts;
   const meta = result.meta ?? {};
@@ -274,7 +268,6 @@ function SpansTable({
                     <Tooltip showOnlyOnOverflow title={label}>
                       {label}
                     </Tooltip>
-                    {i === 0 && getProgressiveLoadingIndicator(isProgressivelyLoading)}
                     {defined(direction) && (
                       <IconArrow
                         size="xs"

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -191,7 +191,7 @@ export function SpansTabContentImpl({
   const tableIsProgressivelyLoading =
     organization.features.includes('visibility-explore-progressive-loading') &&
     (queryType === 'samples'
-      ? spansTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+      ? false // Samples mode won't show the progressive loading spinner
       : queryType === 'aggregate'
         ? aggregatesTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
         : false);

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -196,6 +196,14 @@ export function SpansTabContentImpl({
         ? aggregatesTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
         : false);
 
+  // Progressive loading only shows when we have preflight data and
+  // we're fetching the best effort request
+  const timeseriesIsProgressivelyLoading =
+    organization.features.includes('visibility-explore-progressive-loading') &&
+    defined(timeseriesSamplingMode) &&
+    timeseriesSamplingMode === SAMPLING_MODE.PREFLIGHT &&
+    timeseriesResult.isFetched;
+
   return (
     <Body
       withToolbar={expanded}
@@ -267,11 +275,7 @@ export function SpansTabContentImpl({
             confidences={confidences}
             query={query}
             timeseriesResult={timeseriesResult}
-            isProgressivelyLoading={
-              organization.features.includes('visibility-explore-progressive-loading') &&
-              defined(timeseriesSamplingMode) &&
-              timeseriesSamplingMode !== SAMPLING_MODE.BEST_EFFORT
-            }
+            isProgressivelyLoading={timeseriesIsProgressivelyLoading}
           />
           <ExploreTables
             aggregatesTableResult={aggregatesTableResult}


### PR DESCRIPTION
To prevent a lot of UI flicker when it comes to updating tables with
best effort data, we've decided to skip the best effort data unless the
preflight request comes back empty.

This updates the samples table for both the main explore page and
the multiquery mode. To test, you can add a tag with a value that
won't exist (e.g. `browser:Chrome`) and see that the preflight has 
results and so we don't do the preflight. If you replace `Chrome`
with `tdsklfjjkdafjdajk` then you will do both the preflight and the
best effort request.