### PR TITLE
feat(autofix): Add seer autofix prompt

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -23,6 +23,7 @@ DEFAULT_PROMPTS = {
     "issue_views_add_view_banner": {"required_fields": ["organization_id"]},
     "stacked_navigation_banner": {"required_fields": ["organization_id"]},
     "stacked_navigation_help_menu": {"required_fields": ["organization_id"]},
+    "seer_autofix_setup_acknowledged": {"required_fields": ["organization_id"]},
 }
 
 

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -1,6 +1,7 @@
 import calendar
 from unittest.mock import patch
 
+import orjson
 from django.utils import timezone
 
 from sentry.api.endpoints.group_autofix_setup_check import get_repos_and_access
@@ -72,7 +73,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data={"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())},
+            data=orjson.dumps({"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}),
         )
 
         self.login_as(user=self.user)
@@ -98,7 +99,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data={"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())},
+            data=orjson.dumps({"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}),
         )
 
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -1,3 +1,4 @@
+import calendar
 from unittest.mock import patch
 
 from django.utils import timezone
@@ -71,7 +72,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data={"dismissed_ts": timezone.now()},
+            data={"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())},
         )
 
         self.login_as(user=self.user)
@@ -97,7 +98,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data={"dismissed_ts": timezone.now()},
+            data={"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())},
         )
 
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -73,7 +73,9 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data=orjson.dumps({"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}),
+            data=orjson.dumps(
+                {"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}
+            ).decode("utf-8"),
         )
 
         self.login_as(user=self.user)
@@ -99,7 +101,9 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             feature=feature,
             organization_id=self.organization.id,
             project_id=0,
-            data=orjson.dumps({"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}),
+            data=orjson.dumps(
+                {"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}
+            ).decode("utf-8"),
         )
 
         self.login_as(user=self.user)


### PR DESCRIPTION
So the first user will get a "Enable Seer" prompt. All following users will get a "Try Seer" prompt.

first user in org

![image](https://github.com/user-attachments/assets/794d2038-fbe4-438e-bd77-fa88a10a4e45)

users after first user

![image](https://github.com/user-attachments/assets/1432d8b5-c955-4732-a725-72391e88c0d7)
