### PR TITLE
fix(schema-hints): Remove double scrolling on drawer

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
@@ -161,7 +161,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
   }
 
   return (
-    <Fragment>
+    <DrawerContainer>
       <DrawerHeader hideBar />
       <StyledDrawerBody>
         <HeaderContainer>
@@ -196,7 +196,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
           </ScrollContainer>
         </StyledMultipleCheckbox>
       </StyledDrawerBody>
-    </Fragment>
+    </DrawerContainer>
   );
 }
 
@@ -208,7 +208,10 @@ const SchemaHintsHeader = styled('h4')`
 `;
 
 const StyledDrawerBody = styled(DrawerBody)`
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 `;
 
 const HeaderContainer = styled('div')`
@@ -305,5 +308,15 @@ const NoAttributesMessage = styled('div')`
 const StyledInputGroup = styled(InputGroup)`
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     max-width: 175px;
+  }
+`;
+
+const DrawerContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  > header {
+    flex-shrink: 0;
   }
 `;


### PR DESCRIPTION
The way the drawer css was set up allowed for the hint list to be scrollable as well as the contents of the drawer body (not sure why the total virtualized scroll height was more than the available height). Now I've fixed that so the body is not scrollable, only the list is. 