### PR TITLE
nav: close dot prompt when help is opened

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -310,6 +310,7 @@ export function usePrompt({
     if (!organization) {
       return;
     }
+
     promptsUpdate(api, {
       organization,
       projectId,

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
@@ -11,6 +12,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
+import {useChonkPrompt} from 'sentry/utils/theme/useChonkPrompt';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import {useUser} from 'sentry/utils/useUser';
@@ -29,15 +31,21 @@ type Props = Pick<
 
 function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
   const user = useUser();
-  const {shouldShowHelpMenuDot, onOpenHelpMenu} = useNavPrompts({
+  const navPrompts = useNavPrompts({
     collapsed,
     organization,
   });
+  const chonkPrompts = useChonkPrompt();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
   const openForm = useFeedbackForm();
 
+  const onHelpMenuOpen = useCallback(() => {
+    navPrompts.onOpenHelpMenu();
+    chonkPrompts.dismissDotIndicatorPrompt();
+  }, [navPrompts, chonkPrompts]);
+
   return (
-    <DeprecatedDropdownMenu onOpen={onOpenHelpMenu}>
+    <DeprecatedDropdownMenu onOpen={onHelpMenuOpen}>
       {({isOpen, getActorProps, getMenuProps}) => (
         <HelpRoot>
           <HelpActor {...getActorProps({onClick: hidePanel})}>
@@ -50,7 +58,8 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
               label={t('Help')}
               id="help"
             />
-            {shouldShowHelpMenuDot && (
+            {(navPrompts.shouldShowHelpMenuDot ||
+              chonkPrompts.showDotIndicatorPrompt) && (
               <IndicatorDot
                 orientation={orientation}
                 collapsed={collapsed}
@@ -102,7 +111,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                     );
                   }}
                 >
-                  {t('Try New Navigation')} <Badge type="alpha">Alpha</Badge>
+                  {t('Try New Navigation')} <Badge type="alpha">{t('Alpha')}</Badge>
                 </SidebarMenuItem>
               )}
               {organization?.features?.includes('chonk-ui') ? (
@@ -115,7 +124,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                       });
                     }}
                   >
-                    {t('Switch to old UI theme')}
+                    {t('Switch Back To Our Old Look')}
                   </SidebarMenuItem>
                 ) : (
                   <SidebarMenuItem
@@ -126,7 +135,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                       });
                     }}
                   >
-                    {t('Try New UI2 Theme')} <Badge type="internal">Internal</Badge>
+                    {t('Try Our New Look')} <Badge type="internal">{t('Internal')}</Badge>
                   </SidebarMenuItem>
                 )
               ) : null}

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
@@ -39,13 +38,13 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
   const {mutate: mutateUserOptions} = useMutateUserOptions();
   const openForm = useFeedbackForm();
 
