### PR TITLE
feat(workflow_engine): Return `DetectorOccurrence` from `build_occurrence_and_event_data` instead of `IssueOccurrence`

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -3,18 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
-from uuid import uuid4
 
 from sentry import features
 from sentry.incidents.metric_alert_detector import MetricAlertsDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
 from sentry.incidents.utils.types import MetricDetectorUpdate, QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
-from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
+from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
 
@@ -24,35 +22,17 @@ COMPARISON_DELTA_CHOICES.append(None)
 
 class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate]):
     def build_occurrence_and_event_data(
-        self, group_key: DetectorGroupKey, value: int, new_status: PriorityLevel
-    ) -> tuple[IssueOccurrence, dict[str, Any]]:
+        self, group_key: DetectorGroupKey, new_status: PriorityLevel
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
         # Returning a placeholder for now, this may require us passing more info
-
-        occurrence = IssueOccurrence(
-            id=str(uuid4()),
-            project_id=self.detector.project_id,
-            event_id=str(uuid4()),
-            fingerprint=self.build_fingerprint(group_key),
-            issue_title="Some Issue",
-            subtitle="Some subtitle",
-            resource_id=None,
-            evidence_data={"detector_id": self.detector.id, "value": value},
-            evidence_display=[],
+        occurrence = DetectorOccurrence(
+            issue_title="Some Issue Title",
+            subtitle="An Issue Subtitle",
             type=MetricAlertFire,
-            detection_time=datetime.now(UTC),
             level="error",
             culprit="Some culprit",
-            initial_issue_priority=new_status.value,
         )
-        event_data = {
-            "timestamp": occurrence.detection_time,
-            "project_id": occurrence.project_id,
-            "event_id": occurrence.event_id,
-            "platform": "python",
-            "received": occurrence.detection_time,
-            "tags": {},
-        }
-        return occurrence, event_data
+        return occurrence, {}
 
     @property
     def counter_names(self) -> list[str]:

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -1,9 +1,10 @@
 __all__ = [
-    "DetectorHandler",
     "DetectorEvaluationResult",
+    "DetectorHandler",
+    "DetectorOccurrence",
     "DetectorStateData",
     "StatefulDetectorHandler",
 ]
 
-from .base import DetectorEvaluationResult, DetectorHandler, DetectorStateData
+from .base import DetectorEvaluationResult, DetectorHandler, DetectorOccurrence, DetectorStateData
 from .stateful import StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -1,15 +1,60 @@
 import abc
 import dataclasses
 import logging
+from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any, Generic, TypeVar
 
-from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.grouptype import GroupType
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.types.actor import Actor
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DetectorOccurrence:
+    issue_title: str
+    subtitle: str
+    resource_id: str | None = None
+    evidence_data: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+    evidence_display: Sequence[IssueEvidence] = dataclasses.field(default_factory=list)
+    type: type[GroupType]
+    level: str
+    culprit: str
+    initial_issue_priority: int | None = None
+    assignee: Actor | None = None
+
+    def to_issue_occurrence(
+        self,
+        occurrence_id: str,
+        project_id: int,
+        status: DetectorPriorityLevel,
+        detection_time: datetime,
+        additional_evidence_data: Mapping[str, Any],
+        fingerprint: list[str],
+    ) -> IssueOccurrence:
+        return IssueOccurrence(
+            id=occurrence_id,
+            project_id=project_id,
+            event_id=occurrence_id,
+            fingerprint=fingerprint,
+            issue_title=self.issue_title,
+            subtitle=self.subtitle,
+            resource_id=self.resource_id,
+            evidence_data={**self.evidence_data, **additional_evidence_data},
+            evidence_display=self.evidence_display,
+            type=self.type,
+            detection_time=detection_time,
+            level=self.level,
+            culprit=self.culprit,
+            initial_issue_priority=self.initial_issue_priority or status,
+            assignee=self.assignee,
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -31,6 +31,7 @@ class DetectorOccurrence:
 
     def to_issue_occurrence(
         self,
+        *,
         occurrence_id: str,
         project_id: int,
         status: DetectorPriorityLevel,

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -220,12 +220,12 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
                     "value": value,
                 }
                 result = detector_occurrence.to_issue_occurrence(
-                    str(uuid4()),
-                    self.detector.project_id,
-                    new_status,
-                    datetime.now(UTC),
-                    evidence_data,
-                    self.build_fingerprint(group_key),
+                    occurrence_id=str(uuid4()),
+                    project_id=self.detector.project_id,
+                    status=new_status,
+                    detection_time=datetime.now(UTC),
+                    additional_evidence_data=evidence_data,
+                    fingerprint=self.build_fingerprint(group_key),
                 )
                 event_data["timestamp"] = result.detection_time
                 event_data["project_id"] = result.project_id

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -1,6 +1,7 @@
 import abc
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, TypeVar
+from uuid import uuid4
 
 from django.conf import settings
 from django.db.models import Q
@@ -15,6 +16,7 @@ from sentry.utils.iterators import chunked
 from sentry.workflow_engine.handlers.detector.base import (
     DetectorEvaluationResult,
     DetectorHandler,
+    DetectorOccurrence,
     DetectorStateData,
 )
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
@@ -63,8 +65,8 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
 
     @abc.abstractmethod
     def build_occurrence_and_event_data(
-        self, group_key: DetectorGroupKey, value: int, new_status: PriorityLevel
-    ) -> tuple[IssueOccurrence, dict[str, Any]]:
+        self, group_key: DetectorGroupKey, new_status: PriorityLevel
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
         pass
 
     def build_fingerprint(self, group_key) -> list[str]:
@@ -209,9 +211,29 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
                     new_substatus=None,
                 )
             else:
-                result, event_data = self.build_occurrence_and_event_data(
-                    group_key, value, PriorityLevel(new_status)
+                detector_occurrence, event_data = self.build_occurrence_and_event_data(
+                    group_key, PriorityLevel(new_status)
                 )
+                evidence_data = {
+                    **detector_occurrence.evidence_data,
+                    "detector_id": self.detector.id,
+                    "value": value,
+                }
+                result = detector_occurrence.to_issue_occurrence(
+                    str(uuid4()),
+                    self.detector.project_id,
+                    new_status,
+                    datetime.now(UTC),
+                    evidence_data,
+                    self.build_fingerprint(group_key),
+                )
+                event_data["timestamp"] = result.detection_time
+                event_data["project_id"] = result.project_id
+                event_data["event_id"] = result.event_id
+                event_data.setdefault("platform", "python")
+                event_data.setdefault("received", result.detection_time)
+                event_data.setdefault("tags", {})
+
             return DetectorEvaluationResult(
                 group_key=group_key,
                 is_active=is_active,

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -192,12 +192,12 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             "value": value,
         }
         issue_occurrence = detector_occurrence.to_issue_occurrence(
-            occurrence_id,
-            detector.project_id,
-            priority,
-            detection_time,
-            evidence_data,
-            fingerprint,
+            occurrence_id=occurrence_id,
+            project_id=detector.project_id,
+            status=priority,
+            detection_time=detection_time,
+            additional_evidence_data=evidence_data,
+            fingerprint=fingerprint,
         )
         event_data: dict[str, Any] = {}
         if hasattr(detector_occurrence, "event_data"):

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 from unittest import mock
 
@@ -7,7 +7,11 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.testutils.abstract import Abstract
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult, DetectorHandler
+from sentry.workflow_engine.handlers.detector import (
+    DetectorEvaluationResult,
+    DetectorHandler,
+    DetectorOccurrence,
+)
 from sentry.workflow_engine.handlers.detector.stateful import StatefulDetectorHandler
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
@@ -18,35 +22,19 @@ from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 def build_mock_occurrence_and_event(
     handler: StatefulDetectorHandler,
     group_key: DetectorGroupKey,
-    value: int,
     new_status: PriorityLevel,
-) -> tuple[IssueOccurrence, dict[str, Any]]:
+) -> tuple[DetectorOccurrence, dict[str, Any]]:
     assert handler.detector.group_type is not None
-    occurrence = IssueOccurrence(
-        id="eb4b0acffadb4d098d48cb14165ab578",
-        project_id=handler.detector.project_id,
-        event_id="43878ab4419f4ab181f6379ac376d5aa",
-        fingerprint=handler.build_fingerprint(group_key),
-        issue_title="Some Issue",
-        subtitle="Some subtitle",
-        resource_id=None,
-        evidence_data={},
-        evidence_display=[],
-        type=handler.detector.group_type,
-        detection_time=datetime.now(timezone.utc),
-        level="error",
-        culprit="Some culprit",
-        initial_issue_priority=new_status.value,
+    return (
+        DetectorOccurrence(
+            issue_title="Some Issue",
+            subtitle="Some subtitle",
+            type=handler.detector.group_type,
+            level="error",
+            culprit="Some culprit",
+        ),
+        {},
     )
-    event_data = {
-        "timestamp": occurrence.detection_time,
-        "project_id": occurrence.project_id,
-        "event_id": occurrence.event_id,
-        "platform": "python",
-        "received": occurrence.detection_time,
-        "tags": {},
-    }
-    return occurrence, event_data
 
 
 def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessage):
@@ -69,9 +57,9 @@ class MockDetectorStateHandler(StatefulDetectorHandler[dict]):
         return data_packet.packet.get("group_vals", {})
 
     def build_occurrence_and_event_data(
-        self, group_key: DetectorGroupKey, value: int, new_status: PriorityLevel
-    ) -> tuple[IssueOccurrence, dict[str, Any]]:
-        return build_mock_occurrence_and_event(self, group_key, value, new_status)
+        self, group_key: DetectorGroupKey, new_status: PriorityLevel
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        return build_mock_occurrence_and_event(self, group_key, new_status)
 
 
 class BaseDetectorHandlerTest(BaseGroupTypeTest):
@@ -83,6 +71,10 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             StatusChangeMessage, "__eq__", status_change_comparator
         )
         self.sm_comp_patcher.__enter__()
