### PR TITLE
ref(github): PR comment workflow

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,7 +31,6 @@ from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
 from sentry.conf.types.taskworker import ScheduleConfigMap
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import make_split_task_queues
 
 
@@ -770,6 +769,7 @@ CELERY_IMPORTS = (
     "sentry.hybridcloud.tasks.backfill_outboxes",
     "sentry.hybridcloud.tasks.deliver_from_outbox",
     "sentry.incidents.tasks",
+    "sentry.integrations.source_code_management.tasks",
     "sentry.integrations.github.tasks",
     "sentry.integrations.github.tasks.pr_comment",
     "sentry.integrations.jira.tasks",

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -336,11 +336,6 @@ class GitHubPRCommentWorkflow(PRCommentWorkflow):
     referrer = Referrer.GITHUB_PR_COMMENT_BOT
     referrer_id = GITHUB_PR_BOT_REFERRER
 
-    def queue_task(self, pr: PullRequest, project_id: int) -> None:
-        from sentry.integrations.github.tasks.pr_comment import github_comment_workflow
-
-        github_comment_workflow.delay(pullrequest_id=pr.id, project_id=project_id)
-
     @staticmethod
     def format_comment_subtitle(subtitle: str) -> str:
         return subtitle[:47] + "..." if len(subtitle) > 50 else subtitle

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -31,7 +31,10 @@ from sentry.integrations.github.tasks.link_all_repos import link_all_repos
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
-from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitContextIntegration,
+    PRCommentWorkflow,
+)
 from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
@@ -39,12 +42,17 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.snuba.referrer import Referrer
+from sentry.types.referrer_ids import GITHUB_PR_BOT_REFERRER
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 from sentry.web.frontend.base import determine_active_organization
@@ -173,11 +181,9 @@ def get_document_origin(org) -> str:
 class GitHubIntegration(
     RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration, RepoTreesIntegration
 ):
-    codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+    integration_name = "github"
 
-    @property
-    def integration_name(self) -> str:
-        return "github"
+    codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     def get_client(self) -> GitHubBaseClient:
         if not self.org_integration:
