### PR TITLE
fix(insights): Fix small sizing error in Insights drawers

### DIFF
--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -3,7 +3,7 @@ import keyBy from 'lodash/keyBy';
 
 import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
-import {DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {EventDrawerHeader} from 'sentry/components/events/eventDrawer';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -297,12 +297,12 @@ export function CacheSamplePanel() {
 
   return (
     <PageAlertProvider>
-      <DrawerHeader>
+      <EventDrawerHeader>
         <SampleDrawerHeaderTransaction
           project={project}
           transaction={query.transaction}
         />
-      </DrawerHeader>
+      </EventDrawerHeader>
 
       <SampleDrawerBody>
         <ModuleLayout.Layout>

--- a/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
+++ b/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
@@ -67,7 +67,7 @@ export function SampleDrawerHeaderTransaction(props: SampleDrawerHeaderProps) {
 
 const DELIMITER = ':';
 
-const Bar = styled('div')`
+const Bar = styled('h4')`
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
+++ b/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
@@ -67,12 +67,13 @@ export function SampleDrawerHeaderTransaction(props: SampleDrawerHeaderProps) {
 
 const DELIMITER = ':';
 
-const Bar = styled('h4')`
+const Bar = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
   padding: 0;
   margin: 0;
+  line-height: ${p => p.theme.text.lineHeightBody};
 
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightNormal};

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -2,7 +2,7 @@ import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import {DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {EventDrawerHeader} from 'sentry/components/events/eventDrawer';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
@@ -161,13 +161,13 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
 
   return (
     <PageAlertProvider>
-      <DrawerHeader>
+      <EventDrawerHeader>
         <SampleDrawerHeaderTransaction
           project={project}
           transaction={transactionName}
           transactionMethod={transactionMethod}
         />
-      </DrawerHeader>
+      </EventDrawerHeader>
 
       <SampleDrawerBody>
         <PageAlert />

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -5,7 +5,7 @@ import keyBy from 'lodash/keyBy';
 import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
-import {DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {EventDrawerHeader} from 'sentry/components/events/eventDrawer';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -327,13 +327,13 @@ export function HTTPSamplesPanel() {
 
   return (
     <PageAlertProvider>
-      <DrawerHeader>
+      <EventDrawerHeader>
         <SampleDrawerHeaderTransaction
           project={project}
           transaction={query.transaction}
           transactionMethod={query.transactionMethod}
         />
-      </DrawerHeader>
+      </EventDrawerHeader>
 
       <SampleDrawerBody>
         <ModuleLayout.Layout>

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -4,7 +4,7 @@ import keyBy from 'lodash/keyBy';
 
 import {Button} from 'sentry/components/core/button';
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
-import {DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {EventDrawerHeader} from 'sentry/components/events/eventDrawer';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -253,7 +253,7 @@ export function MessageSpanSamplesPanel() {
 
   return (
     <PageAlertProvider>
-      <DrawerHeader>
+      <EventDrawerHeader>
         <SampleDrawerHeaderTransaction
           project={project}
           transaction={query.transaction}
@@ -261,7 +261,7 @@ export function MessageSpanSamplesPanel() {
             messageActorType === MessageActorType.PRODUCER ? t('Producer') : t('Consumer')
           }
         />
-      </DrawerHeader>
+      </EventDrawerHeader>
 
       <SampleDrawerBody>
         <ModuleLayout.Layout>


### PR DESCRIPTION
The heights of the Samples and Releases drawers used to not match up, which creates a little shift when closing the panel.

**Before (Maddening):**

https://github.com/user-attachments/assets/fffe3b31-27ef-4124-b0d6-e2cf54e23e8d

**After (Classy):**

https://github.com/user-attachments/assets/74bc6a58-3adb-4dd3-8b5f-e436408f75ce

