### PR TITLE
ref: abstract on_create_or_update_comment_error method

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -232,6 +232,11 @@ class GitHubEnterpriseIntegration(
         # TODO: define this, used to migrate repositories
         return False
 
+    # CommitContextIntegration methods
+
+    def on_create_or_update_comment_error(self, api_error: ApiError, metrics_base: str) -> bool:
+        raise NotImplementedError
+
 
 class InstallationForm(forms.Form):
     url = forms.CharField(

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -164,6 +164,11 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         _, _, source_path = url.partition("/")
         return source_path
 
+    # CommitContextIntegration methods
+
+    def on_create_or_update_comment_error(self, api_error: ApiError, metrics_base: str) -> bool:
+        raise NotImplementedError
+
     # Gitlab only functions
 
     def get_group_id(self):

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -34,6 +34,7 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
+    ApiError,
     ApiInvalidRequestError,
     ApiRateLimitedError,
     ApiRetryError,
@@ -374,6 +375,15 @@ class CommitContextIntegration(ABC):
                 logger_event,
                 extra={"new_comment": pr_comment is None, "pr_key": pr_key, "repo": repo.name},
             )
+
+    @abstractmethod
+    def on_create_or_update_comment_error(self, api_error: ApiError, metrics_base: str) -> bool:
+        """
+        Handle errors from the create_or_update_comment method.
+
+        Returns True if the error was handled, False otherwise.
+        """
+        raise NotImplementedError
 
 
 class CommitContextClient(ABC):

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -9,6 +9,7 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.users.models.identity import Identity
@@ -26,8 +27,11 @@ class MockCommitContextIntegration(CommitContextIntegration):
     def get_client(self):
         return self.client
 
+    def on_create_or_update_comment_error(self, api_error: ApiError, metrics_base: str) -> bool:
+        raise NotImplementedError
 
-class CommitContextIntegrationTest(TestCase):
+
+class TestCommitContextIntegrationSLO(TestCase):
     def setUp(self):
         super().setUp()
         self.integration = MockCommitContextIntegration()


### PR DESCRIPTION
Make `on_create_or_update_comment_error` handler generic. They are used in both PR and Open PR workflows. The ultimate goal is to make the PR and Open PR workflows generic.