### PR TITLE
fix(issue-views): Allow org owners/managers and superusers to edit/delete views in their org

### DIFF
--- a/src/sentry/issues/endpoints/bases.py
+++ b/src/sentry/issues/endpoints/bases.py
@@ -1,0 +1,35 @@
+from sentry.api.bases.organization import OrganizationPermission
+from sentry.auth.superuser import is_active_superuser
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.organization import Organization
+
+
+class GroupSearchViewPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+        "DELETE": ["org:read", "org:write", "org:admin"],
+    }
+
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, Organization):
+            return super().has_object_permission(request, view, obj)
+
+        if isinstance(obj, GroupSearchView):
+            # Org members can view or create any GroupSearchView
+            if request.method == "GET" or request.method == "POST":
+                return True
+
+            # The creator can edit their own GroupSearchView
+            # Org owners/managers and superusers may edit any GroupSearchView
+            if (
+                request.user.id == obj.user_id
+                or request.access.has_scope("org:write")
+                or is_active_superuser(request)
+            ):
+                return True
+
+            return False
+
+        return True

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -8,10 +8,11 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
 from sentry.api.serializers.rest_framework.groupsearchview import ViewValidator
+from sentry.issues.endpoints.bases import GroupSearchViewPermission
 from sentry.issues.endpoints.organization_group_search_views import pick_default_project
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
@@ -31,14 +32,6 @@ class GroupSearchViewValidatorResponse(TypedDict):
     timeFilters: NotRequired[dict[str, Any]]
 
 
-class MemberPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["member:read"],
-        "PUT": ["member:read", "member:write"],
-        "DELETE": ["member:read", "member:write"],
-    }
-
-
 @region_silo_endpoint
 class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
