### PR TITLE
fix(insights): Fix bad Y axis in "Average Transaction Duration" chart in Caches

### DIFF
--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -28,6 +28,7 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
     {
       yAxis: ['avg(transaction.duration)'],
       search: MutableSearch.fromQueryObject(search),
+      transformAliasToInputFormat: true,
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION_CHART
   );


### PR DESCRIPTION
We need to fetch unaliased meta so the charts correctly figure out the types and units.
