### PR TITLE
ref(insights): Replace "Top 5 Response Codes" chart with `InsightsTimeSeriesWidget`

### DIFF
--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export function ResponseCodeCountChart({series, isLoading, error}: Props) {
-  // Temporary hack. `DiscoverSeries` meta field and the series name don't
+  // TODO: Temporary hack. `DiscoverSeries` meta field and the series name don't
   // match. This is annoying to work around, and will become irrelevant soon
   // enough. For now, just specify the correct meta for these series since
   // they're known and simple

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -1,33 +1,38 @@
 import {t} from 'sentry/locale';
-import type {Series} from 'sentry/types/echarts';
-import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
-import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
-import {CHART_HEIGHT} from 'sentry/views/insights/http/settings';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 
 interface Props {
   isLoading: boolean;
-  series: Series[];
+  series: DiscoverSeries[];
   error?: Error | null;
 }
 
 export function ResponseCodeCountChart({series, isLoading, error}: Props) {
+  // Temporary hack. `DiscoverSeries` meta field and the series name don't
+  // match. This is annoying to work around, and will become irrelevant soon
+  // enough. For now, just specify the correct meta for these series since
+  // they're known and simple
+  const seriesWithMeta: DiscoverSeries[] = series.map(discoverSeries => {
+    const transformedSeries: DiscoverSeries = {
+      ...discoverSeries,
+      meta: {
+        fields: {
+          [discoverSeries.seriesName]: 'integer',
+        },
+        units: {},
+      },
+    };
+
+    return transformedSeries;
+  });
+
   return (
-    <ChartPanel title={t('Top 5 Response Codes')}>
-      <Chart
-        showLegend
-        height={CHART_HEIGHT}
-        grid={{
-          left: '4px',
-          right: '0',
-          top: '8px',
-          bottom: '0',
-        }}
-        data={series}
-        loading={isLoading}
-        error={error}
-        type={ChartType.LINE}
-        aggregateOutputFormat="number"
-      />
-    </ChartPanel>
+    <InsightsLineChartWidget
+      title={t('Top 5 Response Codes')}
+      series={seriesWithMeta}
+      isLoading={isLoading}
+      error={error ?? null}
+    />
   );
 }

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -93,6 +93,11 @@ describe('HTTPSamplesPanel', () => {
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      body: [],
+    });
   });
 
   afterAll(() => {


### PR DESCRIPTION
**e.g.,**

![Screenshot 2025-04-15 at 4 22 26 PM](https://github.com/user-attachments/assets/b7cc9932-962e-4450-a53f-0bf48328bfc2)
