### PR TITLE
fix(ourlogs): Make columns split properly

### DIFF
--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -565,6 +565,8 @@ const TreeContainer = styled('div')<{columnCount: number}>`
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
   white-space: normal;
+  width: 100%;
+  flex: 1 1 100%;
 `;
 
 const TreeColumn = styled('div')`


### PR DESCRIPTION
The parent container needs to be full-width so that the hook can decide whether to resize the columns.

Flexbox!