### PR TITLE
ref(feedback): add tooltip when delete is disabled

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -7,6 +7,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackAssignedTo from 'sentry/components/feedback/feedbackItem/feedbackAssignedTo';
 import useFeedbackActions from 'sentry/components/feedback/feedbackItem/useFeedbackActions';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -52,7 +53,6 @@ export default function FeedbackActions({
 function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
     disableDelete,
-    hasDelete,
     onDelete,
     isResolved,
     onResolveClick,
@@ -77,11 +77,14 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
       <Button size="xs" onClick={onMarkAsReadClick}>
         {hasSeen ? t('Mark Unread') : t('Mark Read')}
       </Button>
-      {hasDelete && (
+      <Tooltip
+        disabled={!disableDelete}
+        title={t('You must be an admin to delete feedback.')}
+      >
         <Button size="xs" onClick={onDelete} disabled={disableDelete}>
           {t('Delete')}
         </Button>
-      )}
+      </Tooltip>
     </Fragment>
   );
 }
@@ -89,7 +92,6 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
     disableDelete,
-    hasDelete,
     onDelete,
     isResolved,
     onResolveClick,
@@ -132,9 +134,11 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
             key: 'delete',
             priority: 'danger' as const,
             label: t('Delete'),
-            hidden: !hasDelete,
             disabled: disableDelete,
             onAction: onDelete,
+            tooltip: disableDelete
+              ? t('You must be an admin to delete feedback.')
+              : undefined,
           },
         ]}
       />
@@ -145,7 +149,6 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
     disableDelete,
-    hasDelete,
     onDelete,
     isResolved,
     onResolveClick,
@@ -184,9 +187,11 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           key: 'delete',
           priority: 'danger' as const,
           label: t('Delete'),
-          hidden: !hasDelete,
           disabled: disableDelete,
           onAction: onDelete,
+          tooltip: disableDelete
+            ? t('You must be an admin to delete feedback.')
+            : undefined,
         },
       ]}
     />

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -43,7 +43,6 @@ export default function useFeedbackActions({feedbackItem}: Props) {
     projectIds: feedbackItem.project ? [feedbackItem.project.id] : [],
   });
   const onDelete = useDeleteFeedback([feedbackItem.id], projectId);
-  const hasDelete = organization.features.includes('issue-platform-deletion-ui');
   const disableDelete = !organization.access.includes('event:admin');
 
   const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
@@ -76,7 +75,6 @@ export default function useFeedbackActions({feedbackItem}: Props) {
 
   return {
     disableDelete,
-    hasDelete,
     onDelete,
     isResolved,
     onResolveClick,

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -38,8 +38,7 @@ export default function FeedbackListBulkSelection({
   const newMailboxSpam =
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 
-  const hasDelete =
-    organization.features.includes('issue-platform-deletion-ui') && selectedIds !== 'all';
+  const hasDelete = selectedIds !== 'all';
   const disableDelete = !organization.access.includes('event:admin');
 
   return (
@@ -100,6 +99,9 @@ export default function FeedbackListBulkSelection({
                 hidden: !hasDelete,
                 disabled: disableDelete,
                 onAction: onDelete,
+                tooltip: disableDelete
+                  ? t('You must be an admin to delete feedback.')
+                  : undefined,
               },
             ]}
           />


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/87018

the feedback delete button is disabled if event admin access does not exist. add a tooltip explaining why when it's disabled

### large view: 

<img width="315" alt="SCR-20250416-jlao" src="https://github.com/user-attachments/assets/17318a42-1f22-4348-b43e-1a700a4d2793" />

### medium view:

<img width="170" alt="SCR-20250416-jmqs" src="https://github.com/user-attachments/assets/684d5bd7-5fcb-4fc2-aa1b-c782e611e475" />

### small view:

<img width="169" alt="SCR-20250416-jmkt" src="https://github.com/user-attachments/assets/a1630af8-3744-448b-b52c-09faa59acadd" />

### bulk:

<img width="183" alt="SCR-20250416-jnva" src="https://github.com/user-attachments/assets/b49ce694-41bf-466f-bc76-0e881380f4b3" />
