### PR TITLE
fix(issue-views): Fix endpoint sorting by last_visited to query for specific user

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
-from django.db.models import Count, F, Q
+from django.db.models import Count, F, OuterRef, Q, Subquery
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -19,6 +19,7 @@ from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidatorResponse,
 )
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
+from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -37,8 +38,8 @@ class MemberPermission(OrganizationPermission):
 SORT_MAP = {
     "popularity": "popularity",
     "-popularity": "-popularity",
-    "visited": F("groupsearchviewlastvisited__last_visited").asc(nulls_first=True),
-    "-visited": F("groupsearchviewlastvisited__last_visited").desc(nulls_last=True),
+    "visited": F("last_visited").asc(nulls_first=True),
+    "-visited": F("last_visited").desc(nulls_last=True),
     "name": "name",
     "-name": "-name",
     "created": "date_added",
@@ -115,6 +116,15 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
             )
         )
 
+        last_visited_query = Subquery(
+            GroupSearchViewLastVisited.objects.filter(
+                organization=organization,
+                user_id=request.user.id,
+                group_search_view_id=OuterRef("id"),
+            ).values("last_visited")[:1]
+        )
+        starred_count_query = Count("groupsearchviewstarred")
+
         if createdBy == "me":
             starred_query = (
                 base_queryset.filter(
@@ -122,7 +132,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                     id__in=starred_view_ids,
                 )
                 .prefetch_related("projects")
-                .annotate(popularity=Count("groupsearchviewstarred"))
+                .annotate(popularity=starred_count_query, last_visited=last_visited_query)
                 .order_by(*sorts)
             )
             non_starred_query = (
@@ -131,7 +141,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 )
                 .exclude(id__in=starred_view_ids)
                 .prefetch_related("projects")
-                .annotate(popularity=Count("groupsearchviewstarred"))
+                .annotate(popularity=starred_count_query, last_visited=last_visited_query)
                 .order_by(*sorts)
             )
         elif createdBy == "others":
@@ -142,7 +152,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 )
                 .exclude(user_id=request.user.id)
                 .prefetch_related("projects")
-                .annotate(popularity=Count("groupsearchviewstarred"))
+                .annotate(popularity=starred_count_query, last_visited=last_visited_query)
                 .order_by(*sorts)
             )
             non_starred_query = (
@@ -152,7 +162,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 .exclude(user_id=request.user.id)
                 .exclude(id__in=starred_view_ids)
                 .prefetch_related("projects")
-                .annotate(popularity=Count("groupsearchviewstarred"))
+                .annotate(popularity=starred_count_query, last_visited=last_visited_query)
                 .order_by(*sorts)
             )
 


### PR DESCRIPTION
The "Last Visited" sort was acting very strangely, returning the wrong order and in some cases duplicate records. This was because the sort was pointing at the GroupSearchViewLastVisited model, but did not do any querying for the specific user.

Added a `last_visited` annotation that makes the correct query to fix this.