### PR TITLE
fix(explore): Update loading bar tooltips

### DIFF
--- a/static/app/components/segmentedLoadingBar.stories.tsx
+++ b/static/app/components/segmentedLoadingBar.stories.tsx
@@ -39,6 +39,38 @@ export default storyBook('SegmentedLoadingBar', story => {
         transitioning between phases.
       </p>
       <LoadingBarWithNextPhaseControl />
+
+      <p>
+        A callback for tooltips can be provided to display a tooltip for each segment.
+      </p>
+      <Column>
+        <SegmentedLoadingBar
+          segments={3}
+          phase={0}
+          getTooltipText={phase => {
+            const nextPhase = phase + 1;
+            if (nextPhase >= 3) {
+              return 'This is the last phase.';
+            }
+            return `The current phase is ${phase}. The next phase is ${nextPhase}.`;
+          }}
+        />
+        <SegmentedLoadingBar
+          segments={3}
+          phase={1}
+          getTooltipText={phase => {
+            if (phase > 1) {
+              return undefined;
+            }
+
+            const nextPhase = phase + 1;
+            if (nextPhase === 2) {
+              return `The current phase is ${phase}. The next phase is ${nextPhase}. This is the last tooltip`;
+            }
+            return `The current phase is ${phase}. The next phase is ${nextPhase}.`;
+          }}
+        />
+      </Column>
     </div>
   ));
 

--- a/static/app/components/segmentedLoadingBar.tsx
+++ b/static/app/components/segmentedLoadingBar.tsx
@@ -16,25 +16,23 @@ interface SegmentedLoadingBarProps {
   segments: number;
 
   /**
-   * A tooltip to display more information about the active phase.
+   * A callback to get a tooltip text for a given phase.
+   *
+   * The callback takes a phase index that corresponds to the index of the
+   * segment being rendered.
    */
-  activePhaseTooltip?: string;
+  getTooltipText?: (phase: number) => React.ReactNode | undefined;
 }
 
 export function SegmentedLoadingBar({
   segments = 3,
   phase = 0,
-  activePhaseTooltip,
+  getTooltipText,
 }: SegmentedLoadingBarProps) {
   return (
     <LoadingBarContainer>
       {Array.from({length: segments}).map((_, index) => (
-        <Tooltip
-          key={index}
-          title={activePhaseTooltip}
-          disabled={index !== phase}
-          skipWrapper
-        >
+        <Tooltip key={index} title={getTooltipText?.(index)} skipWrapper>
           <LoadingBarSegment
             key={index}
             isActive={index === phase}

--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 
+import Count from 'sentry/components/count';
 import {SegmentedLoadingBar} from 'sentry/components/segmentedLoadingBar';
 import {IconArrow, IconCheckmark} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -44,6 +45,7 @@ export function WidgetExtrapolationFooter({
   let loader;
   // Show the loader if we haven't received best effort results yet
   if (samplingMode !== SAMPLING_MODE.BEST_EFFORT) {
+    const currentPhase = samplingMode === SAMPLING_MODE.PREFLIGHT ? 1 : 0;
     loader = (
       <div
         data-test-id="progressive-loading-indicator"
@@ -56,10 +58,15 @@ export function WidgetExtrapolationFooter({
       >
         <SegmentedLoadingBar
           segments={2}
-          phase={samplingMode === SAMPLING_MODE.PREFLIGHT ? 1 : 0}
-          activePhaseTooltip={
-            defined(samplingMode)
-              ? t('This widget is currently loading higher fidelity data.')
+          phase={currentPhase}
+          getTooltipText={phase =>
+            defined(samplingMode) && phase <= currentPhase
+              ? tct(
+                  'Based on [sampleCount] samples. This widget is currently loading higher fidelity data.',
+                  {
+                    sampleCount: <Count value={sampleCount} />,
+                  }
+                )
               : undefined
           }
         />


### PR DESCRIPTION
We should be able to render a message for all pills, not just the currently active pill.

This shows a message that includes the sample count when the preflight is completed.