### PR TITLE
:wrench: chore: remove staff ga rollout flag

### DIFF
--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -11,7 +11,6 @@ from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
 from sentry.utils.auth import has_completed_sso
@@ -49,19 +48,14 @@ def is_active_staff(request: HttpRequest | Request) -> bool:
     return staff.is_active
 
 
-# TODO(schew2381): Delete after staff is GA'd and the options are removed
+# TODO(iamrajjoshi): Delete after staff is GA'd and the options are removed
 def has_staff_option(user) -> bool:
     """
     This checks two options, the first being whether or not staff has been GA'd.
     If not, it falls back to checking the second option which by email specifies which
     users staff is enabled for.
     """
-    if options.get("staff.ga-rollout"):
-        return True
-
-    if (email := getattr(user, "email", None)) is None:
-        return False
-    return email in options.get("staff.user-email-allowlist")
+    return True
 
 
 def _seconds_to_timestamp(seconds: str) -> datetime:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -276,19 +276,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Staff
-register(
-    "staff.ga-rollout",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "staff.user-email-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Superuser read/write
 register(
     "superuser.read-write.ga-rollout",

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,10 +1,8 @@
 from django.urls import reverse
-from pytest import fixture
 from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -227,11 +225,6 @@ class ApiTokensSuperuserTest(APITestCase):
 @control_silo_test
 class ApiTokensStaffTest(APITestCase):
     url = reverse("sentry-api-0-api-tokens")
-
-    @fixture(autouse=True)
-    def _set_staff_option(self):
-        with override_options({"staff.ga-rollout": True}):
-            yield
 
     def setUp(self):
         self.staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/api/endpoints/test_organization_fork.py
+++ b/tests/sentry/api/endpoints/test_organization_fork.py
@@ -207,9 +207,7 @@ class OrganizationForkTest(APITestCase):
             replying_region_name=EXPORTING_TEST_REGION,
         )
 
-    @override_options(
-        {"relocation.enabled": False, "relocation.daily-limit.small": 1, "staff.ga-rollout": True}
-    )
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
     @assume_test_silo_mode(SiloMode.REGION, region_name=REQUESTING_TEST_REGION)
     def test_good_staff_when_feature_disabled(
         self,
@@ -512,9 +510,7 @@ class OrganizationForkTest(APITestCase):
             assert uploading_start_mock.call_count == 0
             assert analytics_record_mock.call_count == 0
 
-    @override_options(
-        {"relocation.enabled": True, "relocation.daily-limit.small": 1, "staff.ga-rollout": True}
-    )
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
     @assume_test_silo_mode(SiloMode.REGION, region_name=REQUESTING_TEST_REGION)
     def test_good_no_throttle_for_staff(
         self,

--- a/tests/sentry/api/test_data_secrecy.py
+++ b/tests/sentry/api/test_data_secrecy.py
@@ -1,5 +1,4 @@
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.features import with_feature
 
 
@@ -44,7 +43,6 @@ class DataSecrecyTestCase(APITestCase):
             self.get_success_response(self.organization.slug)
 
     @with_feature("organizations:data-secrecy")
-    @override_options({"staff.ga-rollout": True})
     def test_admin_access_when_superuser_no_access(self):
         # When the superuser has no access, the admin should also still work
         superuser = self.create_user(is_superuser=True)

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -33,17 +33,6 @@ class PermissionsTest(DRFPermissionTestCase):
         # With active staff
         assert self.superuser_staff_flagged_permission.has_permission(self.staff_request, APIView())
 
-    def test_superuser_or_staff_feature_flagged_permission_inactive_option(self):
-        # With active staff
-        assert not self.superuser_staff_flagged_permission.has_permission(
-            self.staff_request, APIView()
-        )
-
-        # With active superuser
-        assert self.superuser_staff_flagged_permission.has_permission(
-            self.superuser_request, APIView()
-        )
-
 
 class IsAuthenticatedPermissionsTest(DRFPermissionTestCase):
     user_permission = SentryIsAuthenticated()

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -24,7 +24,6 @@ class PermissionsTest(DRFPermissionTestCase):
     def test_staff_permission(self):
         assert self.staff_permission.has_permission(self.staff_request, APIView())
 
-    @override_options({"staff.ga-rollout": True})
     def test_superuser_or_staff_feature_flagged_permission_active_option(self):
         # With active superuser
         assert not self.superuser_staff_flagged_permission.has_permission(

--- a/tests/sentry/integrations/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/integrations/api/endpoints/test_doc_integrations.py
@@ -9,7 +9,6 @@ from sentry.api.serializers.base import serialize
 from sentry.integrations.models.doc_integration import DocIntegration
 from sentry.integrations.models.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -37,7 +36,6 @@ class DocIntegrationsTest(APITestCase):
 class GetDocIntegrationsTest(DocIntegrationsTest):
     method = "GET"
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_read_docs(self):
         """
         Tests that all DocIntegrations are returned for staff users,

--- a/tests/sentry/relocation/api/endpoints/artifacts/test_index.py
+++ b/tests/sentry/relocation/api/endpoints/artifacts/test_index.py
@@ -7,7 +7,6 @@ from sentry.relocation.api.endpoints.artifacts.index import ERR_NEED_RELOCATION_
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 RELOCATION_ADMIN_PERMISSION = "relocation.admin"
@@ -84,7 +83,6 @@ class GetRelocationArtifactsGoodTest(GetRelocationArtifactsTest):
             file_size = file_info["bytes"]
             assert self.relocation_storage.size(file_name) == file_size
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_with_staff(self):
         self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.staff_user, staff=True)
@@ -99,7 +97,7 @@ class GetRelocationArtifactsGoodTest(GetRelocationArtifactsTest):
 
 
 class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
-    @override_options({"staff.ga-rollout": True})
+
     def test_bad_unprivileged_user(self):
         self.login_as(user=self.owner, superuser=False, staff=False)
 
@@ -117,7 +115,6 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
         self.get_error_response(str(self.relocation.uuid), status_code=403)
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_disabled(self):
         self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.staff_user, staff=False)
@@ -140,7 +137,6 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
 
         assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_has_staff_but_no_relocation_admin_permission(self):
         self.login_as(user=self.staff_user, staff=True)
 
@@ -154,7 +150,6 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
 
         assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_relocation_not_found(self):
         self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/relocation/api/endpoints/test_abort.py
+++ b/tests/sentry/relocation/api/endpoints/test_abort.py
@@ -5,7 +5,6 @@ from sentry.relocation.api.endpoints.abort import ERR_NOT_ABORTABLE_STATUS
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 
@@ -35,7 +34,6 @@ class AbortRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_abort_in_progress(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -54,7 +52,6 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_abort_paused(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -73,7 +70,6 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_already_succeeded(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
@@ -92,7 +88,6 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_already_failed(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
@@ -111,7 +106,6 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
@@ -122,7 +116,6 @@ class AbortRelocationTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    @override_options({"staff.ga-rollout": True})
     def test_superuser_fails_with_option(self):
         self.login_as(user=self.superuser, superuser=True)
         self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/relocation/api/endpoints/test_abort.py
+++ b/tests/sentry/relocation/api/endpoints/test_abort.py
@@ -18,11 +18,10 @@ class AbortRelocationTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(is_superuser=True)
         self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.IN_PROGRESS.value,
             step=Relocation.Step.PREPROCESSING.value,
@@ -43,26 +42,8 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    def test_good_superuser_abort_in_progress(self):
-        self.login_as(user=self.superuser, superuser=True)
-        self.relocation.status = Relocation.Status.PAUSE.value
-        self.relocation.save()
-        response = self.get_success_response(self.relocation.uuid, status_code=200)
-
-        assert response.data["status"] == Relocation.Status.FAILURE.name
-        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
-
     def test_good_staff_abort_paused(self):
         self.login_as(user=self.staff_user, staff=True)
-        self.relocation.status = Relocation.Status.PAUSE.value
-        self.relocation.save()
-        response = self.get_success_response(self.relocation.uuid, status_code=200)
-
-        assert response.data["status"] == Relocation.Status.FAILURE.name
-        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
-
-    def test_good_superuser_abort_paused(self):
-        self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
         response = self.get_success_response(self.relocation.uuid, status_code=200)
@@ -79,26 +60,8 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    def test_bad_superuser_already_succeeded(self):
-        self.login_as(user=self.superuser, superuser=True)
-        self.relocation.status = Relocation.Status.SUCCESS.value
-        self.relocation.save()
-        response = self.get_error_response(self.relocation.uuid, status_code=400)
-
-        assert response.data.get("detail") is not None
-        assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
-
     def test_bad_staff_already_failed(self):
         self.login_as(user=self.staff_user, staff=True)
-        self.relocation.status = Relocation.Status.FAILURE.value
-        self.relocation.save()
-        response = self.get_error_response(self.relocation.uuid, status_code=400)
-
-        assert response.data.get("detail") is not None
-        assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
-
-    def test_bad_superuser_already_failed(self):
-        self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -111,18 +74,9 @@ class AbortRelocationTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    def test_bad_superuser_not_found(self):
-        self.login_as(user=self.superuser, superuser=True)
-        does_not_exist_uuid = uuid4().hex
-        self.get_error_response(str(does_not_exist_uuid), status_code=404)
-
-    def test_superuser_fails_with_option(self):
-        self.login_as(user=self.superuser, superuser=True)
-        self.get_error_response(self.relocation.uuid, status_code=403)
-
     def test_bad_no_auth(self):
         self.get_error_response(self.relocation.uuid, status_code=401)
 
-    def test_bad_no_superuser(self):
-        self.login_as(user=self.superuser, superuser=False)
+    def test_bad_no_staff(self):
+        self.login_as(user=self.staff_user, staff=False)
         self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/relocation/api/endpoints/test_cancel.py
+++ b/tests/sentry/relocation/api/endpoints/test_cancel.py
@@ -23,10 +23,10 @@ class CancelRelocationTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.IN_PROGRESS.value,
             step=Relocation.Step.PREPROCESSING.value,
@@ -48,7 +48,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_cancel_in_progress_at_next_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
 
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
@@ -56,7 +56,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_cancel_paused_at_next_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
         response = self.get_success_response(self.relocation.uuid, status_code=200)
@@ -66,7 +66,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_cancel_in_progress_at_specified_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
@@ -76,7 +76,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
     def test_good_cancel_paused_at_specified_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
         response = self.get_success_response(
@@ -88,7 +88,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
     def test_good_cancel_at_future_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.relocation.uuid, atStep=Relocation.Step.NOTIFYING.name, status_code=200
         )
@@ -98,7 +98,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.NOTIFYING.name
 
     def test_good_already_cancelled(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.scheduled_cancel_at_step = Relocation.Step.IMPORTING.value
         self.relocation.save()
         response = self.get_success_response(
@@ -110,7 +110,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
     def test_good_already_failed(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
         response = self.get_success_response(
@@ -122,12 +122,12 @@ class CancelRelocationTest(APITestCase):
         assert not response.data["scheduledCancelAtStep"]
 
     def test_bad_not_found(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(does_not_exist_uuid, status_code=404)
 
     def test_bad_already_succeeded(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -136,7 +136,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_NOT_CANCELLABLE_STATUS
 
     def test_bad_invalid_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep="nonexistent", status_code=400
         )
@@ -147,7 +147,7 @@ class CancelRelocationTest(APITestCase):
         )
 
     def test_bad_unknown_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.UNKNOWN.name, status_code=400
         )
@@ -158,7 +158,7 @@ class CancelRelocationTest(APITestCase):
         )
 
     def test_bad_current_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.PREPROCESSING.name, status_code=400
         )
@@ -167,7 +167,7 @@ class CancelRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION
 
     def test_bad_past_step(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.UPLOADING.name, status_code=400
         )
@@ -178,7 +178,7 @@ class CancelRelocationTest(APITestCase):
         )
 
     def test_bad_last_step_specified(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         response = self.get_error_response(
             self.relocation.uuid, atStep=Relocation.Step.COMPLETED.name, status_code=400
         )
@@ -189,7 +189,7 @@ class CancelRelocationTest(APITestCase):
         )
 
     def test_bad_last_step_automatic(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.staff_user, staff=True)
         self.relocation.step = Relocation.Step.NOTIFYING.value
         self.relocation.save()
         response = self.get_error_response(self.relocation.uuid, status_code=400)
@@ -201,5 +201,5 @@ class CancelRelocationTest(APITestCase):
         self.get_error_response(self.relocation.uuid, status_code=401)
 
     def test_bad_no_superuser(self):
-        self.login_as(user=self.superuser, superuser=False)
+        self.login_as(user=self.staff_user, staff=False)
         self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/relocation/api/endpoints/test_cancel.py
+++ b/tests/sentry/relocation/api/endpoints/test_cancel.py
@@ -10,7 +10,6 @@ from sentry.relocation.api.endpoints.cancel import (
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 
@@ -39,7 +38,6 @@ class CancelRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_cancel_in_progress_at_next_step(self):
         staff_user = self.create_user(is_staff=True)
         self.login_as(user=staff_user, staff=True)

--- a/tests/sentry/relocation/api/endpoints/test_details.py
+++ b/tests/sentry/relocation/api/endpoints/test_details.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 TEST_DATE_UPDATED = datetime(2023, 1, 23, 1, 24, 45, tzinfo=timezone.utc)
@@ -40,13 +39,11 @@ class GetRelocationDetailsTest(APITestCase):
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_found_with_option(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_superuser_fails_with_option(self):
         self.login_as(user=self.superuser, superuser=True)
         self.get_error_response(self.relocation.uuid, status_code=403)
@@ -56,7 +53,6 @@ class GetRelocationDetailsTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex

--- a/tests/sentry/relocation/api/endpoints/test_details.py
+++ b/tests/sentry/relocation/api/endpoints/test_details.py
@@ -17,11 +17,10 @@ class GetRelocationDetailsTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(is_superuser=True)
         self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
-            creator_id=self.superuser.id,
+            creator_id=self.staff_user.id,
             owner_id=self.owner.id,
             status=Relocation.Status.SUCCESS.value,
             step=Relocation.Step.COMPLETED.value,
@@ -34,24 +33,10 @@ class GetRelocationDetailsTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    def test_good_superuser_found(self):
-        self.login_as(user=self.superuser, superuser=True)
-        response = self.get_success_response(self.relocation.uuid, status_code=200)
-        assert response.data["uuid"] == str(self.relocation.uuid)
-
-    def test_good_staff_found_with_option(self):
+    def test_good_staff_found(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
-
-    def test_bad_superuser_fails_with_option(self):
-        self.login_as(user=self.superuser, superuser=True)
-        self.get_error_response(self.relocation.uuid, status_code=403)
-
-    def test_bad_superuser_not_found(self):
-        self.login_as(user=self.superuser, superuser=True)
-        does_not_exist_uuid = uuid4().hex
-        self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
     def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/relocation/api/endpoints/test_index.py
+++ b/tests/sentry/relocation/api/endpoints/test_index.py
@@ -107,7 +107,6 @@ class GetRelocationsTest(APITestCase):
 
         self.success_uuid = Relocation.objects.get(status=Relocation.Status.SUCCESS.value)
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_simple(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(status_code=200)

--- a/tests/sentry/relocation/api/endpoints/test_pause.py
+++ b/tests/sentry/relocation/api/endpoints/test_pause.py
@@ -12,7 +12,6 @@ from sentry.relocation.api.endpoints.pause import (
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 
@@ -42,7 +41,6 @@ class PauseRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_pause_asap(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)

--- a/tests/sentry/relocation/api/endpoints/test_public_key.py
+++ b/tests/sentry/relocation/api/endpoints/test_public_key.py
@@ -28,27 +28,6 @@ class GetRelocationPublicKeyTest(APITestCase):
         )
 
     @override_options({"relocation.enabled": True})
-    def test_good_superuser_when_feature_enabled(self, fake_kms_client: mock.Mock):
-        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
-        self.login_as(user=superuser, superuser=True)
-        self.mock_kms_client(fake_kms_client)
-        response = self.get_success_response(status_code=200)
-
-        assert response.status_code == 200
-        assert response.data["public_key"].encode() == self.pub_key_pem
-        assert fake_kms_client.return_value.get_public_key.call_count == 1
-
-    def test_good_superuser_when_feature_disabled(self, fake_kms_client: mock.Mock):
-        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
-        self.login_as(user=superuser, superuser=True)
-        self.mock_kms_client(fake_kms_client)
-        response = self.get_success_response(status_code=200)
-
-        assert response.status_code == 200
-        assert response.data["public_key"].encode() == self.pub_key_pem
-        assert fake_kms_client.return_value.get_public_key.call_count == 1
-
-    @override_options({"relocation.enabled": True})
     def test_good_staff_when_feature_enabled(self, fake_kms_client: mock.Mock):
         staff = self.create_user("staff", is_staff=True, is_active=True)
         self.login_as(user=staff, staff=True)
@@ -102,14 +81,6 @@ class GetRelocationPublicKeyTest(APITestCase):
     def test_bad_no_auth(self, fake_kms_client: mock.Mock):
         self.mock_kms_client(fake_kms_client)
         self.get_error_response(status_code=401)
-
-        assert fake_kms_client.return_value.get_public_key.call_count == 0
-
-    def test_bad_superuser_missing_cookie_when_feature_disabled(self, fake_kms_client: mock.Mock):
-        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
-        self.login_as(user=superuser, staff=False)
-        self.mock_kms_client(fake_kms_client)
-        self.get_error_response(status_code=400)
 
         assert fake_kms_client.return_value.get_public_key.call_count == 0
 

--- a/tests/sentry/relocation/api/endpoints/test_public_key.py
+++ b/tests/sentry/relocation/api/endpoints/test_public_key.py
@@ -48,7 +48,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data["public_key"].encode() == self.pub_key_pem
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
-    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
+    @override_options({"relocation.enabled": True})
     def test_good_staff_when_feature_enabled(self, fake_kms_client: mock.Mock):
         staff = self.create_user("staff", is_staff=True, is_active=True)
         self.login_as(user=staff, staff=True)
@@ -59,7 +59,6 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert response.data["public_key"].encode() == self.pub_key_pem
         assert fake_kms_client.return_value.get_public_key.call_count == 1
 
-    @override_options({"staff.ga-rollout": True})
     def test_good_staff_when_feature_disabled(self, fake_kms_client: mock.Mock):
         staff = self.create_user("staff", is_staff=True, is_active=True)
         self.login_as(user=staff, staff=True)
@@ -114,7 +113,6 @@ class GetRelocationPublicKeyTest(APITestCase):
 
         assert fake_kms_client.return_value.get_public_key.call_count == 0
 
-    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_missing_cookie_when_feature_disabled(self, fake_kms_client: mock.Mock):
         staff = self.create_user("staff", is_staff=True, is_active=True)
         self.login_as(user=staff, staff=False)

--- a/tests/sentry/relocation/api/endpoints/test_recover.py
+++ b/tests/sentry/relocation/api/endpoints/test_recover.py
@@ -14,7 +14,6 @@ from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.tasks.process import MAX_FAST_TASK_ATTEMPTS
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 
@@ -44,7 +43,6 @@ class RecoverRelocationTest(APITestCase):
             latest_task_attempts=MAX_FAST_TASK_ATTEMPTS,
         )
 
-    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_colliding_users.delay")
     def test_good_recover_without_pause_as_staff(self, async_task_scheduled: Mock):
         self.login_as(user=self.staff_user, staff=True)
@@ -73,7 +71,6 @@ class RecoverRelocationTest(APITestCase):
         assert async_task_scheduled.call_count == 1
         assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
 
-    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_colliding_users.delay")
     def test_good_recover_with_pause_as_staff(self, async_task_scheduled: Mock):
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/relocation/api/endpoints/test_retry.py
+++ b/tests/sentry/relocation/api/endpoints/test_retry.py
@@ -130,9 +130,7 @@ class RetryRelocationTest(APITestCase):
             uuid=response.data["uuid"],
         )
 
-    @override_options(
-        {"relocation.enabled": False, "relocation.daily-limit.small": 2, "staff.ga-rollout": True}
-    )
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
     @patch("sentry.relocation.tasks.process.uploading_start.delay")
     def test_good_staff_when_feature_disabled(
         self, uploading_start_mock: Mock, analytics_record_mock: Mock
@@ -296,9 +294,7 @@ class RetryRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_FILE_NO_LONGER_EXISTS
         assert uploading_start_mock.call_count == 0
 
-    @override_options(
-        {"relocation.enabled": True, "relocation.daily-limit.small": 2, "staff.ga-rollout": True}
-    )
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.relocation.tasks.process.uploading_start.delay")
     def test_bad_staff_owner_not_found(
         self, uploading_start_mock: Mock, analytics_record_mock: Mock

--- a/tests/sentry/relocation/api/endpoints/test_unpause.py
+++ b/tests/sentry/relocation/api/endpoints/test_unpause.py
@@ -10,7 +10,6 @@ from sentry.relocation.api.endpoints.unpause import ERR_NOT_UNPAUSABLE_STATUS
 from sentry.relocation.models.relocation import Relocation
 from sentry.relocation.utils import OrderedTask
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 
@@ -40,7 +39,6 @@ class UnpauseRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @override_options({"staff.ga-rollout": True})
     @patch("sentry.relocation.tasks.process.preprocessing_scan.delay")
     def test_good_staff_unpause_until_validating(self, async_task_scheduled: Mock):
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -13,7 +13,6 @@ from sentry.sentry_apps.models.servicehook import ServiceHook
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
@@ -165,7 +164,6 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
         self._validate_updated_published_app(response)
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_update_published_app(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
@@ -485,7 +483,6 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         )
         assert SentryApp.objects.get(id=app.id).popularity == popularity
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_can_update_popularity(self):
         self.login_as(user=self.staff_user, staff=True)
         app = self.create_sentry_app(name="SampleApp", organization=self.organization)
@@ -525,7 +522,6 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert app.status == SentryAppStatus.PUBLISHED
         assert app.date_published
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_can_publish_apps(self):
         self.login_as(user=self.staff_user, staff=True)
         app = self.create_sentry_app(name="SampleApp", organization=self.organization)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps_stats.py
@@ -2,7 +2,6 @@ import orjson
 
 from sentry.api.serializers.base import serialize
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -49,7 +48,6 @@ class SentryAppsStatsTest(APITestCase):
         response = self.get_success_response(status_code=200)
         self._check_response(response)
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_has_access(self):
         staff_user = self.create_user(is_staff=True)
         self.login_as(user=staff_user, staff=True)

--- a/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
@@ -393,7 +393,6 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
             assert not Authenticator.objects.filter(id=auth.id).exists()
 
-    @override_options({"staff.ga-rollout": True})
     def test_require_2fa__can_delete_last_auth_staff(self):
         self._require_2fa_for_organization()
 

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -1,5 +1,4 @@
 from django.test import override_settings
-from pytest import fixture
 
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.models.deletedorganization import DeletedOrganization
@@ -59,7 +58,6 @@ class UserDetailsGetTest(UserDetailsTest):
         assert "identities" in resp.data
         assert len(resp.data["identities"]) == 0
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_simple(self):
         self.login_as(user=self.staff_user, staff=True)
 
@@ -425,11 +423,6 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
 class UserDetailsStaffUpdateTest(UserDetailsTest):
     method = "put"
 
-    @fixture(autouse=True)
-    def _activate_staff_mode(self):
-        with override_options({"staff.ga-rollout": True}):
-            yield
-
     def test_staff_can_change_is_active(self):
         self.user.update(is_active=True)
         self.login_as(user=self.staff_user, staff=True)
@@ -657,7 +650,6 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         assert response.data["detail"] == "Missing required permission to hard delete account."
         assert User.objects.filter(id=user2.id).exists()
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_hard_delete_account_without_permission(self):
         self.login_as(user=self.staff_user, staff=True)
         user2 = self.create_user(email="user2@example.com")
@@ -680,7 +672,6 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.get_success_response(user2.id, hardDelete=True, organizations=[], status_code=204)
         assert not User.objects.filter(id=user2.id).exists()
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_hard_delete_account_with_permission(self):
         self.login_as(user=self.staff_user, staff=True)
         user2 = self.create_user(email="user2@example.com")
@@ -691,7 +682,6 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.get_success_response(user2.id, hardDelete=True, organizations=[], status_code=204)
         assert not User.objects.filter(id=user2.id).exists()
 
-    @override_options({"staff.ga-rollout": True})
     def test_superuser_cannot_hard_delete_with_active_option(self):
         self.login_as(user=self.superuser, superuser=True)
         user2 = self.create_user(email="user2@example.com")

--- a/tests/sentry/users/api/endpoints/test_user_index.py
+++ b/tests/sentry/users/api/endpoints/test_user_index.py
@@ -1,5 +1,4 @@
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.userpermission import UserPermission
 
@@ -19,7 +18,6 @@ class UserListTest(APITestCase):
         self.login_as(self.normal_user)
         self.get_error_response(status_code=403)
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff_simple(self):
         self.staff_user = self.create_user(is_staff=True)
         self.login_as(self.staff_user, staff=True)

--- a/tests/sentry/users/api/endpoints/test_user_permission_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_permission_details.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from sentry.api.permissions import StaffPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.userpermission import UserPermission
 
@@ -50,7 +49,6 @@ class UserPermissionDetailsGetTest(UserDetailsTest):
         self.login_as(self.superuser, superuser=True)
         self.get_error_response("me", "broadcasts.admin", status_code=404)
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -60,7 +58,6 @@ class UserPermissionDetailsGetTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_without_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -91,7 +88,6 @@ class UserPermissionDetailsPostTest(UserDetailsTest):
             user=self.superuser, permission="broadcasts.admin"
         ).exists()
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -103,7 +99,6 @@ class UserPermissionDetailsPostTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_duplicate_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -138,7 +133,6 @@ class UserPermissionDetailsDeleteTest(UserDetailsTest):
             user=self.superuser, permission="broadcasts.admin"
         ).exists()
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -151,7 +145,6 @@ class UserPermissionDetailsDeleteTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_without_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)

--- a/tests/sentry/users/api/endpoints/test_user_permissions.py
+++ b/tests/sentry/users/api/endpoints/test_user_permissions.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from sentry.api.permissions import StaffPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -26,7 +25,6 @@ class UserPermissionsGetTest(UserPermissionsTest):
         assert "broadcasts.admin" in response.data
         assert "users.admin" in response.data
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_lookup_self(self, mock_has_permission):
         staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/users/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/users/api/endpoints/test_user_permissions_config.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from sentry.api.permissions import StaffPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -26,7 +25,6 @@ class UserPermissionsConfigGetTest(UserPermissionsConfigTest):
         assert "users.admin" in response.data
         assert "options.admin" in response.data
 
-    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_lookup_self(self, mock_has_permission):
         self.staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/web/frontend/test_data_secrecy_error.py
+++ b/tests/sentry/web/frontend/test_data_secrecy_error.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
@@ -27,7 +26,6 @@ class DataSecrecyErrorTest(TestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed("sentry/data-secrecy.html")
 
-    @override_options({"staff.ga-rollout": True})
     def test_data_secrecy_does_not_render_for_staff_access(self):
         user = self.create_user(is_superuser=True, is_staff=True)
         self.create_identity_provider(type="dummy", external_id="1234")

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -4,7 +4,6 @@ from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -314,11 +313,9 @@ class ReactPageViewTest(TestCase):
     def test_customer_domain_non_member_org_superuser(self):
         self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=False)
 
-    @override_options({"staff.ga-rollout": True})
     def test_customer_domain_non_member_org_staff(self):
         self._run_customer_domain_elevated_privileges(is_superuser=False, is_staff=True)
 
-    @override_options({"staff.ga-rollout": True})
     def test_customer_domain_non_member_org_superuser_and_staff(self):
         self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=True)
 

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -15,7 +15,6 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, region_silo_test
 from sentry.utils import json
 
@@ -283,11 +282,9 @@ class ClientConfigViewTest(TestCase):
     def test_superuser(self):
         self._run_test_with_privileges(is_superuser=True, is_staff=False)
 
-    @override_options({"staff.ga-rollout": True})
     def test_staff(self):
         self._run_test_with_privileges(is_superuser=False, is_staff=True)
 
-    @override_options({"staff.ga-rollout": True})
     def test_superuser_and_staff(self):
         self._run_test_with_privileges(is_superuser=True, is_staff=True)
 


### PR DESCRIPTION
`staff.ga-rollout` has been GA'ed for a while and we have assigned all employees permissions, so we can remove this option now