### PR TITLE
feat(aci): Create missing open periods on update

### DIFF
--- a/tests/sentry/issues/test_status_change.py
+++ b/tests/sentry/issues/test_status_change.py
@@ -259,6 +259,7 @@ class HandleStatusChangeTest(TestCase):
 
         assert len(GroupOpenPeriod.objects.filter(group=self.group)) == 1
         open_period = GroupOpenPeriod.objects.filter(group=self.group).first()
+        assert open_period is not None
         assert open_period.date_started is not None
         assert open_period.date_ended is None
 
@@ -290,5 +291,6 @@ class HandleStatusChangeTest(TestCase):
 
         assert len(GroupOpenPeriod.objects.filter(group=self.group)) == 1
         open_period = GroupOpenPeriod.objects.filter(group=self.group).first()
+        assert open_period is not None
         assert open_period.date_started is not None
         assert open_period.date_ended is None


### PR DESCRIPTION
Until we backfill open periods, we will continue to hit an error case where an open period needs to be updated but does not yet exist. To fix this, we can create those open periods when we expect them to exist. 

This logic can be removed after the backfill, but helps validate the open period creation/update logic in the interim.