### PR TITLE
ref(shared-views): Change owner_id to createdBy, return entire user object

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -6,6 +6,7 @@ from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SORT_LITERALS
+from sentry.users.services.user.service import user_service
 
 
 class GroupSearchViewSerializerResponse(TypedDict):
@@ -48,6 +49,14 @@ class GroupSearchViewSerializer(Serializer):
         )
         last_visited_map = {lv.group_search_view_id: lv for lv in last_visited_views}
 
+        serialized_users = {
+            user["id"]: user
+            for user in user_service.serialize_many(
+                filter={"user_ids": [view.user_id for view in item_list if view.user_id]},
+                as_user=user,
+            )
+        }
+
         for item in item_list:
             last_visited = last_visited_map.get(item.id, None)
             attrs[item] = {}
@@ -55,7 +64,7 @@ class GroupSearchViewSerializer(Serializer):
                 attrs[item]["last_visited"] = last_visited.last_visited
             attrs[item]["starred"] = item.id in user_starred_view_ids
             attrs[item]["stars"] = getattr(item, "popularity", 0)
-
+            attrs[item]["created_by"] = serialized_users.get(str(item.user_id))
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
@@ -71,16 +80,16 @@ class GroupSearchViewSerializer(Serializer):
 
         return {
             "id": str(obj.id),
-            "owner_id": str(obj.user_id),
+            "createdBy": attrs.get("created_by"),
             "name": obj.name,
             "query": obj.query,
             "querySort": obj.query_sort,
             "projects": projects,
             "environments": obj.environments,
             "timeFilters": obj.time_filters,
-            "lastVisited": attrs["last_visited"] if "last_visited" in attrs else None,
-            "starred": attrs["starred"] if attrs else False,
-            "stars": attrs["stars"],
+            "lastVisited": attrs.get("last_visited", None),
+            "starred": attrs.get("starred", False),
+            "stars": attrs.get("stars", 0),
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
         }

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -6,12 +6,13 @@ from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SORT_LITERALS
+from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.services.user.service import user_service
 
 
 class GroupSearchViewSerializerResponse(TypedDict):
     id: str
-    owner_id: str
+    createdBy: UserSerializerResponse
     name: str
     query: str
     querySort: SORT_LITERALS

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -131,18 +131,18 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(self.my_view_2.id)
         assert response.data[0]["name"] == "My View 2"
         assert response.data[0]["stars"] == 1
-        assert response.data[0]["owner_id"] == str(self.user.id)
+        assert response.data[0]["createdBy"]["id"] == str(self.user.id)
         assert response.data[0]["starred"]
         assert response.data[1]["id"] == str(self.my_view_3.id)
         assert response.data[1]["name"] == "My View 3"
         assert response.data[1]["stars"] == 1
-        assert response.data[1]["owner_id"] == str(self.user.id)
+        assert response.data[1]["createdBy"]["id"] == str(self.user.id)
         assert response.data[1]["starred"]
         # View 1 should appear last since it's the only non-starred view
         assert response.data[2]["id"] == str(self.my_view_1.id)
         assert response.data[2]["name"] == "My View 1"
         assert response.data[2]["stars"] == 0
-        assert response.data[2]["owner_id"] == str(self.user.id)
+        assert response.data[2]["createdBy"]["id"] == str(self.user.id)
         assert not response.data[2]["starred"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
@@ -157,13 +157,13 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(self.other_view_2.id)
         assert response.data[0]["name"] == "Other View 2"
         assert response.data[0]["stars"] == 2
-        assert response.data[0]["owner_id"] == str(self.user_2.id)
+        assert response.data[0]["createdBy"]["id"] == str(self.user_2.id)
         assert response.data[0]["starred"]
         # View 1 should appear last since it's not starred
         assert response.data[1]["id"] == str(self.other_view_1.id)
         assert response.data[1]["name"] == "Other View 1"
         assert response.data[1]["stars"] == 0
-        assert response.data[1]["owner_id"] == str(self.user_2.id)
+        assert response.data[1]["createdBy"]["id"] == str(self.user_2.id)
         assert not response.data[1]["starred"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})


### PR DESCRIPTION
1. Changes `owner_id` to `createdBy` (to match dashboards) 
2. Returns the entire user object, rather than just the id. 