### PR TITLE
icons: fix star colors

### DIFF
--- a/static/app/icons/iconStar.tsx
+++ b/static/app/icons/iconStar.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 
 import {useIconDefaults} from 'sentry/icons/useIconDefaults';
+import {isChonkTheme} from 'sentry/utils/theme/withChonk';
 
 import type {SVGIconProps} from './svgIcon';
 import {SvgIcon} from './svgIcon';
@@ -14,13 +15,19 @@ function IconStar({isSolid = false, ...props}: Props) {
   const {color: providedColor = 'currentColor'} = useIconDefaults(props);
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  const color = theme[providedColor] ?? providedColor;
+  let color = theme[providedColor] ?? providedColor;
+
+  // @TODO(jonasbadalic): icons should only use chonk colors.
+  if (isChonkTheme(theme) && providedColor.startsWith('yellow')) {
+    color = theme.colors.chonk.yellow400;
+  }
 
   return (
     <SvgIcon {...props} kind={theme.isChonk ? 'stroke' : 'path'}>
       {theme.isChonk ? (
         <path
           fill={isSolid ? color : 'none'}
+          stroke={color}
           d="m8.27,2.25l1.56,3.16c.04.07.11.12.19.14l3.49.51c.21.03.29.28.14.43l-2.52,2.46c-.06.06-.09.14-.07.22l.6,3.47c.04.2-.18.36-.36.26l-3.12-1.64c-.07-.04-.16-.04-.23,0l-3.12,1.64c-.18.1-.4-.06-.36-.26l.6-3.47c.01-.08-.01-.16-.07-.22l-2.52-2.46c-.15-.14-.07-.4.14-.43l3.49-.51c.08-.01.15-.06.19-.14l1.56-3.16c.09-.19.36-.19.45,0Z"
         />
       ) : isSolid ? (


### PR DESCRIPTION
Remap the colors here. This should ultimately be something like a an enumerable variant where we pass `muted | warning | success ...` so that we don't end up in this same position of having a near infinite number of icons with different colors. A good example is gray100, gray200, gray300... which are all used to style icons...