### PR TITLE
fix(issue-views): Do not render issue views without an ID in the new nav

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, Reorder, useDragControls} from 'framer-motion';
@@ -11,8 +11,6 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useIssueViewUnsavedChanges} from 'sentry/views/issueList/issueViews/useIssueViewUnsavedChanges';
@@ -71,8 +69,6 @@ export function IssueViewNavItemContent({
   setIsDragging,
 }: IssueViewNavItemContentProps) {
   const organization = useOrganization();
-  const location = useLocation();
-  const navigate = useNavigate();
   const {projects} = useProjects();
 
   const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
@@ -82,16 +78,6 @@ export function IssueViewNavItemContent({
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
   const {hasUnsavedChanges, changedParams} = useIssueViewUnsavedChanges();
-
-  useEffect(() => {
-    if (isActive) {
-      if (Object.keys(location.query).length === 0) {
-        navigate(constructViewLink(baseUrl, view), {replace: true});
-        return;
-      }
-    }
-    return;
-  }, [view, isActive, location.query, navigate, baseUrl]);
 
   const projectPlatforms = projects
     .filter(p => view.projects.map(String).includes(p.id))

--- a/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
@@ -1,5 +1,6 @@
 import {useCallback} from 'react';
 
+import {defined} from 'sentry/utils';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFetchStarredGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
@@ -15,7 +16,13 @@ export function useStarredIssueViews() {
     {notifyOnChangeProps: ['data'], staleTime: 0}
   );
 
-  const starredViews = groupSearchViews?.map(convertGSVtoIssueView) ?? [];
+  const starredViews =
+    groupSearchViews
+      // XXX (malwilley): Issue views without the nav require at least one issue view,
+      // so they respond with "fake" issue views that do not have an ID.
+      // We should remove this from the backend and here once we remove the tab-based views.
+      ?.filter(view => defined(view.id))
+      .map(convertGSVtoIssueView) ?? [];
 
   const setStarredIssueViews = useCallback(
     (newViews: NavIssueView[]) => {


### PR DESCRIPTION
Fixes SENTRY-3PNK

This was causing issues for users that did not have any issue views. There is some logic that needs to be cleaned up that is necessary for the tab-based views but not for the new nav.