### PR TITLE
ref: fix variable name typo in eventtypes.base

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -8,7 +8,7 @@ from sentry.utils.strings import strip, truncatechars
 
 
 class BaseEvent:
-    id = None
+    key: str  # abstract
 
     def get_metadata(self, data):
         metadata = self.extract_metadata(data)


### PR DESCRIPTION
2016-era typo fd798fe81d6578f790a508b663f63e7132ce2d51

<!-- Describe your PR here. -->