### PR TITLE
fix(jira-server): Adds external actor mapping base code for Jira Server

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -32,6 +32,7 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.GITLAB,
     ExternalProviders.SLACK,
     ExternalProviders.MSTEAMS,
+    ExternalProviders.JIRA_SERVER,
     ExternalProviders.CUSTOM,
 }
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -120,6 +120,7 @@ class IntegrationFeatures(StrEnum):
     TICKET_RULES = "ticket-rules"
     STACKTRACE_LINK = "stacktrace-link"
     CODEOWNERS = "codeowners"
+    USER_MAPPING = "user-mapping"
 
     # features currently only existing on plugins:
     DATA_FORWARDING = "data-forwarding"

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1286,7 +1286,13 @@ class JiraServerIntegrationProvider(IntegrationProvider):
 
     needs_default_identity = True
 
-    features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.ISSUE_SYNC])
+    features = frozenset(
+        [
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.ISSUE_SYNC,
+            IntegrationFeatures.USER_MAPPING,
+        ]
+    )
 
     setup_dialog_config = {"width": 1030, "height": 1000}
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1165,7 +1165,7 @@ class JiraServerIntegration(IssueSyncIntegration):
                 logger.info(
                     "jira.user-search-request-error",
                     extra={
-                        **logging_context,
+                        **local_logging_context,
                         "error": str(e),
                     },
                 )
@@ -1183,14 +1183,6 @@ class JiraServerIntegration(IssueSyncIntegration):
                 if email.lower() == ue.lower():
                     jira_user = possible_user
                     break
-
-        if jira_user is None:
-            # TODO(jess): do we want to email people about these types of failures?
-            logger.info(
-                "jira.assignee-not-found",
-                extra=local_logging_context,
-            )
-            raise IntegrationError("Failed to assign user to Jira Server issue")
 
         return jira_user
 
@@ -1248,6 +1240,14 @@ class JiraServerIntegration(IssueSyncIntegration):
                 user=user,
                 logging_context=logging_context,
             )
+
+            if jira_user is None:
+                # TODO(jess): do we want to email people about these types of failures?
+                logger.info(
+                    "jira.assignee-not-found",
+                    extra=logging_context,
+                )
+                raise IntegrationError("Failed to assign user to Jira Server issue")
         try:
             id_field = client.user_id_field()
             client.assign_issue(external_issue.key, jira_user and jira_user.get(id_field))

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -40,6 +40,7 @@ class ExternalActor(ReplicatedRegionModel):
             (ExternalProviders.GITHUB, "github"),
             (ExternalProviders.GITHUB_ENTERPRISE, "github_enterprise"),
             (ExternalProviders.GITLAB, "gitlab"),
+            (ExternalProviders.JIRA_SERVER, "jira_server"),
             # TODO: do migration to delete this from database
             (ExternalProviders.CUSTOM, "custom_scm"),
         ),

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -18,6 +18,7 @@ class ExternalProviders(ValueEqualityEnum):
     GITHUB = 200
     GITHUB_ENTERPRISE = 201
     GITLAB = 210
+    JIRA_SERVER = 300
 
     # TODO: do migration to delete this from database
     CUSTOM = 700
@@ -54,6 +55,7 @@ class ExternalProviderEnum(StrEnum):
     GITHUB = IntegrationProviderSlug.GITHUB
     GITHUB_ENTERPRISE = IntegrationProviderSlug.GITHUB_ENTERPRISE
     GITLAB = IntegrationProviderSlug.GITLAB
+    JIRA_SERVER = IntegrationProviderSlug.JIRA_SERVER
 
 
 EXTERNAL_PROVIDERS_REVERSE = {
@@ -81,6 +83,7 @@ EXTERNAL_PROVIDERS = {
     ExternalProviders.GITHUB: ExternalProviderEnum.GITHUB.value,
     ExternalProviders.GITHUB_ENTERPRISE: ExternalProviderEnum.GITHUB_ENTERPRISE.value,
     ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
+    ExternalProviders.JIRA_SERVER: ExternalProviderEnum.JIRA_SERVER.value,
     ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
 }
 

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -939,7 +939,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 client=self.installation.get_client(),
                 external_issue_key="APP-123",
                 user=rpc_user,
-                logging_context={"integration_id": self.integration.id},
+                integration_id=self.integration.id,
             )
 
         assert result is None
@@ -953,7 +953,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,
-            logging_context={"integration_id": self.integration.id},
+            integration_id=self.integration.id,
         )
 
         mock_search_users_for_issue.return_value = [
@@ -984,7 +984,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,
-            logging_context={"integration_id": self.integration.id},
+            integration_id=self.integration.id,
         )
 
         assert result is None
