### PR TITLE
ref(issues): Refactor IssueDetailsContext provider

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -93,7 +93,8 @@ type FetchGroupDetailsState = {
   refetchGroup: () => void;
 };
 
-interface GroupDetailsContentProps extends GroupDetailsProps, FetchGroupDetailsState {
+interface GroupDetailsContentProps extends GroupDetailsProps {
+  event: Event | null;
   group: Group;
   project: Project;
 }
@@ -834,11 +835,12 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
       TourContext={IssueDetailsTourContext}
     >
       <GroupDetailsContent
-        {...props}
         project={projectWithFallback}
         group={props.group}
         event={props.event ?? injectedEvent}
-      />
+      >
+        {props.children}
+      </GroupDetailsContent>
     </TourContextProvider>
   );
 }

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -4,6 +4,7 @@ import {
   type Reducer,
   useCallback,
   useContext,
+  useMemo,
   useReducer,
 } from 'react';
 
@@ -97,12 +98,16 @@ export interface IssueDetailsContextType extends IssueDetailsState {
   dispatch: Dispatch<IssueDetailsActions>;
 }
 
-export const IssueDetailsContext = createContext<IssueDetailsContextType>({
+const initialState: IssueDetailsState = {
   sectionData: {},
   detectorDetails: {},
   isSidebarOpen: true,
-  navScrollMargin: 0,
   eventCount: 0,
+  navScrollMargin: 0,
+};
+
+export const IssueDetailsContext = createContext<IssueDetailsContextType>({
+  ...initialState,
   dispatch: () => {},
 });
 
@@ -177,15 +182,7 @@ function updateEventSection(
  * If trying to use the current state of the issue/event page, you likely want to use
  * `useIssueDetails` instead. This hook is just meant to create state for the provider.
  */
-export function useIssueDetailsReducer() {
-  const initialState: IssueDetailsState = {
-    sectionData: {},
-    detectorDetails: {},
-    isSidebarOpen: true,
-    eventCount: 0,
-    navScrollMargin: 0,
-  };
-
+export function IssueDetailsContextProvider({children}: {children: React.ReactNode}) {
   const reducer: Reducer<IssueDetailsState, IssueDetailsActions> = useCallback(
     (state, action): IssueDetailsState => {
       switch (action.type) {
@@ -208,5 +205,7 @@ export function useIssueDetailsReducer() {
 
   const [issueDetails, dispatch] = useReducer(reducer, initialState);
 
-  return {issueDetails, dispatch};
+  const value = useMemo(() => ({...issueDetails, dispatch}), [issueDetails, dispatch]);
+
+  return <IssueDetailsContext value={value}>{children}</IssueDetailsContext>;
 }

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -1,4 +1,3 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
@@ -8,21 +7,28 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {DemoTourStep, SharedTourElement} from 'sentry/utils/demoMode/demoTours';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import useMedia from 'sentry/utils/useMedia';
 import {
   IssueDetailsTour,
   IssueDetailsTourContext,
 } from 'sentry/views/issueDetails/issueDetailsTour';
 import {
-  IssueDetailsContext,
-  useIssueDetailsReducer,
+  IssueDetailsContextProvider,
+  useIssueDetails,
 } from 'sentry/views/issueDetails/streamline/context';
 import {EventDetailsHeader} from 'sentry/views/issueDetails/streamline/eventDetailsHeader';
 import {IssueEventNavigation} from 'sentry/views/issueDetails/streamline/eventNavigation';
 import StreamlinedGroupHeader from 'sentry/views/issueDetails/streamline/header/header';
 import StreamlinedSidebar from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 import {ToggleSidebar} from 'sentry/views/issueDetails/streamline/sidebar/toggleSidebar';
-import {getGroupReprocessingStatus} from 'sentry/views/issueDetails/utils';
+
+function GroupLayoutBody({children}: {children: React.ReactNode}) {
+  const {isSidebarOpen} = useIssueDetails();
+  return (
+    <StyledLayoutBody data-test-id="group-event-details" sidebarOpen={isSidebarOpen}>
+      {children}
+    </StyledLayoutBody>
+  );
+}
 
 interface GroupDetailsLayoutProps {
   children: React.ReactNode;
@@ -37,26 +43,13 @@ export function GroupDetailsLayout({
   project,
   children,
 }: GroupDetailsLayoutProps) {
-  const theme = useTheme();
-  const {issueDetails, dispatch} = useIssueDetailsReducer();
-  const isScreenSmall = useMedia(`(max-width: ${theme.breakpoints.large})`);
-  const shouldDisplaySidebar = issueDetails.isSidebarOpen || isScreenSmall;
   const issueTypeConfig = getConfigForIssueType(group, group.project);
-  const groupReprocessingStatus = getGroupReprocessingStatus(group);
   const hasFilterBar = issueTypeConfig.header.filterBar.enabled;
 
   return (
-    <IssueDetailsContext value={{...issueDetails, dispatch}}>
-      <StreamlinedGroupHeader
-        group={group}
-        event={event ?? null}
-        project={project}
-        groupReprocessingStatus={groupReprocessingStatus}
-      />
-      <StyledLayoutBody
-        data-test-id="group-event-details"
-        sidebarOpen={issueDetails.isSidebarOpen}
-      >
+    <IssueDetailsContextProvider>
+      <StreamlinedGroupHeader group={group} event={event ?? null} project={project} />
+      <GroupLayoutBody>
         <div>
           <SharedTourElement<IssueDetailsTour>
             id={IssueDetailsTour.AGGREGATES}
@@ -90,11 +83,9 @@ export function GroupDetailsLayout({
             </GroupContent>
           </SharedTourElement>
         </div>
-        {shouldDisplaySidebar ? (
-          <StreamlinedSidebar group={group} event={event} project={project} />
-        ) : null}
-      </StyledLayoutBody>
-    </IssueDetailsContext>
+        <StreamlinedSidebar group={group} event={event} project={project} />
+      </GroupLayoutBody>
+    </IssueDetailsContextProvider>
   );
 }
 

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -41,19 +41,20 @@ import {ReplayBadge} from 'sentry/views/issueDetails/streamline/header/replayBad
 import {UserFeedbackBadge} from 'sentry/views/issueDetails/streamline/header/userFeedbackBadge';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
-import {ReprocessingStatus} from 'sentry/views/issueDetails/utils';
+import {
+  getGroupReprocessingStatus,
+  ReprocessingStatus,
+} from 'sentry/views/issueDetails/utils';
 
 interface GroupHeaderProps {
   event: Event | null;
   group: Group;
-  groupReprocessingStatus: ReprocessingStatus;
   project: Project;
 }
 
 export default function StreamlinedGroupHeader({
   event,
   group,
-  groupReprocessingStatus,
   project,
 }: GroupHeaderProps) {
   const location = useLocation();
@@ -65,6 +66,7 @@ export default function StreamlinedGroupHeader({
   const {title: primaryTitle, subtitle} = getTitle(group);
   const secondaryTitle = getMessage(group);
   const isComplete = group.status === 'resolved' || group.status === 'ignored';
+  const groupReprocessingStatus = getGroupReprocessingStatus(group);
   const disableActions = [
     ReprocessingStatus.REPROCESSING,
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IssueDetailsTour,
   IssueDetailsTourContext,
 } from 'sentry/views/issueDetails/issueDetailsTour';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import StreamlinedActivitySection from 'sentry/views/issueDetails/streamline/sidebar/activitySection';
 import {DetectorSection} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 import {ExternalIssueSidebarList} from 'sentry/views/issueDetails/streamline/sidebar/externalIssueSidebarList';
@@ -34,6 +35,7 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
   const theme = useTheme();
   const activeUser = useUser();
   const organization = useOrganization();
+  const {isSidebarOpen} = useIssueDetails();
 
   const {userParticipants, teamParticipants, viewers} = useMemo(() => {
     return {
@@ -50,6 +52,11 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
   const showPeopleSection = group.participants.length > 0 || viewers.length > 0;
   const issueTypeConfig = getConfigForIssueType(group, group.project);
   const isBottomSidebar = useMedia(`(max-width: ${theme.breakpoints.large})`);
+  const shouldDisplaySidebar = isSidebarOpen || isBottomSidebar;
+
+  if (!shouldDisplaySidebar) {
+    return null;
+  }
 
   return (
     <SharedTourElement<IssueDetailsTour>


### PR DESCRIPTION
Set up the provider in one place, remove extra useMedia that duplicates checks in the sidebar component. Removes a few extra props being passed down to group layout.
