### PR TITLE
chore(metric alerts): Zoom out alert chart for anomaly detection

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -224,10 +224,14 @@ def build_metric_alert_chart(
             "end": timezone.now().strftime(TIME_FORMAT),
         }
 
+    # Force dynamic alerts to display the past 14 days of data
     if alert_context.detection_type == AlertRuleDetectionType.DYNAMIC:
-        time_period["start"] = (open_period_context.date_started - timedelta(days=14)).strftime(
-            TIME_FORMAT
-        )
+        end_dt = datetime.strptime(time_period["end"], TIME_FORMAT)
+        start_dt = end_dt - timedelta(days=14)
+        time_period = {
+            "start": start_dt.strftime(TIME_FORMAT),
+            "end": time_period["end"],
+        }
 
     chart_data = {
         "rule": alert_rule_serialized_response,

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -224,6 +224,11 @@ def build_metric_alert_chart(
             "end": timezone.now().strftime(TIME_FORMAT),
         }
 
+    if alert_context.detection_type == AlertRuleDetectionType.DYNAMIC:
+        time_period["start"] = (open_period_context.date_started - timedelta(days=14)).strftime(
+            TIME_FORMAT
+        )
+
     chart_data = {
         "rule": alert_rule_serialized_response,
         "selectedIncident": selected_incident_serialized,


### PR DESCRIPTION
- Make Dynamic Alert metric alert charts display 14 days worth of data
    - Received feedback that charts are too zoomed in so everything looked like a false postive. Upon zooming out, it was clear that there is an anomaly.