### PR TITLE
✨ feat(aci): create test fire actions endpoint using a new group type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -36,6 +36,7 @@ class GroupCategory(IntEnum):
     FEEDBACK = 6
     UPTIME = 7
     METRIC_ALERT = 8
+    TEST_NOTIFICATION = 9
 
 
 GROUP_CATEGORIES_CUSTOM_EMAIL = (

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from sentry import features
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
@@ -27,4 +26,4 @@ class SendTestNotification(GroupType):
 
     @classmethod
     def allow_ingest(cls, organization: Organization) -> bool:
-        return features.has("organizations:workflow-engine-test-notifications", organization)
+        return True

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -11,7 +11,7 @@ from sentry.ratelimits.sliding_windows import Quota
 @dataclass(frozen=True)
 class SendTestNotification(GroupType):
     type_id = 9888
-    slug = "send-test-notification"
+    slug = "send_test_notification"
     description = "Send test notification"
     category = GroupCategory.TEST_NOTIFICATION.value
     released = False

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -10,15 +10,15 @@ from sentry.ratelimits.sliding_windows import Quota
 
 @dataclass(frozen=True)
 class SendTestNotification(GroupType):
-    type_id = 9888
-    slug = "send_test_notification"
+    type_id = 9001
+    slug = "send-test-notification"
     description = "Send test notification"
     category = GroupCategory.TEST_NOTIFICATION.value
     released = False
     in_default_search = False
-    enable_auto_resolve = False
+    enable_auto_resolve = True
     enable_escalation_detection = False
-    enable_status_change_workflow_notifications = False
+    enable_status_change_workflow_notifications = True
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
 
     @classmethod

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry import features
+from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.models.organization import Organization
+from sentry.ratelimits.sliding_windows import Quota
+
+
+@dataclass(frozen=True)
+class SendTestNotification(GroupType):
+    type_id = 9888
+    slug = "send-test-notification"
+    description = "Send test notification"
+    category = GroupCategory.TEST_NOTIFICATION.value
+    released = False
+    in_default_search = False
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    enable_status_change_workflow_notifications = False
+    creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
+
+    @classmethod
+    def allow_post_process_group(cls, organization: Organization) -> bool:
+        return False
+
+    @classmethod
+    def allow_ingest(cls, organization: Organization) -> bool:
+        return features.has("organizations:workflow-engine-test-notifications", organization)

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -5,7 +5,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND
+from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -90,7 +90,7 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
         if not project:
             return Response(
                 {"detail": "No projects found for this organization that the user has access to"},
-                status=HTTP_404_NOT_FOUND,
+                status=HTTP_400_BAD_REQUEST,
             )
 
         action_exceptions = []

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -86,14 +86,11 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
 
         action_exceptions = []
 
-        # Create a test event for the project
         test_event = create_sample_event(
             project, platform=project.platform, default="javascript", tagged=True
         )
 
-        # Create a dummy workflow and detector for testing
         workflow_id = -1
-
         workflow_event_data = WorkflowEventData(
             event=test_event,
             workflow_id=workflow_id,
@@ -107,7 +104,6 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
             type="error",
         )
 
-        # Process each action
         for action_data in data.get("actions", []):
             # Create a temporary Action object (not saved to database)
             action = Action(

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
@@ -98,7 +98,7 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
         return Response(status=status, data=response_data)
 
 
-def test_fire_actions(actions: list[Action], project: Project):
+def test_fire_actions(actions: list[dict[str, Any]], project: Project):
     action_exceptions = []
 
     test_event = get_test_notification_event_data(project)

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -1,0 +1,133 @@
+import logging
+from typing import TypedDict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.models.project import Project
+from sentry.utils.samples import create_sample_event
+from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_action
+from sentry.workflow_engine.endpoints.validators.base.action import BaseActionValidator
+from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.types import WorkflowEventData
+
+logger = logging.getLogger(__name__)
+
+
+class TestActionValidator(BaseActionValidator[Action]):
+    class Meta:
+        model = Action
+        fields = ["data", "config", "type", "integration_id"]
+
+
+class TestActionsValidator(CamelSnakeSerializer):
+    actions = serializers.ListField(required=True)
+
+    def validate_actions(self, value):
+        for action in value:
+            TestActionValidator(data=action).is_valid(raise_exception=True)
+        return value
+
+
+class TestFireActionErrorsResponse(TypedDict):
+    actions: list[str]
+
+
+@region_silo_endpoint
+class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    @extend_schema(
+        operation_id="Test Fire Actions",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
+        responses={
+            200: None,
+            400: TestFireActionErrorsResponse,
+            401: RESPONSE_UNAUTHORIZED,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(self, request: Request, organization) -> Response:
+        """
+        Test fires a list of actions without saving them to the database.
+
+        The actions will be fired against a sample event in the first project of the organization.
+        """
+        serializer = TestActionsValidator(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+
+        # Get the first project associated with the organization
+        # This is because we don't have a project when test firing actions
+        project = Project.objects.filter(organization=organization).first()
+        if not project:
+            return Response(
+                {"detail": "No projects found for this organization"},
+                status=HTTP_404_NOT_FOUND,
+            )
+
+        action_exceptions = []
+
+        # Create a test event for the project
+        test_event = create_sample_event(
+            project, platform=project.platform, default="javascript", tagged=True
+        )
+
+        # Create a dummy workflow and detector for testing
+        workflow_id = -1
+
+        workflow_event_data = WorkflowEventData(
+            event=test_event,
+            workflow_id=workflow_id,
+        )
+
+        detector = Detector(
+            id=-1,
+            project=project,
+            name="Test Detector",
+            enabled=True,
+            type="error",
+        )
+
+        # Process each action
+        for action_data in data.get("actions", []):
+            # Create a temporary Action object (not saved to database)
+            action = Action(
+                id=-1,
+                type=action_data["type"],
+                integration_id=action_data.get("integration_id"),
+                data=action_data.get("data", {}),
+                config=action_data.get("config", {}),
+            )
+
+            # Test fire the action and collect any exceptions
+            exceptions = test_fire_action(action, workflow_event_data, detector)
+            if exceptions:
+                action_exceptions.extend(exceptions)
+
+        # Return any exceptions that occurred
+        status = None
+        response_data = None
+        if len(action_exceptions) > 0:
+            status = HTTP_400_BAD_REQUEST
+            response_data = {"actions": action_exceptions}
+
+        return Response(status=status, data=response_data)

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -48,7 +48,7 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ECOSYSTEM
 
     @extend_schema(
         operation_id="Test Fire Actions",

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -4,6 +4,7 @@ from .organization_available_action_index import OrganizationAvailableActionInde
 from .organization_data_condition_index import OrganizationDataConditionIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
 from .organization_detector_workflow_index import OrganizationDetectorWorkflowIndexEndpoint
+from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
 from .project_detector_details import ProjectDetectorDetailsEndpoint
@@ -63,5 +64,10 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^\/]+)/available-actions/$",
         OrganizationAvailableActionIndexEndpoint.as_view(),
         name="sentry-api-0-organization-available-action-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/test-fire-actions/$",
+        OrganizationTestFireActionsEndpoint.as_view(),
+        name="sentry-api-0-organization-test-fire-actions",
     ),
 ]

--- a/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
@@ -53,15 +53,15 @@ def get_test_notification_event_data(project) -> GroupEvent | None:
         project_id=project.id,
         event_id=uuid4().hex,
         fingerprint=[md5(str(uuid4()).encode("utf-8")).hexdigest()],
-        issue_title="Some Issue",
-        subtitle="Some subtitle",
+        issue_title="Test Issue",
+        subtitle="Test issue created to test a notification related action",
         resource_id=None,
         evidence_data={},
         evidence_display=[],
         type=SendTestNotification,
         detection_time=datetime.now(UTC),
         level="error",
-        culprit="Some culprit",
+        culprit="Test notification",
     )
 
     # Load mock data

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -201,4 +201,6 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
 
         response = self.get_error_response(self.organization.slug, actions=action_data)
         assert response.status_code == 404
-        assert response.data == {"detail": "No projects found for this organization"}
+        assert response.data == {
+            "detail": "No projects found for this organization that the user has access to"
+        }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -1,0 +1,204 @@
+from unittest import mock
+
+import sentry_sdk
+
+from sentry.integrations.jira.integration import JiraIntegration
+from sentry.integrations.pagerduty.client import PagerDutyClient
+from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
+from sentry.models.project import Project
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.notification_action.group_type_notification_registry import (
+    IssueAlertRegistryHandler,
+)
+from sentry.notifications.notification_action.issue_alert_registry import (
+    PagerDutyIssueAlertHandler,
+    PluginIssueAlertHandler,
+)
+from sentry.rules.actions.notify_event import NotifyEventAction
+from sentry.shared_integrations.exceptions import IntegrationFormError
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import Action
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+pytestmark = [requires_snuba]
+
+
+class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
+    endpoint = "sentry-api-0-organization-test-fire-actions"
+    method = "POST"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.workflow = self.create_workflow()
+
+    def setup_pd_service(self) -> PagerDutyServiceDict:
+        service_info = {
+            "type": "service",
+            "integration_key": "PND123",
+            "service_name": "Sentry Service",
+        }
+        _integration, org_integration = self.create_provider_integration_for(
+            provider="pagerduty",
+            name="Example PagerDuty",
+            external_id="example-pd",
+            metadata={"services": [service_info]},
+            organization=self.organization,
+            user=self.user,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return add_service(
+                org_integration,
+                service_name=service_info["service_name"],
+                integration_key=service_info["integration_key"],
+            )
+
+    @mock.patch.object(PagerDutyClient, "send_trigger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
+        return_value=IssueAlertRegistryHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
+        return_value=PagerDutyIssueAlertHandler,
+    )
+    def test_pagerduty_action(
+        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_send_trigger
+    ):
+        """Test a PagerDuty action"""
+        service_info = self.setup_pd_service()
+
+        action_data = [
+            {
+                "type": Action.Type.PAGERDUTY.value,
+                "integration_id": service_info["integration_id"],
+                "data": {
+                    "priority": "info",
+                },
+                "config": {
+                    "target_identifier": str(service_info["id"]),
+                    "target_type": ActionTarget.SPECIFIC.value,
+                },
+            }
+        ]
+
+        response = self.get_success_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 200
+        assert mock_send_trigger.call_count == 1
+        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
+        assert pagerduty_data["payload"]["summary"].startswith("[Test Detector]:")
+
+    @mock.patch.object(NotifyEventAction, "after")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
+        return_value=IssueAlertRegistryHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
+        return_value=PluginIssueAlertHandler,
+    )
+    def test_plugin_notify_event_action(
+        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_after
+    ):
+        """Test a Plugin action (NotifyEventAction)"""
+        action_data = [
+            {
+                "type": Action.Type.PLUGIN.value,
+                "data": {},
+                "config": {},
+            }
+        ]
+
+        response = self.get_success_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 200
+        assert mock_after.called
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    @mock.patch.object(sentry_sdk, "capture_exception")
+    def test_action_with_integration_form_error(self, mock_sdk_capture, mock_create_issue):
+        """Test that integration form errors are returned correctly"""
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
+
+        form_errors = {"broken": "something went wrong"}
+        mock_create_issue.side_effect = IntegrationFormError(form_errors)
+        mock_sdk_capture.return_value = "abc-1234"
+
+        action_data = [
+            {
+                "type": Action.Type.JIRA.value,
+                "integration_id": self.jira_integration.id,
+                "data": {
+                    "dynamic_form_fields": [
+                        {
+                            "fake_field": "fake_value",
+                        }
+                    ],
+                },
+                "config": {"target_type": ActionTarget.SPECIFIC.value},
+            }
+        ]
+
+        response = self.get_error_response(self.organization.slug, actions=action_data)
+
+        assert response.status_code == 400
+        assert mock_create_issue.call_count == 1
+        assert response.data == {"actions": [str(form_errors)]}
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    @mock.patch.object(sentry_sdk, "capture_exception")
+    def test_action_with_unexpected_error(self, mock_sdk_capture, mock_create_issue):
+        """Test that unexpected errors are handled correctly"""
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
+
+        mock_create_issue.side_effect = Exception("Something went wrong")
+        mock_sdk_capture.return_value = "abc-1234"
+
+        action_data = [
+            {
+                "type": Action.Type.JIRA.value,
+                "integration_id": self.jira_integration.id,
+                "data": {
+                    "dynamic_form_fields": [
+                        {
+                            "fake_field": "fake_value",
+                        }
+                    ],
+                },
+                "config": {
+                    "target_type": ActionTarget.SPECIFIC.value,
+                },
+            }
+        ]
+
+        response = self.get_error_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 400
+        assert mock_create_issue.call_count == 1
+        assert response.data == {"actions": ["An unexpected error occurred. Error ID: 'abc-1234'"]}
+
+    def test_no_projects_available(self):
+        """Test behavior when no projects are available for the organization"""
+        Project.objects.filter(organization=self.organization).delete()
+
+        action_data = [
+            {
+                "type": Action.Type.PLUGIN.value,
+                "data": {},
+                "config": {},
+            }
+        ]
+
+        response = self.get_error_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 404
+        assert response.data == {"detail": "No projects found for this organization"}

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -200,7 +200,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         ]
 
         response = self.get_error_response(self.organization.slug, actions=action_data)