-  const onHelpMenuOpen = useCallback(() => {
-    navPrompts.onOpenHelpMenu();
-    chonkPrompts.dismissDotIndicatorPrompt();
-  }, [navPrompts, chonkPrompts]);
-
   return (
-    <DeprecatedDropdownMenu onOpen={onHelpMenuOpen}>
+    <DeprecatedDropdownMenu
+      onOpen={() => {
+        navPrompts.onOpenHelpMenu();
+        chonkPrompts.dismissDotIndicatorPrompt();
+      }}
+    >
       {({isOpen, getActorProps, getMenuProps}) => (
         <HelpRoot>
           <HelpActor {...getActorProps({onClick: hidePanel})}>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -49,6 +49,7 @@ import {space} from 'sentry/styles/space';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {ChonkOptInBanner} from 'sentry/utils/theme/ChonkOptInBanner';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -529,6 +530,8 @@ function Sidebar() {
                 collapsed={collapsed || horizontal}
                 organization={organization}
               />
+              <ChonkOptInBanner collapsed={collapsed || horizontal} />
+
               {HookStore.get('sidebar:try-business').length > 0 &&
                 HookStore.get('sidebar:try-business')[0]!({
                   orientation,

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -1,0 +1,107 @@
+import {ThemeProvider} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import Panel from 'sentry/components/panels/panel';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {space} from 'sentry/styles/space';
+import {DO_NOT_USE_lightChonkTheme} from 'sentry/utils/theme/theme.chonk';
+import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
+
+import {useChonkPrompt} from './useChonkPrompt';
+
+export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
+  const chonkPrompt = useChonkPrompt();
+  const config = useLegacyStore(ConfigStore);
+  const {mutate: mutateUserOptions} = useMutateUserOptions();
+
+  if (props.collapsed === true || !chonkPrompt.showbannerPrompt) {
+    return null;
+  }
+
+  return (
+    <TranslucentBackgroundPanel
+      isDarkMode={config.theme === 'dark'}
+      position={props.collapsed === 'never' ? 'absolute' : 'relative'}
+    >
+      <Title>{t('Sentry has a new look')}</Title>
+      <Description>
+        {t(`We've updated Sentry with a fresh new look, try it out by opting in below.`)}
+      </Description>
+      <ThemeProvider theme={DO_NOT_USE_lightChonkTheme}>
+        <OptInButton
+          priority="primary"
+          size="xs"
+          analyticsEventKey="navigation.banner_opt_in_chonk_ui_clicked"
+          analyticsEventName="Navigation: Chonk UI Banner Opt In Clicked"
+          onClick={() => {
+            mutateUserOptions({prefersChonkUI: true});
+            chonkPrompt.dismiss();
+          }}
+        >
+          {t('Try It Out')}
+        </OptInButton>
+      </ThemeProvider>
+      <DismissButton
+        icon={<IconClose />}
+        aria-label={t('Dismiss')}
+        onClick={chonkPrompt.dismissBannerPrompt}
+        size="xs"
+        borderless
+        analyticsEventKey="navigation.banner_dismiss_chonk_ui"
+        analyticsEventName="Navigation: Chonk UI Banner Dismissed"
+      />
+    </TranslucentBackgroundPanel>
+  );
+}
+
+const TranslucentBackgroundPanel = styled(Panel)<{
+  isDarkMode: boolean;
+  position: 'absolute' | 'relative';
+}>`
+  /* 186px is the same width as what we render in the legacy nav */
+  width: ${p => (p.position === 'absolute' ? '186px' : undefined)};
+  /* 66px is the same left offset that we need to render due to collapsed nav */
+  left: ${p => (p.position === 'absolute' ? '66px' : undefined)};
+  position: relative;
+  background: ${p => p.theme.background};
+  border: 1px solid ${p => p.theme.border};
+  padding: ${space(1)};
+  color: ${p => p.theme.textColor};
+
+  margin-bottom: ${space(1)};
+`;
+
+const Title = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin: 0;
+
+  display: flex;
+  align-items: center;
+`;
+
+const Description = styled('p')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin: ${space(0.5)} 0;
+`;
+
+const OptInButton = styled(Button)`
+  margin: 0 auto;
+  width: 100%;
+`;
+
+const DismissButton = styled(Button)`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  color: currentColor;
+
+  &:hover {
+    color: currentColor;
+  }
+`;

--- a/static/app/utils/theme/useChonkPrompt.spec.tsx
+++ b/static/app/utils/theme/useChonkPrompt.spec.tsx
@@ -33,7 +33,7 @@ describe('useChonkPrompt', () => {
       wrapper: makeWrapper(OrganizationFixture({features: []})),
     });
 
-    expect(result.current.showTooltipPrompt).toBe(false);
+    expect(result.current.showbannerPrompt).toBe(false);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 
@@ -47,7 +47,7 @@ describe('useChonkPrompt', () => {
       wrapper: makeWrapper(OrganizationFixture({features: ['chonk-ui']})),
     });
 
-    expect(result.current.showTooltipPrompt).toBe(true);
+    expect(result.current.showbannerPrompt).toBe(true);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 
@@ -66,22 +66,22 @@ describe('useChonkPrompt', () => {
       wrapper: makeWrapper(OrganizationFixture({features: ['chonk-ui']})),
     });
 
-    expect(result.current.showTooltipPrompt).toBe(true);
+    expect(result.current.showbannerPrompt).toBe(true);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
 
-    result.current.dismissTooltipPrompt();
+    result.current.dismissBannerPrompt();
 
     expect(dismissMock).toHaveBeenCalledWith(
       '/organizations/org-slug/prompts-activity/',
       expect.objectContaining({
         data: expect.objectContaining({
-          feature: 'chonk-ui-tooltip',
+          feature: 'chonk_ui_banner',
           status: 'dismissed',
         }),
       })
     );
 
-    await waitFor(() => expect(result.current.showTooltipPrompt).toBe(false));
+    await waitFor(() => expect(result.current.showbannerPrompt).toBe(false));
     await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(true));
   });
 
@@ -100,7 +100,7 @@ describe('useChonkPrompt', () => {
       wrapper: makeWrapper(OrganizationFixture({features: ['chonk-ui']})),
     });
 
-    expect(result.current.showTooltipPrompt).toBe(false);
+    expect(result.current.showbannerPrompt).toBe(false);
     expect(result.current.showDotIndicatorPrompt).toBe(true);
 
     result.current.dismissDotIndicatorPrompt();
@@ -109,13 +109,13 @@ describe('useChonkPrompt', () => {
       '/organizations/org-slug/prompts-activity/',
       expect.objectContaining({
         data: expect.objectContaining({
-          feature: 'chonk-ui-dot-indicator',
+          feature: 'chonk_ui_dot_indicator',
           status: 'dismissed',
         }),
       })
     );
 
-    await waitFor(() => expect(result.current.showTooltipPrompt).toBe(false));
+    await waitFor(() => expect(result.current.showbannerPrompt).toBe(false));
     await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(false));
   });
 
@@ -139,7 +139,7 @@ describe('useChonkPrompt', () => {
       wrapper: makeWrapper(OrganizationFixture({features: ['chonk-ui']})),
     });
 
-    expect(result.current.showTooltipPrompt).toBe(false);
+    expect(result.current.showbannerPrompt).toBe(false);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 });

