### PR TITLE
feat(insights): Allow turning off the legend in Insights charts

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -44,6 +44,7 @@ export interface InsightsTimeSeriesWidgetProps extends WidgetTitleProps {
   interactiveTitle?: () => React.ReactNode;
   legendSelection?: LegendSelection | undefined;
   onLegendSelectionChange?: ((selection: LegendSelection) => void) | undefined;
+  showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
   stacked?: boolean;
 }
 
@@ -59,6 +60,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
     })) ?? [];
 
   const visualizationProps: TimeSeriesWidgetVisualizationProps = {
+    showLegend: props.showLegend,
     plottables: (props.series.filter(Boolean) ?? [])?.map(serie => {
       const timeSeries = convertSeriesToTimeseries(serie);
       const PlottableDataConstructor =


### PR DESCRIPTION
Some charts, like the sidebar sample charts don't have a legend, kind of with good reason. Add a pass-through prop to hide it.
