### PR TITLE
fix(trace-view): Hide runtime label in event highlights

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -56,8 +56,8 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
   const shouldDisplayDevice =
     isMobilePlatform(projectPlatform) || isNativePlatform(projectPlatform);
 
-  // Errors thrown on the backend of a Meta-Framework (e.g. Next.js) also include the client context
-  const isMetaFrameworkBackendIssue =
+  // Events from the backend of a Meta-Framework (e.g. Next.js) also include the client context
+  const isMetaFrameworkBackendEvent =
     Object.keys(event.contexts).includes('client_os') &&
     Object.keys(event.contexts).includes('os');
 
@@ -81,8 +81,8 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
     }))
     .filter((item, _index, array) => {
       if (
-        // Hide client information in backend issues (always prefer `os` over `client_os`)
-        isMetaFrameworkBackendIssue &&
+        // Hide client information in backend events (always prefer `os` over `client_os`)
+        isMetaFrameworkBackendEvent &&
         (item.contextType === 'browser' || item.alias === 'client_os')
       ) {
         return false;

--- a/static/app/components/events/highlights/util.spec.tsx
+++ b/static/app/components/events/highlights/util.spec.tsx
@@ -89,6 +89,7 @@ describe('getHighlightTagData', function () {
 describe('getRuntimeLabel', function () {
   it('returns null for non-JavaScript SDK events', function () {
     const event = EventFixture({
+      type: 'error',
       sdk: {name: 'python'},
     });
 
@@ -97,6 +98,7 @@ describe('getRuntimeLabel', function () {
 
   it('returns null for javascript issues without context information', function () {
     const event = EventFixture({
+      type: 'error',
       sdk: {name: 'javascript'},
     });
 
@@ -105,6 +107,7 @@ describe('getRuntimeLabel', function () {
 
   it('returns inferred runtime from browser context', function () {
     const frontendEvent = EventFixture({
+      type: 'error',
       sdk: {name: 'javascript'},
       contexts: {
         browser: {name: 'Chrome'},
@@ -127,6 +130,7 @@ describe('getRuntimeLabel', function () {
     'returns correct runtime label and tooltip for %s runtime',
     (runtimeName, expectedTooltip) => {
       const event = EventFixture({
+        type: 'error',
         sdk: {name: 'javascript'},
         contexts: {
           runtime: {name: runtimeName},
@@ -142,8 +146,21 @@ describe('getRuntimeLabel', function () {
 
   it('returns null when no runtime can be determined', function () {
     const event = EventFixture({
+      type: 'error',
       sdk: {name: 'javascript'},
       contexts: {}, // No browser or runtime context
+    });
+
+    expect(getRuntimeLabelAndTooltip(event)).toBeNull();
+  });
+
+  it('returns null when it is not an error event', function () {
+    const event = EventFixture({
+      type: 'transaction',
+      sdk: {name: 'javascript'},
+      contexts: {
+        browser: {name: 'Chrome'},
+      },
     });
 
     expect(getRuntimeLabelAndTooltip(event)).toBeNull();

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -174,12 +174,12 @@ export function getHighlightTagData({
 
 /**
  * Returns a label that can be used in the Event Highlight Summary.
- * Currently only used for JavaScript-based events.
+ * Currently only used for JavaScript-based error events.
  */
 export function getRuntimeLabelAndTooltip(
   event: Event
 ): {label: string; tooltip: string} | null {
-  if (!event.sdk?.name?.includes('javascript')) {
+  if (event.type !== 'error' || !event.sdk?.name?.includes('javascript')) {
     return null;
   }
 


### PR DESCRIPTION
Hide the Frontend/Backend runtime label in the trace view.
