### PR TITLE
feat(eap-spans): dynamically set sampling mode in nested queries

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -137,7 +137,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             if sampling_mode is not None:
                 if sampling_mode.upper() not in SAMPLING_MODE_MAP:
                     raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
-                sampling_mode = cast(SAMPLING_MODES, sampling_mode)
+                sampling_mode = cast(SAMPLING_MODES, sampling_mode.upper())
 
             if quantize_date_params:
                 filter_params = self.quantize_date_params(request, filter_params)

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -32,10 +32,9 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.eap.constants import SAMPLING_MODE_MAP
-from sentry.search.eap.types import SAMPLING_MODES
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.types import SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import discover
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.utils import DATASET_LABELS, DATASET_OPTIONS, get_dataset

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -424,7 +424,6 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
         dataset = self.get_dataset(request)
         metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
-        sampling_mode = request.GET.get("sampling")
 
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
@@ -470,7 +469,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         use_aggregate_conditions=use_aggregate_conditions,
                         fields_acl=FieldsACL(functions={"time_spent_percentage"}),
                     ),
-                    sampling_mode=sampling_mode,
+                    sampling_mode=snuba_params.sampling_mode,
                 )
             query_source = self.get_request_source(request)
             return dataset_query(

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -283,7 +283,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         use_rpc = (
             request.GET.get("useRpc", "0") == "1" and dataset == spans_eap
         ) or dataset == ourlogs
-        sampling_mode = request.GET.get("sampling")
         transform_alias_to_input_format = (
             request.GET.get("transformAliasToInputFormat") == "1" or use_rpc
         )
@@ -314,7 +313,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                             auto_fields=False,
                             use_aggregate_conditions=True,
                         ),
-                        sampling_mode=sampling_mode,
+                        sampling_mode=snuba_params.sampling_mode,
                     )
                 return scoped_dataset.top_events_timeseries(
                     timeseries_columns=query_columns,
@@ -353,7 +352,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         auto_fields=False,
                         use_aggregate_conditions=True,
                     ),
-                    sampling_mode=sampling_mode,
+                    sampling_mode=snuba_params.sampling_mode,
                     comparison_delta=comparison_delta,
                 )
 

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -211,7 +211,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
         include_other = request.GET.get("excludeOther") != "1"
         referrer = request.GET.get("referrer")
-        sampling_mode = request.GET.get("sampling")
         referrer = (
             referrer
             if referrer in ALLOWED_EVENTS_STATS_REFERRERS.union(METRICS_ENHANCED_REFERRERS)
@@ -247,7 +246,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                         auto_fields=False,
                         use_aggregate_conditions=True,
                     ),
-                    sampling_mode=sampling_mode,
+                    sampling_mode=snuba_params.sampling_mode,
                 )
             return dataset.top_events_timeseries(
                 timeseries_columns=query_columns,
@@ -284,7 +283,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     auto_fields=False,
                     use_aggregate_conditions=True,
                 ),
-                sampling_mode=sampling_mode,
+                sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,
             )
 

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter
 
-from sentry.search.eap.types import SupportedTraceItemType
+from sentry.search.eap.types import SAMPLING_MODES, SupportedTraceItemType
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS, DurationUnit, SizeUnit
 
 # Mapping from our supported string enum types to the protobuf enum types
@@ -157,7 +157,7 @@ RESPONSE_CODE_MAP = {
     5: ["500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511"],
 }
 
