### PR TITLE
feat(aci): WorkflowGroupHistory endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -6,8 +6,6 @@ from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -19,23 +17,15 @@ from sentry.apidocs.parameters import GlobalParams, WorkflowParams
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowEndpoint,
+)
 from sentry.workflow_engine.endpoints.serializers import WorkflowSerializer
 from sentry.workflow_engine.models import Workflow
 
 
 @region_silo_endpoint
-class OrganizationWorkflowDetailsEndpoint(OrganizationEndpoint):
-    def convert_args(self, request: Request, workflow_id, *args, **kwargs):
-        args, kwargs = super().convert_args(request, *args, **kwargs)
-        try:
-            kwargs["workflow"] = Workflow.objects.get(
-                organization=kwargs["organization"], id=workflow_id
-            )
-        except Workflow.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        return args, kwargs
-
+class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_group_history.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_group_history.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime
-from typing import TypedDict, cast
-
-from django.db.models import Count, Max, OuterRef, Subquery
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -13,71 +8,18 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams, WorkflowParams
 from sentry.exceptions import InvalidParams
-from sentry.models.group import Group
 from sentry.models.organization import Organization
-from sentry.utils.cursors import Cursor, CursorResult
 from sentry.workflow_engine.endpoints.organization_workflow_index import (
     OrganizationWorkflowEndpoint,
 )
