### PR TITLE
:wrench: chore(aci): add workflow enginealert rule serializer scaffolding

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_alert_rule.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from sentry.api.serializers import Serializer
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.workflow_engine.models import Detector
+
+
+class WorkflowEngineAlertRuleSerializer(Serializer):
+    def serialize(self, obj: Detector, attrs, user, **kwargs) -> AlertRuleSerializerResponse:
+        # TODO: Implement this
+        return {
+            "id": "-2",
+            "name": "Test Alert Rule",
+            "organizationId": "-2",
+            "status": 1,
+            "query": "test",
+            "aggregate": "test",
+            "timeWindow": 1,
+            "resolution": 1,
+            "thresholdPeriod": 1,
+            "triggers": [
+                {
+                    "id": "-1",
+                    "status": 1,
+                    "dateModified": datetime.now(),
+                    "dateCreated": datetime.now(),
+                }
+            ],
+            "dateModified": datetime.now(),
+            "dateCreated": datetime.now(),
+            "createdBy": {},
+            "description": "test",
+            "detectionType": "test",
+        }


### PR DESCRIPTION
added the scaffolding for the `WorkflowEngineAlertRuleSerializer` to unblock the notification action work.

i need this to start wiring the logic to invoke the correct serializers so i can generate charts