### PR TITLE
feat(issues): Disable stack trace setup in preview

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -233,6 +233,7 @@ function DeprecatedLine({
                   frame={data}
                   line={contextLine ? contextLine[1] : ''}
                   event={event}
+                  disableSetup={isHoverPreviewed}
                 />
               </ErrorBoundary>
             )}

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -46,7 +46,9 @@ describe('StacktraceLink', function () {
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       body: {config: null, sourceUrl: null, integrations: [integration]},
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />);
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
+    );
     expect(await screen.findByText('Set up Code Mapping')).toBeInTheDocument();
   });
 
@@ -55,7 +57,9 @@ describe('StacktraceLink', function () {
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />);
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
+    );
     const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://something.io#L233');
@@ -70,7 +74,9 @@ describe('StacktraceLink', function () {
         integrations: [integration],
       },
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />);
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
+    );
     expect(
       await screen.findByRole('button', {name: 'Set up Code Mapping'})
     ).toBeInTheDocument();
@@ -90,6 +96,7 @@ describe('StacktraceLink', function () {
         frame={frame}
         event={{...event, platform: 'javascript'}}
         line="{snip} somethingInsane=e.IsNotFound {snip}"
+        disableSetup={false}
       />
     );
     await waitFor(() => {
@@ -107,7 +114,12 @@ describe('StacktraceLink', function () {
       },
     });
     const {container} = render(
-      <StacktraceLink frame={frame} event={{...event, platform: 'unreal'}} line="" />
+      <StacktraceLink
+        frame={frame}
+        event={{...event, platform: 'unreal'}}
+        line=""
+        disableSetup={false}
+      />
     );
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
@@ -136,9 +148,12 @@ describe('StacktraceLink', function () {
         coverageUrl: 'https://app.codecov.io/gh/path/to/file.py',
       },
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      organization,
-    });
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />,
+      {
+        organization,
+      }
+    );
 
     const link = await screen.findByRole('link', {name: 'Open in Codecov'});
     expect(link).toBeInTheDocument();
@@ -172,9 +187,12 @@ describe('StacktraceLink', function () {
       url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
       body: {status: CodecovStatusCode.NO_COVERAGE_DATA},
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      organization,
-    });
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />,
+      {
+        organization,
+      }
+    );
     expect(await screen.findByText('Code Coverage not found')).toBeInTheDocument();
   });
 
@@ -196,9 +214,12 @@ describe('StacktraceLink', function () {
       url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
       body: {status: CodecovStatusCode.NO_COVERAGE_DATA},
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      organization,
-    });
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />,
+      {
+        organization,
+      }
+    );
     expect(
       await screen.findByRole('link', {name: 'Open this line in GitHub'})
     ).toBeInTheDocument();
@@ -223,6 +244,7 @@ describe('StacktraceLink', function () {
         frame={dotnetFrame}
         event={{...event, platform: 'csharp'}}
         line="foo()"
+        disableSetup={false}
       />
     );
     const link = await screen.findByRole('link', {name: 'GitHub'});
@@ -238,7 +260,9 @@ describe('StacktraceLink', function () {
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
-    render(<StacktraceLink frame={frame} event={event} line="foo()" />);
+    render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
+    );
 
     const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
     expect(link).toBeInTheDocument();
@@ -247,5 +271,18 @@ describe('StacktraceLink', function () {
     expect(link).toHaveTextContent('');
 
     expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the setup button when disableSetup is true', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      body: {config: null, sourceUrl: null, integrations: [integration]},
+    });
+    const {container} = render(
+      <StacktraceLink frame={frame} event={event} line="foo()" disableSetup />
+    );
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 });

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -107,6 +107,10 @@ function CodecovLink({
 }
 
 interface StacktraceLinkProps {
+  /**
+   * If true, the setup button will not be shown
+   */
+  disableSetup: boolean;
   event: Event;
   frame: Frame;
   /**
@@ -115,7 +119,7 @@ interface StacktraceLinkProps {
   line: string | null;
 }
 
-export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
+export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLinkProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const validFilePath = hasFileExtension(frame.absPath || frame.filename || '');
@@ -302,7 +306,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     event.platform as PlatformKey
   );
 
-  const hideErrors = isMinifiedJsError || isUnsupportedPlatform;
+  const hideErrors = isMinifiedJsError || isUnsupportedPlatform || disableSetup;
   // for .NET projects, if there is no match found but there is a GitHub source link, use that
   if (
     frame.sourceLink &&

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -391,6 +391,7 @@ function NativeFrame({
                   frame={frame}
                   line={contextLine ? contextLine[1] : ''}
                   event={event}
+                  disableSetup={isHoverPreviewed}
                 />
               </ErrorBoundary>
             )}


### PR DESCRIPTION
Disables the set up buttons when viewing stack trace as a preview on the issues stream.

![image](https://github.com/user-attachments/assets/717bd432-651e-423d-be08-8af7a2f9ad12)
