### PR TITLE
fix(cp): round to 3 decimal points in stats page if data is sufficiently small

### DIFF
--- a/static/app/views/organizationStats/utils.spec.tsx
+++ b/static/app/views/organizationStats/utils.spec.tsx
@@ -160,6 +160,8 @@ describe('formatUsageWithUnits', function () {
       expect(formatUsageWithUnits(7.6 * hourInMs, dataCategory)).toBe('7.6');
       expect(formatUsageWithUnits(hourInMs, dataCategory)).toBe('1');
       expect(formatUsageWithUnits(24 * hourInMs, dataCategory)).toBe('24');
+      expect(formatUsageWithUnits(0.001 * hourInMs, dataCategory)).toBe('0.001');
+      expect(formatUsageWithUnits(0.011 * hourInMs, dataCategory)).toBe('0.01');
     });
   });
 

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -53,8 +53,9 @@ export function formatUsageWithUnits(
     Number.isFinite(usageQuantity)
   ) {
     // Profile duration is in milliseconds, convert to hours
-    return (usageQuantity / 1000 / 60 / 60).toLocaleString(undefined, {
-      maximumFractionDigits: 2,
+    const hours = usageQuantity / 1000 / 60 / 60;
+    return hours.toLocaleString(undefined, {
+      maximumFractionDigits: hours < 0.01 ? 3 : 2,
     });
   }
 


### PR DESCRIPTION
Adds third decimal if hours are less than `0.01` otherwise keep rounding with 2 decimals. (0.001 hours is 3.6 seconds so 3 decimals places should be granular enough for real use cases)

### before
<img width="1238" alt="Screenshot 2025-04-14 at 2 55 27 PM" src="https://github.com/user-attachments/assets/e02869ea-3a35-4561-9cb4-26ef77357abe" />


### after
<img width="1236" alt="Screenshot 2025-04-14 at 2 50 25 PM" src="https://github.com/user-attachments/assets/c9e69c26-199a-49b5-980b-76d41c036799" />
