### PR TITLE
:wrench: chore(slack): add log when group update fails from slack

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -107,7 +107,7 @@ def update_group(
 
     resp = update_groups(request=request, groups=[group], user=user, data=data)
     if resp.status_code != 200:
-        _logger.info(
+        _logger.error(
             "slack.action.update-group-error",
             extra={
                 "group_id": group.id,

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -117,6 +117,8 @@ def update_group(
             },
         )
 
+    return resp
+
 
 def get_rule(slack_request: SlackActionRequest) -> Rule | None:
     """Get the rule that fired"""

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -105,7 +105,17 @@ def update_group(
             status_code=403, body="The user does not have access to the organization."
         )
 
-    return update_groups(request=request, groups=[group], user=user, data=data)
+    resp = update_groups(request=request, groups=[group], user=user, data=data)
+    if resp.status_code != 200:
+        _logger.info(
+            "slack.action.update-group-error",
+            extra={
+                "group_id": group.id,
+                "user_id": user.id,
+                "data": data,
+                "response": str(resp),
+            },
+        )
 
 
 def get_rule(slack_request: SlackActionRequest) -> Rule | None:


### PR DESCRIPTION
currently, we fail silently when we don't update the group status when a user resolves/archives from the slack integration