### PR TITLE
fix(explore): Spinner loading tooltips

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -41,6 +41,7 @@ import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import {WidgetViewerContext} from 'sentry/views/dashboards/widgetViewer/widgetViewerContext';
+import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 import {getMenuOptions, useIndexedEventsWarning} from './widgetCardContextMenu';
@@ -266,10 +267,11 @@ function WidgetCard(props: Props) {
           borderless={props.borderless}
           revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
           noVisualizationPadding
-          isProgressivelyLoading={
+          titleBadges={getProgressiveLoadingIndicator(
             organization.features.includes('visibility-explore-progressive-loading') &&
-            isProgressivelyLoading
-          }
+              isProgressivelyLoading,
+            widget.displayType === DisplayType.TABLE ? 'table' : 'chart'
+          )}
         >
           <WidgetCardChartContainer
             location={location}

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -10,7 +10,6 @@ import {t} from 'sentry/locale';
 import type {StateProps} from 'sentry/views/dashboards/widgets/common/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import type {WidgetDescriptionProps} from 'sentry/views/dashboards/widgets/widget/widgetDescription';
-import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 
 import {TooltipIconTrigger} from './tooltipIconTrigger';
 import {WarningsList} from './warningsList';
@@ -22,12 +21,12 @@ export interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   badgeProps?: string | string[];
   borderless?: boolean;
   children?: React.ReactNode;
-  isProgressivelyLoading?: boolean;
   noVisualizationPadding?: boolean;
   onFullScreenViewClick?: () => void | Promise<void>;
   revealActions?: 'always' | 'hover';
   revealTooltip?: 'always' | 'hover';
   title?: string;
+  titleBadges?: React.ReactNode;
   warnings?: string[];
 }
 
@@ -82,7 +81,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
       revealActions={
         props.revealTooltip === 'always' ? 'always' : (props.revealActions ?? 'hover')
       }
