### PR TITLE
fix(widget-builder): Trigger onClose when the span search bar changes

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -176,6 +176,7 @@ export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderPr
   numberTags: TagCollection;
   stringTags: TagCollection;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
+  onChange?: (query: string, state: CallbackSearchState) => void;
   portalTarget?: HTMLElement | null;
   supportedAggregates?: AggregationKey[];
 }
@@ -284,6 +285,7 @@ export function EAPSpanSearchQueryBuilder({
   supportedAggregates = [],
   projects,
   portalTarget,
+  onChange,
 }: EAPSpanSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useEAPSpanSearchQueryBuilderProps({
     initialQuery,
@@ -299,5 +301,5 @@ export function EAPSpanSearchQueryBuilder({
     portalTarget,
   });
 
-  return <SearchQueryBuilder {...searchQueryBuilderProps} />;
+  return <SearchQueryBuilder {...searchQueryBuilderProps} onChange={onChange} />;
 }

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -193,6 +193,7 @@ export function useEAPSpanSearchQueryBuilderProps({
   supportedAggregates = [],
   projects,
   portalTarget,
+  onChange,
 }: EAPSpanSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -270,6 +271,7 @@ export function useEAPSpanSearchQueryBuilderProps({
     recentSearches: SavedSearchType.SPAN,
     showUnsubmittedIndicator: true,
     portalTarget,
+    onChange,
   };
 }
 
@@ -299,7 +301,8 @@ export function EAPSpanSearchQueryBuilder({
     supportedAggregates,
     projects,
     portalTarget,
+    onChange,
   });
 
-  return <SearchQueryBuilder {...searchQueryBuilderProps} onChange={onChange} />;
+  return <SearchQueryBuilder {...searchQueryBuilderProps} />;
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -16,10 +16,11 @@ interface MockedTagValue
 function renderWithProvider({
   widgetQuery,
   onSearch,
+  onClose,
 }: ComponentProps<typeof SpansSearchBar>) {
   return render(
     <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
-      <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} />
+      <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />
     </SpanTagsProvider>
   );
 }
@@ -107,6 +108,7 @@ describe('SpansSearchBar', () => {
     renderWithProvider({
       widgetQuery: WidgetQueryFixture({conditions: 'span.op:function'}),
       onSearch: jest.fn(),
+      onClose: jest.fn(),
     });
 
     await screen.findByLabelText('span.op:function');
@@ -115,7 +117,11 @@ describe('SpansSearchBar', () => {
   it('calls onSearch with the correct query', async () => {
     const onSearch = jest.fn();
 
-    renderWithProvider({widgetQuery: WidgetQueryFixture({conditions: ''}), onSearch});
+    renderWithProvider({
+      widgetQuery: WidgetQueryFixture({conditions: ''}),
+      onSearch,
+      onClose: jest.fn(),
+    });
 
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
@@ -128,6 +134,25 @@ describe('SpansSearchBar', () => {
 
     await waitFor(() => {
       expect(onSearch).toHaveBeenCalledWith('span.op:function', expect.anything());
+    });
+  });
+
+  it('triggers onClose when the query changes', async () => {
+    const onClose = jest.fn();
+
+    renderWithProvider({
+      widgetQuery: WidgetQueryFixture({conditions: ''}),
+      onSearch: jest.fn(),
+      onClose,
+    });
+
+    const searchInput = await screen.findByRole('combobox', {
+      name: 'Add a search term',
+    });
+    await userEvent.type(searchInput, 'span.op:function');
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -12,7 +12,11 @@ function SpansSearchBar({
   widgetQuery,
   onSearch,
   portalTarget,
-}: Pick<WidgetBuilderSearchBarProps, 'widgetQuery' | 'onSearch' | 'portalTarget'>) {
+  onClose,
+}: Pick<
+  WidgetBuilderSearchBarProps,
+  'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
+>) {
   const {
     selection: {projects},
   } = usePageFilters();
@@ -28,6 +32,9 @@ function SpansSearchBar({
       searchSource="dashboards"
       projects={projects}
       portalTarget={portalTarget}
+      onChange={(query, state) => {
+        onClose?.(query, {validSearch: state.queryIsValid});
+      }}
     />
   );
 }


### PR DESCRIPTION
Passes down a handler that calls the dispatch to submit the query. Prevents users from adding filters but not realizing they need to hit enter to submit the changes.