### PR TITLE
ref(feedback): remove dead euser code from save_userreport

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -89,11 +89,6 @@ def save_userreport(
             project.id, report["event_id"]
         )
 
-        euser = find_event_user(event)
-
-        if euser and not euser.name and report.get("name"):
-            euser.name = report["name"]
-
         if event:
             # if the event is more than 30 minutes old, we don't allow updates
             # as it might be abusive


### PR DESCRIPTION
The `euser` object is unused. This is leftover code from the migration away from the `EventUser` model and `event_user_id` column in user reports (see https://github.com/getsentry/sentry/blob/1fd37fb8a0144a443bf46ea3e48e46e2998dab63/src/sentry/ingest/userreport.py#L53)