### PR TITLE
chore(aci): serialize a Workflow in the shape of RuleSerializer (without actions)

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -363,12 +363,12 @@ class WorkflowEngineRuleSerializer(Serializer):
         if workflow.created_by_id is None:
             creator = None
         else:
-            u = users.get(workflow.created_by_id)
-            if u:
+            user = users.get(workflow.created_by_id)
+            if user:
                 creator = {
-                    "id": u.id,
-                    "name": u.get_display_name(),
-                    "email": u.email,
+                    "id": user.id,
+                    "name": user.get_display_name(),
+                    "email": user.email,
                 }
             else:
                 creator = None

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -371,13 +371,14 @@ class WorkflowEngineRuleSerializer(Serializer):
             return None
 
         user = users.get(workflow.created_by_id)
-        if user:
-            return {
-                "id": user.id,
-                "name": user.get_display_name(),
-                "email": user.email,
-            }
-        return None
+        if not user:
+            return None
+
+        return {
+            "id": user.id,
+            "name": user.get_display_name(),
+            "email": user.email,
+        }
 
     def _fetch_workflow_owner(self, workflow: Workflow) -> str | None:
         actor = workflow.owner

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -368,18 +368,16 @@ class WorkflowEngineRuleSerializer(Serializer):
         self, workflow: Workflow, users: dict[int, RpcUser]
     ) -> dict[str, Any] | None:
         if workflow.created_by_id is None:
-            creator = None
-        else:
-            user = users.get(workflow.created_by_id)
-            if user:
-                creator = {
-                    "id": user.id,
-                    "name": user.get_display_name(),
-                    "email": user.email,
-                }
-            else:
-                creator = None
-        return creator
+            return None
+
+        user = users.get(workflow.created_by_id)
+        if user:
+            return {
+                "id": user.id,
+                "name": user.get_display_name(),
+                "email": user.email,
+            }
+        return None
 
     def _fetch_workflow_owner(self, workflow: Workflow) -> str | None:
         actor = workflow.owner
@@ -500,7 +498,7 @@ class WorkflowEngineRuleSerializer(Serializer):
             "actions": [],  # TODO: reverse translate actions
             "actionMatch": action_match,
             "filterMatch": filter_match,
-            "frequency": obj.config.get("frequency") or 0,
+            "frequency": obj.config.get("frequency", 0),
             "name": obj.name,
             "dateCreated": obj.date_added,
             "owner": attrs.get("owner", None),

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from sentry.rules.conditions.event_frequency import ComparisonType
-from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 
 ConditionAndFilters = tuple[dict[str, Any], list[dict[str, Any]]]
