### PR TITLE
feat(autofix): Add support for multiline input

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -16,7 +16,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {SeerIcon} from 'sentry/components/ai/SeerIcon';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Button} from 'sentry/components/core/button';
-import {Input} from 'sentry/components/core/input';
+import {TextArea} from 'sentry/components/core/textarea';
 import {
   makeAutofixQueryKey,
   useAutofixData,
@@ -317,6 +317,14 @@ function AutofixHighlightPopupContent({
             maxLength={4096}
             size="sm"
             autoFocus
+            maxRows={5}
+            autosize
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit(e);
+              }
+            }}
           />
           <StyledButton
             size="zero"
@@ -536,12 +544,15 @@ const InputWrapper = styled('form')`
   position: relative;
 `;
 
-const StyledInput = styled(Input)`
+const StyledInput = styled(TextArea)`
   flex-grow: 1;
   background: ${p => p.theme.background}
     linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
   border-color: ${p => p.theme.innerBorder};
   padding-right: ${space(4)};
+  padding-top: ${space(0.75)};
+  padding-bottom: ${space(0.75)};
+  resize: none;
 
   &:hover {
     border-color: ${p => p.theme.border};
@@ -620,6 +631,7 @@ const MessageContent = styled('div')`
   color: ${p => p.theme.textColor};
   word-break: break-word;
   overflow-wrap: break-word;
+  white-space: pre-wrap;
 `;
 
 const CircularSeerIcon = styled('div')`

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -5,7 +5,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import {Input} from 'sentry/components/core/input';
+import {TextArea} from 'sentry/components/core/textarea';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRootCause';
@@ -144,6 +144,19 @@ function AutofixInsightCard({
     };
   }, [insight.insight, isNewInsight]);
 
+  let truncatedTitle = displayedInsightTitle;
+  const newlineIndex = displayedInsightTitle.indexOf('\n');
+  if (newlineIndex !== -1 && newlineIndex < displayedInsightTitle.length - 1) {
+    truncatedTitle = displayedInsightTitle.substring(0, newlineIndex) + '...';
+  }
+
+  let fullJustification = isUserMessage ? '' : insight.justification;
+  if (newlineIndex !== -1) {
+    const excludedText = displayedInsightTitle.substring(newlineIndex + 1);
+    const excludedTextWithEllipsis = excludedText ? '...' + excludedText : '';
+    fullJustification = excludedTextWithEllipsis + '\n\n' + fullJustification;
+  }
+
   return (
     <ContentWrapper>
       <AnimatePresence initial={isNewInsight}>
@@ -162,12 +175,20 @@ function AutofixInsightCard({
                 <form onSubmit={handleSubmit}>
                   <EditFormRow>
                     <EditInput
-                      type="text"
+                      autosize
                       value={editText}
                       maxLength={4096}
                       onChange={e => setEditText(e.target.value)}
                       placeholder={t('Share your own insight here...')}
                       autoFocus
+                      maxRows={5}
+                      size="sm"
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          handleSubmit(e);
+                        }
+                      }}
                     />
                     <ButtonBar merged>
                       <Button
@@ -193,10 +214,7 @@ function AutofixInsightCard({
                 </form>
               </EditContainer>
             ) : (
-              <InsightCardRow
-                onClick={isUserMessage ? undefined : toggleExpand}
-                isUserMessage={isUserMessage}
-              >
+              <InsightCardRow onClick={toggleExpand}>
                 <AutofixHighlightWrapper
                   groupId={groupId}
                   runId={runId}
@@ -205,26 +223,24 @@ function AutofixInsightCard({
                 >
                   <MiniHeader
                     dangerouslySetInnerHTML={{
-                      __html: singleLineRenderer(displayedInsightTitle),
+                      __html: singleLineRenderer(truncatedTitle),
                     }}
                   />
                 </AutofixHighlightWrapper>
 
                 <RightSection>
-                  {!isUserMessage && (
-                    <Button
-                      size="zero"
-                      borderless
-                      title={expanded ? t('Hide evidence') : t('Show evidence')}
-                      icon={
-                        <StyledIconChevron
-                          direction={expanded ? 'down' : 'right'}
-                          size="sm"
-                        />
-                      }
-                      aria-label={expanded ? t('Hide evidence') : t('Show evidence')}
-                    />
-                  )}
+                  <Button
+                    size="zero"
+                    borderless
+                    title={expanded ? t('Hide evidence') : t('Show evidence')}
+                    icon={
+                      <StyledIconChevron
+                        direction={expanded ? 'down' : 'right'}
+                        size="sm"
+                      />
+                    }
+                    aria-label={expanded ? t('Hide evidence') : t('Show evidence')}
+                  />
                   <EditButton
                     size="zero"
                     borderless
@@ -238,7 +254,7 @@ function AutofixInsightCard({
             )}
 
             <AnimatePresence>
-              {expanded && !isUserMessage && (
+              {expanded && (
                 <motion.div
                   initial={{height: 0, opacity: 0}}
                   animate={{height: 'auto', opacity: 1}}
@@ -256,12 +272,12 @@ function AutofixInsightCard({
                     retainInsightCardIndex={insightCardAboveIndex}
                   >
                     <ContextBody>
-                      {insight.justification || !insight.change_diff ? (
+                      {fullJustification || !insight.change_diff ? (
                         <p
                           dangerouslySetInnerHTML={{
                             __html: marked(
                               replaceHeadersWithBold(
-                                insight.justification || t('No details here.')
+                                fullJustification || t('No details here.')
                               )
                             ),
                           }}
@@ -457,7 +473,7 @@ export function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: 
           run_id: runId,
           payload: {
             type: 'restart_from_point_with_feedback',
-            message: params.message,
+            message: params.message.trim(),
             step_index: params.step_index,
             retain_insight_card_index: params.retain_insight_card_index,
           },
@@ -569,9 +585,9 @@ const InsightCardRow = styled('div')<{isUserMessage?: boolean}>`
   display: flex;
   justify-content: space-between;
   align-items: stretch;
-  cursor: ${p => (p.isUserMessage ? 'default' : 'pointer')};
+  cursor: pointer;
   &:hover {
-    background-color: ${p => (p.isUserMessage ? 'inherit' : p.theme.backgroundSecondary)};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;
 
@@ -752,8 +768,9 @@ const EditFormRow = styled('div')`
   width: 100%;
 `;
 
-const EditInput = styled(Input)`
+const EditInput = styled(TextArea)`
   flex: 1;
+  resize: none;
 `;
 
 const EditButton = styled(Button)`

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -139,30 +139,6 @@ export function AutofixOutputStream({
     };
   }, [stream, displayedText]);
 
-  // Animation for active log
-  useEffect(() => {
-    const newActiveLog = activeLog;
-
-    if (!newActiveLog.startsWith(displayedActiveLog)) {
-      previousActiveLog.current = newActiveLog;
-      activeLogIndexRef.current = 0;
-      setDisplayedActiveLog('');
-    }
-
-    const interval = window.setInterval(() => {
-      if (activeLogIndexRef.current < newActiveLog.length) {
-        setDisplayedActiveLog(newActiveLog.slice(0, activeLogIndexRef.current + 1));
-        activeLogIndexRef.current++;
-      } else {
-        window.clearInterval(interval);
-      }
-    }, 10);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [displayedActiveLog, activeLog]);
-
   const handleSend = (e: FormEvent) => {
     e.preventDefault();
     if (isInitializingRun) {

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -6,7 +6,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {SeerLoadingIcon} from 'sentry/components/ai/SeerIcon';
 import {Button} from 'sentry/components/core/button';
-import {Input} from 'sentry/components/core/input';
+import {TextArea} from 'sentry/components/core/textarea';
 import {FlyingLinesEffect} from 'sentry/components/events/autofix/FlyingLinesEffect';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import {IconChevron} from 'sentry/icons';
@@ -159,7 +159,7 @@ export function AutofixOutputStream({
     };
   }, [displayedActiveLog, activeLog]);
 
-  const handleSend = (e: FormEvent<HTMLFormElement>) => {
+  const handleSend = (e: FormEvent) => {
     e.preventDefault();
     if (isInitializingRun) {
       // don't send message during loading state
@@ -220,13 +220,21 @@ export function AutofixOutputStream({
             )}
             <InputWrapper onSubmit={handleSend}>
               <StyledInput
-                type="text"
+                autosize
                 value={message}
                 onChange={e => setMessage(e.target.value)}
                 maxLength={4096}
                 placeholder={
                   responseRequired ? 'Please answer to continue...' : 'Interrupt me...'
                 }
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSend(e);
+                  }
+                }}
+                maxRows={5}
+                size="sm"
               />
               <StyledButton
                 type="submit"
@@ -327,12 +335,13 @@ const InputWrapper = styled('form')`
   position: relative;
 `;
 
-const StyledInput = styled(Input)`
+const StyledInput = styled(TextArea)`
   flex-grow: 1;
   background: ${p => p.theme.background}
     linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
   border-color: ${p => p.theme.innerBorder};
   padding-right: ${space(4)};
+  resize: none;
 
   &:hover {
     border-color: ${p => p.theme.border};

--- a/static/app/components/events/autofix/autofixStartBox.tsx
+++ b/static/app/components/events/autofix/autofixStartBox.tsx
@@ -1,0 +1,183 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import starImage from 'sentry-images/spot/banner-star.svg';
+
+import {SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
+import {Button} from 'sentry/components/core/button';
+import {TextArea} from 'sentry/components/core/textarea';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface AutofixStartBoxProps {
+  groupId: string;
+  onSend: (message: string) => void;
+}
+
+export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSend(message);
+  };
+
+  return (
+    <Wrapper>
+      <ScaleContainer>
+        <StyledArrow direction="down" size="sm" />
+        <Container>
+          <AutofixStartText>
+            <BackgroundStar
+              src={starImage}
+              style={{
+                width: '20px',
+                height: '20px',
+                right: '5%',
+                top: '20%',
+                transform: 'rotate(15deg)',
+              }}
+            />
+            <BackgroundStar
+              src={starImage}
+              style={{
+                width: '16px',
+                height: '16px',
+                right: '35%',
+                top: '40%',
+                transform: 'rotate(45deg)',
+              }}
+            />
+            <BackgroundStar
+              src={starImage}
+              style={{
+                width: '14px',
+                height: '14px',
+                right: '25%',
+                top: '60%',
+                transform: 'rotate(30deg)',
+              }}
+            />
+            <StartTextRow>
+              <StyledSeerWaitingIcon size="lg" />
+              <Fragment>Need help digging deeper?</Fragment>
+            </StartTextRow>
+          </AutofixStartText>
+          <InputWrapper onSubmit={handleSubmit}>
+            <StyledInput
+              autosize
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit(e);
+                }
+              }}
+              placeholder="(Optional) Share helpful context here..."
+              maxLength={4096}
+              maxRows={10}
+              size="sm"
+            />
+            <StyledButton
+              type="submit"
+              priority="primary"
+              analyticsEventKey={
+                message
+                  ? 'autofix.give_instructions_clicked'
+                  : 'autofix.start_fix_clicked'
+              }
+              analyticsEventName={
+                message
+                  ? 'Autofix: Give Instructions Clicked'
+                  : 'Autofix: Start Fix Clicked'
+              }
+              analyticsParams={{group_id: groupId}}
+            >
+              {t('Start Autofix')}
+            </StyledButton>
+          </InputWrapper>
+        </Container>
+      </ScaleContainer>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: ${space(1)} ${space(4)};
+  gap: ${space(1)};
+`;
+
+const ScaleContainer = styled('div')`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const Container = styled('div')`
+  position: relative;
+  width: 100%;
+  border-radius: ${p => p.theme.borderRadius};
+  background: ${p => p.theme.background}
+    linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
+  overflow: hidden;
+  padding: ${space(0.5)};
+  border: 1px solid ${p => p.theme.border};
+`;
+
+const AutofixStartText = styled('div')`
+  margin: 0;
+  padding: ${space(1)};
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: ${p => p.theme.fontSizeLarge};
+  position: relative;
+`;
+
+const StartTextRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const StyledSeerWaitingIcon = styled(SeerWaitingIcon)`
+  color: ${p => p.theme.textColor};
+`;
+
+const BackgroundStar = styled('img')`
+  position: absolute;
+  filter: sepia(1) saturate(3) hue-rotate(290deg);
+  opacity: 0.7;
+  pointer-events: none;
+  z-index: 0;
+`;
+
+const StyledArrow = styled(IconArrow)`
+  color: ${p => p.theme.subText};
+  opacity: 0.5;
+`;
+
+const InputWrapper = styled('form')`
+  display: flex;
+  gap: ${space(0.5)};
+  padding: ${space(0.25)} ${space(0.25)};
+`;
+
+const StyledInput = styled(TextArea)`
+  resize: none;
+
+  border-color: ${p => p.theme.innerBorder};
+  &:hover {
+    border-color: ${p => p.theme.border};
+  }
+`;
+
+const StyledButton = styled(Button)`
+  flex-shrink: 0;
+`;

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -1,20 +1,17 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import starImage from 'sentry-images/spot/banner-star.svg';
-
 import Feature from 'sentry/components/acl/feature';
-import {SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Flex} from 'sentry/components/container/flex';
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import {Input} from 'sentry/components/core/input';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import {AutofixProgressBar} from 'sentry/components/events/autofix/autofixProgressBar';
+import {AutofixStartBox} from 'sentry/components/events/autofix/autofixStartBox';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import AutofixPreferenceDropdown from 'sentry/components/events/autofix/preferences/autofixPreferenceDropdown';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
@@ -26,7 +23,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {IconArrow} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -38,92 +34,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventTitle';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 import {SeerNotices} from 'sentry/views/issueDetails/streamline/sidebar/seerNotices';
-
-interface AutofixStartBoxProps {
-  groupId: string;
-  onSend: (message: string) => void;
-}
-
-function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
-  const [message, setMessage] = useState('');
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onSend(message);
-  };
-
-  return (
-    <Wrapper>
-      <ScaleContainer>
-        <StyledArrow direction="down" size="sm" />
-        <Container>
-          <AutofixStartText>
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '20px',
-                height: '20px',
-                right: '5%',
-                top: '20%',
-                transform: 'rotate(15deg)',
-              }}
-            />
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '16px',
-                height: '16px',
-                right: '35%',
-                top: '40%',
-                transform: 'rotate(45deg)',
-              }}
-            />
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '14px',
-                height: '14px',
-                right: '25%',
-                top: '60%',
-                transform: 'rotate(30deg)',
-              }}
-            />
-            <StartTextRow>
-              <StyledSeerWaitingIcon size="lg" />
-              <Fragment>Need help digging deeper?</Fragment>
-            </StartTextRow>
-          </AutofixStartText>
-          <InputWrapper onSubmit={handleSubmit}>
-            <StyledInput
-              type="text"
-              value={message}
-              onChange={e => setMessage(e.target.value)}
-              placeholder="(Optional) Share helpful context here..."
-              maxLength={4096}
-            />
-            <StyledButton
-              type="submit"
-              priority="primary"
-              analyticsEventKey={
-                message
-                  ? 'autofix.give_instructions_clicked'
-                  : 'autofix.start_fix_clicked'
-              }
-              analyticsEventName={
-                message
-                  ? 'Autofix: Give Instructions Clicked'
-                  : 'Autofix: Start Fix Clicked'
-              }
-              analyticsParams={{group_id: groupId}}
-            >
-              {t('Start Autofix')}
-            </StyledButton>
-          </InputWrapper>
-        </Container>
-      </ScaleContainer>
-    </Wrapper>
-  );
-}
 
 interface SeerDrawerProps {
   event: Event;
@@ -370,85 +280,6 @@ export const useOpenSeerDrawer = (
     });
   }, [openDrawer, buttonRef, event, group, project]);
 };