@@ -309,6 +315,80 @@ class GitHubIntegration(
                 return True
 
         return False
+
+    def get_pr_comment_workflow(self) -> PRCommentWorkflow:
+        return GitHubPRCommentWorkflow(integration=self)
+
+
+MERGED_PR_COMMENT_BODY_TEMPLATE = """\
+## Suspect Issues
+This pull request was deployed and Sentry observed the following issues:
+
+{issue_list}
+
+<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
+
+
+class GitHubPRCommentWorkflow(PRCommentWorkflow):
+    organization_option_key = "sentry:github_pr_bot"
+    referrer = Referrer.GITHUB_PR_COMMENT_BOT
+    referrer_id = GITHUB_PR_BOT_REFERRER
+
+    def queue_task(self, pr: PullRequest, project_id: int) -> None:
+        from sentry.integrations.github.tasks.pr_comment import github_comment_workflow
+
+        github_comment_workflow.delay(pullrequest_id=pr.id, project_id=project_id)
+
+    @staticmethod
+    def format_comment_subtitle(subtitle: str) -> str:
+        return subtitle[:47] + "..." if len(subtitle) > 50 else subtitle
+
+    @staticmethod
+    def format_comment_url(url: str, referrer: str) -> str:
+        return url + "?referrer=" + referrer
+
+    def get_comment_body(self, issue_ids: list[int]) -> str:
+        issues = Group.objects.filter(id__in=issue_ids).order_by("id").all()
+
+        issue_list = "\n".join(
+            [
+                MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
+                    title=issue.title,
+                    subtitle=self.format_comment_subtitle(issue.culprit),
+                    url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
+                )
+                for issue in issues
+            ]
+        )
+
+        return MERGED_PR_COMMENT_BODY_TEMPLATE.format(issue_list=issue_list)
+
+    def get_comment_data(
+        self,
+        organization: Organization,
+        repo: Repository,
+        pr: PullRequest,
+        comment_body: str,
+        issue_ids: list[int],
+    ) -> dict[str, Any]:
+        enabled_copilot = features.has("organizations:gen-ai-features", organization)
+
+        comment_data = {
+            "body": comment_body,
+        }
+        if enabled_copilot:
+            comment_data["actions"] = [
+                {
+                    "name": f"Root cause #{i + 1}",
+                    "type": "copilot-chat",
+                    "prompt": f"@sentry root cause issue {str(issue_id)} with PR URL https://github.com/{repo.name}/pull/{str(pr.key)}",
+                }
+                for i, issue_id in enumerate(issue_ids[:3])
+            ]
+
+        return comment_data
 
 
 class GitHubIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/github/tasks/open_pr_comment.py
+++ b/src/sentry/integrations/github/tasks/open_pr_comment.py
@@ -24,7 +24,6 @@ from snuba_sdk import Request as SnubaRequest
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.integrations.github.client import GitHubApiClient
 from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
-from sentry.integrations.github.tasks.pr_comment import format_comment_url
 from sentry.integrations.github.tasks.utils import (
     GithubAPIErrorType,
     PullRequestFile,
@@ -89,6 +88,10 @@ OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
 OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
 
 MAX_RECENT_ISSUES = 5000
+
+
+def format_comment_url(url: str, referrer: str) -> str:
+    return url + "?referrer=" + referrer
 
 
 def format_open_pr_comment(issue_tables: list[str]) -> str:
@@ -615,9 +618,8 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     try:
         installation.create_or_update_comment(
             repo=repo,
-            pr_key=pull_request.key,
+            pr=pull_request,
             comment_data={"body": comment_body},
-            pullrequest_id=pull_request.id,
             issue_list=issue_id_list,
             comment_type=CommentType.OPEN_PR,
             metrics_base=OPEN_PR_METRICS_BASE,

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.source_code_management.commit_context import run_pr_comment_workflow
+from sentry.integrations.source_code_management.tasks import pr_comment_workflow
 from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
     ),
 )
 def github_comment_workflow(pullrequest_id: int, project_id: int):
-    run_pr_comment_workflow(integration_name="github", pr_id=pullrequest_id, project_id=project_id)
+    # TODO(jianyuan): Using `sentry.integrations.source_code_management.tasks.pr_comment_workflow` now.
+    # Keep this task temporarily to avoid breaking changes.
+    pr_comment_workflow(pr_id=pullrequest_id, project_id=project_id)
 
 
 @instrumented_task(

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -2,135 +2,24 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 import sentry_sdk
-from django.db import connection
-from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query
-from snuba_sdk import Request as SnubaRequest
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
-from sentry.integrations.github.tasks.utils import PullRequestIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.models.group import Group
-from sentry.models.groupowner import GroupOwnerType
-from sentry.models.options.organization_option import OrganizationOption
-from sentry.models.organization import Organization
-from sentry.models.project import Project
+from sentry.integrations.source_code_management.commit_context import run_pr_comment_workflow
 from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import integrations_tasks
-from sentry.types.referrer_ids import GITHUB_PR_BOT_REFERRER
 from sentry.utils import metrics
-from sentry.utils.cache import cache
 from sentry.utils.query import RangeQuerySetWrapper
-from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
-
-MERGED_PR_METRICS_BASE = "{integration}.pr_comment.{key}"
-
-MERGED_PR_COMMENT_BODY_TEMPLATE = """\
-## Suspect Issues
-This pull request was deployed and Sentry observed the following issues:
-
-{issue_list}
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
-
-MAX_SUSPECT_COMMITS = 1000
-
-
-def format_comment_subtitle(subtitle):
-    return subtitle[:47] + "..." if len(subtitle) > 50 else subtitle
-
-
-def format_comment_url(url, referrer):
-    return url + "?referrer=" + referrer
-
-
-def format_comment(issues: list[PullRequestIssue]):
-    issue_list = "\n".join(
-        [
-            MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
-                title=issue.title,
-                subtitle=format_comment_subtitle(issue.subtitle),
-                url=format_comment_url(issue.url, GITHUB_PR_BOT_REFERRER),
-            )
-            for issue in issues
-        ]
-    )
-
-    return MERGED_PR_COMMENT_BODY_TEMPLATE.format(issue_list=issue_list)
-
-
-def pr_to_issue_query(pr_id: int):
-    with connection.cursor() as cursor:
-        cursor.execute(
-            f"""
-            SELECT pr.repository_id repo_id,
-                pr.key pr_key,
-                pr.organization_id org_id,
-                array_agg(go.group_id ORDER BY go.date_added) issues
-            FROM sentry_groupowner go
-            JOIN sentry_pullrequest_commit c ON c.commit_id = (go.context::jsonb->>'commitId')::bigint
-            JOIN sentry_pull_request pr ON c.pull_request_id = pr.id
-            WHERE go.type=0
-            AND pr.id={pr_id}
-            GROUP BY repo_id,
-                pr_key,
-                org_id
-            """,
-            [GroupOwnerType.SUSPECT_COMMIT.value],
-        )
-        return cursor.fetchall()
-
-
-def get_top_5_issues_by_count(issue_list: list[int], project: Project) -> list[dict[str, Any]]:
-    """Given a list of issue group ids, return a sublist of the top 5 ordered by event count"""
-    request = SnubaRequest(
-        dataset=Dataset.Events.value,
-        app_id="default",
-        tenant_ids={"organization_id": project.organization_id},
-        query=(
-            Query(Entity("events"))
-            .set_select([Column("group_id"), Function("count", [], "event_count")])
-            .set_groupby([Column("group_id")])
-            .set_where(
-                [
-                    Condition(Column("project_id"), Op.EQ, project.id),
-                    Condition(Column("group_id"), Op.IN, issue_list),
-                    Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=30)),
-                    Condition(Column("timestamp"), Op.LT, datetime.now()),
-                    Condition(Column("level"), Op.NEQ, "info"),
-                ]
-            )
-            .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
-            .set_limit(5)
-        ),
-    )
-    return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
-
-
-def get_comment_contents(issue_list: list[int]) -> list[PullRequestIssue]:
-    """Retrieve the issue information that will be used for comment contents"""
-    issues = Group.objects.filter(id__in=issue_list).order_by("id").all()
-    return [
-        PullRequestIssue(title=issue.title, subtitle=issue.culprit, url=issue.get_absolute_url())
-        for issue in issues
-    ]
 
 
 @instrumented_task(
@@ -141,124 +30,7 @@ def get_comment_contents(issue_list: list[int]) -> list[PullRequestIssue]:
     ),
 )
 def github_comment_workflow(pullrequest_id: int, project_id: int):
