### PR TITLE
test(ui): Extend time for ArithmeticBuilder test

### DIFF
--- a/static/app/components/arithmeticBuilder/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/index.spec.tsx
@@ -72,8 +72,8 @@ describe('ArithmeticBuilder', function () {
       await waitFor(focus);
     }
 
-    expect(screen.queryAllByRole('row')).toHaveLength(1);
-  });
+    await waitFor(() => expect(screen.queryAllByRole('row')).toHaveLength(1));
+  }, 20_000);
 
   it('can delete tokens with backspace', async function () {
     const expression = '( sum(span.duration) + count(span.self_time) )';


### PR DESCRIPTION
It seems to take about 5 seconds https://sentry.sentry.io/explore/discover/trace/81354710e5c2edba895727db2c4c0a81/?node=txn-90fd309e29894f679c354b20e10d1ad2
