### PR TITLE
feat(onboarding): add-args-sourcemaps-wizard

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -255,6 +255,10 @@ function SentryWizardCallout({
   projectSlug?: string;
 }) {
   const isSelfHosted = ConfigStore.get('isSelfHosted');
+  const wizardCommand = `npx @sentry/wizard@latest -i sourcemaps${
+    isSelfHosted ? '' : ' --saas'
+  } --org ${orgSlug} --project ${projectSlug}`;
+
   return (
     <Fragment>
       <WizardInstructionParagraph>
@@ -278,7 +282,7 @@ function SentryWizardCallout({
           );
         }}
       >
-        {`npx @sentry/wizard@latest -i sourcemaps${isSelfHosted ? '' : ' --saas'} --org ${orgSlug} --project ${projectSlug}`}
+        {wizardCommand}
       </InstructionCodeSnippet>
     </Fragment>
   );

--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -1,7 +1,7 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
+import {getSourceMapsWizardSnippet} from 'sentry/utils/gettingStartedDocs/sourceMapsWizard';
 
 export function getUploadSourceMapsStep({
   guideLink,
@@ -12,12 +12,12 @@ export function getUploadSourceMapsStep({
   isSelfHosted,
   title,
   description,
+  ...rest
 }: DocsParams & {
   description?: React.ReactNode;
   guideLink?: string;
   title?: string;
 }) {
-  const urlParam = isSelfHosted ? '' : '--saas';
   return {
     title: title ?? t('Upload Source Maps'),
     description: description ?? (
@@ -31,42 +31,14 @@ export function getUploadSourceMapsStep({
       </p>
     ),
     configurations: [
-      {
-        language: 'bash',
-        code: `npx @sentry/wizard@latest -i sourcemaps ${urlParam}`,
-        onCopy: () => {
-          if (!organization || !projectId || !platformKey) {
-            return;
-          }
-
-          trackAnalytics(
-            newOrg
-              ? 'onboarding.source_maps_wizard_button_copy_clicked'
-              : 'project_creation.source_maps_wizard_button_copy_clicked',
-            {
-              project_id: projectId,
-              platform: platformKey,
-              organization,
-            }
-          );
-        },
-        onSelectAndCopy: () => {
-          if (!organization || !projectId || !platformKey) {
-            return;
-          }
-
-          trackAnalytics(
-            newOrg
-              ? 'onboarding.source_maps_wizard_selected_and_copied'
-              : 'project_creation.source_maps_wizard_selected_and_copied',
-            {
-              project_id: projectId,
-              platform: platformKey,
-              organization,
-            }
-          );
-        },
-      },
+      getSourceMapsWizardSnippet({
+        organization,
+        platformKey,
+        projectId,
+        newOrg,
+        isSelfHosted,
+        ...rest,
+      } as DocsParams),
     ],
   };
 }

--- a/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
+++ b/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
@@ -7,7 +7,6 @@ export function getSourceMapsWizardSnippet(params: DocsParams) {
   const {isSelfHosted, organization, projectSlug} = params;
   const urlParam = isSelfHosted ? '' : '--saas';
 
-  // Include org and project slugs in the command
   const commandWithFlags = `sourcemaps ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
 
   return {

--- a/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
+++ b/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
@@ -1,0 +1,61 @@
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+/**
+ * Generate a standardized sourcemaps wizard command with organization and project slugs
+ */
+export function getSourceMapsWizardSnippet(params: DocsParams) {
+  const {isSelfHosted, organization, projectSlug} = params;
+  const urlParam = isSelfHosted ? '' : '--saas';
+
+  // Include org and project slugs in the command
+  const commandWithFlags = `sourcemaps ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
+
+  // Get version from registry if available, or use fallback
+  const version = getPackageVersion(params, 'sentry.wizard', '4.0.1');
+
+  return {
+    language: 'bash',
+    code: `npx @sentry/wizard@latest -i ${commandWithFlags}`,
+    onCopy: () => {
+      if (!organization || !projectSlug || !params.platformKey) {
+        return;
+      }
+
+      // Preserving any existing analytics
+      if (typeof params.newOrg !== 'undefined') {
+        const eventName = params.newOrg
+          ? 'onboarding.source_maps_wizard_button_copy_clicked'
+          : 'project_creation.source_maps_wizard_button_copy_clicked';
+
+        import('sentry/utils/analytics').then(({trackAnalytics}) => {
+          trackAnalytics(eventName, {
+            project_id: params.projectId,
+            platform: params.platformKey,
+            organization,
+          });
+        });
+      }
+    },
+    onSelectAndCopy: () => {
+      if (!organization || !projectSlug || !params.platformKey) {
+        return;
+      }
+
+      // Preserving any existing analytics
+      if (typeof params.newOrg !== 'undefined') {
+        const eventName = params.newOrg
+          ? 'onboarding.source_maps_wizard_selected_and_copied'
+          : 'project_creation.source_maps_wizard_selected_and_copied';
+
+        import('sentry/utils/analytics').then(({trackAnalytics}) => {
+          trackAnalytics(eventName, {
+            project_id: params.projectId,
+            platform: params.platformKey,
+            organization,
+          });
+        });
+      }
+    },
+  };
+}

--- a/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
+++ b/static/app/utils/gettingStartedDocs/sourceMapsWizard.ts
@@ -1,5 +1,4 @@
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
 /**
  * Generate a standardized sourcemaps wizard command with organization and project slugs
@@ -10,9 +9,6 @@ export function getSourceMapsWizardSnippet(params: DocsParams) {
 
   // Include org and project slugs in the command
   const commandWithFlags = `sourcemaps ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
-
-  // Get version from registry if available, or use fallback
-  const version = getPackageVersion(params, 'sentry.wizard', '4.0.1');
 
   return {
     language: 'bash',


### PR DESCRIPTION
Source maps wizard for JS project creation is not currently taking advantage of the org and project slugs, which can be provided to skip steps in the wizard flow.

This is now handled similar to how we do with mobileWizard.ts. Eventually it would make sense to have one single implementation. And update all the onboarding wizard snippets based on a single logic.
