### PR TITLE
fix(onboarding): update outdated tracing setup instructions for python

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -288,7 +288,7 @@ export const performanceOnboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            "Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions. Note that [code:enable_tracing] is available in Sentry Python SDK version [code:≥ 1.16.0]. To enable tracing in older SDK versions ([code:≥ 0.11.2]), use [code:traces_sample_rate=1.0].",
+            "Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions. To enable tracing, use [code:traces_sample_rate=1.0] in the sentry_sdk.init() call.",
             {code: <code />}
           ),
           language: 'python',


### PR DESCRIPTION
Before: 
<img width="682" alt="Screenshot 2025-04-15 at 09 43 31" src="https://github.com/user-attachments/assets/4f49352c-55a0-428c-8cab-99565f0f6b25" />


After: 
<img width="665" alt="Screenshot 2025-04-15 at 09 45 01" src="https://github.com/user-attachments/assets/2056daa2-e048-4d59-a163-0e589ac1771f" />