-
-const Wrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: ${space(1)} ${space(4)};
-  gap: ${space(1)};
-`;
-
-const ScaleContainer = styled('div')`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: ${space(1)};
-`;
-
-const Container = styled('div')`
-  position: relative;
-  width: 100%;
-  border-radius: ${p => p.theme.borderRadius};
-  background: ${p => p.theme.background}
-    linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
-  overflow: hidden;
-  padding: ${space(0.5)};
-  border: 1px solid ${p => p.theme.border};
-`;
-
-const AutofixStartText = styled('div')`
-  margin: 0;
-  padding: ${space(1)};
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: ${p => p.theme.fontSizeLarge};
-  position: relative;
-`;
-
-const StartTextRow = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-`;
-
-const StyledSeerWaitingIcon = styled(SeerWaitingIcon)`
-  color: ${p => p.theme.textColor};
-`;
-
-const BackgroundStar = styled('img')`
-  position: absolute;
-  filter: sepia(1) saturate(3) hue-rotate(290deg);
-  opacity: 0.7;
-  pointer-events: none;
-  z-index: 0;
-`;
-
-const StyledArrow = styled(IconArrow)`
-  color: ${p => p.theme.subText};
-  opacity: 0.5;
-`;
-
-const InputWrapper = styled('form')`
-  display: flex;
-  gap: ${space(0.5)};
-  padding: ${space(0.25)} ${space(0.25)};
-`;
-
-const StyledInput = styled(Input)`
-  flex-grow: 1;
-  background: ${p => p.theme.background};
-  border-color: ${p => p.theme.innerBorder};
-
-  &:hover {
-    border-color: ${p => p.theme.border};
-  }
-`;
-
-const StyledButton = styled(Button)`
-  flex-shrink: 0;
-`;
 
 const StyledCard = styled('div')`
   background: ${p => p.theme.backgroundElevated};


### PR DESCRIPTION
Switch all user inputs in Autofix to be TextArea's so users can use shift + enter to add multiline text. No visible changes by default though.

Also add some truncation logic to insight cards to show just the first line of multiline cards by default, and show the rest when expanded.