### PR TITLE
ref(shared-views): Don't show ellipsis menu and remove editable view title in nav (with sharing enabled) 

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -81,7 +81,7 @@ export function IssueViewsTable({
             <SavedEntityTable.CellQuery query={view.query} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTimeSince date={view.lastVisited ?? null} />
+            <SavedEntityTable.CellTimeSince date={view.lastVisited} />
           </SavedEntityTable.Cell>
         </SavedEntityTable.Row>
       ))}

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsTable.tsx
@@ -81,7 +81,7 @@ export function IssueViewsTable({
             <SavedEntityTable.CellQuery query={view.query} />
           </SavedEntityTable.Cell>
           <SavedEntityTable.Cell>
-            <SavedEntityTable.CellTimeSince date={view.lastVisited} />
+            <SavedEntityTable.CellTimeSince date={view.lastVisited ?? null} />
           </SavedEntityTable.Cell>
         </SavedEntityTable.Row>
       ))}

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -72,14 +72,15 @@ export function IssueViewNavItemContent({
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const {projects} = useProjects();
+
+  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
 
   const controls = useDragControls();
 
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
   const {hasUnsavedChanges, changedParams} = useIssueViewUnsavedChanges();
-
-  const {projects} = useProjects();
 
   useEffect(() => {
     if (isActive) {
@@ -163,12 +164,14 @@ export function IssueViewNavItemContent({
             }}
           >
             <IssueViewNavQueryCount view={view} isActive={isActive} />
-            <IssueViewNavEllipsisMenu
-              isLastView={isLastView}
-              setIsEditing={setIsEditing}
-              view={view}
-              sectionRef={sectionRef}
-            />
+            {!hasIssueViewSharing && (
+              <IssueViewNavEllipsisMenu
+                isLastView={isLastView}
+                setIsEditing={setIsEditing}
+                view={view}
+                sectionRef={sectionRef}
+              />
+            )}
           </TrailingItemsWrapper>
         }
         onPointerDown={e => {
@@ -185,14 +188,19 @@ export function IssueViewNavItemContent({
           }
         }}
         analyticsItemName="issues_view_starred"
+        hasIssueViewSharing={hasIssueViewSharing}
       >
-        <IssueViewNavEditableTitle
-          view={view}
-          isEditing={isEditing}
-          setIsEditing={setIsEditing}
-          isDragging={!!isDragging}
-          isActive={isActive}
-        />
+        {hasIssueViewSharing ? (
+          view.label
+        ) : (
+          <IssueViewNavEditableTitle
+            view={view}
+            isEditing={isEditing}
+            setIsEditing={setIsEditing}
+            isDragging={!!isDragging}
+            isActive={isActive}
+          />
+        )}
         {isActive && hasUnsavedChanges && changedParams && (
           <Tooltip
             title={constructUnsavedTooltipTitle(changedParams)}
@@ -261,15 +269,18 @@ const TrailingItemsWrapper = styled('div')`
   margin-right: ${space(0.25)};
 `;
 
-const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
+const StyledSecondaryNavItem = styled(SecondaryNav.Item)<{hasIssueViewSharing: boolean}>`
   position: relative;
   padding-right: ${space(0.5)};
 
   /* Hide the ellipsis menu if the item is not hovered */
   :not(:hover) {
-    [data-ellipsis-menu-trigger]:not([aria-expanded='true']) {
-      ${p => p.theme.visuallyHidden}
-    }
+    ${p =>
+      !p.hasIssueViewSharing &&
+      `
+      [data-ellipsis-menu-trigger]:not([aria-expanded='true']) {
+        ${p.theme.visuallyHidden}
+      }`}
 
     [data-drag-icon] {
       ${p => p.theme.visuallyHidden}
@@ -278,9 +289,14 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
 
   /* Hide the query count if the ellipsis menu is not expanded */
   :hover {
-    [data-issue-view-query-count] {
-      ${p => p.theme.visuallyHidden}
-    }
+    ${p =>
+      !p.hasIssueViewSharing &&
+      `
+      [data-issue-view-query-count] {
+        ${p.theme.visuallyHidden}
+      }
+      `}
+
     [data-project-icon] {
       ${p => p.theme.visuallyHidden}
     }

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, Reorder, useDragControls} from 'framer-motion';
 
@@ -160,7 +161,9 @@ export function IssueViewNavItemContent({
         trailingItems={
           <TrailingItemsWrapper
             onClickCapture={e => {
-              e.preventDefault();
+              if (!hasIssueViewSharing) {
+                e.preventDefault();
+              }
             }}
           >
             <IssueViewNavQueryCount view={view} isActive={isActive} />
@@ -277,10 +280,11 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)<{hasIssueViewSharing: b
   :not(:hover) {
     ${p =>
       !p.hasIssueViewSharing &&
-      `
-      [data-ellipsis-menu-trigger]:not([aria-expanded='true']) {
-        ${p.theme.visuallyHidden}
-      }`}
+      css`
+        [data-ellipsis-menu-trigger]:not([aria-expanded='true']) {
+          ${p.theme.visuallyHidden}
+        }
+      `}
 
     [data-drag-icon] {
       ${p => p.theme.visuallyHidden}
@@ -291,10 +295,10 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)<{hasIssueViewSharing: b
   :hover {
     ${p =>
       !p.hasIssueViewSharing &&
-      `
-      [data-issue-view-query-count] {
-        ${p.theme.visuallyHidden}
-      }
+      css`
+        [data-issue-view-query-count] {
+          ${p.theme.visuallyHidden}
+        }
       `}
 
     [data-project-icon] {


### PR DESCRIPTION
Removes the ellipsis menu and editable tab title in navigation if you have the issue view sharing flag on. 

Needs to be rebased once #89441 is merged