### PR TITLE
fix(insights): apply `is_transaction:true` filter to backend table

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -265,6 +265,10 @@ function GenericBackendOverviewPage() {
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
   ];
 
+  if (useEap) {
+    existingQuery.addFilterValue('is_transaction', 'true');
+  }
+
   const response = useEAPSpans(
     {
       search: existingQuery,


### PR DESCRIPTION
We weren't applying this filter resulting some crazy numbers because we were adding up all metrics for all spans, instead of the transaction span.