### PR TITLE
Unrevert webhooks only dispatch for subset of projects

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -335,6 +335,9 @@ from sentry.sentry_apps.api.endpoints.installation_external_issues import (
 from sentry.sentry_apps.api.endpoints.installation_external_requests import (
     SentryAppInstallationExternalRequestsEndpoint,
 )
+from sentry.sentry_apps.api.endpoints.installation_service_hook_projects import (
+    SentryAppInstallationServiceHookProjectsEndpoint,
+)
 from sentry.sentry_apps.api.endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
 from sentry.sentry_apps.api.endpoints.sentry_app_authorizations import (
     SentryAppAuthorizationsEndpoint,
@@ -3097,6 +3100,11 @@ SENTRY_APP_INSTALLATION_URLS = [
         r"^(?P<uuid>[^\/]+)/external-issues/(?P<external_issue_id>[^\/]+)/$",
         SentryAppInstallationExternalIssueDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-app-installation-external-issue-details",
+    ),
+    re_path(
+        r"^(?P<uuid>[^\/]+)/service-hook-projects/$",
+        SentryAppInstallationServiceHookProjectsEndpoint.as_view(),
+        name="sentry-api-0-sentry-app-installation-service-hook-projects",
     ),
 ]
 

--- a/src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_service_hook_projects.py
@@ -1,0 +1,195 @@
+from django.db import router, transaction
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import deletions
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers.base import serialize
+from sentry.projects.services.project.service import project_service
+from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
+from sentry.sentry_apps.api.serializers.servicehookproject import ServiceHookProjectSerializer
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
+from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
+
+
+class ProjectAccessError(Exception):
+    pass
+
+
+class ServiceHookProjectsInputSerializer(serializers.Serializer):
+    projects = serializers.ListField(required=True)
+
+    def validate_projects(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError(
+                "Projects must be a list, not %s" % type(value).__name__
+            )
+
+        if not value:
+            raise serializers.ValidationError("Projects list cannot be empty")
+
+        # Check the type of the first element to determine expected type
+        first_elem = value[0]
+
+        if not isinstance(first_elem, (str, int)):
+            raise serializers.ValidationError(
+                "Project identifiers must be either all strings (slugs) or all integers (IDs)"
+            )
+
+        expected_type = type(first_elem)
+
+        # Verify all elements are of the same type
+        if not all(isinstance(x, expected_type) for x in value):
+            raise serializers.ValidationError(
+                "Mixed types detected. All project identifiers must be of the same type "
+                "(either all strings/slugs or all integers/IDs)"
+            )
+
+        return value
+
+
+@region_silo_endpoint
+class SentryAppInstallationServiceHookProjectsEndpoint(SentryAppInstallationBaseEndpoint):
+    owner = ApiOwner.INTEGRATIONS
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.PRIVATE,
+    }
+
+    def _replace_hook_projects(
+        self, installation: RpcSentryAppInstallation, new_project_ids: set[int], request: Request
+    ) -> list[ServiceHookProject]:
+        with transaction.atomic(router.db_for_write(ServiceHookProject)):
+            hook = ServiceHook.objects.get(installation_id=installation.id)
+            existing_project_ids = set(
+                ServiceHookProject.objects.filter(service_hook_id=hook.id).values_list(
+                    "project_id", flat=True
+                )
+            )
+
+            # Determine which projects to add and which to remove
+            projects_to_add = new_project_ids - existing_project_ids
+            projects_to_remove = existing_project_ids - new_project_ids
+
+            for p in projects_to_remove:
+                p_obj = project_service.get_by_id(
+                    organization_id=installation.organization_id, id=p
+                )
+                if not request.access.has_project_access(p_obj):
+                    raise ProjectAccessError("Can not remove projects that are not accessible")
+
+            self._delete_servicehookprojects(hook.id, projects_to_remove)
+            added_hook_projects = self._add_servicehookprojects(hook.id, projects_to_add)
+
+            kept_project_ids = existing_project_ids & new_project_ids
+            return sorted(
+                added_hook_projects
+                + list(ServiceHookProject.objects.filter(project_id__in=kept_project_ids)),
+                key=lambda x: x.project_id,
+            )
+
+    def _delete_servicehookprojects(self, service_hook_id: int, project_ids: set[int]) -> None:
+        ServiceHookProject.objects.filter(
+            service_hook_id=service_hook_id, project_id__in=project_ids
+        ).delete()
+
+    def _add_servicehookprojects(
+        self, service_hook_id: int, project_ids: set[int]
+    ) -> list[ServiceHookProject]:
+        res = []
+        for project_id in project_ids:
+            res.append(
+                ServiceHookProject.objects.create(
+                    project_id=project_id,
+                    service_hook_id=service_hook_id,
+                )
+            )
+        return res
+
+    def get(self, request: Request, installation: RpcSentryAppInstallation) -> Response:
+        hook = ServiceHook.objects.get(installation_id=installation.id)
+        hook_projects = list(ServiceHookProject.objects.filter(service_hook_id=hook.id))
+
+        for hp in hook_projects:
+            p_obj = project_service.get_by_id(
+                organization_id=installation.organization_id, id=hp.project_id
+            )
+            if not request.access.has_project_access(p_obj):
+                return Response(
+                    status=400,
+                    data={"error": "Some projects are not accessible"},
+                )
+
+        return self.paginate(
+            request=request,
+            queryset=hook_projects,
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(
+                x, request.user, access=request.access, serializer=ServiceHookProjectSerializer()
+            ),
+        )
+
+    """
+        POST will replace all existing project filters with the new set.
+    """
+
+    def post(self, request: Request, installation: RpcSentryAppInstallation) -> Response:
+
+        serializer = ServiceHookProjectsInputSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        projects = serializer.validated_data["projects"]
+
+        # convert slugs to ids if needed
+        org_id = installation.organization_id
+        project_ids = set()
+        for project in set(projects):
+            if isinstance(project, int):
+                project_obj = project_service.get_by_id(organization_id=org_id, id=project)
+            else:
+                project_obj = project_service.get_by_slug(organization_id=org_id, slug=project)
+            if project_obj and request.access.has_project_access(project_obj):
+                project_ids.add(project_obj.id)
+            else:
+                return Response(
+                    status=400,
+                    data={"error": f"Project '{project}' does not exist or is not accessible"},
+                )
+
+        try:
+            hook_projects = self._replace_hook_projects(installation, project_ids, request)
+        except ProjectAccessError:
+            return Response(
+                status=400,
+                data={"error": "Some projects affected by this request are not accessible"},
+            )
+
+        return self.paginate(
+            request=request,
+            queryset=hook_projects,
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(
+                x, request.user, access=request.access, serializer=ServiceHookProjectSerializer()
+            ),
+        )
+
+    def delete(self, request: Request, installation: RpcSentryAppInstallation) -> Response:
+        hook = ServiceHook.objects.get(installation_id=installation.id)
+        hook_projects = ServiceHookProject.objects.filter(service_hook_id=hook.id)
+        for hp in hook_projects:
+            p_obj = project_service.get_by_id(
+                organization_id=installation.organization_id, id=hp.project_id
+            )
+            if not request.access.has_project_access(p_obj):
+                return Response(
+                    status=400,
+                    data={"error": "Some projects affected by this request are not accessible"},
+                )
+        deletions.exec_sync_many(list(hook_projects))
+        return Response(status=204)

--- a/src/sentry/sentry_apps/api/serializers/servicehookproject.py
+++ b/src/sentry/sentry_apps/api/serializers/servicehookproject.py
@@ -1,0 +1,11 @@
+from sentry.api.serializers import Serializer, register
+from sentry.sentry_apps.models.servicehook import ServiceHookProject
+
+
+@register(ServiceHookProject)
+class ServiceHookProjectSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {
+            "id": str(obj.id),
+            "project_id": str(obj.project_id),
+        }

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -49,6 +49,7 @@ from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
+from sentry.utils.function_cache import cache_func_for_models
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import send_and_save_webhook_request
 from sentry.utils.sentry_apps.service_hook_manager import (
@@ -310,10 +311,71 @@ def _process_resource_change(
                 data[name] = serialize(instance)
 
             for installation in installations:
-                # Trigger a new task for each webhook
-                send_resource_change_webhook.delay(
-                    installation_id=installation.id, event=str(event), data=data
-                )
+
+                if _is_project_allowed(installation, instance.project_id):
+                    # Trigger a new task for each webhook
+                    send_resource_change_webhook.delay(
+                        installation_id=installation.id, event=str(event), data=data
+                    )
+
+
+def _is_project_allowed(installation: RpcSentryAppInstallation, project_id: int) -> bool:
+    service_hook = _load_service_hook(installation.organization_id, installation.id)
+    if not service_hook:
+        logger.info("send_webhooks.missing_servicehook", extra={"installation_id": installation.id})
+        return False
+    # must use 2 separate helpers for cache invalidation to work correctly in [] <-> [project1, ...] scenarios
+    return not _is_project_filtering_enabled(service_hook.id) or _does_project_filter_allow_project(
+        service_hook.id, project_id
+    )
+
+
+@cache_func_for_models(
+    [
+        (
+            ServiceHook,
+            lambda service_hook: (service_hook.organization_id, service_hook.actor_id),
+        )
+    ],
+    recalculate=False,
+)
+def _load_service_hook(organization_id: int | None, installation_id: int) -> ServiceHook | None:
+    try:
+        service_hook = ServiceHook.objects.get(
+            organization_id=organization_id,
+            actor_id=installation_id,
+        )
+        if service_hook.installation_id != service_hook.actor_id:
+            logger.error(
+                "service_hook.installation_id != service_hook.actor_id",
+                extra={"service_hook_id": service_hook.id},
+            )
+        return service_hook
+    except ServiceHook.DoesNotExist:
+        return None
+
+
+@cache_func_for_models(
+    [(ServiceHookProject, lambda hook_project: (hook_project.service_hook_id,))],
+    recalculate=False,
+)
+def _is_project_filtering_enabled(service_hook_id: int) -> bool:
+    return ServiceHookProject.objects.filter(service_hook_id=service_hook_id).exists()
+
+
+@cache_func_for_models(
+    [
+        (
+            ServiceHookProject,
+            lambda hook_project: (hook_project.service_hook_id, hook_project.project_id),
+        )
+    ],
+    recalculate=False,
+)
+def _does_project_filter_allow_project(service_hook_id: int, project_id: int) -> bool:
+    return ServiceHookProject.objects.filter(
+        service_hook_id=service_hook_id, project_id=project_id
+    ).exists()
 
 
 @instrumented_task(
@@ -557,12 +619,10 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
         event_type=SentryAppEventType(event),
     ).capture() as lifecycle:
-        servicehook: ServiceHook
-        try:
-            servicehook = ServiceHook.objects.get(
-                organization_id=installation.organization_id, actor_id=installation.id
-            )
-        except ServiceHook.DoesNotExist:
+        servicehook: ServiceHook | None = _load_service_hook(
+            installation.organization_id, installation.id
+        )
+        if not servicehook:
             lifecycle.add_extra("events", installation.sentry_app.events)
             lifecycle.add_extras(
                 {
@@ -580,11 +640,6 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
                 message=SentryAppWebhookFailureReason.EVENT_NOT_IN_SERVCEHOOK
             )
 
-        # The service hook applies to all projects if there are no
-        # ServiceHookProject records. Otherwise we want check if
-        # the event is within the allowed projects.
-        project_limited = ServiceHookProject.objects.filter(service_hook_id=servicehook.id).exists()
-
         # TODO(nola): This is disabled for now, because it could potentially affect internal integrations w/ error.created
         # # If the event is error.created & the request is going out to the Org that owns the Sentry App,
         # # Make sure we don't send the request, to prevent potential infinite loops
@@ -600,14 +655,13 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         #     )
         #     return
 
-        if not project_limited:
-            resource, action = event.split(".")
+        resource, action = event.split(".")
 
-            kwargs["resource"] = resource
-            kwargs["action"] = action
-            kwargs["install"] = installation
+        kwargs["resource"] = resource
+        kwargs["action"] = action
+        kwargs["install"] = installation
 
-            request_data = AppPlatformEvent(**kwargs)
+        request_data = AppPlatformEvent(**kwargs)
 
     send_and_save_webhook_request(
         installation.sentry_app,

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -346,7 +346,7 @@ def _load_service_hook(organization_id: int | None, installation_id: int) -> Ser
             actor_id=installation_id,
         )
         if service_hook.installation_id != service_hook.actor_id:
-            logger.error(
+            logger.info(
                 "service_hook.installation_id != service_hook.actor_id",
                 extra={"service_hook_id": service_hook.id},
             )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1387,7 +1387,13 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_service_hook(actor=None, org=None, project=None, events=None, url=None, **kwargs):
+    def create_service_hook(
+        actor=None, org=None, project=None, events=None, url=None, project_ids=None, **kwargs
+    ):
+        if project:
+            if project_ids is not None:
+                raise ValueError("Cannot provide both project and project_ids")
+            project_ids = [project.id]
         if not actor:
             actor = Factories.create_user()
         if not org:
@@ -1395,8 +1401,8 @@ class Factories:
                 org = project.organization
             else:
                 org = Factories.create_organization(owner=actor)
-        if not project:
-            project = Factories.create_project(organization=org)
+        if project_ids is None:  # empty list for project_ids is valid and means no project filter
+            project_ids = [Factories.create_project(organization=org).id]
         if events is None:
             events = ["event.created"]
         if not url:
@@ -1413,7 +1419,7 @@ class Factories:
             actor_id=actor.id,
             installation_id=installation_id,
             organization_id=org.id,
-            project_ids=[project.id],
+            project_ids=project_ids,
             events=events,
             url=url,
         ).id

--- a/src/sentry/utils/function_cache.py
+++ b/src/sentry/utils/function_cache.py
@@ -19,12 +19,16 @@ Ts = TypeVarTuple("Ts")
 R = TypeVar("R")
 S = TypeVar("S", bound=models.Model)
 
+_NONE_HASHABLE = "DD47DB9F-6165-42E1-A719-D0CF702E1788"
+
 
 def arg_to_hashable(arg: object) -> object:
     if isinstance(arg, (int, float, str, Decimal, uuid.UUID)):
         return arg
     elif isinstance(arg, models.Model):
         return f"{arg._meta.label}:{arg.pk}"
+    elif arg is None:
+        return _NONE_HASHABLE  # won't change across runs/interpreter versions
     else:
         raise ValueError(
             "Can only cache functions whose parameters can be hashed in a consistent way"

--- a/tests/sentry/sentry_apps/api/endpoints/test_installation_service_hook_projects.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_installation_service_hook_projects.py
@@ -1,0 +1,111 @@
+from django.urls import reverse
+
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
+from sentry.testutils.cases import APITestCase
+
+
+class SentryAppInstallationServiceHookProjectsEndpointTest(APITestCase):
+    def setUp(self):
+        self.user = self.create_user(email="boop@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.project2 = self.create_project(organization=self.org)
+        self.project3 = self.create_project(organization=self.org)
+
+        self.sentry_app = self.create_sentry_app(
+            name="Testin",
+            organization=self.org,
+            webhook_url="https://example.com",
+            scopes=["org:admin", "org:integrations", "event:admin"],
+        )
+
+        self.install = self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app.slug, user=self.user
+        )
+
+        self.api_token = self.create_internal_integration_token(
+            install=self.install, user=self.user  # using same install for auth token and webhooks
+        )
+
+        self.service_hook = ServiceHook.objects.get(
+            installation_id=self.install.id,
+        )
+
+        self.url = reverse(
+            "sentry-api-0-sentry-app-installation-service-hook-projects", args=[self.install.uuid]
+        )
+
+    def test_get_service_hook_projects(self):
+        # Create a service hook project
+        ServiceHookProject.objects.create(
+            project_id=self.project.id, service_hook_id=self.service_hook.id
+        )
+
+        response = self.client.get(
+            self.url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["project_id"] == str(self.project.id)
+
+    def test_post_service_hook_projects(self):
+        ServiceHookProject.objects.create(
+            project_id=self.project2.id, service_hook_id=self.service_hook.id
+        )
+        ServiceHookProject.objects.create(
+            project_id=self.project3.id, service_hook_id=self.service_hook.id
+        )
+
+        data = {"projects": [self.project.id, self.project2.id]}
+
+        response = self.client.post(
+            self.url, data=data, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        response_data = {response.data[0]["project_id"], response.data[1]["project_id"]}
+        assert response_data == {str(self.project.id), str(self.project2.id)}
+
+        # Verify both projects are in the database
+        hook_projects = ServiceHookProject.objects.filter(service_hook_id=self.service_hook.id)
+        assert hook_projects.count() == 2
+        project_ids = {hp.project_id for hp in hook_projects}
+        assert project_ids == {self.project.id, self.project2.id}
+
+    def test_post_service_hook_projects_mixed_types(self):
+        data = {"projects": [self.project.slug, self.project2.id]}
+
+        response = self.client.post(
+            self.url, data=data, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 400
+
+    def test_post_service_hook_projects_with_invalid_project(self):
+        data = {"projects": ["invalid-project"]}
+
+        response = self.client.post(
+            self.url, data=data, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 400
+
+    def test_post_service_hook_projects_without_projects(self):
+        response = self.client.post(
+            self.url, data={}, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 400
+
+    def test_delete_service_hook_projects(self):
+        # Create some service hook projects first
+        ServiceHookProject.objects.create(
+            project_id=self.project.id, service_hook_id=self.service_hook.id
+        )
+        ServiceHookProject.objects.create(
+            project_id=self.project2.id, service_hook_id=self.service_hook.id
+        )
+
+        response = self.client.delete(self.url, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}")
+        assert response.status_code == 204
+
+        # Verify all hook projects were deleted
+        assert ServiceHookProject.objects.filter(service_hook_id=self.service_hook.id).count() == 0

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -26,7 +26,7 @@ from sentry.models.rule import Rule
 from sentry.sentry_apps.metrics import SentryAppWebhookFailureReason, SentryAppWebhookHaltReason
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.models.servicehook import ServiceHook
+from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.tasks.sentry_apps import (
     build_comment_webhook,
     installation_webhook,
@@ -59,6 +59,9 @@ from sentry.users.services.user.service import user_service
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
+from sentry.utils.sentry_apps.service_hook_manager import (
+    create_or_update_service_hooks_for_installation,
+)
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = [requires_snuba]
@@ -676,6 +679,137 @@ class TestProcessResourceChange(TestCase):
         )
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_project_filter_no_filters_sends_webhook(self, mock_record, safe_urlopen):
+        create_or_update_service_hooks_for_installation(
+            installation=self.install,
+            webhook_url=self.sentry_app.webhook_url,
+            events=self.sentry_app.events,
+        )
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error,
+            )
+
+        assert safe_urlopen.called
+        ((args, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "created"
+        assert data["installation"]["uuid"] == self.install.uuid
+        assert data["data"]["issue"]["id"] == str(event.group.id)
+
+        # SLO assertions
+        assert_success_metric(mock_record)
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success) -> SEND_WEBHOOK (success) SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=4
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_project_filter_matches_project_sends_webhook(self, mock_record, safe_urlopen):
+        with assume_test_silo_mode_of(ServiceHookProject):
+            ServiceHookProject.objects.all().delete()
+            ServiceHook.objects.all().delete()
+
+        self.create_service_hook(
+            project_ids=[self.project.id],  # matches project of issue
+            installation=self.install,
+            application=self.sentry_app,
+            events=["issue.created"],
+            org=self.organization,
+            actor=self.install,
+        )
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error,
+            )
+
+        assert safe_urlopen.called
+        ((args, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "created"
+        assert data["installation"]["uuid"] == self.install.uuid
+        assert data["data"]["issue"]["id"] == str(event.group.id)
+
+        # SLO assertions
+        assert_success_metric(mock_record)
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success) -> SEND_WEBHOOK (success) -> SEND_WEBHOOK (success)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=4
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_project_filter_no_match_does_not_send_webhook(self, mock_record, safe_urlopen):
+        with assume_test_silo_mode_of(ServiceHookProject):
+            ServiceHookProject.objects.all().delete()
+            ServiceHook.objects.all().delete()
+
+        project_2 = self.create_project(
+            name="Bar2", slug="bar2", teams=[self.team], fire_project_created=False
+        )
+
+        self.create_service_hook(
+            project_ids=[project_2.id],  # no match
+            installation=self.install,
+            application=self.sentry_app,
+            events=["issue.created"],
+            org=self.organization,
+            actor=self.install,
+        )
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error,
+            )
+
+        assert not safe_urlopen.called
+
+        # SLO assertions
+        assert_success_metric(mock_record)
+        # PREPARE_WEBHOOK (success)
+        # Did not send a webhook bc per-project filter on project_id 2 and post_process was for project_id 1
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=1
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=1
         )
 
     # TODO(nola): Enable this test whenever we prevent infinite loops w/ error.created integrations


### PR DESCRIPTION
un-reverting https://github.com/getsentry/sentry/pull/85502 which was reverted out of abundance of caution
+ switch `logger.error` -> `logger.info` when `actor_id` and `installation_id` don't match

# Context

**christina**
Looked into the installation_id & actor_id mismatch and all the affected hooks had the installation_id under the actor_id , and the hook's installation_id property would be null causing the mismatch.
That's probably why the original code also looked up by actor_id :bufo-melting:  . Imo, I think we're safe then, and downgrade the log level info. I have a ticket on my backlog to backfill servicehooks with similar issues so it would be nice if we kept track of what hooks are in a weird state. (edited) 
**Kosty**
 yeah this should have been a warn/info
we are still using actor_id like before, that didn’t change, so should be safe
:bufo-thumbsup:
1

**dan**
 cool, we can revert the revert and just change the log and merge early monday then