-SAMPLING_MODES = {
+SAMPLING_MODE_MAP: dict[SAMPLING_MODES, DownsampledStorageConfig.Mode.ValueType] = {
     "BEST_EFFORT": DownsampledStorageConfig.MODE_BEST_EFFORT,
     "PREFLIGHT": DownsampledStorageConfig.MODE_PREFLIGHT,
 }

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -6,8 +6,9 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter
 
-from sentry.search.eap.types import SAMPLING_MODES, SupportedTraceItemType
+from sentry.search.eap.types import SupportedTraceItemType
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS, DurationUnit, SizeUnit
+from sentry.search.events.types import SAMPLING_MODES
 
 # Mapping from our supported string enum types to the protobuf enum types
 SUPPORTED_TRACE_ITEM_TYPE_MAP = {

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -47,7 +47,7 @@ from sentry.search.eap.columns import (
     VirtualColumnDefinition,
 )
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import SAMPLING_MODES, SearchResolverConfig
 from sentry.search.eap.utils import validate_sampling
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
@@ -90,7 +90,9 @@ class SearchResolver:
             raise InvalidSearchQuery(f"Unknown function {function_name}")
 
     @sentry_sdk.trace
-    def resolve_meta(self, referrer: str, sampling_mode: str | None = None) -> RequestMeta:
+    def resolve_meta(
+        self, referrer: str, sampling_mode: SAMPLING_MODES | None = None
+    ) -> RequestMeta:
         if self.params.organization_id is None:
             raise Exception("An organization is required to resolve queries")
         span = sentry_sdk.get_current_span()

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -47,12 +47,12 @@ from sentry.search.eap.columns import (
     VirtualColumnDefinition,
 )
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
-from sentry.search.eap.types import SAMPLING_MODES, SearchResolverConfig
+from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.eap.utils import validate_sampling
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
-from sentry.search.events.types import SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 
 
 @dataclass(frozen=True)

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -163,7 +163,7 @@ def get_count_of_vital(vital: str, settings: ResolverSettings) -> float:
         orderby=None,
         offset=0,
         limit=1,
-        sampling_mode=None,
+        sampling_mode="best_effort",
         config=SearchResolverConfig(
             auto_fields=True,
         ),
@@ -433,7 +433,7 @@ def time_spent_percentage(
         orderby=None,
         offset=0,
         limit=1,
-        sampling_mode=None,
+        sampling_mode=snuba_params.sampling_mode,
         config=SearchResolverConfig(),
     )
 

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -163,7 +163,7 @@ def get_count_of_vital(vital: str, settings: ResolverSettings) -> float:
         orderby=None,
         offset=0,
         limit=1,
-        sampling_mode="best_effort",
+        sampling_mode=snuba_params.sampling_mode,
         config=SearchResolverConfig(
             auto_fields=True,
         ),

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -48,3 +48,6 @@ class TraceItemAttribute(TypedDict):
 
 class EAPResponse(EventsResponse):
     confidence: ConfidenceData
+
+
+SAMPLING_MODES = Literal["BEST_EFFORT", "PREFLIGHT"]

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -48,6 +48,3 @@ class TraceItemAttribute(TypedDict):
 
 class EAPResponse(EventsResponse):
     confidence: ConfidenceData
-
-
-SAMPLING_MODES = Literal["BEST_EFFORT", "PREFLIGHT"]

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -12,7 +12,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
 
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.constants import SAMPLING_MODES
+from sentry.search.eap.constants import SAMPLING_MODE_MAP
 from sentry.search.eap.ourlogs.attributes import (
     LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     LOGS_PRIVATE_ATTRIBUTES,
@@ -21,7 +21,7 @@ from sentry.search.eap.spans.attributes import (
     SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SPANS_PRIVATE_ATTRIBUTES,
 )
-from sentry.search.eap.types import SupportedTraceItemType
+from sentry.search.eap.types import SAMPLING_MODES, SupportedTraceItemType
 
 # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
 BINARY_FORMULA_OPERATOR_MAP = {
@@ -98,14 +98,14 @@ def transform_column_to_expression(column: Column) -> Expression:
     )
 
 
-def validate_sampling(sampling_mode: str | None) -> DownsampledStorageConfig:
+def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorageConfig:
     if sampling_mode is None:
         return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_UNSPECIFIED)
     sampling_mode = sampling_mode.upper()
-    if sampling_mode not in SAMPLING_MODES:
+    if sampling_mode not in SAMPLING_MODE_MAP:
         raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
     else:
-        return DownsampledStorageConfig(mode=SAMPLING_MODES[sampling_mode])
+        return DownsampledStorageConfig(mode=SAMPLING_MODE_MAP[sampling_mode])
 
 
 INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -21,7 +21,8 @@ from sentry.search.eap.spans.attributes import (
     SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SPANS_PRIVATE_ATTRIBUTES,
 )
-from sentry.search.eap.types import SAMPLING_MODES, SupportedTraceItemType
+from sentry.search.eap.types import SupportedTraceItemType
+from sentry.search.events.types import SAMPLING_MODES
 
 # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
 BINARY_FORMULA_OPERATOR_MAP = {

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -102,7 +102,6 @@ def transform_column_to_expression(column: Column) -> Expression:
 def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorageConfig:
     if sampling_mode is None:
         return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_UNSPECIFIED)
-    sampling_mode = sampling_mode.upper()
     if sampling_mode not in SAMPLING_MODE_MAP:
         raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
     else:

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import (
@@ -106,6 +106,7 @@ def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorag
     if sampling_mode not in SAMPLING_MODE_MAP:
         raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
     else:
+        sampling_mode = cast(SAMPLING_MODES, sampling_mode)
         return DownsampledStorageConfig(mode=SAMPLING_MODE_MAP[sampling_mode])
 
 

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -21,6 +21,7 @@ from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.search.eap.types import SAMPLING_MODES
 from sentry.users.services.user import RpcUser
 from sentry.utils.validators import INVALID_SPAN_ID, is_span_id
 
@@ -95,6 +96,7 @@ class SnubaParams:
     user: RpcUser | None = None
     teams: Iterable[Team] = field(default_factory=list)
     organization: Organization | None = None
+    sampling_mode: SAMPLING_MODES | None
 
     def __post_init__(self) -> None:
         if self.start:

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, NotRequired, Optional, TypedDict, Union
+from typing import Any, Literal, NotRequired, Optional, TypedDict, Union
 
 from django.utils import timezone as django_timezone
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -21,7 +21,6 @@ from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
-from sentry.search.eap.types import SAMPLING_MODES
 from sentry.users.services.user import RpcUser
 from sentry.utils.validators import INVALID_SPAN_ID, is_span_id
 
@@ -82,6 +81,9 @@ class EventsResponse(TypedDict):
     meta: EventsMeta
 
 
+SAMPLING_MODES = Literal["BEST_EFFORT", "PREFLIGHT"]
+
+
 @dataclass
 class SnubaParams:
     start: datetime | None = None
@@ -96,7 +98,7 @@ class SnubaParams:
     user: RpcUser | None = None
     teams: Iterable[Team] = field(default_factory=list)
     organization: Organization | None = None
-    sampling_mode: SAMPLING_MODES | None
+    sampling_mode: SAMPLING_MODES | None = None
 
     def __post_init__(self) -> None:
         if self.start:

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -22,7 +22,7 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.constants import MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
+from sentry.search.eap.types import CONFIDENCES, SAMPLING_MODES, ConfidenceData, EAPResponse
 from sentry.search.eap.utils import handle_downsample_meta, transform_binary_formula_to_expression
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
@@ -161,7 +161,7 @@ def run_table_query(
     offset: int,
     limit: int,
     referrer: str,
-    sampling_mode: str | None,
+    sampling_mode: SAMPLING_MODES | None,
     resolver: SearchResolver,
     debug: bool = False,
 ) -> EAPResponse:

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -104,7 +104,7 @@ def get_timeseries_query(
     y_axes: list[str],
     groupby: list[str],
     referrer: str,
-    sampling_mode: str | None,
+    sampling_mode: SAMPLING_MODES | None,
     extra_conditions: TraceItemFilter | None = None,
 ) -> tuple[
     TimeSeriesRequest,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -22,10 +22,10 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.constants import MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import CONFIDENCES, SAMPLING_MODES, ConfidenceData, EAPResponse
+from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse
 from sentry.search.eap.utils import handle_downsample_meta, transform_binary_formula_to_expression
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
 from sentry.utils import json, snuba_rpc
 from sentry.utils.snuba import process_value
 

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,7 +13,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import SAMPLING_MODES, EAPResponse, SearchResolverConfig
 from sentry.search.eap.utils import handle_downsample_meta
 from sentry.search.events.fields import is_function
 from sentry.search.events.types import EventsMeta, SnubaParams
@@ -46,7 +46,7 @@ def run_table_query(
     limit: int,
     referrer: str,
     config: SearchResolverConfig,
-    sampling_mode: str | None,
+    sampling_mode: SAMPLING_MODES | None,
     search_resolver: SearchResolver | None = None,
     debug: bool = False,
 ) -> EAPResponse:

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -199,7 +199,7 @@ def run_top_events_timeseries_query(
     limit: int,
     referrer: str,
     config: SearchResolverConfig,
-    sampling_mode: str | None,
+    sampling_mode: SAMPLING_MODES | None,
 ) -> Any:
     """We intentionally duplicate run_timeseries_query code here to reduce the complexity of needing multiple helper
     functions that both would call

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,10 +13,10 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import SAMPLING_MODES, EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.eap.utils import handle_downsample_meta
 from sentry.search.events.fields import is_function
-from sentry.search.events.types import EventsMeta, SnubaParams
+from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key, zerofill
 from sentry.utils import snuba_rpc

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -70,7 +70,7 @@ def run_timeseries_query(
     y_axes: list[str],
     referrer: str,
     config: SearchResolverConfig,
-    sampling_mode: str | None,
+    sampling_mode: SAMPLING_MODES | None,
     comparison_delta: timedelta | None = None,
 ) -> SnubaTSResult:
     """Make the query"""


### PR DESCRIPTION
1. Sets sampling mode on queries used in a formula resolver.
2. Adds sampling mode to a snuba params so that it automatically propagates into the formula resolvers