### PR TITLE
fix(taskworker) Move relocation namespace with the others

### DIFF
--- a/src/sentry/relocation/tasks/__init__.py
+++ b/src/sentry/relocation/tasks/__init__.py
@@ -1,4 +1,0 @@
-from sentry.taskworker.registry import TaskNamespace, taskregistry
-
-relocation_tasks: TaskNamespace = taskregistry.create_namespace("relocation")
-relocation_control_tasks: TaskNamespace = taskregistry.create_namespace("relocation.control")

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -58,7 +58,6 @@ from sentry.relocation.models.relocationtransfer import (
     RegionRelocationTransfer,
     RelocationTransferState,
 )
-from sentry.relocation.tasks import relocation_tasks
 from sentry.relocation.tasks.transfer import process_relocation_transfer_region
 from sentry.relocation.utils import (
     TASK_TO_STEP,
@@ -76,6 +75,7 @@ from sentry.signals import relocated, relocation_redeem_promo_code
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import relocation_tasks
 from sentry.taskworker.retry import LastAction, Retry
 from sentry.types.region import get_local_region
 from sentry.users.models.lostpasswordhash import LostPasswordHash

--- a/src/sentry/relocation/tasks/transfer.py
+++ b/src/sentry/relocation/tasks/transfer.py
@@ -18,10 +18,10 @@ from sentry.relocation.services.relocation_export.service import (
     control_relocation_export_service,
     region_relocation_export_service,
 )
-from sentry.relocation.tasks import relocation_control_tasks, relocation_tasks
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import relocation_control_tasks, relocation_tasks
 from sentry.types.region import get_local_region
 
 logger = logging.getLogger("sentry.relocation")

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -52,6 +52,8 @@ tempest_tasks = taskregistry.create_namespace("tempest")
 
 uptime_tasks = taskregistry.create_namespace("uptime")
 
+relocation_tasks = taskregistry.create_namespace("relocation")
+relocation_control_tasks = taskregistry.create_namespace("relocation.control")
 
 # Namespaces for testing taskworker tasks
 exampletasks = taskregistry.create_namespace(name="examples")


### PR DESCRIPTION
Move the relocation and relocation_control namespaces to live with the other namespace declarations.
