### PR TITLE
fix(issues): Open drawers without resetting scroll

### DIFF
--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -354,6 +354,7 @@ export const StyledButton = styled(
     external,
     to,
     replace,
+    preventScrollReset,
     href,
     disabled,
     ref: forwardRefAlt,
@@ -372,6 +373,7 @@ export const StyledButton = styled(
           ref={ref as React.Ref<HTMLAnchorElement>}
           to={to}
           replace={replace}
+          preventScrollReset={preventScrollReset}
           disabled={disabled}
         />
       );
@@ -403,6 +405,7 @@ export const StyledButton = styled(
       prop === 'forwardRef' ||
       prop === 'external' ||
       prop === 'replace' ||
+      prop === 'preventScrollReset' ||
       (typeof prop === 'string' && isPropValid(prop)),
   }
 )<ButtonProps>`

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -34,6 +34,7 @@ export interface LinkProps
    * Indicator if the link should be disabled
    */
   disabled?: boolean;
+  preventScrollReset?: ReactRouterLinkProps['preventScrollReset'];
   ref?: React.Ref<HTMLAnchorElement>;
   replace?: ReactRouterLinkProps['replace'];
   state?: ReactRouterLinkProps['state'];

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -112,6 +112,7 @@ function EventNavigationButton({
             query: {...location.query, referrer},
           }}
           disabled={disabled}
+          preventScrollReset
         />
       </div>
     </Tooltip>

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
@@ -134,6 +134,7 @@ export function IssueDetailsEventNavigation({
               pathname: `${baseEventsPath}${event?.previousEventID}/`,
               query: {...location.query, referrer: 'previous-event'},
             }}
+            preventScrollReset
             css={grayText}
             onMouseEnter={handleHoverPagination(
               'previous',
@@ -158,6 +159,7 @@ export function IssueDetailsEventNavigation({
               pathname: `${baseEventsPath}${event?.nextEventID}/`,
               query: {...location.query, referrer: 'next-event'},
             }}
+            preventScrollReset
             css={grayText}
             onMouseEnter={handleHoverPagination('next', defined(event?.nextEventID))}
             onClick={() => {

--- a/static/app/views/issueDetails/streamline/sidebar/mergedSidebarSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/mergedSidebarSection.tsx
@@ -19,7 +19,6 @@ export function MergedIssuesSidebarSection() {
           pathname: `${baseUrl}${TabPaths[Tab.MERGED]}`,
           query: location.query,
         }}
-        replace
       >
         {t('View')}
       </ViewButton>

--- a/static/app/views/issueDetails/streamline/sidebar/similarIssuesSidebarSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/similarIssuesSidebarSection.tsx
@@ -19,7 +19,6 @@ export function SimilarIssuesSidebarSection() {
           pathname: `${baseUrl}${TabPaths[Tab.SIMILAR_ISSUES]}`,
           query: location.query,
         }}
-        replace
       >
         {t('View')}
       </ViewButton>


### PR DESCRIPTION
Follow up to #89445 the prop wasn't getting to the router link because of the forward props, remove more "replace" links.

Also prevent scroll reset on previous / next event
