### PR TITLE
ref(feedback): temporarily hide new linked error tags from suggestions

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -35,6 +35,9 @@ const EXCLUDED_TAGS: string[] = [
   'device',
   'os',
   'user',
+  // TODO(aliu): Include these new tags until all feedbacks in the last 14-30d have them - early to mid may 2025
+  'associated_event_id',
+  'has_linked_error',
 ];
 
 const EXCLUDED_SUGGESTIONS: string[] = [


### PR DESCRIPTION
Following https://github.com/getsentry/sentry/pull/89788, we need to wait a while for all feedbacks to be tagged, or these searches will be incorrect/misleading. This is a low priority feature with no customer requests, so should be fine to hide for now.