### PR TITLE
ref(issue-details): Remove outdated performance query in all events table

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -47,16 +47,13 @@ function AllEventsTable({organization, excludedTags, group}: Props) {
     groupId: group.id,
   });
 
-  const queryEnabled = group.issueCategory === IssueCategory.PERFORMANCE;
-  const {data, isPending, isLoadingError} = useApiQuery<EventTransaction>([endpointUrl], {
+  const isRegressionIssue =
+    group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
+    group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION;
+  const {data, isLoading, isLoadingError} = useApiQuery<EventTransaction>([endpointUrl], {
     staleTime: 60000,
-    enabled: queryEnabled,
+    enabled: isRegressionIssue,
   });
-
-  // TODO: this is a temporary way to check whether
-  // perf issue is backed by occurrences or transactions
-  // Once migration to the issue platform is complete a call to /latest should be removed
-  const groupIsOccurrenceBacked = !!data?.occurrence;
 
   const eventView: EventView = EventView.fromLocation(location);
   if (config.usesIssuePlatform) {
@@ -78,14 +75,8 @@ function AllEventsTable({organization, excludedTags, group}: Props) {
 
   eventView.statsPeriod = '90d';
 
-  const isRegressionIssue =
-    group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
-    group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION;
-
   let idQuery = `issue.id:${group.id}`;
-  if (group.issueCategory === IssueCategory.PERFORMANCE && !groupIsOccurrenceBacked) {
-    idQuery = `performance.issue_ids:${group.id} event.type:transaction`;
-  } else if (isRegressionIssue && groupIsOccurrenceBacked) {
+  if (isRegressionIssue) {
     const {transaction, aggregateRange2, breakpoint} =
       data?.occurrence?.evidenceData ?? {};
 
@@ -126,7 +117,7 @@ function AllEventsTable({organization, excludedTags, group}: Props) {
       transactionName=""
       columnTitles={columnTitles.slice()}
       referrer="api.issues.issue_events"
-      isEventLoading={queryEnabled ? isPending : false}
+      isEventLoading={isLoading}
     />
   );
 }

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -209,7 +209,7 @@ describe('groupEvents', () => {
         '/organizations/org-slug/events/',
         expect.objectContaining({
           query: expect.objectContaining({
-            query: 'performance.issue_ids:1 event.type:transaction ',
+            query: 'issue.id:1 ',
           }),
         })
       );


### PR DESCRIPTION
Following the logic from the todo comment, this query is no longer required for performance issues since the migration to the issue platform was completed some time ago. This query is still used for regression issues though.