### PR TITLE
:wrench: chore: rename `APIClient` to `PluginAPIClient`

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/client.py
+++ b/src/sentry/plugins/sentry_webhooks/client.py
@@ -1,7 +1,7 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class WebhookApiClient(ApiClient):
+class WebhookApiClient(PluginApiClient):
     plugin_name = "webhook"
     allow_redirects = False
     metrics_prefix = "integrations.webhook"

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -11,7 +11,7 @@ from sentry.shared_integrations.exceptions import ApiUnauthorized
 from sentry.users.services.usersocialauth.service import usersocialauth_service
 
 
-class ApiClient(BaseApiClient):
+class PluginApiClient(BaseApiClient):
     integration_type = "plugin"
 
     metrics_prefix = "sentry-plugins"
@@ -21,7 +21,7 @@ class ApiClient(BaseApiClient):
     plugin_name = "undefined"
 
 
-class AuthApiClient(ApiClient):
+class AuthApiClient(PluginApiClient):
     def __init__(self, auth=None, *args, **kwargs):
         self.auth = auth
         super().__init__(*args, **kwargs)
@@ -89,7 +89,7 @@ class AuthApiClient(ApiClient):
         kwargs = self.ensure_auth(**kwargs)
 
         try:
-            return ApiClient._request(self, method, path, **kwargs)
+            return PluginApiClient._request(self, method, path, **kwargs)
         except Exception as exc:
             if not self.exception_means_unauthorized(exc):
                 raise
@@ -102,4 +102,4 @@ class AuthApiClient(ApiClient):
         )
         usersocialauth_service.refresh_token(filter={"id": self.auth.id})
         kwargs = self.bind_auth(**kwargs)
-        return ApiClient._request(self, method, path, **kwargs)
+        return PluginApiClient._request(self, method, path, **kwargs)

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -5,7 +5,7 @@ import time
 from sentry import options
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.utils import jwt
-from sentry_plugins.client import ApiClient, AuthApiClient
+from sentry_plugins.client import AuthApiClient, PluginApiClient
 
 
 class GithubPluginClientMixin(AuthApiClient):
@@ -72,7 +72,7 @@ class GithubPluginClient(GithubPluginClientMixin, AuthApiClient):
         return self._request("GET", "/user/installations", headers=headers)
 
 
-class GithubPluginAppsClient(GithubPluginClientMixin, ApiClient):
+class GithubPluginAppsClient(GithubPluginClientMixin, PluginApiClient):
     def __init__(self, integration: RpcIntegration):
         self.integration = integration
         self.token: str | None = None

--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -1,10 +1,10 @@
 from urllib.parse import quote
 
 from sentry.shared_integrations.exceptions import ApiError
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class GitLabClient(ApiClient):
+class GitLabClient(PluginApiClient):
     allow_redirects = False
     plugin_name = "gitlab"
 

--- a/src/sentry_plugins/jira/client.py
+++ b/src/sentry_plugins/jira/client.py
@@ -5,7 +5,7 @@ from hashlib import md5 as _md5
 from django.utils.encoding import force_bytes
 
 from sentry.shared_integrations.exceptions import ApiError
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 log = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ def md5(*bits):
     return _md5(b":".join(force_bytes(bit, errors="replace") for bit in bits))
 
 
-class JiraClient(ApiClient):
+class JiraClient(PluginApiClient):
     """
     The JIRA API Client, so you don't have to.
     """

--- a/src/sentry_plugins/opsgenie/client.py
+++ b/src/sentry_plugins/opsgenie/client.py
@@ -1,7 +1,7 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class OpsGenieApiClient(ApiClient):
+class OpsGenieApiClient(PluginApiClient):
     monitoring_tool = "sentry"
     plugin_name = "opsgenie"
     allow_redirects = False

--- a/src/sentry_plugins/pagerduty/client.py
+++ b/src/sentry_plugins/pagerduty/client.py
@@ -1,11 +1,11 @@
 from sentry.utils.http import absolute_uri
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 # https://v2.developer.pagerduty.com/docs/events-api
 INTEGRATION_API_URL = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
 
 
-class PagerDutyPluginClient(ApiClient):
+class PagerDutyPluginClient(PluginApiClient):
     client = "sentry"
     plugin_name = "pagerduty"
     allow_redirects = False

