### PR TITLE
chore(vscode): Use spaces in new .tsx files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
   "[javascript][typescript][javascriptreact][typescriptreact]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
+    "editor.insertSpaces": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
When starting a new .tsx file it defaults to tabs for whatever reason until prettier formats it. Hardcode it to use spaces.
