### PR TITLE
chore(seer grouping): Add platform to similar issues request metric

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -280,9 +280,12 @@ def get_seer_similar_issues(
     }
     event.data.pop("stacktrace_string", None)
 
-    seer_request_metric_tags = {"hybrid_fingerprint": event_has_hybrid_fingerprint}
+    seer_request_metric_tags = {"platform": event.platform or "unknown"}
 
-    seer_results = get_similarity_data_from_seer(request_data, seer_request_metric_tags)
+    seer_results = get_similarity_data_from_seer(
+        request_data,
+        {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
+    )
 
     # All of these will get overridden if we find a usable match
     matching_seer_result = None  # JSON of result data
@@ -347,7 +350,7 @@ def get_seer_similar_issues(
 
         # We only want this for the side effect, and we know it'll return no matches, so we don't
         # bother to capture the return value.
-        get_similarity_data_from_seer(request_data)
+        get_similarity_data_from_seer(request_data, seer_request_metric_tags)
 
     is_hybrid_fingerprint_case = (
         event_has_hybrid_fingerprint

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -109,7 +109,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "referrer": "ingest",
                 "use_reranking": True,
             },
-            {"hybrid_fingerprint": False},
+            {"platform": "python", "hybrid_fingerprint": False},
         )
 
     @patch("sentry.grouping.ingest.seer.metrics.incr")
@@ -164,7 +164,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "referrer": "ingest",
                         "use_reranking": True,
                     },
-                    {"hybrid_fingerprint": False},
+                    {"platform": "python", "hybrid_fingerprint": False},
                 ),
                 # Second call to store the event's data since the match that came back from Seer
                 # wasn't usable
@@ -174,7 +174,8 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "k": 0,
                         "referrer": "ingest_follow_up",
                         "use_reranking": False,
-                    }
+                    },
+                    {"platform": "python"},
                 ),
             ]
 

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -61,7 +61,7 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 "referrer": "ingest",
                 "use_reranking": True,
             },
-            {"hybrid_fingerprint": False},
+            {"platform": "python", "hybrid_fingerprint": False},
         )
 
     @patch("sentry.grouping.ingest.seer.record_did_call_seer_metric")
@@ -183,5 +183,5 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 "referrer": "ingest",
                 "use_reranking": True,
             },
-            {"hybrid_fingerprint": False},
+            {"platform": "python", "hybrid_fingerprint": False},
         )


### PR DESCRIPTION
This adds platform to the `seer.similar_issues_request` metric resulting from ingest Seer calls by passing it to `get_similarity_data_from_seer` as part of `metric_tags`.