### PR TITLE
ref: remove reqest.auth management from sentry.middleware.auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ module = [
     "sentry.integrations.vsts.integration",
     "sentry.integrations.vsts.issues",
     "sentry.issues.search",
-    "sentry.middleware.auth",
     "sentry.middleware.ratelimit",
     "sentry.net.http",
     "sentry.net.socket",

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -6,81 +6,52 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
-from rest_framework.authentication import get_authorization_header
-from rest_framework.exceptions import AuthenticationFailed
 
-from sentry.api.authentication import (
-    ApiKeyAuthentication,
-    OrgAuthTokenAuthentication,
-    UserAuthTokenAuthentication,
-)
+from sentry.users.models.user import User
 from sentry.users.models.userip import UserIP
 from sentry.utils.auth import AuthUserPasswordExpired, logger
 
 
-def get_user(request):
-    if not hasattr(request, "_cached_user"):
-        user = auth_get_user(request)
-        # If the user bound to this request matches a real user,
-        # we need to validate the session's nonce. This nonce is
-        # to make sure that the session is valid for effectively the
-        # current "version" of the user. When security related
-        # actions take place, this nonce will rotate causing a
-        # mismatch here forcing the session to be logged out and
-        # requiring re-validation.
-        if user.is_authenticated and not user.is_sentry_app:
-            # We only need to check the nonce if there is a nonce
-            # currently set on the User. By default, the value will
-            # be None until the first action has been taken, at
-            # which point, a nonce will always be required.
-            if user.session_nonce and request.session.get("_nonce", "") != user.session_nonce:
-                # If the nonces don't match, this session is anonymous.
-                logger.info(
-                    "user.auth.invalid-nonce",
-                    extra={
-                        "ip_address": request.META["REMOTE_ADDR"],
-                        "user_id": user.id,
-                    },
-                )
-                user = AnonymousUser()
-            else:
-                UserIP.log(user, request.META["REMOTE_ADDR"])
-        request._cached_user = user
-    return request._cached_user
+def _get_user(request: HttpRequest) -> User | AnonymousUser:
+    user = auth_get_user(request)
+    # If the user bound to this request matches a real user,
+    # we need to validate the session's nonce. This nonce is
+    # to make sure that the session is valid for effectively the
+    # current "version" of the user. When security related
+    # actions take place, this nonce will rotate causing a
+    # mismatch here forcing the session to be logged out and
+    # requiring re-validation.
+    if user.is_authenticated and not user.is_sentry_app:
+        # We only need to check the nonce if there is a nonce
+        # currently set on the User. By default, the value will
+        # be None until the first action has been taken, at
+        # which point, a nonce will always be required.
+        if user.session_nonce and request.session.get("_nonce", "") != user.session_nonce:
+            # If the nonces don't match, this session is anonymous.
+            logger.info(
+                "user.auth.invalid-nonce",
+                extra={
+                    "ip_address": request.META["REMOTE_ADDR"],
+                    "user_id": user.id,
+                },
+            )
+            user = AnonymousUser()
+        else:
+            UserIP.log(user, request.META["REMOTE_ADDR"])
+    return user
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> None:
+        request.auth = None  # request.auth will be set by rest_framework
+
         if request.path.startswith("/api/0/internal/rpc/"):
             # Avoid doing RPC authentication when we're already
             # in an RPC request.
-            request.user, request.auth = AnonymousUser(), None
-            return
-
-        auth = get_authorization_header(request).split()
-
-        if auth:
-            for authenticator_class in (
-                UserAuthTokenAuthentication,
-                OrgAuthTokenAuthentication,
-                ApiKeyAuthentication,
-            ):
-                authenticator = authenticator_class()
-                if not authenticator.accepts_auth(auth):
-                    continue
-                try:
-                    result = authenticator.authenticate(request)
-                except AuthenticationFailed:
-                    result = None
-                if result:
-                    request.user, request.auth = result
-                else:
-                    # default to anonymous user and use IP ratelimit
-                    request.user, request.auth = SimpleLazyObject(lambda: get_user(request)), None
-                return
-
-        # default to anonymous user and use IP ratelimit
-        request.user, request.auth = SimpleLazyObject(lambda: get_user(request)), None
+            request.user = AnonymousUser()
+        else:
+            # default to anonymous user and use IP ratelimit
+            request.user = SimpleLazyObject(lambda: _get_user(request))  # type: ignore[assignment]  # proxy object faking the real one
 
     def process_exception(
         self, request: HttpRequest, exception: Exception

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -22,7 +22,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from rest_framework.request import Request
 
 from sentry import options
 from sentry.api.exceptions import DataSecrecyError
@@ -80,7 +79,7 @@ class ViewSiloLimit(SiloLimit):
         current_mode: SiloMode,
         available_modes: Iterable[SiloMode],
     ) -> Callable[..., Any]:
-        def handle(obj: Any, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        def handle(obj: Any, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
             mode_str = ", ".join(str(m) for m in available_modes)
             message = (
                 f"Received {request.method} request at {request.path!r} to server in "

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -599,7 +599,8 @@ class ClientConfigViewTest(TestCase):
         assert "activeorg" not in self.client.session
 
         # Load client config
-        response = self.client.get(self.path, HTTP_AUTHORIZATION=HTTP_AUTHORIZATION)
+        self.login_as(self.user)
+        response = self.client.get(self.path)
         assert response.status_code == 200
         assert response["Content-Type"] == "application/json"
 


### PR DESCRIPTION
request.auth is a rest_framework thing -- we're doing this work twice for no (?) reason?

<!-- Describe your PR here. -->