### PR TITLE
deps(ui): Upgrade tanstack virtual

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@tanstack/react-query": "^5.72.1",
     "@tanstack/react-query-devtools": "^5.72.1",
     "@tanstack/react-query-persist-client": "^5.72.1",
-    "@tanstack/react-virtual": "^3.5.1",
+    "@tanstack/react-virtual": "^3.13.6",
     "@types/color": "^3.0.3",
     "@types/diff": "5.2.1",
     "@types/gtag.js": "^0.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,17 +3667,17 @@
   dependencies:
     "@tanstack/query-core" "5.72.1"
 
-"@tanstack/react-virtual@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.5.1.tgz#1ce466f530a10f781871360ed2bf7ff83e664f85"
-  integrity sha512-jIsuhfgy8GqA67PdWqg73ZB2LFE+HD9hjWL1L6ifEIZVyZVAKpYmgUG4WsKQ005aEyImJmbuimPiEvc57IY0Aw==
+"@tanstack/react-virtual@^3.13.6":
+  version "3.13.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.6.tgz#30243c8c3166673caf66bfbf5352e1b314a3a4cd"
+  integrity sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==
   dependencies:
-    "@tanstack/virtual-core" "3.5.1"
+    "@tanstack/virtual-core" "3.13.6"
 
-"@tanstack/virtual-core@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.5.1.tgz#f519149bce9156d0e7954b9531df15f446f2fc12"
-  integrity sha512-046+AUSiDru/V9pajE1du8WayvBKeCvJ2NmKPy/mR8/SbKKrqmSbj7LJBfXE+nSq4f5TBXvnCzu0kcYebI9WdQ==
+"@tanstack/virtual-core@3.13.6":
+  version "3.13.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.6.tgz#329f962f1596b3280736c266a982897ed2112157"
+  integrity sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==
 
 "@testing-library/dom@10.4.0":
   version "10.4.0"


### PR DESCRIPTION
silences warning on install

```
warning " > @tanstack/react-virtual@3.5.1" has incorrect peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
warning " > @tanstack/react-virtual@3.5.1" has incorrect peer dependency "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0".
```
