### PR TITLE
feat(seer-rpc) Fetch issues given function names

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -28,7 +28,10 @@ from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcR
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.models.organization import Organization
 from sentry.seer.autofix_tools import get_error_event_details, get_profile_details
-from sentry.seer.fetch_issues.fetch_issues_given_patches import get_issues_related_to_file_patches
+from sentry.seer.fetch_issues.fetch_issues import (
+    get_issues_related_to_file_patches,
+    get_issues_related_to_function_names,
+)
 from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
 
@@ -171,6 +174,7 @@ seer_method_registry: dict[str, Callable[..., dict[str, Any]]] = {
     "get_organization_slug": get_organization_slug,
     "get_organization_autofix_consent": get_organization_autofix_consent,
     "get_issues_related_to_file_patches": get_issues_related_to_file_patches,
+    "get_issues_related_to_function_names": get_issues_related_to_function_names,
     "get_error_event_details": get_error_event_details,
     "get_profile_details": get_profile_details,
 }

--- a/src/sentry/seer/fetch_issues/fetch_issues.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues.py
@@ -362,6 +362,7 @@ def get_issues_related_to_function_names(
         logger_extra = {"file": filename, "run_id": run_id}
         logger.info("Processing file", extra=logger_extra)
 
+        # Only add the file to filename_to_issues if it makes it to the querying step.
         if not function_names:
             logger.warning("No function names", extra=logger_extra)
             continue
@@ -415,10 +416,9 @@ def get_issues_related_to_file_patches(
 
     filename_to_function_names = {}
     for file in pullrequest_files:
-        logger_extra = {"file": file.filename, "run_id": run_id}
         file_extension = file.filename.split(".")[-1]
         if file_extension not in patch_parsers_more:
-            logger.warning("No language parser", extra=logger_extra)
+            logger.warning("No language parser", extra={"file": file.filename, "run_id": run_id})
             continue
         language_parser = patch_parsers_more[file_extension]
         function_names = language_parser.extract_functions_from_patch(file.patch)

--- a/src/sentry/seer/fetch_issues/fetch_issues.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues.py
@@ -321,18 +321,20 @@ def _get_projects_and_filenames_from_source_file(
     return projects_set, sentry_filenames
 
 
-def get_issues_related_to_file_patches(
+def get_issues_related_to_function_names(
     *,
     organization_id: int,
     provider: str,
     external_id: str,
-    pr_files: list[PrFile],
+    filename_to_function_names: dict[str, list[str]],
     max_num_issues_per_file: int = MAX_NUM_ISSUES_PER_FILE_DEFAULT,
     run_id: int | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """
-    Get the top issues related to each file by looking at matches between functions in the patch
-    and functions in the issue's event's stacktrace.
+    Get issues related to each file by matching inputted filename-functions with
+    filename-functions in the issue's event's stacktrace.
+
+    Assumes `filename_to_function_names` are from one repository.
 
     Each issue includes its latest serialized event.
     """
@@ -355,36 +357,22 @@ def get_issues_related_to_file_patches(
 
     repo_id = repo.id
 
-    pr_files = safe_for_fetching_issues(pr_files)
-    pullrequest_files = [
-        PullRequestFile(filename=file["filename"], patch=file["patch"]) for file in pr_files
-    ]
-
     filename_to_issues = {}
-
-    for file in pullrequest_files:
-        logger_extra = {"file": file.filename, "run_id": run_id}
+    for filename, function_names in filename_to_function_names.items():
+        logger_extra = {"file": filename, "run_id": run_id}
         logger.info("Processing file", extra=logger_extra)
 
+        if not function_names:
+            logger.warning("No function names", extra=logger_extra)
+            continue
+        logger.info("Function names", extra=logger_extra | {"function_names": function_names})
+
         projects, sentry_filenames = _get_projects_and_filenames_from_source_file(
-            organization_id, repo_id, file.filename
+            organization_id, repo_id, filename
         )
         if not projects:
             logger.error("No projects", extra=logger_extra)
             continue
-
-        file_extension = file.filename.split(".")[-1]
-        if file_extension not in patch_parsers_more:
-            logger.warning("No language parser", extra=logger_extra)
-            continue
-
-        language_parser = patch_parsers_more[file_extension]
-        function_names = language_parser.extract_functions_from_patch(file.patch)
-        if not function_names:
-            logger.warning("No function names", extra=logger_extra)
-            continue
-
-        logger.info("Function names", extra=logger_extra | {"function_names": function_names})
 
         issues = get_issues_with_event_details_for_file(
             list(projects),
@@ -397,6 +385,50 @@ def get_issues_related_to_file_patches(
             logger.info("Found issues", extra=logger_extra | {"num_issues": len(issues)})
         else:
             logger.warning("No issues found", extra=logger_extra)
-        filename_to_issues[file.filename] = issues
+        filename_to_issues[filename] = issues
 
     return filename_to_issues
+
+
+def get_issues_related_to_file_patches(
+    *,
+    organization_id: int,
+    provider: str,
+    external_id: str,
+    pr_files: list[PrFile],
+    max_num_issues_per_file: int = MAX_NUM_ISSUES_PER_FILE_DEFAULT,
+    run_id: int | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Get issues related to each file by matching filename-functions parsed from file patches with
+    filename-functions in the issue's event's stacktrace.
+
+    Assumes `pr_files` are from one repository.
+
+    Each issue includes its latest serialized event.
+    """
+
+    pr_files = safe_for_fetching_issues(pr_files)
+    pullrequest_files = [
+        PullRequestFile(filename=file["filename"], patch=file["patch"]) for file in pr_files
+    ]
+
+    filename_to_function_names = {}
+    for file in pullrequest_files:
+        logger_extra = {"file": file.filename, "run_id": run_id}
+        file_extension = file.filename.split(".")[-1]
+        if file_extension not in patch_parsers_more:
+            logger.warning("No language parser", extra=logger_extra)
+            continue
+        language_parser = patch_parsers_more[file_extension]
+        function_names = language_parser.extract_functions_from_patch(file.patch)
+        filename_to_function_names[file.filename] = list(function_names)
+
+    return get_issues_related_to_function_names(
+        organization_id=organization_id,
+        provider=provider,
+        external_id=external_id,
+        filename_to_function_names=filename_to_function_names,
+        max_num_issues_per_file=max_num_issues_per_file,
+        run_id=run_id,
+    )

--- a/tests/sentry/seer/fetch_issues/test_fetch_issues.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues.py
@@ -261,7 +261,7 @@ class TestGetIssues(IntegrationTestCase, CreateEventTestCase):
         mock_get_projects_and_filenames_from_source_file.return_value = ({self.project}, {"foo.py"})
 
         filename_to_function_names_related = {"foo.py": ["world", "planet"]}
-        filename_to_function_names_unrelated = {"no_function_names.py": []}
+        filename_to_function_names_unrelated: dict[str, list[str]] = {"no_function_names.py": []}
         filename_to_issues_expected = {
             filename: self.issues_with_event_details
             for filename in filename_to_function_names_related

--- a/tests/sentry/seer/fetch_issues/test_fetch_issues.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues.py
@@ -5,7 +5,7 @@ from sentry import eventstore
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.models.group import Group
 from sentry.models.repository import Repository
-from sentry.seer.fetch_issues.fetch_issues_given_patches import (
+from sentry.seer.fetch_issues.fetch_issues import (
     NUM_DAYS_AGO,
     STACKFRAME_COUNT,
     PrFile,
@@ -13,6 +13,7 @@ from sentry.seer.fetch_issues.fetch_issues_given_patches import (
     _get_projects_and_filenames_from_source_file,
     _left_truncated_paths,
     get_issues_related_to_file_patches,
+    get_issues_related_to_function_names,
     get_issues_with_event_details_for_file,
     safe_for_fetching_issues,
 )
@@ -179,7 +180,7 @@ def test__left_truncated_paths():
     ]
 
 
-class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase):
+class TestGetIssues(IntegrationTestCase, CreateEventTestCase):
     # Mostly copied from tests/sentry/integrations/github/tasks/test_open_pr_comment.py
     base_url = "https://api.github.com"
 
@@ -247,14 +248,41 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
         assert projects == {self.project}
         assert filenames == {"some/path/foo.py", "path/foo.py", "foo.py"}
 
-    @patch("sentry.seer.fetch_issues.fetch_issues_given_patches.safe_for_fetching_issues")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches._get_projects_and_filenames_from_source_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues._get_projects_and_filenames_from_source_file")
+    @patch("sentry.seer.fetch_issues.fetch_issues.get_issues_with_event_details_for_file")
+    def test_get_issues_related_to_function_names(
+        self,
+        mock_get_issues_with_event_details_for_file: Mock,
+        mock_get_projects_and_filenames_from_source_file: Mock,
+    ):
+        mock_get_issues_with_event_details_for_file.side_effect = (
+            lambda *args, **kwargs: self.issues_with_event_details
+        )
+        mock_get_projects_and_filenames_from_source_file.return_value = ({self.project}, {"foo.py"})
+
+        filename_to_function_names_related = {"foo.py": ["world", "planet"]}
+        filename_to_function_names_unrelated = {"no_function_names.py": []}
+        filename_to_issues_expected = {
+            filename: self.issues_with_event_details
+            for filename in filename_to_function_names_related
+        }
+
+        assert self.gh_repo.provider is not None
+
+        filename_to_issues = get_issues_related_to_function_names(
+            organization_id=self.organization.id,
+            provider=self.gh_repo.provider,
+            external_id=self.gh_repo.external_id,  # type: ignore[arg-type]
+            filename_to_function_names=(
+                filename_to_function_names_related | filename_to_function_names_unrelated
+            ),
+        )
+        assert filename_to_issues == filename_to_issues_expected
+
+    @patch("sentry.seer.fetch_issues.fetch_issues.safe_for_fetching_issues")
+    @patch("sentry.seer.fetch_issues.fetch_issues._get_projects_and_filenames_from_source_file")
     @patch("sentry.seer.fetch_issues.more_parsing.PythonParserMore.extract_functions_from_patch")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches.get_issues_with_event_details_for_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues.get_issues_with_event_details_for_file")
     def test_get_issues_related_to_file_patches(
         self,
         mock_get_issues_with_event_details_for_file: Mock,
@@ -266,7 +294,7 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
             lambda *args, **kwargs: self.issues_with_event_details
         )
         mock_extract_functions_from_patch.return_value = {"world", "planet"}
-        mock_get_projects_and_filenames_from_source_file.return_value = ({self.project}, {"foo.py"})
+        mock_get_projects_and_filenames_from_source_file.return_value = ({self.project}, {"bar.py"})
         mock_safe_for_fetching_issues.side_effect = lambda x: x
 
         pr_files_related: list[PrFile] = [
@@ -291,14 +319,10 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
         )
         assert filename_to_issues == filename_to_issues_expected
 
-    @patch("sentry.seer.fetch_issues.fetch_issues_given_patches.safe_for_fetching_issues")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches._get_projects_and_filenames_from_source_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues.safe_for_fetching_issues")
+    @patch("sentry.seer.fetch_issues.fetch_issues._get_projects_and_filenames_from_source_file")
     @patch("sentry.seer.fetch_issues.more_parsing.PythonParserMore.extract_functions_from_patch")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches.get_issues_with_event_details_for_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues.get_issues_with_event_details_for_file")
     def test_get_issues_related_to_file_patches_no_function_names(
         self,
         mock_get_issues_with_event_details_for_file: Mock,
@@ -329,14 +353,10 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
         )
         assert filename_to_issues == filename_to_issues_expected
 
-    @patch("sentry.seer.fetch_issues.fetch_issues_given_patches.safe_for_fetching_issues")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches._get_projects_and_filenames_from_source_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues.safe_for_fetching_issues")
+    @patch("sentry.seer.fetch_issues.fetch_issues._get_projects_and_filenames_from_source_file")
     @patch("sentry.seer.fetch_issues.more_parsing.PythonParserMore.extract_functions_from_patch")
-    @patch(
-        "sentry.seer.fetch_issues.fetch_issues_given_patches.get_issues_with_event_details_for_file"
-    )
+    @patch("sentry.seer.fetch_issues.fetch_issues.get_issues_with_event_details_for_file")
     def test_get_issues_related_to_file_patches_no_issues_found(
         self,
         mock_get_issues_with_event_details_for_file: Mock,


### PR DESCRIPTION
Adds a Seer RPC endpoint, `get_issues_related_to_function_names`, which fetches issues by filename-functions mappings