### PR TITLE
fix(seer grouping): Retry getting parent hash group id when missing

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -159,6 +159,7 @@ def get_similarity_data_from_seer(
     metric_tags["outcome"] = "similar_groups_found"
 
     normalized_results = []
+    results_missing_group_id = []
 
     for raw_similar_issue_data in response_data:
         try:
@@ -231,7 +232,6 @@ def get_similarity_data_from_seer(
             # The same caveats apply here as with the `SimilarHashNotFoundError` above, except that
             # landing here should be even rarer, in that it's theoretically impossible - but
             # nonetheless has happened, when events have seemingly vanished mid-ingest.
-            metric_tags.update({"outcome": "error", "error": "SimilarHashMissingGroupError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_hash_missing_group",
                 extra={
@@ -250,10 +250,58 @@ def get_similarity_data_from_seer(
             # race conditions, the value is under a second - but stuff happens.)
             if not parent_grouphash_age or parent_grouphash_age > 60:
                 delete_seer_grouping_records_by_hash.delay(project_id, [parent_hash])
+
+                # We're not going to go through the rety flow, so we need to set this here
+                metric_tags.update({"outcome": "error", "error": "SimilarHashMissingGroupError"})
             else:
-                # TODO: If we *are* in a race condition, we should consider retrying getting the
-                # group id here, now that a few more milliseconds have elapsed
-                pass
+                # If we are in fact in a race condition, queue the raw result data so we can retry
+                # getting the parent hash after we're done processing the other results
+                results_missing_group_id.append(raw_similar_issue_data)
+
+    # Retry normalization for any results whose parent hashes were missing group id as the result of
+    # a race condition, in hopes that enough time has elapsed that things are no longer so racy
+    for raw_similar_issue_data in results_missing_group_id:
+        parent_hash = raw_similar_issue_data.get("parent_hash")
+        parent_grouphash_age = None
+        parent_grouphash_date_added = (
+            GroupHashMetadata.objects.filter(
+                grouphash__project_id=project_id, grouphash__hash=parent_hash
+            )
+            .values_list("date_added", flat=True)
+            .first()
+        )
+
+        if parent_grouphash_date_added:
+            parent_grouphash_age = (timezone.now() - parent_grouphash_date_added).total_seconds()
+
+        logger_extra = {
+            "hash": request_hash,
+            "parent_hash": parent_hash,
+            "project_id": project_id,
+            "event_id": event_id,
+            "parent_gh_age_in_sec": parent_grouphash_age,
+        }
+
+        # Try again to find the parent hash's group id
+        try:
+            normalized = SeerSimilarIssueData.from_raw(project_id, raw_similar_issue_data)
+        # If the group id is still missing, just log it and move on
+        except SimilarHashMissingGroupError:
+            metric_tags.update({"outcome": "error", "error": "SimilarHashMissingGroupError"})
+            logger.info(
+                "get_similarity_data_from_seer.parent_hash_missing_group.retry_failure",
+                extra=logger_extra,
+            )
+        # Otherwise, if the retry worked, treat it the same way we would have had the group id been
+        # there from the start
+        else:
+            logger.info(
+                "get_similarity_data_from_seer.parent_hash_missing_group.retry_success",
+                extra=logger_extra,
+            )
+            normalized_results.append(normalized)
+            if normalized.should_group and metric_tags["outcome"] != "error":
+                metric_tags["outcome"] = "matching_group_found"
 
     metrics.incr(
         "seer.similar_issues_request",


### PR DESCRIPTION
When we make calls to Seer during ingest, it's possible to end up in a race condition where the a parent hash that Seer sends back is so new that it itself is still in the pipeline, and hasn't yet been assigned a group. Currently, when we hit such a case, we just discard the result.

This PR adds a retry to the process. When a race condition is detected, the parent hash is added to a list for future retries, and then that list is looped over again after the rest of the Seer matches have been processed. Ideally, in the time it's taken to finish the first pass over the full set of results, the race condition will have sorted itself out and we'll have valid group ids to use.

