### PR TITLE
Fix(explore): Fix `starred` attribute always false in explore saved query details endpoint

### DIFF
--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -81,7 +81,7 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
 
         self.check_object_permissions(request, query)
 
-        return Response(serialize(query), status=200)
+        return Response(serialize(query, request.user), status=200)
 
     @extend_schema(
         operation_id="Edit an Organization's Explore Saved Query",


### PR DESCRIPTION
Fixes an issue in the explore saved query detail endpoint not passing the request user to serializer, causing the starred attribute not being picked up