-      TitleBadges={getProgressiveLoadingIndicator(props.isProgressivelyLoading)}
+      TitleBadges={props.titleBadges}
       Actions={
         <Fragment>
           {props.description && (

--- a/static/app/views/explore/components/progressiveLoadingIndicator.tsx
+++ b/static/app/views/explore/components/progressiveLoadingIndicator.tsx
@@ -5,7 +5,11 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
-function ProgressiveLoadingIndicator() {
+function ProgressiveLoadingIndicator({
+  visualizationType,
+}: {
+  visualizationType: 'chart' | 'table';
+}) {
   const organization = useOrganization();
   const canUseProgressiveLoading = organization.features.includes(
     'visibility-explore-progressive-loading'
@@ -23,8 +27,13 @@ function ProgressiveLoadingIndicator() {
     return null;
   }
 
+  const tooltip =
+    visualizationType === 'chart'
+      ? t('Chart is currently loading more data')
+      : t('Table is currently loading more data');
+
   return (
-    <Tooltip title={t('This widget is currently loading higher fidelity data.')}>
+    <Tooltip title={tooltip}>
       <_ProgressiveLoadingIndicator
         relative
         mini
@@ -35,9 +44,17 @@ function ProgressiveLoadingIndicator() {
   );
 }
 
-export const getProgressiveLoadingIndicator = (isProgressivelyLoading = false) => {
+export const getProgressiveLoadingIndicator = (
+  isProgressivelyLoading = false,
+  visualizationType: 'chart' | 'table'
+) => {
   if (isProgressivelyLoading) {
-    return <ProgressiveLoadingIndicator key="progressive-loading-indicator" />;
+    return (
+      <ProgressiveLoadingIndicator
+        key="progressive-loading-indicator"
+        visualizationType={visualizationType}
+      />
+    );
   }
   return null;
 };

--- a/static/app/views/explore/multiQueryMode/queryRow.tsx
+++ b/static/app/views/explore/multiQueryMode/queryRow.tsx
@@ -82,9 +82,11 @@ export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
   const tableIsProgressivelyLoading =
     organization.features.includes('visibility-explore-progressive-loading') &&
     (mode === Mode.SAMPLES
-      ? spansTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+      ? false // The loading indicator is not displayed because we do not change to best effort for samples
       : mode === Mode.AGGREGATE
-        ? aggregatesTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+        ? // The loading indicator is displayed when the aggregate table has preflight data and the query is pending
+          aggregatesTableResult.samplingMode === SAMPLING_MODE.PREFLIGHT &&
+          aggregatesTableResult.result.isFetched
         : false);
 
   return (

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -118,7 +118,9 @@ function AggregatesTable({
           <TableRow>
             <TableHeadCell isFirst={false}>
               <TableHeadCellContent>
-                {getProgressiveLoadingIndicator(isProgressivelyLoading)}
+                <LoadingIndicatorWrapper>
+                  {getProgressiveLoadingIndicator(isProgressivelyLoading, 'table')}
+                </LoadingIndicatorWrapper>
               </TableHeadCellContent>
             </TableHeadCell>
             {fields.map((field, i) => {
@@ -355,4 +357,11 @@ const TableHeadCellContent = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+`;
+
+const LoadingIndicatorWrapper = styled('div')`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 `;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -202,7 +202,9 @@ export function SpansTabContentImpl({
     (queryType === 'samples'
       ? false // Samples mode won't show the progressive loading spinner
       : queryType === 'aggregate'
-        ? aggregatesTableResult.samplingMode !== SAMPLING_MODE.BEST_EFFORT
+        ? // Only show the progressive spinner after the preflight query has been run
+          aggregatesTableResult.samplingMode === SAMPLING_MODE.PREFLIGHT &&
+          aggregatesTableResult.result.isFetched
         : false);
 
   const eapSpanSearchQueryBuilderProps = {

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -91,7 +91,9 @@ export function AggregatesTable({
           <TableRow>
             <TableHeadCell isFirst={false}>
               <TableHeadCellContent>
-                {getProgressiveLoadingIndicator(isProgressivelyLoading)}
+                <LoadingIndicatorWrapper>
+                  {getProgressiveLoadingIndicator(isProgressivelyLoading, 'table')}
+                </LoadingIndicatorWrapper>
               </TableHeadCellContent>
             </TableHeadCell>
             {fields.map((field, i) => {
@@ -222,4 +224,14 @@ const TopResultsIndicator = styled('div')<{color: string}>`
 
 const StyledLink = styled(Link)`
   display: flex;
+`;
+
+// Positions the loading indicator in the center of the cell that
+// corresponds to the stack column. Prevents layout shift when the
+// loading indicator is removed.
+const LoadingIndicatorWrapper = styled('div')`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 `;

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -10,7 +10,6 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {fieldAlignment, prettifyTagKey} from 'sentry/utils/discover/fields';
-import {getProgressiveLoadingIndicator} from 'sentry/views/explore/components/progressiveLoadingIndicator';
 import {
   Table,
   TableBody,
@@ -33,11 +32,10 @@ import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansT
 import {FieldRenderer} from './fieldRenderer';
 
 interface SpansTableProps {
-  isProgressivelyLoading: boolean;
   spansTableResult: SpansTableResult;
 }
 
-export function SpansTable({spansTableResult, isProgressivelyLoading}: SpansTableProps) {
+export function SpansTable({spansTableResult}: SpansTableProps) {
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();
   const setSortBys = useSetExploreSortBys();
@@ -93,7 +91,6 @@ export function SpansTable({spansTableResult, isProgressivelyLoading}: SpansTabl
                     <Tooltip showOnlyOnOverflow title={label}>
                       {label}
                     </Tooltip>
-                    {i === 0 && getProgressiveLoadingIndicator(isProgressivelyLoading)}
                     {defined(direction) && (
                       <IconArrow
                         size="xs"


### PR DESCRIPTION
These tooltips show a vague message referencing the word widget. We can change the tooltip to reflect the type of widget it is indicating. This means on explore all of the spinning tooltips are referencing tables and on dashboards they're referencing a chart or a table.

I updated some styling so the spinner doesn't shift any of the table cells and fixed some loading states because we only want to show the loading spinner after preflight data has been fetched (i.e. we're starting the best effort request)

I should rework the hook response so we can more semantically check if `samplingMode === BEST_EFFORT && results.isPending` because right now it doesn't switch the sampling mode until the request succeeds, but this is a future TODO.