### PR TITLE
fix(autofix): Make copy clearer for agent-initiated comments

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -341,7 +341,7 @@ export function AutofixChanges({
                       : null
                   }
                   isAgentComment
-                  blockName={t('Code Changes')}
+                  blockName={t('Autofix is uncertain of the code changes...')}
                 />
               )}
             </AnimatePresence>

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -309,7 +309,9 @@ function AutofixHighlightPopupContent({
       {commentThread?.is_completed !== true && (
         <InputWrapper onSubmit={handleSubmit}>
           <StyledInput
-            placeholder={t('Questions? Instructions?')}
+            placeholder={
+              isAgentComment ? t('Share your context...') : t('Questions? Instructions?')
+            }
             value={comment}
             onChange={e => setComment(e.target.value)}
             maxLength={4096}

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -387,7 +387,7 @@ function AutofixRootCauseDisplay({
                   : null
               }
               isAgentComment
-              blockName={t('Root Cause')}
+              blockName={t('Autofix is uncertain of the root cause...')}
             />
           )}
         </AnimatePresence>

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -634,7 +634,7 @@ function AutofixSolutionDisplay({
                   : null
               }
               isAgentComment
-              blockName={t('Solution')}
+              blockName={t('Autofix is uncertain of the solution...')}
             />
           )}
         </AnimatePresence>


### PR DESCRIPTION
Simply copy changes for clarity when Autofix starts the thread instead of the user.