### PR TITLE
fix(issue-detais): add `group_has_replay` to streamined issues

### DIFF
--- a/static/app/views/issueDetails/streamline/header/replayBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/replayBadge.tsx
@@ -8,6 +8,7 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
@@ -19,6 +20,10 @@ export function ReplayBadge({group, project}: {group: Group; project: Project}) 
     statsPeriod: '90d',
   });
   const replaysCount = getReplayCountForIssue(group.id, group.issueCategory) ?? 0;
+
+  useRouteAnalyticsParams({
+    group_has_replay: replaysCount > 0,
+  });
 
   if (!issueTypeConfig.pages.replays.enabled || replaysCount <= 0) {
     return null;


### PR DESCRIPTION
this was one of the analytics attributes we set as a default and updated in a component, which is now not being used in the streamlined ui. 