### PR TITLE
fix(auto_source): Prevent creating duplicate rules

### DIFF
--- a/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
+++ b/src/sentry/issues/auto_source_code_config/in_app_stack_trace_rules.py
@@ -25,7 +25,12 @@ def save_in_app_stack_trace_rules(
     current_enhancements = project.get_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
     current_rules = set(current_enhancements.split("\n")) if current_enhancements else set()
 
-    united_rules = rules_from_code_mappings.union(current_rules)
+    developer_enhancements = project.get_option("sentry:grouping_enhancements")
+    developer_rules = set(developer_enhancements.split("\n")) if developer_enhancements else set()
+
+    # We do not want to duplicate rules from the developer enhancements
+    united_rules = rules_from_code_mappings.union(current_rules).difference(developer_rules)
+
     dry_run = platform_config.is_dry_run_platform(project.organization)
     if not dry_run and united_rules != current_rules:
         project.update_option(DERIVED_ENHANCEMENTS_OPTION_KEY, "\n".join(sorted(united_rules)))

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -813,6 +813,19 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
             expected_new_in_app_stack_trace_rules=["stack.module:x.y.** +app"],
         )
 
+    def test_prevent_creating_duplicate_rules(self) -> None:
+        # Rules set by the customer prevent configuration changes
+        self.project.update_option("sentry:grouping_enhancements", "stack.module:foo.bar.** +app")
+        # Manually created code mapping
+        self.create_repo_and_code_mapping(REPO1, "foo/bar/", "src/foo/")
+        # We do not expect code mappings or in-app rules to be created since
+        # the developer already created the code mapping and in-app rule
+        self._process_and_assert_configuration_changes(
+            repo_trees={REPO1: ["src/foo/bar/Baz.java"]},
+            frames=[self.frame_from_module("foo.bar.Baz", "Baz.java")],
+            platform=self.platform,
+        )
+
     def test_basic_case(self) -> None:
         repo_trees = {REPO1: ["src/com/example/foo/Bar.kt"]}
         frames = [


### PR DESCRIPTION
This prevents creating in-app rules that the developer has already defined.