-from sentry.workflow_engine.endpoints.serializers import (
-    WorkflowGroupHistory,
-    WorkflowGroupHistorySerializer,
-)
-from sentry.workflow_engine.models import Workflow, WorkflowFireHistory
-
-
-class _Result(TypedDict):
-    group: int
-    count: int
-    last_triggered: datetime
-    event_id: str
-
-
-def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory]:
-    group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
-    return [
-        WorkflowGroupHistory(
-            group_lookup[r["group"]], r["count"], r["last_triggered"], r["event_id"]
-        )
-        for r in results
-    ]
-
-
-def fetch_workflow_groups_paginated(
-    workflow: Workflow,
-    start: datetime,
-    end: datetime,
-    cursor: Cursor | None = None,
-    per_page: int = 25,
-) -> CursorResult[Group]:
-    filtered_history = WorkflowFireHistory.objects.filter(
-        workflow=workflow,
-        date_added__gte=start,
-        date_added__lt=end,
-    )
-
-    # subquery that retrieves row with the largest date in a group
-    group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
-    qs = (
-        filtered_history.select_related("group")
-        .values("group")
-        .annotate(count=Count("group"))
-        .annotate(event_id=Subquery(group_max_dates.values("event_id")))
-        .annotate(last_triggered=Max("date_added"))
-    )
-
-    return cast(
-        CursorResult[Group],
-        OffsetPaginator(
-            qs, order_by=("-count", "-last_triggered"), on_results=convert_results
-        ).get_result(per_page, cursor),
-    )
+from sentry.workflow_engine.endpoints.serializers import WorkflowGroupHistorySerializer
+from sentry.workflow_engine.models import Workflow
+from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_groups_paginated
 
 
 @region_silo_endpoint

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_group_history.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_group_history.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, TypedDict, cast
+
+from django.db.models import Count, Max, OuterRef, Subquery
+from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import Serializer, serialize
+from sentry.api.serializers.models.group import BaseGroupSerializerResponse
+from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, WorkflowParams
+from sentry.exceptions import InvalidParams
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.utils.cursors import Cursor, CursorResult
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowEndpoint,
+)
+from sentry.workflow_engine.models import Workflow, WorkflowFireHistory
+
+
+@dataclass(frozen=True)
+class WorkflowGroupHistory:
+    group: Group
+    count: int
+    last_triggered: datetime
+    event_id: str
+
+
+class _Result(TypedDict):
+    group: int
+    count: int
+    last_triggered: datetime
+    event_id: str
+
+
+def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory]:
+    group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
+    return [
+        WorkflowGroupHistory(
+            group_lookup[r["group"]], r["count"], r["last_triggered"], r["event_id"]
+        )
+        for r in results
+    ]
+
+
+def fetch_workflow_groups_paginated(
+    workflow: Workflow,
+    start: datetime,
+    end: datetime,
+    cursor: Cursor | None = None,
+    per_page: int = 25,
+) -> CursorResult[Group]:
+    filtered_history = WorkflowFireHistory.objects.filter(
+        workflow=workflow,
+        date_added__gte=start,
+        date_added__lt=end,
+    )
+
+    # subquery that retrieves row with the largest date in a group
+    group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
+    qs = (
+        filtered_history.select_related("group")
+        .values("group")
+        .annotate(count=Count("group"))
+        .annotate(event_id=Subquery(group_max_dates.values("event_id")))
+        .annotate(last_triggered=Max("date_added"))
+    )
+
+    return cast(
+        CursorResult[Group],
+        OffsetPaginator(
+            qs, order_by=("-count", "-last_triggered"), on_results=convert_results
+        ).get_result(per_page, cursor),
+    )
+
+
+class WorkflowFireHistoryResponse(TypedDict):
+    group: BaseGroupSerializerResponse
+    count: int
+    lastTriggered: datetime
+    eventId: str
+
+
+class WorkflowGroupHistorySerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[WorkflowFireHistory], user: Any, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
+        serialized_groups = {
+            g["id"]: g for g in serialize([item.group for item in item_list], user)
+        }
+        return {
+            history: {"group": serialized_groups[str(history.group.id)]} for history in item_list
+        }
+
+    def serialize(
+        self, obj: WorkflowGroupHistory, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
+    ) -> WorkflowFireHistoryResponse:
+        return {
+            "group": attrs["group"],
+            "count": obj.count,
+            "lastTriggered": obj.last_triggered,
+            "eventId": obj.event_id,
+        }
+
+
+@region_silo_endpoint
+class OrganizationWorkflowGroupHistoryEndpoint(OrganizationWorkflowEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    @extend_schema(
+        operation_id="Retrieve Group Firing History for a Workflow",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            WorkflowParams.WORKFLOW_ID,
+        ],
+        responses={
+            200: WorkflowGroupHistorySerializer,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, organization: Organization, workflow: Workflow) -> Response:
+        per_page = self.get_per_page(request)
+        cursor = self.get_cursor_from_request(request)
+        try:
+            start, end = get_date_range_from_params(request.GET)
+        except InvalidParams:
+            raise ParseError(detail="Invalid start and end dates")
+
+        results = fetch_workflow_groups_paginated(workflow, start, end, cursor, per_page)
+
+        response = Response(
+            serialize(results.results, request.user, WorkflowGroupHistorySerializer())
+        )
+        self.add_cursor_headers(request, response, results)
+        return response

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,5 +1,9 @@
 from django.urls import re_path
 
+from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
+    OrganizationWorkflowGroupHistoryEndpoint,
+)
+
 from .organization_available_action_index import OrganizationAvailableActionIndexEndpoint
 from .organization_data_condition_index import OrganizationDataConditionIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
@@ -44,6 +48,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/$",
         OrganizationWorkflowDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/fire-history$",
