### PR TITLE
ref(replay): Collapse Replay diff Before/After labels into components with tooltips

### DIFF
--- a/static/app/components/contentSliderDiff/contentSliderDiff.stories.tsx
+++ b/static/app/components/contentSliderDiff/contentSliderDiff.stories.tsx
@@ -3,8 +3,11 @@ import {Fragment} from 'react';
 import BadStackTraceExample from 'sentry-images/issue_details/bad-stack-trace-example.png';
 import GoodStackTraceExample from 'sentry-images/issue_details/good-stack-trace-example.png';
 
+import {Flex} from 'sentry/components/container/flex';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import storyBook from 'sentry/stories/storyBook';
+import {space} from 'sentry/styles/space';
 
 import {ContentSliderDiff} from '.';
 
@@ -26,8 +29,14 @@ export default storyBook('ContentSliderDiff', story => {
         </p>
         <div>
           <ContentSliderDiff.Header>
-            <ContentSliderDiff.BeforeLabel help="This is the before image" />
-            <ContentSliderDiff.AfterLabel help="This is the after image" />
+            <Flex align="center" gap={space(0.5)}>
+              Before
+              <QuestionTooltip title="This is the before image" size="xs" />
+            </Flex>
+            <Flex align="center" gap={space(0.5)}>
+              After
+              <QuestionTooltip title="This is the after image" size="xs" />
+            </Flex>
           </ContentSliderDiff.Header>
           <ContentSliderDiff.Body
             before={<img src={BadStackTraceExample} />}

--- a/static/app/components/contentSliderDiff/index.spec.tsx
+++ b/static/app/components/contentSliderDiff/index.spec.tsx
@@ -1,57 +1,22 @@
-import {Fragment} from 'react';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as useDimensions from 'sentry/utils/useDimensions';
 
-import {ContentSliderDiff, type ContentSliderDiffBodyProps} from '.';
-
-const beforeHelpText = 'This is before help text';
-const afterHelpText = 'This is after help text';
-
-function MockComponent({
-  onDragHandleMouseDown,
-}: Pick<ContentSliderDiffBodyProps, 'onDragHandleMouseDown'>) {
-  return (
-    <Fragment>
-      <ContentSliderDiff.Header>
-        <ContentSliderDiff.BeforeLabel help={beforeHelpText} />
-        <ContentSliderDiff.AfterLabel help={afterHelpText} />
-      </ContentSliderDiff.Header>
-      <ContentSliderDiff.Body
-        before={<div>Before Content</div>}
-        after={<div>After Content</div>}
-        onDragHandleMouseDown={onDragHandleMouseDown}
-      />
-    </Fragment>
-  );
-}
+import {ContentSliderDiff} from '.';
 
 describe('ContentSliderDiff', function () {
-  it('renders tooltip when help is provided', async function () {
-    jest.spyOn(useDimensions, 'useDimensions').mockReturnValue({width: 300, height: 300});
-
-    render(<MockComponent />);
-
-    // Before Tooltip
-    await userEvent.hover(screen.getAllByTestId('more-information')[0]!);
-    expect(await screen.findByText(beforeHelpText)).toBeInTheDocument();
-
-    // After Tooltip
-    await userEvent.hover(screen.getAllByTestId('more-information')[1]!);
-    expect(await screen.findByText(afterHelpText)).toBeInTheDocument();
-  });
-
   it('divider can be dragged', async function () {
     jest.spyOn(useDimensions, 'useDimensions').mockReturnValue({width: 300, height: 300});
 
     const mockDragHandleMouseDown = jest.fn();
 
-    render(<MockComponent onDragHandleMouseDown={mockDragHandleMouseDown} />);
-
-    // Ensure that 'Before' and 'After' labels are rendered correctly
-    expect(screen.getByText('Before')).toBeInTheDocument();
-    expect(screen.getByText('After')).toBeInTheDocument();
+    render(
+      <ContentSliderDiff.Body
+        before={<div>Before Content</div>}
+        after={<div>After Content</div>}
+        onDragHandleMouseDown={mockDragHandleMouseDown}
+      />
+    );
 
     const dragHandle = screen.getByTestId('drag-handle');
 
@@ -67,7 +32,12 @@ describe('ContentSliderDiff', function () {
   it('does not render content when dimensions are zero', function () {
     jest.spyOn(useDimensions, 'useDimensions').mockReturnValue({width: 0, height: 0});
 
-    render(<MockComponent />);
+    render(
+      <ContentSliderDiff.Body
+        before={<div>Before Content</div>}
+        after={<div>After Content</div>}
+      />
+    );
 
     expect(screen.queryByTestId('before-content')).not.toBeInTheDocument();
   });

--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -1,16 +1,14 @@
-import {Fragment, useRef} from 'react';
+import {type CSSProperties, Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
-import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconGrabbable} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import toPixels from 'sentry/utils/number/toPixels';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
-export interface ContentSliderDiffBodyProps {
+interface Props {
   /**
    * The content to display after the divider. Usually an image or replay.
    */
@@ -19,7 +17,7 @@ export interface ContentSliderDiffBodyProps {
    * The content to display before the divider. Usually an image or replay.
    */
   before: React.ReactNode;
-  minHeight?: `${number}px` | `${number}%`;
+  minHeight?: CSSProperties['minHeight'];
   /**
    * A callback function triggered when the divider is clicked (mouse down event).
    * Useful when we want to track analytics.
@@ -33,12 +31,7 @@ export interface ContentSliderDiffBodyProps {
  * The before and after contents are not directly defined here and have to be provided, so it can be very flexible
  * (e.g. images, replays, etc).
  */
-function Body({
-  onDragHandleMouseDown,
-  after,
-  before,
-  minHeight = '0px',
-}: ContentSliderDiffBodyProps) {
+function Body({onDragHandleMouseDown, after, before, minHeight = '0px'}: Props) {
   const positionedRef = useRef<HTMLDivElement>(null);
   const viewDimensions = useDimensions({elementRef: positionedRef});
 
@@ -60,48 +53,13 @@ function Body({
   );
 }
 
-export interface ContentSliderDiffBeforeOrAfterLabelProps {
-  children?: React.ReactNode;
-  help?: React.ReactNode;
-}
-
-function BeforeLabel({help, children}: ContentSliderDiffBeforeOrAfterLabelProps) {
-  return (
-    <div>
-      <Label>
-        {t('Before')}
-        {help && <QuestionTooltip title={help} size="xs" />}
-      </Label>
-      {children}
-    </div>
-  );
-}
-
-function AfterLabel({help, children}: ContentSliderDiffBeforeOrAfterLabelProps) {
-  return (
-    <div>
-      <Label>
-        {t('After')}
-        {help && <QuestionTooltip title={help} size="xs" />}
-      </Label>
-      {children}
-    </div>
-  );
-}
-
 const BORDER_WIDTH = 3;
 
-interface ContentSliderDiffSidesProps
-  extends Pick<ContentSliderDiffBodyProps, 'onDragHandleMouseDown' | 'before' | 'after'> {
-  viewDimensions: {height: number; width: number};
+interface SideProps extends Pick<Props, 'onDragHandleMouseDown' | 'before' | 'after'> {
+  viewDimensions: ReturnType<typeof useDimensions>;
 }
 
-function Sides({
-  onDragHandleMouseDown,
-  viewDimensions,
-  before,
-  after,
-}: ContentSliderDiffSidesProps) {
+function Sides({onDragHandleMouseDown, viewDimensions, before, after}: SideProps) {
   const beforeElemRef = useRef<HTMLDivElement>(null);
   const dividerElem = useRef<HTMLDivElement>(null);
   const width = toPixels(viewDimensions.width);
@@ -169,9 +127,11 @@ const Header = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(1)};
+
   font-weight: ${p => p.theme.fontWeightBold};
   line-height: 1.2;
   justify-content: space-between;
+  margin-bottom: ${space(0.5)};
 
   & > *:first-child {
     color: ${p => p.theme.error};
@@ -180,14 +140,6 @@ const Header = styled('div')`
   & > *:last-child {
     color: ${p => p.theme.success};
   }
-  margin-bottom: ${space(0.5)};
-`;
-
-const Label = styled('div')`
-  display: flex;
-  gap: ${space(0.5)};
-  align-items: center;
-  font-weight: bold;
 `;
 
 const FullHeightContainer = styled(NegativeSpaceContainer)`
@@ -303,6 +255,4 @@ const Placement = styled('div')`
 export const ContentSliderDiff = {
   Body,
   Header,
-  BeforeLabel,
-  AfterLabel,
 };

--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -127,7 +127,6 @@ const Header = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(1)};
-
   font-weight: ${p => p.theme.fontWeightBold};
   line-height: 1.2;
   justify-content: space-between;

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -9,6 +9,7 @@ import GoodStackTraceExample from 'sentry-images/issue_details/good-stack-trace-
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {Flex} from 'sentry/components/container/flex';
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {Alert} from 'sentry/components/core/alert';
 import {sourceMapSdkDocsMap} from 'sentry/components/events/interfaces/crashContent/exception/utils';
@@ -522,8 +523,8 @@ export function SourceMapsDebuggerModal({
           </p>
           <Fragment>
             <ContentSliderDiff.Header>
-              <ContentSliderDiff.BeforeLabel />
-              <ContentSliderDiff.AfterLabel />
+              <Flex align="center">{t('Before')}</Flex>
+              <Flex align="center">{t('After')}</Flex>
             </ContentSliderDiff.Header>
             <ContentSliderDiff.Body
               before={

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -521,10 +521,10 @@ export function SourceMapsDebuggerModal({
               'An image says more than a thousand words. Below you can see a comparison of how a bad and a good stack trace look like:'
             )}
           </p>
-          <Fragment>
+          <div>
             <ContentSliderDiff.Header>
-              <Flex align="center">{t('Before')}</Flex>
-              <Flex align="center">{t('After')}</Flex>
+              <Flex align="center">{t('Without Source Maps')}</Flex>
+              <Flex align="center">{t('With Source Maps')}</Flex>
             </ContentSliderDiff.Header>
             <ContentSliderDiff.Body
               before={
@@ -535,7 +535,7 @@ export function SourceMapsDebuggerModal({
               }
               minHeight="300px"
             />
-          </Fragment>
+          </div>
         </DebuggerSection>
         <DebuggerSection title={t('Troubleshooting Your Source Maps')}>
           {metaFrameworksWithSentryWizardInOnboarding.includes(platform) ? (

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,9 +1,6 @@
-import {Fragment, useCallback, useRef} from 'react';
+import {type CSSProperties, Fragment, useCallback, useRef} from 'react';
 
-import {
-  ContentSliderDiff,
-  type ContentSliderDiffBodyProps,
-} from 'sentry/components/contentSliderDiff';
+import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import {After, Before} from 'sentry/components/replays/diff/utils';
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
@@ -14,9 +11,11 @@ import {ReplayPlayerStateContextProvider} from 'sentry/utils/replays/playback/pr
 import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function ReplaySliderDiff({
-  minHeight,
-}: Pick<ContentSliderDiffBodyProps, 'minHeight'>) {
+interface Props {
+  minHeight?: CSSProperties['minHeight'];
+}
+
+export function ReplaySliderDiff({minHeight}: Props) {
   const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
   const organization = useOrganization();
   const dividerClickedRef = useRef(false); // once set, never flips back to false

--- a/static/app/components/replays/diff/utils.tsx
+++ b/static/app/components/replays/diff/utils.tsx
@@ -1,6 +1,8 @@
+import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
+import {Flex} from 'sentry/components/container/flex';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import ReplayTooltipTime from 'sentry/components/replays/replayTooltipTime';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -8,15 +10,24 @@ import {space} from 'sentry/styles/space';
 interface BeforeAfterProps {
   offset: number;
   startTimestampMs: number;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
-export function Before({children, offset, startTimestampMs}: BeforeAfterProps) {
+function ReplayDiffTooltip({
+  children,
+  offset,
+  startTimestampMs,
+}: {
+  children: ReactNode;
+  offset: number;
+  startTimestampMs: number;
+}) {
   return (
-    <ContentSliderDiff.BeforeLabel
-      help={
+    <QuestionTooltip
+      size="xs"
+      title={
         <LeftAligned>
-          {t('The server-rendered page')}
+          {children}
           <div>
             <ReplayTooltipTime
               timestampMs={startTimestampMs + offset}
@@ -25,29 +36,31 @@ export function Before({children, offset, startTimestampMs}: BeforeAfterProps) {
           </div>
         </LeftAligned>
       }
-    >
+    />
+  );
+}
+
+export function Before({children, offset, startTimestampMs}: BeforeAfterProps) {
+  return (
+    <Flex gap={space(0.5)} align="center">
+      {t('Client')}
+      <ReplayDiffTooltip offset={offset} startTimestampMs={startTimestampMs}>
+        {t('The server-rendered page')}
+      </ReplayDiffTooltip>
       {children}
-    </ContentSliderDiff.BeforeLabel>
+    </Flex>
   );
 }
 
 export function After({children, offset, startTimestampMs}: BeforeAfterProps) {
   return (
-    <ContentSliderDiff.AfterLabel
-      help={
-        <LeftAligned>
-          {t('After React re-rendered the page, and reported a hydration error')}
-          <div>
-            <ReplayTooltipTime
-              timestampMs={startTimestampMs + offset}
-              startTimestampMs={startTimestampMs}
-            />
-          </div>
-        </LeftAligned>
-      }
-    >
+    <Flex gap={space(0.5)} align="center">
+      {t('Server')}
+      <ReplayDiffTooltip offset={offset} startTimestampMs={startTimestampMs}>
+        {t('After React re-rendered the page, and reported a hydration error')}
+      </ReplayDiffTooltip>
       {children}
-    </ContentSliderDiff.AfterLabel>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
I've also update the label to say "Server" and "Client" instead of "Before" and "After" in the case of replay diffs. Per internal [feedback](https://sentry.slack.com/archives/CQDHVRS2W/p1744839501049869).

This also fixes an alignment issue inside the HTML Diff tab in the modal:
| Before | After |
| --- | --- |
| <img width="166" alt="SCR-20250417-htob" src="https://github.com/user-attachments/assets/4b4a4206-69bb-4934-ab28-edb4041bfa30" /> | <img width="196" alt="SCR-20250417-htqy" src="https://github.com/user-attachments/assets/b58f1873-a7a8-4fd6-9d32-553fb73d83e9" />


Fixes TRI-763