### PR TITLE
feat(releases): Refactor to support deep-linked Issues Chart

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -4,6 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {EVENT_GRAPH_WIDGET_ID} from 'sentry/views/issueDetails/streamline/eventGraphWidget';
 
 interface Props extends LoadableChartWidgetProps {
   /**
@@ -26,7 +27,13 @@ interface Props extends LoadableChartWidgetProps {
 export function ChartWidgetLoader(props: Props) {
   const query = useQuery<{default: React.FC<LoadableChartWidgetProps>}>({
     queryKey: [`widget-${props.id}`],
-    queryFn: () => import(`sentry/views/insights/common/components/widgets/${props.id}`),
+    queryFn: () => {
+      if (props.id === EVENT_GRAPH_WIDGET_ID) {
+        return import('sentry/views/issueDetails/streamline/eventGraphWidget');
+      }
+
+      return import(`sentry/views/insights/common/components/widgets/${props.id}`);
+    },
   });
 
   if (query.isPending) {

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -38,7 +38,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {getBucketSize} from 'sentry/views/dashboards/utils/getBucketSize';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
-import {EVENT_GRAPH_WIDGET_ID} from 'sentry/views/issueDetails/streamline/eventGraphWidget';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/hooks/featureFlags/useFlagSeries';
 import {useCurrentEventMarklineSeries} from 'sentry/views/issueDetails/streamline/hooks/useEventMarkLineSeries';
 import {

--- a/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import {useParams} from 'sentry/utils/useParams';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
+import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+
+export default function EventGraphWidget({pageFilters}: LoadableChartWidgetProps) {
+  const {groupId} = useParams();
+
+  const {
+    data: groupData,
+    isPending: loadingGroup,
+    isError: isGroupError,
+  } = useGroup({groupId: groupId!});
+
+  const eventView = useIssueDetailsEventView({
+    group: groupData!,
+    isSmallContainer: true,
+    pageFilters,
+  });
+
+  if (loadingGroup) {
+    return (
+      <Container>
+        <Placeholder height="100%" />
+      </Container>
+    );
+  }
+
+  if (isGroupError) {
+    return (
+      <Container>
+        <Placeholder height="100%" error={t('Error loading chart')} />
+      </Container>
+    );
+  }
+
+  return (
+    <EventGraph
+      event={undefined}
+      eventView={eventView}
+      group={groupData}
+      showSummary={false}
+      showReleasesAs="line"
+      disableZoomNavigation
+    />
+  );
+}
+
+const Container = styled('div')`
+  height: 100%;
+`;
+
+export const EVENT_GRAPH_WIDGET_ID = 'event-graph-widget';

--- a/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
@@ -1,4 +1,5 @@
 import {getInterval} from 'sentry/components/charts/utils';
+import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import type {NewQuery, SavedQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
@@ -16,11 +17,13 @@ import {useGroupDefaultStatsPeriod} from 'sentry/views/issueDetails/useGroupDefa
 
 export function useIssueDetailsEventView({
   group,
+  pageFilters,
   queryProps,
   isSmallContainer = false,
 }: {
   group: Group;
   isSmallContainer?: boolean;
+  pageFilters?: PageFilters;
   queryProps?: Partial<SavedQuery>;
 }) {
   const searchQuery = useEventQuery({groupId: group.id});
@@ -29,13 +32,15 @@ export function useIssueDetailsEventView({
   const hasSetStatsPeriod =
     location.query.statsPeriod || location.query.start || location.query.end;
   const defaultStatsPeriod = useGroupDefaultStatsPeriod(group, group.project);
-  const periodQuery = hasSetStatsPeriod
-    ? getPeriod({
-        start: location.query.start as string,
-        end: location.query.end as string,
-        period: location.query.statsPeriod as string,
-      })
-    : defaultStatsPeriod;
+  const periodQuery = pageFilters
+    ? getPeriod(pageFilters.datetime)
+    : hasSetStatsPeriod
+      ? getPeriod({
+          start: location.query.start as string,
+          end: location.query.end as string,
+          period: location.query.statsPeriod as string,
+        })
+      : defaultStatsPeriod;
 
   const interval = getInterval(
     {


### PR DESCRIPTION
This PR creates a "chart widget" similar to what we did for Insights widgets (e.g. https://github.com/getsentry/sentry/pull/89344). This is so that we can deep-link to the `EventGraph` using only `groupId` from URL parameters.

This also makes some changes to `EventGraph` so that we can use a custom date range (/page filters). This is used when we click a release bubble, we want the chart in the drawer to refetch the same stats (but at a different interval) according to the bubble's time bucket.


Part of https://github.com/getsentry/sentry/issues/88560