@@ -1020,7 +1020,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,
-            logging_context={"integration_id": self.integration.id},
+            integration_id=self.integration.id,
         )
 
         assert result == mock_jira_user

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -855,30 +855,6 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
 
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.assign_issue")
-    def test_sync_assignee_outbound_no_email(self, mock_assign_issue):
-        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
-        issue_id = "APP-123"
-        fake_jira_user = {"accountId": "deadbeef123", "displayName": "Dead Beef", "name": "Beef"}
-        external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.installation.model.id,
-            key=issue_id,
-        )
-        responses.add(
-            responses.GET,
-            "https://jira.example.org/rest/api/2/user/assignable/search",
-            json=[fake_jira_user],
-        )
-
-        self.installation.sync_assignee_outbound(external_issue, user)
-
-        mock_assign_issue.assert_called_with(
-            issue_id,
-            "Beef",
-        )
-
-    @responses.activate
-    @patch("sentry.integrations.jira_server.integration.JiraServerClient.assign_issue")
     def test_sync_assignee_outbound_unauthorized(self, mock_assign_issue):
         mock_assign_issue.side_effect = ApiUnauthorized("Oops, unauthorized")
         user = serialize_rpc_user(self.create_user(email="bob@example.com"))
@@ -895,7 +871,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 {
                     "accountId": "deadbeef123",
                     "displayName": "Dead Beef",
-                    "username": "bob@example.com",
+                    "email": "bob@example.com",
                 }
             ],
         )

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -916,18 +916,19 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
     def test_get_user_by_external_actor_multiple_actors(self, mock_search_users_for_issue):
+        rpc_user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         ExternalActor.objects.create(
             organization_id=self.organization.id,
             integration_id=self.integration.id,
             provider=ExternalProviders.JIRA_SERVER.value,
-            user_id=self.user.id,
+            user_id=rpc_user.id,
             external_name="jira_user_1",
         )
         ExternalActor.objects.create(
             organization_id=self.organization.id,
             integration_id=self.integration.id,
             provider=ExternalProviders.JIRA_SERVER.value,
-            user_id=self.user.id,
+            user_id=rpc_user.id,
             external_name="jira_user_2",
         )
 
@@ -937,7 +938,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             result = self.installation._get_user_by_external_actor(
                 client=self.installation.get_client(),
                 external_issue_key="APP-123",
-                user=self.user,
+                user=rpc_user,
                 logging_context={"integration_id": self.integration.id},
             )
 
@@ -947,10 +948,11 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
     def test_get_user_by_external_actor_no_actor(self, mock_search_users_for_issue):
+        rpc_user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         result = self.installation._get_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
-            user=self.user,
+            user=rpc_user,
             logging_context={"integration_id": self.integration.id},
         )
 
@@ -967,11 +969,12 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
     def test_get_user_by_external_actor_no_matching_jira_user(self, mock_search_users_for_issue):
+        rpc_user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         ExternalActor.objects.create(
             organization_id=self.organization.id,
             integration_id=self.integration.id,
             provider=ExternalProviders.JIRA_SERVER.value,
-            user_id=self.user.id,
+            user_id=rpc_user.id,
             external_name="nonexistent_user",
         )
 
@@ -980,7 +983,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         result = self.installation._get_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
-            user=self.user,
+            user=rpc_user,
             logging_context={"integration_id": self.integration.id},
         )
 
@@ -990,11 +993,12 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
     def test_get_user_by_external_actor_matching_user(self, mock_search_users_for_issue):
+        rpc_user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         ExternalActor.objects.create(
             organization_id=self.organization.id,
             integration_id=self.integration.id,
             provider=ExternalProviders.JIRA_SERVER.value,
-            user_id=self.user.id,
+            user_id=rpc_user.id,
             external_name="JiraUser",
         )
 
@@ -1015,7 +1019,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         result = self.installation._get_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
-            user=self.user,
+            user=rpc_user,
             logging_context={"integration_id": self.integration.id},
         )
 

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -11,10 +11,12 @@ from django.urls import reverse
 from fixtures.integrations.jira.stub_client import StubJiraApiClient
 from fixtures.integrations.stub_service import StubService
 from sentry.integrations.jira_server.integration import JiraServerIntegration
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import ExternalProviders
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
@@ -871,7 +873,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 {
                     "accountId": "deadbeef123",
                     "displayName": "Dead Beef",
-                    "email": "bob@example.com",
+                    "emailAddress": "bob@example.com",
                 }
             ],
         )
@@ -910,6 +912,115 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             )
 
         assert str(exc_info.value) == "Failed to assign user to Jira Server issue"