--- a/static/app/utils/theme/useChonkPrompt.tsx
+++ b/static/app/utils/theme/useChonkPrompt.tsx
@@ -1,9 +1,11 @@
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 
 function noop() {}
 
 export function useChonkPrompt() {
+  const user = useUser();
   const organization = useOrganization();
   const hasChonkUI = organization?.features.includes('chonk-ui');
 
@@ -19,7 +21,9 @@ export function useChonkPrompt() {
     options: {enabled: hasChonkUI},
   });
 
-  if (!hasChonkUI) {
+  // User is optional because we useUser hooks reads the value from ConfigStore,
+  // and I have little trust in its type safety.
+  if (!hasChonkUI || user?.options?.prefersChonkUI) {
     return {
       showTooltipPrompt: false,
       showDotIndicatorPrompt: false,

--- a/static/app/utils/theme/useChonkPrompt.tsx
+++ b/static/app/utils/theme/useChonkPrompt.tsx
@@ -29,6 +29,7 @@ export function useChonkPrompt() {
       showDotIndicatorPrompt: false,
       dismissBannerPrompt: noop,
       dismissDotIndicatorPrompt: noop,
+      dismiss: noop,
     };
   }
 
@@ -41,14 +42,22 @@ export function useChonkPrompt() {
     showbannerPrompt: !bannerPrompt.isPromptDismissed,
     showDotIndicatorPrompt,
     dismissBannerPrompt: () => {
-      if (!bannerPrompt.isPromptDismissed) {
-        bannerPrompt.dismissPrompt();
+      if (bannerPrompt.isPromptDismissed) {
+        return;
       }
+
+      bannerPrompt.dismissPrompt();
     },
     dismissDotIndicatorPrompt: () => {
-      if (showDotIndicatorPrompt) {
-        dotIndicatorPrompt.dismissPrompt();
+      if (!showDotIndicatorPrompt) {
+        return;
       }
+
+      dotIndicatorPrompt.dismissPrompt();
+    },
+    dismiss: () => {
+      bannerPrompt.dismissPrompt();
+      dotIndicatorPrompt.dismissPrompt();
     },
   };
 }

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -33,7 +33,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'performance-trace-explorer',
   'profiling',
-  'chonk-ui',
 ];
 
 const mockUsingCustomerDomain = jest.fn();
@@ -82,7 +81,9 @@ describe('Nav', function () {
   function renderNav({
     initialPathname = '/organizations/org-slug/issues/',
     route,
+    features = ALL_AVAILABLE_FEATURES,
   }: {
+    features?: string[];
     initialPathname?: string;
     route?: string;
   } = {}) {
@@ -92,7 +93,7 @@ describe('Nav', function () {
         <div id="main" />
       </NavContextProvider>,
       {
-        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        organization: OrganizationFixture({features}),
         enableRouterMocks: false,
         initialRouterConfig: {
           route,
@@ -381,9 +382,16 @@ describe('Nav', function () {
   });
 
   describe('chonk-ui', function () {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/prompts-activity/',
+        body: {data: {dismissed_ts: null}},
+      });
+    });
+
     describe('enabled', function () {
       it('shows the chonk-ui toggle in the help menu', async function () {
-        renderNav();
+        renderNav({features: ALL_AVAILABLE_FEATURES.concat('chonk-ui')});
         const helpMenu = screen.getByRole('button', {name: 'Help'});
         await userEvent.click(helpMenu);
 
@@ -399,7 +407,7 @@ describe('Nav', function () {
           },
         });
 
-        renderNav();
+        renderNav({features: ALL_AVAILABLE_FEATURES.concat('chonk-ui')});
         const helpMenu = screen.getByRole('button', {name: 'Help'});
         await userEvent.click(helpMenu);
 
@@ -409,7 +417,7 @@ describe('Nav', function () {
 
     describe('disabled', function () {
       it('does not show the chonk-ui toggle in the help menu', async function () {
-        renderNav();
+        renderNav({features: ALL_AVAILABLE_FEATURES});
         const helpMenu = screen.getByRole('button', {name: 'Help'});
         await userEvent.click(helpMenu);
 

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -36,6 +36,7 @@ interface SidebarItemDropdownProps {
   label: string;
   children?: React.ReactNode;
   forceLabel?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 interface SidebarButtonProps {
@@ -76,6 +77,7 @@ export function SidebarMenu({
   analyticsKey,
   label,
   forceLabel,
+  onClick,
 }: SidebarItemDropdownProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -96,6 +98,7 @@ export function SidebarMenu({
               onClick={event => {
                 recordPrimaryItemClick(analyticsKey, organization);
                 props.onClick?.(event);
+                onClick?.(event);
               }}
               isMobile={layout === NavLayout.MOBILE}
             >

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -36,7 +36,7 @@ interface SidebarItemDropdownProps {
   label: string;
   children?: React.ReactNode;
   forceLabel?: boolean;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
+  onOpen?: MouseEventHandler<HTMLButtonElement>;
 }
 
 interface SidebarButtonProps {
@@ -77,7 +77,7 @@ export function SidebarMenu({
   analyticsKey,
   label,
   forceLabel,
-  onClick,
+  onOpen,
 }: SidebarItemDropdownProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -98,7 +98,7 @@ export function SidebarMenu({
               onClick={event => {
                 recordPrimaryItemClick(analyticsKey, organization);
                 props.onClick?.(event);
-                onClick?.(event);
+                onOpen?.(event);
               }}
               isMobile={layout === NavLayout.MOBILE}
             >

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -142,7 +142,7 @@ export function PrimaryNavigationHelp() {
                 ? user.options.prefersChonkUI
                   ? {
                       key: 'new-chonk-ui',
-                      label: t('Switch to old UI theme'),
+                      label: t('Switch Back To Our Old Look'),
                       onAction() {
                         mutateUserOptions({prefersChonkUI: false});
                         trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
@@ -152,7 +152,7 @@ export function PrimaryNavigationHelp() {
                     }
                   : {
                       key: 'new-chonk-ui',
-                      label: t('Try New UI2 Theme'),
+                      label: t('Try Our New Look'),
                       onAction() {
                         mutateUserOptions({prefersChonkUI: true});
                         trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useChonkPrompt} from 'sentry/utils/theme/useChonkPrompt';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -55,10 +56,12 @@ export function PrimaryNavigationHelp() {
   const contactSupportItem = getContactSupportItem({organization});
   const openForm = useFeedbackForm();
   const {startTour} = useStackedNavigationTour();
+  const chonkPrompt = useChonkPrompt();
 
   return (
     <StackedNavigationTourReminder>
       <SidebarMenu
+        onClick={chonkPrompt.dismissDotIndicatorPrompt}
         items={[
           {
             key: 'search',

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -61,7 +61,7 @@ export function PrimaryNavigationHelp() {
   return (
     <StackedNavigationTourReminder>
       <SidebarMenu
-        onClick={chonkPrompt.dismissDotIndicatorPrompt}
+        onOpen={chonkPrompt.dismissDotIndicatorPrompt}
         items={[
           {
             key: 'search',

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -11,6 +11,7 @@ import {
   IconSearch,
   IconSettings,
 } from 'sentry/icons';
+import {ChonkOptInBanner} from 'sentry/utils/theme/ChonkOptInBanner';
 import useOrganization from 'sentry/utils/useOrganization';
 import {CODECOV_BASE_URL, COVERAGE_BASE_URL} from 'sentry/views/codecov/settings';
 import {getDefaultExploreRoute} from 'sentry/views/explore/utils';
@@ -148,6 +149,7 @@ export function PrimaryNavigationItems() {
       </SidebarBody>
 
       <SidebarFooter>
+        <ChonkOptInBanner collapsed="never" />
         <PrimaryNavigationHelp />
 
         <SeparatorItem />


### PR DESCRIPTION
Do not show any indicators if user has opted into chonk already and wire up dismiss actions with help menu opening