+        # Set up UUID mocking at the base class level
+        self.uuid_patcher = mock.patch("sentry.workflow_engine.handlers.detector.stateful.uuid4")
+        self.mock_uuid4 = self.uuid_patcher.start()
+        self.mock_uuid4.return_value = self.get_mock_uuid()
         project_id = self.project.id
 
         class NoHandlerGroupType(GroupType):
@@ -142,7 +134,8 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
     def tearDown(self):
         super().tearDown()
-        self.sm_comp_patcher.__exit__(None, None, None)
+        self.uuid_patcher.stop()
+        self.sm_comp_patcher.stop()
 
     def create_detector_and_conditions(self, type: str | None = None):
         if type is None:
@@ -181,3 +174,41 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             assert handler.state_updates.get(group_key) == (active, priority)
         else:
             assert group_key not in handler.state_updates
+
+    def detector_to_issue_occurrence(
+        self,
+        detector_occurrence: DetectorOccurrence,
+        detector: Detector,
+        group_key: DetectorGroupKey,
+        value: int,
+        priority: DetectorPriorityLevel,
+        detection_time: datetime,
+        occurrence_id: str,
+    ) -> tuple[IssueOccurrence, dict[str, Any]]:
+        fingerprint = [f"{detector.id}{':' + group_key if group_key is not None else ''}"]
+        evidence_data = {
+            **detector_occurrence.evidence_data,
+            "detector_id": detector.id,
+            "value": value,
+        }
+        issue_occurrence = detector_occurrence.to_issue_occurrence(
+            occurrence_id,
+            detector.project_id,
+            priority,
+            detection_time,
+            evidence_data,
+            fingerprint,
+        )
+        event_data: dict[str, Any] = {}
+        if hasattr(detector_occurrence, "event_data"):
+            event_data = (
+                detector_occurrence.event_data.copy() if detector_occurrence.event_data else {}
+            )
+
+        event_data["timestamp"] = detection_time
+        event_data["project_id"] = detector.project_id
+        event_data["event_id"] = occurrence_id
+        event_data.setdefault("platform", "python")
+        event_data.setdefault("received", detection_time)
+        event_data.setdefault("tags", {})
+        return issue_occurrence, event_data


### PR DESCRIPTION
We want to be able to put standard fields into `IssueOccurrence`. To do this, we'll have the detector return a `DetectorOccurrence` with a subset of fields from `build_occurrence_and_event_data`.

We might need to add more fields as we introduce more group types, but this is a starting point.
