### PR TITLE
ref(insights): update session health onboarding links with new docs

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -29,6 +29,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   MODULE_DATA_TYPES,
   MODULE_DATA_TYPES_PLURAL,
@@ -79,6 +80,13 @@ export function ModulesOnboarding({children, moduleName}: ModuleOnboardingProps)
 }
 
 export function ModulesOnboardingPanel({moduleName}: {moduleName: ModuleName}) {
+  const {view} = useDomainViewFilters();
+  const docLink =
+    typeof MODULE_PRODUCT_DOC_LINKS[moduleName] === 'string'
+      ? MODULE_PRODUCT_DOC_LINKS[moduleName]
+      : view && MODULE_PRODUCT_DOC_LINKS[moduleName][view]
+        ? MODULE_PRODUCT_DOC_LINKS[moduleName][view]
+        : '';
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const emptyStateContent = EMPTY_STATE_CONTENT[moduleName];
   return (
@@ -106,11 +114,7 @@ export function ModulesOnboardingPanel({moduleName}: {moduleName: ModuleName}) {
             <PerfImage src={emptyStateImg} />
           </Sidebar>
         </SplitMainContent>
-        <LinkButton
-          priority="primary"
-          external
-          href={MODULE_PRODUCT_DOC_LINKS[moduleName]}
-        >
+        <LinkButton priority="primary" external href={docLink}>
           {t('Read the docs')}
         </LinkButton>
       </Container>

--- a/static/app/views/insights/sessions/settings.ts
+++ b/static/app/views/insights/sessions/settings.ts
@@ -6,7 +6,10 @@ export const DATA_TYPE = t('Session');
 export const DATA_TYPE_PLURAL = t('Sessions');
 export const BASE_URL = 'sessions';
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/releases/setup/';
+export const MOBILE_MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/mobile/session-health/';
+export const FRONTEND_MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/frontend/session-health/';
 
 export const MODULE_VISIBLE_FEATURES = ['insights-session-health-tab-ui'];
 

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -82,6 +82,9 @@ import {
   MODULE_FEATURES as MOBILE_UI_MODULE_FEATURES,
   MODULE_TITLE as MOBILE_UI_MODULE_TITLE,
 } from 'sentry/views/insights/mobile/ui/settings';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {
   DATA_TYPE as QUEUE_DATA_TYPE,
   DATA_TYPE_PLURAL as QUEUE_DATA_TYPE_PLURAL,
@@ -92,7 +95,8 @@ import {
 import {
   DATA_TYPE as SESSIONS_DATA_TYPE,
   DATA_TYPE_PLURAL as SESSIONS_DATA_TYPE_PLURAL,
-  MODULE_DOC_LINK as SESSIONS_MODULE_DOC_LINK,
+  FRONTEND_MODULE_DOC_LINK as FRONTEND_SESSIONS_MODULE_DOC_LINK,
+  MOBILE_MODULE_DOC_LINK as MOBILE_SESSIONS_MODULE_DOC_LINK,
   MODULE_TITLE as SESSIONS_MODULE_TITLE,
   MODULE_VISIBLE_FEATURES as SESSIONS_MODULE_VISIBLE_FEATURES,
 } from 'sentry/views/insights/sessions/settings';
@@ -171,7 +175,10 @@ export const MODULE_DATA_TYPES_PLURAL: Record<ModuleName, string> = {
   [ModuleName.OTHER]: '',
 };
 
-export const MODULE_PRODUCT_DOC_LINKS: Record<ModuleName, string> = {
+// Use if the doc link differs by domain view
+type DocLinkMap = Partial<Record<DomainView, string>>;
+
+export const MODULE_PRODUCT_DOC_LINKS: Record<ModuleName, string | DocLinkMap> = {
   [ModuleName.DB]: DB_MODULE_DOC_LINK,
   [ModuleName.HTTP]: HTTP_MODULE_DOC_LINK,
   [ModuleName.CACHE]: CACHE_MODULE_DOC_LINK,
@@ -186,7 +193,10 @@ export const MODULE_PRODUCT_DOC_LINKS: Record<ModuleName, string> = {
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_MODULE_DOC_LINK,
   [ModuleName.UPTIME]: UPTIME_MODULE_DOC_LINK,
   [ModuleName.CRONS]: CRONS_MODULE_DOC_LINK,
-  [ModuleName.SESSIONS]: SESSIONS_MODULE_DOC_LINK,
+  [ModuleName.SESSIONS]: {
+    [MOBILE_LANDING_SUB_PATH]: MOBILE_SESSIONS_MODULE_DOC_LINK,
+    [FRONTEND_LANDING_SUB_PATH]: FRONTEND_SESSIONS_MODULE_DOC_LINK,
+  },
   [ModuleName.OTHER]: '',
 };
 


### PR DESCRIPTION
the "Read the docs" link used to link to https://docs.sentry.io/product/releases/setup/. now they link to the new docs pages depending on which module (mobile vs frontend) is selected

<img width="1243" alt="SCR-20250415-nbco" src="https://github.com/user-attachments/assets/7de779f8-e007-405d-8a3e-31982f07b192" />

- mobile: https://docs.sentry.io/product/insights/mobile/session-health/ 
- frontend: https://docs.sentry.io/product/insights/frontend/session-health/
