### PR TITLE
feat(explore): Add support for count_unique in eap

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -829,6 +829,7 @@ export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanIndexedField[] = [
 
 export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
+  AggregationKey.COUNT_UNIQUE,
   AggregationKey.AVG,
   AggregationKey.P50,
   AggregationKey.P75,

--- a/static/app/views/alerts/rules/metric/eapField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.spec.tsx
@@ -100,7 +100,7 @@ describe('EAPField', () => {
     expect(screen.getByText('spans')).toBeInTheDocument();
   });
 
-  it('defaults count_unique argument to user', async function () {
+  it('defaults count_unique argument to span.op', async function () {
     function Component() {
       const [aggregate, setAggregate] = useState('count(span.duration)');
       return (

--- a/static/app/views/alerts/rules/metric/eapField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.spec.tsx
@@ -82,18 +82,6 @@ describe('EAPField', () => {
     }
 
     render(<Component />);
-    expect(fieldsMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/spans/fields/`,
-      expect.objectContaining({
-        query: expect.objectContaining({type: 'number'}),
-      })
-    );
-    expect(fieldsMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/spans/fields/`,
-      expect.objectContaining({
-        query: expect.objectContaining({type: 'string'}),
-      })
-    );
 
     // switch from count(spans) -> max(span.duration)
     await userEvent.click(screen.getByText('count'));
@@ -110,5 +98,38 @@ describe('EAPField', () => {
     await userEvent.click(await screen.findByText('count'));
     expect(screen.getByText('count')).toBeInTheDocument();
     expect(screen.getByText('spans')).toBeInTheDocument();
+  });
+
+  it('defaults count_unique argument to user', async function () {
+    function Component() {
+      const [aggregate, setAggregate] = useState('count(span.duration)');
+      return (
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <EAPField aggregate={aggregate} onChange={setAggregate} />
+        </SpanTagsProvider>
+      );
+    }
+
+    render(<Component />);
+
+    // switch from count(spans) -> count_unique(span.op)
+    await userEvent.click(screen.getByText('count'));
+    await userEvent.click(await screen.findByText('count_unique'));
+    expect(screen.getByText('count_unique')).toBeInTheDocument();
+    expect(screen.getByText('span.op')).toBeInTheDocument();
+
+    // switch from count_unique(span.op) -> avg(span.self_time)
+    await userEvent.click(screen.getByText('count_unique'));
+    await userEvent.click(await screen.findByText('avg'));
+    await userEvent.click(screen.getByText('span.duration'));
+    await userEvent.click(await screen.findByText('span.self_time'));
+    expect(screen.getByText('avg')).toBeInTheDocument();
+    expect(screen.getByText('span.self_time')).toBeInTheDocument();
+
+    // switch from avg(span.self_time) -> count_unique(span.op)
+    await userEvent.click(screen.getByText('avg'));
+    await userEvent.click(await screen.findByText('count_unique'));
+    expect(screen.getByText('count_unique')).toBeInTheDocument();
+    expect(screen.getByText('span.op')).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -7,16 +7,17 @@ import {space} from 'sentry/styles/space';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {parseFunction, prettifyTagKey} from 'sentry/utils/discover/fields';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {AggregationKey, ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {
   DEFAULT_VISUALIZATION,
-  DEFAULT_VISUALIZATION_AGGREGATE,
   DEFAULT_VISUALIZATION_FIELD,
+  updateVisualizeAggregate,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
+export const DEFAULT_EAP_AGGREGATION = 'count';
 export const DEFAULT_EAP_FIELD = 'span.duration';
-export const DEFAULT_EAP_METRICS_ALERT_FIELD = `count(${DEFAULT_EAP_FIELD})`;
+export const DEFAULT_EAP_METRICS_ALERT_FIELD = `${DEFAULT_EAP_AGGREGATION}(${DEFAULT_EAP_FIELD})`;
 
 interface Props {
   aggregate: string;
@@ -48,7 +49,10 @@ function EAPField({aggregate, onChange}: Props) {
   // compatibility, we don't want to lock down all `count` queries immediately.
   const lockOptions = aggregate === DEFAULT_VISUALIZATION;
 
-  const {tags: storedTags} = useSpanTags('number');
+  const {tags: storedStringTags} = useSpanTags('string');
+  const {tags: storedNumberTags} = useSpanTags('number');
+  const storedTags =
+    aggregation === AggregationKey.COUNT_UNIQUE ? storedStringTags : storedNumberTags;
   const numberTags: TagCollection = useMemo(() => {
     const availableTags: TagCollection = storedTags;
     if (field && !defined(storedTags[field])) {
@@ -84,13 +88,14 @@ function EAPField({aggregate, onChange}: Props) {
 
   const handleOperationChange = useCallback(
     (option: any) => {
-      const newAggregate =
-        option.value === DEFAULT_VISUALIZATION_AGGREGATE
-          ? DEFAULT_VISUALIZATION
-          : `${option.value}(${field || DEFAULT_EAP_FIELD})`;
+      const newAggregate = updateVisualizeAggregate({
+        newAggregate: option.value,
+        oldAggregate: aggregation || DEFAULT_EAP_AGGREGATION,
+        oldArgument: field || DEFAULT_EAP_FIELD,
+      });
       onChange(newAggregate, {});
     },
-    [field, onChange]
+    [aggregation, field, onChange]
   );
 
   // As SelectControl does not support an options size limit out of the box

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -21,7 +21,7 @@ import {
   doDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {AggregationKey, ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {
@@ -177,15 +177,22 @@ function _isNotNumericTag(option: FieldValueOption) {
   return true;
 }
 
-function filterAggregateParams(option: FieldValueOption) {
+function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
   // Allow for unknown values to be used for aggregate functions
   // This supports showing the tag value even if it's not in the current
   // set of tags.
   if ('unknown' in option.value.meta && option.value.meta.unknown) {
     return true;
   }
+
+  const expectedDataType =
+    fieldValue?.kind === 'function' &&
+    fieldValue?.function[0] === AggregationKey.COUNT_UNIQUE
+      ? 'string'
+      : 'number';
+
   if ('dataType' in option.value.meta) {
-    return option.value.meta.dataType === 'number';
+    return option.value.meta.dataType === expectedDataType;
   }
   return true;
 }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1391,7 +1391,7 @@ describe('Visualize', () => {
     );
   });
 
-  it('defaults count_unique argument to user', async function () {
+  it('defaults count_unique argument to span.op', async function () {
     render(
       <WidgetBuilderProvider>
         <Visualize />

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -42,8 +42,19 @@ describe('Visualize', () => {
         return {tags, isLoading: false};
       }
 
+      const tags: TagCollection = {
+        'span.op': {
+          key: 'span.op',
+          name: 'span.op',
+        },
+        'span.description': {
+          key: 'span.description',
+          name: 'span.description',
+        },
+      };
+
       return {
-        tags: {},
+        tags,
         isLoading: false,
       };
     });
@@ -1378,5 +1389,71 @@ describe('Visualize', () => {
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
       'spans'
     );
+  });
+
+  it('defaults count_unique argument to user', async function () {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.LINE,
+              yAxis: ['count(span.duration)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toBeEnabled();
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('count');
+    expect(
+      await screen.findByRole('button', {name: 'Column Selection'})
+    ).toHaveTextContent('spans');
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: 'count_unique'}));
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('count_unique');
+    expect(
+      await screen.findByRole('button', {name: 'Column Selection'})
+    ).toHaveTextContent('span.op');
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: 'avg'}));
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('avg');
+    expect(
+      await screen.findByRole('button', {name: 'Column Selection'})
+    ).toHaveTextContent('span.duration');
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: 'count_unique'}));
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('count_unique');
+    expect(
+      await screen.findByRole('button', {name: 'Column Selection'})
+    ).toHaveTextContent('span.op');
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -968,7 +968,7 @@ describe('WidgetBuilder', function () {
       await screen.findByText('Sort by a y-axis');
       await selectEvent.openMenu(screen.getAllByText('count(\u2026)')[1]!);
 
-      // 12 options in the dropdown
+      // Check the number of options in the dropdown
       expect(screen.queryAllByTestId('menu-list-item-label')).toHaveLength(13);
 
       // Appears once in the y-axis section, dropdown, and in the sort by field

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -969,7 +969,7 @@ describe('WidgetBuilder', function () {
       await selectEvent.openMenu(screen.getAllByText('count(\u2026)')[1]!);
 
       // 12 options in the dropdown
-      expect(screen.queryAllByTestId('menu-list-item-label')).toHaveLength(12);
+      expect(screen.queryAllByTestId('menu-list-item-label')).toHaveLength(13);
 
       // Appears once in the y-axis section, dropdown, and in the sort by field
       expect(await screen.findAllByText('count(\u2026)')).toHaveLength(3);

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -5,11 +5,13 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {
+  AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   ALLOWED_EXPLORE_VISUALIZE_FIELDS,
 } from 'sentry/utils/fields';
 import {decodeList} from 'sentry/utils/queryString';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 export const MAX_VISUALIZES = 4;
 
@@ -99,4 +101,35 @@ export function updateLocationWithVisualizes(
   } else if (visualizes === null) {
     delete location.query.visualize;
   }
+}
+
+export function updateVisualizeAggregate({
+  newAggregate,
+  oldAggregate,
+  oldArgument,
+}: {
+  newAggregate: string;
+  oldAggregate: string;
+  oldArgument: string;
+}): string {
+  // the default aggregate only has 1 allowed field
+  if (newAggregate === DEFAULT_VISUALIZATION_AGGREGATE) {
+    return DEFAULT_VISUALIZATION;
+  }
+
+  // count_unique uses a different set of fields
+  if (newAggregate === AggregationKey.COUNT_UNIQUE) {
+    // The general thing to do here is to valid the the argument type
+    // and carry the argument if it's the same type, reset to a default
+    // if it's not the same type. Just hard coding it for now for simplicity
+    // as `count_unique` is the only aggregate that takes a string.
+    return `${AggregationKey.COUNT_UNIQUE}(${SpanIndexedField.SPAN_OP})`;
+  }
+
+  // switching away from count_unique means we need to reset the field
+  if (oldAggregate === AggregationKey.COUNT_UNIQUE) {
+    return `${newAggregate}(${DEFAULT_VISUALIZATION_FIELD})`;
+  }
+
+  return `${newAggregate}(${oldArgument})`;
 }

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -7,12 +7,30 @@ import {
   parseFunction,
   prettifyTagKey,
 } from 'sentry/utils/discover/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-type Props = {yAxes: string[]};
+interface Props {
+  /**
+   * All the aggregates that are in use. The arguments will be extracted
+   * and injected as options if they are compatible.
+   */
+  yAxes: string[];
+  /**
+   * The current aggregate in use. Used to determine what the argument
+   * types will be compatible.
+   */
+  yAxis?: string;
+}
 
-export function useVisualizeFields({yAxes}: Props) {
+export function useVisualizeFields({yAxis, yAxes}: Props) {
+  const {tags: stringTags} = useSpanTags('string');
   const {tags: numberTags} = useSpanTags('number');
+
+  const parsedYAxis = useMemo(() => (yAxis ? parseFunction(yAxis) : undefined), [yAxis]);
+
+  const tags =
+    parsedYAxis?.name === AggregationKey.COUNT_UNIQUE ? stringTags : numberTags;
 
   const parsedYAxes: ParsedFunction[] = useMemo(() => {
     return yAxes.map(parseFunction).filter(defined);
@@ -24,7 +42,7 @@ export function useVisualizeFields({yAxes}: Props) {
         return entry.arguments;
       })
       .filter(option => {
-        return !numberTags.hasOwnProperty(option);
+        return !tags.hasOwnProperty(option);
       });
 
     const options = [
@@ -33,7 +51,7 @@ export function useVisualizeFields({yAxes}: Props) {
         value: option,
         textValue: option,
       })),
-      ...Object.values(numberTags).map(tag => {
+      ...Object.values(tags).map(tag => {
         return {label: tag.name, value: tag.key, textValue: tag.name};
       }),
     ];
@@ -51,7 +69,7 @@ export function useVisualizeFields({yAxes}: Props) {
     });
 
     return options;
-  }, [numberTags, parsedYAxes]);
+  }, [tags, parsedYAxes]);
 
   return fieldOptions;
 }

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -189,6 +189,100 @@ describe('MultiQueryModeContent', function () {
     ]);
   });
 
+  it('defaults count_unique argument to user', async function () {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {enableRouterMocks: false}
+    );
+
+    const section = await screen.findByTestId('section-visualize-0');
+
+    expect(queries).toEqual([
+      {
+        chartType: 1,
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'span.duration',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(queries).toEqual([
+      {
+        chartType: 1,
+        yAxes: ['count_unique(span.op)'],
+        sortBys: [
+          {
+            field: 'id',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.op'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count_unique'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+
+    expect(queries).toEqual([
+      {
+        chartType: 1,
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'id',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(queries).toEqual([
+      {
+        chartType: 1,
+        yAxes: ['count_unique(span.op)'],
+        sortBys: [
+          {
+            field: 'id',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.op'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
   it('updates visualization and outdated sorts', async function () {
     let queries: any;
     function Component() {

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -189,7 +189,7 @@ describe('MultiQueryModeContent', function () {
     ]);
   });
 
-  it('defaults count_unique argument to user', async function () {
+  it('defaults count_unique argument to span.op', async function () {
     let queries: any;
     function Component() {
       queries = useReadQueriesFromLocation();

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -226,7 +226,7 @@ describe('ExploreToolbar', function () {
     ]);
   });
 
-  it('defaults count_unique argument to user', async function () {
+  it('defaults count_unique argument to span.op', async function () {
     let visualizes: any;
     function Component() {
       visualizes = useExploreVisualizes();

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -226,6 +226,74 @@ describe('ExploreToolbar', function () {
     ]);
   });
 
+  it('defaults count_unique argument to user', async function () {
+    let visualizes: any;
+    function Component() {
+      visualizes = useExploreVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {enableRouterMocks: false}
+    );
+
+    const section = screen.getByTestId('section-visualizes');
+
+    // this is the default
+    expect(visualizes).toEqual([
+      {
+        chartType: ChartType.BAR,
+        label: 'A',
+        yAxes: ['count(span.duration)'],
+      },
+    ]);
+
+    // try changing the aggregate
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(visualizes).toEqual([
+      {
+        chartType: ChartType.BAR,
+        label: 'A',
+        yAxes: ['count_unique(span.op)'],
+      },
+    ]);
+
+    // try changing the aggregate + field
+    await userEvent.click(within(section).getByRole('button', {name: 'count_unique'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+
+    // try changing the field
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+
+    expect(visualizes).toEqual([
+      {
+        chartType: ChartType.BAR,
+        label: 'A',
+        yAxes: ['avg(span.self_time)'],
+      },
+    ]);
+    //
+    // try changing the aggregate back to count_unique
+    await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(visualizes).toEqual([
+      {
+        chartType: ChartType.BAR,
+        label: 'A',
+        yAxes: ['count_unique(span.op)'],
+      },
+    ]);
+  });
+
   it('allows changing visualizes', async function () {
     let fields, visualizes: any;
     function Component() {

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -20,9 +20,9 @@ import {
 import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
   DEFAULT_VISUALIZATION,
-  DEFAULT_VISUALIZATION_AGGREGATE,
   DEFAULT_VISUALIZATION_FIELD,
   MAX_VISUALIZES,
+  updateVisualizeAggregate,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -200,7 +200,10 @@ function VisualizeDropdown({
     ],
     []
   );
-  const defaultFieldOptions: Array<SelectOption<string>> = useVisualizeFields({yAxes});
+  const defaultFieldOptions: Array<SelectOption<string>> = useVisualizeFields({
+    yAxes,
+    yAxis,
+  });
   const fieldOptions = lockOptions ? countFieldOptions : defaultFieldOptions;
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
@@ -225,10 +228,11 @@ function VisualizeDropdown({
   const setChartAggregate = useCallback(
     ({value}: SelectOption<SelectKey>) => {
       const newVisualizes = visualizes.slice();
-      newVisualizes[group]!.yAxes[index] =
-        value === DEFAULT_VISUALIZATION_AGGREGATE
-          ? DEFAULT_VISUALIZATION
-          : `${value}(${parsedVisualize.arguments[0]})`;
+      newVisualizes[group]!.yAxes[index] = updateVisualizeAggregate({
+        newAggregate: value as string,
+        oldAggregate: parsedVisualize.name,
+        oldArgument: parsedVisualize.arguments[0]!,
+      });
       setVisualizes(newVisualizes);
     },
     [group, index, parsedVisualize, setVisualizes, visualizes]
@@ -310,7 +314,7 @@ function VisualizeEquation({
     return visualizes.flatMap(visualize => visualize.yAxes);
   }, [visualizes]);
 
-  const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({yAxes});
+  const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({yAxes, yAxis});
 
   const functionArguments = useMemo(() => {
     return fieldOptions.map(o => {


### PR DESCRIPTION
This adds support for the `count_unique` aggregate in eap enabled views.

Closes EXP-7