### PR TITLE
fix(profiling): Preserve selected function in side panel when collapsing

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -172,7 +172,9 @@ export function TransactionProfilesContent(props: TransactionProfilesContentProp
                   </RequestStateMessageContainer>
                 ) : null}
               </ProfileVisualizationContainer>
-              {showSidePanel && <AggregateFlamegraphSidePanel scheduler={scheduler} />}
+              <div style={showSidePanel ? {} : {display: 'none'}}>
+                <AggregateFlamegraphSidePanel scheduler={scheduler} />
+              </div>
             </TransactionProfilesContentContainer>
           </FlamegraphProvider>
         </FlamegraphThemeProvider>

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -277,7 +277,9 @@ export function LandingAggregateFlamegraph(): React.ReactNode {
                   />
                 )}
               </AggregateFlamegraphContainer>
-              {showSidePanel && <AggregateFlamegraphSidePanel scheduler={scheduler} />}
+              <div style={showSidePanel ? {} : {display: 'none'}}>
+                <AggregateFlamegraphSidePanel scheduler={scheduler} />
+              </div>
             </AggregateFlamegraphLayout>
           </FlamegraphProvider>
         </FlamegraphThemeProvider>


### PR DESCRIPTION
Previously, the side panel component is unmounted causing it to lose state when remounting. Here, we opt to hide the component when collapsing to preserve state.