### PR TITLE
fix(uptime): Enforce migration dependency on workflow_engine

### DIFF
--- a/src/sentry/uptime/migrations/0033_uptime_backfill_to_detectors.py
+++ b/src/sentry/uptime/migrations/0033_uptime_backfill_to_detectors.py
@@ -77,6 +77,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("uptime", "0032_stats_on_subscription"),
+        ("workflow_engine", "0045_add_unique_constraint_alert_rule_detector"),
     ]
 
     operations = [


### PR DESCRIPTION
Without this I believe we're ending up with an older version of the
workflow_engine state