### PR TITLE
fix(logs): Prevent progressive loading UI from rendering

### DIFF
--- a/static/app/views/explore/charts/index.spec.tsx
+++ b/static/app/views/explore/charts/index.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DurationUnit} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ExploreCharts} from 'sentry/views/explore/charts';
 import {defaultVisualizes} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -31,6 +32,7 @@ describe('ExploreCharts', () => {
         timeseriesResult={mockTimeseriesResult}
         visualizes={defaultVisualizes()}
         setVisualizes={() => {}}
+        dataset={DiscoverDatasets.SPANS_EAP}
       />,
       {
         organization: OrganizationFixture({
@@ -52,6 +54,7 @@ describe('ExploreCharts', () => {
         visualizes={defaultVisualizes()}
         setVisualizes={() => {}}
         samplingMode={SAMPLING_MODE.BEST_EFFORT}
+        dataset={DiscoverDatasets.SPANS_EAP}
       />
     );
 

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -11,6 +11,7 @@ import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -37,6 +38,7 @@ import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/use
 interface ExploreChartsProps {
   canUsePreviousResults: boolean;
   confidences: Confidence[];
+  dataset: DiscoverDatasets;
   query: string;
   setVisualizes: (visualizes: Visualize[]) => void;
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
@@ -71,6 +73,7 @@ export function ExploreCharts({
   setVisualizes,
   hideContextMenu,
   samplingMode,
+  dataset,
 }: ExploreChartsProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -208,6 +211,7 @@ export function ExploreCharts({
                       confidence={undefined}
                       topEvents={undefined}
                       dataScanned={undefined}
+                      dataset={dataset}
                     />
                   )
                 }
@@ -329,6 +333,7 @@ export function ExploreCharts({
                   }
                   dataScanned={chartInfo.dataScanned}
                   samplingMode={samplingMode}
+                  dataset={dataset}
                 />
               }
             />

--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -7,6 +7,7 @@ import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 import {
@@ -21,16 +22,21 @@ export function WidgetExtrapolationFooter({
   topEvents,
   dataScanned,
   samplingMode,
+  dataset,
 }: {
   confidence: Confidence | undefined;
   dataScanned: 'full' | 'partial' | undefined;
+  dataset: DiscoverDatasets;
   isSampled: boolean | null;
   sampleCount: number;
   topEvents: number | undefined;
   samplingMode?: SamplingMode;
 }) {
   const organization = useOrganization();
-  if (!organization.features.includes('visibility-explore-progressive-loading')) {
+  if (
+    !organization.features.includes('visibility-explore-progressive-loading') ||
+    ![DiscoverDatasets.SPANS_EAP, DiscoverDatasets.SPANS_EAP_RPC].includes(dataset)
+  ) {
     return (
       <ConfidenceFooter
         sampleCount={sampleCount}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -176,6 +176,7 @@ export function LogsTabContent({
                 setVisualizes={setVisualizes}
                 // TODO: we do not support log alerts nor adding to dashboards yet
                 hideContextMenu
+                dataset={DiscoverDatasets.OURLOGS}
               />
             </LogsItemContainer>
           </Feature>

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -13,6 +13,7 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -183,6 +184,7 @@ export function MultiQueryModeChart({
               confidence={undefined}
               topEvents={undefined}
               dataScanned={undefined}
+              dataset={DiscoverDatasets.SPANS_EAP}
             />
           )
         }
@@ -344,6 +346,7 @@ export function MultiQueryModeChart({
           topEvents={isTopN ? numSeries : undefined}
           dataScanned={dataScanned}
           samplingMode={samplingMode}
+          dataset={DiscoverDatasets.SPANS_EAP}
         />
       }
     />

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -24,6 +24,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   type AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
@@ -313,6 +314,7 @@ export function SpansTabContentImpl({
                 visualizes={visualizes}
                 setVisualizes={setVisualizes}
                 samplingMode={timeseriesSamplingMode}
+                dataset={DiscoverDatasets.SPANS_EAP}
               />
               <ExploreTables
                 aggregatesTableResult={aggregatesTableResult}


### PR DESCRIPTION
The UI here shouldn't be showing the progressive loading indicator. Instead it should display the normal confidence footer. To separate these two, I just pass down the dataset and make sure if it's not an explore dataset, we show the original footer.

![image](https://github.com/user-attachments/assets/5e2b3b06-14ed-4476-b378-7115c0fd5268)
