### PR TITLE
fix(replay): fix banner showing up incorrectly in issue details

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -37,6 +37,7 @@ function ReplayClipPreview({
     orgSlug,
     replaySlug,
     clipWindow,
+    eventTimestampMs,
   });
 
   const {fetching, replay} = replayReaderResult;

--- a/static/app/utils/replays/hooks/useLoadReplayReader.tsx
+++ b/static/app/utils/replays/hooks/useLoadReplayReader.tsx
@@ -11,6 +11,7 @@ type Props = {
     endTimestampMs: number;
     startTimestampMs: number;
   };
+  eventTimestampMs?: number;
   group?: Group;
 };
 
@@ -23,6 +24,7 @@ export default function useLoadReplayReader({
   orgSlug,
   replaySlug,
   clipWindow,
+  eventTimestampMs,
   group,
 }: Props): ReplayReaderResult {
   const replayId = parseReplayId(replaySlug);
@@ -61,8 +63,9 @@ export default function useLoadReplayReader({
         errors,
         fetching,
         replayRecord,
+        eventTimestampMs,
       }),
-    [attachments, memoizedClipWindow, errors, fetching, replayRecord]
+    [attachments, memoizedClipWindow, errors, fetching, replayRecord, eventTimestampMs]
   );
 
   return {


### PR DESCRIPTION
fix the logic for showing the message in clip previews -- it should be based on the event timestamp, not the clip start time


<img width="1069" alt="SCR-20250415-kmca" src="https://github.com/user-attachments/assets/c27d0834-36d9-4324-8f39-409fae10bd8e" />
