### PR TITLE
fix(ui): Silence framer motion warning

### DIFF
--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -62,7 +62,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   ${p => p.textCss?.(p)}
 `;
 
-const AnimatedText = motion(Text);
+const AnimatedText = motion.create(Text);
 
 const animatedTextDefaultProps = {
   initial: {opacity: 0, y: -10},
@@ -183,7 +183,7 @@ const RingBar = styled('circle')<{
     stroke 100ms;
 `;
 
-const MotionRingBar = motion(RingBar);
+const MotionRingBar = motion.create(RingBar);
 
 export default ProgressRing;
 


### PR DESCRIPTION
After updating calling `motion()` throws a warning telling us to use motion.create
