### PR TITLE
feat(workflow_engine): Add `can_process_data_packet` method to `StatefulDetector`

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -47,6 +47,9 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
     ) -> dict[DetectorGroupKey, int]:
         return {None: data_packet.packet["values"]["value"]}
 
+    def can_process_data_packet(self, group_key: DetectorGroupKey) -> bool:
+        return True
+
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something
 # like these when we're sending issues as alerts

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -130,6 +130,10 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
             )
         return results
 
+    @abc.abstractmethod
+    def can_process_data_packet(self, data_packet: DataPacket) -> bool:
+        pass
+
     def evaluate(
         self, data_packet: DataPacket[T]
     ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
@@ -138,10 +142,13 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
         There will be one result for each group key result in the packet, unless the
         evaluation is skipped due to various rules.
         """
+        results = {}
+        if not self.can_process_data_packet(data_packet):
+            return results
+
         dedupe_value = self.get_dedupe_value(data_packet)
         group_values = self.get_group_key_values(data_packet)
         all_state_data = self.get_state_data(list(group_values.keys()))
-        results = {}
         for group_key, group_value in group_values.items():
             result = self.evaluate_group_key_value(
                 group_key, group_value, all_state_data[group_key], dedupe_value

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -61,6 +61,9 @@ class MockDetectorStateHandler(StatefulDetectorHandler[dict]):
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:
         return build_mock_occurrence_and_event(self, group_key, new_status)
 
+    def can_process_data_packet(self, group_key: DetectorGroupKey) -> bool:
+        return True
+
 
 class BaseDetectorHandlerTest(BaseGroupTypeTest):
     __test__ = Abstract(__module__, __qualname__)


### PR DESCRIPTION
We have various preconditions that are enforced by the uptime results consumer, like https://github.com/getsentry/sentry/blob/d86b8323384ecbdfae7167c9374e31da6eb7fdda/src/sentry/uptime/consumers/results_consumer.py#L207-L211

We need a way to include these as part of the abstraction. Adding this now and will implement for `UptimeDetector`.

We might also need `can_process_data_packet_group` for any checks that might be group specific. We could also put the de-dupe checks there in the base class.
