### PR TITLE
chore(issues) - remove use of option for new postgres query timeout error handling

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -428,7 +428,7 @@ def handle_query_errors() -> Generator[None]:
     except OperationalError as error:
         error_message = str(error)
         is_timeout = "canceling statement due to statement timeout" in error_message
-        if is_timeout and options.get("api.postgres-query-timeout-error-handling.enabled"):
+        if is_timeout:
             sentry_sdk.set_tag("query.error_reason", "Postgres statement timeout")
             sentry_sdk.capture_exception(error, level="warning")
             raise Throttled(

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -18,7 +18,6 @@ from sentry.api.utils import (
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidParams, InvalidSearchQuery
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.snuba import (
     DatasetSelectionError,
     QueryConnectionFailed,
@@ -204,37 +203,25 @@ class HandleQueryErrorsTest(APITestCase):
             def __str__(self):
                 return "canceling statement due to statement timeout"
 
-        # Test when option is disabled (default)
         try:
             with handle_query_errors():
                 raise TimeoutError()
         except Exception as e:
-            assert isinstance(e, TimeoutError)  # Should propagate original error
-
-        # Test when option is enabled
-        with override_options({"api.postgres-query-timeout-error-handling.enabled": True}):
-            try:
-                with handle_query_errors():
-                    raise TimeoutError()
-            except Exception as e:
-                assert isinstance(e, Throttled)
-                assert (
-                    str(e)
-                    == "Query timeout. Please try with a smaller date range or fewer conditions."
-                )
+            assert isinstance(e, Throttled)
+            assert (
+                str(e) == "Query timeout. Please try with a smaller date range or fewer conditions."
+            )
 
     def test_handle_postgres_user_cancel(self):
         class UserCancelError(OperationalError):
             def __str__(self):
                 return "canceling statement due to user request"
 
-        # Should propagate the error regardless of the feature flag
-        with override_options({"api.postgres-query-timeout-error-handling.enabled": True}):
-            try:
-                with handle_query_errors():
-                    raise UserCancelError()
-            except Exception as e:
-                assert isinstance(e, UserCancelError)  # Should propagate original error
+        try:
+            with handle_query_errors():
+                raise UserCancelError()
+        except Exception as e:
+            assert isinstance(e, UserCancelError)  # Should propagate original error
 
     @patch("sentry.api.utils.ParseError")
     def test_handle_other_operational_error(self, mock_parse_error):


### PR DESCRIPTION
Was just used to verify this works as replicating locally was problematic, no need for it now that it is deployed and works