### PR TITLE
feat(issue-views): Add new view page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2203,6 +2203,10 @@ function buildRoutes() {
           () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')
         )}
       />
+      <Route
+        path="views/new/"
+        component={make(() => import('sentry/views/issueList/newViewPage'))}
+      />
       <Route path="views/:viewId/" component={errorHandler(OverviewWrapper)} />
       <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
 

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -291,6 +291,10 @@ export type IssueEventParameters = {
   'issue_views.deleted_view': Record<string, unknown>;
   'issue_views.discarded_changes': Record<string, unknown>;
   'issue_views.duplicated_view': Record<string, unknown>;
+  'issue_views.new_view.suggested_query_clicked': {
+    query: string;
+    query_label: string;
+  };
   'issue_views.page_filters_logged': {
     user_id: string;
   };
@@ -483,6 +487,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.temp_view_saved': 'Issue Views: Temporary View Saved',
   'issue_views.page_filters_logged': 'Issue Views: Page Filters Logged',
   'issue_views.table.sort_changed': 'Issue Views: Changed Sort',
+  'issue_views.new_view.suggested_query_clicked': 'Issue Views: Suggested Query Clicked',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',
   'issue.search_sidebar_clicked': 'Issue Search Sidebar Clicked',

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -307,6 +307,7 @@ export type IssueEventParameters = {
     query: string;
   };
   'issue_views.switched_views': Record<string, unknown>;
+  'issue_views.table.create_view_clicked': Record<string, unknown>;
   'issue_views.table.sort_changed': {
     sort: string;
   };
@@ -487,6 +488,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.temp_view_saved': 'Issue Views: Temporary View Saved',
   'issue_views.page_filters_logged': 'Issue Views: Page Filters Logged',
   'issue_views.table.sort_changed': 'Issue Views: Changed Sort',
+  'issue_views.table.create_view_clicked': 'Issue Views: Create View Clicked',
   'issue_views.new_view.suggested_query_clicked': 'Issue Views: Suggested Query Clicked',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -11,9 +11,12 @@ import type {PageFilters} from 'sentry/types/core';
 import type {SavedSearch} from 'sentry/types/group';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {useLocation} from 'sentry/utils/useLocation';
 import IssueListActions from 'sentry/views/issueList/actions';
 import AddViewPage from 'sentry/views/issueList/addViewPage';
 import GroupListBody from 'sentry/views/issueList/groupListBody';
+import {isNewViewPage} from 'sentry/views/issueList/issueViews/utils';
+import {NewViewEmptyState} from 'sentry/views/issueList/newViewEmptyState';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
@@ -23,6 +26,7 @@ interface IssueListTableProps {
   error: string | null;
   groupIds: string[];
   issuesLoading: boolean;
+  issuesSuccessfullyLoaded: boolean;
   memberList: IndexedMembersByProject;
   onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
   onCursor: CursorHandler;
@@ -62,8 +66,20 @@ function IssueListTable({
   paginationAnalyticsEvent,
   personalSavedSearches,
   organizationSavedSearches,
+  issuesSuccessfullyLoaded,
 }: IssueListTableProps) {
+  const location = useLocation();
   const {newViewActive} = useContext(NewTabContext);
+
+  const isNewViewEmptyStateActive =
+    isNewViewPage(location.pathname) &&
+    !issuesLoading &&
+    !error &&
+    !issuesSuccessfullyLoaded;
+
+  if (isNewViewEmptyStateActive) {
+    return <NewViewEmptyState />;
+  }
 
   return newViewActive ? (
     <AddViewPage

--- a/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
@@ -2,7 +2,6 @@ import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
-import selectEvent from 'sentry-test/selectEvent';
 
 import {
   makeClosableHeader,
@@ -21,6 +20,17 @@ describe('CreateIssueViewModal', function () {
     Footer: ModalFooter,
     CloseButton: makeCloseButton(jest.fn()),
     closeModal: jest.fn(),
+    projects: [2],
+    environments: ['env2'],
+    timeFilters: {
+      period: '30d',
+      start: null,
+      end: null,
+      utc: null,
+    },
+    query: 'is:unresolved foo',
+    querySort: IssueSortOptions.TRENDS,
+    starred: false,
   };
 
   it('can create a new view', async function () {
@@ -71,28 +81,6 @@ describe('CreateIssueViewModal', function () {
 
     const nameInput = screen.getByRole('textbox', {name: 'Name'});
     await userEvent.type(nameInput, 'foo');
-
-    // Set project
-    await userEvent.click(screen.getByRole('button', {name: 'project-1'}));
-    await userEvent.click(screen.getByRole('row', {name: 'project-2'}));
-
-    // Set environment
-    await userEvent.click(screen.getByRole('button', {name: 'All Envs'}));
-    await userEvent.click(screen.getByRole('row', {name: 'env2'}));
-
-    // Set time range
-    await userEvent.click(screen.getByRole('button', {name: '14D'}));
-    await userEvent.click(screen.getByRole('option', {name: 'Last 30 days'}));
-
-    // Add "foo" after "is:unresolved"
-    await userEvent.click(
-      screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)!
-    );
-    await userEvent.keyboard('foo{enter}');
-
-    // Set sort
-    const select = screen.getByRole('textbox', {name: 'Sort'});
-    await selectEvent.select(select, ['Trends']);
 
     await userEvent.click(screen.getByRole('button', {name: 'Create View'}));
 

--- a/static/app/views/issueList/issueViews/createIssueViewModal.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.tsx
@@ -1,26 +1,17 @@
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
-import SelectField from 'sentry/components/forms/fields/selectField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import FormField from 'sentry/components/forms/formField';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getUtcDateString} from 'sentry/utils/dates';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
-import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
-import {getSortLabel, IssueSortOptions} from 'sentry/views/issueList/utils';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 interface CreateIssueViewModalProps
   extends ModalRenderProps,
@@ -30,19 +21,6 @@ interface CreateIssueViewModalProps
         'query' | 'querySort' | 'projects' | 'environments' | 'timeFilters'
       >
     > {}
-
-const sortOptions = [
-  IssueSortOptions.DATE,
-  IssueSortOptions.NEW,
-  IssueSortOptions.TRENDS,
-  IssueSortOptions.FREQ,
-  IssueSortOptions.USER,
-];
-
-const selectFieldSortOptions = sortOptions.map(sortOption => ({
-  value: sortOption,
-  label: getSortLabel(sortOption),
-}));
 
 export function CreateIssueViewModal({
   Header,
@@ -132,109 +110,6 @@ export function CreateIssueViewModal({
           required
           autoFocus
         />
-        <PageFiltersContainer disablePersistence skipLoadLastUsed>
-          {!defined(incomingProjects) && (
-            <FormField
-              key="projects"
-              name="projects"
-              label={t('Projects')}
-              inline={false}
-              stacked
-              flexibleControlStateSize
-            >
-              {({onChange, onBlur, disabled}) => (
-                <ProjectPageFilter
-                  disabled={disabled}
-                  onChange={newValue => {
-                    onChange(newValue, {});
-                    onBlur(newValue, {});
-                  }}
-                />
-              )}
-            </FormField>
-          )}
-          {!defined(incomingEnvironments) && (
-            <FormField
-              key="environments"
-              name="environments"
-              label={t('Environments')}
-              inline={false}
-              stacked
-              flexibleControlStateSize
-            >
-              {({onChange, onBlur, disabled}) => (
-                <EnvironmentPageFilter
-                  disabled={disabled}
-                  onChange={newValue => {
-                    onChange(newValue, {});
-                    onBlur(newValue, {});
-                  }}
-                />
-              )}
-            </FormField>
-          )}
-
-          {!defined(incomingTimeFilters) && (
-            <FormField
-              key="timeFilters"
-              name="timeFilters"
-              label={t('Time Range')}
-              inline={false}
-              stacked
-              flexibleControlStateSize
-            >
-              {({onChange, onBlur, disabled}) => (
-                <DatePageFilter
-                  disabled={disabled}
-                  onChange={newValue => {
-                    const convertedValue = {
-                      period: newValue.relative ?? null,
-                      start: newValue.start ? getUtcDateString(newValue.start) : null,
-                      end: newValue.end ? getUtcDateString(newValue.end) : null,
-                      utc: newValue.utc ?? null,
-                    };
-                    onChange(convertedValue, {});
-                    onBlur(convertedValue, {});
-                  }}
-                />
-              )}
-            </FormField>
-          )}
-        </PageFiltersContainer>
-        {!defined(incomingQuery) && (
-          <FormField
-            key="query"
-            name="query"
-            label={t('Query')}
-            inline={false}
-            stacked
-            flexibleControlStateSize
-          >
-            {({onChange, onBlur, disabled, value}) => (
-              <IssueListSearchBar
-                organization={organization}
-                onChange={newValue => {
-                  onChange(newValue, {});
-                  onBlur(newValue, {});
-                }}
-                disabled={disabled}
-                initialQuery={value}
-                searchSource="saved_searches_modal"
-              />
-            )}
-          </FormField>
-        )}
-        {!defined(incomingQuerySort) && (
-          <SelectField
-            key="querySort"
-            name="querySort"
-            options={selectFieldSortOptions}
-            label={t('Sort')}
-            inline={false}
-            stacked
-            flexibleControlStateSize
-          />
-        )}
         <BooleanField
           key="starred"
           name="starred"

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -1,8 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {openModal} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/core/button';
+import {Button, LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -18,7 +17,6 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {CreateIssueViewModal} from 'sentry/views/issueList/issueViews/createIssueViewModal';
 import {IssueViewsTable} from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsTable';
 import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
 import {
@@ -210,19 +208,14 @@ export default function IssueViewsList() {
                 {t('Give Feedback')}
               </Button>
             ) : null}
-            <Button
+            <LinkButton
+              to={`/organizations/${organization.slug}/issues/views/new/`}
               priority="primary"
               icon={<IconAdd />}
               size="sm"
-              onClick={() => {
-                trackAnalytics('issue_views.create_view_clicked', {
-                  organization,
-                });
-                openModal(props => <CreateIssueViewModal {...props} />);
-              }}
             >
               {t('Create View')}
-            </Button>
+            </LinkButton>
           </ButtonBar>
         </Layout.HeaderActions>
       </Layout.Header>

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -213,6 +213,11 @@ export default function IssueViewsList() {
               priority="primary"
               icon={<IconAdd />}
               size="sm"
+              onClick={() => {
+                trackAnalytics('issue_views.table.create_view_clicked', {
+                  organization,
+                });
+              }}
             >
               {t('Create View')}
             </LinkButton>

--- a/static/app/views/issueList/issueViews/utils.tsx
+++ b/static/app/views/issueList/issueViews/utils.tsx
@@ -1,6 +1,16 @@
 import type {User} from 'sentry/types/user';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
+const NEW_VIEW_PAGE_REGEX = /\/issues\/views\/new\/?$/;
+
+/**
+ * Returns true if the current path is the "New View" page
+ * /issues/views/new/
+ */
+export function isNewViewPage(pathname: string) {
+  return NEW_VIEW_PAGE_REGEX.test(pathname);
+}
+
 export function canEditIssueView({
   groupSearchView,
   user,

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -10,13 +10,14 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {EditableIssueViewHeader} from 'sentry/views/issueList/editableIssueViewHeader';
 import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
-import {canEditIssueView} from 'sentry/views/issueList/issueViews/utils';
+import {canEditIssueView, isNewViewPage} from 'sentry/views/issueList/issueViews/utils';
 import {useDeleteGroupSearchView} from 'sentry/views/issueList/mutations/useDeleteGroupSearchView';
 import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
 import {makeFetchGroupSearchViewKey} from 'sentry/views/issueList/queries/useFetchGroupSearchView';
@@ -29,6 +30,7 @@ type LeftNavViewsHeaderProps = {
 
 function PageTitle() {
   const organization = useOrganization();
+  const location = useLocation();
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const user = useUser();
   const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
@@ -43,6 +45,10 @@ function PageTitle() {
 
   if (groupSearchView) {
     return <Layout.Title>{groupSearchView?.name ?? t('Issues')}</Layout.Title>;
+  }
+
+  if (isNewViewPage(location.pathname)) {
+    return <Layout.Title>{t('New View')}</Layout.Title>;
   }
 
   return <Layout.Title>{t('Issues')}</Layout.Title>;

--- a/static/app/views/issueList/newViewEmptyState.tsx
+++ b/static/app/views/issueList/newViewEmptyState.tsx
@@ -1,0 +1,149 @@
+import styled from '@emotion/styled';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Panel from 'sentry/components/panels/panel';
+import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type SearchSuggestion = {
+  label: string;
+  query: string;
+};
+
+const RECOMMENDED_SEARCHES: SearchSuggestion[] = [
+  {label: t('Prioritized'), query: 'is:unresolved issue.priority:[high, medium]'},
+  {label: t('Assigned to Me'), query: 'is:unresolved assigned_or_suggested:me'},
+  {
+    label: t('For Review'),
+    query: 'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
+  },
+  {label: t('Request Errors'), query: 'is:unresolved http.status_code:5*'},
+  {label: t('High Volume Issues'), query: 'is:unresolved timesSeen:>100'},
+  {label: t('Recent Errors'), query: 'is:unresolved issue.category:error firstSeen:-24h'},
+  {label: t('Function Regressions'), query: 'issue.type:profile_function_regression'},
+];
+
+function Query({label, query}: SearchSuggestion) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const setQuery = () => {
+    navigate({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        query,
+      },
+    });
+
+    trackAnalytics('issue_views.new_view.suggested_query_clicked', {
+      query,
+      query_label: label,
+      organization,
+    });
+  };
+
+  return (
+    <QueryRow>
+      <QueryButton onClick={setQuery}>
+        <InteractionStateLayer />
+        <div>{label}</div>
+        <div>
+          <FormattedQuery query={query} />
+        </div>
+      </QueryButton>
+    </QueryRow>
+  );
+}
+
+export function NewViewEmptyState() {
+  return (
+    <Wrapper>
+      <Card>
+        <CardHeading>{t('Suggested Queries')}</CardHeading>
+        <p>{t('Here are a few to get you started.')}</p>
+        <QueryGrid>
+          {RECOMMENDED_SEARCHES.map(query => (
+            <Query key={query.query} {...query} />
+          ))}
+        </QueryGrid>
+      </Card>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: ${space(4)};
+`;
+
+const Card = styled(Panel)`
+  background-color: ${p => p.theme.backgroundSecondary};
+  padding: ${space(2)};
+`;
+
+const CardHeading = styled('h2')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin-bottom: ${space(1)};
+`;
+
+const QueryGrid = styled('ul')`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: ${space(2)};
+  margin: 0 -${space(2)};
+  padding: 0;
+`;
+
+const QueryRow = styled('li')`
+  position: relative;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1/-1;
+  list-style: none;
+
+  &:not(:last-child) {
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      border-bottom: 1px solid ${p => p.theme.innerBorder};
+    }
+  }
+`;
+
+const QueryButton = styled('button')`
+  position: relative;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1/-1;
+  font-weight: ${p => p.theme.fontWeightNormal};
+  background: none;
+  border: none;
+  margin: 0;
+  width: 100%;
+  text-align: left;
+  padding: ${space(1)} ${space(2)};
+  border-radius: 0;
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${p => p.theme.button.default.focusBorder};
+  }
+`;
+
+const FormattedQuery = styled(ProvidedFormattedQuery)`
+  position: relative;
+`;

--- a/static/app/views/issueList/newViewPage.tsx
+++ b/static/app/views/issueList/newViewPage.tsx
@@ -1,0 +1,26 @@
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import useOrganization from 'sentry/utils/useOrganization';
+import IssueListContainer from 'sentry/views/issueList';
+import IssueListOverview from 'sentry/views/issueList/overview';
+
+type Props = RouteComponentProps;
+
+export default function NewViewPage(props: Props) {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={t('New View')} orgSlug={organization.slug}>
+      <IssueListContainer>
+        <PageFiltersContainer skipLoadLastUsed disablePersistence skipInitializeUrlParams>
+          <NoProjectMessage organization={organization}>
+            <IssueListOverview {...props} />
+          </NoProjectMessage>
+        </PageFiltersContainer>
+      </IssueListContainer>
+    </SentryDocumentTitle>
+  );
+}

--- a/static/app/views/issueList/newViewPage.tsx
+++ b/static/app/views/issueList/newViewPage.tsx
@@ -17,7 +17,7 @@ export default function NewViewPage(props: Props) {
       <IssueListContainer>
         <PageFiltersContainer skipLoadLastUsed disablePersistence skipInitializeUrlParams>
           <NoProjectMessage organization={organization}>
-            <IssueListOverview {...props} />
+            <IssueListOverview {...props} shouldFetchOnMount={false} initialQuery="" />
           </NoProjectMessage>
         </PageFiltersContainer>
       </IssueListContainer>

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1483,15 +1483,20 @@ describe('IssueList', function () {
         },
       });
 
-      const {router: testRouter} = render(<IssueListOverview {...routerProps} />, {
-        enableRouterMocks: false,
-        initialRouterConfig: {
-          location: {
-            pathname: '/organizations/org-slug/issues/views/new/',
+      const {router: testRouter} = render(
+        <IssueListOverview {...routerProps} initialQuery="" shouldFetchOnMount={false} />,
+        {
+          enableRouterMocks: false,
+          initialRouterConfig: {
+            ...initialRouterConfig,
+            location: {
+              ...initialRouterConfig.location,
+              pathname: '/organizations/org-slug/issues/views/new/',
+              query: {},
+            },
           },
-          route: '/organizations/:orgId/issues/views/new/',
-        },
-      });
+        }
+      );
 
       await screen.findByText('Suggested Queries');
       expect(fetchDataMock).not.toHaveBeenCalled();

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1472,4 +1472,41 @@ describe('IssueList', function () {
       });
     });
   });
+
+  describe('new view page', function () {
+    it('displays empty state when first loaded', async function () {
+      const fetchDataMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [group],
+        headers: {
+          Link: DEFAULT_LINKS_HEADER,
+        },
+      });
+
+      const {router: testRouter} = render(<IssueListOverview {...routerProps} />, {
+        enableRouterMocks: false,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/issues/views/new/',
+          },
+          route: '/organizations/:orgId/issues/views/new/',
+        },
+      });
+
+      await screen.findByText('Suggested Queries');
+      expect(fetchDataMock).not.toHaveBeenCalled();
+
+      const highVolumeIssuesQuery = screen.getByRole('button', {
+        name: 'High Volume Issues is:unresolved timesSeen:>100',
+      });
+
+      // Clicking query should add it, remove suggested queries, and search issues
+      await userEvent.click(highVolumeIssuesQuery);
+      await waitFor(() => {
+        expect(testRouter.location.query.query).toBe('is:unresolved timesSeen:>100');
+      });
+      expect(fetchDataMock).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('Suggested Queries')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -10,6 +10,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {IssueViewParams} from 'sentry/views/issueList/issueViews/issueViews';
+import {isNewViewPage} from 'sentry/views/issueList/issueViews/utils';
 import {useUpdateGroupSearchViewStarredOrder} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewAddViewButton} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton';
@@ -92,6 +93,11 @@ export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps)
           {t('All Views')}
         </SecondaryNav.Item>
       )}
+      {isNewViewPage(location.pathname) ? (
+        <SecondaryNav.Item to={`${baseUrl}/views/new/`} isActive>
+          {t('New View')}
+        </SecondaryNav.Item>
+      ) : null}
     </SecondaryNav.Section>
   );
 }

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -4,7 +4,6 @@ import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useFetchStarredGroupSearchViews} from 'sentry/views/issueList/queries/useFetchStarredGroupSearchViews';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewNavItems} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
@@ -13,11 +12,6 @@ import {PrimaryNavGroup} from 'sentry/views/nav/types';
 export function IssuesSecondaryNav() {
   const organization = useOrganization();
   const sectionRef = useRef<HTMLDivElement>(null);
-
-  const {data: starredGroupSearchViews} = useFetchStarredGroupSearchViews({
-    orgSlug: organization.slug,
-  });
-
   const baseUrl = `/organizations/${organization.slug}/issues`;
 
   return (
@@ -37,9 +31,7 @@ export function IssuesSecondaryNav() {
             {t('Feedback')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        {starredGroupSearchViews && (
-          <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
-        )}
+        <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>
     </SecondaryNav>

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -31,7 +31,9 @@ export function IssuesSecondaryNav() {
             {t('Feedback')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
+        {organization.features.includes('issue-stream-custom-views') && (
+          <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
+        )}
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>
     </SecondaryNav>


### PR DESCRIPTION
Instead of using a modal for the new view creation (from the all views page), we want a seaparate page to handle this (located at `/issues/views/new/`). It works very similarly to the feed, but has a different title and displays an empty state with recommended queries.

![CleanShot 2025-04-18 at 11 37 26@2x](https://github.com/user-attachments/assets/cad580ce-d737-493c-88da-548f9997281a)
