### PR TITLE
chore(seer grouping): Add referrer to Seer request timer metric

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -19,6 +19,7 @@ def make_signed_seer_api_request(
     path: str,
     body: bytes,
     timeout: int | None = None,
+    metric_tags: dict[str, Any] | None = None,
 ) -> BaseHTTPResponse:
     host = connection_pool.host
     if connection_pool.port:
@@ -36,7 +37,7 @@ def make_signed_seer_api_request(
     with metrics.timer(
         "seer.request_to_seer",
         sample_rate=1.0,
-        tags={"endpoint": parsed.path},
+        tags={"endpoint": parsed.path, **(metric_tags or {})},
     ):
         return connection_pool.urlopen(
             "POST",

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -71,6 +71,7 @@ def get_similarity_data_from_seer(
             json.dumps({"threshold": SEER_MAX_GROUPING_DISTANCE, **similar_issues_request}).encode(
                 "utf8"
             ),
+            metric_tags={"referrer": referrer} if referrer else {},
         )
     # See `SEER_GROUPING_TIMEOUT` in `sentry.conf.server`
     except (TimeoutError, MaxRetryError) as e:


### PR DESCRIPTION
Now that we're making a second request to Seer during grouping (to store the data of hybrid fingerprint events which couldn't use any of the returned Seer results), and passing different parameters to the endpoint, it would be helpful to be able to break the request timing metric down by purpose. This therefore adds a `referrer` tag to the `seer.request_to_seer` timing metric.