### PR TITLE
feat(issue-views): Accept multiple sorts in list endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -104,7 +104,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 )
 
         createdBy = serializer.validated_data.get("createdBy", "me")
-        sorts = [SORT_MAP[sort] for sort in serializer.validated_data.get("sort", ["-visited"])]
+        sorts = [SORT_MAP[sort] for sort in serializer.validated_data["sort"]]
         query = serializer.validated_data.get("query")
         base_queryset = (
             GroupSearchView.objects.filter(organization=organization)

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -41,6 +41,8 @@ SORT_MAP = {
     "-visited": "-groupsearchviewlastvisited__last_visited",
     "name": "name",
     "-name": "-name",
+    "created": "date_added",
+    "-created": "-date_added",
 }
 
 
@@ -49,9 +51,10 @@ class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
         choices=("me", "others"),
         required=False,
     )
-    sort = serializers.ChoiceField(
-        choices=list(SORT_MAP.keys()),
+    sort = serializers.ListField(
+        child=serializers.ChoiceField(choices=list(SORT_MAP.keys())),
         required=False,
+        default=["-visited"],
     )
     query = serializers.CharField(required=False)
 
@@ -101,7 +104,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 )
 
         createdBy = serializer.validated_data.get("createdBy", "me")
-        sort = SORT_MAP[serializer.validated_data.get("sort", "-visited")]
+        sorts = [SORT_MAP[sort] for sort in serializer.validated_data.get("sort", ["-visited"])]
         query = serializer.validated_data.get("query")
         base_queryset = (
             GroupSearchView.objects.filter(organization=organization)
@@ -120,7 +123,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 )
                 .prefetch_related("projects")
                 .annotate(popularity=Count("groupsearchviewstarred"))
