### PR TITLE
fix(partner-sso): previously partnered orgs should be able to continu…

### DIFF
--- a/src/sentry/web/frontend/auth_channel_login.py
+++ b/src/sentry/web/frontend/auth_channel_login.py
@@ -30,6 +30,14 @@ class AuthChannelLoginView(AuthOrganizationLoginView):
         # Checking for duplicate orgs
         auth_provider_model = AuthProvider.objects.filter(provider=channel, config=config_data)
 
+        if not auth_provider_model.exists():
+            # After moving away from partner plan we append "-non-partner" to the provider name
+            # But coming to Sentry from partner's website would still use the partner provider name
+            # So we need to check both
+            auth_provider_model = AuthProvider.objects.filter(
+                provider=f"{channel}-non-partner", config=config_data
+            )
+
         if not auth_provider_model.exists() or len(auth_provider_model) > 1:
             return self.redirect(reverse("sentry-login"))
 


### PR DESCRIPTION
Both downgrade and upgrade from partner plan changes the SSO provider name from `channel` to `channel-non-partner`. The difference between these 2 providers is that `channel` is required SSO and users cannot disable it but when they're out of partnership we move them to `channel-non-partner` which allows them to remove the SSO as well.

There is a bug with this flow though that this PR is fixing:
There are entries to Sentry through partner's website and people using the same links should still be able to login to Sentry. Our AuthChannelLoginView is written so that it will only be called by partnered orgs but that is not correct in this case. These orgs hit the same endpoint post migration and we end up not finding the right SSO for them.

Fixes: https://linear.app/getsentry/issue/ECO-413/flyio-sso-issue
