### PR TITLE
fix(issue-views): Lock down issue view title if not owner

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
@@ -228,9 +228,7 @@ describe('IssueViewSaveButton', function () {
     await screen.findByTestId('save-button-unsaved');
 
     await userEvent.click(screen.getByRole('button', {name: 'More save options'}));
-    await userEvent.click(
-      screen.getByRole('menuitemradio', {name: 'Discard unsaved changes'})
-    );
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Reset'}));
 
     // Discarding unsaved changes should reset URL query params
     await waitFor(() => {

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -74,7 +74,8 @@ function SegmentedIssueViewSaveButton({
         items={[
           {
             key: 'reset',
-            label: t('Discard unsaved changes'),
+            label: t('Reset'),
+            disabled: !hasUnsavedChanges,
             onAction: () => {
               trackAnalytics('issue_views.reset.clicked', {organization});
               discardUnsavedChanges();

--- a/static/app/views/issueList/issueViews/useSelectedGroupSeachView.tsx
+++ b/static/app/views/issueList/issueViews/useSelectedGroupSeachView.tsx
@@ -24,7 +24,12 @@ export function useSelectedGroupSearchView() {
       orgSlug: organization.slug,
     })
   );
-  const matchingView = queryFromStarredViews?.find(v => v.id === viewId);
+  const matchingView = queryFromStarredViews
+    // XXX (malwilley): Issue views without the nav require at least one issue view,
+    // so they respond with "fake" issue views that do not have an ID.
+    // We should remove this from the backend and here once we remove the tab-based views.
+    ?.filter(view => defined(view.id))
+    ?.find(v => v.id === viewId);
 
   return useFetchGroupSearchView(
     {

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -30,9 +30,14 @@ type LeftNavViewsHeaderProps = {
 function PageTitle() {
   const organization = useOrganization();
   const {data: groupSearchView} = useSelectedGroupSearchView();
+  const user = useUser();
   const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
 
-  if (hasIssueViewSharing && groupSearchView) {
+  if (
+    hasIssueViewSharing &&
+    groupSearchView &&
+    canEditIssueView({groupSearchView, user})
+  ) {
     return <EditableIssueViewHeader view={groupSearchView} />;
   }
 


### PR DESCRIPTION
Couple small changes:

- Prevents editing an issue view that you don't own
- Small adjustment to text in the reset button 