### PR TITLE
fix(codecov): Fix when codecov notification should be sent

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -84,7 +84,7 @@ comment:
   ######################
   # This is the addition of carry forward builds and fresh builds, thus, it's the addition
   # of the FE and BE builds
-  after_n_builds: 22
+  after_n_builds: 33
   # What to render in the comment
   layout: 'diff, condensed_files'
   # Do not show the project coverage in the comment


### PR DESCRIPTION
After CI/CD refactor last week, number of codecov shards was updated ([after_n_builds](https://github.com/getsentry/sentry/pull/89172)),  but there is still one place missed which was supposed to be updated.

This caused codecov notifications to be triggered too early which meant that we would get wrong coverage reports because not all of the jobs were finished processing. Now `after_n_builds` sums up to FE + BE builds