### PR TITLE
fix(ourlogs): Sort attribute key before building

### DIFF
--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -218,7 +218,7 @@ function LogFieldsTreeColumns({
     const visibleAttributes = attributes
       .map(key => getAttribute(key, hiddenAttributes))
       .filter(defined)
-      .sort((a, b) => (a.attribute_key < b.attribute_key ? -1 : 1));
+      .sort((a, b) => ((a.attribute_key ?? "") < (b.attribute_key ?? "") ? -1 : 1));
 
     // Create the AttributeTree data structure using all the given attributes
     const attributeTree = visibleAttributes.reduce<AttributeTree>(

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -217,7 +217,8 @@ function LogFieldsTreeColumns({
     // Convert attributes record to the format expected by addToAttributeTree
     const visibleAttributes = attributes
       .map(key => getAttribute(key, hiddenAttributes))
-      .filter(defined);
+      .filter(defined)
+      .sort((a, b) => (a.attribute_key < b.attribute_key ? -1 : 1));
 
     // Create the AttributeTree data structure using all the given attributes
     const attributeTree = visibleAttributes.reduce<AttributeTree>(

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -218,7 +218,7 @@ function LogFieldsTreeColumns({
     const visibleAttributes = attributes
       .map(key => getAttribute(key, hiddenAttributes))
       .filter(defined)
-      .sort((a, b) => ((a.attribute_key ?? "") < (b.attribute_key ?? "") ? -1 : 1));
+      .sort((a, b) => ((a.attribute_key ?? '') < (b.attribute_key ?? '') ? -1 : 1));
 
     // Create the AttributeTree data structure using all the given attributes
     const attributeTree = visibleAttributes.reduce<AttributeTree>(
@@ -566,6 +566,8 @@ const TreeContainer = styled('div')<{columnCount: number}>`
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
   white-space: normal;
+  width: 100%;
+  flex: 1 1 100%;
 `;
 
 const TreeColumn = styled('div')`


### PR DESCRIPTION
The core issue here is there were attributes `trace` and `trace.parent_span_id` - where the latter was not being added.

The reason it was being dropped is that the sort order returned from the backend had `parent_span_id` first and then `trace`

That would hit this case:
```
  if (tree[trunk] === undefined) {
    tree[trunk] = {value: '', subtree: {}};
  }
```

Which would create a 'pseudo attribute' for 'trace'

But then when 'trace' was seen in the list, it would clobber the pseudo-attribute.

By sorting lexicographically, we can ensure that a parent is always inserted before its children, avoiding this class of issue.