### PR TITLE
fix(aci): allow creating AssignedTo data condition with targetType=Unassigned

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -21,8 +21,15 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
             "target_type": {"type": "string", "enum": [*AssigneeTargetType]},
             "target_identifier": {"type": ["integer", "string"]},
         },
-        "required": ["target_type", "target_identifier"],
+        "required": ["target_type"],
         "additionalProperties": False,
+        "allOf": [
+            {
+                "if": {"properties": {"target_type": {"const": AssigneeTargetType.UNASSIGNED}}},
+                "then": {"required": ["target_type"]},
+                "else": {"required": ["target_type", "target_identifier"]},
+            }
+        ],
     }
 
     @staticmethod

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from sentry.notifications.types import AssigneeTargetType
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_frequency import ComparisonType
 from sentry.rules.match import MatchType
@@ -164,8 +165,10 @@ def create_assigned_to_data_condition(
 ) -> DataConditionKwargs:
     comparison = {
         "target_type": data["targetType"],
-        "target_identifier": data["targetIdentifier"],
     }
+
+    if data["targetType"] != AssigneeTargetType.UNASSIGNED:
+        comparison["target_identifier"] = data["targetIdentifier"]
 
     return DataConditionKwargs(
         type=Condition.ASSIGNED_TO,

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -40,6 +40,19 @@ class TestAssignedToCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+        payload = {
+            "id": AssignedToFilter.id,
+            "targetType": "Unassigned",
+        }
+        dc = self.translate_to_data_condition(payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "target_type": "Unassigned",
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
     def test_json_schema(self):
         self.dc.comparison.update({"target_type": "Team"})
         self.dc.save()
@@ -53,6 +66,10 @@ class TestAssignedToCondition(ConditionTestCase):
             self.dc.save()
 
         self.dc.comparison.update({"hello": "there"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"target_type": "Unassigned", "target_identifier": 0})
         with pytest.raises(ValidationError):
             self.dc.save()
 


### PR DESCRIPTION
Fix the json schema for `Condition.ASSIGNED_TO`: if the `target_type` is `UNASSIGNED` then we should not have a `target_identifier`