### PR TITLE
fix(issue-details): Update page for reprocessing 

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -38,7 +38,11 @@ import {OccurrenceSummary} from 'sentry/views/issueDetails/streamline/occurrence
 import {getDetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 import {ToggleSidebar} from 'sentry/views/issueDetails/streamline/sidebar/toggleSidebar';
 import {useGroupDefaultStatsPeriod} from 'sentry/views/issueDetails/useGroupDefaultStatsPeriod';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
+import {
+  getGroupReprocessingStatus,
+  ReprocessingStatus,
+  useEnvironmentsFromUrl,
+} from 'sentry/views/issueDetails/utils';
 
 interface EventDetailsHeaderProps {
   group: Group;
@@ -54,6 +58,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
   const searchQuery = useEventQuery({groupId: group.id});
   const issueTypeConfig = getConfigForIssueType(group, project);
   const {dispatch} = useIssueDetails();
+  const groupReprocessingStatus = getGroupReprocessingStatus(group);
 
   const hasSetStatsPeriod =
     location.query.statsPeriod || location.query.start || location.query.end;
@@ -86,6 +91,10 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
     'Filter %s\u2026',
     issueTypeConfig.customCopy.eventUnits.toLocaleLowerCase()
   );
+
+  if (groupReprocessingStatus === ReprocessingStatus.REPROCESSING) {
+    return null;
+  }
 
   return (
     <PageErrorBoundary mini message={t('There was an error loading the event filters')}>

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -22,7 +22,10 @@ import {IssueEventNavigation} from 'sentry/views/issueDetails/streamline/eventNa
 import StreamlinedGroupHeader from 'sentry/views/issueDetails/streamline/header/header';
 import StreamlinedSidebar from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 import {ToggleSidebar} from 'sentry/views/issueDetails/streamline/sidebar/toggleSidebar';
-import {getGroupReprocessingStatus} from 'sentry/views/issueDetails/utils';
+import {
+  getGroupReprocessingStatus,
+  ReprocessingStatus,
+} from 'sentry/views/issueDetails/utils';
 
 interface GroupDetailsLayoutProps {
   children: React.ReactNode;
@@ -81,11 +84,13 @@ export function GroupDetailsLayout({
             position="top"
           >
             <GroupContent>
-              <NavigationSidebarWrapper hasToggleSidebar={!hasFilterBar}>
-                <IssueEventNavigation event={event} group={group} />
-                {/* Since the event details header is disabled, display the sidebar toggle here */}
-                {!hasFilterBar && <ToggleSidebar size="sm" />}
-              </NavigationSidebarWrapper>
+              {groupReprocessingStatus !== ReprocessingStatus.REPROCESSING && (
+                <NavigationSidebarWrapper hasToggleSidebar={!hasFilterBar}>
+                  <IssueEventNavigation event={event} group={group} />
+                  {/* Since the event details header is disabled, display the sidebar toggle here */}
+                  {!hasFilterBar && <ToggleSidebar size="sm" />}
+                </NavigationSidebarWrapper>
+              )}
               <ContentPadding>{children}</ContentPadding>
             </GroupContent>
           </SharedTourElement>

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -49,6 +49,7 @@ export function GroupDetailsLayout({
 }: GroupDetailsLayoutProps) {
   const issueTypeConfig = getConfigForIssueType(group, group.project);
   const hasFilterBar = issueTypeConfig.header.filterBar.enabled;
+  const groupReprocessingStatus = getGroupReprocessingStatus(group);
 
   return (
     <IssueDetailsContextProvider>


### PR DESCRIPTION
the streamlined ui shows too much when the issue is reprocessing which can sometimes error (things like the graph). better to hide it like in the old ui if the issue is being reprocessed - this pr hides the navigation and aggregation sections

![Screenshot 2025-04-15 at 4 33 51 PM](https://github.com/user-attachments/assets/061b9d47-dc65-4197-81cd-0d8b2f878baa)
