### PR TITLE
fix(feedback): fix typing for shims from v2 to v1

### DIFF
--- a/src/sentry/feedback/lib/types.py
+++ b/src/sentry/feedback/lib/types.py
@@ -1,8 +1,9 @@
 from typing import NotRequired, TypedDict
 
 
-# Use for weak type checking of user report data. Keys correspond to fields of the UserReport model.
 class UserReportDict(TypedDict):
+    """Use for weak type checking of user report data. Keys correspond to fields of the UserReport model."""
+
     event_id: str
     comments: str
     # required for the model, but functions usually infer this from an explicit Project argument.

--- a/src/sentry/feedback/lib/types.py
+++ b/src/sentry/feedback/lib/types.py
@@ -1,12 +1,14 @@
 from typing import NotRequired, TypedDict
 
 
+# Use for weak type checking of user report data. Keys correspond to fields of the UserReport model.
 class UserReportDict(TypedDict):
     event_id: str
-    project_id: int
     comments: str
+    # required for the model, but functions usually infer this from an explicit Project argument.
+    project_id: NotRequired[int]
     name: NotRequired[str]
     email: NotRequired[str]
-    environment_id: NotRequired[int]
+    environment_id: NotRequired[int]  # defaults to "production".
     group_id: NotRequired[int]
-    level: NotRequired[str]
+    level: NotRequired[str]  # defaults to "info".

--- a/src/sentry/feedback/lib/types.py
+++ b/src/sentry/feedback/lib/types.py
@@ -1,0 +1,12 @@
+from typing import NotRequired, TypedDict
+
+
+class UserReportDict(TypedDict):
+    event_id: str
+    project_id: int
+    comments: str
+    name: NotRequired[str]
+    email: NotRequired[str]
+    environment_id: NotRequired[int]
+    group_id: NotRequired[int]
+    level: NotRequired[str]

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -4,7 +4,7 @@ import logging
 import random
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any
 from uuid import uuid4
 
 import jsonschema
@@ -12,6 +12,7 @@ import jsonschema
 from sentry import features, options
 from sentry.constants import DataCategory
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.usecases.spam_detection import is_spam, spam_detection_enabled
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -450,16 +451,8 @@ def auto_ignore_spam_feedbacks(project, issue_fingerprint):
 ###########
 
 
-class UserReportShimDict(TypedDict):
-    name: str
-    email: str
-    comments: str
-    event_id: str
-    level: str
-
-
 def shim_to_feedback(
-    report: UserReportShimDict,
+    report: UserReportDict,
     event: Event | GroupEvent,
     project: Project,
     source: FeedbackCreationSource,
@@ -490,7 +483,7 @@ def shim_to_feedback(
             "contexts": {
                 "feedback": {
                     "name": report.get("name", ""),
-                    "contact_email": report["email"],
+                    "contact_email": report.get("email", ""),
                     "message": report["comments"],
                 },
             },

--- a/src/sentry/feedback/usecases/save_feedback_event.py
+++ b/src/sentry/feedback/usecases/save_feedback_event.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
@@ -42,12 +42,12 @@ def save_feedback_event(event_data: Mapping[str, Any], project_id: int):
                     # XXX(aliu): including environment ensures the update_user_reports task
                     # will not shim the report back to feedback.
                     "environment_id": fixed_event_data.get("environment", "production"),
-                    "name": feedback_context["name"],
-                    "email": feedback_context["contact_email"],
+                    "name": feedback_context.get("name", ""),
+                    "email": feedback_context.get("contact_email", ""),
                     "comments": feedback_context["message"],
                 },
                 FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
-                start_time=datetime.fromtimestamp(fixed_event_data["timestamp"], UTC),
+                start_time=datetime.fromisoformat(fixed_event_data["timestamp"]),
             )
             metrics.incr("feedback.shim_to_userreport.success")
 

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from datetime import datetime, timedelta
+from typing import NotRequired, TypedDict
 
 from django.db import IntegrityError, router
 from django.utils import timezone
