### PR TITLE
fix: Insights Date Picker dropdown doesn't depend on trial for paid features

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -2,14 +2,15 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
-import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboardingPanel} from 'sentry/views/insights/common/components/modulesOnboarding';
-import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
-import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
@@ -40,15 +41,11 @@ export function SessionsOverview() {
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
-              <ToolRibbon>
-                <ModulePageFilterBar
-                  moduleName={ModuleName.SESSIONS}
-                  extraFilters={<SubregionSelector />}
-                  onProjectChange={() => {
-                    setFilters(['']);
-                  }}
-                />
-              </ToolRibbon>
+              <PageFilterBar>
+                <ProjectPageFilter resetParamsOnChange={['cursor']} />
+                <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
+                <DatePageFilter />
+              </PageFilterBar>
             </ModuleLayout.Full>
             {showOnboarding ? (
               <ModuleLayout.Full>


### PR DESCRIPTION
before the 14d and 30d options were disabled, that was added because of a check here:
https://github.com/getsentry/sentry/blob/d175c18a42a6f6f1be51d112d297d94dd8a6dda1/static/app/views/insights/common/components/modulePageFilterBar.tsx#L45-L47

**Before**
![SCR-20250415-kkve](https://github.com/user-attachments/assets/86878adc-d2c7-4095-b077-1d7ff003850a)


**After**
![SCR-20250415-kksv](https://github.com/user-attachments/assets/ee845483-5215-44dd-8c9f-8744617e365d)
