### PR TITLE
fix(feedback): reload list after updating feedback status

### DIFF
--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -51,14 +51,9 @@ export default function useFeedbackActions({feedbackItem}: Props) {
     organization,
     projectIds: feedbackItem.project ? [feedbackItem.project.id] : [],
   });
-  const deleteFeedback = useDeleteFeedback([feedbackItem.id], projectId);
-
+  const onDelete = useDeleteFeedback([feedbackItem.id], projectId, reloadListData);
   const hasDelete = organization.features.includes('issue-platform-deletion-ui');
   const disableDelete = !organization.access.includes('event:admin');
-  const onDelete = () => {
-    deleteFeedback();
-    reloadListData();
-  };
 
   const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
   const onResolveClick = useCallback(() => {

--- a/static/app/components/feedback/list/useRefetchFeedbackList.tsx
+++ b/static/app/components/feedback/list/useRefetchFeedbackList.tsx
@@ -1,0 +1,19 @@
+import {useCallback} from 'react';
+
+import useFeedbackCache from 'sentry/components/feedback/useFeedbackCache';
+import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
+import {useQueryClient} from 'sentry/utils/queryClient';
+
+export default function useRefetchFeedbackList() {
+  const queryClient = useQueryClient();
+  const {listQueryKey, resetListHeadTime} = useFeedbackQueryKeys();
+  const {invalidateListCache} = useFeedbackCache();
+
+  const refetchFeedbackList = useCallback(() => {
+    queryClient.invalidateQueries({queryKey: listQueryKey});
+    resetListHeadTime();
+    invalidateListCache();
+  }, [queryClient, listQueryKey, resetListHeadTime, invalidateListCache]);
+
+  return {refetchFeedbackList};
+}

--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -11,7 +11,11 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
-export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
+export const useDeleteFeedback = (
+  feedbackIds: any,
+  projectId: any,
+  reloadListData: () => void
+) => {
   const organization = useOrganization();
   const api = useApi({
     persistInFlight: false,
@@ -32,6 +36,7 @@ export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
           },
           {
             complete: () => {
+              reloadListData();
               navigate(
                 normalizeUrl({
                   pathname: makeFeedbackPathname({
@@ -63,5 +68,6 @@ export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
     navigate,
     organization,
     projectId,
+    reloadListData,
   ]);
 };

--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import {bulkDelete} from 'sentry/actionCreators/group';
 import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
+import useRefetchFeedbackList from 'sentry/components/feedback/list/useRefetchFeedbackList';
 import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
@@ -11,17 +12,15 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
-export const useDeleteFeedback = (
-  feedbackIds: any,
-  projectId: any,
-  reloadListData: () => void
-) => {
+export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
   const organization = useOrganization();
   const api = useApi({
     persistInFlight: false,
   });
   const navigate = useNavigate();
   const {query: locationQuery} = useLocation();
+
+  const {refetchFeedbackList} = useRefetchFeedbackList();
 
   return useCallback(() => {
     openConfirmModal({
@@ -36,7 +35,7 @@ export const useDeleteFeedback = (
           },
           {
             complete: () => {
-              reloadListData();
+              refetchFeedbackList();
               navigate(
                 normalizeUrl({
                   pathname: makeFeedbackPathname({
@@ -68,6 +67,6 @@ export const useDeleteFeedback = (
     navigate,
     organization,
     projectId,
-    reloadListData,
+    refetchFeedbackList,
   ]);
 };


### PR DESCRIPTION
After a feedback mutation is successful, invalidate the list query response and empty the cache (similar to what we do in "Load new feedback"), causing the list to refetch.

Closes https://github.com/getsentry/sentry/issues/84722
Closes https://github.com/getsentry/sentry/issues/76920

Demo of all actions except delete (I don't have permission):

https://github.com/user-attachments/assets/fe23c1aa-9a81-4ba4-a1b4-aecd57ca783e