--- a/src/sentry_plugins/pushover/client.py
+++ b/src/sentry_plugins/pushover/client.py
@@ -1,7 +1,7 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class PushoverClient(ApiClient):
+class PushoverClient(PluginApiClient):
     base_url = "https://api.pushover.net/1"
     allow_redirects = False
     plugin_name = "pushover"

--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
 from typing import Any
 
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class SlackApiClient(ApiClient):
+class SlackApiClient(PluginApiClient):
     plugin_name = "slack"
     allow_redirects = False
 

--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -1,7 +1,7 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class SplunkApiClient(ApiClient):
+class SplunkApiClient(PluginApiClient):
     plugin_name = "splunk"
     allow_redirects = False
     metrics_prefix = "integrations.splunk"

--- a/src/sentry_plugins/trello/client.py
+++ b/src/sentry_plugins/trello/client.py
@@ -1,4 +1,4 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 ORG_BOARD_PATH = "/organizations/%s/boards"
 MEMBER_ORG_PATH = "/members/me/organizations"
@@ -12,7 +12,7 @@ SEARCH_PATH = "/search"
 CARD_FIELDS = ",".join(["name", "shortLink", "idShort"])
 
 
-class TrelloApiClient(ApiClient):
+class TrelloApiClient(PluginApiClient):
     base_url = "https://api.trello.com/1"
     plugin_name = "trello"
 

--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -2,10 +2,10 @@ from base64 import b64encode
 
 from django.utils.encoding import force_bytes
 
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class TwilioApiClient(ApiClient):
+class TwilioApiClient(PluginApiClient):
     plugin_name = "twilio"
     allow_redirects = False
     twilio_messages_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/Messages.json"

--- a/src/sentry_plugins/victorops/client.py
+++ b/src/sentry_plugins/victorops/client.py
@@ -1,7 +1,7 @@
-from sentry_plugins.client import ApiClient
+from sentry_plugins.client import PluginApiClient
 
 
-class VictorOpsClient(ApiClient):
+class VictorOpsClient(PluginApiClient):
     monitoring_tool = "sentry"
     routing_key = "everyone"
     plugin_name = "victorops"

--- a/tests/sentry_plugins/test_client.py
+++ b/tests/sentry_plugins/test_client.py
@@ -12,7 +12,7 @@ from sentry.shared_integrations.exceptions import (
 from sentry.shared_integrations.response.base import BaseApiResponse
 from sentry.testutils.cases import TestCase
 from sentry.users.services.usersocialauth.serial import serialize_usersocialauth
-from sentry_plugins.client import ApiClient, AuthApiClient
+from sentry_plugins.client import AuthApiClient, PluginApiClient
 
 
 class ApiClientTest(TestCase):
@@ -20,7 +20,7 @@ class ApiClientTest(TestCase):
     def test_get(self):
         responses.add(responses.GET, "http://example.com", json={})
 
-        resp = ApiClient().get("http://example.com")
+        resp = PluginApiClient().get("http://example.com")
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 
@@ -28,7 +28,7 @@ class ApiClientTest(TestCase):
     def test_post(self):
         responses.add(responses.POST, "http://example.com", json={})
 
-        resp = ApiClient().post("http://example.com")
+        resp = PluginApiClient().post("http://example.com")
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 
@@ -36,7 +36,7 @@ class ApiClientTest(TestCase):
     def test_delete(self):
         responses.add(responses.DELETE, "http://example.com", json={})
 
-        resp = ApiClient().delete("http://example.com")
+        resp = PluginApiClient().delete("http://example.com")
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 
@@ -44,7 +44,7 @@ class ApiClientTest(TestCase):
     def test_put(self):
         responses.add(responses.PUT, "http://example.com", json={})
 
-        resp = ApiClient().put("http://example.com")
+        resp = PluginApiClient().put("http://example.com")
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 
@@ -52,7 +52,7 @@ class ApiClientTest(TestCase):
     def test_patch(self):
         responses.add(responses.PATCH, "http://example.com", json={})
 
-        resp = ApiClient().patch("http://example.com")
+        resp = PluginApiClient().patch("http://example.com")
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 


### PR DESCRIPTION
i got burnt by this a few times, making is explicit that this client is used by plugins