### PR TITLE
feat(insights): Append ECharts tooltips to `document.body` for `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -591,6 +591,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         props?.onLegendSelectionChange?.(event.selected);
       }}
       tooltip={{
+        appendToBody: true,
         trigger: 'axis',
         axisPointer: {
           type: 'cross',


### PR DESCRIPTION
Using the `appendToBody` option, we can have ECharts render tooltips to `<body>`. This means that if ECharts is inside of a DOM element w/ `overflow: hidden` (e.g. Global Drawer), the tooltip will not get cutoff. A small side-effect of this is that for every chart that is rendered, we will have an empty `<div>` element. (e.g. if you have 20 charts on the page, you will have 20 empty divs in the body el).

This previously done in https://github.com/getsentry/sentry/pull/88698 but reverted because I saw some weird behavior that I'm no longer seeing...