-    cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(pullrequest_id)
-
-    gh_repo_id, pr_key, org_id, issue_list = pr_to_issue_query(pullrequest_id)[0]
-
-    # cap to 1000 issues in which the merge commit is the suspect commit
-    issue_list = issue_list[:MAX_SUSPECT_COMMITS]
-
-    try:
-        organization = Organization.objects.get_from_cache(id=org_id)
-    except Organization.DoesNotExist:
-        cache.delete(cache_key)
-        logger.info("github.pr_comment.org_missing")
-        metrics.incr(
-            MERGED_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "missing_org"},
-        )
-        return
-
-    if not OrganizationOption.objects.get_value(
-        organization=organization,
-        key="sentry:github_pr_bot",
-        default=True,
-    ):
-        logger.info("github.pr_comment.option_missing", extra={"organization_id": org_id})
-        return
-
-    try:
-        project = Project.objects.get_from_cache(id=project_id)
-    except Project.DoesNotExist:
-        cache.delete(cache_key)
-        logger.info("github.pr_comment.project_missing", extra={"organization_id": org_id})
-        metrics.incr(
-            MERGED_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "missing_project"},
-        )
-        return
-
-    top_5_issues = get_top_5_issues_by_count(issue_list, project)
-    if not top_5_issues:
-        logger.info(
-            "github.pr_comment.no_issues",
-            extra={"organization_id": org_id, "pr_id": pullrequest_id},
-        )
-        cache.delete(cache_key)
-        return
-
-    top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
-
-    issue_comment_contents = get_comment_contents(top_5_issue_ids)
-
-    try:
-        repo = Repository.objects.get(id=gh_repo_id)
-    except Repository.DoesNotExist:
-        cache.delete(cache_key)
-        logger.info("github.pr_comment.repo_missing", extra={"organization_id": org_id})
-        metrics.incr(
-            MERGED_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "missing_repo"},
-        )
-        return
-
-    integration = integration_service.get_integration(
-        integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
-    )
-    if not integration:
-        cache.delete(cache_key)
-        logger.info("github.pr_comment.integration_missing", extra={"organization_id": org_id})
-        metrics.incr(
-            MERGED_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "missing_integration"},
-        )
-        return
-
-    installation = integration.get_installation(organization_id=org_id)
-    assert isinstance(installation, CommitContextIntegration)
-
-    comment_body = format_comment(issue_comment_contents)
-    logger.info("github.pr_comment.comment_body", extra={"body": comment_body})
-
-    top_24_issues = issue_list[:24]  # 24 is the P99 for issues-per-PR
-
-    enabled_copilot = features.has("organizations:gen-ai-features", organization)
-
-    comment_data = {
-        "body": comment_body,
-    }
-    if enabled_copilot:
-        comment_data["actions"] = [
-            {
-                "name": f"Root cause #{i + 1}",
-                "type": "copilot-chat",
-                "prompt": f"@sentry root cause issue {str(issue_id)} with PR URL https://github.com/{repo.name}/pull/{str(pr_key)}",
-            }
-            for i, issue_id in enumerate(top_24_issues[:3])
-        ]
-
-    try:
-        installation.create_or_update_comment(
-            repo=repo,
-            pr_key=pr_key,
-            comment_data=comment_data,
-            pullrequest_id=pullrequest_id,
-            issue_list=top_24_issues,
-            metrics_base=MERGED_PR_METRICS_BASE,
-        )
-    except ApiError as e:
-        cache.delete(cache_key)
-
-        if installation.on_create_or_update_comment_error(
-            api_error=e, metrics_base=MERGED_PR_METRICS_BASE
-        ):
-            return
-
-        metrics.incr(
-            MERGED_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "api_error"},
-        )
-        raise
+    run_pr_comment_workflow(integration_name="github", pr_id=pullrequest_id, project_id=project_id)
 
 
 @instrumented_task(

--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -1,0 +1,176 @@
+import logging
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.commit_context import (
+    MAX_SUSPECT_COMMITS,
+    MERGED_PR_METRICS_BASE,
+    CommitContextIntegration,
+    _debounce_pr_comment_cache_key,
+    _pr_comment_log,
+)
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import integrations_tasks
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.integrations.source_code_management.tasks.pr_comment_workflow",
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=integrations_tasks,
+    ),
+)
+def pr_comment_workflow(pr_id: int, project_id: int):
+    cache_key = _debounce_pr_comment_cache_key(pullrequest_id=pr_id)
+
+    try:
+        pr = PullRequest.objects.get(id=pr_id)
+        assert isinstance(pr, PullRequest)
+    except PullRequest.DoesNotExist:
+        cache.delete(cache_key)
+        logger.info(_pr_comment_log(integration_name="source_code_management", suffix="pr_missing"))
+        return
+
+    try:
+        organization = Organization.objects.get_from_cache(id=pr.organization_id)
+        assert isinstance(organization, Organization)
+    except Organization.DoesNotExist:
+        cache.delete(cache_key)
+        logger.info(
+            _pr_comment_log(integration_name="source_code_management", suffix="org_missing")
+        )
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(integration="source_code_management", key="error"),
+            tags={"type": "missing_org"},
+        )
+        return
+
+    try:
+        repo = Repository.objects.get(id=pr.repository_id)
+        assert isinstance(repo, Repository)
+    except Repository.DoesNotExist:
+        cache.delete(cache_key)
+        logger.info(
+            _pr_comment_log(integration_name="source_code_management", suffix="repo_missing"),
+            extra={"organization_id": organization.id},
+        )
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(integration="source_code_management", key="error"),
+            tags={"type": "missing_repo"},
+        )
+        return
+
+    integration = integration_service.get_integration(
+        integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
+    )
+    if not integration:
+        cache.delete(cache_key)
+        logger.info(
+            _pr_comment_log(
+                integration_name="source_code_management", suffix="integration_missing"
+            ),
+            extra={"organization_id": organization.id},
+        )
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(integration="source_code_management", key="error"),
+            tags={"type": "missing_integration"},
+        )
+        return
+
+    installation = integration.get_installation(organization_id=organization.id)
+    assert isinstance(installation, CommitContextIntegration)
+
+    integration_name = installation.integration_name
+    pr_comment_workflow = installation.get_pr_comment_workflow()
+
+    # cap to 1000 issues in which the merge commit is the suspect commit
+    issue_ids = pr_comment_workflow.get_issue_ids_from_pr(pr=pr, limit=MAX_SUSPECT_COMMITS)
+
+    if not OrganizationOption.objects.get_value(
+        organization=organization,
+        key=pr_comment_workflow.organization_option_key,
+        default=True,
+    ):
+        logger.info(
+            _pr_comment_log(integration_name=integration_name, suffix="option_missing"),
+            extra={"organization_id": organization.id},
+        )
+        return
+
+    try:
+        project = Project.objects.get_from_cache(id=project_id)
+        assert isinstance(project, Project)
+    except Project.DoesNotExist:
+        cache.delete(cache_key)
+        logger.info(
+            _pr_comment_log(integration_name=integration_name, suffix="project_missing"),
+            extra={"organization_id": organization.id},
+        )
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(integration=integration_name, key="error"),
+            tags={"type": "missing_project"},
+        )
+        return
+
+    top_5_issues = pr_comment_workflow.get_top_5_issues_by_count(
+        issue_ids=issue_ids, project=project
+    )
+    if not top_5_issues:
+        logger.info(
+            _pr_comment_log(integration_name=integration_name, suffix="no_issues"),
+            extra={"organization_id": organization.id, "pr_id": pr.id},
+        )
+        cache.delete(cache_key)
+        return
+
+    top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
+
+    comment_body = pr_comment_workflow.get_comment_body(issue_ids=top_5_issue_ids)
+    logger.info(
+        _pr_comment_log(integration_name=integration_name, suffix="comment_body"),
+        extra={"body": comment_body},
+    )
+
+    top_24_issue_ids = issue_ids[:24]  # 24 is the P99 for issues-per-PR
+
+    comment_data = pr_comment_workflow.get_comment_data(
+        organization=organization,
+        repo=repo,
+        pr=pr,
+        comment_body=comment_body,
+        issue_ids=top_24_issue_ids,
+    )
+
+    try:
+        installation.create_or_update_comment(
+            repo=repo,
+            pr=pr,
+            comment_data=comment_data,
+            issue_list=top_24_issue_ids,
+            metrics_base=MERGED_PR_METRICS_BASE,
+        )
+    except ApiError as e:
+        cache.delete(cache_key)
+
+        if installation.on_create_or_update_comment_error(
+            api_error=e, metrics_base=MERGED_PR_METRICS_BASE
+        ):
+            return
+
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(integration=integration_name, key="error"),
+            tags={"type": "api_error"},
+        )
+        raise

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -7,21 +7,17 @@ import responses
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.github.integration import GitHubIntegrationProvider
+from sentry.integrations.github.integration import GitHubIntegration, GitHubIntegrationProvider
 from sentry.integrations.github.tasks.pr_comment import (
-    format_comment,
-    get_comment_contents,
-    get_top_5_issues_by_count,
     github_comment_reactions,
     github_comment_workflow,
-    pr_to_issue_query,
 )
