### PR TITLE
chore(workflow_engine): Refactor detector configuration

### DIFF
--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -7,7 +7,7 @@ from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
 from sentry.workflow_engine.handlers.detector.base import DetectorEvaluationResult, DetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
 
 T = TypeVar("T")
 
@@ -28,7 +28,7 @@ class ErrorGroupType(GroupType):
     category = GroupCategory.ERROR.value
     default_priority = PriorityLevel.MEDIUM
     released = True
-    detector_config = DetectorConfig(
+    detector_settings = DetectorSettings(
         handler=ErrorDetectorHandler,
         validator=ErrorDetectorValidator,
         config_schema={"type": "object", "additionalProperties": False},

--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -7,7 +7,7 @@ from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
 from sentry.workflow_engine.handlers.detector.base import DetectorEvaluationResult, DetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import DetectorGroupKey
+from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey
 
 T = TypeVar("T")
 
@@ -28,6 +28,8 @@ class ErrorGroupType(GroupType):
     category = GroupCategory.ERROR.value
     default_priority = PriorityLevel.MEDIUM
     released = True
-    detector_validator = ErrorDetectorValidator
-    detector_handler = ErrorDetectorHandler
-    detector_config_schema = {"type": "object", "additionalProperties": False}  # empty schema
+    detector_config = DetectorConfig(
+        handler=ErrorDetectorHandler,
+        validator=ErrorDetectorValidator,
+        config_schema={"type": "object", "additionalProperties": False},
+    )

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -16,7 +16,7 @@ from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import DetectorGroupKey
+from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -80,27 +80,29 @@ class MetricAlertFire(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
-    detector_handler = MetricAlertDetectorHandler
-    detector_validator = MetricAlertsDetectorValidator
-    detector_config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "A representation of a metric alert firing",
-        "type": "object",
-        "required": ["threshold_period", "detection_type"],
-        "properties": {
-            "threshold_period": {"type": "integer", "minimum": 1, "maximum": 20},
-            "comparison_delta": {
-                "type": ["integer", "null"],
-                "enum": COMPARISON_DELTA_CHOICES,
+    detector_config = DetectorConfig(
+        handler=MetricAlertDetectorHandler,
+        validator=MetricAlertsDetectorValidator,
+        config_schema={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "A representation of a metric alert firing",
+            "type": "object",
+            "required": ["threshold_period", "detection_type"],
+            "properties": {
+                "threshold_period": {"type": "integer", "minimum": 1, "maximum": 20},
+                "comparison_delta": {
+                    "type": ["integer", "null"],
+                    "enum": COMPARISON_DELTA_CHOICES,
+                },
+                "detection_type": {
+                    "type": "string",
+                    "enum": [detection_type.value for detection_type in AlertRuleDetectionType],
+                },
+                "sensitivity": {"type": ["string", "null"]},
+                "seasonality": {"type": ["string", "null"]},
             },
-            "detection_type": {
-                "type": "string",
-                "enum": [detection_type.value for detection_type in AlertRuleDetectionType],
-            },
-            "sensitivity": {"type": ["string", "null"]},
-            "seasonality": {"type": ["string", "null"]},
         },
-    }
+    )
 
     @classmethod
     def allow_post_process_group(cls, organization: Organization) -> bool:

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -16,7 +16,7 @@ from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -80,7 +80,7 @@ class MetricAlertFire(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
-    detector_config = DetectorConfig(
+    detector_settings = DetectorSettings(
         handler=MetricAlertDetectorHandler,
         validator=MetricAlertsDetectorValidator,
         config_schema={

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import IntEnum, StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
 from django.apps import apps
@@ -18,12 +18,11 @@ from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
+from sentry.workflow_engine.types import DetectorConfig
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
-    from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
-    from sentry.workflow_engine.handlers.detector import DetectorHandler
 
 logger = logging.getLogger(__name__)
 
@@ -176,12 +175,10 @@ class GroupType:
     # Quota around many of these issue types can be created per project in a given time window
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
     notification_config: NotificationConfig = NotificationConfig()
-    detector_handler: type[DetectorHandler] | None = None
-    detector_validator: type[BaseDetectorTypeValidator] | None = None
+    detector_config: DetectorConfig | None = None
     # Controls whether status change (i.e. resolved, regressed) workflow notifications are enabled.
     # Defaults to true to maintain the default workflow notification behavior as it exists for error group types.
     enable_status_change_workflow_notifications: bool = True
-    detector_config_schema: ClassVar[dict[str, Any]] = {}
 
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -18,7 +18,7 @@ from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
-from sentry.workflow_engine.types import DetectorConfig
+from sentry.workflow_engine.types import DetectorSettings
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -175,7 +175,7 @@ class GroupType:
     # Quota around many of these issue types can be created per project in a given time window
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
     notification_config: NotificationConfig = NotificationConfig()
-    detector_config: DetectorConfig | None = None
+    detector_settings: DetectorSettings | None = None
     # Controls whether status change (i.e. resolved, regressed) workflow notifications are enabled.
     # Defaults to true to maintain the default workflow notification behavior as it exists for error group types.
     enable_status_change_workflow_notifications: bool = True

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.types import DetectorConfig
+from sentry.workflow_engine.types import DetectorSettings
 
 
 @dataclass(frozen=True)
@@ -18,7 +18,7 @@ class UptimeDomainCheckFailure(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
-    detector_config = DetectorConfig(
+    detector_settings = DetectorSettings(
         config_schema={
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "description": "A representation of an uptime alert",

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.types import DetectorConfig
 
 
 @dataclass(frozen=True)
@@ -17,18 +18,20 @@ class UptimeDomainCheckFailure(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
-    detector_config_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "A representation of an uptime alert",
-        "type": "object",
-        "required": ["mode", "environment"],
-        "properties": {
-            "mode": {
-                "type": ["integer"],
-                # TODO: Enable this when we can move this grouptype out of this file
-                # "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+    detector_config = DetectorConfig(
+        config_schema={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "A representation of an uptime alert",
+            "type": "object",
+            "required": ["mode", "environment"],
+            "properties": {
+                "mode": {
+                    "type": ["integer"],
+                    # TODO: Enable this when we can move this grouptype out of this file
+                    # "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+                },
+                "environment": {"type": ["string"]},
             },
-            "environment": {"type": ["string"]},
+            "additionalProperties": False,
         },
-        "additionalProperties": False,
-    }
+    )

--- a/src/sentry/workflow_engine/endpoints/organization_detector_types.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_types.py
@@ -43,7 +43,7 @@ class OrganizationDetectorTypeIndexEndpoint(OrganizationEndpoint):
         type_slugs = [
             gt.slug
             for gt in grouptype.registry.get_visible(organization)
-            if gt.detector_config is not None and gt.detector_config.handler is not None
+            if gt.detector_settings is not None and gt.detector_settings.handler is not None
         ]
         type_slugs.sort()
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_types.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_types.py
@@ -43,7 +43,7 @@ class OrganizationDetectorTypeIndexEndpoint(OrganizationEndpoint):
         type_slugs = [
             gt.slug
             for gt in grouptype.registry.get_visible(organization)
-            if gt.detector_handler is not None
+            if gt.detector_config is not None and gt.detector_config.handler is not None
         ]
         type_slugs.sort()
 

--- a/src/sentry/workflow_engine/endpoints/project_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_details.py
@@ -89,7 +89,9 @@ class ProjectDetectorDetailsEndpoint(ProjectEndpoint):
         request=PolymorphicProxySerializer(
             "GenericDetectorSerializer",
             serializers=[
-                gt.detector_validator for gt in grouptype.registry.all() if gt.detector_validator
+                gt.detector_config.validator
+                for gt in grouptype.registry.all()
+                if gt.detector_config and gt.detector_config.validator
             ],
             resource_type_field_name=None,
         ),

--- a/src/sentry/workflow_engine/endpoints/project_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_details.py
@@ -89,9 +89,9 @@ class ProjectDetectorDetailsEndpoint(ProjectEndpoint):
         request=PolymorphicProxySerializer(
             "GenericDetectorSerializer",
             serializers=[
-                gt.detector_config.validator
+                gt.detector_settings.validator
                 for gt in grouptype.registry.all()
-                if gt.detector_config and gt.detector_config.validator
+                if gt.detector_settings and gt.detector_settings.validator
             ],
             resource_type_field_name=None,
         ),

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -29,10 +29,10 @@ def get_detector_validator(
     if detector_type is None:
         raise ValidationError({"detectorType": ["Unknown detector type"]})
 
-    if detector_type.detector_validator is None:
+    if detector_type.detector_config is None or detector_type.detector_config.validator is None:
         raise ValidationError({"detectorType": ["Detector type not compatible with detectors"]})
 
-    return detector_type.detector_validator(
+    return detector_type.detector_config.validator(
         instance=instance,
         context={
             "project": project,
@@ -97,7 +97,9 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         request=PolymorphicProxySerializer(
             "GenericDetectorSerializer",
             serializers=[
-                gt.detector_validator for gt in grouptype.registry.all() if gt.detector_validator
+                gt.detector_config.validator
+                for gt in grouptype.registry.all()
+                if gt.detector_config and gt.detector_config.validator
             ],
             resource_type_field_name=None,
         ),

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -29,10 +29,10 @@ def get_detector_validator(
     if detector_type is None:
         raise ValidationError({"detectorType": ["Unknown detector type"]})
 
-    if detector_type.detector_config is None or detector_type.detector_config.validator is None:
+    if detector_type.detector_settings is None or detector_type.detector_settings.validator is None:
         raise ValidationError({"detectorType": ["Detector type not compatible with detectors"]})
 
-    return detector_type.detector_config.validator(
+    return detector_type.detector_settings.validator(
         instance=instance,
         context={
             "project": project,
@@ -97,9 +97,9 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         request=PolymorphicProxySerializer(
             "GenericDetectorSerializer",
             serializers=[
-                gt.detector_config.validator
+                gt.detector_settings.validator
                 for gt in grouptype.registry.all()
-                if gt.detector_config and gt.detector_config.validator
+                if gt.detector_settings and gt.detector_settings.validator
             ],
             resource_type_field_name=None,
         ),

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -32,7 +32,10 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         detector_type = grouptype.registry.get_by_slug(value)
         if detector_type is None:
             raise serializers.ValidationError("Unknown detector type")
-        if detector_type.detector_config is None or detector_type.detector_config.validator is None:
+        if (
+            detector_type.detector_settings is None
+            or detector_type.detector_settings.validator is None
+        ):
             raise serializers.ValidationError("Detector type not compatible with detectors")
         # TODO: Probably need to check a feature flag to decide if a given
         # org/user is allowed to add a detector

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -32,7 +32,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         detector_type = grouptype.registry.get_by_slug(value)
         if detector_type is None:
             raise serializers.ValidationError("Unknown detector type")
-        if detector_type.detector_validator is None:
+        if detector_type.detector_config is None or detector_type.detector_config.validator is None:
             raise serializers.ValidationError("Detector type not compatible with detectors")
         # TODO: Probably need to check a feature flag to decide if a given
         # org/user is allowed to add a detector

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -87,7 +87,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
             return None
 
-        if not group_type.detector_config or not group_type.detector_config.handler:
+        if not group_type.detector_settings or not group_type.detector_settings.handler:
             logger.error(
                 "Registered grouptype for detector has no detector_handler",
                 extra={
@@ -97,7 +97,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
                 },
             )
             return None
-        return group_type.detector_config.handler(self)
+        return group_type.detector_settings.handler(self)
 
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
@@ -121,10 +121,10 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
     if not group_type:
         raise ValueError(f"No group type found with type {instance.type}")
 
-    if not group_type.detector_config:
+    if not group_type.detector_settings:
         return
 
     if not isinstance(instance.config, dict):
         raise ValidationError("Detector config must be a dictionary")
 
-    instance.validate_config(group_type.detector_config.config_schema)
+    instance.validate_config(group_type.detector_settings.config_schema)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -87,7 +87,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
             return None
 
-        if not group_type.detector_handler:
+        if not group_type.detector_config or not group_type.detector_config.handler:
             logger.error(
                 "Registered grouptype for detector has no detector_handler",
                 extra={
@@ -97,7 +97,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
                 },
             )
             return None
-        return group_type.detector_handler(self)
+        return group_type.detector_config.handler(self)
 
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
@@ -121,8 +121,10 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
     if not group_type:
         raise ValueError(f"No group type found with type {instance.type}")
 
+    if not group_type.detector_config:
+        raise ValueError(f"No detector_config specified for this group type {instance.type}")
+
     if not isinstance(instance.config, dict):
         raise ValidationError("Detector config must be a dictionary")
 
-    config_schema = group_type.detector_config_schema
-    instance.validate_config(config_schema)
+    instance.validate_config(group_type.detector_config.config_schema)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -122,7 +122,7 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
         raise ValueError(f"No group type found with type {instance.type}")
 
     if not group_type.detector_config:
-        raise ValueError(f"No detector_config specified for this group type {instance.type}")
+        return
 
     if not isinstance(instance.config, dict):
         raise ValidationError("Detector config must be a dictionary")

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -123,7 +123,7 @@ class SnubaQueryDataSourceType(TypedDict):
 
 
 @dataclass(frozen=True)
-class DetectorConfig:
+class DetectorSettings:
     handler: type[DetectorHandler] | None = None
     validator: type[BaseDetectorTypeValidator] | None = None
     config_schema: dict[str, Any] = field(default_factory=dict)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from sentry.eventstream.base import GroupState
     from sentry.models.environment import Environment
     from sentry.snuba.models import SnubaQueryEventType
+    from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
+    from sentry.workflow_engine.handlers.detector import DetectorHandler
     from sentry.workflow_engine.models import Action, Detector
     from sentry.workflow_engine.models.data_condition import Condition
 
@@ -118,3 +120,10 @@ class SnubaQueryDataSourceType(TypedDict):
     resolution: float
     environment: str
     event_types: list[SnubaQueryEventType]
+
+
+@dataclass(frozen=True)
+class DetectorConfig:
+    handler: type[DetectorHandler] | None = None
+    validator: type[BaseDetectorTypeValidator] | None = None
+    config_schema: dict[str, Any] = field(default_factory=dict)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -14,7 +14,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, DetectorHandler
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey, DetectorPriorityLevel
 
 
 @region_silo_test
@@ -43,7 +43,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = MetricAlertFire.slug
             description = "Metric alert"
             category = GroupCategory.METRIC_ALERT.value
-            detector_handler = MockDetectorHandler
+            detector_config = DetectorConfig(handler=MockDetectorHandler)
             released = True
 
         @dataclass(frozen=True)
@@ -52,7 +52,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = MonitorIncidentType.slug
             description = "Crons"
             category = GroupCategory.CRON.value
-            detector_handler = MockDetectorHandler
+            detector_handler = DetectorConfig(handler=MockDetectorHandler)
             released = True
 
         @dataclass(frozen=True)
@@ -61,7 +61,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = UptimeDomainCheckFailure.slug
             description = "Uptime"
             category = GroupCategory.UPTIME.value
-            detector_handler = MockDetectorHandler
+            detector_config = DetectorConfig(handler=MockDetectorHandler)
             released = True
 
         # Should not be included in the response

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -52,7 +52,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = MonitorIncidentType.slug
             description = "Crons"
             category = GroupCategory.CRON.value
-            detector_handler = DetectorConfig(handler=MockDetectorHandler)
+            detector_config = DetectorConfig(handler=MockDetectorHandler)
             released = True
 
         @dataclass(frozen=True)
@@ -79,7 +79,6 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
 
     def test_simple(self):
         response = self.get_success_response(self.organization.slug, status_code=200)
-        assert len(response.data) == 3
         assert response.data == [
             MetricAlertFire.slug,
             MonitorIncidentType.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -14,7 +14,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, DetectorHandler
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorSettings
 
 
 @region_silo_test
@@ -43,7 +43,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = MetricAlertFire.slug
             description = "Metric alert"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config = DetectorConfig(handler=MockDetectorHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
         @dataclass(frozen=True)
@@ -52,7 +52,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = MonitorIncidentType.slug
             description = "Crons"
             category = GroupCategory.CRON.value
-            detector_config = DetectorConfig(handler=MockDetectorHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
         @dataclass(frozen=True)
@@ -61,7 +61,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             slug = UptimeDomainCheckFailure.slug
             description = "Uptime"
             category = GroupCategory.UPTIME.value
-            detector_config = DetectorConfig(handler=MockDetectorHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
         # Should not be included in the response

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -111,7 +111,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
 
     def test_incompatible_group_type(self):
         with mock.patch("sentry.issues.grouptype.registry.get_by_slug") as mock_get:
-            mock_get.return_value = mock.Mock(detector_validator=None)
+            mock_get.return_value = mock.Mock(detector_settings=None)
             data = {**self.valid_data, "detectorType": "incompatible_type"}
             response = self.get_error_response(
                 self.organization.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Dat
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import DetectorConfig, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorPriorityLevel, DetectorSettings
 from tests.sentry.workflow_engine.test_base import MockModel
 
 
@@ -119,7 +119,7 @@ class TestBaseGroupTypeDetectorValidator(BaseValidatorTest):
                 slug="test_type",
                 description="no handler",
                 category=GroupCategory.METRIC_ALERT.value,
-                detector_config=DetectorConfig(validator=MetricAlertsDetectorValidator),
+                detector_settings=DetectorSettings(validator=MetricAlertsDetectorValidator),
             )
             validator = self.validator_class()
             result = validator.validate_detector_type("test_type")

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -236,7 +236,7 @@ class DetectorValidatorTest(BaseValidatorTest):
 
     def test_validate_detector_type_incompatible(self):
         with mock.patch("sentry.issues.grouptype.registry.get_by_slug") as mock_get:
-            mock_get.return_value = mock.Mock(detector_validator=None)
+            mock_get.return_value = mock.Mock(detector_settings=None)
             validator = MockDetectorValidator(
                 data={**self.valid_data, "detectorType": "incompatible_type"}
             )

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Dat
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorConfig, DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import MockModel
 
 
@@ -119,7 +119,7 @@ class TestBaseGroupTypeDetectorValidator(BaseValidatorTest):
                 slug="test_type",
                 description="no handler",
                 category=GroupCategory.METRIC_ALERT.value,
-                detector_validator=MetricAlertsDetectorValidator,
+                detector_config=DetectorConfig(validator=MetricAlertsDetectorValidator),
             )
             validator = self.validator_class()
             result = validator.validate_detector_type("test_type")
@@ -141,7 +141,6 @@ class TestBaseGroupTypeDetectorValidator(BaseValidatorTest):
                 slug="test_type",
                 description="no handler",
                 category=GroupCategory.METRIC_ALERT.value,
-                detector_validator=None,
             )
             validator = self.validator_class()
             with pytest.raises(

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -11,7 +11,7 @@ from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, D
 from sentry.workflow_engine.handlers.detector.stateful import StatefulDetectorHandler
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorSettings
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
@@ -119,21 +119,21 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             slug = "handler"
             description = "handler"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config = DetectorConfig(handler=MockDetectorHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
 
         class HandlerStateGroupType(GroupType):
             type_id = 3
             slug = "handler_with_state"
             description = "handler with state"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config = DetectorConfig(handler=MockDetectorStateHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorStateHandler)
 
         class HandlerUpdateGroupType(GroupType):
             type_id = 4
             slug = "handler_update"
             description = "handler update"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config = DetectorConfig(handler=MockDetectorWithUpdateHandler)
+            detector_settings = DetectorSettings(handler=MockDetectorWithUpdateHandler)
 
         self.no_handler_type = NoHandlerGroupType
         self.handler_type = HandlerGroupType

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -11,7 +11,7 @@ from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, D
 from sentry.workflow_engine.handlers.detector.stateful import StatefulDetectorHandler
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorConfig, DetectorGroupKey, DetectorPriorityLevel
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
@@ -119,21 +119,21 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             slug = "handler"
             description = "handler"
             category = GroupCategory.METRIC_ALERT.value
-            detector_handler = MockDetectorHandler
+            detector_config = DetectorConfig(handler=MockDetectorHandler)
 
         class HandlerStateGroupType(GroupType):
             type_id = 3
             slug = "handler_with_state"
             description = "handler with state"
             category = GroupCategory.METRIC_ALERT.value
-            detector_handler = MockDetectorStateHandler
+            detector_config = DetectorConfig(handler=MockDetectorStateHandler)
 
         class HandlerUpdateGroupType(GroupType):
             type_id = 4
             slug = "handler_update"
             description = "handler update"
             category = GroupCategory.METRIC_ALERT.value
-            detector_handler = MockDetectorWithUpdateHandler
+            detector_config = DetectorConfig(handler=MockDetectorWithUpdateHandler)
 
         self.no_handler_type = NoHandlerGroupType
         self.handler_type = HandlerGroupType

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -6,6 +6,7 @@ from jsonschema import ValidationError
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.testutils.cases import APITestCase
+from sentry.workflow_engine.types import DetectorConfig
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
@@ -43,7 +44,7 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            detector_config_schema = self.example_schema
+            detector_config = DetectorConfig(config_schema=self.example_schema)
 
         @dataclass(frozen=True)
         class ExampleGroupType(GroupType):
@@ -51,7 +52,9 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             slug = "example"
             description = "Example"
             category = GroupCategory.PERFORMANCE.value
-            detector_config_schema = {"type": "object", "additionalProperties": False}
+            detector_config = DetectorConfig(
+                config_schema={"type": "object", "additionalProperties": False},
+            )
 
 
 # TODO - Move this to the detector model test
@@ -100,7 +103,9 @@ class TestMetricAlertFireDetectorConfig(JSONConfigBaseTest, APITestCase):
             slug = "test_metric_alert_fire"
             description = "Metric alert fired"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config_schema = MetricAlertFire.detector_config_schema
+            detector_config = DetectorConfig(
+                config_schema=MetricAlertFire.detector_config.config_schema,
+            )
 
     def test_detector_correct_schema(self):
         self.create_detector(

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -104,7 +104,7 @@ class TestMetricAlertFireDetectorConfig(JSONConfigBaseTest, APITestCase):
             description = "Metric alert fired"
             category = GroupCategory.METRIC_ALERT.value
             detector_settings = DetectorSettings(
-                config_schema=MetricAlertFire.detector_config.config_schema,
+                config_schema=MetricAlertFire.detector_settings.config_schema,
             )
 
     def test_detector_correct_schema(self):

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -6,7 +6,7 @@ from jsonschema import ValidationError
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.testutils.cases import APITestCase
-from sentry.workflow_engine.types import DetectorConfig
+from sentry.workflow_engine.types import DetectorSettings
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
@@ -44,7 +44,7 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            detector_config = DetectorConfig(config_schema=self.example_schema)
+            detector_settings = DetectorSettings(config_schema=self.example_schema)
 
         @dataclass(frozen=True)
         class ExampleGroupType(GroupType):
@@ -52,7 +52,7 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             slug = "example"
             description = "Example"
             category = GroupCategory.PERFORMANCE.value
-            detector_config = DetectorConfig(
+            detector_settings = DetectorSettings(
                 config_schema={"type": "object", "additionalProperties": False},
             )
 
@@ -103,7 +103,7 @@ class TestMetricAlertFireDetectorConfig(JSONConfigBaseTest, APITestCase):
             slug = "test_metric_alert_fire"
             description = "Metric alert fired"
             category = GroupCategory.METRIC_ALERT.value
-            detector_config = DetectorConfig(
+            detector_settings = DetectorSettings(
                 config_schema=MetricAlertFire.detector_config.config_schema,
             )
 


### PR DESCRIPTION
We want to consolidate the detector config together, rather than keeping it as top level properties on the grouptype.

I thought through a few options here, and it seems like the cleanest is to have an enclosing `DetectorConfig` dataclass. The separate config values in here don't really interact with each other, and so it seemed simplest to keep them separate.

<!-- Describe your PR here. -->