### PR TITLE
fix(seer-rpc): Don't extract function name, simplify ifs

### DIFF
--- a/src/sentry/seer/fetch_issues/fetch_issues.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues.py
@@ -43,7 +43,7 @@ The number of previous days from now to find issues and events.
 This number is global so that fetching issues and events is consistent.
 """
 
-STACKFRAME_COUNT = 4
+STACKFRAME_COUNT = 20
 """
 The number of stack frames to check for function name and file name matches.
 """

--- a/src/sentry/seer/fetch_issues/more_parsing.py
+++ b/src/sentry/seer/fetch_issues/more_parsing.py
@@ -1,11 +1,21 @@
 import re
 
+from snuba_sdk import Condition, Op
+
 from sentry.integrations.source_code_management.language_parsers import (
     PATCH_PARSERS,
     LanguageParser,
     PythonParser,
     SimpleLanguageParser,
+    stackframe_function_name,
 )
+
+
+def simple_function_name_conditions(
+    function_names: list[str],
+    stack_frame_idx: int,
+):
+    return Condition(stackframe_function_name(stack_frame_idx), Op.IN, function_names)
 
 
 class PythonParserMore(PythonParser):


### PR DESCRIPTION
Have been debugging why the issue fetching query sometimes breaks, and it seems like it's related to the more complicated parsers. Wanna see whether a simpler query works.

Seer never uses the `function_name`, so it can be safely removed