+        OrganizationWorkflowGroupHistoryEndpoint.as_view(),
+        name="sentry-api-0-organization-workflow-group-history",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/data-conditions/$",

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -50,7 +50,7 @@ organization_urlpatterns = [
         name="sentry-api-0-organization-workflow-details",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/fire-history$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/group-history$",
         OrganizationWorkflowGroupHistoryEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-group-history",
     ),

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import TypedDict, cast
+
+from django.db.models import Count, Max, OuterRef, Subquery
+
+from sentry.api.paginator import OffsetPaginator
+from sentry.models.group import Group
+from sentry.utils.cursors import Cursor, CursorResult
+from sentry.workflow_engine.endpoints.serializers import WorkflowGroupHistory
+from sentry.workflow_engine.models import Workflow, WorkflowFireHistory
+
+
+class _Result(TypedDict):
+    group: int
+    count: int
+    last_triggered: datetime
+    event_id: str
+
+
+def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory]:
+    group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
+    return [
+        WorkflowGroupHistory(
+            group_lookup[r["group"]], r["count"], r["last_triggered"], r["event_id"]
+        )
+        for r in results
+    ]
+
+
+def fetch_workflow_groups_paginated(
+    workflow: Workflow,
+    start: datetime,
+    end: datetime,
+    cursor: Cursor | None = None,
+    per_page: int = 25,
+) -> CursorResult[Group]:
+    filtered_history = WorkflowFireHistory.objects.filter(
+        workflow=workflow,
+        date_added__gte=start,
+        date_added__lt=end,
+    )
+
+    # subquery that retrieves row with the largest date in a group
+    group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
+    qs = (
+        filtered_history.select_related("group")
+        .values("group")
+        .annotate(count=Count("group"))
+        .annotate(event_id=Subquery(group_max_dates.values("event_id")))
+        .annotate(last_triggered=Max("date_added"))
+    )
+
+    return cast(
+        CursorResult[Group],
+        OffsetPaginator(
+            qs, order_by=("-count", "-last_triggered"), on_results=convert_results
+        ).get_result(per_page, cursor),
+    )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sentry.api.serializers import serialize
+from sentry.rules.history.base import RuleGroupHistory
+from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
+    WorkflowGroupHistory,
+    WorkflowGroupHistorySerializer,
+)
+from sentry.workflow_engine.models import WorkflowFireHistory
+
+pytestmark = [requires_snuba]
+
+
+class RuleGroupHistorySerializerTest(TestCase):
+    def test(self):
+        current_date = datetime.now()
+        group_history = RuleGroupHistory(self.group, 50, current_date)
+        result = serialize([group_history], self.user, WorkflowGroupHistorySerializer())
+        assert result == [
+            {
+                "group": serialize(self.group, self.user),
+                "count": group_history.count,
+                "lastTriggered": current_date,
+                "eventId": None,
+            }
+        ]
+
+
+@freeze_time()
+class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-workflow-group-history"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.group = self.create_group()
+        self.project = self.group.project
+        self.organization = self.project.organization
+
+        self.history: list[WorkflowFireHistory] = []
+        self.workflow = self.create_workflow(organization=self.organization)
+        for i in range(3):
+            self.history.append(
+                WorkflowFireHistory(workflow=self.workflow, group=self.group, event_id=uuid4().hex)
+            )
+        self.group_2 = self.create_group()
+        self.history.append(
+            WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
+        )
+        histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
+
+        # manually update date_added
+        for i in range(3):
+            histories[i].update(date_added=before_now(days=i + 1))
+        histories[-1].update(date_added=before_now(days=1))
+
+        self.base_triggered_date = before_now(days=1)
+
+        self.login_as(self.user)
+
+    def test_simple(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            start=before_now(days=6),
+            end=before_now(days=0),
+        )
+        assert resp.data == serialize(
+            [
+                WorkflowGroupHistory(
+                    self.group, 3, self.base_triggered_date, self.history[0].event_id
+                ),
+                WorkflowGroupHistory(
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                ),
+            ],
+            self.user,
+            WorkflowGroupHistorySerializer(),
+        )
+
+    def test_pagination(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            per_page=1,
+        )
+        assert resp.data == serialize(
+            [
+                WorkflowGroupHistory(
+                    self.group, 3, self.base_triggered_date, self.history[0].event_id
+                )
+            ],
+            self.user,
+            WorkflowGroupHistorySerializer(),
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            per_page=1,
+            cursor=self.get_cursor_headers(resp)[1],
+        )
+        assert resp.data == serialize(
+            [
+                WorkflowGroupHistory(
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                )
+            ],
+            self.user,
+            WorkflowGroupHistorySerializer(),
+        )
+
+    def test_invalid_dates(self):
+        self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            start=before_now(days=0),
+            end=before_now(days=6),
+            status_code=400,
+        )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,13 +1,9 @@
-from datetime import timedelta
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
-    fetch_workflow_groups_paginated,
-)
 from sentry.workflow_engine.endpoints.serializers import (
     WorkflowGroupHistory,
     WorkflowGroupHistorySerializer,
@@ -38,149 +34,16 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.history.append(
             WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
         )
-        self.group_3 = self.create_group()
-        for i in range(2):
-            self.history.append(
-                WorkflowFireHistory(
-                    workflow=self.workflow,
-                    group=self.group_3,
-                    event_id=uuid4().hex,
-                )
-            )
-        self.workflow_2 = self.create_workflow(organization=self.organization)
-        self.history.append(
-            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
-        )
-
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 
         # manually update date_added
         for i in range(3):
             histories[i].update(date_added=before_now(days=i + 1))
-        histories[3].update(date_added=before_now(days=1))
-        for i in range(2):
-            histories[i + 4].update(date_added=before_now(days=i + 1))
-        histories[-1].update(date_added=before_now(days=0))
+        histories[-1].update(date_added=before_now(days=1))
 
         self.base_triggered_date = before_now(days=1)
 
         self.login_as(self.user)
-
-    def assert_correct_pagination(self, rule, start, end, expected, cursor=None, per_page=25):
-        result = fetch_workflow_groups_paginated(rule, start, end, cursor, per_page)
-        assert result.results == expected, (result.results, expected)
-        return result
-
-    def test_workflow_groups_paginated(self):
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=3,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=2,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-            ],
-        )
-        result = self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=3,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-            ],
-            per_page=1,
-        )
-        result = self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=2,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-            ],
-            cursor=result.next,
-            per_page=1,
-        )
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-            ],
-            cursor=result.next,
-            per_page=1,
-        )
-
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=1),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-            ],
-        )
-
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=3),
-            before_now(days=2),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=1,
-                    last_triggered=self.base_triggered_date - timedelta(days=2),
-                    event_id=self.history[2].event_id,
-                ),
-            ],
-        )
 
     def test_simple(self):
         resp = self.get_success_response(
@@ -195,10 +58,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                     self.group, 3, self.base_triggered_date, self.history[0].event_id
                 ),
                 WorkflowGroupHistory(
-                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
-                ),
-                WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[3].event_id
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
                 ),
             ],
             self.user,
