### PR TITLE
chore(aci): create translator from DataCondition to Rule condition json blob

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -107,7 +107,7 @@ def create_tagged_event_condition(
 
 def create_age_comparison_filter(
     data_condition: DataCondition, is_filter: bool = False
-) -> dict[str, Any]:
+) -> ConditionAndFilters:
     return {}, [
         {
             "id": "sentry.rules.filters.age_comparison.AgeComparisonFilter",
@@ -120,7 +120,7 @@ def create_age_comparison_filter(
 
 def create_assigned_to_filter(
     data_condition: DataCondition, is_filter: bool = False
-) -> dict[str, Any]:
+) -> ConditionAndFilters:
     payload = {
         "id": "sentry.rules.filters.assigned_to.AssignedToFilter",
         "targetType": data_condition.comparison["target_type"],
@@ -133,7 +133,7 @@ def create_assigned_to_filter(
 
 def create_issue_category_filter(
     data_condition: DataCondition, is_filter: bool = False
-) -> dict[str, Any]:
+) -> ConditionAndFilters:
     return {}, [
         {
             "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
@@ -222,7 +222,7 @@ def create_percent_sessions_condition(
 def create_event_unique_user_frequency_condition(
     data_condition: DataCondition, is_filter: bool = False
 ) -> ConditionAndFilters:
-    filters = []
+    filters: list[dict[str, Any]] = []
     if data_condition.comparison.get("filters"):
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions",
@@ -294,7 +294,7 @@ data_condition_to_rule_condition_mapping = {
 def translate_to_rule_condition_filters(
     data_condition: DataCondition, is_filter: bool
 ) -> ConditionAndFilters:
-    translator = data_condition_to_rule_condition_mapping.get(data_condition.type)
+    translator = data_condition_to_rule_condition_mapping.get(Condition(data_condition.type))
     if not translator:
         raise ValueError(f"Unsupported condition: {data_condition.type}")
 

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -1,0 +1,301 @@
+from typing import Any
+
+from sentry.rules.conditions.event_frequency import ComparisonType
+from sentry.rules.match import MatchType
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
+
+ConditionAndFilters = tuple[dict[str, Any], list[dict[str, Any]]]
+
+
+def create_reappeared_event_condition(
+    data_condition: DataCondition,
+    is_filter: bool = False,
+) -> ConditionAndFilters:
+    return {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}, []
+
+
+def create_regression_event_condition(
+    data_condition: DataCondition,
+    is_filter: bool = False,
+) -> ConditionAndFilters:
+    return {
+        "id": "sentry.rules.conditions.regression_event.RegressionEventCondition",
+    }, []
+
+
+def create_existing_high_priority_issue_condition(
+    data_condition: DataCondition,
+    is_filter: bool = False,
+) -> ConditionAndFilters:
+    return {
+        "id": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
+    }, []
+
+
+def create_event_attribute_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    if is_filter:
+        id = "sentry.rules.filters.event_attribute.EventAttributeFilter"
+    else:
+        id = "sentry.rules.conditions.event_attribute.EventAttributeCondition"
+    payload = {
+        "id": id,
+        "match": data_condition.comparison["match"],
+        "value": data_condition.comparison["value"],
+        "attribute": data_condition.comparison["attribute"],
+    }
+
+    if is_filter:
+        return {}, [payload]
+
+    return payload, []
+
+
+def create_first_seen_event_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}, []
+
+
+def create_new_high_priority_issue_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return {"id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"}, []
+
+
+def create_level_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    if is_filter:
+        id = "sentry.rules.filters.level.LevelFilter"
+    else:
+        id = "sentry.rules.conditions.level.LevelCondition"
+
+    payload = {
+        "id": id,
+        "match": data_condition.comparison["match"],
+        "level": str(data_condition.comparison["level"]),
+    }
+
+    if is_filter:
+        return {}, [payload]
+
+    return payload, []
+
+
+def create_tagged_event_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    if is_filter:
+        id = "sentry.rules.filters.tagged_event.TaggedEventFilter"
+    else:
+        id = "sentry.rules.conditions.tagged_event.TaggedEventCondition"
+
+    payload = {
+        "id": id,
+        "match": data_condition.comparison["match"],
+        "value": data_condition.comparison.get("value"),
+        "key": data_condition.comparison["key"],
+    }
+
+    if is_filter:
+        return {}, [payload]
+
+    return payload, []
+
+
+def create_age_comparison_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> dict[str, Any]:
+    return {}, [
+        {
+            "id": "sentry.rules.filters.age_comparison.AgeComparisonFilter",
+            "comparison_type": str(data_condition.comparison["comparison_type"]),
+            "value": data_condition.comparison["value"],
+            "time": data_condition.comparison["time"],
+        }
+    ]
+
+
+def create_assigned_to_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> dict[str, Any]:
+    payload = {
+        "id": "sentry.rules.filters.assigned_to.AssignedToFilter",
+        "targetType": data_condition.comparison["target_type"],
+    }
+    if data_condition.comparison.get("target_identifier"):
+        payload["targetIdentifier"] = data_condition.comparison["target_identifier"]
+
+    return {}, [payload]
+
+
+def create_issue_category_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> dict[str, Any]:
+    return {}, [
+        {
+            "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
+            "value": data_condition.comparison["value"],
+        }
+    ]
+
+
+def create_issue_occurrences_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return {}, [
+        {
+            "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+            "value": data_condition.comparison["value"],
+        }
+    ]
+
+
+def create_latest_release_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return {}, [
+        {
+            "id": "sentry.rules.filters.latest_release.LatestReleaseFilter",
+        }
+    ]
+
+
+def create_latest_adopted_release_filter(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return {}, [
+        {
+            "id": "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter",
+            "oldest_or_newest": data_condition.comparison["release_age_type"],
+            "older_or_newer": data_condition.comparison["age_comparison"],
+            "environment": data_condition.comparison["environment"],
+        }
+    ]
+
+
+def create_base_event_frequency_condition(
+    id: str,
+    data_condition: DataCondition,
+    count_type: Condition,
+    percent_type: Condition,
+) -> ConditionAndFilters:
+    payload = {
+        "id": id,
+        "comparisonType": (
+            ComparisonType.COUNT if data_condition.type == count_type else ComparisonType.PERCENT
+        ),
+        "interval": data_condition.comparison["interval"],
+        "value": data_condition.comparison["value"],
+    }
+
+    if data_condition.type == percent_type:
+        payload["comparisonInterval"] = data_condition.comparison["comparison_interval"]
+
+    return payload, []
+
+
+def create_event_frequency_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return create_base_event_frequency_condition(
+        id="sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+        data_condition=data_condition,
+        count_type=Condition.EVENT_FREQUENCY_COUNT,
+        percent_type=Condition.EVENT_FREQUENCY_PERCENT,
+    )
+
+
+def create_percent_sessions_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    return create_base_event_frequency_condition(
+        id="sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+        data_condition=data_condition,
+        count_type=Condition.PERCENT_SESSIONS_COUNT,
+        percent_type=Condition.PERCENT_SESSIONS_PERCENT,
+    )
+
+
+def create_event_unique_user_frequency_condition(
+    data_condition: DataCondition, is_filter: bool = False
+) -> ConditionAndFilters:
+    filters = []
+    if data_condition.comparison.get("filters"):
+        condition = {
+            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions",
+            "comparisonType": (
+                ComparisonType.COUNT
+                if data_condition.type == Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
+                else ComparisonType.PERCENT
+            ),
+            "interval": data_condition.comparison["interval"],
+            "value": data_condition.comparison["value"],
+        }
+        if data_condition.type == Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT:
+            condition["comparisonInterval"] = data_condition.comparison["comparison_interval"]
+
+        filters = []
+        for filter in data_condition.comparison["filters"]:
+            has_attribute = filter.get("attribute") is not None
+            if has_attribute:
+                filter_payload = {
+                    "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
+                    "attribute": filter["attribute"],
+                    "match": filter["match"],
+                }
+            else:
+                filter_payload = {
+                    "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                    "key": filter["key"],
+                    "match": filter["match"],
+                }
+            if filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
+                filter_payload["value"] = filter["value"]
+
+            filters.append(filter_payload)
+
+        return condition, filters
+
+    return create_base_event_frequency_condition(
+        id="sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+        data_condition=data_condition,
+        count_type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+        percent_type=Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+    )
+
+
+data_condition_to_rule_condition_mapping = {
+    Condition.REAPPEARED_EVENT: create_reappeared_event_condition,
+    Condition.REGRESSION_EVENT: create_regression_event_condition,
+    Condition.EXISTING_HIGH_PRIORITY_ISSUE: create_existing_high_priority_issue_condition,
+    Condition.NEW_HIGH_PRIORITY_ISSUE: create_new_high_priority_issue_condition,
+    Condition.LEVEL: create_level_condition,
+    Condition.EVENT_ATTRIBUTE: create_event_attribute_condition,
+    Condition.FIRST_SEEN_EVENT: create_first_seen_event_condition,
+    Condition.TAGGED_EVENT: create_tagged_event_condition,
+    Condition.AGE_COMPARISON: create_age_comparison_filter,
+    Condition.ASSIGNED_TO: create_assigned_to_filter,
+    Condition.ISSUE_CATEGORY: create_issue_category_filter,
+    Condition.ISSUE_OCCURRENCES: create_issue_occurrences_filter,
+    Condition.LATEST_RELEASE: create_latest_release_filter,
+    Condition.LATEST_ADOPTED_RELEASE: create_latest_adopted_release_filter,
+    Condition.EVENT_FREQUENCY_COUNT: create_event_frequency_condition,
+    Condition.EVENT_FREQUENCY_PERCENT: create_event_frequency_condition,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT: create_event_unique_user_frequency_condition,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT: create_event_unique_user_frequency_condition,
+    Condition.PERCENT_SESSIONS_COUNT: create_percent_sessions_condition,
+    Condition.PERCENT_SESSIONS_PERCENT: create_percent_sessions_condition,
+}
+
+
+def translate_to_rule_condition_filters(
+    data_condition: DataCondition, is_filter: bool
+) -> ConditionAndFilters:
+    translator = data_condition_to_rule_condition_mapping.get(data_condition.type)
+    if not translator:
+        raise ValueError(f"Unsupported condition: {data_condition.type}")
+
+    return translator(data_condition, is_filter)

--- a/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
@@ -1,0 +1,243 @@
+from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
+    create_event_unique_user_frequency_condition_with_conditions,
+)
+from sentry.workflow_engine.migration_helpers.rule_conditions import (
+    translate_to_rule_condition_filters,
+)
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class RuleConditionTranslationTest(ConditionTestCase):
+    def setUp(self):
+        self.dcg = self.create_data_condition_group()
+
+    def assert_basic_condition_translated(self, payload):
+        dc = self.translate_to_data_condition(payload, self.dcg)
+        condition, filters = translate_to_rule_condition_filters(dc, is_filter=False)
+        assert condition == payload
+        assert filters == []
+
+    def assert_basic_filter_translated(self, payload):
+        dc = self.translate_to_data_condition(payload, self.dcg)
+        condition, filters = translate_to_rule_condition_filters(dc, is_filter=True)
+        assert condition == {}
+        assert filters == [payload]
+
+    def test_reappeared_event(self):
+        payload = {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}
+        self.assert_basic_condition_translated(payload)
+
+    def test_regression_event(self):
+        payload = {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}
+        self.assert_basic_condition_translated(payload)
+
+    def test_existing_high_priority_issue(self):
+        payload = {
+            "id": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_attribute_condition(self):
+        payload = {
+            "id": "sentry.rules.conditions.event_attribute.EventAttributeCondition",
+            "attribute": "http.url",
+            "match": "nc",
+            "value": "localhost",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_attribute_filter(self):
+        payload = {
+            "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
+            "attribute": "http.url",
+            "match": "nc",
+            "value": "localhost",
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_first_seen_event(self):
+        payload = {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+        self.assert_basic_condition_translated(payload)
+
+    def test_new_high_priority_issue(self):
+        payload = {
+            "id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_level_condition(self):
+        payload = {
+            "id": "sentry.rules.conditions.level.LevelCondition",
+            "match": "eq",
+            "level": "50",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_level_filter(self):
+        payload = {
+            "id": "sentry.rules.filters.level.LevelFilter",
+            "match": "eq",
+            "level": "50",
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_tagged_event_condition(self):
+        payload = {
+            "id": "sentry.rules.conditions.tagged_event.TaggedEventCondition",
+            "key": "level",
+            "match": "eq",
+            "value": "error",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_tagged_event_filter(self):
+        payload = {
+            "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+            "key": "level",
+            "match": "eq",
+            "value": "error",
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_age_comparison_filter(self):
+        payload = {
+            "id": "sentry.rules.filters.age_comparison.AgeComparisonFilter",
+            "comparison_type": "older",
+            "value": 3,
+            "time": "week",
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_assigned_to_filter(self):
+        payload = {
+            "id": "sentry.rules.filters.assigned_to.AssignedToFilter",
+            "targetType": "Unassigned",
+        }
+        self.assert_basic_filter_translated(payload)
+
+        payload = {
+            "id": "sentry.rules.filters.assigned_to.AssignedToFilter",
+            "targetType": "Member",
+            "targetIdentifier": 895329789,
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_issue_category(self):
+        payload = {"id": "sentry.rules.filters.issue_category.IssueCategoryFilter", "value": 2}
+        self.assert_basic_filter_translated(payload)
+
+    def test_issue_occurrences(self):
+        payload = {
+            "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+            "value": 120,
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_latest_release(self):
+        payload = {"id": "sentry.rules.filters.latest_release.LatestReleaseFilter"}
+        self.assert_basic_filter_translated(payload)
+
+    def test_latest_adopted_release(self):
+        payload = {
+            "id": "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter",
+            "oldest_or_newest": "oldest",
+            "older_or_newer": "newer",
+            "environment": "prod",
+        }
+        self.assert_basic_filter_translated(payload)
+
+    def test_event_frequency_count(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "value": 50,
+            "comparisonType": "count",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_frequency_percent(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "value": 50,
+            "comparisonType": "percent",
+            "comparisonInterval": "1h",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_unique_user_frequency_count(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+            "value": 50,
+            "comparisonType": "count",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_unique_user_frequency_percent(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+            "value": 50,
+            "comparisonType": "percent",
+            "comparisonInterval": "1h",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_percent_sessions_count(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+            "value": 17.2,
+            "comparisonType": "count",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_percent_sessions_percent(self):
+        payload = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+            "value": 17.2,
+            "comparisonType": "percent",
+            "comparisonInterval": "1h",
+        }
+        self.assert_basic_condition_translated(payload)
+
+    def test_event_unique_user_frequency_with_conditions(self):
+        payload: dict[str, str | int | float] = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions",
+            "value": 50,
+            "comparisonType": "count",
+        }
+
+        conditions = [
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "match": "eq",
+                "key": "LOGGER",
+                "value": "sentry.example",
+            },
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "match": "is",
+                "key": "environment",
+            },
+            {
+                "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
+                "match": "nc",
+                "value": "hi",
+                "attribute": "message",
+            },
+        ]
+        dc = create_event_unique_user_frequency_condition_with_conditions(
+            payload, self.dcg, conditions
+        )
+        dc.save()
+        condition, filters = translate_to_rule_condition_filters(dc, is_filter=False)
+        assert condition == payload
+
+        assert len(filters) == len(conditions)
+        # Check that the filters are the same as the conditions (dictionaries)
+        for filter in filters:
+            assert filter in conditions

--- a/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     create_event_unique_user_frequency_condition_with_conditions,
 )
@@ -109,7 +111,7 @@ class RuleConditionTranslationTest(ConditionTestCase):
         self.assert_basic_filter_translated(payload)
 
     def test_assigned_to_filter(self):
-        payload = {
+        payload: dict[str, Any] = {
             "id": "sentry.rules.filters.assigned_to.AssignedToFilter",
             "targetType": "Unassigned",
         }


### PR DESCRIPTION
When serializing a workflow in the shape of `RuleSerializer`, we will need to be able to translate from workflow `DataConditions` back into the Rule condition JSON blobs, since everything on the Rule is stored in the `data` column.

Add translator functions for each `Condition` that create the Rule JSON conditions & filters given a `DataCondition`.

NOTE: a DataCondition can become a serialized condition (trigger), or filter.

NOTE 2: There is a `EventUniqueUserFrequencyConditionWithConditions` condition that also uses the filter conditions in a Rule to query Snuba. This becomes 1 `DataCondition` in workflow engine but currently exists as 1 condition + N filters within a `Rule`.