### PR TITLE
:wrench: chore: add logging context for number of rules in digest notifs

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -211,6 +211,7 @@ class DigestNotification(ProjectNotification):
                 "user_ids": user_ids,
                 "notification_uuid": self.notification_uuid,
                 "number_of_rules": len(shared_context.get("rules_details", [])),
+                "group_count": shared_context.get("event_counts", 0),
             },
         )
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -210,6 +210,7 @@ class DigestNotification(ProjectNotification):
                 "team_ids": team_ids,
                 "user_ids": user_ids,
                 "notification_uuid": self.notification_uuid,
+                "number_of_rules": len(shared_context.get("rules_details", [])),
             },
         )
 

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -137,6 +137,8 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
                 "team_ids": ANY,
                 "user_ids": ANY,
                 "notification_uuid": ANY,
+                "number_of_rules": ANY,
+                "group_count": ANY,
             },
         )
 


### PR DESCRIPTION
to figure out how effective digest notifications are (and whether i can port this later), logging out extra information for digests