### PR TITLE
ref(replay): Inline ReplaySettingsAlert where its used

### DIFF
--- a/static/app/components/replays/alerts/replaySettingsAlert.tsx
+++ b/static/app/components/replays/alerts/replaySettingsAlert.tsx
@@ -1,8 +1,0 @@
-import HookOrDefault from 'sentry/components/hookOrDefault';
-
-const ReplaySettingsAlert = HookOrDefault({
-  hookName: 'component:replay-settings-alert',
-  defaultComponent: null,
-});
-
-export default ReplaySettingsAlert;

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -3,8 +3,8 @@ import {LinkButton} from 'sentry/components/core/button';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {JsonFormObject} from 'sentry/components/forms/types';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import Link from 'sentry/components/links/link';
-import ReplaySettingsAlert from 'sentry/components/replays/alerts/replaySettingsAlert';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -13,6 +13,11 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
+
+const ReplaySettingsAlert = HookOrDefault({
+  hookName: 'component:replay-settings-alert',
+  defaultComponent: null,
+});
 
 type RouteParams = {
   projectId: string;


### PR DESCRIPTION
This is used in one spot, doesn't need to be it's own file inside `components/replays/alerts/`