### PR TITLE
feat(explore): Update extrapolation message to use dataScanned

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -328,6 +328,7 @@ export type EventsStats = {
       // 0 sample count can result in null sampling rate
       samplingRate?: AccuracyStats<number | null>;
     };
+    dataScanned?: 'full' | 'partial';
     dataset?: string;
     datasetReason?: string;
     discoverSplitDecision?: WidgetType;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -37,6 +37,7 @@ export type TimeSeries = {
   field: string;
   meta: TimeSeriesMeta;
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   sampleCount?: AccuracyStats<number>;
   samplingRate?: AccuracyStats<number | null>;
 };

--- a/static/app/views/explore/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.spec.tsx
@@ -1,0 +1,163 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ConfidenceFooter} from './confidenceFooter';
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return <div data-test-id="wrapper">{children}</div>;
+}
+
+describe('ConfidenceFooter', () => {
+  describe('low confidence', () => {
+    it('renders for full scan without grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="low"
+          sampleCount={100}
+          topEvents={undefined}
+          dataScanned="full"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Based on 100 samples');
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(/You may not have enough samples for high accuracy./)
+      ).toBeInTheDocument();
+    });
+    it('renders for full scan with grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="low"
+          sampleCount={100}
+          topEvents={5}
+          dataScanned="full"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Top 5 groups based on 100 samples'
+      );
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(/You may not have enough samples for high accuracy./)
+      ).toBeInTheDocument();
+    });
+    it('renders for partial scan without grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="low"
+          sampleCount={100}
+          topEvents={undefined}
+          dataScanned="partial"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Based on 100 samples (Max. Limit)'
+      );
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(
+          /We could not scan all available data due to time or resource limits./
+        )
+      ).toBeInTheDocument();
+    });
+    it('renders for partial scan with grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="low"
+          sampleCount={100}
+          topEvents={5}
+          dataScanned="partial"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Top 5 groups based on 100 samples (Max. Limit)'
+      );
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(
+          /We could not scan all available data due to time or resource limits./
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('high confidence', () => {
+    it('renders for full scan without grouping', () => {
+      render(
+        <ConfidenceFooter
+          confidence="high"
+          sampleCount={100}
+          topEvents={undefined}
+          dataScanned="full"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Based on 100 samples');
+    });
+    it('renders for full scan with grouping', () => {
+      render(
+        <ConfidenceFooter
+          confidence="high"
+          sampleCount={100}
+          topEvents={5}
+          dataScanned="full"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Top 5 groups based on 100 samples'
+      );
+    });
+    it('renders for partial scan without grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="high"
+          sampleCount={100}
+          topEvents={undefined}
+          dataScanned="partial"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Based on 100 samples (Max. Limit)'
+      );
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(
+          /We could not scan all available data due to time or resource limits./
+        )
+      ).toBeInTheDocument();
+    });
+    it('renders for partial scan with grouping', async () => {
+      render(
+        <ConfidenceFooter
+          confidence="high"
+          sampleCount={100}
+          topEvents={5}
+          dataScanned="partial"
+        />,
+        {wrapper: Wrapper}
+      );
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Top 5 groups based on 100 samples (Max. Limit)'
+      );
+      await userEvent.hover(screen.getByText('100'));
+      expect(
+        await screen.findByText(
+          /We could not scan all available data due to time or resource limits./
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.tsx
@@ -8,6 +8,7 @@ import {defined} from 'sentry/utils';
 
 type Props = {
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   isSampled?: boolean | null;
   sampleCount?: number;
   topEvents?: number;
@@ -17,7 +18,13 @@ export function ConfidenceFooter(props: Props) {
   return <Container>{confidenceMessage(props)}</Container>;
 }
 
-function confidenceMessage({sampleCount, confidence, topEvents, isSampled}: Props) {
+function confidenceMessage({
+  sampleCount,
+  confidence,
+  topEvents,
+  isSampled,
+  dataScanned,
+}: Props) {
   const isTopN = defined(topEvents) && topEvents > 1;
   if (!defined(sampleCount)) {
     return isTopN
@@ -27,59 +34,128 @@ function confidenceMessage({sampleCount, confidence, topEvents, isSampled}: Prop
 
   const noSampling = defined(isSampled) && !isSampled;
 
+  const partialScanTooltip = <_PartialScanTooltip />;
+  const lowAccuracyFullSampleCount = <_LowAccuracyFullTooltip noSampling={noSampling} />;
+  const sampleCountComponent = <Count value={sampleCount} />;
   if (confidence === 'low') {
-    const lowAccuracySampleCount = (
-      <Tooltip
-        title={
-          <div>
-            {t('You may not have enough samples for high accuracy.')}
-            <br />
-            <br />
-            {t(
-              'You can try adjusting your query by removing filters or increasing the time interval.'
-            )}
-            <br />
-            <br />
-            {t(
-              'You can also increase your sampling rates to get more samples and accurate trends.'
-            )}
-          </div>
-        }
-        disabled={noSampling}
-        maxWidth={270}
-      >
-        <InsufficientSamples>
-          <Count value={sampleCount} />
-        </InsufficientSamples>
-      </Tooltip>
-    );
-
     if (isTopN) {
-      return tct('Sample count for top [topEvents] groups: [sampleCount]', {
-        topEvents,
-        sampleCount: lowAccuracySampleCount,
+      if (dataScanned === 'partial') {
+        return tct(
+          'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples (Max. Limit)]',
+          {
+            topEvents,
+            tooltip: partialScanTooltip,
+            sampleCountComponent,
+          }
+        );
+      }
+
+      return tct(
+        'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples]',
+        {
+          topEvents,
+          tooltip: lowAccuracyFullSampleCount,
+          sampleCountComponent,
+        }
+      );
+    }
+
+    if (dataScanned === 'partial') {
+      return tct('Based on [tooltip:[sampleCountComponent] samples (Max. Limit)]', {
+        tooltip: partialScanTooltip,
+        sampleCountComponent,
       });
     }
-    return tct('Sample count: [sampleCount]', {
-      sampleCount: lowAccuracySampleCount,
+
+    return tct('Based on [tooltip:[sampleCountComponent] samples]', {
+      tooltip: lowAccuracyFullSampleCount,
+      sampleCountComponent,
     });
   }
 
   if (isTopN) {
-    return tct('Sample count for top [topEvents] groups: [sampleCount]', {
+    if (dataScanned === 'partial') {
+      return tct(
+        'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples (Max. Limit)]',
+        {
+          topEvents,
+          tooltip: partialScanTooltip,
+          sampleCountComponent,
+        }
+      );
+    }
+
+    return tct('Top [topEvents] groups based on [sampleCountComponent] samples', {
       topEvents,
-      sampleCount: <Count value={sampleCount} />,
+      sampleCountComponent,
     });
   }
 
-  return tct('Sample count: [sampleCount]', {
-    sampleCount: <Count value={sampleCount} />,
+  if (dataScanned === 'partial') {
+    return tct('Based on [tooltip:[sampleCountComponent] samples (Max. Limit)]', {
+      tooltip: partialScanTooltip,
+      sampleCountComponent,
+    });
+  }
+
+  return tct('Based on [sampleCountComponent] samples', {
+    sampleCountComponent,
   });
 }
 
-const InsufficientSamples = styled('span')`
-  text-decoration: underline dotted ${p => p.theme.gray300};
-`;
+function _LowAccuracyFullTooltip({
+  noSampling,
+  children,
+}: {
+  noSampling: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <Tooltip
+      title={
+        <div>
+          {t('You may not have enough samples for high accuracy.')}
+          <br />
+          <br />
+          {t(
+            'You can try adjusting your query by removing filters or increasing the time interval.'
+          )}
+          <br />
+          <br />
+          {t(
+            'You can also increase your sampling rates to get more samples and accurate trends.'
+          )}
+        </div>
+      }
+      disabled={noSampling}
+      maxWidth={270}
+      showUnderline
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
+function _PartialScanTooltip({children}: {children?: React.ReactNode}) {
+  return (
+    <Tooltip
+      title={
+        <div>
+          {t('We could not scan all available data due to time or resource limits.')}
+          <br />
+          <br />
+          {t(
+            'Try reducing your time range or removing filters to get more accurate trends.'
+          )}
+        </div>
+      }
+      maxWidth={270}
+      showUnderline
+    >
+      {children}
+    </Tooltip>
+  );
+}
 
 const Container = styled('span')`
   color: ${p => p.theme.subText};

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -136,10 +136,8 @@ export function ExploreCharts({
 
       const {data, error, loading} = getSeries(dedupedYAxes, formattedYAxes);
 
-      const {sampleCount, isSampled} = determineSeriesSampleCountAndIsSampled(
-        data,
-        isTopN
-      );
+      const {sampleCount, isSampled, dataScanned} =
+        determineSeriesSampleCountAndIsSampled(data, isTopN);
 
       return {
         chartIcon: <IconGraph type={chartIcon} />,
@@ -153,6 +151,7 @@ export function ExploreCharts({
         confidence: confidences[index],
         sampleCount,
         isSampled,
+        dataScanned,
       };
     });
   }, [confidences, getSeries, visualizes, isTopN]);
@@ -307,6 +306,7 @@ export function ExploreCharts({
                   topEvents={
                     topEvents ? Math.min(topEvents, chartInfo.data.length) : undefined
                   }
+                  dataScanned={chartInfo.dataScanned}
                 />
               }
             />

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -246,6 +246,7 @@ export function convertEventsStatsToTimeSeriesData(
     confidence: determineSeriesConfidence(seriesData),
     sampleCount: seriesData.meta?.accuracy?.sampleCount,
     samplingRate: seriesData.meta?.accuracy?.samplingRate,
+    dataScanned: seriesData.meta?.dataScanned,
   };
 
   return [seriesData.order ?? 0, serie];


### PR DESCRIPTION
dataScanned indicates if we were able to hit tier 1 and scan all of the data, or do a partial scan (i.e. any of the other tiers). We have new text copy that indicates to the user whether they've hit the full tier or not and possible actions they may take to increase accuracy or query for more samples.

Users without progressive loading enabled will only see the `Based on x samples` or `Top x groups based on y samples` copy because if progressive loading isn't enabled, the endpoint always returns with a full scan and renders the old tooltip if applicable.

The tests should map to the cases described in the linked ticket below. Another PR will be opened to incorporate this data in dashboards.

Resolves [EXP-56](https://linear.app/getsentry/issue/EXP-56/clarify-extrapolation-copy-for-sampled-storage)