### PR TITLE
fix(explore): Cap max interval to selection

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -33,6 +33,7 @@ export const FORTY_EIGHT_HOURS = 2880;
 export const TWENTY_FOUR_HOURS = 1440;
 export const SIX_HOURS = 360;
 export const ONE_HOUR = 60;
+export const FIVE_MINUTES = 5;
 
 /**
  * If there are more releases than this number we hide "Releases" series by default

--- a/static/app/views/explore/hooks/useChartInterval.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.tsx
@@ -2,9 +2,11 @@ import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
 import {
+  FIVE_MINUTES,
   FORTY_EIGHT_HOURS,
   getDiffInMinutes,
   GranularityLadder,
+  ONE_HOUR,
   ONE_WEEK,
   SIX_HOURS,
   THIRTY_DAYS,
@@ -112,7 +114,9 @@ const MAXIMUM_INTERVAL = new GranularityLadder([
   [ONE_WEEK, '12h'],
   [FORTY_EIGHT_HOURS, '4h'],
   [SIX_HOURS, '1h'],
-  [0, '15m'],
+  [ONE_HOUR, '15m'],
+  [FIVE_MINUTES, '5m'],
+  [0, '1m'],
 ]);
 
 export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {


### PR DESCRIPTION
The max interval for small selections was 5 minutes which was causing issues with the api. Cap the interval to the selection so we don't use bad intervals.