### PR TITLE
feat(new-trace): Adding profile context for non-eap trace views

### DIFF
--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -7,7 +7,6 @@ import {
   useReducer,
   useRef,
 } from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -33,14 +32,10 @@ import {useDividerResizeSync} from 'sentry/views/performance/newTraceDetails/use
 import {useTraceSpaceListeners} from 'sentry/views/performance/newTraceDetails/useTraceSpaceListeners';
 
 import type {TraceTreeNode} from './traceModels/traceTreeNode';
-import {TraceScheduler} from './traceRenderers/traceScheduler';
-import {TraceView as TraceViewModel} from './traceRenderers/traceView';
-import {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
 import {useTraceState, useTraceStateDispatch} from './traceState/traceStateProvider';
 import {usePerformanceSubscriptionDetails} from './traceTypeWarnings/usePerformanceSubscriptionDetails';
 import {Trace} from './trace';
 import {traceAnalytics} from './traceAnalytics';
-import type {TraceReducerState} from './traceState';
 import {
   traceNodeAdjacentAnalyticsProperties,
   traceNodeAnalyticsName,
@@ -54,13 +49,13 @@ import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
 
 const noopTraceSearch = () => {};
 
-interface IssuesTraceWaterfallProps extends Omit<TraceWaterfallProps, 'tree'> {
+interface IssuesTraceWaterfallProps
+  extends Omit<TraceWaterfallProps, 'tree' | 'traceWaterfallScrollHandlers'> {
   event: Event;
   tree: IssuesTraceTree;
 }
 
 export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
-  const theme = useTheme();
   const {projects} = useProjects();
   const organization = useOrganization();
   const traceState = useTraceState();
@@ -69,8 +64,6 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
 
   const [forceRender, rerender] = useReducer(x => (x + 1) % Number.MAX_SAFE_INTEGER, 0);
 
-  const traceView = useMemo(() => new TraceViewModel(), []);
-  const traceScheduler = useMemo(() => new TraceScheduler(), []);
   const problemSpans = useMemo((): ReturnType<typeof getProblemSpansForSpanTree> => {
     if (props.event.type === 'transaction') {
       return getProblemSpansForSpanTree(props.event);
@@ -93,29 +86,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
     null
   );
 
-  // Assign the trace state to a ref so we can access it without re-rendering
-  const traceStateRef = useRef<TraceReducerState>(traceState);
-  traceStateRef.current = traceState;
-
-  const traceStatePreferencesRef = useRef<
-    Pick<TraceReducerState['preferences'], 'autogroup' | 'missing_instrumentation'>
-  >(traceState.preferences);
-  traceStatePreferencesRef.current = traceState.preferences;
-
-  // Initialize the view manager right after the state reducer
-  const viewManager = useMemo(() => {
-    return new VirtualizedViewManager(
-      {
-        list: {width: traceState.preferences.list.width},
-        span_list: {width: 1 - traceState.preferences.list.width},
-      },
-      traceScheduler,
-      traceView,
-      theme
-    );
-    // We only care about initial state when we initialize the view manager
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const {viewManager, traceScheduler, traceView} = props.traceWaterfallModels;
 
   // Initialize the tabs reducer when the tree initializes
   useLayoutEffect(() => {

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -497,6 +497,7 @@ export function Trace({
       <div
         ref={setScrollContainer}
         data-test-id="trace-virtualized-list-scroll-container"
+        id="trace-waterfall"
       >
         <div data-test-id="trace-virtualized-list">{virtualizedList.rendered}</div>
         <div className="TraceRow Hidden">

--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -11,18 +11,21 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceContextProfiles} from 'sentry/views/performance/newTraceDetails/traceContextProfiles';
 import {TraceContextVitals} from 'sentry/views/performance/newTraceDetails/traceContextVitals';
 import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
 import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceViewLogsSection} from 'sentry/views/performance/newTraceDetails/traceOurlogs';
 
 type Props = {
+  onScrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
   rootEvent: UseApiQueryResult<EventTransaction, RequestError>;
   tree: TraceTree;
 };
 
-export function TraceContextPanel({tree, rootEvent}: Props) {
+export function TraceContextPanel({tree, rootEvent, onScrollToNode}: Props) {
   const renderTags = useCallback(() => {
     if (!rootEvent.data) {
       return null;
@@ -70,18 +73,21 @@ export function TraceContextPanel({tree, rootEvent}: Props) {
       <VitalMetersContainer id={TraceContextSectionKeys.WEB_VITALS}>
         <TraceContextVitals tree={tree} />
       </VitalMetersContainer>
-      <TraceTagsContainer>
+      <ContextRow>
         <FoldSection
           sectionKey={TraceContextSectionKeys.TAGS as string as SectionKey}
           title={t('Trace Tags')}
         >
           {renderTags()}
         </FoldSection>
-      </TraceTagsContainer>
+      </ContextRow>
+      <ContextRow>
+        <TraceContextProfiles tree={tree} onScrollToNode={onScrollToNode} />
+      </ContextRow>
       <Feature features={['ourlogs-enabled']}>
-        <TraceTagsContainer>
+        <ContextRow>
           <TraceViewLogsSection />
-        </TraceTagsContainer>
+        </ContextRow>
       </Feature>
     </Container>
   );
@@ -103,7 +109,7 @@ const VitalMetersContainer = styled('div')`
   width: 100%;
 `;
 
-const TraceTagsContainer = styled('div')`
+const ContextRow = styled('div')`
   background-color: ${p => p.theme.background};
   width: 100%;
   border: 1px solid ${p => p.theme.border};

--- a/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
@@ -1,0 +1,37 @@
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceProfiles} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles';
+import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+import {EmptyStateText} from 'sentry/views/traces/styles';
+
+export function TraceContextProfiles({
+  tree,
+  onScrollToNode,
+}: {
+  onScrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
+  tree: TraceTree;
+}) {
+  return (
+    <FoldSection
+      sectionKey={TraceContextSectionKeys.PROFILES as string as SectionKey}
+      title={t('Profiles')}
+    >
+      {tree.type === 'loading' ? (
+        <LoadingIndicator />
+      ) : tree.type === 'trace' ? (
+        <TraceProfiles tree={tree} onScrollToNode={onScrollToNode} />
+      ) : (
+        <EmptyStateWarning withIcon>
+          <EmptyStateText size="fontSizeExtraLarge">
+            {t('No profiles found')}
+          </EmptyStateText>
+        </EmptyStateWarning>
+      )}
+    </FoldSection>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
@@ -16,6 +16,8 @@ export function TraceContextProfiles({
   onScrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
   tree: TraceTree;
 }) {
+  const hasProfiles = tree.profiled_events.size > 0;
+
   return (
     <FoldSection
       sectionKey={TraceContextSectionKeys.PROFILES as string as SectionKey}
@@ -23,7 +25,7 @@ export function TraceContextProfiles({
     >
       {tree.type === 'loading' ? (
         <LoadingIndicator />
-      ) : tree.type === 'trace' ? (
+      ) : tree.type === 'trace' && hasProfiles ? (
         <TraceProfiles tree={tree} onScrollToNode={onScrollToNode} />
       ) : (
         <EmptyStateWarning withIcon>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles.tsx
@@ -17,6 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {
+  isEAPSpanNode,
   isSpanNode,
   isTransactionNode,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
@@ -139,7 +140,9 @@ export function TraceProfiles({
             </ProfilesTableRow>
           );
         }
-        if (isSpanNode(node)) {
+        if (isSpanNode(node) || isEAPSpanNode(node)) {
+          const spanId =
+            'span_id' in node.value ? node.value.span_id : node.value.event_id;
           return (
             <ProfilesTableRow key={index}>
               <div>
@@ -150,7 +153,7 @@ export function TraceProfiles({
                       ? node.value.description.length > 100
                         ? node.value.description.slice(0, 100).trim() + '\u2026'
                         : node.value.description
-                      : (node.value.span_id ?? 'unknown')}
+                      : (spanId ?? 'unknown')}
                   </span>
                 </a>
               </div>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceProfiles.tsx
@@ -11,6 +11,8 @@ import {
   generateContinuousProfileFlamechartRouteWithQuery,
   generateProfileFlamechartRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
@@ -30,6 +32,8 @@ export function TraceProfiles({
 }) {
   const {projects} = useProjects();
   const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const projectLookup: Record<string, PlatformKey | undefined> = useMemo(() => {
     return projects.reduce<Record<Project['slug'], Project['platform']>>(
@@ -58,6 +62,17 @@ export function TraceProfiles({
       }
     },
     [organization]
+  );
+
+  const onNodeIdClick = useCallback(
+    (node: TraceTreeNode<TraceTree.NodeValue>) => {
+      navigate({
+        ...location,
+        hash: `#trace-waterfall`,
+      });
+      onScrollToNode(node);
+    },
+    [location, navigate, onScrollToNode]
   );
 
   return (
@@ -108,7 +123,7 @@ export function TraceProfiles({
           return (
             <ProfilesTableRow key={index}>
               <div>
-                <a onClick={() => onScrollToNode(node)}>
+                <a onClick={() => onNodeIdClick(node)}>
                   <PlatformIcon
                     platform={projectLookup[node.value.project_slug] ?? 'default'}
                   />
@@ -128,7 +143,7 @@ export function TraceProfiles({
           return (
             <ProfilesTableRow key={index}>
               <div>
-                <a onClick={() => onScrollToNode(node)}>
+                <a onClick={() => onNodeIdClick(node)}>
                   <span>{node.value.op ?? '<unknown>'}</span> —{' '}
                   <span className="TraceDescription" title={node.value.description}>
                     {node.value.description

--- a/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
@@ -13,12 +13,14 @@ export const enum TraceContextSectionKeys {
   TAGS = 'trace-context-tags',
   WEB_VITALS = 'trace-context-web-vitals',
   LOGS = 'trace-context-logs',
+  PROFILES = 'trace-context-profiles',
 }
 
 const sectionLabels: Partial<Record<TraceContextSectionKeys, string>> = {
   [TraceContextSectionKeys.TAGS]: t('Tags'),
   [TraceContextSectionKeys.WEB_VITALS]: t('Web Vitals'),
   [TraceContextSectionKeys.LOGS]: t('Logs'),
+  [TraceContextSectionKeys.PROFILES]: t('Profiles'),
 };
 
 function SectionLink({
@@ -55,6 +57,7 @@ function SectionLink({
 function ScrollToSectionLinks({tree}: {tree: TraceTree}) {
   const location = useLocation();
   const hasValidVitals = treeHasValidVitals(tree);
+  const hasProfiles = tree.profiled_events.size > 0;
 
   return (
     <Wrapper>
@@ -66,6 +69,9 @@ function ScrollToSectionLinks({tree}: {tree: TraceTree}) {
         />
       )}
       <SectionLink sectionKey={TraceContextSectionKeys.TAGS} location={location} />
+      {hasProfiles && (
+        <SectionLink sectionKey={TraceContextSectionKeys.PROFILES} location={location} />
+      )}
       <Feature features={['ourlogs-enabled']}>
         <SectionLink sectionKey={TraceContextSectionKeys.LOGS} location={location} />
       </Feature>

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -117,11 +117,23 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
         value.performance_issues.forEach(issue => this.occurences.add(issue));
       }
 
-      if ('profile_id' in value && typeof value.profile_id === 'string') {
-        this.profiles.push({profile_id: value.profile_id});
-      }
-      if ('profiler_id' in value && typeof value.profiler_id === 'string') {
-        this.profiles.push({profiler_id: value.profiler_id});
+      const isNonTransactionEAPSpan = isEAPSpan(value) && !value.is_transaction;
+
+      if (!isNonTransactionEAPSpan) {
+        if (
+          'profile_id' in value &&
+          typeof value.profile_id === 'string' &&
+          value.profile_id.trim() !== ''
+        ) {
+          this.profiles.push({profile_id: value.profile_id});
+        }
+        if (
+          'profiler_id' in value &&
+          typeof value.profiler_id === 'string' &&
+          value.profiler_id.trim() !== ''
+        ) {
+          this.profiles.push({profiler_id: value.profiler_id});
+        }
       }
     }
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -10,7 +10,6 @@ import {
   useState,
 } from 'react';
 import {flushSync} from 'react-dom';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import * as qs from 'query-string';
@@ -45,18 +44,14 @@ import {
 import {useDividerResizeSync} from 'sentry/views/performance/newTraceDetails/useDividerResizeSync';
 import {useHasTraceNewUi} from 'sentry/views/performance/newTraceDetails/useHasTraceNewUi';
 import {useTraceSpaceListeners} from 'sentry/views/performance/newTraceDetails/useTraceSpaceListeners';
+import type {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
+import type {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 import type {TraceMetaQueryResults} from './traceApi/useTraceMeta';
 import {TraceDrawer} from './traceDrawer/traceDrawer';
 import type {TraceTreeNode} from './traceModels/traceTreeNode';
-import {TraceScheduler} from './traceRenderers/traceScheduler';
-import {TraceView as TraceViewModel} from './traceRenderers/traceView';
-import {
-  type ViewManagerScrollAnchor,
-  VirtualizedViewManager,
-} from './traceRenderers/virtualizedViewManager';
 import {
   searchInTraceTreeText,
   searchInTraceTreeTokens,
@@ -117,6 +112,8 @@ export interface TraceWaterfallProps {
   trace: UseApiQueryResult<TraceTree.Trace, RequestError>;
   traceEventView: EventView;
   traceSlug: string;
+  traceWaterfallModels: ReturnType<typeof useTraceWaterfallModels>;
+  traceWaterfallScrollHandlers: ReturnType<typeof useTraceWaterfallScroll>;
   tree: TraceTree;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;
@@ -128,21 +125,24 @@ function clampHeight(height: number) {
 }
 
 export function TraceWaterfall(props: TraceWaterfallProps) {
-  const theme = useTheme();
   const api = useApi();
   const filters = usePageFilters();
   const {projects} = useProjects();
   const organization = useOrganization();
 
-  const traceState = useTraceState();
   const traceDispatch = useTraceStateDispatch();
   const traceStateEmitter = useTraceStateEmitter();
   const hasTraceNewUi = useHasTraceNewUi();
 
-  const [forceRender, rerender] = useReducer(x => (x + 1) % Number.MAX_SAFE_INTEGER, 0);
+  const traceState = useTraceState();
 
-  const traceView = useMemo(() => new TraceViewModel(), []);
-  const traceScheduler = useMemo(() => new TraceScheduler(), []);
+  const traceStateRef = useRef<TraceReducerState>(traceState);
+  traceStateRef.current = traceState;
+
+  const {viewManager, traceScheduler, traceView} = props.traceWaterfallModels;
+  const {onScrollToNode, scrollRowIntoView} = props.traceWaterfallScrollHandlers;
+
+  const [forceRender, rerender] = useReducer(x => (x + 1) % Number.MAX_SAFE_INTEGER, 0);
 
   const projectsRef = useRef<Project[]>(projects);
   projectsRef.current = projects;
@@ -185,30 +185,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.tree, props.replayTraces]);
 
-  // Assign the trace state to a ref so we can access it without re-rendering
-  const traceStateRef = useRef<TraceReducerState>(traceState);
-  traceStateRef.current = traceState;
-
-  const traceStatePreferencesRef = useRef<
-    Pick<TraceReducerState['preferences'], 'autogroup' | 'missing_instrumentation'>
-  >(traceState.preferences);
-  traceStatePreferencesRef.current = traceState.preferences;
-
-  // Initialize the view manager right after the state reducer
-  const viewManager = useMemo(() => {
-    return new VirtualizedViewManager(
-      {
-        list: {width: traceState.preferences.list.width},
-        span_list: {width: 1 - traceState.preferences.list.width},
-      },
-      traceScheduler,
-      traceView,
-      theme
-    );
-    // We only care about initial state when we initialize the view manager
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // Initialize the tabs reducer when the tree initializes
   useLayoutEffect(() => {
     return traceDispatch({
@@ -236,7 +212,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       });
     }
 
-    if (props.tree.profiled_events.size > 0) {
+    if (props.tree.profiled_events.size > 0 && !hasTraceNewUi) {
       newTabs.push({
         node: 'profiles',
         label: 'Profiles',
@@ -444,73 +420,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       });
     },
     [setRowAsFocused, traceDispatch, organization, projects, hasTraceNewUi]
-  );
-
-  const scrollRowIntoView = useCallback(
-    (
-      node: TraceTreeNode<TraceTree.NodeValue>,
-      index: number,
-      anchor?: ViewManagerScrollAnchor,
-      force?: boolean
-    ) => {
-      // Last node we scrolled to is the same as the node we want to scroll to
-      if (previouslyScrolledToNodeRef.current === node && !force) {
-        return;
-      }
-
-      // Always scroll to the row vertically
-      viewManager.scrollToRow(index, anchor);
-      if (viewManager.isOutsideOfView(node)) {
-        viewManager.scrollRowIntoViewHorizontally(node, 0, 48, 'measured');
-      }
-      previouslyScrolledToNodeRef.current = node;
-    },
-    [viewManager]
-  );
-
-  const onScrollToNode = useCallback(
-    (
-      node: TraceTreeNode<TraceTree.NodeValue>
-    ): Promise<TraceTreeNode<TraceTree.NodeValue> | null> => {
-      return TraceTree.ExpandToPath(props.tree, TraceTree.PathToNode(node), {
-        api,
-        organization: props.organization,
-        preferences: traceStatePreferencesRef.current,
-      }).then(() => {
-        const maybeNode = TraceTree.Find(props.tree.root, n => n === node);
-
-        if (!maybeNode) {
-          return null;
-        }
-
-        const index = TraceTree.EnforceVisibility(props.tree, maybeNode);
-        if (index === -1) {
-          return null;
-        }
-
-        scrollRowIntoView(maybeNode, index, 'center if outside', true);
-        traceDispatch({
-          type: 'set roving index',
-          node: maybeNode,
-          index,
-          action_source: 'click',
-        });
-
-        if (traceStateRef.current.search.resultsLookup.has(maybeNode)) {
-          traceDispatch({
-            type: 'set search iterator index',
-            resultIndex: index,
-            resultIteratorIndex:
-              traceStateRef.current.search.resultsLookup.get(maybeNode)!,
-          });
-        } else if (traceStateRef.current.search.resultIteratorIndex !== null) {
-          traceDispatch({type: 'clear search iterator index'});
-        }
-
-        return maybeNode;
-      });
-    },
-    [api, props.organization, scrollRowIntoView, props.tree, traceDispatch]
   );
 
   const onTabScrollToNode = useCallback(

--- a/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceWaterfallModels.tsx
@@ -1,0 +1,31 @@
+import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {TraceScheduler} from './traceRenderers/traceScheduler';
+import {TraceView} from './traceRenderers/traceView';
+import {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
+
+export function useTraceWaterfallModels() {
+  const theme = useTheme();
+  const traceState = useTraceState();
+  const traceView = useMemo(() => new TraceView(), []);
+  const traceScheduler = useMemo(() => new TraceScheduler(), []);
+
+  const viewManager = useMemo(() => {
+    return new VirtualizedViewManager(
+      {
+        list: {width: traceState.preferences.list.width},
+        span_list: {width: 1 - traceState.preferences.list.width},
+      },
+      traceScheduler,
+      traceView,
+      theme
+    );
+    // We only care about initial state when we initialize the view manager
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {traceView, traceScheduler, viewManager};
+}

--- a/static/app/views/performance/newTraceDetails/useTraceWaterfallScroll.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceWaterfallScroll.tsx
@@ -1,0 +1,117 @@
+import {useCallback, useRef} from 'react';
+
+import type {Organization} from 'sentry/types/organization';
+import useApi from 'sentry/utils/useApi';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+import type {TraceTreeNode} from './traceModels/traceTreeNode';
+import type {
+  ViewManagerScrollAnchor,
+  VirtualizedViewManager,
+} from './traceRenderers/virtualizedViewManager';
+import {useTraceState, useTraceStateDispatch} from './traceState/traceStateProvider';
+import type {TraceReducerState} from './traceState';
+
+export function useTraceWaterfallScroll({
+  organization,
+  tree,
+  viewManager,
+}: {
+  organization: Organization;
+  tree: TraceTree;
+  viewManager: VirtualizedViewManager;
+}): {
+  onScrollToNode: (
+    node: TraceTreeNode<TraceTree.NodeValue>
+  ) => Promise<TraceTreeNode<TraceTree.NodeValue> | null>;
+  scrollRowIntoView: (
+    node: TraceTreeNode<TraceTree.NodeValue>,
+    index: number,
+    anchor?: ViewManagerScrollAnchor,
+    force?: boolean
+  ) => void;
+} {
+  const api = useApi();
+  const traceDispatch = useTraceStateDispatch();
+  const previouslyScrolledToNodeRef = useRef<TraceTreeNode<TraceTree.NodeValue> | null>(
+    null
+  );
+  const traceState = useTraceState();
+
+  const traceStateRef = useRef<TraceReducerState>(traceState);
+  traceStateRef.current = traceState;
+
+  const traceStatePreferencesRef = useRef<
+    Pick<TraceReducerState['preferences'], 'autogroup' | 'missing_instrumentation'>
+  >(traceState.preferences);
+  traceStatePreferencesRef.current = traceState.preferences;
+
+  const scrollRowIntoView = useCallback(
+    (
+      node: TraceTreeNode<TraceTree.NodeValue>,
+      index: number,
+      anchor?: ViewManagerScrollAnchor,
+      force?: boolean
+    ) => {
+      // Last node we scrolled to is the same as the node we want to scroll to
+      if (previouslyScrolledToNodeRef.current === node && !force) {
+        return;
+      }
+
+      // Always scroll to the row vertically
+      viewManager.scrollToRow(index, anchor);
+      if (viewManager.isOutsideOfView(node)) {
+        viewManager.scrollRowIntoViewHorizontally(node, 0, 48, 'measured');
+      }
+      previouslyScrolledToNodeRef.current = node;
+    },
+    [viewManager]
+  );
+
+  const onScrollToNode = useCallback(
+    (
+      node: TraceTreeNode<TraceTree.NodeValue>
+    ): Promise<TraceTreeNode<TraceTree.NodeValue> | null> => {
+      return TraceTree.ExpandToPath(tree, TraceTree.PathToNode(node), {
+        api,
+        organization,
+        preferences: traceStatePreferencesRef.current,
+      }).then(() => {
+        const maybeNode = TraceTree.Find(tree.root, n => n === node);
+
+        if (!maybeNode) {
+          return null;
+        }
+
+        const index = TraceTree.EnforceVisibility(tree, maybeNode);
+        if (index === -1) {
+          return null;
+        }
+
+        scrollRowIntoView(maybeNode, index, 'center if outside', true);
+        traceDispatch({
+          type: 'set roving index',
+          node: maybeNode,
+          index,
+          action_source: 'click',
+        });
+
+        if (traceStateRef.current.search.resultsLookup.has(maybeNode)) {
+          traceDispatch({
+            type: 'set search iterator index',
+            resultIndex: index,
+            resultIteratorIndex:
+              traceStateRef.current.search.resultsLookup.get(maybeNode)!,
+          });
+        } else if (traceStateRef.current.search.resultIteratorIndex !== null) {
+          traceDispatch({type: 'clear search iterator index'});
+        }
+
+        return maybeNode;
+      });
+    },
+    [api, organization, scrollRowIntoView, tree, traceDispatch]
+  );
+
+  return {onScrollToNode, scrollRowIntoView};
+}

--- a/static/app/views/replays/detail/trace/index.tsx
+++ b/static/app/views/replays/detail/trace/index.tsx
@@ -2,7 +2,7 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import Trace, {NewTraceView} from 'sentry/views/replays/detail/trace/trace';
+import Trace, {NewTraceViewImpl} from 'sentry/views/replays/detail/trace/trace';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 const features = ['organizations:performance-view'];
@@ -29,7 +29,7 @@ function TraceFeature({replayRecord}: {replayRecord: ReplayRecord | undefined}) 
       renderDisabled={PerfDisabled}
     >
       {organization.features.includes('replay-trace-view-v1') ? (
-        <NewTraceView replay={replayRecord} />
+        <NewTraceViewImpl replay={replayRecord} />
       ) : (
         <Trace replay={replayRecord} />
       )}

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -21,6 +21,8 @@ import type {TracePreferencesState} from 'sentry/views/performance/newTraceDetai
 import {loadTraceViewPreferences} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
+import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
+import {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
 import TraceView, {
   StyledTracePanel,
 } from 'sentry/views/performance/traceDetails/traceView';
@@ -155,6 +157,24 @@ function Trace({replay}: {replay: undefined | ReplayRecord}) {
 }
 
 export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
+  const preferences = useMemo(
+    () =>
+      loadTraceViewPreferences('replay-trace-view-preferences') ||
+      DEFAULT_REPLAY_TRACE_VIEW_PREFERENCES,
+    []
+  );
+
+  return (
+    <TraceStateProvider
+      initialPreferences={preferences}
+      preferencesStorageKey="replay-trace-view-preferences"
+    >
+      <NewTraceViewImpl replay={replay} />
+    </TraceStateProvider>
+  );
+}
+
+export function NewTraceViewImpl({replay}: {replay: undefined | ReplayRecord}) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {eventView, indexComplete, indexError, replayTraces} = useReplayTraces({
@@ -174,12 +194,12 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
     replay: replay ?? null,
   });
 
-  const preferences = useMemo(
-    () =>
-      loadTraceViewPreferences('replay-trace-view-preferences') ||
-      DEFAULT_REPLAY_TRACE_VIEW_PREFERENCES,
-    []
-  );
+  const traceWaterfallModels = useTraceWaterfallModels();
+  const traceWaterfallScroll = useTraceWaterfallScroll({
+    organization,
+    tree,
+    viewManager: traceWaterfallModels.viewManager,
+  });
 
   const otherReplayTraces = useMemo(() => {
     if (!replayTraces) {
@@ -219,25 +239,22 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
   }
 
   return (
-    <TraceStateProvider
-      initialPreferences={preferences}
-      preferencesStorageKey="replay-trace-view-preferences"
-    >
-      <TraceViewWaterfallWrapper>
-        <TraceWaterfall
-          traceSlug={firstTrace.traceSlug}
-          trace={trace}
-          tree={tree}
-          rootEvent={rootEvent}
-          replayTraces={otherReplayTraces}
-          organization={organization}
-          traceEventView={eventView}
-          meta={meta}
-          source="replay"
-          replay={replay}
-        />
-      </TraceViewWaterfallWrapper>
-    </TraceStateProvider>
+    <TraceViewWaterfallWrapper>
+      <TraceWaterfall
+        traceSlug={firstTrace.traceSlug}
+        trace={trace}
+        tree={tree}
+        rootEvent={rootEvent}
+        replayTraces={otherReplayTraces}
+        organization={organization}
+        traceEventView={eventView}
+        meta={meta}
+        source="replay"
+        replay={replay}
+        traceWaterfallScrollHandlers={traceWaterfallScroll}
+        traceWaterfallModels={traceWaterfallModels}
+      />
+    </TraceViewWaterfallWrapper>
   );
 }
 


### PR DESCRIPTION
Adds a trace level profile context section under the waterfall. 

I had to move out the 'scroll to node' functionality to a level above the `TraceWaterfall`. To extract the logic I added a `useTraceWaterfallModels` and a `useTraceWaterfallScroll` where the latter requires a param from the first.  I thought about combining them and sending it to the embedded components using a Provider, but they don't seem to belong together, unless we strip out all of the waterfall functionality into a hook a level above the waterfall, which is unnecessary.

Supports both eap and non-eap traces. 

<img width="1241" alt="Screenshot 2025-04-15 at 12 31 37 PM" src="https://github.com/user-attachments/assets/831ccaa2-5cb8-43c5-be0c-a6a8905fe0e9" />

