### PR TITLE
dashboards: dont restyle badge

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -7,7 +7,7 @@ import sortBy from 'lodash/sortBy';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import AvatarList, {CollapsedAvatars} from 'sentry/components/core/avatar/avatarList';
 import {TeamAvatar} from 'sentry/components/core/avatar/teamAvatar';
-import {Badge} from 'sentry/components/core/badge';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
@@ -219,7 +219,7 @@ function EditAccessSelector({
   // Avatars/Badges in the Edit Access Selector Button
   const triggerAvatars =
     selectedOptions.includes('_allUsers') || !dashboardCreator ? (
-      <StyledBadge key="_all" size={listOnly ? 26 : 20} type="default">
+      <StyledBadge key="_all" size={listOnly ? 26 : 20} type="info">
         {t('All')}
       </StyledBadge>
     ) : selectedOptions.length === 2 ? (
@@ -411,9 +411,7 @@ const LabelContainer = styled('div')`
   margin-right: ${space(1)};
 `;
 
-const StyledBadge = styled(Badge)<{size: number}>`
-  color: ${p => p.theme.white};
-  background: ${p => p.theme.purple300};
+const StyledBadge = styled(Tag)<{size: number}>`
   padding: 0;
   height: ${p => p.size}px;
   width: ${p => p.size}px;


### PR DESCRIPTION
Use a builtin badge variant as opposed to restyling it. The color is a bit different, but imo, it still conveys the message well enough.

Before
![CleanShot 2025-04-16 at 17 23 41@2x](https://github.com/user-attachments/assets/adac7434-9b43-44b5-b5ff-835890e08f52)

After
![CleanShot 2025-04-16 at 17 23 45@2x](https://github.com/user-attachments/assets/86324d3e-9519-4512-8f54-5f02a8fa230a)

Chonk
![CleanShot 2025-04-16 at 17 23 50@2x](https://github.com/user-attachments/assets/9a796211-61e6-4a03-b2d4-0ab91650bcdb)
![CleanShot 2025-04-16 at 17 23 58@2x](https://github.com/user-attachments/assets/d97b4e19-c34b-45c5-8d3c-60ab13f9f9df)
