### PR TITLE
ref(issue-taxonomy): Cleanup unnecessary references to cron and uptime issue catgegories

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -18,7 +18,7 @@ describe('UptimeAlertDetails', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/?limit=1&project=${project.id}&query=issue.category%3Auptime%20tags%5Buptime_rule%5D%3A1`,
+      url: `/organizations/${organization.slug}/issues/?limit=1&project=${project.id}&query=issue.type%3Auptime_domain_failure%20tags%5Buptime_rule%5D%3A1`,
       body: [],
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
@@ -3,7 +3,7 @@ import GroupList from 'sentry/components/issues/groupList';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
-import {IssueCategory} from 'sentry/types/group';
+import {IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 
 interface Props {
@@ -13,7 +13,7 @@ interface Props {
 
 export function UptimeIssues({project, ruleId}: Props) {
   // TODO(davidenwang): Replace this with an actual query for the specific uptime alert rule
-  const query = `issue.category:${IssueCategory.UPTIME} tags[uptime_rule]:${ruleId}`;
+  const query = `issue.type:${IssueType.UPTIME_DOMAIN_FAILURE} tags[uptime_rule]:${ruleId}`;
 
   const emptyMessage = () => {
     return (

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -61,7 +61,7 @@ import {space} from 'sentry/styles/space';
 import type {Entry, EntryException, Event, EventTransaction} from 'sentry/types/event';
 import {EntryType, EventOrGroupType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {IssueCategory} from 'sentry/types/group';
+import {IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -215,10 +215,10 @@ export function EventDetailsContent({
         }) ? (
         <LazyLoad LazyComponent={LLMMonitoringSection} event={event} />
       ) : null}
-      {!hasStreamlinedUI && group.issueCategory === IssueCategory.UPTIME && (
+      {!hasStreamlinedUI && group.issueType === IssueType.UPTIME_DOMAIN_FAILURE && (
         <UptimeDataSection event={event} project={project} group={group} />
       )}
-      {!hasStreamlinedUI && group.issueCategory === IssueCategory.CRON && (
+      {!hasStreamlinedUI && group.issueType === IssueType.MONITOR_CHECK_IN_FAILURE && (
         <CronTimelineSection
           event={event}
           organization={organization}


### PR DESCRIPTION
Uptime and Cron issues will be under the same category soon, so we need to remove references to the existing categories. For these it's a simple replacement with the issue type since these only have a single issue type.