### PR TITLE
chore(seer grouping): Remove flaky assertion in test of `SimilarHashMissingGroupError`

### DIFF
--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -485,7 +485,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
         logged_gh_age = mock_logger.warning.call_args.kwargs["extra"]["parent_gh_age_in_sec"]
         assert isinstance(logged_gh_age, float)
-        assert logged_gh_age > 0 and logged_gh_age < 1
 
         # Note that unlike in the missing grouphash test below, we're not testing Seer deletion here
         # because it only happens conditionally, behavior that's tested in `test_similar_issues.py`


### PR DESCRIPTION
This removes an assertion on the value we log for `parent_gh_age_in_sec` when we get a result back from Seer which doesn't have a group attached. Though it's rare, it's possible for this to flake if the test takes more than a second to run. Asserting on type is good enough, so this removes the value assertion.

Fixes https://sentry.sentry.io/issues/6537309730.