### PR TITLE
feat(explore): schema spacing and border line

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -402,12 +402,12 @@ const TopSection = styled('div')`
   grid-column: 1/3;
   display: flex;
   flex-direction: column;
-  gap: ${space(2)};
+  gap: ${space(1)};
 `;
 
 const FilterSection = styled('div')`
   display: grid;
-  gap: ${space(2)};
+  gap: ${space(1)};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     grid-template-columns: minmax(300px, auto) 1fr;

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -12,6 +12,7 @@ import {Button, LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
@@ -195,7 +196,7 @@ export function ToolbarSaveAs() {
   }
 
   return (
-    <ToolbarSection data-test-id="section-save-as">
+    <StyledToolbarSection data-test-id="section-save-as">
       <ButtonBar gap={1}>
         <DropdownMenu
           items={items}
@@ -235,12 +236,17 @@ export function ToolbarSaveAs() {
           >{`${t('Compare Queries')}`}</LinkButton>
         )}
       </ButtonBar>
-    </ToolbarSection>
+    </StyledToolbarSection>
   );
 }
 
 const DisabledText = styled('span')`
   color: ${p => p.theme.disabled};
+`;
+
+const StyledToolbarSection = styled(ToolbarSection)`
+  border-top: 1px solid ${p => p.theme.border};
+  padding-top: ${space(2)};
 `;
 
 const SaveAsButton = styled(Button)`


### PR DESCRIPTION
- Reduced spacing between search and schema hints
- Added a line between buttons and form

**Before:**
![Screenshot 2025-04-15 at 12 15 46 PM](https://github.com/user-attachments/assets/0bd46e6c-c32d-48c7-8a9a-e98b6853f68b)

**After:**
![Screenshot 2025-04-15 at 12 14 09 PM](https://github.com/user-attachments/assets/d82a70d0-b819-4068-85f5-766b8b1ec061)