### PR TITLE
feat(explore): Highlights the save button when a change is made on a saved query

### DIFF
--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 
 import type {Actor} from 'sentry/types/core';
+import {defined} from 'sentry/utils';
 import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -30,7 +31,6 @@ export type SavedQuery = {
   createdBy: Actor;
   dateAdded: string;
   dateUpdated: string;
-  end: string;
   environment: string[];
   id: number;
   interval: string;
@@ -40,9 +40,10 @@ export type SavedQuery = {
   projects: number[];
   query: [Query, ...Query[]];
   queryDataset: string;
-  range: string;
   starred: boolean;
-  start: string;
+  end?: string;
+  range?: string;
+  start?: string;
 };
 
 type Props = {
@@ -97,4 +98,27 @@ export function useInvalidateSavedQueries() {
       queryKey: [`/organizations/${organization.slug}/explore/saved/`],
     });
   }, [queryClient, organization.slug]);
+}
+
+export function useGetSavedQuery(id?: string) {
+  const organization = useOrganization();
+  const {data, isLoading, ...rest} = useApiQuery<SavedQuery>(
+    [`/organizations/${organization.slug}/explore/saved/${id}/`],
+    {
+      staleTime: 0,
+      enabled: defined(id),
+    }
+  );
+  return {data, isLoading, ...rest};
+}
+
+export function useInvalidateSavedQuery(id?: string) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${organization.slug}/explore/saved/${id}/`],
+    });
+  }, [queryClient, organization.slug, id]);
 }

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -9,6 +9,7 @@ import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
   type SavedQuery,
   useInvalidateSavedQueries,
+  useInvalidateSavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 
 const TRACE_EXPLORER_DATASET = 'spans';
@@ -24,6 +25,7 @@ export function useSaveQuery() {
   const api = useApi();
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();
+  const invalidateSavedQuery = useInvalidateSavedQuery(id);
 
   const visualize = visualizes.map(({chartType, yAxes}) => ({
     chartType,
@@ -81,9 +83,10 @@ export function useSaveQuery() {
         }
       );
       invalidateSavedQueries();
+      invalidateSavedQuery();
       return response;
     },
-    [api, organization.slug, data, invalidateSavedQueries]
+    [api, organization.slug, data, invalidateSavedQueries, invalidateSavedQuery]
   );
 
   const updateQuery = useCallback(async () => {
@@ -95,8 +98,9 @@ export function useSaveQuery() {
       }
     );
     invalidateSavedQueries();
+    invalidateSavedQuery();
     return response;
-  }, [api, organization.slug, id, data, invalidateSavedQueries]);
+  }, [api, organization.slug, id, data, invalidateSavedQueries, invalidateSavedQuery]);
 
   const saveQueryFromSavedQuery = useCallback(
     async (savedQuery: SavedQuery) => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -869,4 +869,85 @@ describe('ExploreToolbar', function () {
       );
     });
   });
+
+  it('highlights save button when saved query is changed', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/123/`,
+      method: 'GET',
+      body: {
+        query: [
+          {
+            query: '',
+            fields: ['count(span.duration)'],
+            groupby: ['span.op'],
+            orderby: '-count(span.duration)',
+            visualize: [
+              {
+                chartType: 1,
+                yAxes: ['count(span.duration)'],
+              },
+            ],
+            mode: 'aggregate',
+          },
+        ],
+        range: '14d',
+        projects: [],
+        environment: [],
+      },
+    });
+
+    const router = RouterFixture({
+      location: {
+        pathname: '/traces/',
+        query: {
+          query: '',
+          visualize: '{"chartType":1,"yAxes":["count(span.duration)"]}',
+          groupBy: ['span.op'],
+          sort: ['-count(span.duration)'],
+          field: ['count(span.duration)'],
+          id: '123',
+          mode: 'aggregate',
+        },
+      },
+    });
+
+    function Component() {
+      return <ExploreToolbar />;
+    }
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {router, organization}
+    );
+    screen.getByText('Save as\u2026');
+    const section = screen.getByTestId('section-sort-by');
+    await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'Asc'}));
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sort: ['count(span.duration)'],
+        }),
+      })
+    );
+
+    // Simulate navigation from sort change
+    router.location.query.sort = ['count(span.duration)'];
+    router.push(router.location);
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>,
+      {router, organization}
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -15,7 +16,9 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
+import {encodeSort} from 'sentry/utils/discover/eventView';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
+import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -32,6 +35,7 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useAddToDashboard} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {ToolbarSection} from 'sentry/views/explore/toolbar/styles';
@@ -190,6 +194,71 @@ export function ToolbarSaveAs() {
     });
   }
 
