### PR TITLE
feat(replays): Cache selector responses for 15 minutes

### DIFF
--- a/src/sentry/replays/date.py
+++ b/src/sentry/replays/date.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+
+def round_date_to_minute_interval(date: datetime, interval: int) -> datetime:
+    """
+    Round date to the nearest minute interval.
+
+    This function always rounds dates down. It never queries for dates in the future.
+    """
+    assert interval > 0, interval
+    assert interval < 60, interval
+
+    # Bucket the minute by dividing and rounding down. If given "15" as the interval four possible
+    # buckets will be produced: 0, 1, 2, and 3.
+    minute_bucket = date.minute // interval
+
+    # After finding the bucket we multiply by the interval to get a minute value. If the interval
+    # was 15 0 becomes 0, 1 becomes 15, and so on. Crucially because we're rounding down we will
+    # never exceed minute 45. Producing a minute value of 60 or over would raise an exception. If
+    # we had rounded up then we would need to incremen the hour, day, month, year, etc. which
+    # becomes a significantly more complex (but doable) operation.
+    minute = minute_bucket * interval
+
+    return date.replace(minute=minute, second=0, microsecond=0)

--- a/tests/sentry/replays/test_organization_selector_index.py
+++ b/tests/sentry/replays/test_organization_selector_index.py
@@ -39,8 +39,8 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
         project = self.create_project(teams=[self.team])
 
         replay_id = uuid.uuid4().hex
-        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
-        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(minutes=15, seconds=22)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(minutes=15, seconds=5)
         self.store_replays(mock_replay(seq1_timestamp, project.id, replay_id))
         self.store_replays(mock_replay(seq2_timestamp, project.id, replay_id))
         self.store_replays(
@@ -112,8 +112,8 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
     def test_get_replays_filter_clicks(self):
         """Test replays conform to the interchange format."""
         replay_id = uuid.uuid4().hex
-        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
-        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(minutes=15, seconds=22)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(minutes=15, seconds=5)
 
         self.store_replays(mock_replay(seq1_timestamp, self.project.id, replay_id))
         self.store_replays(
@@ -174,9 +174,9 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
 
     def test_get_click_filter_environment(self):
         """Test that clicks can be filtered by environment."""
-        prod_env = self.create_environment(name="prod", project=self.project)
-        dev_env = self.create_environment(name="dev", project=self.project)
-        staging_env = self.create_environment(name="staging", project=self.project)
+        self.create_environment(name="prod", project=self.project)
+        self.create_environment(name="dev", project=self.project)
+        self.create_environment(name="staging", project=self.project)
 
         timestamp = datetime.datetime.now() - datetime.timedelta(hours=1)
         replay_id_prod = uuid.uuid4().hex
@@ -184,14 +184,14 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
         replay_id_staging = uuid.uuid4().hex
 
         self.store_replays(
-            mock_replay(timestamp, self.project.id, replay_id_prod, environment=prod_env.name)
+            mock_replay(timestamp, self.project.id, replay_id_prod, environment="prod")
         )
         self.store_replays(
             mock_replay_click(
                 timestamp,
                 self.project.id,
                 replay_id_prod,
-                environment=prod_env.name,
+                environment="prod",
                 node_id=1,
                 tag="div",
                 id="myid",
@@ -202,14 +202,14 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
         )
 
         self.store_replays(
-            mock_replay(timestamp, self.project.id, replay_id_dev, environment=dev_env.name)
+            mock_replay(timestamp, self.project.id, replay_id_dev, environment="dev")
         )
         self.store_replays(
             mock_replay_click(
                 timestamp,
                 self.project.id,
                 replay_id_dev,
-                environment=dev_env.name,
+                environment="dev",
                 node_id=1,
                 tag="div",
                 id="myid",
@@ -220,14 +220,14 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
         )
 
         self.store_replays(
-            mock_replay(timestamp, self.project.id, replay_id_staging, environment=staging_env.name)
+            mock_replay(timestamp, self.project.id, replay_id_staging, environment="staging")
         )
         self.store_replays(
             mock_replay_click(
                 timestamp,
                 self.project.id,
                 replay_id_staging,
-                environment=staging_env.name,
+                environment="staging",
                 node_id=1,
                 tag="div",
                 id="myid",
@@ -239,7 +239,7 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
 
         with self.feature(REPLAYS_FEATURES):
             # Test single environment
-            response = self.client.get(self.url + f"?environment={prod_env.name}")
+            response = self.client.get(self.url + "?environment=prod")
             assert response.status_code == 200
             response_data = response.json()
             assert len(response_data["data"]) == 1
@@ -247,9 +247,7 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert response_data["data"][0]["count_rage_clicks"] == 0
 
             # Test multiple environments
-            response = self.client.get(
-                self.url + f"?environment={prod_env.name}&environment={dev_env.name}"
-            )
+            response = self.client.get(self.url + "?environment=prod&environment=dev")
             assert response.status_code == 200
             response_data = response.json()
             assert len(response_data["data"]) == 1


### PR DESCRIPTION
The dead and rage click aggregations don't materially change over small intervals.  To the extent that they do perfect accuracy isn't required.  We expect a ranking with a relatively accurate count.  Refreshing every 15 minutes shouldn't be a big deal.

This will give us:
- Higher performance
- Less load on our ClickHouse cluster.