### PR TITLE
fix(issue-views): Add missing organization argument to serializer

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -122,7 +122,9 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
                 view,
                 request.user,
                 serializer=GroupSearchViewSerializer(
-                    has_global_views=has_global_views, default_project=default_project
+                    has_global_views=has_global_views,
+                    default_project=default_project,
+                    organization=organization,
                 ),
             ),
             status=status.HTTP_200_OK,


### PR DESCRIPTION
The missing `organization` argument was causing the wrong results to be returned for `starred` and `last_visited`. Simple fix.