### PR TITLE
fix(dashboards): Fix `BaselineMarkline` crash

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
@@ -1,16 +1,14 @@
-import {useTheme} from '@emotion/react';
-
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
+import type {Theme} from 'sentry/utils/theme';
 
 interface Props {
+  theme: Theme;
+  value: number;
   label?: string;
-  value?: number;
 }
 
-export function BaselineMarkLine({value, label}: Props = {}) {
-  const theme = useTheme();
-
+export function BaselineMarkLine({theme, value, label}: Props) {
   return MarkLine({
     data: [
       {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -266,7 +266,11 @@ export class Samples implements Plottable {
         return symbol;
       },
       markLine: config.baselineValue
-        ? BaselineMarkLine({value: config.baselineValue, label: config.baselineLabel})
+        ? BaselineMarkLine({
+            theme,
+            value: config.baselineValue,
+            label: config.baselineLabel,
+          })
         : undefined,
       animation: false,
       emphasis: {


### PR DESCRIPTION
`BaselineMarkline` uses `useTheme()` to fetch the theme. This works-ish, but causes a React crash on re-render because it's a _conditional hook call_. `BaselineMarkline` isn't a real component. Our ESLint check for hooks doesn't catch these, maybe because it thinks it's a real component (since it looks like one).

This is illegal. Instead, these non-components should accept the theme as a prop.
