### PR TITLE
ref(feature flags): Refactor <FeatureFlagSort> so options can be injected at the callsite

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -14,7 +14,9 @@ import FeatureFlagSettingsButton from 'sentry/components/events/featureFlags/fea
 import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
 import {
   FlagControlOptions,
+  ORDER_BY_OPTIONS,
   OrderBy,
+  SORT_BY_OPTIONS,
   SortBy,
   sortedFlags,
 } from 'sentry/components/events/featureFlags/utils';
@@ -251,10 +253,18 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagListP
             onClick={() => onViewAllFlags(FlagControlOptions.SEARCH)}
           />
           <FeatureFlagSort
+            sortByOptions={SORT_BY_OPTIONS}
+            orderByOptions={ORDER_BY_OPTIONS}
+            onChange={selection => {
+              trackAnalytics('flags.sort_flags', {
+                organization,
+                sortMethod: selection.value,
+              });
+            }}
             orderBy={orderBy}
-            sortBy={sortBy}
-            setSortBy={setSortBy}
             setOrderBy={setOrderBy}
+            setSortBy={setSortBy}
+            sortBy={sortBy}
           />
         </Fragment>
       )}

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -255,15 +255,21 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagListP
           <FeatureFlagSort
             sortByOptions={SORT_BY_OPTIONS}
             orderByOptions={ORDER_BY_OPTIONS}
