### PR TITLE
ref: Move language_parsers to source_code_management

### DIFF
--- a/src/sentry/integrations/github/constants.py
+++ b/src/sentry/integrations/github/constants.py
@@ -1,6 +1,3 @@
 ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
-
-# Number of stackframes to check for filename + function combo, starting from the top
-STACKFRAME_COUNT = 4

--- a/src/sentry/integrations/github/tasks/open_pr_comment.py
+++ b/src/sentry/integrations/github/tasks/open_pr_comment.py
@@ -23,12 +23,7 @@ from snuba_sdk import Request as SnubaRequest
 
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.integrations.github.client import GitHubApiClient
-from sentry.integrations.github.constants import (
-    ISSUE_LOCKED_ERROR_MESSAGE,
-    RATE_LIMITED_MESSAGE,
-    STACKFRAME_COUNT,
-)
-from sentry.integrations.github.tasks.language_parsers import PATCH_PARSERS
+from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.pr_comment import format_comment_url
 from sentry.integrations.github.tasks.utils import (
     GithubAPIErrorType,
@@ -38,6 +33,8 @@ from sentry.integrations.github.tasks.utils import (
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
+from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project

--- a/src/sentry/integrations/source_code_management/constants.py
+++ b/src/sentry/integrations/source_code_management/constants.py
@@ -1,0 +1,2 @@
+# Number of stackframes to check for filename + function combo, starting from the top
+STACKFRAME_COUNT = 4

--- a/src/sentry/integrations/source_code_management/language_parsers.py
+++ b/src/sentry/integrations/source_code_management/language_parsers.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Function, Op
 
-from sentry.integrations.github.constants import STACKFRAME_COUNT
+from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
 
 stackframe_function_name = lambda i: Function(
     "arrayElement",

--- a/src/sentry/seer/fetch_issues/more_parsing.py
+++ b/src/sentry/seer/fetch_issues/more_parsing.py
@@ -1,6 +1,6 @@
 import re
 
-from sentry.integrations.github.tasks.language_parsers import (
+from sentry.integrations.source_code_management.language_parsers import (
     PATCH_PARSERS,
     LanguageParser,
     PythonParser,

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -6,8 +6,6 @@ import responses
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.github.constants import STACKFRAME_COUNT
-from sentry.integrations.github.tasks.language_parsers import PATCH_PARSERS
 from sentry.integrations.github.tasks.open_pr_comment import (
     format_issue_table,
     format_open_pr_comment,
@@ -20,6 +18,8 @@ from sentry.integrations.github.tasks.open_pr_comment import (
 )
 from sentry.integrations.github.tasks.utils import PullRequestFile, PullRequestIssue
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
+from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
 from sentry.models.group import Group, GroupStatus
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
@@ -825,7 +825,7 @@ Your pull request is modifying functions with the following pre-existing issues:
     "sentry.integrations.github.tasks.open_pr_comment.get_projects_and_filenames_from_source_file"
 )
 @patch(
-    "sentry.integrations.github.tasks.language_parsers.PythonParser.extract_functions_from_patch"
+    "sentry.integrations.source_code_management.language_parsers.PythonParser.extract_functions_from_patch"
 )
 @patch("sentry.integrations.github.tasks.open_pr_comment.get_top_5_issues_by_count_for_file")
 @patch("sentry.integrations.github.tasks.open_pr_comment.safe_for_comment")

--- a/tests/sentry/integrations/source_code_management/test_language_parsers.py
+++ b/tests/sentry/integrations/source_code_management/test_language_parsers.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from sentry.integrations.github.tasks.language_parsers import (
+from sentry.integrations.source_code_management.language_parsers import (
     JavascriptParser,
     PHPParser,
     PythonParser,


### PR DESCRIPTION
Move language_parsers from the github module to source_code_management.