### PR TITLE
chore(slos): add tags to sentry lifecycle issues

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -6,6 +6,8 @@ from enum import StrEnum
 from types import TracebackType
 from typing import Any, Self
 
+import sentry_sdk
+
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.utils import metrics
@@ -142,6 +144,8 @@ class EventLifecycle:
             log_params["exc_info"] = outcome_reason
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
+
+        sentry_sdk.set_tags(self.payload.get_metric_tags())
 
         if outcome == EventLifecycleOutcome.FAILURE:
             logger.error(key, **log_params)

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -134,7 +134,7 @@ class EventLifecycle:
         sample_rate = 1.0
         metrics.incr(key, tags=tags, sample_rate=sample_rate)
 
-        sentry_sdk.set_tags(self.payload.get_metric_tags())
+        sentry_sdk.set_tags(tags)
 
         extra = dict(self._extra)
         extra.update(tags)

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -134,6 +134,8 @@ class EventLifecycle:
         sample_rate = 1.0
         metrics.incr(key, tags=tags, sample_rate=sample_rate)
 
+        sentry_sdk.set_tags(self.payload.get_metric_tags())
+
         extra = dict(self._extra)
         extra.update(tags)
         log_params: dict[str, Any] = {
@@ -144,8 +146,6 @@ class EventLifecycle:
             log_params["exc_info"] = outcome_reason
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
-
-        sentry_sdk.set_tags(self.payload.get_metric_tags())
 
         if outcome == EventLifecycleOutcome.FAILURE:
             logger.error(key, **log_params)


### PR DESCRIPTION
Idk if this is how you add tags to Sentry issues, but Imo, it would be reallyyyyy nice if I could search in Sentry `interaction_type is create_external_issue` and then boom all the related issues for that slo showed up. I also think this would make investigating SLOs faster!