### PR TITLE
fix(autofix): Make cursor pointer on clickable items

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -1,4 +1,6 @@
 import React, {useRef} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 import {AnimatePresence} from 'framer-motion';
 
 import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
@@ -34,9 +36,9 @@ export function AutofixHighlightWrapper({
 
   return (
     <React.Fragment>
-      <div ref={containerRef} className={className}>
+      <Wrapper ref={containerRef} className={className} isSelected={!!selection}>
         {children}
-      </div>
+      </Wrapper>
 
       <AnimatePresence>
         {selection && (
@@ -55,3 +57,17 @@ export function AutofixHighlightWrapper({
     </React.Fragment>
   );
 }
+
+const Wrapper = styled('div')<{isSelected: boolean}>`
+  &:hover {
+    ${p =>
+      !p.isSelected &&
+      css`
+        cursor: pointer;
+
+        * {
+          ${p.theme.tooltipUnderline('gray200')};
+        }
+      `};
+  }
+`;


### PR DESCRIPTION
On items where you can click to trigger the popup, make the cursor a pointer and add a subtle tooltip underline to make it more obvious that you can click.