+
+    @responses.activate
+    @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
+    def test_get_user_by_external_actor_multiple_actors(self, mock_search_users_for_issue):
+        ExternalActor.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.JIRA_SERVER.value,
+            user_id=self.user.id,
+            external_name="jira_user_1",
+        )
+        ExternalActor.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.JIRA_SERVER.value,
+            user_id=self.user.id,
+            external_name="jira_user_2",
+        )
+
+        with self.assertLogs(
+            logger="sentry.integrations.jira_server", level="WARNING"
+        ) as log_context:
+            result = self.installation._get_user_by_external_actor(
+                client=self.installation.get_client(),
+                external_issue_key="APP-123",
+                user=self.user,
+                logging_context={"integration_id": self.integration.id},
+            )
+
+        assert result is None
+        assert "jira_server.user_external_actor.multiple_actors" in log_context.output[0]
+
+    @responses.activate
+    @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
+    def test_get_user_by_external_actor_no_actor(self, mock_search_users_for_issue):
+        result = self.installation._get_user_by_external_actor(
+            client=self.installation.get_client(),
+            external_issue_key="APP-123",
+            user=self.user,
+            logging_context={"integration_id": self.integration.id},
+        )
+
+        mock_search_users_for_issue.return_value = [
+            {
+                "name": "jirauser",
+                "displayName": "Jira User",
+                "emailAddress": "some_email@example.com",
+            }
+        ]
+
+        assert result is None
+
+    @responses.activate
+    @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
+    def test_get_user_by_external_actor_no_matching_jira_user(self, mock_search_users_for_issue):
+        ExternalActor.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.JIRA_SERVER.value,
+            user_id=self.user.id,
+            external_name="nonexistent_user",
+        )
+
+        mock_search_users_for_issue.return_value = []
+
+        result = self.installation._get_user_by_external_actor(
+            client=self.installation.get_client(),
+            external_issue_key="APP-123",
+            user=self.user,
+            logging_context={"integration_id": self.integration.id},
+        )
+
+        assert result is None
+        mock_search_users_for_issue.assert_called_once_with("APP-123", "nonexistent_user")
+
+    @responses.activate
+    @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
+    def test_get_user_by_external_actor_matching_user(self, mock_search_users_for_issue):
+        ExternalActor.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.JIRA_SERVER.value,
+            user_id=self.user.id,
+            external_name="JiraUser",
+        )
+
+        mock_jira_user = {
+            "name": "jirauser",
+            "displayName": "Jira User",
+            "emailAddress": "some_other_email@example.com",
+        }
+
+        # Tests case where a username query matches multiple users,
+        # we expect an exact match on the name
+        mock_search_users_for_issue.return_value = [
+            {"name": "other_user", "displayName": "Other User"},
+            mock_jira_user,
+            {"name": "another_user", "displayName": "Another User"},
+        ]
+
+        result = self.installation._get_user_by_external_actor(
+            client=self.installation.get_client(),
+            external_issue_key="APP-123",
+            user=self.user,
+            logging_context={"integration_id": self.integration.id},
+        )
+
+        assert result == mock_jira_user
+        mock_search_users_for_issue.assert_called_once_with("APP-123", "JiraUser")
 
     def test_get_config_data(self):
         integration = self.create_integration(

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -935,7 +935,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         with self.assertLogs(
             logger="sentry.integrations.jira_server", level="WARNING"
         ) as log_context:
-            result = self.installation._get_user_by_external_actor(
+            result = self.installation._get_matching_jira_server_user_by_external_actor(
                 client=self.installation.get_client(),
                 external_issue_key="APP-123",
                 user=rpc_user,
@@ -949,7 +949,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.search_users_for_issue")
     def test_get_user_by_external_actor_no_actor(self, mock_search_users_for_issue):
         rpc_user = serialize_rpc_user(self.create_user(email="bob@example.com"))
-        result = self.installation._get_user_by_external_actor(
+        result = self.installation._get_matching_jira_server_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,
@@ -980,7 +980,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
 
         mock_search_users_for_issue.return_value = []
 
-        result = self.installation._get_user_by_external_actor(
+        result = self.installation._get_matching_jira_server_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,
@@ -1016,7 +1016,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             {"name": "another_user", "displayName": "Another User"},
         ]
 
-        result = self.installation._get_user_by_external_actor(
+        result = self.installation._get_matching_jira_server_user_by_external_actor(
             client=self.installation.get_client(),
             external_issue_key="APP-123",
             user=rpc_user,


### PR DESCRIPTION
## Problem this addresses:
Usernames in Jira Server are arbitrary. They can either match the user's email address, or can be something entirely different. To account for this, we're proposing using `ExternalActor` objects as a link between a Jira Server user and Sentry user, which can be manually set in the integrations' configuration pane.

This PR only contains the backend changes required to set mappings, as well as the updated sync logic that accounts for these mappings. UI changes will be managed in a separate PR.

## Changes:
- Adds core enums, new integration feature for user mapping in Jira Server
- Updates sync logic to try linking via external actor first, then by email address match after
- Removes outdated or flat out incorrect user linking logic, as well as old logging.


## References:
[Jira Docs](https://developer.atlassian.com/server/jira/platform/rest/v10002/api-group-serverinfo/#api-group-serverinfo)
Fixes RTC-439
