### PR TITLE
ref(feedback): emit metric for userreport conflicts and handle in save_feedback_event

### DIFF
--- a/src/sentry/feedback/usecases/save_feedback_event.py
+++ b/src/sentry/feedback/usecases/save_feedback_event.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
-from sentry.ingest.userreport import save_userreport
+from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.utils import metrics
@@ -62,6 +62,9 @@ def save_feedback_event(event_data: Mapping[str, Any], project_id: int):
                 start_time=start_time,
             )
             metrics.incr("feedback.shim_to_userreport.success")
+
+    except Conflict:
+        pass
 
     except Exception:
         metrics.incr("feedback.shim_to_userreport.failed")

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -98,6 +98,10 @@ def save_userreport(
             # if the event is more than 30 minutes old, we don't allow updates
             # as it might be abusive
             if event.datetime < start_time - timedelta(minutes=30):
+                metrics.incr(
+                    "user_report.create_user_report.filtered",
+                    tags={"reason": "event_too_old", "referrer": source.value},
+                )
                 raise Conflict("Feedback for this event cannot be modified.")
 
             report["environment_id"] = event.get_environment().id
@@ -124,6 +128,10 @@ def save_userreport(
             # if the existing report was submitted more than 5 minutes ago, we dont
             # allow updates as it might be abusive (replay attacks)
             if existing_report.date_added < timezone.now() - timedelta(minutes=5):
+                metrics.incr(
+                    "user_report.create_user_report.filtered",
+                    tags={"reason": "existing_report", "referrer": source.value},
+                )
                 raise Conflict("Feedback for this event cannot be modified.")
 
             existing_report.update(


### PR DESCRIPTION
These `Conflict` errors are from user error and can be safely ignored in the shim to v1 pipeline. Worth a metric/outcome though.

Fixes SENTRY-3SGD
Fixes SENTRY-3SH5