### PR TITLE
feat(seer): Switch "hide ai features" to Enable Seer Features

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -1,7 +1,14 @@
 import type {FieldObject} from 'sentry/components/forms/types';
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
+
+export const defaultEnableSeerFeaturesValue = (organization: Organization) => {
+  const isBaa = false; // TODO: add check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
+  const isDeRegion = getRegionDataFromOrganization(organization)?.name === 'de';
+  return !organization.hideAiFeatures && !(isDeRegion || isBaa);
+};
 
 export const makeHideAiFeaturesField = (organization: Organization): FieldObject => {
   const isBaa = false; // TODO: add a check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
@@ -10,10 +17,21 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
   return {
     name: 'hideAiFeatures',
     type: 'boolean',
-    label: t('Hide AI Features '),
-    help: t('Hide features built with AI by default'),
-    defaultValue: isDeRegion || isBaa, // With a BAA or in the EU, we show this toggle as on when it's disabled, even though the option is false. This means we should check for the value of this field to be true.
+    label: t('Enable Seer Features'),
+    help: tct(
+      'Enables [docs:Seer features] including issue summary, autofix, and LLM-assisted search.',
+      {
+        docs: (
+          <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />
+        ),
+      }
+    ),
+    defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => isDeRegion || !access.has('org:write'),
+    getValue: value => {
+      // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
+      return !value;
+    },
     disabledReason: isBaa
       ? t(
           'To remain HIPAA compliant, Generative AI features are disabled for BAA customers'

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -18,14 +18,11 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     name: 'hideAiFeatures',
     type: 'boolean',
     label: t('Enable Seer Features'),
-    help: tct(
-      'Enables [docs:Seer features] including issue summary, autofix, and LLM-assisted search.',
-      {
-        docs: (
-          <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />
-        ),
-      }
-    ),
+    help: tct('Enables [docs:features] powered by the Seer agent.', {
+      docs: (
+        <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />
+      ),
+    }),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => isDeRegion || !access.has('org:write'),
     getValue: value => {

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -228,4 +228,43 @@ describe('OrganizationGeneralSettings', function () {
       );
     });
   });
+
+  it('can toggle "Enable Seer Features"', async function () {
+    // Default org fixture has hideAiFeatures: false, so Seer is enabled by default
+    const hiddenAiOrg = OrganizationFixture({hideAiFeatures: true});
+    render(<OrganizationGeneralSettings />, {organization: hiddenAiOrg});
+    const mock = MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'PUT',
+    });
+
+    const checkbox = screen.getByRole('checkbox', {name: 'Enable Seer Features'});
+
+    // Inverted from hideAiFeatures
+    expect(checkbox).not.toBeChecked();
+
+    // Click to uncheck (disable Seer -> hideAiFeatures = true)
+    await userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          data: {hideAiFeatures: false},
+        })
+      );
+    });
+
+    // Inverted from hideAiFeatures
+    expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({data: {hideAiFeatures: true}})
+      );
+    });
+  });
 });

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -228,43 +228,4 @@ describe('OrganizationGeneralSettings', function () {
       );
     });
   });
-
-  it('can toggle "Enable Seer Features"', async function () {
-    // Default org fixture has hideAiFeatures: false, so Seer is enabled by default
-    const hiddenAiOrg = OrganizationFixture({hideAiFeatures: true});
-    render(<OrganizationGeneralSettings />, {organization: hiddenAiOrg});
-    const mock = MockApiClient.addMockResponse({
-      url: ENDPOINT,
-      method: 'PUT',
-    });
-
-    const checkbox = screen.getByRole('checkbox', {name: 'Enable Seer Features'});
-
-    // Inverted from hideAiFeatures
-    expect(checkbox).not.toBeChecked();
-
-    // Click to uncheck (disable Seer -> hideAiFeatures = true)
-    await userEvent.click(checkbox);
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith(
-        ENDPOINT,
-        expect.objectContaining({
-          data: {hideAiFeatures: false},
-        })
-      );
-    });
-
-    // Inverted from hideAiFeatures
-    expect(checkbox).toBeChecked();
-
-    await userEvent.click(checkbox);
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith(
-        ENDPOINT,
-        expect.objectContaining({data: {hideAiFeatures: true}})
-      );
-    });
-  });
 });

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -25,6 +25,7 @@ import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
+import {defaultEnableSeerFeaturesValue} from 'sentry/views/settings/organizationGeneralSettings/aiFeatureSettings';
 import {OrganizationRegionAction} from 'sentry/views/settings/organizationGeneralSettings/organizationRegionAction';
 
 import OrganizationSettingsForm from './organizationSettingsForm';
@@ -115,7 +116,13 @@ export default function OrganizationGeneralSettings() {
         />
         <OrganizationPermissionAlert />
 
-        <OrganizationSettingsForm initialData={organization} onSave={handleSaveForm} />
+        <OrganizationSettingsForm
+          initialData={{
+            ...organization,
+            hideAiFeatures: defaultEnableSeerFeaturesValue(organization),
+          }}
+          onSave={handleSaveForm}
+        />
 
         {organization.access.includes('org:admin') && !organization.isDefault && (
           <Panel>


### PR DESCRIPTION
Inverts what is being done, reuses the hideAiFeatures flag

before

![image](https://github.com/user-attachments/assets/ab4d81f3-56fd-40f5-bdaa-8faf33ae7429)


after

![image](https://github.com/user-attachments/assets/22858577-178c-4b57-8122-a6c973a21dde)
