### PR TITLE
fix(aci): move issue alert dual write lock outside of transaction

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -6,7 +6,6 @@ from rest_framework import status
 from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.locks import locks
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
@@ -99,23 +98,14 @@ class IssueAlertMigrator:
                 error_detector = Detector(type=ErrorGroupType.slug, project=self.project)
 
         else:
-            lock = locks.get(
-                f"workflow-engine-project-error-detector:{self.project.id}",
-                duration=10,
-                name="workflow_engine_issue_alert",
+            error_detector, _ = Detector.objects.get_or_create(
+                type=ErrorGroupType.slug,
+                project=self.project,
+                defaults={"config": {}, "name": "Error Detector"},
             )
-            with lock.acquire():
-                error_detector, _ = Detector.objects.get_or_create(
-                    type=ErrorGroupType.slug,
-                    project=self.project,
-                    defaults={"config": {}, "name": "Error Detector"},
-                )
-                _, created = AlertRuleDetector.objects.get_or_create(
-                    detector=error_detector, rule_id=self.rule.id
-                )
-
-                # Detector is required for migration, migration should fail if unable to acquire lock
-                # UnableToAcquireLock exception should be handled by caller
+            _, created = AlertRuleDetector.objects.get_or_create(
+                detector=error_detector, rule_id=self.rule.id
+            )
 
         if not created:
             raise Exception("Issue alert already migrated")

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -5,7 +5,6 @@ from jsonschema.exceptions import ValidationError
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.locks import locks
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_frequency import (
@@ -21,7 +20,6 @@ from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
-from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import (
     Action,
@@ -374,17 +372,6 @@ class IssueAlertMigratorTest(TestCase):
         assert DataCondition.objects.all().count() == 1
         dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
         assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
-
-    def test_run__lock(self):
-        lock = locks.get(
-            f"workflow-engine-project-error-detector:{self.project.id}",
-            duration=10,
-            name="workflow_engine_issue_alert",
-        )
-        lock.acquire()
-
-        with pytest.raises(UnableToAcquireLock):
-            IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
     def test_dry_run(self):
         IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()


### PR DESCRIPTION
The lock should live outside of the transaction, as the new objects are not created until the transaction is committed. 

Putting the lock around the `get_or_create` can still error with multiple objects returned if the lock is released before the transaction is committed.