### PR TITLE
chore(alerts): fix typing for group on time

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
-from typing import NamedTuple, TypeAlias
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple, TypeAlias
 
 from sentry import tsdb
 from sentry.digests.types import Notification, Record, RecordWithRuleObjects
@@ -22,7 +22,7 @@ Digest: TypeAlias = dict[Rule, dict[Group, list[RecordWithRuleObjects]]]
 class DigestInfo(NamedTuple):
     digest: Digest
     event_counts: dict[int, int]
-    user_counts: dict[int, int]
+    user_counts: Mapping[Any, int]
 
 
 def split_key(
@@ -113,7 +113,7 @@ def _group_records(
 
 
 def _sort_digest(
-    digest: Digest, event_counts: dict[int, int], user_counts: dict[int, int]
+    digest: Digest, event_counts: dict[int, int], user_counts: Mapping[Any, int]
 ) -> Digest:
     # sort inner groups dict by (event_count, user_count) descending
     for key, rule_groups in digest.items():
@@ -142,7 +142,7 @@ def _build_digest_impl(
     groups: dict[int, Group],
     rules: dict[int, Rule],
     event_counts: dict[int, int],
-    user_counts: dict[int, int],
+    user_counts: Mapping[Any, int],
 ) -> Digest:
     # sans-io implementation details
     bound_records = _bind_records(records, groups, rules)

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -590,7 +590,7 @@ class BaseTSDB(Service):
     def get_distinct_counts_totals(
         self,
         model: TSDBModel,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start: datetime,
         end: datetime | None = None,
         rollup: int | None = None,
@@ -601,7 +601,7 @@ class BaseTSDB(Service):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, Any]:
+    ) -> Mapping[TSDBKey, int]:
         """
         Count distinct items during a time range with optional conditions
         """

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -64,7 +64,7 @@ class DummyTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start,
         end=None,
         rollup=None,

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -529,7 +529,7 @@ class RedisTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model: TSDBModel,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start: datetime,
         end: datetime | None = None,
         rollup: int | None = None,
@@ -540,7 +540,7 @@ class RedisTSDB(BaseTSDB):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, Any]:
+    ) -> Mapping[TSDBKey, int]:
         """
         Count distinct items during a time range.
         """

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -819,7 +819,7 @@ class SnubaTSDB(BaseTSDB):
     def get_distinct_counts_totals(
         self,
         model,
-        keys: Sequence[int],
+        keys: Sequence[TSDBKey],
         start,
         end=None,
         rollup=None,
@@ -830,7 +830,7 @@ class SnubaTSDB(BaseTSDB):
         referrer_suffix=None,
         conditions=None,
         group_on_time: bool = False,
-    ):
+    ) -> Mapping[TSDBKey, int]:
         return self.get_data(
             model,
             keys,

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -25,7 +25,7 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
 )
 from sentry.rules.match import MatchType
-from sentry.tsdb.base import SnubaCondition, TSDBModel
+from sentry.tsdb.base import SnubaCondition, TSDBKey, TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
 from sentry.utils.snuba import options_override
@@ -39,7 +39,7 @@ class TSDBFunction(Protocol):
     def __call__(
         self,
         model: TSDBModel,
-        keys: list[int],
+        keys: list[TSDBKey],
         start: datetime,
         end: datetime,
         rollup: int | None = None,
@@ -50,7 +50,7 @@ class TSDBFunction(Protocol):
         referrer_suffix: str | None = None,
         conditions: list[SnubaCondition] | None = None,
         group_on_time: bool = False,
-    ) -> dict[int, int]: ...
+    ) -> Mapping[TSDBKey, int]: ...
 
 
 class InvalidFilter(Exception):


### PR DESCRIPTION
The main thing is we need to update the return type in get_distinct_count_totals which also affects digest types