### PR TITLE
button: remove redundant button label styles

### DIFF
--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -1,7 +1,8 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {ButtonProps} from 'sentry/components/core/button';
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 
@@ -78,8 +79,16 @@ const StyledButton = styled(Button)<StyledButtonProps>`
   max-width: 100%;
   z-index: 2;
 
-  ${p => (p.isOpen || p.disabled) && 'box-shadow: none;'}
-  ${p => p.hasPrefix && `${ButtonLabel} {font-weight: ${p.theme.fontWeightNormal};}`}
+  ${p =>
+    (p.isOpen || p.disabled) &&
+    css`
+      box-shadow: none;
+    `}
+  ${p =>
+    p.hasPrefix &&
+    css`
+      font-weight: ${p.theme.fontWeightNormal};
+    `}
 `;
 
 const LabelText = styled('span')`

--- a/static/gsApp/components/features/disabledRelay.tsx
+++ b/static/gsApp/components/features/disabledRelay.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import Panel from 'sentry/components/panels/panel';
 import {IconBroadcast, IconBusiness} from 'sentry/icons';
@@ -71,9 +71,6 @@ const ButtonBar = styled('div')`
   justify-content: center;
   align-items: center;
   margin: -${space(0.75)};
-  ${ButtonLabel} {
-    white-space: nowrap;
-  }
 `;
 
 const StyledButton = styled(Button)`

--- a/static/gsApp/hooks/disabledCustomSymbolSources.tsx
+++ b/static/gsApp/hooks/disabledCustomSymbolSources.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {IconBusiness, IconLock} from 'sentry/icons';
@@ -78,9 +78,7 @@ const Content = styled(EmptyMessage)`
 
 const StyledButton = styled(Button)`
   margin: ${space(0.75)};
-  ${ButtonLabel} {
-    white-space: nowrap;
-  }
+  white-space: nowrap;
 `;
 
 const StyledLearnMoreButton = styled(LearnMoreButton)`


### PR DESCRIPTION
Nowrap is already applied to ButtonLabel by its styling, and font-weight shouldn't require targeting via ButtonLabel as the original styles do not apply it