-            onChange={selection => {
+            orderBy={orderBy}
+            setOrderBy={value => {
+              setOrderBy(value);
               trackAnalytics('flags.sort_flags', {
                 organization,
-                sortMethod: selection.value,
+                sortMethod: value as string,
               });
             }}
-            orderBy={orderBy}
-            setOrderBy={setOrderBy}
-            setSortBy={setSortBy}
+            setSortBy={value => {
+              setSortBy(value);
+              trackAnalytics('flags.sort_flags', {
+                organization,
+                sortMethod: value as string,
+              });
+            }}
             sortBy={sortBy}
           />
         </Fragment>

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -18,7 +18,9 @@ import {
 import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
 import {
   FlagControlOptions,
+  ORDER_BY_OPTIONS,
   type OrderBy,
+  SORT_BY_OPTIONS,
   type SortBy,
   sortedFlags,
 } from 'sentry/components/events/featureFlags/utils';
@@ -33,7 +35,9 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getShortEventId} from 'sentry/utils/events';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface FlagDrawerProps {
   event: Event;
@@ -54,6 +58,7 @@ export function FeatureFlagDrawer({
   hydratedFlags,
   focusControl: initialFocusControl,
 }: FlagDrawerProps) {
+  const organization = useOrganization();
   const [sortBy, setSortBy] = useState<SortBy>(initialSortBy);
   const [orderBy, setOrderBy] = useState<OrderBy>(initialOrderBy);
   const [search, setSearch] = useState('');
@@ -80,10 +85,18 @@ export function FeatureFlagDrawer({
         </InputGroup.TrailingItems>
       </InputGroup>
       <FeatureFlagSort
+        sortByOptions={SORT_BY_OPTIONS}
+        orderByOptions={ORDER_BY_OPTIONS}
+        onChange={selection => {
+          trackAnalytics('flags.sort_flags', {
+            organization,
+            sortMethod: selection.value,
+          });
+        }}
         orderBy={orderBy}
-        sortBy={sortBy}
-        setSortBy={setSortBy}
         setOrderBy={setOrderBy}
+        setSortBy={setSortBy}
+        sortBy={sortBy}
       />
     </ButtonBar>
   );

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -87,6 +87,7 @@ export function FeatureFlagDrawer({
       <FeatureFlagSort
         sortByOptions={SORT_BY_OPTIONS}
         orderByOptions={ORDER_BY_OPTIONS}
+        orderBy={orderBy}
         setOrderBy={value => {
           setOrderBy(value);
           trackAnalytics('flags.sort_flags', {
@@ -101,7 +102,6 @@ export function FeatureFlagDrawer({
             sortMethod: value as string,
           });
         }}
-        orderBy={orderBy}
         sortBy={sortBy}
       />
     </ButtonBar>

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -87,15 +87,21 @@ export function FeatureFlagDrawer({
       <FeatureFlagSort
         sortByOptions={SORT_BY_OPTIONS}
         orderByOptions={ORDER_BY_OPTIONS}
-        onChange={selection => {
+        setOrderBy={value => {
+          setOrderBy(value);
           trackAnalytics('flags.sort_flags', {
             organization,
-            sortMethod: selection.value,
+            sortMethod: value as string,
+          });
+        }}
+        setSortBy={value => {
+          setSortBy(value);
+          trackAnalytics('flags.sort_flags', {
+            organization,
+            sortMethod: value as string,
           });
         }}
         orderBy={orderBy}
-        setOrderBy={setOrderBy}
-        setSortBy={setSortBy}
         sortBy={sortBy}
       />
     </ButtonBar>

--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -1,6 +1,5 @@
 import {Button} from 'sentry/components/core/button';
 import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
-import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import {
   getDefaultOrderBy,
   getSelectionType,
@@ -23,11 +22,9 @@ interface Props {
     label: string;
     value: SortBy;
   }>;
-  onChange?: (selection: SelectOption<SortBy | OrderBy>) => void;
 }
 
 export default function FeatureFlagSort({
-  onChange,
   sortBy,
   orderBy,
   setOrderBy,
@@ -55,7 +52,6 @@ export default function FeatureFlagSort({
             setOrderBy(getDefaultOrderBy(selection.value));
           }
           setSortBy(selection.value);
-          onChange?.(selection);
         }}
         options={sortByOptions}
       />
@@ -64,7 +60,6 @@ export default function FeatureFlagSort({
         value={orderBy}
         onChange={selection => {
           setOrderBy(selection.value);
-          onChange?.(selection);
         }}
         options={orderByOptions.map(o => {
           const selectionType = getSelectionType(o.value);

--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -1,28 +1,40 @@
 import {Button} from 'sentry/components/core/button';
 import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
+import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import {
   getDefaultOrderBy,
   getSelectionType,
-  ORDER_BY_OPTIONS,
   type OrderBy,
-  SORT_BY_OPTIONS,
   type SortBy,
 } from 'sentry/components/events/featureFlags/utils';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   orderBy: OrderBy;
+  orderByOptions: Array<{
+    label: string;
+    value: OrderBy;
+  }>;
   setOrderBy: (value: React.SetStateAction<OrderBy>) => void;
   setSortBy: (value: React.SetStateAction<SortBy>) => void;
   sortBy: SortBy;
+  sortByOptions: Array<{
+    label: string;
+    value: SortBy;
+  }>;
+  onChange?: (selection: SelectOption<SortBy | OrderBy>) => void;
 }
 
-export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}: Props) {
-  const organization = useOrganization();
-
+export default function FeatureFlagSort({
+  onChange,
+  sortBy,
+  orderBy,
+  setOrderBy,
+  setSortBy,
+  orderByOptions,
+  sortByOptions,
+}: Props) {
   return (
     <CompositeSelect
       trigger={triggerProps => (
@@ -43,24 +55,18 @@ export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}
             setOrderBy(getDefaultOrderBy(selection.value));
           }
           setSortBy(selection.value);
-          trackAnalytics('flags.sort_flags', {
-            organization,
-            sortMethod: selection.value,
-          });
+          onChange?.(selection);
         }}
-        options={SORT_BY_OPTIONS}
+        options={sortByOptions}
       />
       <CompositeSelect.Region
         label={t('Order By')}
         value={orderBy}
         onChange={selection => {
           setOrderBy(selection.value);
-          trackAnalytics('flags.sort_flags', {
-            organization,
-            sortMethod: selection.value,
-          });
+          onChange?.(selection);
         }}
-        options={ORDER_BY_OPTIONS.map(o => {
+        options={orderByOptions.map(o => {
           const selectionType = getSelectionType(o.value);
           return selectionType === sortBy ? o : {...o, disabled: true};
         })}


### PR DESCRIPTION
I'm going to re-use this component to sort feature flags by suspiciousness in a new place. So i wanted to make the options configurable and only show the 'sus' option sometimes. Showing that option will depend on a feature flag, and the specific callsite, so i decided to allow injecting options, instead of importing the lists directly. Because we're still using the enum, the allowable options are still well-known and directly related to feature flags, which will help keep things tidy over time.
