### PR TITLE
feat(explore): Switch trace samples over to rpc

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -268,6 +268,7 @@ export interface NewQuery {
   expired?: boolean;
   id?: string;
   interval?: string;
+  multiSort?: boolean;
   orderby?: string | string[];
   projects?: readonly number[];
   query?: string;

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -283,6 +283,7 @@ export type EventViewOptions = {
   dataset?: DiscoverDatasets;
   expired?: boolean;
   interval?: string;
+  multiSort?: boolean;
   utc?: string | boolean | undefined;
   yAxis?: string | string[] | undefined;
 };
@@ -308,6 +309,7 @@ class EventView {
   createdBy: User | undefined;
   additionalConditions: MutableSearch; // This allows views to always add additional conditions to the query to get specific data. It should not show up in the UI unless explicitly called.
   dataset?: DiscoverDatasets;
+  multiSort?: boolean;
 
   constructor(props: EventViewOptions) {
     const fields: Field[] = Array.isArray(props.fields) ? props.fields : [];
@@ -333,8 +335,12 @@ class EventView {
       }
     });
 
-    const sort = sorts.find(currentSort => sortKeys.includes(currentSort.field));
-    sorts = sort ? [sort] : [];
+    if (props.multiSort) {
+      sorts = sorts.filter(currentSort => sortKeys.includes(currentSort.field));
+    } else {
+      const sort = sorts.find(currentSort => sortKeys.includes(currentSort.field));
+      sorts = sort ? [sort] : [];
+    }
 
     const id = props.id !== null && props.id !== void 0 ? String(props.id) : void 0;
 
@@ -475,6 +481,7 @@ class EventView {
       expired: saved.expired,
       additionalConditions: new MutableSearch([]),
       dataset: saved.dataset,
+      multiSort: saved.multiSort,
     });
   }
 
@@ -812,6 +819,7 @@ class EventView {
       expired: this.expired,
       createdBy: this.createdBy,
       additionalConditions: this.additionalConditions.copy(),
+      multiSort: this.multiSort,
     });
   }
 

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -88,9 +88,13 @@ export function useTraces({
       project: selection.projects,
       environment: selection.environments,
       ...normalizeDateTimeParams(datetime ?? selection.datetime),
-      // RPC not supported here yet, fall back to EAP directly
       dataset:
         dataset === DiscoverDatasets.SPANS_EAP_RPC ? DiscoverDatasets.SPANS_EAP : dataset,
+      useRpc:
+        organization.features.includes('visibility-explore-dataset') &&
+        dataset === DiscoverDatasets.SPANS_EAP_RPC
+          ? '1'
+          : undefined,
       query,
       sort, // only has an effect when `dataset` is `EAPSpans`
       per_page: limit,


### PR DESCRIPTION
This switches the traces samples table to use RPC instead of SnQL