@@ -32,9 +33,18 @@ class Conflict(Exception):
     pass
 
 
+class UserReportDict(TypedDict):
+    event_id: str
+    project_id: int
+    comments: str
+    name: NotRequired[str]
+    email: NotRequired[str]
+    environment_id: NotRequired[str]
+
+
 def save_userreport(
     project: Project,
-    report,
+    report: UserReportDict,
     source: FeedbackCreationSource,
     start_time: datetime | None = None,
 ) -> UserReport | None:
@@ -126,7 +136,7 @@ def save_userreport(
 
             existing_report.update(
                 name=report.get("name", ""),
-                email=report["email"],
+                email=report.get("email", ""),
                 comments=report["comments"],
             )
             report_instance = existing_report

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import random
 from datetime import datetime, timedelta
-from typing import NotRequired, TypedDict
 
 from django.db import IntegrityError, router
 from django.utils import timezone
@@ -11,6 +10,7 @@ from django.utils import timezone
 from sentry import eventstore, options
 from sentry.constants import DataCategory
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.usecases.create_feedback import (
     UNREAL_FEEDBACK_UNATTENDED_MESSAGE,
     FeedbackCreationSource,
@@ -31,15 +31,6 @@ logger = logging.getLogger(__name__)
 
 class Conflict(Exception):
     pass
-
-
-class UserReportDict(TypedDict):
-    event_id: str
-    project_id: int
-    comments: str
-    name: NotRequired[str]
-    email: NotRequired[str]
-    environment_id: NotRequired[str]
 
 
 def save_userreport(
@@ -110,7 +101,8 @@ def save_userreport(
                 raise Conflict("Feedback for this event cannot be modified.")
 
             report["environment_id"] = event.get_environment().id
-            report["group_id"] = event.group_id
+            if event.group_id:
+                report["group_id"] = event.group_id
 
         # Save the report.
         try:

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.userreport import save_userreport
 from sentry.models.group import GroupStatus
@@ -132,11 +133,12 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         )
 
         # Simulate how ingest saves reports to get event_user connections
-        report_data = {
+        report_data: UserReportDict = {
             "event_id": event.event_id,
             "name": "",
             "email": "",
             "comments": "It broke",
+            "project_id": self.project_1.id,
         }
         save_userreport(
             self.project_1, report_data, FeedbackCreationSource.USER_REPORT_DJANGO_ENDPOINT

--- a/tests/sentry/feedback/usecases/test_save_feedback_event.py
+++ b/tests/sentry/feedback/usecases/test_save_feedback_event.py
@@ -37,11 +37,19 @@ def test_save_feedback_event_no_associated_error(
 
 
 @django_db_all
+@pytest.mark.parametrize(
+    "timestamp_format",
+    ["number", "iso"],
+)
 def test_save_feedback_event_with_associated_error(
-    default_project, mock_create_feedback_issue, mock_save_userreport
+    default_project, mock_create_feedback_issue, mock_save_userreport, timestamp_format
 ):
     event_data = mock_feedback_event(default_project.id)
     event_data["contexts"]["feedback"]["associated_event_id"] = "abcd" * 8
+    start_time = datetime.now(UTC)
+    event_data["timestamp"] = (
+        start_time.timestamp() if timestamp_format == "number" else start_time.isoformat()
+    )
     mock_create_feedback_issue.return_value = event_data
 
     save_feedback_event(event_data, default_project.id)
@@ -62,5 +70,43 @@ def test_save_feedback_event_with_associated_error(
             "comments": feedback_context["message"],
         },
         FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
-        start_time=datetime.fromtimestamp(event_data["timestamp"], UTC),
+        start_time=start_time,
+    )
+
+
+@django_db_all
+def test_save_feedback_event_with_associated_error_and_missing_fields(
+    default_project, mock_create_feedback_issue, mock_save_userreport
+):
+    event_data = mock_feedback_event(default_project.id)
+    event_data["contexts"]["feedback"]["associated_event_id"] = "abcd" * 8
+    start_time = datetime.now(UTC)
+    event_data["timestamp"] = start_time.isoformat()
+
+    # Remove name, email, environment
+    del event_data["contexts"]["feedback"]["name"]
+    del event_data["contexts"]["feedback"]["contact_email"]
+    del event_data["environment"]
+
+    mock_create_feedback_issue.return_value = event_data
+
+    save_feedback_event(event_data, default_project.id)
+
+    mock_create_feedback_issue.assert_called_once_with(
+        event_data, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+    )
+
+    feedback_context = event_data["contexts"]["feedback"]
+    mock_save_userreport.assert_called_once_with(
+        default_project,
+        {
+            "event_id": "abcd" * 8,
+            "project_id": default_project.id,
+            "environment_id": "production",
+            "name": "",
+            "email": "",
+            "comments": feedback_context["message"],
+        },
+        FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
+        start_time=start_time,
     )

--- a/tests/sentry/ingest/test_userreport.py
+++ b/tests/sentry/ingest/test_userreport.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 from django.utils import timezone
 
+from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.usecases.create_feedback import (
     UNREAL_FEEDBACK_UNATTENDED_MESSAGE,
     FeedbackCreationSource,
@@ -73,7 +74,7 @@ def test_save_user_report_returns_instance(default_project, monkeypatch):
     )
 
     # Test data
-    report = {
+    report: UserReportDict = {
         "event_id": "123456",
         "name": "Test User",
         "email": "test@example.com",
@@ -91,7 +92,7 @@ def test_save_user_report_returns_instance(default_project, monkeypatch):
 @django_db_all
 def test_save_user_report_denylist(default_project, monkeypatch):
     monkeypatch.setattr("sentry.ingest.userreport.is_in_feedback_denylist", lambda org: True)
-    report = {
+    report: UserReportDict = {
         "event_id": "123456",
         "name": "Test User",
         "email": "test@example.com",
@@ -116,7 +117,7 @@ def test_save_user_report_filters_large_message(default_project, monkeypatch):
     if not max_length:
         assert False, "Missing max_length for UserReport comments field!"
 
-    report = {
+    report: UserReportDict = {
         "event_id": "123456",
         "name": "Test User",
         "email": "test@example.com",
@@ -145,7 +146,7 @@ def test_save_user_report_shims_if_event_found(default_project, monkeypatch):
     mock_shim_to_feedback = Mock()
     monkeypatch.setattr("sentry.ingest.userreport.shim_to_feedback", mock_shim_to_feedback)
 
-    report = {
+    report: UserReportDict = {
         "event_id": event.event_id,
         "name": "Test User",
         "email": "test@example.com",
@@ -176,7 +177,7 @@ def test_save_user_report_does_not_shim_if_event_found_but_source_is_new_feedbac
     mock_shim_to_feedback = Mock()
     monkeypatch.setattr("sentry.ingest.userreport.shim_to_feedback", mock_shim_to_feedback)
 
-    report = {
+    report: UserReportDict = {
         "event_id": event.event_id,
         "name": "Test User",
         "email": "test@example.com",


### PR DESCRIPTION
Follow-up on https://github.com/getsentry/sentry/pull/89685.

Fixes [SENTRY-3SEX](https://sentry.sentry.io/issues/6551468609/events/9a88f59af64d4f86bddf42060cdff0d9/)
Fixes [SENTRY-3SEZ](https://sentry.sentry.io/issues/6551532041/events/bd020dada1a74f1ba96faa07c33df30c/)
Fixes [SENTRY-3SEY](https://sentry.sentry.io/issues/6551484362/events/42136852328a4acdb6f21922bd6425af/)

Only the message/comments field is required, so we need to handle missing name or email. Also event timestamp is a ISO str.

Also adds better typing to `save_userreport` and cleans up the event formatting code in `create_feedback` a bit. Functionality is the same, except now we'll always include the `user.email` context/tag, defaulting to empty str `""`