### PR TITLE
chore(aci): cache last processed project in redis in issue alert migration

### DIFF
--- a/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
@@ -2240,7 +2240,7 @@ def migrate_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) ->
     ):
         migrate_projects_issue_alerts(projects)
         # Update the progress in Redis
-        redis_client.set(backfill_key, projects[-1])
+        redis_client.set(backfill_key, projects[-1], ex=60 * 60 * 24 * 7)
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
@@ -2240,7 +2240,7 @@ def migrate_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) ->
     ):
         migrate_projects_issue_alerts(projects)
         # Update the progress in Redis
-        redis_client.set(backfill_key, projects[-1].id)
+        redis_client.set(backfill_key, projects[-1])
 
 
 class Migration(CheckedMigration):

--- a/tests/sentry/workflow_engine/migrations/test_0047_migrate_issue_alerts.py
+++ b/tests/sentry/workflow_engine/migrations/test_0047_migrate_issue_alerts.py
@@ -251,10 +251,14 @@ class TestMigrateIssueAlerts(TestMigrations):
         self._test_run__none_matches()
         self._test_run__disabled_rule()
         self._test_run__snoozed_rule()
+
+    def test_2(self):
         self._test_run__snoozed_rule_for_user()
         self._test_run__skip_invalid_conditions()
         self._test_run__skip_migration_if_no_valid_conditions()
         self._test_run__no_double_migrate()
+
+    def test_3(self):
         self._test_run__detector_exists()
         self._test_run__every_event_condition()
         self._test_run__invalid_action()


### PR DESCRIPTION
Make the migration able to pick up where it left off if it takes a long time + is interrupted. Cache the last `project_id` it processed in Redis.