-from sentry.integrations.github.tasks.utils import PullRequestIssue
 from sentry.integrations.models.integration import Integration
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.pullrequest import (
     CommentType,
@@ -32,8 +28,9 @@ from sentry.models.pullrequest import (
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
-from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase, TestCase
+from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
@@ -47,6 +44,10 @@ class GithubCommentTestCase(IntegrationTestCase):
 
     def setUp(self):
         super().setUp()
+        self.installation = get_installation_of_type(
+            GitHubIntegration, integration=self.integration, org_id=self.organization.id
+        )
+        self.pr_comment_workflow = self.installation.get_pr_comment_workflow()
         self.another_integration = self.create_integration(
             organization=self.organization, external_id="1", provider="gitlab"
         )
@@ -169,9 +170,9 @@ class TestPrToIssueQuery(GithubCommentTestCase):
         pr = self.add_pr_to_commit(commit)
         groupowner = self.add_groupowner_to_commit(commit, self.project, self.user)
 
-        results = pr_to_issue_query(pr.id)
+        results = self.pr_comment_workflow.get_issue_ids_from_pr(pr=pr)
 
-        assert results[0] == (self.gh_repo.id, pr.key, self.organization.id, [groupowner.group_id])
+        assert results == [groupowner.group_id]
 
     def test_multiple_issues(self):
         """one pr with multiple issues"""
@@ -181,14 +182,9 @@ class TestPrToIssueQuery(GithubCommentTestCase):
         groupowner_2 = self.add_groupowner_to_commit(commit, self.project, self.user)
         groupowner_3 = self.add_groupowner_to_commit(commit, self.project, self.user)
 
-        results = pr_to_issue_query(pr.id)
+        results = self.pr_comment_workflow.get_issue_ids_from_pr(pr=pr)
 
-        assert results[0][0:3] == (self.gh_repo.id, pr.key, self.organization.id)
-        assert (
-            groupowner_1.group_id in results[0][3]
-            and groupowner_2.group_id in results[0][3]
-            and groupowner_3.group_id in results[0][3]
-        )
+        assert results == [groupowner_1.group_id, groupowner_2.group_id, groupowner_3.group_id]
 
     def test_multiple_prs(self):
         """multiple eligible PRs with one issue each"""
@@ -199,21 +195,11 @@ class TestPrToIssueQuery(GithubCommentTestCase):
         groupowner_1 = self.add_groupowner_to_commit(commit_1, self.project, self.user)
         groupowner_2 = self.add_groupowner_to_commit(commit_2, self.project, self.user)
 
-        results = pr_to_issue_query(pr_1.id)
-        assert results[0] == (
-            self.gh_repo.id,
-            pr_1.key,
-            self.organization.id,
-            [groupowner_1.group_id],
-        )
+        results = self.pr_comment_workflow.get_issue_ids_from_pr(pr=pr_1)
+        assert results == [groupowner_1.group_id]
 
-        results = pr_to_issue_query(pr_2.id)
-        assert results[0] == (
-            self.gh_repo.id,
-            pr_2.key,
-            self.organization.id,
-            [groupowner_2.group_id],
-        )
+        results = self.pr_comment_workflow.get_issue_ids_from_pr(pr=pr_2)
+        assert results == [groupowner_2.group_id]
 
     def test_multiple_commits(self):
         """Multiple eligible commits with one issue each"""
@@ -223,16 +209,11 @@ class TestPrToIssueQuery(GithubCommentTestCase):
         self.add_branch_commit_to_pr(commit_2, pr)
         groupowner_1 = self.add_groupowner_to_commit(commit_1, self.project, self.user)
         groupowner_2 = self.add_groupowner_to_commit(commit_2, self.project, self.user)
-        results = pr_to_issue_query(pr.id)
-        assert results[0] == (
-            self.gh_repo.id,
-            pr.key,
-            self.organization.id,
-            [groupowner_1.group_id, groupowner_2.group_id],
-        )
+        results = self.pr_comment_workflow.get_issue_ids_from_pr(pr=pr)
+        assert results == [groupowner_1.group_id, groupowner_2.group_id]
 
 
-class TestTop5IssuesByCount(TestCase, SnubaTestCase):
+class TestTop5IssuesByCount(GithubCommentTestCase, SnubaTestCase):
     def test_simple(self):
         group1 = [
             self.store_event(
@@ -255,7 +236,9 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
             )
             for _ in range(4)
         ][0].group.id
-        res = get_top_5_issues_by_count([group1, group2, group3], self.project)
+        res = self.pr_comment_workflow.get_top_5_issues_by_count(
+            [group1, group2, group3], self.project
+        )
         assert [issue["group_id"] for issue in res] == [group2, group3, group1]
 
     def test_over_5_issues(self):
@@ -266,7 +249,7 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
             ).group.id
             for idx in range(6)
         ]
