### PR TITLE
ref(issue-stream): Use issue type config for events label

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -38,7 +38,6 @@ import type {
   InboxDetails,
   PriorityLevel,
 } from 'sentry/types/group';
-import {IssueCategory} from 'sentry/types/group';
 import type {NewQuery} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {defined, percent} from 'sentry/utils';
@@ -426,15 +425,6 @@ function StreamGroup({
     withChart && group && group.filtered && statsPeriod && useFilteredStats
   );
 
-  const groupCategoryCountTitles: Record<IssueCategory, string> = {
-    [IssueCategory.ERROR]: t('Error Events'),
-    [IssueCategory.PERFORMANCE]: t('Transaction Events'),
-    [IssueCategory.CRON]: t('Cron Events'),
-    [IssueCategory.REPLAY]: t('Replay Events'),
-    [IssueCategory.UPTIME]: t('Uptime Events'),
-    [IssueCategory.METRIC_ALERT]: t('Metric Alert Events'),
-  };
-
   const groupCount = defined(primaryCount) ? (
     <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
       <Tooltip
@@ -442,7 +432,7 @@ function StreamGroup({
         isHoverable
         title={
           <CountTooltipContent>
-            <h4>{groupCategoryCountTitles[group.issueCategory]}</h4>
+            <h4>{issueTypeConfig.customCopy.eventUnits}</h4>
             {group.filtered && (
               <Fragment>
                 <div>{queryFilterDescription ?? t('Matching filters')}</div>


### PR DESCRIPTION
Going over all the issue category usages in the frontend and trying to use the config where necessary. This is only used when filtering by events and is shown in the tooltip. There is already a config that decides what is shown in issue details, so I think it makes most sense to mirror that here.

Note that this does change "transaction events", "replay events", etc to just "Events" but I think that is good for consistency.

![CleanShot 2025-04-14 at 16 14 27@2x](https://github.com/user-attachments/assets/ee9ab353-bf49-4ceb-9759-032ff769b5d9)
