### PR TITLE
feat(issues): Remove frames-omitted global styles

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -163,7 +163,7 @@ describe('StackTrace', function () {
   });
 
   it('if frames are omitted, renders omitted frames', function () {
-    const newData = {
+    const newData: StacktraceType = {
       ...data,
       framesOmitted: [0, 3],
     };
@@ -171,7 +171,7 @@ describe('StackTrace', function () {
     render(<StackTraceContent {...defaultProps} data={newData} event={event} />);
 
     const omittedFrames = screen.getByText(
-      'Frames 0 until 3 were omitted and not available.'
+      'Frames 0 to 3 were omitted and not available.'
     );
     expect(omittedFrames).toBeInTheDocument();
   });

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -12,12 +12,12 @@ import {
   stackTracePlatformIcon,
 } from 'sentry/components/events/interfaces/utils';
 import Panel from 'sentry/components/panels/panel';
-import {t} from 'sentry/locale';
 import type {Event, Frame} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/project';
 import type {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
+import {OmittedFrames} from './omittedFrames';
 import StacktracePlatformIcon from './platformIcon';
 
 type DefaultProps = {
@@ -61,7 +61,7 @@ function Content({
 }: Props) {
   const [toggleFrameMap, setToggleFrameMap] = useState(setInitialFrameMap());
 
-  const {frames = [], framesOmitted, registers} = data;
+  const {frames = [], registers} = data;
 
   function frameIsVisible(frame: Frame, nextFrame: Frame) {
     return (
@@ -115,20 +115,6 @@ function Content({
     }));
   };
 
-  function renderOmittedFrames(firstFrameOmitted: any, lastFrameOmitted: any) {
-    return (
-      <li key="omitted" className="frame frames-omitted">
-        {t(
-          'Frames %d until %d were omitted and not available.',
-          firstFrameOmitted,
-          lastFrameOmitted
-        )}
-      </li>
-    );
-  }
-
-  const firstFrameOmitted = framesOmitted?.[0] ?? null;
-  const lastFrameOmitted = framesOmitted?.[1] ?? null;
   const lastFrameIndex = getLastFrameIndex(frames);
   const frameCountMap = getInitialFrameCounts();
   const hiddenFrameIndices: number[] = getHiddenFrameIndices({
@@ -184,11 +170,11 @@ function Content({
 
         nRepeats = 0;
 
-        if (frameIndex === firstFrameOmitted) {
+        if (frameIndex === data.framesOmitted?.[0]) {
           return (
             <Fragment key={frameIndex}>
               <DeprecatedLine {...frameProps} />
-              {renderOmittedFrames(firstFrameOmitted, lastFrameOmitted)}
+              <OmittedFrames omittedFrames={data.framesOmitted} />
             </Fragment>
           );
         }
@@ -200,11 +186,11 @@ function Content({
         nRepeats = 0;
       }
 
-      if (frameIndex !== firstFrameOmitted) {
+      if (frameIndex !== data.framesOmitted?.[0]) {
         return null;
       }
 
-      return renderOmittedFrames(firstFrameOmitted, lastFrameOmitted);
+      return <OmittedFrames key={frameIndex} omittedFrames={data.framesOmitted} />;
     })
     .filter((frame): frame is React.ReactElement => !!frame);
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
-import StacktracePlatformIcon from 'sentry/components/events/interfaces/crashContent/stackTrace/platformIcon';
 import NativeFrame from 'sentry/components/events/interfaces/nativeFrame';
 import {
   findImageForAddress,
@@ -12,12 +11,14 @@ import {
   stackTracePlatformIcon,
 } from 'sentry/components/events/interfaces/utils';
 import Panel from 'sentry/components/panels/panel';
-import {t} from 'sentry/locale';
 import type {Event, Frame} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {PlatformKey} from 'sentry/types/project';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
+
+import {OmittedFrames} from './omittedFrames';
+import StacktracePlatformIcon from './platformIcon';
 
 function isFrameUsedForGrouping(
   frame: Frame,
@@ -30,14 +31,6 @@ function isFrameUsedForGrouping(
   }
 
   return minGroupingLevel <= groupingCurrentLevel;
-}
-
-function renderOmittedFrames(firstFrameOmitted: boolean, lastFrameOmitted: boolean) {
-  return t(
-    'Frames %d until %d were omitted and not available.',
-    firstFrameOmitted,
-    lastFrameOmitted
-  );
 }
 
 type Props = {
@@ -129,8 +122,6 @@ export function NativeContent({
     }));
   };
 
-  const firstFrameOmitted = data.framesOmitted?.[0] ?? null;
-  const lastFrameOmitted = data.framesOmitted?.[1] ?? null;
   const lastFrameIndex = getLastFrameIndex(frames);
   const frameCountMap = getInitialFrameCounts();
   const hiddenFrameIndices: number[] = getHiddenFrameIndices({
@@ -206,11 +197,11 @@ export function NativeContent({
           registersMeta: meta?.registers,
         };
 
-        if (frameIndex === firstFrameOmitted) {
+        if (frameIndex === data.framesOmitted?.[0]) {
           return (
             <Fragment key={frameIndex}>
               <NativeFrame {...frameProps} />
-              {renderOmittedFrames(firstFrameOmitted, lastFrameOmitted)}
+              <OmittedFrames omittedFrames={data.framesOmitted} />
             </Fragment>
           );
         }
@@ -218,11 +209,11 @@ export function NativeContent({
         return <NativeFrame key={frameIndex} {...frameProps} />;
       }
 
-      if (frameIndex !== firstFrameOmitted) {
+      if (frameIndex !== data.framesOmitted?.[0]) {
         return null;
       }
 
-      return renderOmittedFrames(firstFrameOmitted, lastFrameOmitted);
+      return <OmittedFrames key={frameIndex} omittedFrames={data.framesOmitted} />;
     })
     .filter((frame): frame is React.ReactElement => !!frame);
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/omittedFrames.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/omittedFrames.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {StacktraceType} from 'sentry/types/stacktrace';
+
+export function OmittedFrames({
+  omittedFrames,
+}: {
+  omittedFrames: StacktraceType['framesOmitted'];
+}) {
+  if (!omittedFrames) {
+    return null;
+  }
+
+  const [start, end] = omittedFrames;
+  return (
+    <FramesOmittedListItem>
+      {t('Frames %d to %d were omitted and not available.', start, end)}
+    </FramesOmittedListItem>
+  );
+}
+
+const FramesOmittedListItem = styled('li')`
+  color: #493e54;
+  font-size: 14px;
+  font-weight: ${p => p.theme.fontWeightBold};
+  border-left: 2px solid ${p => p.theme.red300};
+  border-top: 1px solid ${p => p.theme.border};
+  background: ${p => p.theme.red100};
+  padding: ${space(1)} ${space(2)};
+`;

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -66,7 +66,7 @@ describe('StackTracePreview', () => {
       stacktrace: {
         hasSystemFrames: false,
         registers: {},
-        framesOmitted: 0,
+        framesOmitted: null,
         frames: [frame],
       },
       mechanism: null,

--- a/static/app/types/stacktrace.tsx
+++ b/static/app/types/stacktrace.tsx
@@ -12,7 +12,10 @@ export enum StackType {
 }
 
 export interface StacktraceType {
-  framesOmitted: any;
+  /**
+   * Omitted segment of frames (start, end)
+   */
+  framesOmitted: [start: number, end: number] | null;
   hasSystemFrames: boolean;
   registers: Record<string, string | null> | null;
   frames?: Frame[];

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -141,7 +141,7 @@ describe('Quick Context Content: Event ID Column', function () {
       stacktrace: {
         hasSystemFrames: false,
         registers: {},
-        framesOmitted: 0,
+        framesOmitted: null,
         frames: [frame],
       },
       mechanism: null,

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -202,20 +202,6 @@ div.traceback > ul {
 * ============================================================================
 */
 
-.frames-omitted,
-.exc-omitted {
-  color: @gray-dark;
-  font-size: 14px;
-  font-weight: 600;
-  border-left: 3px solid @red;
-  border-right: 1px solid lighten(@red, 30%);
-  background: lighten(@red, 35%);
-  padding: 10px 20px;
-  margin-bottom: 10px !important;
-  margin-left: -21px;
-  margin-right: -21px;
-}
-
 .exception {
   margin: 0 0 20px;
 


### PR DESCRIPTION
before - nonnative

![image](https://github.com/user-attachments/assets/041c3fb3-fcab-42f1-bb20-c205e052512d)


after - nonnative

![image](https://github.com/user-attachments/assets/1d93524d-195f-48e3-8c86-e57303f4768b)

before - native
![image](https://github.com/user-attachments/assets/b1390c35-1405-4d7e-9c70-5281c55ace52)


after - native
![image](https://github.com/user-attachments/assets/754788ee-06af-4b20-98e2-35e8a9e767b6)
