### PR TITLE
fix(autofix): Fix loading spinner styling

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -451,11 +451,6 @@ const HeaderIconWrapper = styled('div')`
   justify-content: center;
 `;
 
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  right: ${space(1)};
-  top: 5px;
-`;
-
 function CreatePRsButton({
   changes,
   groupId,
@@ -517,7 +512,7 @@ function CreatePRsButton({
     <Button
       priority="primary"
       onClick={createPRs}
-      icon={hasClicked && <StyledLoadingIndicator size={14} mini />}
+      icon={hasClicked && <LoadingIndicator size={14} />}
       size="sm"
       busy={isBusy || hasClicked}
       disabled={isBusy || hasClicked}
@@ -589,7 +584,7 @@ function CreateBranchButton({
   return (
     <Button
       onClick={pushToBranch}
-      icon={hasClicked && <StyledLoadingIndicator size={14} mini />}
+      icon={hasClicked && <LoadingIndicator size={14} />}
       size="sm"
       busy={isBusy || hasClicked}
       disabled={isBusy || hasClicked}


### PR DESCRIPTION
Someone changed the spinner component again so it's alignment got messed up again. So fixing it again.