@@ -234,14 +94,14 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
-                ),
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                )
             ],
             self.user,
             WorkflowGroupHistorySerializer(),
         )
 
-    def test_invalid_dates(self):
+    def test_invalid_dates_error(self):
         self.get_error_response(
             self.organization.slug,
             self.workflow.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -14,7 +14,7 @@ pytestmark = [requires_snuba]
 
 
 @freeze_time()
-class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
+class WorkflowGroupHistoryEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-workflow-group-history"
 
     def setUp(self):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
@@ -5,6 +6,9 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
+    fetch_workflow_groups_paginated,
+)
+from sentry.workflow_engine.endpoints.serializers import (
     WorkflowGroupHistory,
     WorkflowGroupHistorySerializer,
 )
@@ -34,16 +38,149 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.history.append(
             WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
         )
+        self.group_3 = self.create_group()
+        for i in range(2):
+            self.history.append(
+                WorkflowFireHistory(
+                    workflow=self.workflow,
+                    group=self.group_3,
+                    event_id=uuid4().hex,
+                )
+            )
+        self.workflow_2 = self.create_workflow(organization=self.organization)
+        self.history.append(
+            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
+        )
+
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 
         # manually update date_added
         for i in range(3):
             histories[i].update(date_added=before_now(days=i + 1))
-        histories[-1].update(date_added=before_now(days=1))
+        histories[3].update(date_added=before_now(days=1))
+        for i in range(2):
+            histories[i + 4].update(date_added=before_now(days=i + 1))
+        histories[-1].update(date_added=before_now(days=0))
 
         self.base_triggered_date = before_now(days=1)
 
         self.login_as(self.user)
+
+    def assert_correct_pagination(self, rule, start, end, expected, cursor=None, per_page=25):
+        result = fetch_workflow_groups_paginated(rule, start, end, cursor, per_page)
+        assert result.results == expected, (result.results, expected)
+        return result
+
+    def test_workflow_groups_paginated(self):
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+        )
+        result = self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+            ],
+            per_page=1,
+        )
+        result = self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=1),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+        )
+
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=3),
+            before_now(days=2),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date - timedelta(days=2),
+                    event_id=self.history[2].event_id,
+                ),
+            ],
+        )
 
     def test_simple(self):
         resp = self.get_success_response(
@@ -58,7 +195,10 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                     self.group, 3, self.base_triggered_date, self.history[0].event_id
                 ),
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
+                ),
+                WorkflowGroupHistory(
+                    self.group_2, 1, self.base_triggered_date, self.history[3].event_id
                 ),
             ],
             self.user,
