### PR TITLE
ref(releases): remove unresolved query from issues table in drawer

### DIFF
--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -29,10 +29,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     limit: 10,
     sort: IssueSortOptions.FREQ,
     groupStatsPeriod: 'auto',
-    query: new MutableSearch([
-      `first-release:${release}`,
-      'is:unresolved',
-    ]).formatString(),
+    query: new MutableSearch([`first-release:${release}`]).formatString(),
   };
 
   const renderEmptyMessage = () => {
@@ -49,7 +46,6 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
       withChart={withChart}
       renderEmptyMessage={renderEmptyMessage}
       withPagination={false}
-      // onFetchSuccess={}
       source="release-drawer"
     />
   );


### PR DESCRIPTION
the badge + table view were inconsistent -- table view was showing only unresolved issues, and the badge count was a value from releaseMeta that just counts all new issues regardless of resolved status. to keep these two consistent, let's show all the new issues in the table, regardless of resolved status:

before:

<img width="651" alt="SCR-20250416-luuj" src="https://github.com/user-attachments/assets/b340b1db-937d-4bac-a51f-1e7145165d6d" />


after:

<img width="647" alt="SCR-20250416-luta" src="https://github.com/user-attachments/assets/4bd7d5ae-4d32-416b-8707-953cf0bba615" />
