### PR TITLE
update copy around allowed domains field

### DIFF
--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -58,7 +58,7 @@ export default function ProjectToolbarSettings({
               {t('Domains where the dev toolbar is allowed to access your data.')}
               <br />
               {t(
-                'Protocol and port are optional; wildcard subdomains (*) are are supported.'
+                'Protocol and port are optional; wildcard subdomains (*) are supported.'
               )}
               <br />
               {tct(


### PR DESCRIPTION
Just removing double `are` words.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
