### PR TITLE
ref: fix logic error in member invite role validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
+++ b/src/sentry/api/serializers/rest_framework/organizationmemberinvite.py
@@ -98,7 +98,7 @@ class OrganizationMemberInviteRequestValidator(serializers.Serializer):
                 "You do not have permission to invite a member with that org-level role"
             )
         if (
-            not features.has("organizations:team-roles", self.context["organization"])
+            features.has("organizations:team-roles", self.context["organization"])
             and role_obj.is_retired
         ):
             raise serializers.ValidationError(

--- a/tests/sentry/api/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_invite_details.py
@@ -102,7 +102,7 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         )
 
     @with_feature("organizations:team-roles")
-    def can_update_from_retired_role_with_flag(self):
+    def test_can_update_from_retired_role_with_flag(self):
         invite = self.create_member_invite(
             organization=self.organization,
             email="pistachio@croissant.com",
@@ -113,8 +113,8 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         invite.refresh_from_db()
         assert invite.role == "member"
 
-    @with_feature({"organizations:team-roles", False})
-    def can_update_from_retired_role_without_flag(self):
+    @with_feature({"organizations:team-roles": False})
+    def test_can_update_from_retired_role_without_flag(self):
         invite = self.create_member_invite(
             organization=self.organization,
             email="pistachio@croissant.com",
@@ -125,8 +125,8 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         invite.refresh_from_db()
         assert invite.role == "member"
 
-    @with_feature({"organizations:team-roles", False})
-    def can_update_to_retired_role_without_flag(self):
+    @with_feature({"organizations:team-roles": False})
+    def test_can_update_to_retired_role_without_flag(self):
         invite = self.create_member_invite(
             organization=self.organization,
             email="pistachio@croissant.com",
@@ -138,7 +138,7 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         assert invite.role == "admin"
 
     @with_feature("organizations:team-roles")
-    def cannot_update_to_retired_role_with_flag(self):
+    def test_cannot_update_to_retired_role_with_flag(self):
         invite = self.create_member_invite(
             organization=self.organization,
             email="pistachio@croissant.com",

--- a/tests/sentry/api/validators/test_organization_member_invite_validator.py
+++ b/tests/sentry/api/validators/test_organization_member_invite_validator.py
@@ -102,8 +102,8 @@ class OrganizationMemberInviteRequestValidatorTest(TestCase):
             "email": ["There is an existing invite request for test@gmail.com"]
         }
 
-    @with_feature({"organizations:team-roles": False})
-    def test_deprecated_org_role_without_flag(self):
+    @with_feature("organizations:team-roles")
+    def test_deprecated_org_role_with_flag(self):
         context = {
             "organization": self.organization,
             "allowed_roles": [roles.get("admin"), roles.get("member")],
@@ -119,8 +119,8 @@ class OrganizationMemberInviteRequestValidatorTest(TestCase):
             ]
         }
 
-    @with_feature("organizations:team-roles")
-    def test_deprecated_org_role_with_flag(self):
+    @with_feature({"organizations:team-roles": False})
+    def test_deprecated_org_role_without_flag(self):
         context = {
             "organization": self.organization,
             "allowed_roles": [roles.get("admin"), roles.get("member")],


### PR DESCRIPTION
three bugs here lined up to make this broken:
- the `with_features` decorator was being passed a `set[str | bool]` (this is how I found the code to begin with -- I'm fixing the typing of the decorator)
- the tests were named incorrectly (missing `test_`) so they weren't running
- once re-enabled the tests were failing (the logic on deprecated roles was inverted in the view)
    - here's an equivalent check for seemingly the same thing: https://github.com/getsentry/sentry/blob/123a078374db0bba217f9119825331a28320bd84/src/sentry/api/endpoints/organization_member/details.py#L335-L343

<!-- Describe your PR here. -->