### PR TITLE
fix(aci): allow for no values in comparison JSON if match=is_set/not_set in EventAttributeHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -4,7 +4,7 @@ import sentry_sdk
 
 from sentry.eventstore.models import GroupEvent
 from sentry.rules import MatchType, match_values
-from sentry.rules.conditions.event_attribute import attribute_registry
+from sentry.rules.conditions.event_attribute import ATTR_CHOICES, attribute_registry
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -19,11 +19,36 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
-            "attribute": {"type": "string"},
-            "match": {"type": "string", "enum": [*MatchType]},
-            "value": {"type": "string"},
+            "attribute": {"type": "string", "enum": list(ATTR_CHOICES.keys())},
+            "match": {
+                "type": "string",
+                "enum": [*MatchType],
+            },
+            "value": {
+                "type": "string",
+                "optional": True,
+            },
         },
-        "required": ["attribute", "match", "value"],
+        "oneOf": [
+            {
+                "properties": {
+                    "attribute": {"type": "string", "enum": list(ATTR_CHOICES.keys())},
+                    "match": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
+                },
+                "required": ["attribute", "match"],
+                "not": {"required": ["value"]},
+            },
+            {
+                "properties": {
+                    "attribute": {"type": "string", "enum": list(ATTR_CHOICES.keys())},
+                    "match": {
+                        "not": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
+                    },
+                    "value": {"type": "string"},
+                },
+                "required": ["attribute", "match", "value"],
+            },
+        ],
         "additionalProperties": False,
     }
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -67,9 +67,10 @@ def create_event_attribute_data_condition(
 ) -> DataConditionKwargs:
     comparison = {
         "match": data["match"],
-        "value": data["value"],
         "attribute": data["attribute"],
     }
+    if comparison["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
+        comparison["value"] = data["value"]
 
     return DataConditionKwargs(
         type=Condition.EVENT_ATTRIBUTE,

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -137,6 +137,21 @@ class TestEventAttributeCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+        payload = {
+            "id": EventAttributeCondition.id,
+            "match": MatchType.IS_SET,
+            "attribute": "platform",
+        }
+        dc = self.translate_to_data_condition(payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "match": MatchType.IS_SET,
+            "attribute": "platform",
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
     def test_dual_write_filter(self):
         self.payload["id"] = EventAttributeFilter.id
         dcg = self.create_data_condition_group()
@@ -188,6 +203,16 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "attribute": "platform", "value": 2000, "extra": "extra"}
         )
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update(
+            {"match": MatchType.IS_SET, "attribute": "platform", "value": 2000}
+        )
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "asdf", "value": 2000})
         with pytest.raises(ValidationError):
             self.dc.save()
 


### PR DESCRIPTION
If the match is `IS_SET` or `NOT_SET`, then we should enforce not having a `value` key in the comparison json for event attribute `DataConditions`. We already do this for `TaggedEvent` but somehow not for `EventAttribute`.

Also improves the allowable attributes from all strings to a list of values (`ATTR_CHOICES`), this is the same as the FE