### PR TITLE
fix(schema-hints): Replace user tag with an available `user.*` tags

### DIFF
--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -30,11 +30,13 @@ import {
   getSchemaHintsListOrder,
   removeHiddenKeys,
   SchemaHintsSources,
+  USER_IDENTIFIER_KEY,
 } from 'sentry/views/explore/components/schemaHintsUtils/schemaHintsListOrder';
 import type {LogPageParamsUpdate} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import type {WritablePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 export const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
 
@@ -65,7 +67,18 @@ const hideListTag: Tag = {
 };
 
 function getTagsFromKeys(keys: string[], tags: TagCollection): Tag[] {
-  return keys.map(key => tags[key]).filter(tag => !!tag);
+  return keys
+    .map(key => {
+      if (key === USER_IDENTIFIER_KEY) {
+        return (
+          tags[SpanIndexedField.USER_EMAIL] ||
+          tags[SpanIndexedField.USER_USERNAME] ||
+          tags[SpanIndexedField.USER_ID]
+        );
+      }
+      return tags[key];
+    })
+    .filter(tag => !!tag);
 }
 
 export function addFilterToQuery(

--- a/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
+++ b/static/app/views/explore/components/schemaHintsUtils/schemaHintsListOrder.tsx
@@ -3,13 +3,11 @@ import {FieldKey} from 'sentry/utils/fields';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
-const FRONTEND_HINT_KEYS = [SpanIndexedField.BROWSER_NAME, SpanIndexedField.USER];
+export const USER_IDENTIFIER_KEY = 'user.key';
 
-const MOBILE_HINT_KEYS = [
-  FieldKey.OS_NAME,
-  FieldKey.DEVICE_FAMILY,
-  SpanIndexedField.USER,
-];
+const FRONTEND_HINT_KEYS = [SpanIndexedField.BROWSER_NAME, USER_IDENTIFIER_KEY];
+
+const MOBILE_HINT_KEYS = [FieldKey.OS_NAME, FieldKey.DEVICE_FAMILY, USER_IDENTIFIER_KEY];
 
 const COMMON_HINT_KEYS = [
   SpanIndexedField.IS_TRANSACTION,


### PR DESCRIPTION
The user tag was not mapping (to email, username, etc.) as expected. I've replaced the tag in the visible hint list with either `user.email` `user.username` or `user.id` in that precedence depending on which is available.

![image](https://github.com/user-attachments/assets/dd0f702e-9568-4936-baf7-8038b02e9213)
