### PR TITLE
feat(router): Prevent scroll reset on browserHistory.replace

### DIFF
--- a/static/app/utils/browserHistory.tsx
+++ b/static/app/utils/browserHistory.tsx
@@ -70,7 +70,13 @@ export function DANGEROUS_SET_REACT_ROUTER_6_HISTORY(router: Router) {
   // functions to keep things working
   const compat6BrowserHistory: History = {
     push: to => router.navigate(locationDescriptorToTo(to)),
-    replace: to => router.navigate(locationDescriptorToTo(to), {replace: true}),
+    replace: to =>
+      router.navigate(locationDescriptorToTo(to), {
+        replace: true,
+        // Note that useNavigate replace does not automatically prevent scroll reset
+        // Here we're replicating the behavior of react router 3
+        preventScrollReset: true,
+      }),
     go: n => router.navigate(n),
     goBack: () => router.navigate(-1),
     goForward: () => router.navigate(1),


### PR DESCRIPTION
We've started scrolling back to the top on navigation when we added [ScrollRestoration](https://reactrouter.com/6.30.0/components/scroll-restoration)

Prevents scroll from going back to the top of the page when using browserHistory.replace. In this case the trace viewer is using it here in this class

https://github.com/getsentry/sentry/blob/515d2a1ad9d7e6ae4e5cbc9cc89a264cc2b9d0ef/static/app/views/performance/newTraceDetails/traceWaterfall.tsx#L340-L346