### PR TITLE
analytics: add labels for chonk theme events

### DIFF
--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -3,7 +3,9 @@ type NavigationItemClicked = {
 };
 
 export type NavigationEventParameters = {
+  'navigation.help_menu_opt_in_chonk_ui_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
+  'navigation.help_menu_opt_out_chonk_ui_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.primary_item_clicked': NavigationItemClicked;
   'navigation.secondary_item_clicked': NavigationItemClicked;
@@ -18,4 +20,8 @@ export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | nu
     'Navigation: Help Menu Opt Out Of Stacked Navigation Clicked',
   'navigation.primary_item_clicked': 'Navigation: Primary Item Clicked',
   'navigation.secondary_item_clicked': 'Navigation: Secondary Item Clicked',
+  'navigation.help_menu_opt_out_chonk_ui_clicked':
+    'Navigation: Help Menu Opt Out Chonk UI Clicked',
+  'navigation.help_menu_opt_in_chonk_ui_clicked':
+    'Navigation: Help Menu Opt In Chonk UI Clicked',
 };


### PR DESCRIPTION
It might be that our trackAnalytics types are broken, as these were missing and no TS errors were generated