### PR TITLE
feat(nav): Add pending deletion visual indicator to org items

### DIFF
--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -132,19 +132,24 @@ export function OrgDropdown({className}: {className?: string}) {
               key: 'switch-organization',
               label: t('Switch Organization'),
               isSubmenu: true,
-              disabled: !organizations?.length,
               hidden: config.singleOrganization || isDemoModeActive(),
               children: [
-                ...orderBy(organizations, ['status.id', 'name']).map(switchOrg => ({
-                  key: switchOrg.id,
-                  label: <OrganizationBadge organization={switchOrg} />,
-                  textValue: switchOrg.name,
-                  to: resolveRoute(
-                    `/organizations/${switchOrg.slug}/issues/`,
-                    organization,
-                    switchOrg
-                  ),
-                })),
+                ...orderBy(organizations, ['status.id', 'name']).map(switchOrg => {
+                  const pendingDeletion = switchOrg.status.id === 'pending_deletion';
+
+                  return {
+                    key: switchOrg.id,
+                    label: <OrganizationBadge organization={switchOrg} />,
+                    textValue: switchOrg.name,
+                    to: resolveRoute(
+                      `/organizations/${switchOrg.slug}/issues/`,
+                      organization,
+                      switchOrg
+                    ),
+                    priority: pendingDeletion ? ('danger' as const) : undefined,
+                    tooltip: pendingDeletion ? t('Pending deletion') : undefined,
+                  };
+                }),
                 createOrganizationMenuItem(),
               ],
             },


### PR DESCRIPTION
Adds the `danger` priority to org items which are pending deletion.

![CleanShot 2025-04-16 at 13 15 43](https://github.com/user-attachments/assets/3ba89235-cf4c-4081-9ff9-2212bd5b54e9)
