### PR TITLE
fix(onboarding): Wait for projects to be loaded before loading getting started docs 

### DIFF
--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -27,7 +27,7 @@ export function useConfigureSdk({
   onComplete: (selectedPlatform: OnboardingSelectedSDK) => void;
 }) {
   const {teams, fetching: isLoadingTeams} = useTeams();
-  const {projects} = useProjects();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
   const createProject = useCreateProject();
@@ -130,5 +130,5 @@ export function useConfigureSdk({
     [createPlatformProject, onboardingContext, organization]
   );
 
-  return {configureSdk, isLoadingData: isLoadingTeams};
+  return {configureSdk, isLoadingData: isLoadingTeams || !projectsLoaded};
 }


### PR DESCRIPTION
While investigating JAVASCRIPT-2YQ7, we noticed that we do not wait for the projects to be loaded before checking if a project already exists. This can lead to scenarios where a request to create a project is sent unnecessarily, even if the project already exists.