-        assert response.status_code == 404
+        assert response.status_code == 400
         assert response.data == {
             "detail": "No projects found for this organization that the user has access to"
         }

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -84,15 +84,3 @@ class TestBaseActionValidator(TestCase):
 
         result = validator.is_valid()
         assert result is False
-
-    def test_validate_integration_id__required(self, mock_action_handler_get):
-        self.valid_data.pop("integrationId")
-
-        validator = MockActionValidator(
-            data={
-                **self.valid_data,
-            },
-        )
-
-        result = validator.is_valid()
-        assert result is True

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -84,3 +84,15 @@ class TestBaseActionValidator(TestCase):
 
         result = validator.is_valid()
         assert result is False
+
+    def test_validate_integration_id__required(self, mock_action_handler_get):
+        self.valid_data.pop("integrationId")
+
+        validator = MockActionValidator(
+            data={
+                **self.valid_data,
+            },
+        )
+
+        result = validator.is_valid()
+        assert result is True


### PR DESCRIPTION
this pr create the test fire actions endpoint for the "Send Test Notification" Button

it is a different version of https://github.com/getsentry/sentry/pull/89218,

this time i create a new `GroupType` so i can hide the test issue from the issue stream.


Issue Details
![image](https://github.com/user-attachments/assets/eebfd06c-9840-4a37-9300-25c14adfd8ba)

Issue Stream
![image](https://github.com/user-attachments/assets/d1fa9902-9b8b-40f4-977d-bc0f7ebce34a)
(doesn't have the issue)

Notification
![image](https://github.com/user-attachments/assets/05086eb9-af69-4618-bc42-d0a4dc7b877e)

Note: the copy of the issue is updated in the code