### PR TITLE
fix(issue-details): Don't show release info if no first/last seen 

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -64,7 +64,9 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
             environment={shortEnvironmentLabel}
           />
         </Flex>
-        <ReleaseText project={group.project} release={groupReleaseData?.lastRelease} />
+        {lastSeen && (
+          <ReleaseText project={group.project} release={groupReleaseData?.lastRelease} />
+        )}
       </div>
       <div>
         <Flex gap={space(0.5)}>
@@ -78,7 +80,9 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
             environment={shortEnvironmentLabel}
           />
         </Flex>
-        <ReleaseText project={group.project} release={groupReleaseData?.firstRelease} />
+        {group.firstSeen && (
+          <ReleaseText project={group.project} release={groupReleaseData?.firstRelease} />
+        )}
       </div>
     </Flex>
   );


### PR DESCRIPTION
this pr fixes an issue where the first seen could be "First seen n/a in release X" . doesn't fix the issue where if there's an environment selected the release might not match 