### PR TITLE
fix(billing): Remove uptime subscription on project deletion

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -45,6 +45,7 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
         from sentry.replays.models import ReplayRecordingSegment
         from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
         from sentry.snuba.models import QuerySubscription
+        from sentry.uptime.models import ProjectUptimeSubscription
 
         relations: list[BaseRelation] = [
             # ProjectKey gets revoked immediately, in bulk
@@ -84,6 +85,7 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             ProguardArtifactRelease,
             DiscoverSavedQueryProject,
             IncidentProject,
+            ProjectUptimeSubscription,
         ):
             relations.append(ModelRelation(m1, {"project_id": instance.id}, BulkModelDeletionTask))
 


### PR DESCRIPTION
Closes: https://github.com/getsentry/sentry/issues/89523

The uptime monitor should be disabled or deleted when the project no longer exists. The seat should be relinquished.