### PR TITLE
fix(insights): Fix Session Health page filter width

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -11,6 +11,7 @@ import type {Project} from 'sentry/types/project';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboardingPanel} from 'sentry/views/insights/common/components/modulesOnboarding';
+import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
@@ -41,11 +42,13 @@ export function SessionsOverview() {
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
-              <PageFilterBar>
-                <ProjectPageFilter resetParamsOnChange={['cursor']} />
-                <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
-                <DatePageFilter />
-              </PageFilterBar>
+              <ToolRibbon>
+                <PageFilterBar>
+                  <ProjectPageFilter resetParamsOnChange={['cursor']} />
+                  <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
+                  <DatePageFilter />
+                </PageFilterBar>
+              </ToolRibbon>
             </ModuleLayout.Full>
             {showOnboarding ? (
               <ModuleLayout.Full>


### PR DESCRIPTION
I broke this in https://github.com/getsentry/sentry/pull/89644, missing the wrapper

**Broken**
![SCR-20250417-jvwt](https://github.com/user-attachments/assets/dd22dc08-5cd4-4ef3-9bfd-87556a2bf968)


**Fixed**
![SCR-20250417-jvya](https://github.com/user-attachments/assets/a12e45dc-06b9-4360-b18c-dd7bb09afc5b)
