### PR TITLE
cleanup(eap): stop writing to eap_spans in store_span[s] in tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1140,14 +1140,15 @@ class SnubaTestCase(BaseTestCase):
 
     def store_span(self, span, is_eap=False):
         span["ingest_in_eap"] = is_eap
-        assert (
-            requests.post(
-                settings.SENTRY_SNUBA + f"/tests/entities/{'eap_' if is_eap else ''}spans/insert",
-                data=json.dumps([span]),
-            ).status_code
-            == 200
-        )
-        if is_eap:
+        if not is_eap:
+            assert (
+                requests.post(
+                    settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                    data=json.dumps([span]),
+                ).status_code
+                == 200
+            )
+        else:
             assert (
                 requests.post(
                     settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert",
@@ -1159,14 +1160,16 @@ class SnubaTestCase(BaseTestCase):
     def store_spans(self, spans, is_eap=False):
         for span in spans:
             span["ingest_in_eap"] = is_eap
-        assert (
-            requests.post(
-                settings.SENTRY_SNUBA + f"/tests/entities/{'eap_' if is_eap else ''}spans/insert",
-                data=json.dumps(spans),
-            ).status_code
-            == 200
-        )
-        if is_eap:
+
+        if not is_eap:
+            assert (
+                requests.post(
+                    settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                    data=json.dumps(spans),
+                ).status_code
+                == 200
+            )
+        else:
             assert (
                 requests.post(
                     settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert",


### PR DESCRIPTION
Test code change only

As part of the switchover to items, only write to items when in eap and original spans when not

Noticed in https://github.com/getsentry/snuba/pull/7085 that removing EAP_SPANS broke test cases in sentry.