-                .order_by(sort)
+                .order_by(*sorts)
             )
             non_starred_query = (
                 base_queryset.filter(
@@ -129,7 +132,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 .exclude(id__in=starred_view_ids)
                 .prefetch_related("projects")
                 .annotate(popularity=Count("groupsearchviewstarred"))
-                .order_by(sort)
+                .order_by(*sorts)
             )
         elif createdBy == "others":
             starred_query = (
@@ -140,7 +143,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 .exclude(user_id=request.user.id)
                 .prefetch_related("projects")
                 .annotate(popularity=Count("groupsearchviewstarred"))
-                .order_by(sort)
+                .order_by(*sorts)
             )
             non_starred_query = (
                 base_queryset.filter(
@@ -150,7 +153,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 .exclude(id__in=starred_view_ids)
                 .prefetch_related("projects")
                 .annotate(popularity=Count("groupsearchviewstarred"))
-                .order_by(sort)
+                .order_by(*sorts)
             )
 
         return self.paginate(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1428,20 +1428,16 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         response = self.client.get(self.url, {"createdBy": "me", "sort": "created"})
         assert response.status_code == 200
         assert len(response.data) == 3
-        # =============   Starred views   =============
-        # ============= Non-starred views =============
-        assert response.data[0]["id"] == str(view_1.id), not response.data[0]["starred"]
-        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
-        assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
+        assert response.data[0]["id"] == str(view_1.id)
+        assert response.data[1]["id"] == str(view_2.id)
+        assert response.data[2]["id"] == str(view_3.id)
 
         response = self.client.get(self.url, {"createdBy": "me", "sort": "-created"})
         assert response.status_code == 200
         assert len(response.data) == 3
-        # =============   Starred views   =============
-        # ============= Non-starred views =============
-        assert response.data[0]["id"] == str(view_3.id), not response.data[0]["starred"]
-        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
-        assert response.data[2]["id"] == str(view_1.id), not response.data[2]["starred"]
+        assert response.data[0]["id"] == str(view_3.id)
+        assert response.data[1]["id"] == str(view_2.id)
+        assert response.data[2]["id"] == str(view_1.id)
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1433,7 +1433,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(view_1.id), not response.data[0]["starred"]
         assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
         assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
-        # None
 
         response = self.client.get(self.url, {"createdBy": "me", "sort": "-created"})
         assert response.status_code == 200
@@ -1443,7 +1442,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(view_3.id), not response.data[0]["starred"]
         assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
         assert response.data[2]["id"] == str(view_1.id), not response.data[2]["starred"]
-        # None
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
@@ -1468,23 +1466,17 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         response = self.client.get(self.url, {"createdBy": "me", "sort": ["name", "-visited"]})
         assert response.status_code == 200
         assert len(response.data) == 4
-        # =============   Starred views   =============
-        # ============= Non-starred views =============
-        assert response.data[0]["id"] == str(view_2.id), not response.data[0]["starred"]
-        assert response.data[1]["id"] == str(view_1.id), not response.data[1]["starred"]
-        assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
-        assert response.data[3]["id"] == str(view_4.id), not response.data[3]["starred"]
-        # None
+        assert response.data[0]["id"] == str(view_2.id)
+        assert response.data[1]["id"] == str(view_1.id)
+        assert response.data[2]["id"] == str(view_3.id)
+        assert response.data[3]["id"] == str(view_4.id)
 
         # Can sort by first name asc, then last_visited asc
 
         response = self.client.get(self.url, {"createdBy": "me", "sort": ["name", "visited"]})
         assert response.status_code == 200
         assert len(response.data) == 4
-        # =============   Starred views   =============
-        # ============= Non-starred views =============
-        assert response.data[0]["id"] == str(view_1.id), not response.data[0]["starred"]
-        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
-        assert response.data[2]["id"] == str(view_4.id), not response.data[2]["starred"]
-        assert response.data[3]["id"] == str(view_3.id), not response.data[3]["starred"]
-        # None
+        assert response.data[0]["id"] == str(view_1.id)
+        assert response.data[1]["id"] == str(view_2.id)
+        assert response.data[2]["id"] == str(view_4.id)
+        assert response.data[3]["id"] == str(view_3.id)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1415,3 +1415,76 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(view_3.id), response.data[0]["starred"]
         # ============= Non-starred views =============
         # None
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_created_by_me_sort_by_created(self) -> None:
+        self.login_as(user=self.user_1)
+
+        view_1 = self.create_view(user=self.user_1, name="View 1")
+        view_2 = self.create_view(user=self.user_1, name="View 2")
+        view_3 = self.create_view(user=self.user_1, name="View 3")
+
+        response = self.client.get(self.url, {"createdBy": "me", "sort": "created"})
+        assert response.status_code == 200
+        assert len(response.data) == 3
+        # =============   Starred views   =============
+        # ============= Non-starred views =============
+        assert response.data[0]["id"] == str(view_1.id), not response.data[0]["starred"]
+        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
+        assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
+        # None
+
+        response = self.client.get(self.url, {"createdBy": "me", "sort": "-created"})
+        assert response.status_code == 200
+        assert len(response.data) == 3
+        # =============   Starred views   =============
+        # ============= Non-starred views =============
+        assert response.data[0]["id"] == str(view_3.id), not response.data[0]["starred"]
+        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
+        assert response.data[2]["id"] == str(view_1.id), not response.data[2]["starred"]
+        # None
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_multiple_sort_options(self) -> None:
+        self.login_as(user=self.user_1)
+
+        view_1 = self.create_view(
+            user=self.user_1, name="View A", last_visited=timezone.now() - timedelta(days=4)
+        )
+        view_2 = self.create_view(
+            user=self.user_1, name="View A", last_visited=timezone.now() - timedelta(days=1)
+        )
+        view_3 = self.create_view(
+            user=self.user_1, name="View B", last_visited=timezone.now() - timedelta(days=2)
+        )
+        view_4 = self.create_view(
+            user=self.user_1, name="View B", last_visited=timezone.now() - timedelta(days=3)
+        )
+
+        # Can sort by first name asc, then last_visited desc
+
+        response = self.client.get(self.url, {"createdBy": "me", "sort": ["name", "-visited"]})
+        assert response.status_code == 200
+        assert len(response.data) == 4
+        # =============   Starred views   =============
+        # ============= Non-starred views =============
+        assert response.data[0]["id"] == str(view_2.id), not response.data[0]["starred"]
+        assert response.data[1]["id"] == str(view_1.id), not response.data[1]["starred"]
+        assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
+        assert response.data[3]["id"] == str(view_4.id), not response.data[3]["starred"]
+        # None
+
+        # Can sort by first name asc, then last_visited asc
+
+        response = self.client.get(self.url, {"createdBy": "me", "sort": ["name", "visited"]})
+        assert response.status_code == 200
+        assert len(response.data) == 4
+        # =============   Starred views   =============
+        # ============= Non-starred views =============
+        assert response.data[0]["id"] == str(view_1.id), not response.data[0]["starred"]
+        assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
+        assert response.data[2]["id"] == str(view_4.id), not response.data[2]["starred"]
+        assert response.data[3]["id"] == str(view_3.id), not response.data[3]["starred"]
+        # None


### PR DESCRIPTION
This allows the frontend to do things like `?sort=-visited&sort=-popularity` to get more useful sorts. In the future we could use this make the table columns sortable and remember previous sorts as well.