### PR TITLE
feat(insights): Replace cache hit/miss chart in span sample panel with `InsightsTimeSeriesWidget`

### DIFF
--- a/static/app/views/insights/cache/components/charts/hitMissChart.tsx
+++ b/static/app/views/insights/cache/components/charts/hitMissChart.tsx
@@ -1,41 +1,21 @@
-import {useTheme} from '@emotion/react';
-
-import type {Series} from 'sentry/types/echarts';
-import {formatPercentage} from 'sentry/utils/number/formatPercentage';
-import {CHART_HEIGHT} from 'sentry/views/insights/cache/settings';
-import {AVG_COLOR} from 'sentry/views/insights/colors';
-import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
-import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 
 type Props = {
   isLoading: boolean;
-  series: Series;
+  series: DiscoverSeries;
   error?: Error | null;
 };
 
 export function CacheHitMissChart({series, isLoading, error}: Props) {
-  const theme = useTheme();
   return (
-    <ChartPanel title={DataTitles[`cache_miss_rate()`]}>
-      <Chart
-        height={CHART_HEIGHT}
-        grid={{
-          left: '4px',
-          right: '0',
-          top: '8px',
-          bottom: '0',
-        }}
-        data={[series]}
-        loading={isLoading}
-        error={error}
-        chartColors={[AVG_COLOR(theme)]}
-        type={ChartType.LINE}
-        aggregateOutputFormat="percentage"
-        tooltipFormatterOptions={{
-          valueFormatter: value => formatPercentage(value),
-        }}
-      />
-    </ChartPanel>
+    <InsightsLineChartWidget
+      title={DataTitles[`cache_miss_rate()`]}
+      series={[series]}
+      showLegend="never"
+      isLoading={isLoading}
+      error={error ?? null}
+    />
   );
 }


### PR DESCRIPTION
2EZ

Closes [DAIN-171: Replace `CacheHitMissChart` with `InsightsTimeSeriesWidget`](https://linear.app/getsentry/issue/DAIN-171/replace-cachehitmisschart-with-insightstimeserieswidget)

**e.g.,**
![Screenshot 2025-04-15 at 2 26 24 PM](https://github.com/user-attachments/assets/119335be-a6f8-49eb-bc92-fe9a94ef8e37)
