### PR TITLE
feat(aci): add data condition nodes to automation builder

### DIFF
--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -1,5 +1,8 @@
 import {t} from 'sentry/locale';
-import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 
 export const FILTER_MATCH_OPTIONS = [
   {value: DataConditionGroupLogicType.ALL, label: t('all')},
@@ -7,10 +10,123 @@ export const FILTER_MATCH_OPTIONS = [
   {value: DataConditionGroupLogicType.NONE, label: t('none')},
 ];
 
+export const FILTER_DATA_CONDITION_TYPES = [
+  DataConditionType.AGE_COMPARISON,
+  DataConditionType.ISSUE_OCCURRENCES,
+  DataConditionType.ASSIGNED_TO,
+  DataConditionType.ISSUE_PRIORITY_EQUALS,
+  DataConditionType.LATEST_ADOPTED_RELEASE,
+  DataConditionType.LATEST_RELEASE,
+  DataConditionType.EVENT_ATTRIBUTE,
+  DataConditionType.TAGGED_EVENT,
+  DataConditionType.LEVEL,
+];
+
+export enum MatchType {
+  CONTAINS = 'co',
+  ENDS_WITH = 'ew',
+  EQUAL = 'eq',
+  GREATER_OR_EQUAL = 'gte',
+  GREATER = 'gt',
+  IS_SET = 'is',
+  IS_IN = 'in',
+  LESS_OR_EQUAL = 'lte',
+  LESS = 'lt',
+  NOT_CONTAINS = 'nc',
+  NOT_ENDS_WITH = 'new',
+  NOT_EQUAL = 'ne',
+  NOT_SET = 'ns',
+  NOT_STARTS_WITH = 'nsw',
+  NOT_IN = 'nin',
+  STARTS_WITH = 'sw',
+}
+
+export enum Assignee {
+  UNASSIGNED = 'Unassigned',
+  TEAM = 'Team',
+  MEMBER = 'Member',
+}
+
+export enum Priority {
+  LOW = 25,
+  MEDIUM = 50,
+  HIGH = 75,
+}
+
 export enum AgeComparison {
   OLDER = 'older',
   NEWER = 'newer',
 }
+
+export enum ModelAge {
+  OLDEST = 'oldest',
+  NEWEST = 'newest',
+}
+
+export enum Attributes {
+  MESSAGE = 'message',
+  PLATFORM = 'platform',
+  ENVIRONMENT = 'environment',
+  TYPE = 'type',
+  ERROR_HANDLED = 'error.handled',
+  ERROR_UNHANDLED = 'error.unhandled',
+  ERROR_MAIN_THREAD = 'error.main_thread',
+  EXCEPTION_TYPE = 'exception.type',
+  ERROR_VALUE = 'exception.value',
+  USER_ID = 'user.id',
+  USER_EMAIL = 'user.email',
+  USER_USERNAME = 'user.username',
+  USER_IP_ADDRESS = 'user.ip_address',
+  HTTP_METHOD = 'http.method',
+  HTTP_URL = 'http.url',
+  HTTP_STATUS_CODE = 'http.status_code',
+  SDK_NAME = 'sdk.name',
+  STACKTRACE_CODE = 'stacktrace.code',
+  STACKTRACE_MODULE = 'stacktrace.module',
+  STACKTRACE_FILENAME = 'stacktrace.filename',
+  STACKTRACE_ABS_PATH = 'stacktrace.abs_path',
+  STACKTRACE_PACKAGE = 'stacktrace.package',
+  UNREAL_CRASH_TYPE = 'unreal.crash_type',
+  APP_IN_FOREGROUND = 'app.in_foreground',
+  OS_DISTRIBUTION_NAME = 'os.distribution_name',
+  OS_DISTRIBUTION_VERSION = 'os.distribution_version',
+}
+
+export enum Level {
+  FATAL = 50,
+  ERROR = 40,
+  WARNING = 30,
+  INFO = 20,
+  DEBUG = 10,
+  SAMPLING = 0,
+}
+
+export const MATCH_CHOICES = [
+  {value: MatchType.CONTAINS, label: 'contains'},
+  {value: MatchType.EQUAL, label: 'equals'},
+  {value: MatchType.STARTS_WITH, label: 'starts with'},
+  {value: MatchType.ENDS_WITH, label: 'ends with'},
+  {value: MatchType.NOT_CONTAINS, label: 'does not contain'},
+  {value: MatchType.NOT_EQUAL, label: 'does not equal'},
+  {value: MatchType.NOT_STARTS_WITH, label: 'does not start with'},
+  {value: MatchType.NOT_ENDS_WITH, label: 'does not end with'},
+  {value: MatchType.IS_SET, label: 'is set'},
+  {value: MatchType.NOT_SET, label: 'is not set'},
+  {value: MatchType.IS_IN, label: 'is one of'},
+  {value: MatchType.NOT_IN, label: 'is not one of'},
+];
+
+export const ASSIGNEE_CHOICES = [
+  {value: Assignee.UNASSIGNED, label: t('unassigned')},
+  {value: Assignee.MEMBER, label: t('member')},
+  {value: Assignee.TEAM, label: t('team')},
+];
+
+export const PRIORITY_CHOICES = [
+  {value: Priority.HIGH, label: t('high')},
+  {value: Priority.MEDIUM, label: t('medium')},
+  {value: Priority.LOW, label: t('low')},
+];
 
 export const AGE_COMPARISON_CHOICES = [
   {
@@ -21,4 +137,29 @@ export const AGE_COMPARISON_CHOICES = [
     value: AgeComparison.NEWER,
     label: t('newer than'),
   },
+];
+
+export const MODEL_AGE_CHOICES = [
+  {
+    value: ModelAge.OLDEST,
+    label: t('oldest'),
+  },
+  {
+    value: ModelAge.NEWEST,
+    label: t('newest'),
+  },
+];
+
+export const LEVEL_MATCH_CHOICES = [
+  {value: MatchType.EQUAL, label: t('equals')},
+  {value: MatchType.NOT_EQUAL, label: t('does not equal')},
+];
+
+export const LEVEL_CHOICES = [
+  {value: Level.FATAL, label: t('fatal')},
+  {value: Level.ERROR, label: t('error')},
+  {value: Level.WARNING, label: t('warning')},
+  {value: Level.INFO, label: t('info')},
+  {value: Level.DEBUG, label: t('debug')},
+  {value: Level.SAMPLING, label: t('sampling')},
 ];

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -1,0 +1,74 @@
+import {t, tct} from 'sentry/locale';
+import {
+  Attributes,
+  MATCH_CHOICES,
+  type MatchType,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  InlineInputField,
+  InlineSelectControl,
+  selectControlStyles,
+  useDataConditionNodeContext,
+} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function EventAttributeNode() {
+  return tct("The event's [attribute] [match] [value]", {
+    attribute: <AttributeField />,
+    match: <MatchField />,
+    value: <ValueField />,
+  });
+}
+
+function AttributeField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.attribute`}
+      placeholder={t('attribute')}
+      value={condition.comparison.attribute}
+      options={Object.values(Attributes).map(attribute => ({
+        value: attribute,
+        label: attribute,
+      }))}
+      onChange={(value: Attributes) => {
+        onUpdate({
+          attribute: value,
+        });
+      }}
+    />
+  );
+}
+
+function MatchField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.match`}
+      value={condition.comparison.match}
+      options={MATCH_CHOICES}
+      onChange={(value: MatchType) => {
+        onUpdate({
+          match: value,
+        });
+      }}
+    />
+  );
+}
+
+function ValueField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineInputField
+      name={`${condition_id}.comparison.value`}
+      placeholder={t('value')}
+      value={condition.comparison.value}
+      onChange={(value: string) => {
+        onUpdate({
+          value,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -1,0 +1,29 @@
+import {tct} from 'sentry/locale';
+import {
+  type Priority,
+  PRIORITY_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  InlineSelectControl,
+  selectControlStyles,
+  useDataConditionNodeContext,
+} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function IssuePriorityNode() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return tct('Current issue priority is [level]', {
+    level: (
+      <InlineSelectControl
+        styles={selectControlStyles}
+        name={`${condition_id}.comparison`}
+        value={condition.comparison.match}
+        options={PRIORITY_CHOICES}
+        onChange={(value: Priority) => {
+          onUpdate({
+            match: value,
+          });
+        }}
+      />
+    ),
+  });
+}

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -1,0 +1,98 @@
+import {t, tct} from 'sentry/locale';
+import type {Environment} from 'sentry/types/project';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  AGE_COMPARISON_CHOICES,
+  type AgeComparison,
+  MODEL_AGE_CHOICES,
+  type ModelAge,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  InlineSelectControl,
+  selectControlStyles,
+  useDataConditionNodeContext,
+} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function LatestAdoptedReleaseNode() {
+  return tct(
+    "The [releaseAgeType] adopted release associated with the event's issue is [ageComparison] the latest adopted release in [environment]",
+    {
+      releaseAgeType: <ReleaseAgeTypeField />,
+      ageComparison: <AgeComparisonField />,
+      environment: <EnvironmentField />,
+    }
+  );
+}
+
+function ReleaseAgeTypeField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.releaseAgeType`}
+      value={condition.comparison.match}
+      options={MODEL_AGE_CHOICES}
+      onChange={(value: ModelAge) => {
+        onUpdate({
+          match: value,
+        });
+      }}
+    />
+  );
+}
+
+function AgeComparisonField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.ageComparison`}
+      value={condition.comparison.match}
+      options={AGE_COMPARISON_CHOICES}
+      onChange={(value: AgeComparison) => {
+        onUpdate({
+          match: value,
+        });
+      }}
+    />
+  );
+}
+
+function EnvironmentField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+
+  const {environments} = useOrganizationEnvironments();
+  const environmentOptions = environments.map(({id, name}) => ({
+    value: id,
+    label: name,
+  }));
+
+  return (
+    <InlineSelectControl
+      name={`${condition_id}.comparison.environment`}
+      value={condition.comparison.environment}
+      options={environmentOptions}
+      placeholder={t('environment')}
+      onChange={(value: string) => {
+        onUpdate({
+          environment: value,
+        });
+      }}
+    />
+  );
+}
+
+function useOrganizationEnvironments() {
+  const organization = useOrganization();
+  const {data: environments = [], isLoading} = useApiQuery<Environment[]>(
+    [
+      `/organizations/${organization.slug}/environments/`,
+      {query: {visibility: 'visible'}},
+    ],
+    {
+      staleTime: 30_000,
+    }
+  );
+  return {environments, isLoading};
+}

