### PR TITLE
feat(issue-views): Add delete menu to issue view details page

### DIFF
--- a/static/app/views/issueList/issueViews/utils.tsx
+++ b/static/app/views/issueList/issueViews/utils.tsx
@@ -1,0 +1,13 @@
+import type {User} from 'sentry/types/user';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+
+export function canEditIssueView({
+  groupSearchView,
+  user,
+}: {
+  groupSearchView: GroupSearchView;
+  user: User;
+}) {
+  // TODO: Allow org admins to edit issue views
+  return user.id === groupSearchView.createdBy.id;
+}

--- a/static/app/views/issueList/leftNavViewsHeader.spec.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.spec.tsx
@@ -1,0 +1,130 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import LeftNavViewsHeader from 'sentry/views/issueList/leftNavViewsHeader';
+
+describe('LeftNavViewsHeader', function () {
+  const view = GroupSearchViewFixture();
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/123/',
+      method: 'GET',
+      body: view,
+    });
+  });
+
+  const defaultProps = {
+    selectedProjectIds: [],
+  };
+
+  const organization = OrganizationFixture({
+    features: ['issue-view-sharing'],
+  });
+
+  const onIssueViewRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/issues/views/123/',
+    },
+    route: '/organizations/:orgId/issues/views/:viewId/',
+  };
+
+  const onIssueFeedRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/issues/',
+    },
+    route: '/organizations/:orgId/issues/',
+  };
+
+  describe('edit menu', function () {
+    it('does not render if not on a view', async function () {
+      render(<LeftNavViewsHeader {...defaultProps} />, {
+        organization,
+        enableRouterMocks: false,
+        initialRouterConfig: onIssueFeedRouterConfig,
+      });
+
+      await screen.findByText('Issues');
+      expect(screen.queryByRole('button', {name: 'Edit View'})).not.toBeInTheDocument();
+    });
+
+    it('can delete a view', async function () {
+      const mockDeleteView = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/123/',
+        method: 'DELETE',
+      });
+
+      const {router} = render(<LeftNavViewsHeader {...defaultProps} />, {
+        organization,
+        enableRouterMocks: false,
+        initialRouterConfig: onIssueViewRouterConfig,
+      });
+      renderGlobalModal();
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'More issue view options'})
+      );
+
+      await userEvent.click(
+        await screen.findByRole('menuitemradio', {name: 'Delete View'})
+      );
+
+      const confirmButton = await within(screen.getByRole('dialog')).findByRole(
+        'button',
+        {
+          name: 'Delete View',
+        }
+      );
+
+      await userEvent.click(confirmButton);
+
+      // Should navigate back to the issue feed
+      await waitFor(() => {
+        expect(router.location.pathname).toBe('/organizations/org-slug/issues/');
+      });
+
+      // Modal should be closed
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      // Delete endpoint called
+      expect(mockDeleteView).toHaveBeenCalled();
+    });
+
+    it('disables the delete button if the user does not have permission to delete views', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/123/',
+        method: 'GET',
+        body: GroupSearchViewFixture({
+          createdBy: UserFixture({
+            id: '34625', // Someone else
+          }),
+        }),
+      });
+
+      render(<LeftNavViewsHeader {...defaultProps} />, {
+        organization,
+        enableRouterMocks: false,
+        initialRouterConfig: onIssueViewRouterConfig,
+      });
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'More issue view options'})
+      );
+
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Delete View'})
+      ).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+});

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -1,16 +1,23 @@
 import styled from '@emotion/styled';
 
+import {openConfirmModal} from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {IconStar} from 'sentry/icons';
+import {IconEllipsis, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 import {EditableIssueViewHeader} from 'sentry/views/issueList/editableIssueViewHeader';
 import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
+import {canEditIssueView} from 'sentry/views/issueList/issueViews/utils';
+import {useDeleteGroupSearchView} from 'sentry/views/issueList/mutations/useDeleteGroupSearchView';
 import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
 import {makeFetchGroupSearchViewKey} from 'sentry/views/issueList/queries/useFetchGroupSearchView';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
@@ -89,6 +96,72 @@ function IssueViewStarButton() {
           color={groupSearchView?.starred ? 'yellow300' : 'subText'}
         />
       }
+      size="sm"
+    />
+  );
+}
+
+function IssueViewEditMenu() {
+  const organization = useOrganization();
+  const {data: groupSearchView} = useSelectedGroupSearchView();
+  const user = useUser();
+  const {mutate: deleteIssueView} = useDeleteGroupSearchView();
+  const navigate = useNavigate();
+
+  if (!organization.features.includes('issue-view-sharing') || !groupSearchView) {
+    return null;
+  }
+
+  const canDeleteView = canEditIssueView({groupSearchView, user});
+
+  return (
+    <DropdownMenu
+      items={[
+        {
+          key: 'delete',
+          label: t('Delete View'),
+          priority: 'danger',
+          disabled: !canDeleteView,
+          details: canDeleteView
+            ? undefined
+            : t('You do not have permission to delete this view.'),
+          onAction: () => {
+            openConfirmModal({
+              message: t(
+                'Are you sure you want to delete the view "%s"?',
+                groupSearchView.name
+              ),
+              isDangerous: true,
+              confirmText: t('Delete View'),
+              priority: 'danger',
+              onConfirm: () => {
+                deleteIssueView(
+                  {
+                    id: groupSearchView.id,
+                  },
+                  {
+                    onSuccess: () => {
+                      navigate(
+                        normalizeUrl(`/organizations/${organization.slug}/issues/`)
+                      );
+                    },
+                  }
+                );
+              },
+            });
+          },
+        },
+      ]}
+      trigger={props => (
+        <Button
+          size="sm"
+          {...props}
+          icon={<IconEllipsis />}
+          aria-label={t('More issue view options')}
+        />
+      )}
+      position="bottom-end"
+      minMenuWidth={160}
     />
   );
 }
@@ -105,7 +178,10 @@ function LeftNavViewsHeader({selectedProjectIds}: LeftNavViewsHeaderProps) {
       <Layout.HeaderContent unified={prefersStackedNav}>
         <StyledLayoutTitle>
           <PageTitle />
-          <IssueViewStarButton />
+          <Actions>
+            <IssueViewStarButton />
+            <IssueViewEditMenu />
+          </Actions>
         </StyledLayoutTitle>
       </Layout.HeaderContent>
       <Layout.HeaderActions />
@@ -127,7 +203,12 @@ const StyledGlobalEventProcessingAlert = styled(GlobalEventProcessingAlert)`
   }
 `;
 
-const StyledLayoutTitle = styled(Layout.Title)`
+const StyledLayoutTitle = styled('div')`
   display: flex;
   justify-content: space-between;
+`;
+
+const Actions = styled('div')`
+  display: flex;
+  gap: ${space(1)};
 `;


### PR DESCRIPTION
Still only visible under `issue-view-sharing` flag

![CleanShot 2025-04-16 at 09 09 37](https://github.com/user-attachments/assets/5256fa87-c0e8-4614-bf0e-31f2016b9f66)
![CleanShot 2025-04-16 at 09 09 42](https://github.com/user-attachments/assets/fb8baef3-8d7f-4360-a639-35410ae09738)
![CleanShot 2025-04-16 at 09 09 56](https://github.com/user-attachments/assets/ac40f960-364f-40f3-bd64-1b0762f64554)