@@ -47,7 +40,7 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
-    permission_classes = (MemberPermission,)
+    permission_classes = (GroupSearchViewPermission,)
 
     def get(self, request: Request, organization: Organization, view_id: str) -> Response:
         """
@@ -86,11 +79,11 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
-            view = GroupSearchView.objects.get(
-                id=view_id, organization=organization, user_id=request.user.id
-            )
+            view = GroupSearchView.objects.get(id=view_id, organization=organization)
         except GroupSearchView.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+        self.check_object_permissions(request, view)
 
         serializer = ViewValidator(
             data=request.data,
@@ -140,18 +133,11 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
-            view = GroupSearchView.objects.get(id=view_id)
+            view = GroupSearchView.objects.get(id=view_id, organization=organization)
         except GroupSearchView.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        # Only view creators and org admins can delete views
-        has_delete_access = (
-            view.user_id == request.user.id
-            or request.access.has_scope("org:admin")
-            or request.access.has_scope("team:admin")
-        )
-        if not has_delete_access:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+        self.check_object_permissions(request, view)
 
         try:
             GroupSearchViewStarred.objects.clear_starred_view_for_all_members(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -162,31 +162,42 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
     method = "delete"
 
     def setUp(self) -> None:
-        self.login_as(user=self.user)
         self.base_data = self.create_base_data()
 
-        # Get the first view's ID for testing
-        self.view_id = str(self.base_data["user_one_views"][0].id)
+        # For most tests, we'll be deleting views from user_2 (no special permissions)
+        self.login_as(user=self.user_2)
 
-        self.url = reverse(
+        self.user_1_view_id = str(self.base_data["user_one_views"][0].id)
+        self.user_2_view_id = str(self.base_data["user_two_views"][0].id)
+
+        self.user_1_view_url = reverse(
             "sentry-api-0-organization-group-search-view-details",
-            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "view_id": self.user_1_view_id,
+            },
+        )
+        self.user_2_view_url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "view_id": self.user_2_view_id,
+            },
         )
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_view_success(self) -> None:
-
-        response = self.client.delete(self.url)
+        response = self.client.delete(self.user_2_view_url)
         assert response.status_code == 204
 
         # Verify the view was deleted
-        assert not GroupSearchView.objects.filter(id=self.view_id).exists()
+        assert not GroupSearchView.objects.filter(id=self.user_2_view_id).exists()
 
         # Verify other views still exist
         remaining_views = GroupSearchView.objects.filter(
-            organization=self.organization, user_id=self.user.id
+            organization=self.organization, user_id=self.user_2.id
         )
-        assert remaining_views.count() == 2
+        assert remaining_views.count() == 1
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_nonexistent_view(self) -> None:
@@ -202,8 +213,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_view_from_another_user(self) -> None:
-        # Get a view ID from user_two
-        self.login_as(user=self.user_2)
         view_id = str(self.base_data["user_one_views"][0].id)
         url = reverse(
             "sentry-api-0-organization-group-search-view-details",
@@ -217,29 +226,49 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         GroupSearchView.objects.get(id=view_id)
 
     @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_admin_can_delete_view_from_another_user(self) -> None:
-        self.admin_user = self.create_user()
-        self.create_member(
-            user=self.admin_user,
-            organization=self.organization,
-            role="admin",
-        )
-        self.login_as(user=self.admin_user)
-        view_id = str(self.base_data["user_one_views"][0].id)
+    def test_superuser_can_delete_view_from_another_user(self) -> None:
+        # User 1 is a superuser
+        self.login_as(user=self.user)
         url = reverse(
             "sentry-api-0-organization-group-search-view-details",
-            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "view_id": self.user_2_view_id,
+            },
         )
 
         response = self.client.delete(url)
         assert response.status_code == 204
 
-        assert not GroupSearchView.objects.filter(id=view_id).exists()
+        assert not GroupSearchView.objects.filter(id=self.user_2_view_id).exists()
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_org_write_can_delete_view_from_another_user(self) -> None:
+        self.admin_user = self.create_user()
+        self.create_member(
+            user=self.admin_user,
+            organization=self.organization,
+            role="manager",
+        )
+        self.login_as(user=self.admin_user)
+
+        response = self.client.delete(self.user_1_view_url)
+        assert response.status_code == 204
+
+        assert not GroupSearchView.objects.filter(id=self.user_1_view_id).exists()
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_first_starred_view_decrements_succeeding_positions(self) -> None:
         # Delete the first view
-        response = self.client.delete(self.url)
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "view_id": self.user_1_view_id,
+            },
+        )
+        response = self.client.delete(url)
         assert response.status_code == 204
 
         assert (
@@ -261,6 +290,7 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_last_starred_view_does_not_decrement_positions(self) -> None:
         # Delete the last view
+        self.login_as(user=self.user)
         response = self.client.delete(
             reverse(
                 "sentry-api-0-organization-group-search-view-details",
@@ -287,10 +317,10 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
             assert self.base_data["user_one_views"][idx].id == gsv.group_search_view.id
 
     def test_delete_without_feature_flag(self) -> None:
-        response = self.client.delete(self.url)
+        response = self.client.delete(self.user_1_view_url)
         assert response.status_code == 404
 
-        GroupSearchView.objects.get(id=self.view_id)
+        GroupSearchView.objects.get(id=self.user_2_view_id)
 
 
 class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
@@ -406,11 +436,11 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
     method = "put"
 
     def setUp(self) -> None:
-        self.login_as(user=self.user)
         self.base_data = self.create_base_data()
+        self.login_as(user=self.user_2)
 
-        # Get the first view's ID for testing
-        self.view_id = str(self.base_data["user_one_views"][0].id)
+        # Get the second user's views for testing
+        self.view_id = str(self.base_data["user_two_views"][0].id)
 
         self.url = reverse(
             "sentry-api-0-organization-group-search-view-details",
@@ -509,6 +539,8 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_put_view_from_another_user(self) -> None:
+        # Log in as user 3 (no access to user_two's views)
+        self.login_as(user=self.user_3)
         # Get a view ID from user_two
         view_id = str(self.base_data["user_two_views"][0].id)
         url = reverse(
@@ -525,7 +557,33 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         }
 
         response = self.client.put(url, data=data)
-        assert response.status_code == 404
+        assert response.status_code == 403
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_put_view_from_another_user_superuser(self) -> None:
+        # User 1 is a superuser
+        self.login_as(user=self.user)
+        # Get a view ID from user_two
+        view_id = str(self.base_data["user_two_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        data = {
+            "name": "Updated View",
+            "query": "is:unresolved",
+            "projects": [self.project.id],
+            "environments": [],
+            "timeFilters": {"period": "14d"},
+        }
+
+        response = self.client.put(url, data=data)
+        assert response.status_code == 200
+
+        # Verify the view was updated
+        updated_view = GroupSearchView.objects.get(id=self.view_id)
+        assert updated_view.name == "Updated View"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_put_invalid_data(self) -> None:


### PR DESCRIPTION
Cleans up some items related to issue view edit permissions. Now edit/delete permissions are allowed for the creator, superuser, or those with org write permissions. Previously this was only allowed for deleting (and it was checking for admin permissions)