### PR TITLE
feat(explore): Apply new loading indicator to explore charts

### DIFF
--- a/static/app/components/segmentedLoadingBar.tsx
+++ b/static/app/components/segmentedLoadingBar.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 
 interface SegmentedLoadingBarProps {
@@ -13,17 +14,33 @@ interface SegmentedLoadingBarProps {
    * The number of segments to display.
    */
   segments: number;
+
+  /**
+   * A tooltip to display more information about the active phase.
+   */
+  activePhaseTooltip?: string;
 }
 
-export function SegmentedLoadingBar({segments = 3, phase = 0}: SegmentedLoadingBarProps) {
+export function SegmentedLoadingBar({
+  segments = 3,
+  phase = 0,
+  activePhaseTooltip,
+}: SegmentedLoadingBarProps) {
   return (
     <LoadingBarContainer>
       {Array.from({length: segments}).map((_, index) => (
-        <LoadingBarSegment
+        <Tooltip
           key={index}
-          isActive={index === phase}
-          isCompleted={index < phase}
-        />
+          title={activePhaseTooltip}
+          disabled={index !== phase}
+          skipWrapper
+        >
+          <LoadingBarSegment
+            key={index}
+            isActive={index === phase}
+            isCompleted={index < phase}
+          />
+        </Tooltip>
       ))}
     </LoadingBarContainer>
   );

--- a/static/app/views/explore/charts/index.spec.tsx
+++ b/static/app/views/explore/charts/index.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {DurationUnit} from 'sentry/utils/discover/fields';
 import {ExploreCharts} from 'sentry/views/explore/charts';
 import {defaultVisualizes} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 describe('ExploreCharts', () => {
   it('renders the progressive loading indicator when the widget is progressively loading', async () => {
@@ -28,7 +29,6 @@ describe('ExploreCharts', () => {
         confidences={[]}
         query={''}
         timeseriesResult={mockTimeseriesResult}
-        isProgressivelyLoading
         visualizes={defaultVisualizes()}
         setVisualizes={() => {}}
       />,
@@ -49,9 +49,9 @@ describe('ExploreCharts', () => {
         confidences={[]}
         query={''}
         timeseriesResult={mockTimeseriesResult}
-        isProgressivelyLoading={false}
         visualizes={defaultVisualizes()}
         setVisualizes={() => {}}
+        samplingMode={SAMPLING_MODE.BEST_EFFORT}
       />
     );
 

--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -46,6 +46,7 @@ export function WidgetExtrapolationFooter({
   if (samplingMode !== SAMPLING_MODE.BEST_EFFORT) {
     loader = (
       <div
+        data-test-id="progressive-loading-indicator"
         style={{
           width: '100px',
           display: 'flex',

--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -1,0 +1,99 @@
+import styled from '@emotion/styled';
+
+import {SegmentedLoadingBar} from 'sentry/components/segmentedLoadingBar';
+import {IconArrow, IconCheckmark} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Confidence} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
+import {
+  SAMPLING_MODE,
+  type SamplingMode,
+} from 'sentry/views/explore/hooks/useProgressiveQuery';
+
+export function WidgetExtrapolationFooter({
+  sampleCount,
+  isSampled,
+  confidence,
+  topEvents,
+  dataScanned,
+  samplingMode,
+}: {
+  confidence: Confidence | undefined;
+  dataScanned: 'full' | 'partial' | undefined;
+  isSampled: boolean | null;
+  sampleCount: number;
+  topEvents: number | undefined;
+  samplingMode?: SamplingMode;
+}) {
+  const organization = useOrganization();
+  if (!organization.features.includes('visibility-explore-progressive-loading')) {
+    return (
+      <ConfidenceFooter
+        sampleCount={sampleCount}
+        isSampled={isSampled}
+        confidence={confidence}
+        topEvents={topEvents}
+        dataScanned={dataScanned}
+      />
+    );
+  }
+
+  let loader;
+  // Show the loader if we haven't received best effort results yet
+  if (samplingMode !== SAMPLING_MODE.BEST_EFFORT) {
+    loader = (
+      <div
+        style={{
+          width: '100px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <SegmentedLoadingBar
+          segments={2}
+          phase={samplingMode === SAMPLING_MODE.PREFLIGHT ? 1 : 0}
+          activePhaseTooltip={
+            defined(samplingMode)
+              ? t('This widget is currently loading higher fidelity data.')
+              : undefined
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Container>
+      {loader}
+      <ExtrapolationMessageWrapper isVisible={!loader}>
+        {dataScanned === 'partial' && <IconArrow direction="down" size="xs" />}
+        {dataScanned === 'full' && <IconCheckmark size="xs" />}
+        <ConfidenceFooter
+          sampleCount={sampleCount}
+          isSampled={isSampled}
+          confidence={confidence}
+          topEvents={topEvents}
+          dataScanned={dataScanned}
+        />
+      </ExtrapolationMessageWrapper>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+// Use visibility to hide the footer when the loader is visible
+// to prevent layout shift when the loader disappears
+const ExtrapolationMessageWrapper = styled('div')<{isVisible: boolean}>`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  visibility: ${p => (p.isVisible ? 'visible' : 'hidden')};
+`;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -228,14 +228,6 @@ export function SpansTabContentImpl({
     eapSpanSearchQueryBuilderProps
   );
 
-  // Progressive loading only shows when we have preflight data and
-  // we're fetching the best effort request
-  const timeseriesIsProgressivelyLoading =
-    organization.features.includes('visibility-explore-progressive-loading') &&
-    defined(timeseriesSamplingMode) &&
-    timeseriesSamplingMode === SAMPLING_MODE.PREFLIGHT &&
-    timeseriesResult.isFetched;
-
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
       <Body withToolbar={expanded}>
@@ -283,9 +275,9 @@ export function SpansTabContentImpl({
               confidences={confidences}
               query={query}
               timeseriesResult={timeseriesResult}
-              isProgressivelyLoading={timeseriesIsProgressivelyLoading}
               visualizes={visualizes}
               setVisualizes={setVisualizes}
+              samplingMode={timeseriesSamplingMode}
             />
             <ExploreTables
               aggregatesTableResult={aggregatesTableResult}


### PR DESCRIPTION
Adds the segmented loader UI to the footer of the charts. Currently only implemented for the explore timeseries chart. There was some layout shift happening when the loader would finish and render the extrapolation message, so I opted to use `visibility` to render the text behind the scenes and take up the correct space to prevent shifting.


https://github.com/user-attachments/assets/6bfe81f5-7dac-47cb-9502-4d2263851c07

