### PR TITLE
fix(issue-views): Update endpoint to sort null last_visited values correctly

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
-from django.db.models import Count, Q
+from django.db.models import Count, F, Q
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -37,8 +37,8 @@ class MemberPermission(OrganizationPermission):
 SORT_MAP = {
     "popularity": "popularity",
     "-popularity": "-popularity",
-    "visited": "groupsearchviewlastvisited__last_visited",
-    "-visited": "-groupsearchviewlastvisited__last_visited",
+    "visited": F("groupsearchviewlastvisited__last_visited").asc(nulls_first=True),
+    "-visited": F("groupsearchviewlastvisited__last_visited").desc(nulls_last=True),
     "name": "name",
     "-name": "-name",
     "created": "date_added",

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1214,25 +1214,27 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         )
         view_2 = self.create_view(user=self.user_1, last_visited=timezone.now() - timedelta(days=1))
         view_3 = self.create_view(user=self.user_1, last_visited=timezone.now() - timedelta(days=2))
+        view_4 = self.create_view(user=self.user_1, last_visited=None)
 
         response = self.client.get(self.url, {"createdBy": "me"})
         assert response.status_code == 200
-        assert len(response.data) == 3
+        assert len(response.data) == 4
         # =============   Starred views   =============
         assert response.data[0]["id"] == str(view_1.id), response.data[0]["starred"]
         # ============= Non-starred views =============
         assert response.data[1]["id"] == str(view_2.id), not response.data[1]["starred"]
         assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
-
+        assert response.data[3]["id"] == str(view_4.id), not response.data[3]["starred"]
         response = self.client.get(self.url, {"createdBy": "me", "sort": "visited"})
 
         assert response.status_code == 200
-        assert len(response.data) == 3
+        assert len(response.data) == 4
         # =============   Starred views   =============
         assert response.data[0]["id"] == str(view_1.id), response.data[0]["starred"]
         # ============= Non-starred views =============
-        assert response.data[1]["id"] == str(view_3.id), not response.data[1]["starred"]
-        assert response.data[2]["id"] == str(view_2.id), not response.data[2]["starred"]
+        assert response.data[1]["id"] == str(view_4.id), not response.data[1]["starred"]
+        assert response.data[2]["id"] == str(view_3.id), not response.data[2]["starred"]
+        assert response.data[3]["id"] == str(view_2.id), not response.data[3]["starred"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})


### PR DESCRIPTION
Sorting by recently viewed was putting null values at the top, which is not the intended result. this ensure that last_visited desc sorts null values at the bottom, and the opposite for ascending.