### PR TITLE
ref(replays/perf): fix statsPeriod query param when switching to replays tab in transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -182,6 +182,7 @@ function TransactionHeader({
     [hasWebVitals, location, projects, eventView]
   );
 
+  // Hard-code 90d for the replay tab to surface more interesting data.
   const {getReplayCountForTransaction} = useReplayCountForTransactions({
     statsPeriod: '90d',
   });

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -35,13 +35,7 @@ function TransactionReplays() {
 
   return (
     <PageLayout
-      location={{
-        ...location,
-        query: {
-          ...location.query,
-          statsPeriod: '90d',
-        },
-      }}
+      location={location}
       organization={organization}
       projects={projects}
       tab={Tab.REPLAYS}
@@ -98,7 +92,13 @@ function ReplaysContentWrapper({
 }: ChildProps) {
   const {data, fetchError, isFetching, pageLinks} = useReplaysFromTransaction({
     replayIdsEventView,
-    location,
+    location: {
+      ...location,
+      query: {
+        ...location.query,
+        statsPeriod: '90d',
+      },
+    },
     organization,
   });
 

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -90,6 +90,7 @@ function ReplaysContentWrapper({
   organization,
   setError,
 }: ChildProps) {
+  // Hard-code 90d to match the count query. There's no date selector for the replay tab.
   const {data, fetchError, isFetching, pageLinks} = useReplaysFromTransaction({
     replayIdsEventView,
     location: {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/75973
Relates to https://github.com/getsentry/sentry/pull/68396

This change will keep the global statsPeriod in the URL unchanged, when switching to the replays tab. There's no date selector for that tab so we're choosing to make results + count badge always be from the last 90 days. Neither of these queries will use the location query for statsPeriod.

Fix vs what's currently on prod:
https://github.com/user-attachments/assets/75618689-ca7d-43c6-95b7-f67d445cb62b

