### PR TITLE
fix(issue-views): Fix animation on route transition and add tooltip

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -176,7 +176,9 @@ export function IssueViewNavItemContent({
         hasIssueViewSharing={hasIssueViewSharing}
       >
         {hasIssueViewSharing ? (
-          view.label
+          <Tooltip title={view.label} position="top" showOnlyOnOverflow skipWrapper>
+            <TruncatedTitle>{view.label}</TruncatedTitle>
+          </Tooltip>
         ) : (
           <IssueViewNavEditableTitle
             view={view}
@@ -251,7 +253,7 @@ const StyledInteractionStateLayer = styled(InteractionStateLayer)`
 const TrailingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
-  margin-right: ${space(0.25)};
+  margin-left: ${space(0.5)};
 `;
 
 const StyledSecondaryNavItem = styled(SecondaryNav.Item)<{hasIssueViewSharing: boolean}>`
@@ -335,4 +337,8 @@ const GrabHandleWrapper = styled(motion.div)`
   &:active {
     cursor: grabbing;
   }
+`;
+
+const TruncatedTitle = styled('div')`
+  ${p => p.theme.overflowEllipsis}
 `;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -86,8 +86,6 @@ export function IssueViewNavItemContent({
 
   const {startInteraction, endInteraction, isInteractingRef} = useNavContext();
 
-  const scrollPosition = window.scrollY || document.documentElement.scrollTop;
-
   return (
     <StyledReorderItem
       as="div"
@@ -111,7 +109,7 @@ export function IssueViewNavItemContent({
       // upon scrolling down on the page and triggering a page navigation.
       // See: https://github.com/motiondivision/motion/issues/2006
       style={{
-        ...(isDragging || scrollPosition === 0
+        ...(isDragging
           ? {}
           : {
               originY: '0px',


### PR DESCRIPTION
- Fixes the issue views animation that happens when you scroll down the page and navigate to a new page. We were checking for scroll position when that was not necessary and didn't update as you scrolled down the page.
- Adds a tooltip to the title when issue view sharing is enabled