### PR TITLE
chore(plugins): Add logging to understand plugin users

### DIFF
--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -61,4 +61,4 @@ def process_service_hook(servicehook_id, event, **kwargs):
     safe_urlopen(
         url=servicehook.url, data=json.dumps(payload), headers=headers, timeout=5, verify_ssl=False
     )
-    logger.info("service_hook.success", extra={"project_id": event.project.id})
+    logger.info("service_hook.success", extra={"project_id": event.project_id})

--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -1,3 +1,4 @@
+import logging
 from time import time
 
 from sentry.api.serializers import serialize
@@ -7,6 +8,8 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import json
+
+logger = logging.getLogger(__name__)
 
 
 def get_payload_v0(event):
@@ -58,3 +61,4 @@ def process_service_hook(servicehook_id, event, **kwargs):
     safe_urlopen(
         url=servicehook.url, data=json.dumps(payload), headers=headers, timeout=5, verify_ssl=False
     )
+    logger.info("service_hook.success", extra={"project_id": event.project.id})

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1296,6 +1296,13 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         logger.info("post_process.process_error_ignored", extra={"exception": e})
     except Exception as e:
         logger.exception("post_process.process_error", extra={"exception": e})
+    logger.info(
+        "post_process.plugin_success",
+        extra={
+            "project_id": event.project_id,
+            "plugin_slug": plugin_slug,
+        },
+    )
 
 
 def feedback_filter_decorator(func):


### PR DESCRIPTION
Planning the comms to deprecate plugins, I want to query all the organizations that are using the deprecated plugins. For each organization I want to know what plugins they're actively using as well.

This is not possible today. We can query all the org plugins [here](https://redash.getsentry.net/queries/8728) but will not know if they're actually actively used.
You can also see [all plugin requests](https://app.datadoghq.com/s/FH6-Y3/eq3-hx6-t4j) here but cannot see the orgs.