--- a/static/app/views/automations/components/actionFilters/level.tsx
+++ b/static/app/views/automations/components/actionFilters/level.tsx
@@ -1,0 +1,53 @@
+import {tct} from 'sentry/locale';
+import {
+  type Level,
+  LEVEL_CHOICES,
+  LEVEL_MATCH_CHOICES,
+  type MatchType,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  InlineSelectControl,
+  selectControlStyles,
+  useDataConditionNodeContext,
+} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function LevelNode() {
+  return tct("The event's level [match] [level]", {
+    match: <MatchField />,
+    level: <LevelField />,
+  });
+}
+
+function MatchField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.match`}
+      value={condition.comparison.match}
+      options={LEVEL_MATCH_CHOICES}
+      onChange={(value: MatchType) => {
+        onUpdate({
+          match: value,
+        });
+      }}
+    />
+  );
+}
+
+function LevelField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.level`}
+      value={condition.comparison.level}
+      options={LEVEL_CHOICES}
+      onChange={(value: Level) => {
+        onUpdate({
+          level: value,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -1,0 +1,68 @@
+import {t, tct} from 'sentry/locale';
+import {
+  MATCH_CHOICES,
+  type MatchType,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  InlineInputField,
+  InlineSelectControl,
+  selectControlStyles,
+  useDataConditionNodeContext,
+} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function TaggedEventNode() {
+  return tct("The event's [key] [match] [value]", {
+    key: <KeyField />,
+    match: <MatchField />,
+    value: <ValueField />,
+  });
+}
+
+function KeyField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineInputField
+      name={`${condition_id}.comparison.key`}
+      placeholder={t('tag')}
+      value={condition.comparison.key}
+      onChange={(value: string) => {
+        onUpdate({
+          key: value,
+        });
+      }}
+    />
+  );
+}
+
+function MatchField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineSelectControl
+      styles={selectControlStyles}
+      name={`${condition_id}.comparison.match`}
+      value={condition.comparison.match}
+      options={MATCH_CHOICES}
+      onChange={(value: MatchType) => {
+        onUpdate({
+          match: value,
+        });
+      }}
+    />
+  );
+}
+
+function ValueField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <InlineInputField
+      name={`${condition_id}.comparison.value`}
+      placeholder={t('value')}
+      value={condition.comparison.value}
+      onChange={(value: string) => {
+        onUpdate({
+          value,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -6,10 +6,16 @@ import SelectField from 'sentry/components/forms/fields/selectField';
 import {IconAdd, IconDelete, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {FILTER_MATCH_OPTIONS} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  FILTER_DATA_CONDITION_TYPES,
+  FILTER_MATCH_OPTIONS,
+} from 'sentry/views/automations/components/actionFilters/constants';
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import RuleNodeList from 'sentry/views/automations/components/ruleNodeList';
-import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
+import {
+  TRIGGER_DATA_CONDITION_TYPES,
+  TRIGGER_MATCH_OPTIONS,
+} from 'sentry/views/automations/components/triggers/constants';
 
 export default function AutomationBuilder() {
   const {state, actions} = useAutomationBuilderContext();
@@ -48,6 +54,8 @@ export default function AutomationBuilder() {
         </StepLead>
       </Step>
       <RuleNodeList
+        // TODO: replace constant dataConditionTypes with DataConditions API response
+        dataConditionTypes={TRIGGER_DATA_CONDITION_TYPES}
         placeholder={t('Select a trigger...')}
         conditions={state.triggers.conditions}
         group="triggers"
@@ -128,6 +136,8 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
             />
           </Flex>
           <RuleNodeList
+            // TODO: replace constant dataConditionTypes with DataConditions API response
+            dataConditionTypes={FILTER_DATA_CONDITION_TYPES}
             placeholder={t('Filter by...')}
             group={`actionFilters.${groupIndex}`}
             conditions={actionFilterBlock?.conditions || []}

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -1,6 +1,7 @@
 import {createContext, useContext} from 'react';
 import styled from '@emotion/styled';
 
+import InputField from 'sentry/components/forms/fields/inputField';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import {t} from 'sentry/locale';
@@ -9,7 +10,11 @@ import {
   type NewDataCondition,
 } from 'sentry/types/workflowEngine/dataConditions';
 import AgeComparisonNode from 'sentry/views/automations/components/actionFilters/ageComparison';
+import {AssignedToNode} from 'sentry/views/automations/components/actionFilters/assignedTo';
+import EventAttributeNode from 'sentry/views/automations/components/actionFilters/eventAttribute';
 import IssueOccurrencesNode from 'sentry/views/automations/components/actionFilters/issueOccurrences';
+import LatestAdoptedReleaseNode from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
+import TaggedEventNode from 'sentry/views/automations/components/actionFilters/taggedEvent';
 
 interface DataConditionNodeProps {
   condition: NewDataCondition;
@@ -58,7 +63,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
   [
     DataConditionType.AGE_COMPARISON,
     {
-      label: t('Compare the age of an issue'),
+      label: t('Issue age'),
       dataCondition: <AgeComparisonNode />,
     },
   ],
@@ -69,7 +74,52 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       dataCondition: <IssueOccurrencesNode />,
     },
   ],
+  [
+    DataConditionType.ASSIGNED_TO,
+    {
+      label: t('Issue assignment'),
+      dataCondition: <AssignedToNode />,
+    },
+  ],
+  [
+    DataConditionType.LATEST_ADOPTED_RELEASE,
+    {
+      label: t('Release age'),
+      dataCondition: <LatestAdoptedReleaseNode />,
+    },
+  ],
+  [
+    DataConditionType.LATEST_RELEASE,
+    {
+      label: t('Latest release'),
+      dataCondition: t('The issue is from the latest release'),
+    },
+  ],
+  [
+    DataConditionType.EVENT_ATTRIBUTE,
+    {
+      label: t('Event attribute'),
+      dataCondition: <EventAttributeNode />,
+    },
+  ],
+  [
+    DataConditionType.TAGGED_EVENT,
+    {
+      label: t('Tagged event'),
+      dataCondition: <TaggedEventNode />,
+    },
+  ],
 ]);
+
+export const InlineInputField = styled(InputField)`
+  padding: 0;
+  width: 180px;
+  height: 28px;
+  min-height: 28px;
+  > div {
+    padding-left: 0;
+  }
+`;
 
 export const InlineNumberInput = styled(NumberField)`
   padding: 0;

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -10,7 +10,6 @@ import {
   type NewDataCondition,
 } from 'sentry/types/workflowEngine/dataConditions';
 import AgeComparisonNode from 'sentry/views/automations/components/actionFilters/ageComparison';
-import {AssignedToNode} from 'sentry/views/automations/components/actionFilters/assignedTo';
 import EventAttributeNode from 'sentry/views/automations/components/actionFilters/eventAttribute';
 import IssueOccurrencesNode from 'sentry/views/automations/components/actionFilters/issueOccurrences';
 import LatestAdoptedReleaseNode from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
@@ -72,13 +71,6 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Issue frequency'),
       dataCondition: <IssueOccurrencesNode />,
-    },
-  ],
-  [
-    DataConditionType.ASSIGNED_TO,
-    {
-      label: t('Issue assignment'),
-      dataCondition: <AssignedToNode />,
     },
   ],
   [

--- a/static/app/views/automations/components/ruleNodeList.tsx
+++ b/static/app/views/automations/components/ruleNodeList.tsx
@@ -11,6 +11,7 @@ import RuleNode from 'sentry/views/automations/components/ruleNode';
 
 interface RuleNodeListProps {
   conditions: NewDataCondition[];
+  dataConditionTypes: DataConditionType[];
   group: string;
   onAddRow: (type: DataConditionType) => void;
   onDeleteRow: (id: number) => void;
@@ -18,13 +19,8 @@ interface RuleNodeListProps {
   updateCondition: (index: number, condition: Record<string, any>) => void;
 }
 
-// TODO: only show data conditions that are returned by the API
-const options = Array.from(dataConditionNodesMap, ([key, value]) => ({
-  value: key,
-  label: value.label,
-}));
-
 export default function RuleNodeList({
+  dataConditionTypes,
   group,
   placeholder,
   conditions,
@@ -32,6 +28,11 @@ export default function RuleNodeList({
   onDeleteRow,
   updateCondition,
 }: RuleNodeListProps) {
+  const options = Array.from(dataConditionNodesMap, ([key, value]) => ({
+    value: key,
+    label: value.label,
+  })).filter(option => dataConditionTypes.includes(option.value));
+
   return (
     <Fragment>
       {conditions.map((condition, i) => (

--- a/static/app/views/automations/components/ruleNodeList.tsx
+++ b/static/app/views/automations/components/ruleNodeList.tsx
@@ -28,10 +28,9 @@ export default function RuleNodeList({
   onDeleteRow,
   updateCondition,
 }: RuleNodeListProps) {
-  const options = Array.from(dataConditionNodesMap, ([key, value]) => ({
-    value: key,
-    label: value.label,
-  })).filter(option => dataConditionTypes.includes(option.value));
+  const options = Array.from(dataConditionNodesMap.entries())
+    .map(([value, {label}]) => ({value, label}))
+    .filter(({value}) => dataConditionTypes.includes(value));
 
   return (
     <Fragment>

--- a/static/app/views/automations/components/triggers/constants.tsx
+++ b/static/app/views/automations/components/triggers/constants.tsx
@@ -1,7 +1,16 @@
 import {t} from 'sentry/locale';
-import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 
 export const TRIGGER_MATCH_OPTIONS = [
   {value: DataConditionGroupLogicType.ALL, label: t('all')},
   {value: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT, label: t('any')},
+];
+
+export const TRIGGER_DATA_CONDITION_TYPES = [
+  DataConditionType.FIRST_SEEN_EVENT,
+  DataConditionType.REGRESSION_EVENT,
+  DataConditionType.REAPPEARED_EVENT,
 ];


### PR DESCRIPTION
added more data condition nodes:
- event attribute
- issue priority
- latest adopted release
- latest release
- level
- tagged event

also added a `dataCondition` prop to `ruleNodeList` to specify which conditions to display as dropdown options