### PR TITLE
chore(trace-view): loading message

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -878,7 +878,7 @@ describe('trace view', () => {
     mockEventsResponse();
 
     render(<TraceView />, {router});
-    expect(await screen.findByText(/assembling the trace/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Waterfalling/i)).toBeInTheDocument();
   });
 
   it('renders error state if trace fails to load', async () => {
@@ -890,7 +890,7 @@ describe('trace view', () => {
 
     render(<TraceView />, {router});
     expect(
-      await screen.findByText(/Woof. We failed to load your trace./i)
+      await screen.findByText(/Oof. We failed to load your trace./i)
     ).toBeInTheDocument();
   });
 
@@ -909,7 +909,7 @@ describe('trace view', () => {
 
     render(<TraceView />, {router});
     expect(
-      await screen.findByText(/Woof. We failed to load your trace./i)
+      await screen.findByText(/Oof. We failed to load your trace./i)
     ).toBeInTheDocument();
   });
 
@@ -962,7 +962,7 @@ describe('trace view', () => {
     });
     expect(
       await screen.findByText(
-        /We're still processing this trace. Please try refreshing after a minute/i
+        /Still processing. Grab a drink, come back and refresh yourself and the page/i
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -878,7 +878,7 @@ describe('trace view', () => {
     mockEventsResponse();
 
     render(<TraceView />, {router});
-    expect(await screen.findByText(/Waterfalling/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Imagine waterfalling/i)).toBeInTheDocument();
   });
 
   it('renders error state if trace fails to load', async () => {

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
@@ -13,7 +13,7 @@ function TraceLoading() {
     // Dont flash the animation on load because it's annoying
     <LoadingContainer animate={false}>
       <NoMarginIndicator size={24}>
-        <div>{t('Waterfalling')}</div>
+        <div>{t('Imagine waterfalling')}</div>
       </NoMarginIndicator>
     </LoadingContainer>
   );

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
@@ -13,7 +13,7 @@ function TraceLoading() {
     // Dont flash the animation on load because it's annoying
     <LoadingContainer animate={false}>
       <NoMarginIndicator size={24}>
-        <div>{t('Assembling the trace')}</div>
+        <div>{t('Assembling')}</div>
       </NoMarginIndicator>
     </LoadingContainer>
   );
@@ -26,7 +26,7 @@ function TraceError() {
   return (
     <LoadingContainer animate error>
       <div>
-        {t('Woof. We failed to load your trace. If you need to yell at someone, ')}
+        {t('Oof. We failed to load your trace. If you need to yell at someone, ')}
       </div>
       <div>
         {feedback ? (
@@ -52,7 +52,7 @@ function TraceEmpty() {
   // minute buffer to account for this.
   const message =
     timestamp && new Date(timestamp * 1000) >= new Date(Date.now() - TEN_MINUTES_IN_MS)
-      ? t("We're still processing this trace. Please try refreshing after a minute")
+      ? t('Still processing. Grab a drink, come back and refresh yourself and the page')
       : t("This trace is so empty, even tumbleweeds don't roll here");
 
   return (

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
@@ -13,7 +13,7 @@ function TraceLoading() {
     // Dont flash the animation on load because it's annoying
     <LoadingContainer animate={false}>
       <NoMarginIndicator size={24}>
-        <div>{t('Assembling')}</div>
+        <div>{t('Waterfalling')}</div>
       </NoMarginIndicator>
     </LoadingContainer>
   );


### PR DESCRIPTION
**Copy updates for the following scenarios:** 
1. When the content in the page is loading (which takes a few seconds)
"Imagine waterfalling"
3. When it's going to take more time for us to process and they should refresh
"Still processing. Grab a drink, come back and refresh yourself and the page"
4. When it took us awhile to realize there's nothing associated with this page
"Oof. We failed to load your trace. If you need to yell at someone, send feedback"
5. When we straight up failed to load anything because there's a prob on our end
"This trace is so empty, even tumbleweeds don't roll here"