### PR TITLE
flag(new-trace): Using new explore flag for all traceview actions routing to explore

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -131,7 +131,7 @@ function EventTagsTreeRowDropdown({
   const location = useLocation();
   const hasNewTraceUi = useHasTraceNewUi();
   const organization = useOrganization();
-  const hasTraceDrawerAction = organization.features.includes('trace-drawer-action');
+  const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const {onClick: handleCopy} = useCopyToClipboard({
     text: content.value,
   });
@@ -196,7 +196,7 @@ function EventTagsTreeRowDropdown({
     },
   ];
 
-  if (hasNewTraceUi && hasTraceDrawerAction) {
+  if (hasNewTraceUi && hasExploreEnabled) {
     items.push({
       key: 'view-traces',
       label: t('Find more samples with this value'),

--- a/static/app/views/performance/newTraceDetails/traceActionsMenu.tsx
+++ b/static/app/views/performance/newTraceDetails/traceActionsMenu.tsx
@@ -38,7 +38,7 @@ function TraceActionsMenu({
   const organization = useOrganization();
   const {projects} = useProjects();
   const navigate = useNavigate();
-  const hasDrawerAction = organization.features.includes('trace-drawer-action');
+  const hasExploreEnabled = organization.features.includes('visibility-explore-view');
 
   if (!hasTraceNewUi) {
     return null;
@@ -53,13 +53,13 @@ function TraceActionsMenu({
       items={[
         {
           key: 'open_trace_events',
-          label: hasDrawerAction
+          label: hasExploreEnabled
             ? t('Open Events in Explore')
             : t('Open Events in Discover'),
           onAction: () => {
             let target;
 
-            if (hasDrawerAction) {
+            if (hasExploreEnabled) {
               const key = 'trace';
               const value = traceSlug ?? '';
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -80,7 +80,7 @@ export function SpanDescription({
 }) {
   const hasTraceNewUi = useHasTraceNewUi();
   const span = node.value;
-  const hasTraceDrawerAction = organization.features.includes('trace-drawer-action');
+  const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const resolvedModule: ModuleName = resolveSpanModule(
     span.sentry_tags?.op,
     span.sentry_tags?.category
@@ -121,7 +121,7 @@ export function SpanDescription({
   const groupHash = hasNewSpansUIFlag
     ? (span.sentry_tags?.group ?? '')
     : (span.hash ?? '');
-  const showAction = hasTraceDrawerAction ? !!span.description : !!span.op && !!span.hash;
+  const showAction = hasExploreEnabled ? !!span.description : !!span.op && !!span.hash;
   const averageSpanDuration: number | undefined =
     span['span.averageResults']?.['avg(span.duration)'];
 
@@ -134,7 +134,7 @@ export function SpanDescription({
       <SpanSummaryLink event={node.event!} organization={organization} span={span} />
       <Link
         to={
-          hasTraceDrawerAction
+          hasExploreEnabled
             ? getSearchInExploreTarget(
                 organization,
                 location,
@@ -152,7 +152,7 @@ export function SpanDescription({
               })
         }
         onClick={() => {
-          if (hasTraceDrawerAction) {
+          if (hasExploreEnabled) {
             traceAnalytics.trackExploreSearch(
               organization,
               SpanIndexedField.SPAN_DESCRIPTION,
@@ -175,7 +175,7 @@ export function SpanDescription({
         }}
       >
         <StyledIconGraph type="scatter" size="xs" />
-        {hasNewSpansUIFlag || hasTraceDrawerAction
+        {hasNewSpansUIFlag || hasExploreEnabled
           ? t('More Samples')
           : t('View Similar Spans')}
       </Link>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -746,12 +746,12 @@ function KeyValueAction({
   const location = useLocation();
   const organization = useOrganization();
   const hasNewTraceUi = useHasTraceNewUi();
-  const hasTraceDrawerAction = organization.features.includes('trace-drawer-action');
+  const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const [isVisible, setIsVisible] = useState(false);
 
   if (
     !hasNewTraceUi ||
-    !hasTraceDrawerAction ||
+    !hasExploreEnabled ||
     !defined(rowValue) ||
     !defined(rowKey) ||
     !['string', 'number'].includes(typeof rowValue)


### PR DESCRIPTION
I'll be removing the `trace-drawer-action` flag