### PR TITLE
feat(issue-views): Add create button to all views page

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -47,10 +47,10 @@ function useHydrateIssueViewQueryParams({view}: {view: GroupSearchView | undefin
 
     if (
       view &&
-      !previousViewData &&
       !query[URL_PARAM.PROJECT] &&
       !query[URL_PARAM.ENVIRONMENT] &&
-      !DATE_TIME_KEYS.some(key => query[key])
+      !DATE_TIME_KEYS.some(key => query[key]) &&
+      !query.sort
     ) {
       navigate(
         normalizeUrl({

--- a/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
@@ -1,0 +1,124 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import {
+  makeClosableHeader,
+  makeCloseButton,
+  ModalBody,
+  ModalFooter,
+} from 'sentry/components/globalModal/components';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {CreateIssueViewModal} from 'sentry/views/issueList/issueViews/createIssueViewModal';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+describe('CreateIssueViewModal', function () {
+  const defaultProps = {
+    Body: ModalBody,
+    Header: makeClosableHeader(jest.fn()),
+    Footer: ModalFooter,
+    CloseButton: makeCloseButton(jest.fn()),
+    closeModal: jest.fn(),
+  };
+
+  it('can create a new view', async function () {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '1', slug: 'project-1', environments: ['env1']}),
+      ProjectFixture({id: '2', slug: 'project-2', environments: ['env2']}),
+      ProjectFixture({id: '3', slug: 'project-3', environments: ['env3']}),
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    const mockCreateViewEndpoint = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      method: 'POST',
+      body: GroupSearchViewFixture({
+        id: '3',
+        name: 'foo',
+        projects: [2],
+        environments: ['env2'],
+        timeFilters: {
+          period: '30d',
+          start: null,
+          end: null,
+          utc: null,
+        },
+      }),
+    });
+
+    const {router} = render(<CreateIssueViewModal {...defaultProps} />, {
+      enableRouterMocks: false,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/views/',
+        },
+      },
+    });
+
+    const nameInput = screen.getByRole('textbox', {name: 'Name'});
+    await userEvent.type(nameInput, 'foo');
+
+    // Set project
+    await userEvent.click(screen.getByRole('button', {name: 'project-1'}));
+    await userEvent.click(screen.getByRole('row', {name: 'project-2'}));
+
+    // Set environment
+    await userEvent.click(screen.getByRole('button', {name: 'All Envs'}));
+    await userEvent.click(screen.getByRole('row', {name: 'env2'}));
+
+    // Set time range
+    await userEvent.click(screen.getByRole('button', {name: '14D'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Last 30 days'}));
+
+    // Add "foo" after "is:unresolved"
+    await userEvent.click(
+      screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)!
+    );
+    await userEvent.keyboard('foo{enter}');
+
+    // Set sort
+    const select = screen.getByRole('textbox', {name: 'Sort'});
+    await selectEvent.select(select, ['Trends']);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create View'}));
+
+    // When done should redirect to the new view
+    await waitFor(() => {
+      expect(router.location.pathname).toBe('/organizations/org-slug/issues/views/3/');
+    });
+
+    expect(mockCreateViewEndpoint).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          name: 'foo',
+          projects: [2],
+          environments: ['env2'],
+          timeFilters: {
+            period: '30d',
+            start: null,
+            end: null,
+            utc: null,
+          },
+          query: 'is:unresolved foo',
+          querySort: IssueSortOptions.TRENDS,
+          starred: false,
+        },
+      })
+    );
+  });
+});

--- a/static/app/views/issueList/issueViews/createIssueViewModal.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.tsx
@@ -1,33 +1,58 @@
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
+import SelectField from 'sentry/components/forms/fields/selectField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
+import FormField from 'sentry/components/forms/formField';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getUtcDateString} from 'sentry/utils/dates';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
+import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
+import {getSortLabel, IssueSortOptions} from 'sentry/views/issueList/utils';
 
 interface CreateIssueViewModalProps
   extends ModalRenderProps,
-    Pick<
-      GroupSearchView,
-      'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
+    Partial<
+      Pick<
+        GroupSearchView,
+        'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
+      >
     > {}
