### PR TITLE
nav: chonk compat for legacy nav

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -665,7 +665,8 @@ const PrimaryItems = styled('div')`
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
     border-bottom: 1px solid ${p => p.theme.sidebar.border};
     padding-bottom: ${space(1)};
-    box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
+    box-shadow: ${p =>
+      p.theme.isChonk ? 'none' : 'rgba(0, 0, 0, 0.15) 0px -10px 10px inset'};
   }
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     overflow-y: hidden;
@@ -673,10 +674,11 @@ const PrimaryItems = styled('div')`
     flex-direction: row;
     height: 100%;
     align-items: center;
-    border-right: 1px solid ${p => p.theme.sidebar.border};
     padding-right: ${space(1)};
     margin-right: ${space(0.5)};
-    box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
+    border-right: none;
+    box-shadow: ${p =>
+      p.theme.isChonk ? 'none' : 'rgba(0, 0, 0, 0.15) -10px 0px 10px inset'};
     ::-webkit-scrollbar {
       display: none;
     }

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -19,6 +19,7 @@ import {ExpandedContext} from 'sentry/components/sidebar/expandedContextProvider
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {isChonkTheme} from 'sentry/utils/theme/withChonk';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMedia from 'sentry/utils/useMedia';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -275,7 +276,7 @@ const SidebarAccordionExpandButton = styled(Button)<{sidebarCollapsed?: boolean}
   &:hover,
   a:hover &,
   a[active] & {
-    color: ${p => p.theme.white};
+    color: ${p => (isChonkTheme(p.theme) ? p.theme.colors.blue400 : p.theme.white)};
   }
 
   ${p => p.sidebarCollapsed && `display: none;`}

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -214,7 +214,7 @@ const OrgOrUserName = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeLarge};
   line-height: 1.2;
   font-weight: ${p => p.theme.fontWeightBold};
-  color: ${p => (isChonkTheme(p.theme) ? p.theme.black : p.theme.white)};
+  color: ${p => (isChonkTheme(p.theme) ? p.theme.textColor : p.theme.white)};
   text-shadow: ${p =>
     isChonkTheme(p.theme) ? 'none' : '0 0 6px rgba(255, 255, 255, 0)'};
   transition: 0.15s text-shadow linear;
@@ -241,7 +241,7 @@ const SidebarDropdownActor = styled('button')`
         isChonkTheme(p.theme) ? 'none' : '0 0 6px rgba(255, 255, 255, 0.1)'};
     }
     ${UserNameOrEmail} {
-      color: ${p => (isChonkTheme(p.theme) ? p.theme.black : p.theme.white)};
+      color: ${p => (isChonkTheme(p.theme) ? p.theme.textColor : p.theme.white)};
     }
   }
 `;

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -23,6 +23,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
+import {isChonkTheme} from 'sentry/utils/theme/withChonk';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -213,8 +214,9 @@ const OrgOrUserName = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeLarge};
   line-height: 1.2;
   font-weight: ${p => p.theme.fontWeightBold};
-  color: ${p => p.theme.white};
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0);
+  color: ${p => (isChonkTheme(p.theme) ? p.theme.black : p.theme.white)};
+  text-shadow: ${p =>
+    isChonkTheme(p.theme) ? 'none' : '0 0 6px rgba(255, 255, 255, 0)'};
   transition: 0.15s text-shadow linear;
 `;
 
@@ -235,10 +237,11 @@ const SidebarDropdownActor = styled('button')`
 
   &:hover {
     ${OrgOrUserName} {
-      text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
+      text-shadow: ${p =>
+        isChonkTheme(p.theme) ? 'none' : '0 0 6px rgba(255, 255, 255, 0.1)'};
     }
     ${UserNameOrEmail} {
-      color: ${p => p.theme.white};
+      color: ${p => (isChonkTheme(p.theme) ? p.theme.black : p.theme.white)};
     }
   }
 `;
@@ -246,7 +249,7 @@ const SidebarDropdownActor = styled('button')`
 const AvatarStyles = (p: {collapsed: boolean; theme: Theme}) => css`
   margin: ${space(0.25)} 0;
   margin-right: ${p.collapsed ? '0' : space(1.5)};
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.08);
+  box-shadow: ${isChonkTheme(p.theme) ? 'none' : '0 2px 0 rgba(0, 0, 0, 0.08)'};
   border-radius: 6px; /* Fixes background bleeding on corners */
 
   @media (max-width: ${p.theme.breakpoints.medium}) {

--- a/static/app/components/sidebar/sidebarDropdownMenu.styled.tsx
+++ b/static/app/components/sidebar/sidebarDropdownMenu.styled.tsx
@@ -6,9 +6,11 @@ const SidebarDropdownMenu = (p: {theme: Theme}) => css`
   background: ${p.theme.background};
   color: ${p.theme.textColor};
   border-radius: 4px;
-  box-shadow:
-    0 0 0 1px rgba(0, 0, 0, 0.08),
-    0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  border: ${p.theme.isChonk ? `1px solid ${p.theme.border}` : 'none'};
+  border-bottom: ${p.theme.isChonk ? `2px solid ${p.theme.border}` : 'none'};
+  box-shadow: ${p.theme.isChonk
+    ? 'none'
+    : '0 0 0 1px rgba(0, 0, 0, 0.08), 0 4px 20px 0 rgba(0, 0, 0, 0.3)'};
   padding: 5px 0;
   width: 250px;
   z-index: 1000;

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1142,11 +1142,11 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
   },
 
   sidebar: {
-    background: lightAliases.background,
+    background: darkAliases.background,
     scrollbarThumbColor: '#A0A0A0',
     scrollbarColorTrack: 'rgba(45,26,50,92.42)', // end of the gradient which is used for background
-    gradient: `none`,
-    border: 'transparent',
+    gradient: darkAliases.background,
+    border: darkAliases.border,
     superuser: '#880808',
   },
 };

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1072,7 +1072,7 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
     scrollbarThumbColor: '#A0A0A0',
     scrollbarColorTrack: 'rgba(45,26,50,92.42)', // end of the gradient which is used for background
     gradient: lightAliases.background,
-    border: 'transparent',
+    border: lightAliases.border,
     superuser: '#880808',
   },
 };


### PR DESCRIPTION
Backwards compat for the legacy nav, so that we can decouple chonk launch from the nav launch. Chonk uses a light navbar here, so the colors need to be inverted (we were using a lot of white and black colors)
