### PR TITLE
fix(workflow_engine): Add the `name` of the workflow to serialized output

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -351,6 +351,7 @@ class WorkflowSerializer(Serializer):
     def serialize(self, obj: Workflow, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
         return {
             "id": str(obj.id),
+            "name": str(obj.name),
             "organizationId": str(obj.organization_id),
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -404,6 +404,7 @@ class TestWorkflowSerializer(TestCase):
 
         assert result == {
             "id": str(workflow.id),
+            "name": str(workflow.name),
             "organizationId": str(self.organization.id),
             "config": {},
             "dateCreated": workflow.date_added,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -346,6 +346,7 @@ class TestWorkflowSerializer(TestCase):
 
         assert result == {
             "id": str(workflow.id),
+            "name": str(workflow.name),
             "organizationId": str(self.organization.id),
             "config": {},
             "dateCreated": workflow.date_added,


### PR DESCRIPTION
## Description
Looks like the name field was missed in the initialize serializer work. Just adding it in before the demo this afternoon.