### PR TITLE
:recycle: ref(aci): make `email_users` function a pure function

### DIFF
--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -29,9 +29,12 @@ class AlertContext:
     comparison_delta: int | None
     sensitivity: str | None
     resolve_threshold: float | None
+    alert_threshold: float | None
 
     @classmethod
-    def from_alert_rule_incident(cls, alert_rule: AlertRule) -> AlertContext:
+    def from_alert_rule_incident(
+        cls, alert_rule: AlertRule, alert_rule_threshold: float | None = None
+    ) -> AlertContext:
         return cls(
             name=alert_rule.name,
             action_identifier_id=alert_rule.id,
@@ -39,6 +42,7 @@ class AlertContext:
             detection_type=AlertRuleDetectionType(alert_rule.detection_type),
             comparison_delta=alert_rule.comparison_delta,
             sensitivity=alert_rule.sensitivity,
+            alert_threshold=alert_rule_threshold,
             resolve_threshold=alert_rule.resolve_threshold,
         )
 
@@ -56,9 +60,10 @@ class AlertContext:
             threshold_type=threshold_type,
             detection_type=detector.config.get("detection_type"),
             comparison_delta=detector.config.get("comparison_delta"),
-            # TODO(iamrajjoshi): Add sensitivity, resolve_threshold
+            # TODO(iamrajjoshi): Add sensitivity, alert_threshold, resolve_threshold
             sensitivity=None,
             resolve_threshold=None,
+            alert_threshold=None,
         )
 
 

--- a/src/sentry/integrations/messaging/spec.py
+++ b/src/sentry/integrations/messaging/spec.py
@@ -229,7 +229,11 @@ class MessagingActionHandler(DefaultActionHandler):
         )
         if success:
             self.record_alert_sent_analytics(
-                action, incident, project, action.target_identifier, notification_uuid
+                organization_id=incident.organization.id,
+                project_id=project.id,
+                alert_id=incident.alert_rule.id,
+                external_id=action.target_identifier,
+                notification_uuid=notification_uuid,
             )
 
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -100,6 +100,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -101,6 +101,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -97,6 +97,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -95,6 +95,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -108,6 +108,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -103,6 +103,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             threshold_type=None,
             detection_type=None,
             comparison_delta=None,
+            alert_threshold=None,
         )
 
         self.assert_metric_issue_context(

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -137,6 +137,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         comparison_delta: int | None = None,
         sensitivity: AlertRuleSensitivity | None = None,
         resolve_threshold: float | None = None,
+        alert_threshold: float | None = None,
     ):
         assert asdict(alert_context) == {
             "name": name,
@@ -146,6 +147,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
             "comparison_delta": comparison_delta,
             "sensitivity": sensitivity,
             "resolve_threshold": resolve_threshold,
+            "alert_threshold": alert_threshold,
         }
 
     def assert_metric_issue_context(

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -9,10 +9,7 @@ from django.core import mail
 
 from sentry.api.serializers import serialize
 from sentry.conf.types.kafka_definition import Topic
-from sentry.incidents.action_handlers import (
-    EmailActionHandler,
-    generate_incident_trigger_email_context,
-)
+from sentry.incidents.action_handlers import build_message, generate_incident_trigger_email_context
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import (
@@ -160,11 +157,10 @@ class HandleSnubaQueryUpdateTest(TestCase):
             assert active_incident().exists()
 
         assert len(mail.outbox) == 1
-        handler = EmailActionHandler()
         incident_activity = IncidentActivity.objects.filter(
             incident=active_incident().get()
         ).order_by("-id")[0]
-        message_builder = handler.build_message(
+        message_builder = build_message(
             generate_incident_trigger_email_context(
                 project=self.project,
                 organization=self.project.organization,


### PR DESCRIPTION
converting `email_users` to a pure function allows me to invoke it from the NOA