### PR TITLE
feat(theme): Update content accent color

### DIFF
--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -309,7 +309,7 @@ function generateChonkTokens(colorScheme: typeof lightColors) {
     content: {
       primary: colorScheme.gray800,
       muted: colorScheme.gray500,
-      accent: colorScheme.blue500,
+      accent: colorScheme.blue300,
       promotion: colorScheme.pink500,
       danger: colorScheme.red400,
       warning: colorScheme.yellow500,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -233,7 +233,7 @@ const generateTokens = (colors: Colors) => ({
   content: {
     primary: colors.gray400, // theme.textColor
     muted: colors.gray300, // theme.subText
-    accent: colors.blue400, // new
+    accent: colors.purple400, // new
     promotion: colors.pink400, // new
     danger: colors.red400, // theme.errorText
     warning: colors.yellow400, // theme.warningText


### PR DESCRIPTION
The color should still be purple based on the feedback:

- https://github.com/getsentry/sentry/pull/89590#discussion_r2048440119
