### PR TITLE
feat(aci milestone 3): `IssuePriorityGreaterOrEqualConditionHandler`

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -37,7 +37,7 @@ class WorkflowEngineActionSerializer(Serializer):
             condition_group__in=Subquery(
                 DataConditionGroupAction.objects.filter(action=action).values("condition_group")
             ),
-            type=Condition.ISSUE_PRIORITY_EQUALS,
+            type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
             condition_result=True,
         )
         detector_dcg = DetectorWorkflow.objects.filter(

--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "IssueCategoryConditionHandler",
     "IssueOccurrencesConditionHandler",
     "IssuePriorityCondition",
+    "IssuePriorityGreaterOrEqualConditionHandler",
     "IssueResolutionConditionHandler",
     "LatestAdoptedReleaseConditionHandler",
     "LatestReleaseConditionHandler",
@@ -34,6 +35,7 @@ from .first_seen_event_handler import FirstSeenEventConditionHandler
 from .issue_category_handler import IssueCategoryConditionHandler
 from .issue_occurrences_handler import IssueOccurrencesConditionHandler
 from .issue_priority_equals import IssuePriorityCondition
+from .issue_priority_greater_or_equal_handler import IssuePriorityGreaterOrEqualConditionHandler
 from .issue_resolution_condition_handler import IssueResolutionConditionHandler
 from .latest_adopted_release_handler import LatestAdoptedReleaseConditionHandler
 from .latest_release_handler import LatestReleaseConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_greater_or_equal_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_greater_or_equal_handler.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+
+@condition_handler_registry.register(Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL)
+class IssuePriorityGreaterOrEqualConditionHandler(DataConditionHandler[WorkflowEventData]):
+    group = DataConditionHandler.Group.ACTION_FILTER
+    subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+
+    @staticmethod
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        group = event_data.event.group
+        return group.priority >= comparison

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -309,7 +309,7 @@ def migrate_metric_data_conditions(
     action_filter = DataCondition.objects.create(
         comparison=PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH),
         condition_result=True,
-        type=Condition.ISSUE_PRIORITY_EQUALS,
+        type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
         condition_group=data_condition_group,
     )
     return detector_trigger, action_filter

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -47,6 +47,7 @@ class Condition(StrEnum):
     REAPPEARED_EVENT = "reappeared_event"
     TAGGED_EVENT = "tagged_event"
     ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
+    ISSUE_PRIORITY_GREATER_OR_EQUAL = "issue_priority_greater_or_equal"
     ISSUE_RESOLUTION_CHANGE = "issue_resolution_change"
 
     # Event frequency conditions

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -43,6 +43,7 @@ export enum DataConditionType {
   REAPPEARED_EVENT = 'reappeared_event',
   TAGGED_EVENT = 'tagged_event',
   ISSUE_PRIORITY_EQUALS = 'issue_priority_equals',
+  ISSUE_PRIORITY_GREATER_OR_EQUAL = 'issue_priority_greater_or_equal',
 
   // frequency
   EVENT_FREQUENCY_COUNT = 'event_frequency_count',

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -15,6 +15,7 @@ export const FILTER_DATA_CONDITION_TYPES = [
   DataConditionType.ISSUE_OCCURRENCES,
   DataConditionType.ASSIGNED_TO,
   DataConditionType.ISSUE_PRIORITY_EQUALS,
+  DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
   DataConditionType.LATEST_ADOPTED_RELEASE,
   DataConditionType.LATEST_RELEASE,
   DataConditionType.EVENT_ATTRIBUTE,

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_equals.py
@@ -36,6 +36,8 @@ class TestIssuePriorityCondition(ConditionTestCase):
         assert data_condition_critical_tuple is not None
         data_condition_warning = data_condition_warning_tuple[1]
         data_condition_critical = data_condition_critical_tuple[1]
+        data_condition_critical.type = Condition.ISSUE_PRIORITY_EQUALS
+        data_condition_warning.type = Condition.ISSUE_PRIORITY_EQUALS
 
         self.group.update(priority=PriorityLevel.MEDIUM)
         self.assert_passes(data_condition_warning, self.event_data)

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_greater_or_equal.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_greater_or_equal.py
@@ -1,0 +1,46 @@
+from sentry.types.group import PriorityLevel
+from sentry.users.services.user.service import user_service
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    migrate_alert_rule,
+    migrate_metric_data_conditions,
+)
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import WorkflowEventData
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class TestIssuePriorityGreaterOrEqualCondition(ConditionTestCase):
+    condition = Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL
+
+    def setUp(self):
+        super().setUp()
+        self.event_data = WorkflowEventData(event=self.group_event)
+        self.metric_alert = self.create_alert_rule()
+        self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="warning"
+        )
+        self.alert_rule_trigger_critical = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="critical"
+        )
+        self.rpc_user = user_service.get_user(user_id=self.user.id)
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+
+    def test_simple(self):
+        data_condition_warning_tuple = migrate_metric_data_conditions(
+            self.alert_rule_trigger_warning
+        )
+        data_condition_critical_tuple = migrate_metric_data_conditions(
+            self.alert_rule_trigger_critical
+        )
+        assert data_condition_warning_tuple is not None
+        assert data_condition_critical_tuple is not None
+        data_condition_warning = data_condition_warning_tuple[1]
+        data_condition_critical = data_condition_critical_tuple[1]
+
+        self.group.update(priority=PriorityLevel.MEDIUM)
+        self.assert_passes(data_condition_warning, self.event_data)
+        self.assert_does_not_pass(data_condition_critical, self.event_data)
+
+        self.group.update(priority=PriorityLevel.HIGH)
+        self.assert_passes(data_condition_critical, self.event_data)
+        self.assert_passes(data_condition_warning, self.event_data)

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -180,7 +180,7 @@ def assert_alert_rule_trigger_migrated(alert_rule_trigger):
     data_condition = DataCondition.objects.get(
         comparison=condition_result, condition_result=True, condition_group__in=workflow_dcgs
     )
-    assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
+    assert data_condition.type == Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL
     assert data_condition.condition_result is True
     assert WorkflowDataConditionGroup.objects.filter(
         condition_group=data_condition.condition_group
@@ -372,7 +372,7 @@ class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
         action_filter = self.create_data_condition(
             comparison=priority,
             condition_result=True,
-            type=Condition.ISSUE_PRIORITY_EQUALS,
+            type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
             condition_group=data_condition_group,
         )
 


### PR DESCRIPTION
In order to fire the MEDIUM actions when detector status is set to HIGH (preserving existing behavior), change the action filter condition handlers to fire when issue priority is greater than or equal to some detector priority level.