-        res = get_top_5_issues_by_count(issue_ids, self.project)
+        res = self.pr_comment_workflow.get_top_5_issues_by_count(issue_ids, self.project)
         assert len(res) == 5
 
     def test_ignore_info_level_issues(self):
@@ -299,7 +282,9 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
             )
             for _ in range(4)
         ][0].group.id
-        res = get_top_5_issues_by_count([group1, group2, group3], self.project)
+        res = self.pr_comment_workflow.get_top_5_issues_by_count(
+            [group1, group2, group3], self.project
+        )
         assert [issue["group_id"] for issue in res] == [group2]
 
     def test_do_not_ignore_other_issues(self):
@@ -336,11 +321,13 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
             )
             for _ in range(4)
         ][0].group.id
-        res = get_top_5_issues_by_count([group1, group2, group3], self.project)
+        res = self.pr_comment_workflow.get_top_5_issues_by_count(
+            [group1, group2, group3], self.project
+        )
         assert [issue["group_id"] for issue in res] == [group3, group1]
 
 
-class TestCommentBuilderQueries(GithubCommentTestCase):
+class TestGetCommentBody(GithubCommentTestCase):
     def test_simple(self):
         ev1 = self.store_event(
             data={"message": "issue 1", "culprit": "issue1", "fingerprint": ["group-1"]},
@@ -357,54 +344,16 @@ class TestCommentBuilderQueries(GithubCommentTestCase):
             project_id=self.project.id,
         )
         assert ev3.group is not None
