### PR TITLE
fix(explore): Remove preflight skip logic

### DIFF
--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -4,7 +4,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -167,96 +166,6 @@ describe('useProgressiveQuery', function () {
     });
     expect(mockRequestUrl).toHaveBeenNthCalledWith(
       2,
-      '/test',
-      expect.objectContaining({
-        query: {samplingMode: SAMPLING_MODE.BEST_EFFORT, query: 'test value'},
-      })
-    );
-  });
-
-  it.each([
-    ['larger period', {period: '14d', start: null, end: null, utc: false}, 2],
-    ['smaller period', {period: '4d', start: null, end: null, utc: false}, 1],
-    [
-      'absolute date with larger period (8d)',
-      {period: null, start: '2024-01-01', end: '2024-01-09', utc: false},
-      2,
-    ],
-    [
-      'absolute date with smaller period (1d)',
-      {period: null, start: '2024-01-01', end: '2024-01-02', utc: false},
-      1,
-    ],
-  ])(
-    'makes the correct number of requests for a %s',
-    async function (
-      _periodType: string,
-      mockedDatetime: PageFilters['datetime'],
-      expectedCalls: number
-    ) {
-      jest.mocked(usePageFilters).mockReturnValue({
-        isReady: true,
-        desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
-        shouldPersist: true,
-        selection: {
-          datetime: mockedDatetime,
-          environments: [],
-          projects: [],
-        },
-      });
-
-      renderHook(
-        () =>
-          useProgressiveQuery({
-            queryHookImplementation: useMockHookImpl,
-            queryHookArgs: {enabled: true, query: 'test value'},
-            queryOptions: {queryMode: QUERY_MODE.PARALLEL},
-          }),
-        {
-          wrapper: createWrapper(
-            OrganizationFixture({
-              features: ['visibility-explore-progressive-loading'],
-            })
-          ),
-        }
-      );
-
-      await waitFor(() => {
-        expect(mockRequestUrl).toHaveBeenCalledTimes(expectedCalls);
-      });
-      if (expectedCalls === 1) {
-        expect(mockRequestUrl).toHaveBeenCalledWith(
-          '/test',
-          expect.objectContaining({
-            query: {samplingMode: SAMPLING_MODE.BEST_EFFORT, query: 'test value'},
-          })
-        );
-      }
-    }
-  );
-
-  it('skips the preflight request if the feature flag is enabled', function () {
-    renderHook(
-      () =>
-        useProgressiveQuery({
-          queryHookImplementation: useMockHookImpl,
-          queryHookArgs: {enabled: true, query: 'test value'},
-        }),
-      {
-        wrapper: createWrapper(
-          OrganizationFixture({
-            features: [
-              'visibility-explore-skip-preflight',
-              'visibility-explore-progressive-loading',
-            ],
-          })
-        ),
-      }
-    );
-
-    expect(mockRequestUrl).toHaveBeenCalledTimes(1);
-    expect(mockRequestUrl).toHaveBeenCalledWith(
       '/test',
       expect.objectContaining({
         query: {samplingMode: SAMPLING_MODE.BEST_EFFORT, query: 'test value'},

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,9 +1,4 @@
-import {getDiffInMinutes} from 'sentry/components/charts/utils';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-
-// Bypass the preflight request if the time range is less than 7 days
-const SMALL_TIME_RANGE_THRESHOLD = getDiffInMinutes({period: '7d'});
 
 export const SAMPLING_MODE = {
   PREFLIGHT: 'PREFLIGHT',
@@ -69,21 +64,11 @@ export function useProgressiveQuery<
   samplingMode?: SamplingMode;
 } {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
   const canUseProgressiveLoading = organization.features.includes(
     'visibility-explore-progressive-loading'
   );
 
   const queryMode = queryOptions?.queryMode ?? QUERY_MODE.SERIAL;
-
-  // If the time range is small enough, just go directly to the best effort request
-  const isSmallRange = getDiffInMinutes(selection.datetime) < SMALL_TIME_RANGE_THRESHOLD;
-
-  let skipPreflight = isSmallRange;
-  if (organization.features.includes('visibility-explore-skip-preflight')) {
-    // Override the time range check if the feature flag is enabled
-    skipPreflight = true;
-  }
 
   const singleQueryResult = queryHookImplementation({
     ...queryHookArgs,
@@ -93,7 +78,7 @@ export function useProgressiveQuery<
   const preflightRequest = queryHookImplementation({
     ...queryHookArgs,
     queryExtras: LOW_SAMPLING_MODE_QUERY_EXTRAS,
-    enabled: queryHookArgs.enabled && canUseProgressiveLoading && !skipPreflight,
+    enabled: queryHookArgs.enabled && canUseProgressiveLoading,
   });
 
   const triggerBestEffortAfterPreflight =
@@ -110,7 +95,6 @@ export function useProgressiveQuery<
       queryHookArgs.enabled &&
       canUseProgressiveLoading &&
       (queryMode === QUERY_MODE.PARALLEL ||
-        skipPreflight ||
         triggerBestEffortAfterPreflight ||
         triggerBestEffortRequestForEmptyPreflight),
   });


### PR DESCRIPTION
We don't want to skip the preflight anymore, removing this for now.