### PR TITLE
chore(org member invite): block PUT if invite is managed by partnership

### DIFF
--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -99,6 +99,13 @@ class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
         ):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=403)
 
+        if invited_member.partnership_restricted:
+            return Response(
+                {
+                    "detail": "This member is managed by an active partnership and cannot be modified until the end of the partnership."
+                },
+                status=403,
+            )
         allowed_roles = get_allowed_org_roles(request, organization)
         validator = OrganizationMemberInviteRequestValidator(
             data=request.data,

--- a/src/sentry/api/endpoints/organization_member_invite/details.py
+++ b/src/sentry/api/endpoints/organization_member_invite/details.py
@@ -106,6 +106,7 @@ class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
                 },
                 status=403,
             )
+
         allowed_roles = get_allowed_org_roles(request, organization)
         validator = OrganizationMemberInviteRequestValidator(
             data=request.data,

--- a/tests/sentry/api/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_details.py
@@ -223,9 +223,22 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         )
 
     @with_feature({"organizations:invite-members": False})
-    # idk wtf is going on tbh. why is this feature still enabled.
     def test_cannot_approve_if_invite_requests_disabled(self):
         response = self.get_error_response(
             self.organization.slug, self.invite_request.id, approve=1
         )
         assert response.data["approve"][0] == "Your organization is not allowed to invite members."
+
+    def test_cannot_modify_partnership_managed_invite(self):
+        invite = self.create_member_invite(
+            organization=self.organization,
+            email="partnership-mifu@email.com",
+            partnership_restricted=True,
+        )
+        response = self.get_error_response(
+            self.organization.slug, invite.id, orgRole="member", status_code=403
+        )
+        assert (
+            response.data["detail"]
+            == "This member is managed by an active partnership and cannot be modified until the end of the partnership."
+        )


### PR DESCRIPTION
Partnership invites should not be modifiable. All partnership invited members are approved, so we can simply block hitting the endpoint if `invited_member.partnership_restricted` is true.