+  const {data: savedQuery, isLoading: isLoadingSavedQuery} = useGetSavedQuery(id);
+
+  const shouldHighlightSaveButton = useMemo(() => {
+    if (isLoadingSavedQuery || savedQuery === undefined) {
+      return false;
+    }
+    // Compares editable fields from saved query with location params to check for changes
+    const queryIsEqual = valueIsEqual(query, savedQuery?.query[0]?.query);
+    const groupBysIsEqual = valueIsEqual(groupBys, savedQuery?.query[0]?.groupby);
+    const sortByString = sortBys[0] ? encodeSort(sortBys[0]) : undefined;
+    const sortByIsEqual = valueIsEqual(sortByString, savedQuery?.query[0]?.orderby);
+    const fieldsIsEqual = valueIsEqual(fields, savedQuery?.query[0]?.fields);
+    const visualizesIsEqual = valueIsEqual(
+      visualizes.map(({chartType, yAxes}) => ({chartType, yAxes})),
+      savedQuery?.query[0]?.visualize,
+      true
+    );
+    const startIsEqual =
+      (defined(savedQuery.start) ? new Date(savedQuery.start).getTime() : null) ===
+      (pageFilters.selection.datetime.start
+        ? new Date(pageFilters.selection.datetime.start).getTime()
+        : null);
+    const endIsEqual =
+      (defined(savedQuery.end) ? new Date(savedQuery.end).getTime() : null) ===
+      (pageFilters.selection.datetime.end
+        ? new Date(pageFilters.selection.datetime.end).getTime()
+        : null);
+    const periodIsEqual =
+      (savedQuery.range ?? null) === pageFilters.selection.datetime.period;
+    const projectIsEqual = valueIsEqual(
+      savedQuery.projects,
+      pageFilters.selection.projects
+    );
+    const environmentIsEqual = valueIsEqual(
+      savedQuery.environment,
+      pageFilters.selection.environments
+    );
+
+    return (
+      !queryIsEqual ||
+      !groupBysIsEqual ||
+      !sortByIsEqual ||
+      !fieldsIsEqual ||
+      !visualizesIsEqual ||
+      !startIsEqual ||
+      !endIsEqual ||
+      !periodIsEqual ||
+      !projectIsEqual ||
+      !environmentIsEqual
+    );
+  }, [
+    isLoadingSavedQuery,
+    savedQuery,
+    query,
+    groupBys,
+    sortBys,
+    fields,
+    visualizes,
+    pageFilters.selection.datetime.start,
+    pageFilters.selection.datetime.end,
+    pageFilters.selection.datetime.period,
+    pageFilters.selection.projects,
+    pageFilters.selection.environments,
+  ]);
+
   if (items.length === 0) {
     return null;
   }