@@ -42,7 +41,7 @@ def create_event_attribute_condition(
     payload = {
         "id": id,
         "match": data_condition.comparison["match"],
-        "value": data_condition.comparison["value"],
+        "value": data_condition.comparison.get("value", ""),
         "attribute": data_condition.comparison["attribute"],
     }
 
@@ -95,7 +94,7 @@ def create_tagged_event_condition(
     payload = {
         "id": id,
         "match": data_condition.comparison["match"],
-        "value": data_condition.comparison.get("value"),
+        "value": data_condition.comparison.get("value", ""),
         "key": data_condition.comparison["key"],
     }
 
@@ -252,8 +251,7 @@ def create_event_unique_user_frequency_condition(
                     "key": filter["key"],
                     "match": filter["match"],
                 }
-            if filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
-                filter_payload["value"] = filter["value"]
+            filter_payload["value"] = filter.get("value", "")
 
             filters.append(filter_payload)
 

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,0 +1,124 @@
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.rule import WorkflowEngineRuleSerializer
+from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
+from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
+from sentry.rules.conditions.regression_event import RegressionEventCondition
+from sentry.rules.conditions.tagged_event import TaggedEventCondition
+from sentry.rules.filters.age_comparison import AgeComparisonFilter
+from sentry.rules.filters.event_attribute import EventAttributeFilter
+from sentry.rules.filters.tagged_event import TaggedEventFilter
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
+from sentry.workflow_engine.models import WorkflowFireHistory
+
+
+@freeze_time()
+class RuleSerializerTest(TestCase):
+    def setUp(self):
+        conditions = [
+            {"id": ReappearedEventCondition.id},
+            {"id": RegressionEventCondition.id},
+            {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
+            {
+                "id": AgeComparisonFilter.id,
+                "comparison_type": "older",
+                "value": 10,
+                "time": "hour",
+            },
+            {
+                "id": EventAttributeFilter.id,
+                "attribute": "http.url",
+                "match": "nc",
+                "value": "localhost",
+            },
+        ]
+        self.issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=conditions,
+            action_match="any",
+            filter_match="any",
+            frequency=5,
+        )
+
+    def assert_equal_serializers(self, issue_alert):
+        RuleFireHistory.objects.create(project=self.project, rule=issue_alert, group=self.group)
+        serialized_rule = serialize(issue_alert)
+
+        workflow = IssueAlertMigrator(issue_alert).run()
+        WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=self.group,
+            has_fired_actions=True,
+            event_id="fc6d8c0c43fc4630ad850ee518f1b9d0",
+        )
+
+        serialized_workflow_rule = serialize(workflow, self.user, WorkflowEngineRuleSerializer())
+
+        # Pop and compare lists of dicts
+        rule_conditions = serialized_rule.pop("conditions")
+        workflow_conditions = serialized_workflow_rule.pop("conditions")
+        rule_filters = serialized_rule.pop("filters")
+        workflow_filters = serialized_workflow_rule.pop("filters")
+
+        assert len(rule_conditions) == len(workflow_conditions)
+        for condition in rule_conditions:
+            assert condition in workflow_conditions
+
+        assert len(rule_filters) == len(workflow_filters)
+        for filter in rule_filters:
+            assert filter in workflow_filters
+
+        # TODO: test with actions
+        serialized_rule.pop("actions")
+        serialized_workflow_rule.pop("actions")
+
+        assert serialized_rule == serialized_workflow_rule
+
+    def test_rule_serializer(self):
+        self.assert_equal_serializers(self.issue_alert)
+
+    def test_special_condition(self):
+        self.payload = {
+            "interval": "1h",
+            "id": EventUniqueUserFrequencyConditionWithConditions.id,
+            "value": 50,
+            "comparisonType": "count",
+        }
+
+        self.conditions = [
+            {
+                "id": TaggedEventFilter.id,
+                "match": "eq",
+                "key": "LOGGER",
+                "value": "sentry.example",
+            },
+            {
+                "id": TaggedEventFilter.id,
+                "match": "is",
+                "key": "environment",
+                "value": "",  # initializing RuleBase requires "value" key
+            },
+            {
+                "id": EventAttributeFilter.id,
+                "match": "eq",
+                "value": "hi",
+                "attribute": "message",
+            },
+            {
+                "id": EventAttributeFilter.id,
+                "match": "is",
+                "attribute": "platform",
+                "value": "",  # initializing RuleBase requires "value" key
+            },
+        ]
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=self.conditions + [self.payload],
+            action_match="all",
+            filter_match="all",
+            frequency=30,
+        )
+
+        self.assert_equal_serializers(issue_alert)

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -98,7 +98,7 @@ class WorkflowRuleSerializerTest(TestCase):
         workflow = self.create_workflow()
 
         error_detector = self.create_detector(project=self.project, type="error")
-        metric_detector = self.create_detector(project=self.project, type="metric_alert_fire")
+        metric_detector = self.create_detector(project=self.project, type="metric_issue")
         workflow_2 = self.create_workflow()
         # Workflow connected to 2 detectors with the same project
         self.create_detector_workflow(detector=error_detector, workflow=workflow_2)

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -144,9 +144,9 @@ class WorkflowRuleSerializerTest(TestCase):
 
         # Assert following FKs are prefetched and don't make additional queries
         with CaptureQueriesContext(connections[DEFAULT_DB_ALIAS]) as queries:
-            assert workflow_with_prefetch.prefetched_wdcgs == [workflow_dcg]
+            assert workflow_with_prefetch.prefetched_wdcgs == [workflow_dcg]  # type: ignore[attr-defined]
             assert list(
-                workflow_with_prefetch.prefetched_wdcgs[0].condition_group.conditions.all()
+                workflow_with_prefetch.prefetched_wdcgs[0].condition_group.conditions.all()  # type: ignore[attr-defined]
             ) == [filter_condition]
             assert workflow_with_prefetch.when_condition_group
             assert list(workflow_with_prefetch.when_condition_group.conditions.all()) == [

--- a/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
@@ -224,6 +224,7 @@ class RuleConditionTranslationTest(ConditionTestCase):
                 "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
                 "match": "is",
                 "key": "environment",
+                "value": "",
             },
             {
                 "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",


### PR DESCRIPTION
When given a `Workflow` or a list of `Workflows`, we want to be able to serialize them the same way `Rules` are serialized today. When rolling out workflow engine, we only want to be reading from the workflow engine tables but not change the shape of the API response.

For the Rule `endpoints`, we'll be reading the `Workflows` but outputting them the same as they used to be (`RuleSerializer`).

Note that in the future, `Workflows` can have multiple IF filter condition groups, but `Rules` only have 1 that we render in the UI. For this case we will only show a single IF filter condition group from the `Workflow` -- this should be okay because the new UI/APIs aren't available yet.

Still left
- [ ] Serialize `Action` to JSON blob actions