### PR TITLE
fix(ci-cd): skip flaky test

### DIFF
--- a/tests/sentry/uptime/migrations/test_0033_uptime_backfill_to_detectors.py
+++ b/tests/sentry/uptime/migrations/test_0033_uptime_backfill_to_detectors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.testutils.cases import TestMigrations
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription, get_detector
 from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
@@ -46,6 +48,7 @@ class UptimeBackfillToDetectorsTest(TestMigrations):
         )
         DataSourceDetector.objects.create(data_source=data_source, detector=detector)
 
+    @pytest.mark.skip(reason="Flaky test causes problems in our CI/CD")
     def test(self):
         from sentry.workflow_engine.models import Detector
 


### PR DESCRIPTION
Test was added 4 days ago in https://github.com/getsentry/sentry/issues/89908

It is causing problems and fails in unrelated code changes because it takes too long to execute: https://github.com/getsentry/sentry/actions/runs/14592301610/job/40932808276?pr=90042