### PR TITLE
chore(autofix): Send issue's first seen date to autofix

### DIFF
--- a/src/sentry/seer/autofix.py
+++ b/src/sentry/seer/autofix.py
@@ -689,6 +689,7 @@ def _call_autofix(
                 "id": group.id,
                 "title": group.title,
                 "short_id": group.qualified_short_id,
+                "first_seen": group.first_seen.isoformat(),
                 "events": [serialized_event],
             },
             "profile": profile,

--- a/tests/sentry/seer/test_autofix.py
+++ b/tests/sentry/seer/test_autofix.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import orjson
@@ -1272,6 +1272,8 @@ class TestCallAutofix(TestCase):
         group.id = 101112
         group.title = "Test Group"
         group.qualified_short_id = "TEST-123"
+        now = datetime.now()
+        group.first_seen = now
 
         # Test data
         repos = [{"name": "test-repo"}]
@@ -1309,6 +1311,7 @@ class TestCallAutofix(TestCase):
         assert body["issue"]["id"] == 101112
         assert body["issue"]["title"] == "Test Group"
         assert body["issue"]["short_id"] == "TEST-123"
+        assert body["issue"]["first_seen"] == now.isoformat()
         assert body["issue"]["events"] == [serialized_event]
         assert body["profile"] == profile
         assert body["trace_tree"] == trace_tree


### PR DESCRIPTION
Sends the first seen date of the issue to Autofix. I'm planning to use this to filter down commits, but it could potentially be used for other things too.