@@ -202,6 +271,7 @@ export function ToolbarSaveAs() {
           trigger={triggerProps => (
             <SaveAsButton
               {...triggerProps}
+              priority={shouldHighlightSaveButton ? 'primary' : 'default'}
               aria-label={t('Save as')}
               onClick={e => {
                 e.stopPropagation();
@@ -210,7 +280,7 @@ export function ToolbarSaveAs() {
                 triggerProps.onClick?.(e);
               }}
             >
-              {`${t('Save as')}\u2026`}
+              {shouldHighlightSaveButton ? `${t('Save')}` : `${t('Save as')}\u2026`}
             </SaveAsButton>
           )}
         />

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -200,50 +200,34 @@ export function ToolbarSaveAs() {
     if (isLoadingSavedQuery || savedQuery === undefined) {
       return false;
     }
-    // Compares editable fields from saved query with location params to check for changes
-    const queryIsEqual = valueIsEqual(query, savedQuery?.query[0]?.query);
-    const groupBysIsEqual = valueIsEqual(groupBys, savedQuery?.query[0]?.groupby);
-    const sortByString = sortBys[0] ? encodeSort(sortBys[0]) : undefined;
-    const sortByIsEqual = valueIsEqual(sortByString, savedQuery?.query[0]?.orderby);
-    const fieldsIsEqual = valueIsEqual(fields, savedQuery?.query[0]?.fields);
-    const visualizesIsEqual = valueIsEqual(
-      visualizes.map(({chartType, yAxes}) => ({chartType, yAxes})),
-      savedQuery?.query[0]?.visualize,
-      true
-    );
-    const startIsEqual =
-      (defined(savedQuery.start) ? new Date(savedQuery.start).getTime() : null) ===
-      (pageFilters.selection.datetime.start
-        ? new Date(pageFilters.selection.datetime.start).getTime()
-        : null);
-    const endIsEqual =
-      (defined(savedQuery.end) ? new Date(savedQuery.end).getTime() : null) ===
-      (pageFilters.selection.datetime.end
-        ? new Date(pageFilters.selection.datetime.end).getTime()
-        : null);
-    const periodIsEqual =
-      (savedQuery.range ?? null) === pageFilters.selection.datetime.period;
-    const projectIsEqual = valueIsEqual(
-      savedQuery.projects,
-      pageFilters.selection.projects
-    );
-    const environmentIsEqual = valueIsEqual(
-      savedQuery.environment,
-      pageFilters.selection.environments
-    );
+    // The non comparison trace explorer view only supports a single query
+    const singleQuery = savedQuery?.query[0];
+    const locationSortByString = sortBys[0] ? encodeSort(sortBys[0]) : undefined;
 
-    return (
-      !queryIsEqual ||
-      !groupBysIsEqual ||
-      !sortByIsEqual ||
-      !fieldsIsEqual ||
-      !visualizesIsEqual ||
-      !startIsEqual ||
-      !endIsEqual ||
-      !periodIsEqual ||
-      !projectIsEqual ||
-      !environmentIsEqual
-    );
+    // Compares editable fields from saved query with location params to check for changes
+    const hasChangesArray = [
+      !valueIsEqual(query, singleQuery?.query),
+      !valueIsEqual(groupBys, singleQuery?.groupby),
+      !valueIsEqual(locationSortByString, singleQuery?.orderby),
+      !valueIsEqual(fields, singleQuery?.fields),
+      !valueIsEqual(
+        visualizes.map(({chartType, yAxes}) => ({chartType, yAxes})),
+        singleQuery?.visualize,
+        true
+      ),
+      !valueIsEqual(savedQuery.projects, pageFilters.selection.projects),
+      !valueIsEqual(savedQuery.environment, pageFilters.selection.environments),
+      (defined(savedQuery.start) ? new Date(savedQuery.start).getTime() : null) !==
+        (pageFilters.selection.datetime.start
+          ? new Date(pageFilters.selection.datetime.start).getTime()
+          : null),
+      (defined(savedQuery.end) ? new Date(savedQuery.end).getTime() : null) !==
+        (pageFilters.selection.datetime.end
+          ? new Date(pageFilters.selection.datetime.end).getTime()
+          : null),
+      (savedQuery.range ?? null) !== pageFilters.selection.datetime.period,
+    ];
+    return hasChangesArray.some(Boolean);
   }, [
     isLoadingSavedQuery,
     savedQuery,

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -94,9 +94,9 @@ export function getExploreUrlFromSavedQueryUrl({
       title: savedQuery.name,
       selection: {
         datetime: {
-          end: savedQuery.end,
-          period: savedQuery.range,
-          start: savedQuery.start,
+          end: savedQuery.end ?? null,
+          period: savedQuery.range ?? null,
+          start: savedQuery.start ?? null,
           utc: null,
         },
         environments: savedQuery.environment,
@@ -115,9 +115,9 @@ export function getExploreUrlFromSavedQueryUrl({
     mode: savedQuery.query[0].mode as Mode,
     selection: {
       datetime: {
-        end: savedQuery.end,
-        period: savedQuery.range,
-        start: savedQuery.start,
+        end: savedQuery.end ?? null,
+        period: savedQuery.range ?? null,
+        start: savedQuery.start ?? null,
         utc: null,
       },
       environments: savedQuery.environment,


### PR DESCRIPTION
Updates the `Save as...` button in the trace explorer to change text and highlight when a change is detected on a saved query 
![image](https://github.com/user-attachments/assets/39241e10-5d6f-43da-8b51-d54cfc89bf88)
