### PR TITLE
feat(dashboards): Add `onDownplay` handling to `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -36,6 +36,7 @@ import type {
   EChartChartReadyHandler,
   EChartClickHandler,
   EChartDataZoomHandler,
+  EChartDownplayHandler,
   EChartEventHandler,
   EChartFinishedHandler,
   EChartHighlightHandler,
@@ -209,6 +210,7 @@ export interface BaseChartProps {
   onChartReady?: EChartChartReadyHandler;
   onClick?: EChartClickHandler;
   onDataZoom?: EChartDataZoomHandler;
+  onDownplay?: EChartDownplayHandler;
   onFinished?: EChartFinishedHandler;
   onHighlight?: EChartHighlightHandler;
   onLegendSelectChanged?: EChartEventHandler<{
@@ -358,6 +360,7 @@ function BaseChart({
   onClick,
   onLegendSelectChanged,
   onHighlight,
+  onDownplay,
   onMouseOut,
   onMouseOver,
   onDataZoom,
@@ -616,6 +619,7 @@ function BaseChart({
         },
 
         highlight: (props: any, instance: ECharts) => onHighlight?.(props, instance),
+        downplay: (props: any, instance: ECharts) => onDownplay?.(props, instance),
         mouseout: (props: any, instance: ECharts) => onMouseOut?.(props, instance),
         mouseover: (props: any, instance: ECharts) => onMouseOver?.(props, instance),
         datazoom: (props: any, instance: ECharts) => onDataZoom?.(props, instance),
@@ -635,6 +639,7 @@ function BaseChart({
     [
       onClick,
       onHighlight,
+      onDownplay,
       onLegendSelectChanged,
       onMouseOut,
       onMouseOver,

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -64,6 +64,21 @@ export interface EChartsHighlightEventParam {
 
 export type EChartHighlightHandler = EChartEventHandler<EChartsHighlightEventParam>;
 
+export interface EChartsDownplayEventParam {
+  type: 'downplay';
+  batch?: Array<{
+    dataIndex: number;
+    dataIndexInside: number;
+    escapeConnect: boolean;
+    notBlur: boolean;
+    seriesIndex: number;
+    type: string;
+  }>;
+  name?: string;
+}
+
+export type EChartDownplayHandler = EChartEventHandler<EChartsHighlightEventParam>;
+
 /**
  * XXX: These are incomplete types and can also vary depending on the component type
  *

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -62,6 +62,10 @@ export interface Plottable {
    */
   onClick?: (dataIndex: number) => void;
   /**
+   * `TimeSeriesWidgetVisualization` will call this function if the user moves the highlighting (via mouse, or imperatively) from one point to another point on a series that originated from this plottable.
+   */
+  onDownplay?: (dataIndex: number) => void;
+  /**
    * `TimeSeriesWidgetVisualization` will call this function if the user highlights (via mouse, or imperatively) a point on a series that originated from this plottable.
    */
   onHighlight?: (dataIndex: number) => void;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -96,9 +96,7 @@ export class Samples implements Plottable {
     this.chartRef = chartRef;
   }
 
-  highlight(sample: TabularRow | undefined) {
-    const {config} = this;
-
+  highlight(sample: TabularRow) {
     if (!this.chartRef) {
       warn('`Samples.highlight` invoked before chart ref is ready');
       return;
@@ -111,8 +109,6 @@ export class Samples implements Plottable {
       const dataIndex = this.sampleTableData.data.indexOf(sample);
       chart.dispatchAction({type: 'highlight', seriesName, dataIndex});
       config.onHighlight?.(sample);
-    } else {
-      chart.dispatchAction({type: 'downplay', seriesName});
     }
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -54,6 +54,10 @@ export type SamplesConfig = {
    */
   onClick?: (datum: ValidSampleRow) => void;
   /**
+   * Callback for ECharts' `onDownplay`. Called with the sample that corresponds to the downplayed sample in the chart.
+   */
+  onDownplay?: (datum: ValidSampleRow) => void;
+  /**
    * Callback for ECharts' `onHighlight`. Called with the sample that corresponds to the highlighted sample in the chart.
    */
   onHighlight?: (datum: ValidSampleRow) => void;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -50,11 +50,11 @@ export type SamplesConfig = {
    */
   baselineValue?: number;
   /**
-   * Callback for ECharts' `onClick` mouse event. Called with the sample that corresponds to the highlighted sample in the chart
+   * Callback for ECharts' `onClick` mouse event. Called with the sample that corresponds to the clicked sample in the chart
    */
   onClick?: (datum: ValidSampleRow) => void;
   /**
-   * Callback for ECharts' `onHighlight`. Called with the sample that corresponds to the clicked sample in the chart
+   * Callback for ECharts' `onHighlight`. Called with the sample that corresponds to the highlighted sample in the chart.
    */
   onHighlight?: (datum: ValidSampleRow) => void;
 };

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -108,7 +108,21 @@ export class Samples implements Plottable {
     if (sample && isValidSampleRow(sample)) {
       const dataIndex = this.sampleTableData.data.indexOf(sample);
       chart.dispatchAction({type: 'highlight', seriesName, dataIndex});
-      config.onHighlight?.(sample);
+    }
+  }
+
+  downplay(sample: TabularRow) {
+    if (!this.chartRef) {
+      warn('`Samples.downplay` invoked before chart ref is ready');
+      return;
+    }
+
+    const chart = this.chartRef.getEchartsInstance();
+    const seriesName = this.name;
+
+    if (sample && isValidSampleRow(sample)) {
+      const dataIndex = this.sampleTableData.data.indexOf(sample);
+      chart.dispatchAction({type: 'downplay', seriesName, dataIndex});
     }
   }
 
@@ -221,6 +235,15 @@ export class Samples implements Plottable {
     const sample = this.#getSampleByIndex(dataIndex);
     if (sample) {
       config.onHighlight?.(sample);
+    }
+  }
+
+  onDownplay(dataIndex: number): void {
+    const {config} = this;
+
+    const sample = this.#getSampleByIndex(dataIndex);
+    if (sample) {
+      config.onDownplay?.(sample);
     }
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -601,6 +601,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
   });
 
   story('Highlighting', () => {
+    const [legendSelection, setLegendSelection] = useState<LegendSelection>({});
     const [sampleId, setSampleId] = useState<string>();
 
     const aggregatePlottable = new Line(shiftTimeSeriesToNow(sampleDurationTimeSeries), {
@@ -668,6 +669,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
 
         <MediumWidget>
           <TimeSeriesWidgetVisualization
+            legendSelection={legendSelection}
+            onLegendSelectionChange={setLegendSelection}
             plottables={[aggregatePlottable, samplesPlottable]}
           />
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -639,9 +639,10 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           first way is to pass the <code>onHighlight</code> configuration option to your
           plottable. All plottables support this configuration option. It's a callback,
           called whenever a data point is highlighted by bringing the X axis cursor near
-          its timestamp. The second way is to manually cause highlighting on your
-          plottables by calling the <code>highlight</code> method of the plottable
-          instance. Note: only <code>Samples</code> supports this right now.
+          its timestamp. There is also a corresponding <code>onDownplay</code> option. The
+          second way is to manually cause highlighting on your plottables by calling the{' '}
+          <code>highlight</code> method of the plottable instance. Note: only{' '}
+          <code>Samples</code> supports this right now.
         </p>
 
         <p>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -23,6 +23,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type {
   EChartClickHandler,
   EChartDataZoomHandler,
+  EChartDownplayHandler,
   EChartHighlightHandler,
   ReactEchartsRef,
 } from 'sentry/types/echarts';
@@ -539,6 +540,14 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     }
   };
 
+  const handleDownplay: EChartDownplayHandler = event => {
+    // Unlike click events, downplays happen to potentially more than one
+    // series at a time. We have to iterate each item in the batch
+    for (const batch of event.batch ?? []) {
+      runHandler(batch, 'onDownplay');
+    }
+  };
+
   return (
     <BaseChart
       ref={mergeRefs(props.ref, chartRef, handleChartRef)}
@@ -611,6 +620,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       period={period}
       utc={utc ?? undefined}
       onHighlight={handleHighlight}
+      onDownplay={handleDownplay}
       onClick={handleClick}
     />
   );

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -523,9 +523,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       return;
     }
 
-    const handler = affectedPlottable[handlerName];
-
-    handler(getPlottableEventDataIndex(allSeries, batch, affectedRange));
+    affectedPlottable[handlerName](
+      getPlottableEventDataIndex(allSeries, batch, affectedRange)
+    );
   };
 
   const handleClick: EChartClickHandler = event => {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -544,7 +544,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     // Unlike click events, downplays happen to potentially more than one
     // series at a time. We have to iterate each item in the batch
     for (const batch of event.batch ?? []) {
-      runHandler(batch, 'onDownplay');
+      // Downplay events sometimes trigger for the entire series. We are ignoring these. It's not clear why or when they are called, but they appear to be redudant.
+      if (defined(batch.dataIndex) && defined(batch.seriesIndex)) {
+        runHandler(batch, 'onDownplay');
+      }
     }
   };
 


### PR DESCRIPTION
Improves highlight handling by splitting up the functionality and making it more granular. Separate `onHighlight` and `onDownplay` events, and separate dispatching of `highlight` and `downplay` to the plottable. This is more complicated, but it solves a lot of problems caused by the events being tied together in confusing ways. This makes it possible to avoid render loops, and to more granularly control highlighting even if multiple data points are being highlighted at once.

## Changes

- `onDownplay` event added to `BaseChart`
- `Samples` plottable separates `onHighlight` and `onDownplay`. Downplaying is now an explicit action. This makes it possible to highlight multiple samples (e.g., if they have the same timestamp). Caveat: calling `.highlight` no longer called `onHighlight`. This prevents unnecessary renders
- update the story with better state synchronization

Closes [DAIN-197: Add `onDownplay` handling to `Plottable`](https://linear.app/getsentry/issue/DAIN-197/add-ondownplay-handling-to-plottable)