-        comment_contents = get_comment_contents([ev1.group.id, ev2.group.id, ev3.group.id])
-        assert (
-            PullRequestIssue(
-                title="issue 1",
-                subtitle="issue1",
-                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/",
-            )
-            in comment_contents
-        )
-        assert (
-            PullRequestIssue(
-                title="issue 2",
-                subtitle="issue2",
-                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/",
-            )
-            in comment_contents
-        )
-        assert (
-            PullRequestIssue(
-                title="issue 3",
-                subtitle="issue3",
-                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/",
-            )
-            in comment_contents
+        formatted_comment = self.pr_comment_workflow.get_comment_body(
+            [ev1.group.id, ev2.group.id, ev3.group.id]
         )
 
-
-class TestFormatComment(TestCase):
-    def test_format_comment(self):
-        issues = [
-            PullRequestIssue(
-                title="TypeError",
-                subtitle="sentry.tasks.auto_source_code_config.derive_code_mappings",
-                url="https://sentry.sentry.io/issues/",
-            ),
-            PullRequestIssue(
-                title="KafkaException",
-                subtitle="query_subscription_consumer_process_message",
-                url="https://sentry.sentry.io/stats/",
-            ),
-        ]
-
-        formatted_comment = format_comment(issues)
-        expected_comment = """## Suspect Issues
+        expected_comment = f"""## Suspect Issues
 This pull request was deployed and Sentry observed the following issues:
 
-- ‼️ **TypeError** `sentry.tasks.auto_source_code_config.derive_cod...` [View Issue](https://sentry.sentry.io/issues/?referrer=github-pr-bot)
-- ‼️ **KafkaException** `query_subscription_consumer_process_message` [View Issue](https://sentry.sentry.io/stats/?referrer=github-pr-bot)
+- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{ev1.group.id}/?referrer=github-pr-bot)
+- ‼️ **issue 2** `issue2` [View Issue](http://testserver/organizations/foo/issues/{ev2.group.id}/?referrer=github-pr-bot)
+- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/foo/issues/{ev3.group.id}/?referrer=github-pr-bot)
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
         assert formatted_comment == expected_comment
@@ -418,7 +367,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.pr = self.create_pr_issues()
         self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
     @patch("sentry.integrations.source_code_management.commit_context.metrics")
     @responses.activate
     def test_comment_workflow(self, mock_metrics, mock_issues):
@@ -447,7 +398,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         assert pull_request_comment_query[0].comment_type == CommentType.MERGED_PR
         mock_metrics.incr.assert_called_with("github.pr_comment.comment_created")
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
     @patch("sentry.integrations.source_code_management.commit_context.metrics")
     @responses.activate
     @freeze_time(datetime(2023, 6, 8, 0, 0, 0, tzinfo=UTC))
@@ -490,8 +443,10 @@ class TestCommentWorkflow(GithubCommentTestCase):
         assert pull_request_comment.updated_at == timezone.now()
         mock_metrics.incr.assert_called_with("github.pr_comment.comment_updated")
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.tasks.pr_comment.metrics")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
     @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
     def test_comment_workflow_api_error(self, mock_integration_metrics, mock_metrics, mock_issues):
@@ -553,14 +508,22 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
 
     @patch(
-        "sentry.integrations.github.tasks.pr_comment.pr_to_issue_query",
-        return_value=[(0, 0, 0, [])],
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_issue_ids_from_pr",
+        return_value=[],
     )
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.tasks.pr_comment.metrics")
-    def test_comment_workflow_missing_org(self, mock_metrics, mock_issues, mock_issue_query):
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.models.Organization.objects")
+    def test_comment_workflow_missing_org(
+        self, mock_repository, mock_metrics, mock_issues, mock_issue_query
+    ):
         # Organization.DoesNotExist should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
+
+        mock_repository.get_from_cache.side_effect = Organization.DoesNotExist
+
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert not mock_issues.called
@@ -569,7 +532,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
             "github.pr_comment.error", tags={"type": "missing_org"}
         )
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
     def test_comment_workflow_missing_org_option(self, mock_issues):
         OrganizationOption.objects.set_value(
             organization=self.organization, key="sentry:github_pr_bot", value=False
@@ -578,9 +543,11 @@ class TestCommentWorkflow(GithubCommentTestCase):
 
         assert not mock_issues.called
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
     @patch("sentry.models.Project.objects.get_from_cache")
-    @patch("sentry.integrations.github.tasks.pr_comment.metrics")
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
     def test_comment_workflow_missing_project(self, mock_metrics, mock_project, mock_issues):
         # Project.DoesNotExist should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
@@ -596,13 +563,13 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
 
     @patch(
-        "sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count",
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
     @patch("sentry.models.Repository.objects")
-    @patch("sentry.integrations.github.tasks.pr_comment.format_comment")
-    @patch("sentry.integrations.github.tasks.pr_comment.metrics")
+    @patch("sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_comment_body")
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
     def test_comment_workflow_missing_repo(
-        self, mock_metrics, mock_format_comment, mock_repository, mock_issues
+        self, mock_metrics, mock_get_comment_body, mock_repository, mock_issues
     ):
         # Repository.DoesNotExist should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
@@ -614,20 +581,20 @@ class TestCommentWorkflow(GithubCommentTestCase):
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
         ]
 
-        assert mock_issues.called
-        assert not mock_format_comment.called
+        assert not mock_issues.called
+        assert not mock_get_comment_body.called
         assert cache.get(self.cache_key) is None
         mock_metrics.incr.assert_called_with(
             "github.pr_comment.error", tags={"type": "missing_repo"}
         )
 
     @patch(
-        "sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count",
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
-    @patch("sentry.integrations.github.tasks.pr_comment.format_comment")
-    @patch("sentry.integrations.github.tasks.pr_comment.metrics")
+    @patch("sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_comment_body")
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
     def test_comment_workflow_missing_integration(
-        self, mock_metrics, mock_format_comment, mock_issues
+        self, mock_metrics, mock_get_comment_body, mock_issues
     ):
         # missing integration should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
@@ -642,23 +609,25 @@ class TestCommentWorkflow(GithubCommentTestCase):
 
         github_comment_workflow(self.pr.id, self.project.id)
 
-        assert mock_issues.called
-        assert not mock_format_comment.called
+        assert not mock_issues.called
+        assert not mock_get_comment_body.called
         assert cache.get(self.cache_key) is None
         mock_metrics.incr.assert_called_with(
             "github.pr_comment.error", tags={"type": "missing_integration"}
         )
 
-    @patch("sentry.integrations.github.tasks.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.tasks.pr_comment.format_comment")
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
+    @patch("sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_comment_body")
     @responses.activate
-    def test_comment_workflow_no_issues(self, mock_format_comment, mock_issues):
+    def test_comment_workflow_no_issues(self, mock_get_comment_body, mock_issues):
         mock_issues.return_value = []
 
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert mock_issues.called
-        assert not mock_format_comment.called
+        assert not mock_get_comment_body.called
 
 
 class TestCommentReactionsTask(GithubCommentTestCase):

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -446,7 +446,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch(
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
-    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.metrics")
     @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
     def test_comment_workflow_api_error(self, mock_integration_metrics, mock_metrics, mock_issues):
@@ -514,7 +514,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch(
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
-    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.metrics")
     @patch("sentry.models.Organization.objects")
     def test_comment_workflow_missing_org(
         self, mock_repository, mock_metrics, mock_issues, mock_issue_query
@@ -529,7 +529,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         assert not mock_issues.called
         assert cache.get(self.cache_key) is None
         mock_metrics.incr.assert_called_with(
-            "github.pr_comment.error", tags={"type": "missing_org"}
+            "source_code_management.pr_comment.error", tags={"type": "missing_org"}
         )
 
     @patch(
@@ -547,7 +547,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
     @patch("sentry.models.Project.objects.get_from_cache")
-    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.metrics")
     def test_comment_workflow_missing_project(self, mock_metrics, mock_project, mock_issues):
         # Project.DoesNotExist should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
@@ -567,7 +567,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
     )
     @patch("sentry.models.Repository.objects")
     @patch("sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_comment_body")
-    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.metrics")
     def test_comment_workflow_missing_repo(
         self, mock_metrics, mock_get_comment_body, mock_repository, mock_issues
     ):
@@ -585,14 +585,14 @@ class TestCommentWorkflow(GithubCommentTestCase):
         assert not mock_get_comment_body.called
         assert cache.get(self.cache_key) is None
         mock_metrics.incr.assert_called_with(
-            "github.pr_comment.error", tags={"type": "missing_repo"}
+            "source_code_management.pr_comment.error", tags={"type": "missing_repo"}
         )
 
     @patch(
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
     @patch("sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_comment_body")
-    @patch("sentry.integrations.source_code_management.commit_context.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.metrics")
     def test_comment_workflow_missing_integration(
         self, mock_metrics, mock_get_comment_body, mock_issues
     ):
@@ -613,7 +613,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         assert not mock_get_comment_body.called
         assert cache.get(self.cache_key) is None
         mock_metrics.incr.assert_called_with(
-            "github.pr_comment.error", tags={"type": "missing_integration"}
+            "source_code_management.pr_comment.error", tags={"type": "missing_integration"}
         )
 
     @patch(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -839,7 +839,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
     "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
     return_value=[],
 )
-@patch("sentry.integrations.github.tasks.pr_comment.github_comment_workflow.delay")
+@patch("sentry.integrations.source_code_management.tasks.pr_comment_workflow.delay")
 class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
     provider = GitHubIntegrationProvider
     base_url = "https://api.github.com"


### PR DESCRIPTION
Make the PR comment workflow generic. Migrate the GitHub integration to utilize it.

This PR is built on top of https://github.com/getsentry/sentry/pull/89683.