### PR TITLE
chore(ourlogs): Use the renderer for the template field too

### DIFF
--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -135,7 +135,7 @@ export function TraceIDRenderer(props: LogFieldRendererProps) {
   return <Link to={target}>{props.basicRendered}</Link>;
 }
 
-export function LogBodyRenderer(props: LogFieldRendererProps) {
+export function LogBodyAndTemplateRenderer(props: LogFieldRendererProps) {
   const attribute_value = props.item.value as string;
   const highlightTerm = props.extra?.highlightTerms[0] ?? '';
   // TODO: Allow more than one highlight term to be highlighted at once.
@@ -194,7 +194,8 @@ export const LogAttributesRendererMap: Record<
     return TimestampRenderer(props);
   },
   [OurLogKnownFieldKey.SEVERITY_TEXT]: SeverityTextRenderer,
-  [OurLogKnownFieldKey.MESSAGE]: LogBodyRenderer,
+  [OurLogKnownFieldKey.MESSAGE]: LogBodyAndTemplateRenderer,
+  [OurLogKnownFieldKey.TEMPLATE]: LogBodyAndTemplateRenderer,
   [OurLogKnownFieldKey.TRACE_ID]: TraceIDRenderer,
 };
 

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -24,7 +24,7 @@ import {
 import {HiddenLogDetailFields} from 'sentry/views/explore/logs/constants';
 import {
   LogAttributesRendererMap,
-  LogBodyRenderer,
+  LogBodyAndTemplateRenderer,
   LogFieldRenderer,
   SeverityCircleRenderer,
 } from 'sentry/views/explore/logs/fieldRenderers';
@@ -259,7 +259,7 @@ function LogRowDetails({
           <Fragment>
             <DetailsContent>
               <DetailsBody>
-                {LogBodyRenderer({
+                {LogBodyAndTemplateRenderer({
                   item: getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta),
                   extra: {
                     highlightTerms,

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -16,7 +16,7 @@ export enum OurLogKnownFieldKey {
   // From the EAP dataset directly not using a column alias.
   ID = 'sentry.item_id',
   MESSAGE = 'message',
-  TEMPLATE = 'message.template',
+  TEMPLATE = 'sentry.message.template',
   SEVERITY_NUMBER = 'severity_number',
   SEVERITY_TEXT = 'severity_text',
   ORGANIZATION_ID = 'organization.id',

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -16,6 +16,7 @@ export enum OurLogKnownFieldKey {
   // From the EAP dataset directly not using a column alias.
   ID = 'sentry.item_id',
   MESSAGE = 'message',
+  TEMPLATE = 'message.template',
   SEVERITY_NUMBER = 'severity_number',
   SEVERITY_TEXT = 'severity_text',
   ORGANIZATION_ID = 'organization.id',


### PR DESCRIPTION
The template field also contains ANSI codes, sometimes - use a standard renderer for both.