### PR TITLE
Python onboarding init() options

### DIFF
--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -189,9 +189,6 @@ import sentry-sdk
 
 sentry_sdk.init(
     dsn: "${params.dsn.public}",
-    # Add data like request headers and IP for users,
-    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    send_default_pii=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     traces_sample_rate=1.0,

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -188,11 +188,13 @@ const performanceOnboarding: OnboardingConfig = {
 import sentry-sdk
 
 sentry_sdk.init(
-  dsn: "${params.dsn.public}",
-
-  // Set traces_sample_rate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  traces_sample_rate=1.0,
+    dsn: "${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
 )`,
           additionalInfo: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -296,8 +296,13 @@ export const performanceOnboarding: OnboardingConfig = {
 import sentry_sdk
 
 sentry_sdk.init(
-  dsn="${params.dsn.public}",
-  traces_sample_rate=1.0,
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
 )`,
           additionalInfo: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -297,9 +297,6 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
-    # Add data like request headers and IP for users,
-    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    send_default_pii=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for tracing.
     traces_sample_rate=1.0,


### PR DESCRIPTION
Make sure `send_default_pii` is everywhere and has a explanatory comment.