### PR TITLE
feat(discover): map span.duration to transaction.duration in discover

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -94,6 +94,7 @@ class BaseQueryBuilder:
     size_fields: dict[str, str] = {}
     uuid_fields: set[str] = set()
     span_id_fields: set[str] = set()
+    column_remapping: dict[str, str] = {}
 
     def get_middle(self):
         """Get the middle for comparison functions"""
@@ -307,6 +308,7 @@ class BaseQueryBuilder:
         self.end = self.params.end
 
     def resolve_column_name(self, col: str) -> str:
+        col = self.column_remapping.get(col, col)
         # TODO: when utils/snuba.py becomes typed don't need this extra annotation
         column_resolver: Callable[[str], str] = resolve_column(self.dataset)
         column_name = column_resolver(col)
@@ -1237,7 +1239,7 @@ class BaseQueryBuilder:
         self,
         search_filter: event_search.SearchFilter,
     ) -> WhereType | None:
-        name = search_filter.key.name
+        name = self.column_remapping.get(search_filter.key.name, search_filter.key.name)
         value = search_filter.value.value
         if value and (unit := self.get_field_type(name)):
             if unit in constants.SIZE_UNITS or unit in constants.DURATION_UNITS:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -94,7 +94,6 @@ class BaseQueryBuilder:
     size_fields: dict[str, str] = {}
     uuid_fields: set[str] = set()
     span_id_fields: set[str] = set()
-    column_remapping: dict[str, str] = {}
 
     def get_middle(self):
         """Get the middle for comparison functions"""
@@ -308,7 +307,6 @@ class BaseQueryBuilder:
         self.end = self.params.end
 
     def resolve_column_name(self, col: str) -> str:
-        col = self.column_remapping.get(col, col)
         # TODO: when utils/snuba.py becomes typed don't need this extra annotation
         column_resolver: Callable[[str], str] = resolve_column(self.dataset)
         column_name = column_resolver(col)
@@ -1239,7 +1237,7 @@ class BaseQueryBuilder:
         self,
         search_filter: event_search.SearchFilter,
     ) -> WhereType | None:
-        name = self.column_remapping.get(search_filter.key.name, search_filter.key.name)
+        name = search_filter.key.name
         value = search_filter.value.value
         if value and (unit := self.get_field_type(name)):
             if unit in constants.SIZE_UNITS or unit in constants.DURATION_UNITS:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -52,7 +52,10 @@ class DiscoverQueryBuilder(BaseQueryBuilder):
         "trace.span",
         "trace.parent_span",
     }
-    duration_fields = {"transaction.duration"}
+    duration_fields = {"transaction.duration", "span.duration"}
+    column_remapping = {
+        "span.duration": "transaction.duration",
+    }
 
     def load_config(
         self,

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -53,9 +53,6 @@ class DiscoverQueryBuilder(BaseQueryBuilder):
         "trace.parent_span",
     }
     duration_fields = {"transaction.duration", "span.duration"}
-    column_remapping = {
-        "span.duration": "transaction.duration",
-    }
 
     def load_config(
         self,

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -632,6 +632,7 @@ class Columns(Enum):
         issue_platform_name="transaction_duration",
         alias="transaction.duration",
     )
+    # span.duration is here to help migrate the frontend to EAP
     SPAN_DURATION = Column(
         group_name=None,
         event_name=None,

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -632,6 +632,13 @@ class Columns(Enum):
         issue_platform_name="transaction_duration",
         alias="transaction.duration",
     )
+    SPAN_DURATION = Column(
+        group_name=None,
+        event_name=None,
+        transaction_name="duration",
+        discover_name="duration",
+        alias="span.duration",
+    )
     TRANSACTION_STATUS = Column(
         group_name=None,
         event_name=None,

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6870,3 +6870,30 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             "count_scores(measurements.score.lcp)": 1,
             "count_scores(measurements.score.total)": 3,
         }
+
+    def test_remapping(self):
+        self.store_event(self.transaction_data, self.project.id)
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction.duration",
+                    "span.duration",
+                ],
+                "query": "has:span.duration",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert len(data) == 1
+
+        assert data[0]["transaction.duration"] == 3000
+        assert data[0]["span.duration"] == 3000
+
+        assert meta["fields"]["span.duration"] == "duration"
+        assert meta["fields"]["transaction.duration"] == "duration"
+        assert meta["units"]["span.duration"] == "millisecond"
+        assert meta["units"]["transaction.duration"] == "millisecond"


### PR DESCRIPTION
To make it easier to migrate insights to eap, we can map `span.duration` to `transaction.duration` in discover. This helps us because we won't have to do any conditionals on the frontend such as
```javascript
const fields = useEap ? ['span.duration'] : ['transaction.duration']
```