### PR TITLE
:wrench: chore: remove unused incident type

### DIFF
--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -133,7 +133,6 @@ class IncidentManager(BaseManager["Incident"]):
 
 
 class IncidentType(Enum):
-    DETECTED = 0
     ALERT_TRIGGERED = 2
 
 

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -756,7 +756,7 @@ def create_metric_alert_rule(organization: Organization, project: Project) -> No
     create_alert_rule_trigger(alert_rule, "critical", 10)
     create_incident(
         organization,
-        incident_type=IncidentType.DETECTED,
+        incident_type=IncidentType.ALERT_TRIGGERED,
         title="My Incident",
         date_started=datetime.now(timezone.utc),
         alert_rule=alert_rule,


### PR DESCRIPTION
`Detected` isn't used anywhere and it was bothering me while i was writing the `WorkflowEngineIncident` serializer, so removing