+
+const sortOptions = [
+  IssueSortOptions.DATE,
+  IssueSortOptions.NEW,
+  IssueSortOptions.TRENDS,
+  IssueSortOptions.FREQ,
+  IssueSortOptions.USER,
+];
+
+const selectFieldSortOptions = sortOptions.map(sortOption => ({
+  value: sortOption,
+  label: getSortLabel(sortOption),
+}));
 
 export function CreateIssueViewModal({
   Header,
   Body,
   closeModal,
-  query,
-  querySort,
-  projects,
-  environments,
-  timeFilters,
+  query: incomingQuery,
+  querySort: incomingQuerySort,
+  projects: incomingProjects,
+  environments: incomingEnvironments,
+  timeFilters: incomingTimeFilters,
 }: CreateIssueViewModalProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -54,12 +79,27 @@ export function CreateIssueViewModal({
     createIssueView({
       name: data.name,
       starred: data.starred,
-      query,
-      querySort,
-      projects,
-      environments,
-      timeFilters,
+      query: data.query,
+      querySort: data.querySort,
+      projects: data.projects,
+      environments: data.environments,
+      timeFilters: data.timeFilters,
     });
+  };
+
+  const initialData = {
+    name: '',
+    query: incomingQuery ?? 'is:unresolved',
+    querySort: incomingQuerySort ?? IssueSortOptions.DATE,
+    projects: incomingProjects ?? [],
+    environments: incomingEnvironments ?? [],
+    timeFilters: incomingTimeFilters ?? {
+      start: null,
+      end: null,
+      period: '14d',
+      utc: null,
+    },
+    starred: false,
   };
 
   return (
@@ -69,6 +109,7 @@ export function CreateIssueViewModal({
       saveOnBlur={false}
       submitLabel={t('Create View')}
       submitDisabled={isPending}
+      initialData={initialData}
     >
       <Header>
         <h4>{t('New Issue View')}</h4>
@@ -91,6 +132,109 @@ export function CreateIssueViewModal({
           required
           autoFocus
         />
+        <PageFiltersContainer disablePersistence skipLoadLastUsed>
+          {!defined(incomingProjects) && (
+            <FormField
+              key="projects"
+              name="projects"
+              label={t('Projects')}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+            >
+              {({onChange, onBlur, disabled}) => (
+                <ProjectPageFilter
+                  disabled={disabled}
+                  onChange={newValue => {
+                    onChange(newValue, {});
+                    onBlur(newValue, {});
+                  }}
+                />
+              )}
+            </FormField>
+          )}
+          {!defined(incomingEnvironments) && (
+            <FormField
+              key="environments"
+              name="environments"
+              label={t('Environments')}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+            >
+              {({onChange, onBlur, disabled}) => (
+                <EnvironmentPageFilter
+                  disabled={disabled}
+                  onChange={newValue => {
+                    onChange(newValue, {});
+                    onBlur(newValue, {});
+                  }}
+                />
+              )}
+            </FormField>
+          )}
+
+          {!defined(incomingTimeFilters) && (
+            <FormField
+              key="timeFilters"
+              name="timeFilters"
+              label={t('Time Range')}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+            >
+              {({onChange, onBlur, disabled}) => (
+                <DatePageFilter
+                  disabled={disabled}
+                  onChange={newValue => {
+                    const convertedValue = {
+                      period: newValue.relative ?? null,
+                      start: newValue.start ? getUtcDateString(newValue.start) : null,
+                      end: newValue.end ? getUtcDateString(newValue.end) : null,
+                      utc: newValue.utc ?? null,
+                    };
+                    onChange(convertedValue, {});
+                    onBlur(convertedValue, {});
+                  }}
+                />
+              )}
+            </FormField>
+          )}
+        </PageFiltersContainer>
+        {!defined(incomingQuery) && (
+          <FormField
+            key="query"
+            name="query"
+            label={t('Query')}
+            inline={false}
+            stacked
+            flexibleControlStateSize
+          >
+            {({onChange, onBlur, disabled, value}) => (
+              <IssueListSearchBar
+                organization={organization}
+                onChange={newValue => {
+                  onChange(newValue, {});
+                  onBlur(newValue, {});
+                }}
+                disabled={disabled}
+                initialQuery={value}
+                searchSource="saved_searches_modal"
+              />
+            )}
+          </FormField>
+        )}
+        {!defined(incomingQuerySort) && (
+          <SelectField
+            key="querySort"
+            name="querySort"
+            options={selectFieldSortOptions}
+            label={t('Sort')}
+            inline={false}
+            stacked
+            flexibleControlStateSize
+          />
+        )}
         <BooleanField
           key="starred"
           name="starred"

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
@@ -101,6 +101,7 @@ describe('IssueViewSaveButton', function () {
           projects: [1],
           environments: ['prod'],
           timeFilters: {period: '7d', utc: null, start: null, end: null},
+          starred: false,
         },
       })
     );
@@ -153,6 +154,7 @@ describe('IssueViewSaveButton', function () {
           projects: [1],
           environments: ['prod'],
           timeFilters: {period: '7d', utc: null, start: null, end: null},
+          starred: false,
         },
       })
     );

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -1,19 +1,24 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {openModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
 import Redirect from 'sentry/components/redirect';
 import SearchBar from 'sentry/components/searchBar';
-import {IconSort} from 'sentry/icons';
+import {IconAdd, IconMegaphone, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {CreateIssueViewModal} from 'sentry/views/issueList/issueViews/createIssueViewModal';
 import {IssueViewsTable} from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsTable';
 import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
 import {
@@ -56,14 +61,17 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
     isPending,
     isError,
     getResponseHeader,
-  } = useFetchGroupSearchViews({
-    orgSlug: organization.slug,
-    createdBy,
-    limit,
-    sort,
-    cursor,
-    query,
-  });
+  } = useFetchGroupSearchViews(
+    {
+      orgSlug: organization.slug,
+      createdBy,
+      limit,
+      sort,
+      cursor,
+      query,
+    },
+    {staleTime: 0}
+  );
 
   const tableQueryKey = makeFetchGroupSearchViewsKey({
     orgSlug: organization.slug,
@@ -170,6 +178,7 @@ export default function IssueViewsList() {
   const navigate = useNavigate();
   const location = useLocation();
   const query = typeof location.query.query === 'string' ? location.query.query : '';
+  const openFeedbackForm = useFeedbackForm();
 
   if (!organization.features.includes('issue-view-sharing')) {
     return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
@@ -178,7 +187,44 @@ export default function IssueViewsList() {
   return (
     <Layout.Page>
       <Layout.Header unified>
-        <Layout.Title>{t('All Views')}</Layout.Title>
+        <Layout.HeaderContent>
+          <Layout.Title>{t('All Views')}</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            {openFeedbackForm ? (
+              <Button
+                icon={<IconMegaphone />}
+                size="sm"
+                onClick={() => {
+                  openFeedbackForm({
+                    formTitle: t('Give Feedback'),
+                    messagePlaceholder: t('How can we make issue views better for you?'),
+                    tags: {
+                      ['feedback.source']: 'custom_views',
+                      ['feedback.owner']: 'issues',
+                    },
+                  });
+                }}
+              >
+                {t('Give Feedback')}
+              </Button>
+            ) : null}
+            <Button
+              priority="primary"
+              icon={<IconAdd />}
+              size="sm"
+              onClick={() => {
+                trackAnalytics('issue_views.create_view_clicked', {
+                  organization,
+                });
+                openModal(props => <CreateIssueViewModal {...props} />);
+              }}
+            >
+              {t('Create View')}
+            </Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
       </Layout.Header>
       <Layout.Body>
         <Layout.Main fullWidth>

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -63,6 +63,10 @@ export function IssueViewAddViewButton() {
     }
   };
 
+  if (organization.features.includes('issue-view-sharing')) {
+    return null;
+  }
+
   return (
     <AddViewButton
       borderless


### PR DESCRIPTION
Viewable under `issue-view-sharing` flag.

Adds action buttons to the all views page (give feedback, create view). Adds more fields to the create view modal so that you can create it outside of the issue stream.

![CleanShot 2025-04-16 at 12 19 09](https://github.com/user-attachments/assets/c3f2c593-7d1a-4679-ae97-861c03be876d)
![CleanShot 2025-04-16 at 12 19 16](https://github.com/user-attachments/assets/4f041758-6174-41ad-8e99-5a5cfe1765ca)
