### PR TITLE
feat(nextjs-insights): Add user option in types

### DIFF
--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -55,6 +55,7 @@ export interface User extends Omit<AvatarUser, 'options'> {
     language: string;
     prefersChonkUI: boolean;
     prefersIssueDetailsStreamlinedUI: boolean | null;
+    prefersNextjsInsightsOverview: boolean;
     prefersStackedNavigation: boolean;
     quickStartDisplay: QuickStartDisplay;
     stacktraceOrder: number;

--- a/tests/js/fixtures/activityFeed.ts
+++ b/tests/js/fixtures/activityFeed.ts
@@ -55,6 +55,7 @@ export function ActivityFeedFixture(params: Partial<Activity> = {}): Activity {
         stacktraceOrder: -1,
         timezone: 'America/Los_Angeles',
         prefersIssueDetailsStreamlinedUI: false,
+        prefersNextjsInsightsOverview: false,
         prefersStackedNavigation: false,
         prefersChonkUI: false,
         quickStartDisplay: {},

--- a/tests/js/fixtures/commitAuthor.ts
+++ b/tests/js/fixtures/commitAuthor.ts
@@ -40,6 +40,7 @@ export function CommitAuthorFixture(params: Partial<User> = {}): User {
       theme: 'light',
       prefersIssueDetailsStreamlinedUI: false,
       prefersStackedNavigation: false,
+      prefersNextjsInsightsOverview: false,
       prefersChonkUI: false,
       quickStartDisplay: {},
     },

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -17,7 +17,7 @@ export function UserFixture(params: Partial<User> = {}): User {
       stacktraceOrder: -1,
       prefersIssueDetailsStreamlinedUI: true,
       prefersStackedNavigation: false,
-      prefersNextjsInsightsOverview: true,
+      prefersNextjsInsightsOverview: false,
       prefersChonkUI: false,
       quickStartDisplay: {},
     },

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -17,6 +17,7 @@ export function UserFixture(params: Partial<User> = {}): User {
       stacktraceOrder: -1,
       prefersIssueDetailsStreamlinedUI: true,
       prefersStackedNavigation: false,
+      prefersNextjsInsightsOverview: true,
       prefersChonkUI: false,
       quickStartDisplay: {},
     },

--- a/tests/js/fixtures/userDetails.ts
+++ b/tests/js/fixtures/userDetails.ts
@@ -32,6 +32,7 @@ export function UserDetailsFixture(params: Partial<User> = {}): User {
       avatarType: 'gravatar',
       theme: 'light',
       prefersIssueDetailsStreamlinedUI: false,
+      prefersNextjsInsightsOverview: false,
       prefersStackedNavigation: false,
       prefersChonkUI: false,
       quickStartDisplay: {},


### PR DESCRIPTION
Add user option to enable opt-out of the next nextjs insights.

- FE counterpart of https://github.com/getsentry/sentry/pull/89473
- Part of [TET-296: Add opt-out button to NextJS insights](https://linear.app/getsentry/issue/TET-296/add-opt-out-button-to-nextjs-insights)