### PR TITLE
fix(issue-views): Change to 'Save As' button when user has no edit access

### DIFF
--- a/static/app/views/issueList/issueViews/createIssueViewModal.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.tsx
@@ -27,7 +27,7 @@ interface CreateIssueViewModalProps
     Partial<
       Pick<
         GroupSearchView,
-        'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
+        'name' | 'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
       >
     > {}
 
@@ -53,6 +53,7 @@ export function CreateIssueViewModal({
   projects: incomingProjects,
   environments: incomingEnvironments,
   timeFilters: incomingTimeFilters,
+  name: incomingName,
 }: CreateIssueViewModalProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -88,7 +89,7 @@ export function CreateIssueViewModal({
   };
 
   const initialData = {
-    name: '',
+    name: incomingName ?? '',
     query: incomingQuery ?? 'is:unresolved',
     querySort: incomingQuerySort ?? IssueSortOptions.DATE,
     projects: incomingProjects ?? [],

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {
   render,
@@ -136,6 +137,8 @@ describe('IssueViewSaveButton', function () {
 
     const nameInput = within(modal).getByRole('textbox', {name: 'Name'});
 
+    expect(nameInput).toHaveValue(mockGroupSearchView.name);
+    await userEvent.clear(nameInput);
     await userEvent.type(nameInput, 'My View');
 
     await userEvent.click(screen.getByRole('button', {name: 'Create View'}));
@@ -160,7 +163,7 @@ describe('IssueViewSaveButton', function () {
     );
   });
 
-  it('can save changes to a view', async function () {
+  it('can save changes to a view that user has edit access to', async function () {
     const mockUpdateIssueView = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/group-search-views/100/',
       method: 'PUT',
@@ -201,6 +204,68 @@ describe('IssueViewSaveButton', function () {
         data: expect.objectContaining({
           environments: ['dev'],
         }),
+      })
+    );
+  });
+
+  it('can save as a new view when user has no edit access', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/100/',
+      body: {
+        ...mockGroupSearchView,
+        // Created by another user
+        createdBy: UserFixture({id: '98765'}),
+      },
+    });
+    const mockCreateIssueView = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      method: 'POST',
+      body: mockGroupSearchView,
+    });
+
+    PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+
+    const {router} = render(
+      <Fragment>
+        <IssueViewSaveButton {...defaultProps} />
+        <GlobalModal />
+      </Fragment>,
+      {
+        enableRouterMocks: false,
+        initialRouterConfig: initialRouterConfigView,
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save As'}));
+
+    const modal = screen.getByRole('dialog');
+
+    expect(modal).toBeInTheDocument();
+
+    const nameInput = within(modal).getByRole('textbox', {name: 'Name'});
+
+    expect(nameInput).toHaveValue(mockGroupSearchView.name);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'My View');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create View'}));
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe('/organizations/org-slug/issues/views/100/');
+    });
+
+    expect(mockCreateIssueView).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          name: 'My View',
+          query: 'is:unresolved',
+          querySort: IssueSortOptions.DATE,
+          projects: [1],
+          environments: ['prod'],
+          timeFilters: {period: '7d', utc: null, start: null, end: null},
+          starred: false,
+        },
       })
     );
   });


### PR DESCRIPTION
Forgot to handle the save button when the user didn't have edit access. The save button should change to 'Save As' and remove the 'Save As' option from the dropdown.

![CleanShot 2025-04-17 at 15 23 56](https://github.com/user-attachments/assets/f6dfbfc1-f7a3-4a59-aa7e-4ecf824e050e)
