### PR TITLE
fix(autofix): Tweak animation for insight card appearance

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -596,7 +596,7 @@ const InsightContainer = styled(motion.div)`
       from {
         background-color: ${p => p.theme.purple400};
         border-color: ${p => p.theme.purple400};
-        transform: scaleY(0.2);
+        transform: scaleY(0);
         height: 0;
         opacity: 0;
       }


### PR DESCRIPTION
Was a bit stuttery because it started from 0.2 instead of 0.