### PR TITLE
ref(insights): remove `useRpc` from `useEapSpans`

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -70,12 +70,11 @@ export const useOurlogs = <Fields extends OurLogFieldKey[]>(
 
 export const useEAPSpans = <Fields extends EAPSpanProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
-  referrer: string,
-  useRpc?: boolean
+  referrer: string
 ) => {
   return useDiscover<Fields, EAPSpanResponse>(
     options,
-    useRpc ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_EAP,
+    DiscoverDatasets.SPANS_EAP_RPC,
     referrer
   );
 };

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -194,8 +194,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
       pageFilters: selection,
       enabled,
     },
-    'api.performance.service-entry-spans-table',
-    true
+    'api.performance.service-entry-spans-table'
   );
 
   const specificSpansQuery = new MutableSearch('');
@@ -222,8 +221,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
       limit: LIMIT,
       enabled: !!categorizedSpanIds && categorizedSpanIds.length > 0,
     },
-    'api.performance.service-entry-spans-table-with-category',
-    true
+    'api.performance.service-entry-spans-table-with-category'
   );
 
   return {

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -136,8 +136,7 @@ function useSingleQuery(options: UseSingleQueryOptions) {
       pageFilters: selection,
       enabled,
     },
-    'api.performance.service-entry-spans-table',
-    true
+    'api.performance.service-entry-spans-table'
   );
 
   return {

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -69,8 +69,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
       fields: ['failure_rate()'],
       pageFilters: selection,
     },
-    REFERRER,
-    true
+    REFERRER
   );
 
   const getFailureRateBadge = () => {


### PR DESCRIPTION
We should only be accessing eap via the RPC. Therefore we shouldn't have a `useRpc` prop in the `useEapSpans`