@@ -94,8 +234,8 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
-                )
+                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
+                ),
             ],
             self.user,
             WorkflowGroupHistorySerializer(),

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,9 +1,7 @@
-from datetime import datetime
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
-from sentry.rules.history.base import RuleGroupHistory
-from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
@@ -13,21 +11,6 @@ from sentry.workflow_engine.endpoints.organization_workflow_group_history import
 from sentry.workflow_engine.models import WorkflowFireHistory
 
 pytestmark = [requires_snuba]
-
-
-class RuleGroupHistorySerializerTest(TestCase):
-    def test(self):
-        current_date = datetime.now()
-        group_history = RuleGroupHistory(self.group, 50, current_date)
-        result = serialize([group_history], self.user, WorkflowGroupHistorySerializer())
-        assert result == [
-            {
-                "group": serialize(self.group, self.user),
-                "count": group_history.count,
-                "lastTriggered": current_date,
-                "eventId": None,
-            }
-        ]
 
 
 @freeze_time()

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -1,0 +1,184 @@
+from datetime import timedelta
+from uuid import uuid4
+
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.endpoints.serializers import WorkflowGroupHistory
+from sentry.workflow_engine.models import WorkflowFireHistory
+from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_groups_paginated
+
+pytestmark = [requires_snuba]
+
+
+@freeze_time()
+class WorkflowFireHistoryProcessorTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.group = self.create_group()
+        self.project = self.group.project
+        self.organization = self.project.organization
+
+        self.history: list[WorkflowFireHistory] = []
+        self.workflow = self.create_workflow(organization=self.organization)
+        for i in range(3):
+            self.history.append(
+                WorkflowFireHistory(workflow=self.workflow, group=self.group, event_id=uuid4().hex)
+            )
+        self.group_2 = self.create_group()
+        self.history.append(
+            WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
+        )
+        self.group_3 = self.create_group()
+        for i in range(2):
+            self.history.append(
+                WorkflowFireHistory(
+                    workflow=self.workflow,
+                    group=self.group_3,
+                    event_id=uuid4().hex,
+                )
+            )
+        self.workflow_2 = self.create_workflow(organization=self.organization)
+        self.history.append(
+            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
+        )
+
+        histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
+
+        # manually update date_added
+        for i in range(3):
+            histories[i].update(date_added=before_now(days=i + 1))
+        histories[3].update(date_added=before_now(days=1))
+        for i in range(2):
+            histories[i + 4].update(date_added=before_now(days=i + 1))
+        histories[-1].update(date_added=before_now(days=0))
+
+        self.base_triggered_date = before_now(days=1)
+
+        self.login_as(self.user)
+
+    def assert_expected_results(
+        self, workflow, start, end, expected_results, cursor=None, per_page=25
+    ):
+        result = fetch_workflow_groups_paginated(workflow, start, end, cursor, per_page)
+        assert result.results == expected_results, (result.results, expected_results)
+        return result
+
+    def test_workflow_groups_paginated__simple(self):
+        self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+        )
+
+    def test_workflow_groups_paginated__cursor(self):
+        result = self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+            ],
+            per_page=1,
+        )
+        # use the cursor to get the next page
+        result = self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+        # get the next page
+        self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=6),
+            end=before_now(days=0),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+
+    def test_workflow_groups_paginated__filters_counts(self):
+        # Test that the count is updated if the date range affects it
+        self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=1),
+            end=before_now(days=0),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+        )
+
+    def test_workflow_groups_paginated__past_date_range(self):
+        self.assert_expected_results(
+            workflow=self.workflow,
+            start=before_now(days=3),
+            end=before_now(days=2),
+            expected_results=[
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date - timedelta(days=2),
+                    event_id=self.history[2].event_id,
+                ),
+            ],
+        )


### PR DESCRIPTION
The workflow engine equivalent of `ProjectRuleGroupHistory` endpoint (the logic is basically the same too) -- which fetches and serialized the `Groups` that have been triggered for a `Workflow`, along with _when_ they were last triggered, _how many times_ they were triggered in the queried period, and the last `event_id` they triggered with.