### PR TITLE
feat(onboarding): add uv as an option for package management in onboarding for python

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -136,7 +136,12 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))`,
   },
 };
 
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
+const getInstallSnippet = (packageManager?: 'pip' | 'uv') => {
+  if (packageManager === 'uv') {
+    return `uv add sentry-sdk`;
+  }
+  return `pip install --upgrade sentry-sdk`;
+};
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -201,7 +206,7 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Python SDK using [code:pip]:', {
+      description: tct('Install our Python SDK:', {
         code: <code />,
       }),
       configurations: [
@@ -216,7 +221,20 @@ const onboarding: OnboardingConfig = {
                 )
               : undefined,
           language: 'bash',
-          code: getInstallSnippet(),
+          code: [
+            {
+              label: 'pip',
+              value: 'pip',
+              language: 'bash',
+              code: getInstallSnippet('pip'),
+            },
+            {
+              label: 'uv',
+              value: 'uv',
+              language: 'bash',
+              code: getInstallSnippet('uv'),
+            },
+          ],
         },
       ],
     },
@@ -382,6 +400,12 @@ export const featureFlagOnboarding: OnboardingConfig = {
                 value: 'pip',
                 language: 'bash',
                 code: `pip install --upgrade ${packageName}`,
+              },
+              {
+                label: 'uv',
+                value: 'uv',
+                language: 'bash',
+                code: `uv pip install --upgrade ${packageName}`,
               },
             ],
           },


### PR DESCRIPTION
- Closes TET-297

| Before | After |
|--------|-------|
| <img width="665" alt="Screenshot 2025-04-22 at 09 37 24" src="https://github.com/user-attachments/assets/3ab7ec1c-bd5f-4533-843c-c5121039f902" /> | <img width="667" alt="Screenshot 2025-04-22 at 09 37 13" src="https://github.com/user-attachments/assets/a6c9298c-7738-45e2-9ac0-faabc0d9763d" />|
|<img width="480" alt="Screenshot 2025-04-22 at 09 41 13" src="https://github.com/user-attachments/assets/fbfad072-1510-456a-9fa7-94916ad92606" />|<img width="470" alt="Screenshot 2025-04-22 at 09 38 13" src="https://github.com/user-attachments/assets/6baf1435-b4b2-4e26-8caf-ece44fcff3e3" />|
