### PR TITLE
fix(replay): fix mobile replay issue preview no height

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -136,6 +136,7 @@ export default function ReplayClipPreviewPlayer({
         />
       ) : (
         <ReplayPreviewPlayer
+          errorBeforeReplayStart={replayReaderResult.replay.getErrorBeforeReplayStart()}
           replayId={replayReaderResult.replayId}
           fullReplayButtonProps={fullReplayButtonProps}
           replayRecord={replayReaderResult.replayRecord}

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -2,6 +2,7 @@ import type {ComponentProps} from 'react';
 import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Button, LinkButton, type LinkButtonProps} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -32,6 +33,7 @@ import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 export default function ReplayPreviewPlayer({
+  errorBeforeReplayStart,
   replayId,
   fullReplayButtonProps,
   replayRecord,
@@ -41,6 +43,7 @@ export default function ReplayPreviewPlayer({
   showNextAndPrevious,
   playPausePriority,
 }: {
+  errorBeforeReplayStart: boolean;
   replayId: string;
   replayRecord: ReplayRecord;
   fullReplayButtonProps?: Partial<Omit<LinkButtonProps, 'external'>>;
@@ -77,6 +80,13 @@ export default function ReplayPreviewPlayer({
 
   return (
     <PlayerPanel>
+      {errorBeforeReplayStart && (
+        <StyledAlert type="warning">
+          {t(
+            'For this event, the replay recording started after the error happened, so the replay below shows the user experience after the error.'
+          )}
+        </StyledAlert>
+      )}
       <HeaderWrapper>
         <StyledReplayCell
           key="session"
@@ -237,4 +247,8 @@ const HeaderWrapper = styled('div')`
   justify-content: space-between;
   align-items: center;
   margin-bottom: ${space(1)};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: ${space(1)} 0;
 `;

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -306,9 +306,10 @@ export default class ReplayReader {
     const replayEnd = this._replayRecord.finished_at.getTime();
 
     // error event is before the replay started. use the start of the replay as the start of the clip
+    // set the clip to be at most 10 seconds long
     if (clipWindow.startTimestampMs < this._replayRecord.started_at.getTime()) {
       clipStartTimestampMs = replayStart;
-      clipEndTimestampMs = Math.min(replayStart + 5000, replayEnd);
+      clipEndTimestampMs = Math.min(replayStart + 10 * 1000, replayEnd);
     } else {
       clipStartTimestampMs = clamp(clipWindow.startTimestampMs, replayStart, replayEnd);
       clipEndTimestampMs = clamp(

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -298,6 +298,7 @@ export default class ReplayReader {
   private _startOffsetMs = 0;
   private _videoEvents: VideoEvent[] = [];
   private _clipWindow: ClipWindow | undefined = undefined;
+  private _errorBeforeReplayStart = false;
 
   private _applyClipWindow = (clipWindow: ClipWindow) => {
     let clipStartTimestampMs;
@@ -310,6 +311,7 @@ export default class ReplayReader {
     if (clipWindow.startTimestampMs < this._replayRecord.started_at.getTime()) {
       clipStartTimestampMs = replayStart;
       clipEndTimestampMs = Math.min(replayStart + 10 * 1000, replayEnd);
+      this._errorBeforeReplayStart = true;
     } else {
       clipStartTimestampMs = clamp(clipWindow.startTimestampMs, replayStart, replayEnd);
       clipEndTimestampMs = clamp(
@@ -457,6 +459,8 @@ export default class ReplayReader {
   getDurationMs = () => {
     return this._duration.asMilliseconds();
   };
+
+  getErrorBeforeReplayStart = () => this._errorBeforeReplayStart;
 
   getStartOffsetMs = () => this._startOffsetMs;
 

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -460,6 +460,9 @@ export default class ReplayReader {
     return this._duration.asMilliseconds();
   };
 
+  /**
+   * @returns Whether the error happened before the replay started
+   */
   getErrorBeforeReplayStart = () => this._errorBeforeReplayStart;
 
   getStartOffsetMs = () => this._startOffsetMs;


### PR DESCRIPTION
this no height bug was happening on issue details in the replay preview:

<img width="809" alt="SCR-20250414-mjwb" src="https://github.com/user-attachments/assets/01482dc3-fb83-498c-a2d5-383e129ac390" />


what was happening: 

1. the error happened before the replay started recording
2. the clip window is then outside the range of the replay timestamps (the entire clip window is before the replay event starts): https://github.com/getsentry/sentry/blob/affc8f2758cbf3df3492b62d81b3f85ea2a28405/static/app/components/events/eventReplay/replayClipSection.tsx#L44-L47
https://github.com/getsentry/sentry/blob/affc8f2758cbf3df3492b62d81b3f85ea2a28405/static/app/components/events/eventReplay/replayClipPreview.tsx#L28-L34
4. in `replayReader`, we know there's a clip window that needs to be applied. when we applied the clip window before, the clamp got messed up because the clip window was outside the range of the replay timestamp --> clip end + start became the same number, leading the clip duration to become 0. this sets the `replay.duration` to be 0.

example with old clamp logic:
```
    // imagine clipWindow is [3, 8] and replay timestamp is [10, 20]

    const clipStartTimestampMs = clamp(
      clipWindow.startTimestampMs,                       // 3
      this._replayRecord.started_at.getTime(),           // 10
      this._replayRecord.finished_at.getTime()           // 20
    ); 
    // this becomes 10

    const clipEndTimestampMs = clamp(
      clipWindow.endTimestampMs,                       // 8
      clipStartTimestampMs,                            // 10
      this._replayRecord.finished_at.getTime()         // 20
    ); 
    // this is also 10

    // this is 0
    this._duration = duration(clipEndTimestampMs - clipStartTimestampMs); 
```

6. causing this code to be executed: https://github.com/getsentry/sentry/blob/affc8f2758cbf3df3492b62d81b3f85ea2a28405/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx#L118-L129
something went wrong here, which led to a replay preview with no height.

the solution i'm suggesting here is: 
- if the error happens before the replay starts recording, then just show the first 10 seconds of the replay. 
- add a note that the error happened before the replay for more clarity. 


after:

<img width="783" alt="SCR-20250414-mwkj" src="https://github.com/user-attachments/assets/46ba697d-cdd3-4797-bc9d-d4b84d4a8c1e" />


fixes https://github.com/getsentry/sentry/issues/87139