### PR TITLE
fix(autofix): Fix highlight popup not appearing when clicking on code blocks

### DIFF
--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -77,11 +77,11 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement | nul
   );
 
   useEffect(() => {
-    document.addEventListener('click', handleClick);
+    document.addEventListener('click', handleClick, true);
     document.addEventListener('mousedown', clearSelection);
 
     return () => {
-      document.removeEventListener('click', handleClick);
+      document.removeEventListener('click', handleClick, true);
       document.removeEventListener('mousedown', clearSelection);
     };
   }, [handleClick, clearSelection]);


### PR DESCRIPTION
The clicks were not being registered on <code> blocks in markdown text. This fixes it.