### PR TITLE
chore(dashboards): Remove telemetry for `getIntervalForMetricFunction`

### DIFF
--- a/static/app/views/insights/database/utils/getIntervalForMetricFunction.tsx
+++ b/static/app/views/insights/database/utils/getIntervalForMetricFunction.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import type {DateTimeObject, GranularityLadder} from 'sentry/components/charts/utils';
 import {getDiffInMinutes} from 'sentry/components/charts/utils';
 import {
@@ -17,26 +15,8 @@ export function getIntervalForMetricFunction(
   metricFunction: Aggregate | SpanFunctions | string,
   datetimeObj: DateTimeObject
 ) {
-  const {start, end, period, utc} = datetimeObj;
-
-  const interval = Sentry.startSpan(
-    {
-      op: 'function',
-      name: 'getIntervalForMetricFunction',
-      attributes: {
-        start: start ? start.toString() : undefined,
-        end: end ? end.toString() : undefined,
-        period: period || undefined,
-        utc: utc || undefined,
-      },
-    },
-    () => {
-      const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
-      return ladder.getInterval(getDiffInMinutes(datetimeObj));
-    }
-  );
-
-  return interval;
+  const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
+  return ladder.getInterval(getDiffInMinutes(datetimeObj));
 }
 
 type GranularityLookup = Record<string, GranularityLadder>;


### PR DESCRIPTION
I haven't looked at that span in ages, and it's _very_ high TPM. This would be better as logs, anyway, if we decide to do it again.
