### PR TITLE
fix(eap): Handle empty strings better

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -474,32 +474,35 @@ class SearchResolver:
                     context_definition,
                 )
             elif term.operator == "=":
-                TraceItemFilter(
-                    or_filter=OrFilter(
-                        filters=[
-                            TraceItemFilter(
-                                not_filter=NotFilter(
-                                    filters=[
-                                        TraceItemFilter(
-                                            exists_filter=ExistsFilter(
-                                                key=resolved_column.proto_definition,
-                                            )
+                return (
+                    TraceItemFilter(
+                        or_filter=OrFilter(
+                            filters=[
+                                TraceItemFilter(
+                                    not_filter=NotFilter(
+                                        filters=[
+                                            TraceItemFilter(
+                                                exists_filter=ExistsFilter(
+                                                    key=resolved_column.proto_definition,
+                                                )
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                TraceItemFilter(
+                                    comparison_filter=ComparisonFilter(
+                                        key=resolved_column.proto_definition,
+                                        op=operator,
+                                        value=self._resolve_search_value(
+                                            resolved_column, term.operator, value
                                         ),
-                                    ]
-                                )
-                            ),
-                            TraceItemFilter(
-                                comparison_filter=ComparisonFilter(
-                                    key=resolved_column.proto_definition,
-                                    op=operator,
-                                    value=self._resolve_search_value(
-                                        resolved_column, term.operator, value
-                                    ),
-                                )
-                            ),
-                        ]
-                    )
-                ), context_definition
+                                    )
+                                ),
+                            ]
+                        )
+                    ),
+                    context_definition,
+                )
             else:
                 raise InvalidSearchQuery(f"Unsupported operator for empty strings {term.operator}")
 

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -450,8 +450,23 @@ class SearchResolver:
 
         if value == "" and context_definition is None:
             exists_filter = TraceItemFilter(
-                exists_filter=ExistsFilter(
-                    key=resolved_column.proto_definition,
+                and_filter=AndFilter(
+                    filters=[
+                        TraceItemFilter(
+                            exists_filter=ExistsFilter(
+                                key=resolved_column.proto_definition,
+                            )
+                        ),
+                        TraceItemFilter(
+                            comparison_filter=ComparisonFilter(
+                                key=resolved_column.proto_definition,
+                                op=operator,
+                                value=self._resolve_search_value(
+                                    resolved_column, term.operator, value
+                                ),
+                            )
+                        ),
+                    ]
                 )
             )
             if term.operator == "=":

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4191,7 +4191,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert response.status_code == 500, response.content
         mock_sdk.assert_called_once()
 
-    def test_simple(self):
+    def test_empty_string_equal(self):
         self.store_spans(
             [
                 self.create_span(
@@ -4223,6 +4223,43 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             {
                 "user.email": "test@test.com",
                 "description": "foo",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+
+    def test_empty_string_negation(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"user.email": "test@test.com"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "bar", "sentry_tags": {"user.email": ""}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        response = self.do_request(
+            {
+                "field": ["user.email", "description", "count()"],
+                "query": 'user.email:""',
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "user.email": "",
+                "description": "bar",
                 "count()": 1,
             },
         ]

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4190,3 +4190,40 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
 
         assert response.status_code == 500, response.content
         mock_sdk.assert_called_once()
+
+    def test_simple(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"user.email": "test@test.com"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "bar", "sentry_tags": {"user.email": ""}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        response = self.do_request(
+            {
+                "field": ["user.email", "description", "count()"],
+                "query": '!user.email:""',
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "user.email": "test@test.com",
+                "description": "foo",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == self.dataset


### PR DESCRIPTION
- This fixes a bug where filters for empty strings weren't quite working since we only checked if the the value exists as a tag by adding a filter against an empty string as well