### PR TITLE
fix: hot-reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "fix:biome": "biome check . --write",
     "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s(x)?\" --write --log-level=error",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
-    "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 webpack serve",
+    "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 SENTRY_UI_HOT_RELOAD=1 webpack serve",
     "dev-ui-admin": "SENTRY_ADMIN_UI_DEV=1 yarn dev-ui",
     "dev-ui-storybook": "STORYBOOK_TYPES=1 yarn dev-ui",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development webpack --watch",


### PR DESCRIPTION
both the `webpack.config.ts` and the `babel.config.ts` check the `SENTRY_UI_HOT_RELOAD` env variable to enable hot reloading. Without it, it doesn’t work.