### PR TITLE
fix(explore): Fix issue with date range filter not allowing arbitrary ranges

### DIFF
--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -116,7 +116,10 @@ function Content() {
             <DatePageFilter
               defaultPeriod={defaultPeriod}
               maxPickableDays={maxPickableDays}
-              relativeOptions={relativeOptions}
+              relativeOptions={({arbitraryOptions}) => ({
+                ...arbitraryOptions,
+                ...relativeOptions,
+              })}
             />
           </StyledPageFilterBar>
           <DropdownMenu


### PR DESCRIPTION
Fixes an issue where the date range filter in Multi Query mode does not allowed arbitrary ranges