### PR TITLE
ref(✂️): remove unused exports keyword from types

### DIFF
--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -5,7 +5,7 @@ import type {DateString} from 'sentry/types/core';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 
-export type DoReleaseHealthRequestOptions = {
+type DoReleaseHealthRequestOptions = {
   field: string[];
   orgSlug: Organization['slug'];
   cursor?: string;

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -52,7 +52,7 @@ type PromptCheckParams = {
 /**
  * Raw response data from the endpoint
  */
-export type PromptResponseItem = {
+type PromptResponseItem = {
   /**
    * Time since dismissed
    */

--- a/static/app/actionCreators/sessions.tsx
+++ b/static/app/actionCreators/sessions.tsx
@@ -5,7 +5,7 @@ import type {DateString} from 'sentry/types/core';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 
-export type DoSessionsRequestOptions = {
+type DoSessionsRequestOptions = {
   field: string[];
   orgSlug: Organization['slug'];
   cursor?: string;

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -95,7 +95,7 @@ interface RenderDisabledProps extends FeatureRenderProps {
   renderDisabled?: (props: FeatureRenderProps) => React.ReactNode;
 }
 
-export type RenderDisabledFn = (props: RenderDisabledProps) => React.ReactNode;
+type RenderDisabledFn = (props: RenderDisabledProps) => React.ReactNode;
 
 interface ChildRenderProps extends FeatureRenderProps {
   renderDisabled?: boolean | ((props: any) => React.ReactNode);

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -50,7 +50,7 @@ function SetupReleasesPrompt() {
   );
 }
 
-export interface ResolveActionsProps {
+interface ResolveActionsProps {
   hasRelease: boolean;
   onUpdate: (data: GroupStatusResolution) => void;
   confirmLabel?: string;

--- a/static/app/components/arithmeticBuilder/index.tsx
+++ b/static/app/components/arithmeticBuilder/index.tsx
@@ -13,7 +13,7 @@ import type {
 import {Input} from 'sentry/components/core/input';
 import PanelProvider from 'sentry/utils/panelProvider';
 
-export interface ArithmeticBuilderProps {
+interface ArithmeticBuilderProps {
   aggregateFunctions: AggregateFunction[];
   expression: string;
   functionArguments: FunctionArgument[];

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -58,7 +58,7 @@ type AssignableTeam = {
   team: Team;
 };
 
-export interface AssigneeSelectorDropdownProps {
+interface AssigneeSelectorDropdownProps {
   /**
    * The group (issue) that the assignee selector is for
    * TODO: generalize this for alerts

--- a/static/app/components/assistant/types.tsx
+++ b/static/app/components/assistant/types.tsx
@@ -1,4 +1,4 @@
-export type GuideStep = {
+type GuideStep = {
   /**
    * The main body of the step
    */

--- a/static/app/components/charts/barChartZoom.tsx
+++ b/static/app/components/charts/barChartZoom.tsx
@@ -17,7 +17,7 @@ type RenderProps = {
   toolBox: ReturnType<typeof ToolBox>;
 };
 
-export type BarChartBucket = {
+type BarChartBucket = {
   end: number;
   start: number;
 };

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -28,7 +28,7 @@ import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
-export type TimeSeriesData = {
+type TimeSeriesData = {
   allTimeseriesData?: EventsStatsData;
   comparisonTimeseriesData?: Series[];
   originalPreviousTimeseriesData?: EventsStatsData | null;

--- a/static/app/components/charts/heatMapChart.tsx
+++ b/static/app/components/charts/heatMapChart.tsx
@@ -8,7 +8,7 @@ import HeatMapSeries from './series/heatMapSeries';
 import type {BaseChartProps} from './baseChart';
 import BaseChart from './baseChart';
 
-export interface HeatmapSeries
+interface HeatmapSeries
   extends Series,
     Omit<HeatmapSeriesOption, 'data' | 'name' | 'color' | 'id'> {
   dataArray?: HeatmapSeriesOption['data'];

--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -16,7 +16,7 @@ const propNamesToIgnore = ['api', 'children', 'organization'];
 const omitIgnoredProps = (props: Props) =>
   omitBy(props, (_value, key) => propNamesToIgnore.includes(key));
 
-export type SessionsRequestRenderProps = {
+type SessionsRequestRenderProps = {
   errored: boolean;
   loading: boolean;
   reloading: boolean;

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -85,7 +85,7 @@ export function useShortInterval(datetimeObj: DateTimeObject): boolean {
   return computeShortInterval(datetimeObj);
 }
 
-export type GranularityStep = [timeDiff: number, interval: string];
+type GranularityStep = [timeDiff: number, interval: string];
 
 export class GranularityLadder {
   steps: GranularityStep[];

--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -30,7 +30,7 @@ interface CheckInTimelineConfig<Status extends string> {
   style?: React.CSSProperties;
 }
 
-export interface CheckInTimelineProps<Status extends string>
+interface CheckInTimelineProps<Status extends string>
   extends CheckInTimelineConfig<Status> {
   /**
    * Represents each check-in tick as bucketed check-in data.
@@ -100,7 +100,7 @@ export function CheckInTimeline<Status extends string>({
   );
 }
 
-export interface MockCheckInTimelineProps<Status extends string>
+interface MockCheckInTimelineProps<Status extends string>
   extends CheckInTimelineConfig<Status> {
   mockTimestamps: Date[];
   /**

--- a/static/app/components/codecov/datePicker/datePicker.tsx
+++ b/static/app/components/codecov/datePicker/datePicker.tsx
@@ -16,7 +16,7 @@ export const CODECOV_DEFAULT_RELATIVE_PERIODS = {
   '30d': t('Last 30 days'),
 };
 
-export interface DatePickerProps
+interface DatePickerProps
   extends Partial<Partial<Omit<DateSelectorProps, 'relative' | 'menuBody'>>> {}
 
 export function DatePicker({

--- a/static/app/components/codecov/datePicker/dateSelector.tsx
+++ b/static/app/components/codecov/datePicker/dateSelector.tsx
@@ -22,7 +22,7 @@ const SelectorItemsHook = HookOrDefault({
   defaultComponent: SelectorItems,
 });
 
-export type ChangeData = {
+type ChangeData = {
   relative: string | null;
 };
 

--- a/static/app/components/comboBox/types.tsx
+++ b/static/app/components/comboBox/types.tsx
@@ -1,6 +1,6 @@
 import type {SelectValue} from 'sentry/types/core';
 
-export type SelectKey = string | number;
+type SelectKey = string | number;
 
 export interface ComboBoxOption<Value extends SelectKey> extends SelectValue<Value> {
   label: string;
@@ -13,7 +13,7 @@ export interface ComboBoxOption<Value extends SelectKey> extends SelectValue<Val
   hideCheck?: boolean;
 }
 
-export interface ComboBoxSection<Value extends SelectKey> {
+interface ComboBoxSection<Value extends SelectKey> {
   options: Array<ComboBoxOption<Value>>;
   /**
    * When true, all options inside this section will be disabled.
@@ -39,8 +39,7 @@ export type ComboBoxOptionOrSection<Value extends SelectKey> =
   | ComboBoxOption<Value>
   | ComboBoxSection<Value>;
 
-export interface ComboBoxOptionWithKey<Value extends SelectKey>
-  extends ComboBoxOption<Value> {
+interface ComboBoxOptionWithKey<Value extends SelectKey> extends ComboBoxOption<Value> {
   /**
    * Key to identify this section. If not specified, the section's index will
    * be used.
@@ -48,8 +47,7 @@ export interface ComboBoxOptionWithKey<Value extends SelectKey>
   key: SelectKey;
 }
 
-export interface ComboBoxSectionWithKey<Value extends SelectKey>
-  extends ComboBoxSection<Value> {
+interface ComboBoxSectionWithKey<Value extends SelectKey> extends ComboBoxSection<Value> {
   /**
    * Key to identify this section. If not specified, the section's index will
    * be used.

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -31,7 +31,7 @@ export type ConfirmMessageRenderProps = {
   setConfirmCallback: (cb: () => void) => void;
 };
 
-export type ConfirmButtonsRenderProps = {
+type ConfirmButtonsRenderProps = {
   /**
    * Applications can call this function to manually close the modal.
    */

--- a/static/app/components/core/avatar/gravatar.tsx
+++ b/static/app/components/core/avatar/gravatar.tsx
@@ -9,7 +9,7 @@ import {
 } from 'sentry/components/core/avatar/baseAvatarComponentStyles';
 import ConfigStore from 'sentry/stores/configStore';
 
-export interface GravatarProps extends BaseAvatarComponentProps {
+interface GravatarProps extends BaseAvatarComponentProps {
   remoteSize: number;
   gravatarId?: string;
   onError?: () => void;

--- a/static/app/components/core/avatar/letterAvatar.tsx
+++ b/static/app/components/core/avatar/letterAvatar.tsx
@@ -10,7 +10,7 @@ import {
   BaseAvatarComponentStyles,
 } from './baseAvatarComponentStyles';
 
-export interface LetterAvatarProps
+interface LetterAvatarProps
   extends React.HTMLAttributes<SVGSVGElement>,
     BaseAvatarComponentProps {
   displayName?: string;

--- a/static/app/components/core/badge/index.tsx
+++ b/static/app/components/core/badge/index.tsx
@@ -47,7 +47,7 @@ function makeBadgeTheme(
   }
 }
 
-export type BadgeType =
+type BadgeType =
   | 'alpha'
   | 'beta'
   | 'new'

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -6,8 +6,7 @@ import {StyledButton} from 'sentry/components/core/button';
 import type {ValidSize} from 'sentry/styles/space';
 import {space} from 'sentry/styles/space';
 
-export interface ButtonBarProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className'> {
+interface ButtonBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className'> {
   children: React.ReactNode;
   gap?: ValidSize | 0;
   merged?: boolean;

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -26,7 +26,7 @@ interface BaseCompositeSelectRegion<Value extends SelectKey> {
  * renders as a `ul` with its own list state) whose selection values don't interfere
  * with one another.
  */
-export interface SingleCompositeSelectRegion<Value extends SelectKey>
+interface SingleCompositeSelectRegion<Value extends SelectKey>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       SingleListProps<Value>,
@@ -39,7 +39,7 @@ export interface SingleCompositeSelectRegion<Value extends SelectKey>
  * list (each renders as a `ul` with its own list state) whose selection values don't
  * interfere with one another.
  */
-export interface MultipleCompositeSelectRegion<Value extends SelectKey>
+interface MultipleCompositeSelectRegion<Value extends SelectKey>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       MultipleListProps<Value>,
@@ -51,7 +51,7 @@ export interface MultipleCompositeSelectRegion<Value extends SelectKey>
  * selectable list (each renders as a `ul` with its own list state) whose selection
  * values don't interfere with one another.
  */
-export type CompositeSelectRegion<Value extends SelectKey> =
+type CompositeSelectRegion<Value extends SelectKey> =
   | SingleCompositeSelectRegion<Value>
   | MultipleCompositeSelectRegion<Value>;
 
@@ -65,7 +65,7 @@ type CompositeSelectChild =
   | null
   | undefined;
 
-export interface CompositeSelectProps extends ControlProps {
+interface CompositeSelectProps extends ControlProps {
   /**
    * The "regions" inside this composite selector. Each region functions as a separated,
    * self-contained selectable list (each renders as a `ul` with its own list state)

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -48,7 +48,7 @@ function nextFrameCallback(cb: () => void) {
   }
 }
 
-export interface SelectContextValue {
+interface SelectContextValue {
   overlayIsOpen: boolean;
   /**
    * Function to be called once when a list is initialized, to register its state in

--- a/static/app/components/core/input/numberInput.tsx
+++ b/static/app/components/core/input/numberInput.tsx
@@ -14,7 +14,7 @@ import {IconChevron} from 'sentry/icons/iconChevron';
 import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 
-export interface NumberInputProps
+interface NumberInputProps
   extends InputStylesProps,
     AriaNumberFieldProps,
     Pick<

--- a/static/app/components/core/segmentedControl/index.tsx
+++ b/static/app/components/core/segmentedControl/index.tsx
@@ -26,7 +26,7 @@ import {
   type Priority,
 } from './index.chonk';
 
-export interface SegmentedControlItemProps<Value extends string> {
+interface SegmentedControlItemProps<Value extends string> {
   key: Value;
   children?: React.ReactNode;
   disabled?: boolean;
@@ -51,7 +51,7 @@ export interface SegmentedControlItemProps<Value extends string> {
   tooltipOptions?: Omit<TooltipProps, 'children' | 'title' | 'className'>;
 }
 
-export interface SegmentedControlProps<Value extends string>
+interface SegmentedControlProps<Value extends string>
   extends Omit<RadioGroupProps, 'value' | 'defaultValue' | 'onChange' | 'isDisabled'> {
   children: CollectionChildren<Value>;
   onChange: (value: Value) => void;

--- a/static/app/components/core/select/index.tsx
+++ b/static/app/components/core/select/index.tsx
@@ -498,7 +498,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   );
 }
 
-export interface PickerProps<OptionType extends OptionTypeBase>
+interface PickerProps<OptionType extends OptionTypeBase>
   extends ControlProps<OptionType> {
   /**
    * Enable async option loading.

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -26,7 +26,7 @@ import {
   DEFAULT_WIZARD_TEMPLATE,
 } from 'sentry/views/alerts/wizard/options';
 
-export type CreateAlertFromViewButtonProps = Omit<ButtonProps, 'aria-label'> & {
+type CreateAlertFromViewButtonProps = Omit<ButtonProps, 'aria-label'> & {
   /**
    * Discover query used to create the alert
    */

--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -14,9 +14,9 @@ import type {
 import PermissionDenied from 'sentry/views/permissionDenied';
 import RouteError from 'sentry/views/routeError';
 
-export interface AsyncComponentProps extends Partial<RouteComponentProps> {}
+interface AsyncComponentProps extends Partial<RouteComponentProps> {}
 
-export interface AsyncComponentState {
+interface AsyncComponentState {
   [key: string]: any;
   error: boolean;
   errors: Record<string, ResponseMeta>;

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -44,11 +44,11 @@ export type GetActorPropsFn = <E extends Element = Element>(
   opts?: GetActorArgs<E>
 ) => ActorProps<E>;
 
-export type GetMenuPropsFn = <E extends Element = Element>(
+type GetMenuPropsFn = <E extends Element = Element>(
   opts?: GetMenuArgs<E>
 ) => MenuProps<E>;
 
-export type MenuActions = {
+type MenuActions = {
   close: (event?: React.MouseEvent) => void;
   open: (event?: React.MouseEvent) => void;
 };

--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -165,7 +165,7 @@ const pickParserOptions = (props: Props) => {
   } satisfies Partial<SearchConfig>;
 };
 
-export type ActionProps = {
+type ActionProps = {
   api: Client;
   /**
    * The organization
@@ -181,7 +181,7 @@ export type ActionProps = {
   savedSearchType?: SavedSearchType;
 };
 
-export type ActionBarItem = {
+type ActionBarItem = {
   /**
    * Name of the action
    */

--- a/static/app/components/devtoolbar/components/infiniteListState.tsx
+++ b/static/app/components/devtoolbar/components/infiniteListState.tsx
@@ -3,7 +3,7 @@ import type {UseInfiniteQueryResult, UseQueryResult} from '@tanstack/react-query
 
 import type {ApiResult} from 'sentry/components/devtoolbar/types';
 
-export interface Props<Data> {
+interface Props<Data> {
   children: React.ReactNode;
   queryResult:
     | UseQueryResult<ApiResult<Data>, Error>

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -403,7 +403,7 @@ function BaseDraggableTabList({
 
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
-export interface DraggableTabListProps
+interface DraggableTabListProps
   extends AriaTabListOptions<DraggableTabListItemProps>,
     TabListStateOptions<DraggableTabListItemProps> {
   onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;

--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -37,7 +37,7 @@ interface LazyDropdownAutoCompleteProps extends BaseProps {
   items?: never;
 }
 
-export interface StaticDropdownAutoCompleteProps extends BaseProps {
+interface StaticDropdownAutoCompleteProps extends BaseProps {
   items: MenuProps['items'];
   lazyItems?: never;
 }

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -16,7 +16,7 @@ import type {Item, ItemsBeforeFilter} from './types';
 type AutoCompleteChildrenArgs = Parameters<AutoComplete<Item>['props']['children']>[0];
 type Actions = AutoCompleteChildrenArgs['actions'];
 
-export type MenuFooterChildProps = {
+type MenuFooterChildProps = {
   actions: Actions;
 };
 

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -38,12 +38,12 @@ export enum AutofixStatus {
   WAITING_FOR_USER_RESPONSE = 'WAITING_FOR_USER_RESPONSE',
 }
 
-export type AutofixPullRequestDetails = {
+type AutofixPullRequestDetails = {
   pr_number: number;
   pr_url: string;
 };
 
-export type AutofixOptions = {
+type AutofixOptions = {
   iterative_feedback?: boolean;
 };
 
@@ -53,7 +53,7 @@ export type AutofixUpdateEndpointResponse = {
   status?: 'success' | 'error';
 };
 
-export type CodebaseState = {
+type CodebaseState = {
   is_readable: boolean | null;
   is_writeable: boolean | null;
   repo_external_id: string | null;
@@ -145,14 +145,14 @@ export type AutofixRootCauseSelection =
   | {custom_root_cause: string}
   | null;
 
-export interface AutofixRootCauseStep extends BaseStep {
+interface AutofixRootCauseStep extends BaseStep {
   causes: AutofixRootCauseData[];
   selection: AutofixRootCauseSelection;
   type: AutofixStepType.ROOT_CAUSE_ANALYSIS;
   termination_reason?: string;
 }
 
-export interface AutofixSolutionStep extends BaseStep {
+interface AutofixSolutionStep extends BaseStep {
   solution: AutofixSolutionTimelineEvent[];
   solution_selected: boolean;
   type: AutofixStepType.SOLUTION;
@@ -178,7 +178,7 @@ export interface AutofixChangesStep extends BaseStep {
   termination_reason?: string;
 }
 
-export type AutofixRelevantCodeFile = {
+type AutofixRelevantCodeFile = {
   file_path: string;
   repo_name: string;
 };
@@ -206,7 +206,7 @@ export type AutofixRootCauseData = {
   root_cause_reproduction?: AutofixTimelineEvent[];
 };
 
-export type EventMetadataWithAutofix = EventMetadata & {
+type EventMetadataWithAutofix = EventMetadata & {
   autofix?: AutofixData;
 };
 

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -6,11 +6,11 @@ import {
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
-export interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
+interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
   ok: boolean;
 }
 
-export type AutofixSetupResponse = {
+type AutofixSetupResponse = {
   genAIConsent: {
     ok: boolean;
   };

--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -41,7 +41,7 @@ interface ContextCardContentConfig {
   includeAliasInSubject?: boolean;
 }
 
-export interface ContextCardContentProps {
+interface ContextCardContentProps {
   item: KeyValueListDataItem;
   meta: Record<string, any>;
   alias?: string;

--- a/static/app/components/events/contexts/knownContext/browser.tsx
+++ b/static/app/components/events/contexts/knownContext/browser.tsx
@@ -2,7 +2,7 @@ import {getContextKeys} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
 
-export enum BrowserContextKeys {
+enum BrowserContextKeys {
   NAME = 'name',
   VERSION = 'version',
 }

--- a/static/app/components/events/contexts/platformContext/utils.tsx
+++ b/static/app/components/events/contexts/platformContext/utils.tsx
@@ -9,7 +9,7 @@ import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
 import type {IconSize} from 'sentry/utils/theme';
 
-export enum PlatformContextKeys {
+enum PlatformContextKeys {
   LARAVEL = 'laravel',
   REACT = 'react',
   UNITY = 'unity',

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -130,7 +130,7 @@ export function getRelativeTimeFromEventDateCreated(
   );
 }
 
-export type KnownDataDetails = Omit<KeyValueListDataItem, 'key'> | undefined;
+type KnownDataDetails = Omit<KeyValueListDataItem, 'key'> | undefined;
 
 export function getKnownData<Data, DataType>({
   data,

--- a/static/app/components/events/errorItem.tsx
+++ b/static/app/components/events/errorItem.tsx
@@ -32,7 +32,7 @@ const keyMapping = {
   image_path: 'File Path',
 };
 
-export type ErrorItemProps = {
+type ErrorItemProps = {
   error: EventErrorData;
   meta?: Record<any, any>;
 };

--- a/static/app/components/events/interfaces/spans/context.tsx
+++ b/static/app/components/events/interfaces/spans/context.tsx
@@ -8,7 +8,7 @@ type ChildTransaction = {
   transaction: string;
 };
 
-export type SpanEntryContextChildrenProps = {
+type SpanEntryContextChildrenProps = {
   getViewChildTransactionTarget: (
     props: ChildTransaction
   ) => LocationDescriptor | undefined;

--- a/static/app/components/events/interfaces/spans/cursorGuideHandler.tsx
+++ b/static/app/components/events/interfaces/spans/cursorGuideHandler.tsx
@@ -6,7 +6,7 @@ import clamp from 'sentry/utils/number/clamp';
 import type {DragManagerChildrenProps} from './dragManager';
 import type {ParsedTraceType} from './types';
 
-export type CursorGuideManagerChildrenProps = {
+type CursorGuideManagerChildrenProps = {
   displayCursorGuide: (mousePageX: number) => void;
   hideCursorGuide: () => void;
   mouseLeft: number | undefined;

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
@@ -96,7 +96,7 @@ import {
 export const MARGIN_LEFT = 0;
 const SPAN_BAR_HEIGHT = 24;
 
-export type NewTraceDetailsSpanBarProps = SpanBarProps & {
+type NewTraceDetailsSpanBarProps = SpanBarProps & {
   location: Location;
   quickTrace: QuickTraceContextChildrenProps;
   theme: Theme;

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -106,14 +106,14 @@ export type FetchEmbeddedChildrenState =
   | 'loading_embedded_transactions'
   | 'error_fetching_embedded_transactions';
 
-export type SpanGroupProps = {
+type SpanGroupProps = {
   isNestedSpanGroupExpanded: boolean;
   spanNestedGrouping: EnhancedSpan[] | undefined;
   toggleNestedSpanGroup: (() => void) | undefined;
   toggleSiblingSpanGroup: ((span: SpanType) => void) | undefined;
 };
 
-export type SpanSiblingGroupProps = {
+type SpanSiblingGroupProps = {
   isLastSibling: boolean;
   occurrence: number;
   spanSiblingGrouping: EnhancedSpan[] | undefined;

--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -46,7 +46,7 @@ const defaultFeedbackTypes = [
   t('Other reason'),
 ];
 
-export type ChildrenProps<T> = {
+type ChildrenProps<T> = {
   Body: (props: {
     children: React.ReactNode;
     showSelfHostedMessage?: boolean;

--- a/static/app/components/featureFeedback/index.tsx
+++ b/static/app/components/featureFeedback/index.tsx
@@ -7,7 +7,7 @@ import type {Data} from 'sentry/components/forms/types';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-export type FeatureFeedbackProps<T extends Data> = FeedbackModalProps<T> & {
+type FeatureFeedbackProps<T extends Data> = FeedbackModalProps<T> & {
   buttonProps?: Partial<ButtonProps>;
   secondaryAction?: React.ReactNode;
 };

--- a/static/app/components/feedback/useFeedbackCache.tsx
+++ b/static/app/components/feedback/useFeedbackCache.tsx
@@ -9,7 +9,7 @@ import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 
 type TFeedbackIds = 'all' | string[];
 
-export type ListCache = {
+type ListCache = {
   pageParams: unknown[];
   pages: Array<ApiResult<FeedbackIssueListItem[]>>;
 };

--- a/static/app/components/feedback/useMutateActivity.tsx
+++ b/static/app/components/feedback/useMutateActivity.tsx
@@ -14,19 +14,19 @@ export type TError = RequestError;
 export type TVariables = [TPayload, TMethod];
 export type TContext = unknown;
 
-export type DeleteCommentCallback = (
+type DeleteCommentCallback = (
   noteId: string,
   activity: GroupActivity[],
   options?: MutateOptions<TData, TError, TVariables, TContext>
 ) => void;
 
-export type CreateCommentCallback = (
+type CreateCommentCallback = (
   note: NoteType,
   activity: GroupActivity[],
   options?: MutateOptions<TData, TError, TVariables, TContext>
 ) => void;
 
-export type UpdateCommentCallback = (
+type UpdateCommentCallback = (
   note: NoteType,
   noteId: string,
   activity: GroupActivity[],

--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -229,5 +229,3 @@ const StyledInput = styled(Input)<{hasLabel: boolean}>`
 `;
 
 export default RangeSlider;
-
-export type {SliderProps};

--- a/static/app/components/forms/fieldGroup/controlState.tsx
+++ b/static/app/components/forms/fieldGroup/controlState.tsx
@@ -7,7 +7,7 @@ import {IconCheckmark, IconWarning} from 'sentry/icons';
 import {fadeOut, pulse} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
 
-export interface ControlStateProps {
+interface ControlStateProps {
   /**
    * Display the  error indicator
    */

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -9,7 +9,7 @@ import FormField from 'sentry/components/forms/formField';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {space} from 'sentry/styles/space';
 
-export interface SegmentedRadioFieldProps<Choices extends string = string>
+interface SegmentedRadioFieldProps<Choices extends string = string>
   extends Omit<InputFieldProps, 'type'> {
   choices?: RadioGroupProps<Choices>['choices'];
 }

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -10,7 +10,7 @@ import type {SelectFieldProps} from './selectField';
 import SelectField from './selectField';
 
 // projects can be passed as a direct prop as well
-export interface RenderFieldProps extends SelectFieldProps<any> {
+interface RenderFieldProps extends SelectFieldProps<any> {
   avatarSize?: number;
   /**
    * Ensures the only selectable teams are members of the given project.

--- a/static/app/components/forms/formContext.tsx
+++ b/static/app/components/forms/formContext.tsx
@@ -8,7 +8,7 @@ import type FormModel from 'sentry/components/forms/model';
  * These differ from the 'old' forms in that they use mobx observers
  * to update state and expose it via the `FormModel`
  */
-export type FormContextData = {
+type FormContextData = {
   /**
    * The default value is undefined so that FormField components
    * not within a form context boundary create MockModels based

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -104,7 +104,7 @@ interface BaseField {
 // TODO(ts): These are field specific props. May not be needed as we convert
 // the fields as we can grab the props from them
 
-export interface CustomType {
+interface CustomType {
   Component: (arg: BaseField) => React.ReactElement;
   type: 'custom';
 }
@@ -179,22 +179,22 @@ export type ProjectMapperType = {
   type: 'project_mapper';
 };
 
-export type ChoiceMapperType = {
+type ChoiceMapperType = {
   type: 'choice_mapper';
 } & ChoiceMapperProps;
 
 // selects a sentry project with avatars
-export type SentryProjectSelectorType = {
+type SentryProjectSelectorType = {
   projects: Project[];
   type: 'sentry_project_selector';
   avatarSize?: number;
 };
 
-export type SentryOrganizationRoleSelectorType = {
+type SentryOrganizationRoleSelectorType = {
   type: 'sentry_organization_role_selector';
 };
 
-export type SelectAsyncType = {
+type SelectAsyncType = {
   type: 'select_async';
 } & SelectAsyncFieldProps;
 

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -56,7 +56,7 @@ export type GridColumnSortBy<K = ObjectKey> = GridColumn<K> & {
 /**
  * Store state at the start of "resize" action
  */
-export type ColResizeMetadata = {
+type ColResizeMetadata = {
   columnIndex: number; // Column being resized
   columnWidth: number; // Column width at start of resizing
   cursorX: number; // X-coordinate of cursor on window

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -119,7 +119,7 @@ export function Content({
   );
 }
 
-export interface KeyValueDataCardProps {
+interface KeyValueDataCardProps {
   /**
    * ContentProps items to be rendered in this card.
    */

--- a/static/app/components/links/externalLink.tsx
+++ b/static/app/components/links/externalLink.tsx
@@ -1,6 +1,6 @@
 import Anchor from './anchor';
 
-export interface ExternalLinkProps
+interface ExternalLinkProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'target'> {
   disabled?: boolean;
   openInNewTab?: boolean;

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -86,7 +86,7 @@ export interface DocsParams<
   };
 }
 
-export interface NextStep {
+interface NextStep {
   description: string;
   link: string;
   name: string;

--- a/static/app/components/onboarding/platformOptionsControl.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.tsx
@@ -61,7 +61,7 @@ function OptionControl({option, value, onChange}: OptionControlProps) {
   );
 }
 
-export type PlatformOptionsControlProps = {
+type PlatformOptionsControlProps = {
   /**
    * Object with an option array for each platformOption
    */

--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -18,7 +18,7 @@ import useRouter from 'sentry/utils/useRouter';
 
 import {EnvironmentPageFilterTrigger} from './trigger';
 
-export interface EnvironmentPageFilterProps
+interface EnvironmentPageFilterProps
   extends Partial<
     Omit<
       HybridFilterProps<string>,

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -10,7 +10,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
 import type {PageFiltersState} from './types';
 
-export type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
+type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
 
 type SingleParamValue = string | undefined | null;
 type ParamValue = string[] | SingleParamValue;

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -35,7 +35,7 @@ import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 import {ProjectPageFilterMenuFooter} from './menuFooter';
 import {ProjectPageFilterTrigger} from './trigger';
 
-export interface ProjectPageFilterProps
+interface ProjectPageFilterProps
   extends Partial<
     Omit<
       HybridFilterProps<number>,

--- a/static/app/components/profiling/flamegraph/callTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/callTreeTable.tsx
@@ -8,7 +8,7 @@ import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import type {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode';
 import type {VirtualizedTreeRenderedRow} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 
-export const enum CallTreeTableClassNames {
+const enum CallTreeTableClassNames {
   ROW = 'CallTreeTableRow',
   CELL = 'CallTreeTableTableCell',
   FRAME_CELL = 'CallTreeTableTableCellFrame',

--- a/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChartTooltip.tsx
@@ -16,7 +16,7 @@ import {
   FlamegraphTooltipTimelineInfo,
 } from './flamegraphTooltip';
 
-export interface FlamegraphChartTooltipProps {
+interface FlamegraphChartTooltipProps {
   chart: FlamegraphChart;
   chartCanvas: FlamegraphCanvas;
   chartRenderer: FlamegraphChartRenderer;

--- a/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
@@ -23,7 +23,7 @@ export function formatWeightToTransactionDuration(
   return `(${Math.round((span.duration / spanChart.root.duration) * 100)}%)`;
 }
 
-export interface FlamegraphSpanTooltipProps {
+interface FlamegraphSpanTooltipProps {
   configSpaceCursor: vec2;
   hoveredNode: SpanChartNode;
   spanChart: SpanChart;

--- a/static/app/components/profiling/flamegraph/flamegraphSpansContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpansContextMenu.tsx
@@ -22,7 +22,7 @@ function getNodeType(node: SpanChartNode | null) {
   return t('Span');
 }
 
-export interface SpansContextMenuProps {
+interface SpansContextMenuProps {
   contextMenu: ReturnType<typeof useContextMenu>;
   hoveredNode: SpanChartNode | null;
   onCopyDescription: () => void;

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -32,7 +32,7 @@ export function formatWeightToProfileDuration(
   return `${Math.round(weight * 100) / 100}%`;
 }
 
-export interface FlamegraphTooltipProps {
+interface FlamegraphTooltipProps {
   configSpaceCursor: vec2;
   flamegraph: Flamegraph | DifferentialFlamegraph;
   flamegraphCanvas: FlamegraphCanvas;

--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -17,7 +17,7 @@ import {
   FlamegraphTooltipTimelineInfo,
 } from './flamegraphTooltip';
 
-export interface FlamegraphUIFramesTooltipProps {
+interface FlamegraphUIFramesTooltipProps {
   configSpaceCursor: vec2;
   hoveredNode: UIFrames['frames'];
   uiFrames: UIFrames;

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -14,7 +14,7 @@ interface Props {
   defaultTab?: DiffType;
 }
 
-export const enum DiffType {
+const enum DiffType {
   HTML = 'html',
   SLIDER = 'slider',
   VISUAL = 'visual',

--- a/static/app/components/replaysOnboarding/platformOptionDropdown.tsx
+++ b/static/app/components/replaysOnboarding/platformOptionDropdown.tsx
@@ -7,7 +7,7 @@ import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOption
 import {t} from 'sentry/locale';
 import useRouter from 'sentry/utils/useRouter';
 
-export type OptionControlProps = {
+type OptionControlProps = {
   /**
    * The platform options for which the control is rendered
    */

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -17,7 +17,7 @@ import type {FieldDefinition, FieldKind} from 'sentry/utils/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
 import {useDimensions} from 'sentry/utils/useDimensions';
 
-export interface SearchQueryBuilderContextData {
+interface SearchQueryBuilderContextData {
   actionBarRef: React.RefObject<HTMLDivElement | null>;
   disabled: boolean;
   disallowFreeText: boolean;

--- a/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
@@ -19,7 +19,7 @@ type SelectFunc = (params: {
   toEnd?: boolean;
 }) => void;
 
-export interface KeyboardSelectionData {
+interface KeyboardSelectionData {
   selectInDirection: SelectFunc;
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -31,7 +31,7 @@ export interface FilterValueItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export interface RecentFilterItem extends SelectOptionWithKey<string> {
+interface RecentFilterItem extends SelectOptionWithKey<string> {
   type: 'recent-filter';
   value: string;
 }

--- a/static/app/components/slider/thumb.tsx
+++ b/static/app/components/slider/thumb.tsx
@@ -8,7 +8,7 @@ import type {SliderState} from '@react-stately/slider';
 
 import {space} from 'sentry/styles/space';
 
-export interface SliderThumbProps extends Omit<AriaSliderThumbOptions, 'inputRef'> {
+interface SliderThumbProps extends Omit<AriaSliderThumbOptions, 'inputRef'> {
   getFormattedValue: (value: number) => React.ReactNode;
   state: SliderState;
   error?: boolean;

--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -5,7 +5,7 @@ import {IconGrabbable} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
-export type DividerProps = {
+type DividerProps = {
   'data-is-held': boolean;
   'data-slide-direction': 'leftright' | 'updown';
   onDoubleClick: React.MouseEventHandler<HTMLElement>;

--- a/static/app/components/stories/sizingWindow.tsx
+++ b/static/app/components/stories/sizingWindow.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {space} from 'sentry/styles/space';
 
-export interface StyleProps {
+interface StyleProps {
   display?: 'block' | 'flex';
 }
 

--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -26,7 +26,7 @@ type Props = {
   showTitle?: boolean;
 };
 
-export type SegmentValue = {
+type SegmentValue = {
   index: number;
   onClick: () => void;
   to: LocationDescriptor;

--- a/static/app/components/timeRangeSelector/utils.tsx
+++ b/static/app/components/timeRangeSelector/utils.tsx
@@ -18,7 +18,7 @@ import TimeRangeItemLabel from './timeRangeItemLabel';
 type PeriodUnit = 's' | 'm' | 'h' | 'd' | 'w';
 type RelativePeriodUnit = Exclude<PeriodUnit, 's'>;
 
-export type RelativeUnitsMapping = Record<
+type RelativeUnitsMapping = Record<
   string,
   {
     convertToDaysMultiplier: number;

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -31,7 +31,7 @@ type TourSetRegistrationAction = {
   type: 'SET_REGISTRATION';
 };
 
-export type TourAction<T extends TourEnumType> =
+type TourAction<T extends TourEnumType> =
   | TourStartAction<T>
   | TourNextStepAction
   | TourPreviousStepAction

--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PriorityLevel} from 'sentry/types/group';
 
-export interface PriorityControlGridProps {
+interface PriorityControlGridProps {
   name: string;
   onPriorityChange?: (value: PriorityLevel) => void;
   onThresholdChange?: (level: PriorityLevel, threshold: number) => void;
@@ -20,7 +20,7 @@ export interface PriorityControlGridProps {
   thresholds?: PriorityThresholds;
 }
 
-export interface PriorityThresholds {
+interface PriorityThresholds {
   high?: number;
   medium?: number;
 }

--- a/static/app/components/workflowEngine/gridCell/issueCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/issueCell.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 
-export type IssueCellProps = {
+type IssueCellProps = {
   className?: string;
   disabled?: boolean;
   group?: Group;

--- a/static/app/components/workflowEngine/layout/breadcrumbs.tsx
+++ b/static/app/components/workflowEngine/layout/breadcrumbs.tsx
@@ -4,7 +4,7 @@ import type {Crumb, CrumbDropdown} from 'sentry/components/breadcrumbs';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 
-export interface BreadcrumbsContextValue {
+interface BreadcrumbsContextValue {
   crumbs: Array<Crumb | CrumbDropdown>;
 }
 export const BreadcrumbsContext = createContext<BreadcrumbsContextValue>({

--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -9,7 +9,7 @@ import {BreadcrumbsFromContext} from 'sentry/components/workflowEngine/layout/br
 import {space} from 'sentry/styles/space';
 import type {AvatarProject} from 'sentry/types/project';
 
-export interface WorkflowEngineDetailLayoutProps {
+interface WorkflowEngineDetailLayoutProps {
   /**
    * The main content for this page
    * Expected to include `<DetailLayout.Main>` and `<DetailLayout.Sidebar>` components.

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -8,7 +8,7 @@ import {BreadcrumbsFromContext} from 'sentry/components/workflowEngine/layout/br
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-export interface WorkflowEngineEditLayoutProps {
+interface WorkflowEngineEditLayoutProps {
   /**
    * The main content for this page
    * Expected to include `<EditLayout.Chart>` and `<EditLayout.Panel>` components.

--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -4,7 +4,7 @@ import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {ActionsFromContext} from 'sentry/components/workflowEngine/layout/actions';
 import {space} from 'sentry/styles/space';
 
-export interface WorkflowEngineListLayoutProps {
+interface WorkflowEngineListLayoutProps {
   /** The main content for this page */
   children: React.ReactNode;
 }

--- a/static/app/components/workflowEngine/simpleTable/index.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.tsx
@@ -11,7 +11,7 @@ import {
   GridRow,
 } from 'sentry/components/gridEditable/styles';
 
-export interface ColumnConfig<Cell, Row> {
+interface ColumnConfig<Cell, Row> {
   Header: () => React.ReactNode;
   Cell?: (props: {row: Row; value: Cell}) => React.ReactNode;
   /** @default 1fr */

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -3,7 +3,7 @@ import {createStore} from 'reflux';
 
 import type {SentryAppComponent} from 'sentry/types/integrations';
 
-export interface SentryAppComponentsStoreDefinition extends StoreDefinition {
+interface SentryAppComponentsStoreDefinition extends StoreDefinition {
   get: (uuid: string) => SentryAppComponent | undefined;
   getAll: () => SentryAppComponent[];
   getInitialState: () => SentryAppComponent[];

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -157,7 +157,7 @@ interface IssueAlertSentryAppIntegrationConfig extends IssueAlertConfigBase {
 /**
  * The actions that an organization has enabled and can be used to create an issue alert.
  */
-export type IssueAlertConfigurationAction =
+type IssueAlertConfigurationAction =
   | IssueAlertGenericActionConfig
   | IssueAlertTicketIntegrationConfig
   | IssueAlertSentryAppIntegrationConfig

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -101,7 +101,7 @@ export type ChallengeData = {
   webAuthnRegisterData: string;
 };
 
-export type EnrolledAuthenticator = {
+type EnrolledAuthenticator = {
   authId: string;
   createdAt: string;
   lastUsedAt: string | null;
@@ -163,7 +163,7 @@ export enum UserIdentityStatus {
   NEEDED_FOR_ORG_AUTH = 'needed_for_org_auth',
 }
 
-export type UserIdentityProvider = {
+type UserIdentityProvider = {
   key: string;
   name: string;
 };

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -49,7 +49,7 @@ export type EChartChartReadyHandler = (instance: ECharts) => void;
  * from a combination of the ECharts documentation page, and data seen in running code
  * in handlers attached to line charts and pie charts.
  */
-export interface EChartsHighlightEventParam {
+interface EChartsHighlightEventParam {
   type: 'highlight';
   batch?: Array<{
     dataIndex: number;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -39,7 +39,7 @@ export type EventGroupingConfig = {
   strategies: string[];
 };
 
-export type VariantEvidence = {
+type VariantEvidence = {
   desc: string;
   fingerprint: string;
   cause_span_hashes?: string[];
@@ -134,7 +134,7 @@ type EnableIntegrationSuggestion = {
   integrationUrl?: string | null;
 };
 
-export type UpdateSdkSuggestion = {
+type UpdateSdkSuggestion = {
   enables: SDKUpdatesSuggestion[];
   newSdkVersion: string;
   sdkName: string;
@@ -337,7 +337,7 @@ type EntryMessage = {
   type: EntryType.MESSAGE;
 };
 
-export interface EntryRequestDataDefault {
+interface EntryRequestDataDefault {
   apiTarget: null;
   method: string | null;
   url: string;
@@ -405,7 +405,7 @@ export type Entry =
 
 // Contexts: https://develop.sentry.dev/sdk/event-payloads/contexts/
 
-export interface BaseContext {
+interface BaseContext {
   type: string;
 }
 
@@ -527,7 +527,7 @@ type OSContext = {
   version: string;
 };
 
-export enum OtelContextKey {
+enum OtelContextKey {
   ATTRIBUTES = 'attributes',
   RESOURCE = 'resource',
 }
@@ -619,7 +619,7 @@ export interface ThreadPoolInfoContext {
   [ThreadPoolInfoContextKey.AVAILABLE_COMPLETION_PORT_THREADS]: number;
 }
 
-export type MetricAlertContextType = {
+type MetricAlertContextType = {
   alert_rule_id?: string;
 };
 
@@ -641,19 +641,19 @@ export interface ReplayContext {
   [ReplayContextKey.REPLAY_ID]: string;
   type: string;
 }
-export interface BrowserContext {
+interface BrowserContext {
   name: string;
   version: string;
 }
 
-export interface ResponseContext {
+interface ResponseContext {
   data: unknown;
   type: 'response';
 }
 
 // event.contexts.flags can be overriden by the user so the type is not strict
 export type FeatureFlag = {flag?: string; result?: boolean};
-export type Flags = {values?: FeatureFlag[]};
+type Flags = {values?: FeatureFlag[]};
 
 export type EventContexts = {
   'Current Culture'?: CultureContext;
@@ -687,7 +687,7 @@ export type Measurement = {value: number; type?: string; unit?: string};
 
 export type EventTag = {key: string; value: string};
 
-export type EventUser = {
+type EventUser = {
   data?: string | null;
   email?: string;
   id?: string;
@@ -696,7 +696,7 @@ export type EventUser = {
   username?: string | null;
 };
 
-export type PerformanceDetectorData = {
+type PerformanceDetectorData = {
   causeSpanIds: string[];
   offenderSpanIds: string[];
   parentSpanIds: string[];

--- a/static/app/types/experiments.tsx
+++ b/static/app/types/experiments.tsx
@@ -12,7 +12,7 @@ export enum ExperimentType {
  * An experiment configuration object defines an experiment in the frontend.
  * This drives various logic in experiment helpers.
  */
-export type ExperimentConfig = {
+type ExperimentConfig = {
   /**
    * Possible assignment values of the experiment
    */

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -356,12 +356,12 @@ export type TagWithTopValues = {
 /**
  * Inbox, issue owners and Activity
  */
-export type Annotation = {
+type Annotation = {
   displayName: string;
   url: string;
 };
 
-export type InboxReasonDetails = {
+type InboxReasonDetails = {
   count?: number | null;
   until?: string | null;
   user_count?: number | null;
@@ -369,7 +369,7 @@ export type InboxReasonDetails = {
   window?: number | null;
 };
 
-export const enum GroupInboxReason {
+const enum GroupInboxReason {
   NEW = 0,
   UNIGNORED = 1,
   REGRESSION = 2,
@@ -393,7 +393,7 @@ export type SuggestedOwnerReason =
   | 'codeowners';
 
 // Received from the backend to denote suggested owners of an issue
-export type SuggestedOwner = {
+type SuggestedOwner = {
   date_added: string;
   owner: string;
   type: SuggestedOwnerReason;
@@ -561,7 +561,7 @@ interface GroupActivityRegression extends GroupActivityBase {
   type: GroupActivityType.SET_REGRESSION;
 }
 
-export interface GroupActivitySetByResolvedInNextSemverRelease extends GroupActivityBase {
+interface GroupActivitySetByResolvedInNextSemverRelease extends GroupActivityBase {
   data: {
     // Set for semver releases
     current_release_version: string;
@@ -569,7 +569,7 @@ export interface GroupActivitySetByResolvedInNextSemverRelease extends GroupActi
   type: GroupActivityType.SET_RESOLVED_IN_RELEASE;
 }
 
-export interface GroupActivitySetByResolvedInRelease extends GroupActivityBase {
+interface GroupActivitySetByResolvedInRelease extends GroupActivityBase {
   data: {
     version?: string;
   };
@@ -897,12 +897,12 @@ export interface GroupReprocessing extends BaseGroup, GroupStats {
   statusDetails: ReprocessingStatusDetails;
 }
 
-export interface GroupResolved extends BaseGroup, GroupStats {
+interface GroupResolved extends BaseGroup, GroupStats {
   status: GroupStatus.RESOLVED;
   statusDetails: ResolvedStatusDetails;
 }
 
-export interface GroupIgnored extends BaseGroup, GroupStats {
+interface GroupIgnored extends BaseGroup, GroupStats {
   status: GroupStatus.IGNORED;
   statusDetails: IgnoredStatusDetails;
 }
@@ -938,7 +938,7 @@ export type Meta = {
 };
 
 export type MetaError = string | [string, any];
-export type MetaRemark = Array<string | number>;
+type MetaRemark = Array<string | number>;
 
 export type ChunkType = {
   rule_id: string | number;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -58,7 +58,7 @@ export type HookName = keyof Hooks;
 /**
  * Route hooks.
  */
-export type RouteHooks = {
+type RouteHooks = {
   'routes:legacy-organization-redirects': RoutesHook;
   'routes:root': RoutesHook;
   'routes:settings': RoutesHook;
@@ -175,7 +175,7 @@ export type MembershipSettingsProps = {
 /**
  * Component wrapping hooks
  */
-export type ComponentHooks = {
+type ComponentHooks = {
   'component:ai-setup-data-consent': () => React.ComponentType<AiSetupDataConsentProps> | null;
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;
@@ -225,7 +225,7 @@ export type ComponentHooks = {
  *
  * These are very similar to the component wrapping hooks
  */
-export type CustomizationHooks = {
+type CustomizationHooks = {
   'integrations:feature-gates': IntegrationsFeatureGatesHook;
   'member-invite-button:customization': InviteButtonCustomizationHook;
   'member-invite-modal:customization': InviteModalCustomizationHook;
@@ -236,7 +236,7 @@ export type CustomizationHooks = {
 /**
  * Analytics / tracking / and operational metrics backend hooks.
  */
-export type AnalyticsHooks = {
+type AnalyticsHooks = {
   'analytics:init-user': AnalyticsInitUser;
   'analytics:log-experiment': AnalyticsLogExperiment;
   'analytics:raw-track-event': AnalyticsRawTrackEvent;
@@ -290,7 +290,7 @@ export type FeatureDisabledHooks = {
 /**
  * Interface chrome hooks.
  */
-export type InterfaceChromeHooks = {
+type InterfaceChromeHooks = {
   footer: GenericComponentHook;
   'help-modal:footer': HelpModalFooterHook;
   'sidebar:billing-status': GenericOrganizationComponentHook;
@@ -304,7 +304,7 @@ export type InterfaceChromeHooks = {
 /**
  * Onboarding experience hooks
  */
-export type OnboardingHooks = {
+type OnboardingHooks = {
   'onboarding-wizard:skip-help': () => React.ComponentType;
   'onboarding:block-hide-sidebar': () => boolean;
   'onboarding:targeted-onboarding-header': (opts: {source: string}) => React.ReactNode;
@@ -313,7 +313,7 @@ export type OnboardingHooks = {
 /**
  * Settings navigation hooks.
  */
-export type SettingsHooks = {
+type SettingsHooks = {
   'settings:api-navigation-config': SettingsItemsHook;
   'settings:organization-navigation': OrganizationSettingsHook;
   'settings:organization-navigation-config': SettingsConfigHook;
@@ -322,20 +322,20 @@ export type SettingsHooks = {
 /**
  * Feature Specific Hooks
  */
-export interface FeatureSpecificHooks extends SpendVisibilityHooks {}
+interface FeatureSpecificHooks extends SpendVisibilityHooks {}
 
 /**
  * Hooks related to Spend Visibitlity
  * (i.e. Per-Project Spike Protection + Spend Allocations)
  */
-export type SpendVisibilityHooks = {
+type SpendVisibilityHooks = {
   'spend-visibility:spike-protection-project-settings': GenericProjectComponentHook;
 };
 
 /**
  * Hooks that are actually React Hooks as well
  */
-export type ReactHooks = {
+type ReactHooks = {
   'react-hook:route-activated': (
     props: RouteContextInterface
   ) => React.ContextType<typeof RouteAnalyticsContext>;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -166,13 +166,13 @@ export type SentryAppSchemaStacktraceLink = {
   params?: string[];
 };
 
-export type SentryAppSchemaAlertRuleAction = {
+type SentryAppSchemaAlertRuleAction = {
   settings: SentryAppSchemaAlertRuleActionSettings;
   title: string;
   type: 'alert-rule-action';
 };
 
-export type SentryAppSchemaAlertRuleActionSettings = {
+type SentryAppSchemaAlertRuleActionSettings = {
   description: string;
   // a list of FormFields
   required_fields: any[];
@@ -210,7 +210,7 @@ export interface StacktraceLinkResult {
   sourceUrl?: string;
 }
 
-export type StacktraceErrorMessage =
+type StacktraceErrorMessage =
   | 'file_not_found'
   | 'stack_root_mismatch'
   | 'integration_link_forbidden';
@@ -380,7 +380,7 @@ export interface IntegrationProvider extends BaseIntegrationProvider {
   setupDialog: {height: number; url: string; width: number};
 }
 
-export interface OrganizationIntegrationProvider extends BaseIntegrationProvider {
+interface OrganizationIntegrationProvider extends BaseIntegrationProvider {
   aspects: IntegrationAspects;
 }
 
@@ -617,7 +617,7 @@ export interface RepositoryProjectPathConfig extends BaseRepositoryProjectPathCo
   provider: BaseIntegrationProvider | null;
 }
 
-export interface RepositoryProjectPathConfigWithIntegration
+interface RepositoryProjectPathConfigWithIntegration
   extends BaseRepositoryProjectPathConfig {
   integrationId: string;
   provider: BaseIntegrationProvider;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -300,7 +300,7 @@ export type EventsStatsData = Array<
   [number, Array<{count: number; comparisonCount?: number}>]
 >;
 
-export type ConfidenceStatsData = Array<[number, Array<{count: Confidence}>]>;
+type ConfidenceStatsData = Array<[number, Array<{count: Confidence}>]>;
 
 type AccuracyStatsItem<T> = {
   timestamp: number;

--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -26,7 +26,7 @@ export type Trace = {
   trace_annotations?: readonly Annotation[];
 };
 
-export type Span = {
+type Span = {
   duration_ms: number;
   id: string | number;
   name: string;

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -174,7 +174,7 @@ export type Health = {
   totalUsers24h: number | null;
 };
 
-export type HealthGraphData = Record<string, TimeseriesValue[]>;
+type HealthGraphData = Record<string, TimeseriesValue[]>;
 
 export enum ReleaseComparisonChartType {
   CRASH_FREE_USERS = 'crashFreeUsers',

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -335,7 +335,7 @@ export type StatusPageServiceStatus =
   | 'major_outage'
   | 'partial_outage';
 
-export interface StatusPageIncidentComponent {
+interface StatusPageIncidentComponent {
   /**
    * ISO 8601 component creation time
    */
@@ -360,7 +360,7 @@ export interface StatusPageIncidentComponent {
   updated_at: string;
 }
 
-export interface StatusPageAffectedComponent {
+interface StatusPageAffectedComponent {
   code: StatusPageComponent;
   name: string;
   new_status: StatusPageServiceStatus;

--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -4,7 +4,7 @@ export interface Action {
   type: ActionType;
 }
 
-export enum ActionType {
+enum ActionType {
   SLACK = 'slack',
   MSTEAMS = 'msteams',
   DISCORD = 'discord',

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -1,6 +1,6 @@
 import type {Action} from './actions';
 
-export interface SnubaQuery {
+interface SnubaQuery {
   aggregate: string;
   dataset: string;
   id: string;

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -11,7 +11,7 @@ export type DetectorType =
   | 'replay'
   | 'uptime';
 
-export interface NewDetector {
+interface NewDetector {
   config: Record<string, unknown>;
   dataCondition: DataConditionGroup;
   dataSource: DataSource;

--- a/static/app/utils/analytics/alertsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/alertsAnalyticsEvents.tsx
@@ -5,7 +5,7 @@ export type AlertsEventParameters = {
   };
 };
 
-export type AlertsEventKey = keyof AlertsEventParameters;
+type AlertsEventKey = keyof AlertsEventParameters;
 
 export const alertsEventMap: Record<AlertsEventKey, string | null> = {
   'anomaly-detection.feedback-submitted': 'Anomaly Detection Feedback Submitted',

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -152,7 +152,7 @@ export type DashboardsEventParameters = {
   };
 } & DashboardsEventParametersWidgetBuilder;
 
-export type DashboardsEventKey = keyof DashboardsEventParameters;
+type DashboardsEventKey = keyof DashboardsEventParameters;
 
 export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards2.create.cancel': 'Dashboards2: Create cancel',

--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -68,7 +68,7 @@ export type DiscoverEventParameters = SaveQueryEventParameters & {
   'discover_v2.y_axis_change': {y_axis_value: string[]};
 };
 
-export type DiscoverEventKey = keyof DiscoverEventParameters;
+type DiscoverEventKey = keyof DiscoverEventParameters;
 
 export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.add_equation': 'Dicoverv2: Equation added',

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -36,7 +36,7 @@ export type FeatureFlagEventParameters = {
   };
 };
 
-export type FeatureFlagEventKey = keyof FeatureFlagEventParameters;
+type FeatureFlagEventKey = keyof FeatureFlagEventParameters;
 
 export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.cta_dismissed': 'Flag CTA Dismissed',

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -15,7 +15,7 @@ export type FeedbackEventParameters = {
   'feedback.whats-new-banner-viewed': Record<string, unknown>;
 };
 
-export type FeedbackEventKey = keyof FeedbackEventParameters;
+type FeedbackEventKey = keyof FeedbackEventParameters;
 
 export const feedbackEventMap: Record<FeedbackEventKey, string | null> = {
   'feedback.feedback-item-not-found': 'Feedback item not found',

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -402,7 +402,7 @@ export type IssueEventParameters = {
     Partial<Pick<Broadcast, 'category'>>;
 };
 
-export type IssueEventKey = keyof IssueEventParameters;
+type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -28,7 +28,7 @@ export type LogsAnalyticsEventParameters = {
   };
 };
 
-export type LogsAnalyticsEventKey = keyof LogsAnalyticsEventParameters;
+type LogsAnalyticsEventKey = keyof LogsAnalyticsEventParameters;
 
 export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null> = {
   'logs.explorer.metadata': 'Log Explorer Pageload Metadata',

--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -2,7 +2,7 @@ type NavigationItemClicked = {
   item: string;
 };
 
-export type NavigationEventParameters = {
+type NavigationEventParameters = {
   'navigation.help_menu_opt_in_chonk_ui_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_chonk_ui_clicked': Record<string, unknown>;
@@ -11,7 +11,7 @@ export type NavigationEventParameters = {
   'navigation.secondary_item_clicked': NavigationItemClicked;
 };
 
-export type NavigationEventKey = keyof NavigationEventParameters;
+type NavigationEventKey = keyof NavigationEventParameters;
 
 export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | null> = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked':

--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -2,14 +2,14 @@ type NavigationItemClicked = {
   item: string;
 };
 
-export type NavigationEventParameters = {
+type NavigationEventParameters = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
   'navigation.primary_item_clicked': NavigationItemClicked;
   'navigation.secondary_item_clicked': NavigationItemClicked;
 };
 
-export type NavigationEventKey = keyof NavigationEventParameters;
+type NavigationEventKey = keyof NavigationEventParameters;
 
 export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | null> = {
   'navigation.help_menu_opt_in_stacked_navigation_clicked':

--- a/static/app/utils/analytics/nextJsInsightsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/nextJsInsightsAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-export type NextJsInsightsEventParameters = {
+type NextJsInsightsEventParameters = {
   'nextjs-insights.page-view': Record<string, unknown>;
   'nextjs-insights.ui_toggle': {
     isEnabled: boolean;

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -234,7 +234,7 @@ export type PerformanceEventParameters = {
   'performance_views.vitals.vitals_tab_clicked': PageLayoutParams;
 };
 
-export type PerformanceEventKey = keyof PerformanceEventParameters;
+type PerformanceEventKey = keyof PerformanceEventParameters;
 
 export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.create_sample_transaction': 'Growth: Performance Sample Transaction',

--- a/static/app/utils/analytics/releasesAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/releasesAnalyticsEvents.tsx
@@ -13,7 +13,7 @@ export type ReleasesEventParameters = {
   'releases.quickstart_viewed': {project_id: string};
 };
 
-export type ReleasesEventKey = keyof ReleasesEventParameters;
+type ReleasesEventKey = keyof ReleasesEventParameters;
 
 export const releasesEventMap: Record<ReleasesEventKey, string | null> = {
   'releases.bubbles_legend': 'Releases: Toggle Legend for Bubble',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -130,7 +130,7 @@ export type ReplayEventParameters = {
   };
 };
 
-export type ReplayEventKey = keyof ReplayEventParameters;
+type ReplayEventKey = keyof ReplayEventParameters;
 
 export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.canvas-detected-banner-clicked': 'Clicked Canvas Detected in Replay Banner',

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -102,7 +102,7 @@ export type SearchEventParameters = {
   'sidebar_help.select': SelectEvent;
 };
 
-export type SearchEventKey = keyof SearchEventParameters;
+type SearchEventKey = keyof SearchEventParameters;
 
 export const searchEventMap: Record<SearchEventKey, string | null> = {
   'search.searched': 'Search: Performed search',

--- a/static/app/utils/analytics/settingsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/settingsAnalyticsEvents.tsx
@@ -15,7 +15,7 @@ export type SettingsEventParameters = {
   };
 };
 
-export type SettingsEventKey = keyof SettingsEventParameters;
+type SettingsEventKey = keyof SettingsEventParameters;
 
 export const settingsEventMap: Record<SettingsEventKey, string | null> = {
   'notification_settings.index_page_viewed': 'Notification Settings: Index Page Viewed',

--- a/static/app/utils/analytics/starfishAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/starfishAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-export type StarfishEventParameters = {
+type StarfishEventParameters = {
   'starfish.chart.zoom': {
     end: number;
     start: number;

--- a/static/app/utils/analytics/tempestAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/tempestAnalyticsEvents.tsx
@@ -20,7 +20,7 @@ export type TempestEventParameters = {
   };
 };
 
-export type TempestEventKey = keyof TempestEventParameters;
+type TempestEventKey = keyof TempestEventParameters;
 
 export const tempestEventMap: Record<TempestEventKey, string | null> = {
   'tempest.credentials.add_modal_opened': 'Tempest: Credentials Add Modal Opened',

--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -163,7 +163,7 @@ export type TracingEventParameters = {
   };
 };
 
-export type TracingEventKey = keyof TracingEventParameters;
+type TracingEventKey = keyof TracingEventParameters;
 
 export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'compare_queries.add_query': 'Compare Queries: Add Query',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -177,7 +177,7 @@ export type TeamInsightsEventParameters = {
   };
 };
 
-export type TeamInsightsEventKey = keyof TeamInsightsEventParameters;
+type TeamInsightsEventKey = keyof TeamInsightsEventParameters;
 
 export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'alert_builder.filter': 'Alert Builder: Filter',

--- a/static/app/utils/cursor.tsx
+++ b/static/app/utils/cursor.tsx
@@ -1,4 +1,4 @@
-export type CursorInfo = {
+type CursorInfo = {
   isPrev: boolean;
   offset: number;
   value: number;

--- a/static/app/utils/customMeasurements/customMeasurements.tsx
+++ b/static/app/utils/customMeasurements/customMeasurements.tsx
@@ -1,6 +1,6 @@
 import type {Measurement} from 'sentry/utils/measurements/measurements';
 
-export type CustomMeasurement = Measurement & {
+type CustomMeasurement = Measurement & {
   fieldType: string;
   functions: string[];
   unit: string;

--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -30,13 +30,13 @@ export type EventsTableData = {
 
 export type TableDataWithTitle = TableData & {title: string};
 
-export type DiscoverQueryPropsWithThresholds = DiscoverQueryProps & {
+type DiscoverQueryPropsWithThresholds = DiscoverQueryProps & {
   transactionName?: string;
   transactionThreshold?: number;
   transactionThresholdMetric?: TransactionThresholdMetric;
 };
 
-export type DiscoverQueryComponentProps = DiscoverQueryPropsWithThresholds & {
+type DiscoverQueryComponentProps = DiscoverQueryPropsWithThresholds & {
   children: (props: GenericChildrenProps<TableData>) => React.ReactNode;
 };
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -705,7 +705,7 @@ export function formatTagKey(key: string): string {
 // Allows for a less strict field key definition in cases we are returning custom strings as fields
 export type LooseFieldKey = FieldKey | string | '';
 
-export type MeasurementType =
+type MeasurementType =
   | FieldValueType.DURATION
   | FieldValueType.NUMBER
   | FieldValueType.INTEGER

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -120,7 +120,7 @@ export type DiscoverQueryProps = BaseDiscoverQueryProps & {
 type InnerRequestProps<P> = DiscoverQueryProps & P;
 type OuterRequestProps<P> = DiscoverQueryPropsWithContext & P;
 
-export type ReactProps<T> = {
+type ReactProps<T> = {
   children?: (props: GenericChildrenProps<T>) => React.ReactNode;
 };
 

--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -22,7 +22,7 @@ const platforms = [
   'unity',
 ] as const;
 
-export type DocPlatform = (typeof platforms)[number];
+type DocPlatform = (typeof platforms)[number];
 
 const performancePlatforms: DocPlatform[] = [
   'dotnet',

--- a/static/app/utils/featureFlagOverrides.ts
+++ b/static/app/utils/featureFlagOverrides.ts
@@ -5,7 +5,7 @@ type OverrideState = Record<string, boolean>;
 
 // TODO(ryan953): this should import from the devtoolbar definition
 type FlagValue = boolean | string | number | undefined;
-export type FeatureFlagMap = Record<string, {override: FlagValue; value: FlagValue}>;
+type FeatureFlagMap = Record<string, {override: FlagValue; value: FlagValue}>;
 
 const LOCALSTORAGE_KEY = 'feature-flag-overrides';
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -207,7 +207,7 @@ export enum SpanOpBreakdown {
   SPANS_UI = 'spans.ui',
 }
 
-export enum SpanHttpField {
+enum SpanHttpField {
   HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length',
   HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
   HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
@@ -256,7 +256,7 @@ export enum IsFieldValues {
   UNLINKED = 'unlinked',
 }
 
-export type AggregateColumnParameter = {
+type AggregateColumnParameter = {
   /**
    * The types of columns that are valid for this parameter.
    * Can pass a list of FieldValueTypes or a predicate function.
@@ -270,7 +270,7 @@ export type AggregateColumnParameter = {
   defaultValue?: string;
 };
 
-export type AggregateValueParameter = {
+type AggregateValueParameter = {
   dataType: FieldValueType;
   kind: 'value';
   name: string;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -282,9 +282,7 @@ type AggregateValueParameter = {
 
 export type AggregateParameter = AggregateColumnParameter | AggregateValueParameter;
 
-export type ParameterDependentValueType = (
-  parameters: Array<string | null>
-) => FieldValueType;
+type ParameterDependentValueType = (parameters: Array<string | null>) => FieldValueType;
 
 export interface FieldDefinition {
   kind: FieldKind;

--- a/static/app/utils/number/formatMetricUsingUnit.tsx
+++ b/static/app/utils/number/formatMetricUsingUnit.tsx
@@ -110,8 +110,7 @@ export const formattingSupportedMetricUnits = [
   'exabytes',
 ] as const;
 
-export type FormattingSupportedMetricUnit =
-  (typeof formattingSupportedMetricUnits)[number];
+type FormattingSupportedMetricUnit = (typeof formattingSupportedMetricUnits)[number];
 
 const METRIC_UNIT_TO_SHORT: Record<FormattingSupportedMetricUnit, string> = {
   nanosecond: 'ns',

--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -69,7 +69,7 @@ export const useMEPDataContext = _useMEPDataContext;
 
 // A provider for handling all metas on the page, should be used if your queries and components aren't
 // co-located since a local provider doesn't work in that case.
-export interface PerformanceDataMultipleMetaContext {
+interface PerformanceDataMultipleMetaContext {
   metricsExtractedDataMap: ExtractedDataMap;
   setIsMetricsExtractedData: (mapKey: MetricsResultsMetaMapKey, value?: boolean) => void;
 }

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -13,7 +13,7 @@ export enum DismissId {
   CACHE_SDK_UPDATE_ALERT = 1,
 }
 
-export type PageAlertOptions = {
+type PageAlertOptions = {
   message: React.ReactNode | undefined;
   type: PageAlertType;
   dismissId?: DismissId;

--- a/static/app/utils/performance/histogram/spanHistogramQuery.tsx
+++ b/static/app/utils/performance/histogram/spanHistogramQuery.tsx
@@ -20,7 +20,7 @@ type HistogramProps = {
 
 type RequestProps = DiscoverQueryProps & HistogramProps;
 
-export type HistogramQueryChildrenProps = Omit<
+type HistogramQueryChildrenProps = Omit<
   GenericChildrenProps<HistogramProps>,
   'tableData'
 > & {

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -95,7 +95,7 @@ export type TraceSplitResults<U extends TraceFull | TraceFullDetailed | EventLit
   transactions: U[];
 };
 
-export type TraceProps = {
+type TraceProps = {
   traceId: string;
   end?: string;
   start?: string;
@@ -104,7 +104,7 @@ export type TraceProps = {
 
 export type TraceRequestProps = DiscoverQueryProps & TraceProps;
 
-export type EmptyQuickTrace = {
+type EmptyQuickTrace = {
   trace: QuickTraceEvent[];
   type: 'empty' | 'missing';
   orphanErrors?: TraceError[];

--- a/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
@@ -16,7 +16,7 @@ export type TableDataRow = {
   tags_value: string;
 };
 
-export type HistogramTag = {
+type HistogramTag = {
   tags_value: string;
 };
 

--- a/static/app/utils/performance/segmentExplorer/tagTransactionsQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/tagTransactionsQuery.tsx
@@ -5,12 +5,12 @@ import type {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {GenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 
-export type TableDataRow = {
+type TableDataRow = {
   [key: string]: string | number;
   id: string;
 };
 
-export type TableData = {
+type TableData = {
   data: TableDataRow[];
   meta?: MetaType;
 };

--- a/static/app/utils/performance/suspectSpans/types.tsx
+++ b/static/app/utils/performance/suspectSpans/types.tsx
@@ -35,7 +35,7 @@ export type SuspectSpan = SpanExample & {
 
 export type SuspectSpans = SuspectSpan[];
 
-export type SpanOp = {
+type SpanOp = {
   op: string;
 };
 

--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -20,7 +20,7 @@ import {
 } from 'sentry/views/performance/trends/utils';
 import generateTrendFunctionAsString from 'sentry/views/performance/trends/utils/generateTrendFunctionAsString';
 
-export type TrendsRequest = {
+type TrendsRequest = {
   eventView: Partial<TrendView>;
   projects: Project[];
   trendChangeType?: TrendChangeType;

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
@@ -1,8 +1,8 @@
 import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 
-export type DirectionX = 'left' | 'right';
-export type DirectionY = 'up' | 'down';
-export type Direction = DirectionY | DirectionX;
+type DirectionX = 'left' | 'right';
+type DirectionY = 'up' | 'down';
+type Direction = DirectionY | DirectionX;
 /**
  * selectNearestFrame walks a FlamegraphFrame tree the direction specified and returns the nearest
  * FlamegraphFrame relative to the starting node.

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphProfiles.tsx
@@ -12,7 +12,7 @@ type SetRootNode = {
 
 type FlamegraphProfilesAction = SetProfilesThreadId | SetRootNode;
 
-export type FlamegraphProfiles = {
+type FlamegraphProfiles = {
   selectedRoot: FlamegraphFrame | null;
   threadId: number | null;
 };

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
@@ -1,12 +1,12 @@
 import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import type {SpanChartNode} from 'sentry/utils/profiling/spanChart';
 
-export type FlamegraphSearchResult = {
+type FlamegraphSearchResult = {
   frame: FlamegraphFrame;
   match: ReadonlyArray<[number, number]>;
 };
 
-export type SpansSearchResult = {
+type SpansSearchResult = {
   match: ReadonlyArray<[number, number]>;
   span: SpanChartNode;
 };

--- a/static/app/utils/profiling/hooks/types.tsx
+++ b/static/app/utils/profiling/hooks/types.tsx
@@ -1,7 +1,7 @@
 import type {DURATION_UNITS, SIZE_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import type {FieldValueType} from 'sentry/utils/fields';
 
-export type Unit = keyof typeof DURATION_UNITS | keyof typeof SIZE_UNITS | null;
+type Unit = keyof typeof DURATION_UNITS | keyof typeof SIZE_UNITS | null;
 
 type BaseReference =
   | Profiling.BaseTransactionProfileReference
@@ -17,7 +17,7 @@ export type EventsResultsDataRow<F extends string> = Pick<
 > &
   Record<Exclude<F, keyof SpecialColumns>, string[] | string | number | null>;
 
-export type EventsResultsMeta<F extends string> = {
+type EventsResultsMeta<F extends string> = {
   fields: Partial<Record<F, FieldValueType>>;
   units: Partial<Record<F, Unit>>;
 };

--- a/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
+++ b/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
@@ -40,7 +40,7 @@ export type AggregateFlamegraphQueryParameters =
   | TransactionsAggregateFlamegraphQueryParameters
   | ProfilesAggregateFlamegraphQueryParameters;
 
-export type UseAggregateFlamegraphQueryResult = UseApiQueryResult<
+type UseAggregateFlamegraphQueryResult = UseApiQueryResult<
   Profiling.Schema,
   RequestError
 >;

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -10,7 +10,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 
 import type {EventsResults, Sort} from './types';
 
-export interface UseProfileEventsOptions<F extends string = ProfilingFieldType> {
+interface UseProfileEventsOptions<F extends string = ProfilingFieldType> {
   fields: readonly F[];
   referrer: string;
   sort: Sort<F>;

--- a/static/app/utils/profiling/hooks/useProfileFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.tsx
@@ -6,7 +6,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 
 import type {EventsResults, Sort} from './types';
 
-export interface UseProfileFunctionsOptions<F extends string> {
+interface UseProfileFunctionsOptions<F extends string> {
   fields: readonly F[];
   referrer: string;
   sort: Sort<F>;

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -29,7 +29,7 @@ import {
   wrapWithSpan,
 } from './utils';
 
-export interface ImportOptions {
+interface ImportOptions {
   span: Span | undefined;
   type: 'flamegraph' | 'flamechart';
   activeThreadId?: string | null;

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -13,7 +13,7 @@ enum RegionFlagIndicator {
   DE = '🇪🇺',
 }
 
-export interface RegionData {
+interface RegionData {
   displayName: string;
   name: string;
   url: string;

--- a/static/app/utils/replays/replay.tsx
+++ b/static/app/utils/replays/replay.tsx
@@ -15,7 +15,7 @@ interface NetworkMeta {
   warnings?: NetworkMetaWarning[];
 }
 
-export type NetworkBody = JsonObject | JsonArray | string;
+type NetworkBody = JsonObject | JsonArray | string;
 
 export interface ReplayNetworkRequestOrResponse {
   headers: Record<string, string>;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -434,7 +434,7 @@ export type MemoryFrame = HydratedSpan<'memory'>;
 export type NavigationFrame = HydratedSpan<
   'navigation.navigate' | 'navigation.reload' | 'navigation.back_forward'
 >;
-export type PaintFrame = HydratedSpan<'paint'>;
+type PaintFrame = HydratedSpan<'paint'>;
 export type RequestFrame = HydratedSpan<
   'resource.fetch' | 'resource.xhr' | 'resource.http'
 >;
@@ -515,7 +515,7 @@ interface VideoFrame {
   width: number;
 }
 
-export interface VideoFrameEvent {
+interface VideoFrameEvent {
   data: {
     payload: VideoFrame;
     tag: 'video';

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -1,10 +1,8 @@
 export type {
   Aliases,
   Color,
-  ColorMapping,
   ColorOrAlias,
   FormSize,
-  FormTheme,
   IconSize,
   StrictCSSObject,
   Theme,

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -15,7 +15,7 @@ export enum TokenType {
   FREE_TEXT = 2,
 }
 
-export type Token = {
+type Token = {
   type: TokenType;
   value: string;
   key?: string;

--- a/static/app/utils/url/useLocationQuery.tsx
+++ b/static/app/utils/url/useLocationQuery.tsx
@@ -21,7 +21,7 @@ type KnownDecoder =
 
 type GenericDecoder<T = unknown> = (query: QueryValue) => T;
 
-export type Decoder = KnownDecoder | GenericDecoder;
+type Decoder = KnownDecoder | GenericDecoder;
 
 /**
  * Select and memoize query params from location.

--- a/static/app/utils/useCombinedReducer.tsx
+++ b/static/app/utils/useCombinedReducer.tsx
@@ -26,7 +26,7 @@ type ReducerActions<M> = M extends ReducersObject
   : never;
 
 type CombinedState<S> = {} & S;
-export type CombinedReducer<M extends ReducersObject> = Reducer<
+type CombinedReducer<M extends ReducersObject> = Reducer<
   CombinedState<ReducersState<M>>,
   ReducerActions<M>
 >;

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -9,7 +9,7 @@ type PrismHighlightParams = {
   language: string;
 };
 
-export type SyntaxHighlightToken = {
+type SyntaxHighlightToken = {
   children: string;
   className: string;
 };

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -129,7 +129,7 @@ type RuleTaskResponse = {
 
 type RouteParams = {projectId?: string; ruleId?: string};
 
-export type IncompatibleRule = {
+type IncompatibleRule = {
   conditionIndices: number[] | null;
   filterIndices: number[] | null;
 };

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -45,7 +45,7 @@ import RelatedTransactions from './relatedTransactions';
 import {MetricDetailsSidebar} from './sidebar';
 import {getFilter, getPeriodInterval} from './utils';
 
-export interface MetricDetailsBodyProps {
+interface MetricDetailsBodyProps {
   timePeriod: TimePeriodType;
   anomalies?: Anomaly[];
   incidents?: Incident[];

--- a/static/app/views/alerts/rules/metric/utils/anomalyChart.tsx
+++ b/static/app/views/alerts/rules/metric/utils/anomalyChart.tsx
@@ -8,7 +8,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import type {Anomaly} from 'sentry/views/alerts/types';
 import {AnomalyType} from 'sentry/views/alerts/types';
 
-export interface AnomalyMarkerSeriesOptions {
+interface AnomalyMarkerSeriesOptions {
   theme: Theme;
   endDate?: Date;
   startDate?: Date;

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -44,7 +44,7 @@ export type IncidentStats = {
   uniqueUsers: number;
 };
 
-export type ActivityTypeDraft = {
+type ActivityTypeDraft = {
   comment: null | string;
   dateCreated: string;
   id: string;

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -42,7 +42,7 @@ export enum MatchType {
   STARTS_WITH = 'sw',
 }
 
-export enum Assignee {
+enum Assignee {
   UNASSIGNED = 'Unassigned',
   TEAM = 'Team',
   MEMBER = 'Member',

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -90,7 +90,7 @@ export function useAutomationBuilderReducer() {
   return {state, actions};
 }
 
-export interface AutomationBuilderState {
+interface AutomationBuilderState {
   actionFilters: DataConditionGroup[];
   triggers: DataConditionGroup;
 }
@@ -99,7 +99,7 @@ export interface AutomationBuilderState {
 // Any changes to action types must be reflected in both:
 // 1. The individual action type definitions
 // 2. The AutomationActions interface
-export interface AutomationActions {
+interface AutomationActions {
   addIf: () => void;
   addIfCondition: (groupIndex: number, conditionType: DataConditionType) => void;
   addWhenCondition: (conditionType: DataConditionType) => void;
@@ -201,7 +201,7 @@ type UpdateIfLogicTypeAction = {
   type: 'UPDATE_IF_LOGIC_TYPE';
 };
 
-export type AutomationBuilderAction =
+type AutomationBuilderAction =
   | AddWhenConditionAction
   | RemoveWhenConditionAction
   | UpdateWhenConditionAction

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -34,8 +34,8 @@ export enum WidgetType {
 
 // These only pertain to on-demand warnings at this point in time
 // Since they are the only soft-validation we do.
-export type WidgetWarning = Record<string, OnDemandExtractionState>;
-export type WidgetQueryWarning = null | OnDemandExtractionState;
+type WidgetWarning = Record<string, OnDemandExtractionState>;
+type WidgetQueryWarning = null | OnDemandExtractionState;
 
 export interface ValidateWidgetResponse {
   warnings: {

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -14,7 +14,7 @@ import type {WidgetDescriptionProps} from 'sentry/views/dashboards/widgets/widge
 import {TooltipIconTrigger} from './tooltipIconTrigger';
 import {WarningsList} from './warningsList';
 
-export interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
+interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   actions?: MenuItemProps[];
   actionsDisabled?: boolean;
   actionsMessage?: string;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -21,7 +21,7 @@ import type {
 import {DEEMPHASIS_COLOR_NAME, LOADING_PLACEHOLDER} from './settings';
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
-export interface BigNumberWidgetVisualizationProps {
+interface BigNumberWidgetVisualizationProps {
   field: string;
   value: number | string;
   maximumValue?: number;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -18,7 +18,7 @@ type AttributeValueType =
 
 type AttributeValueUnit = DataUnit | null;
 
-export type TimeSeriesValueType = AttributeValueType;
+type TimeSeriesValueType = AttributeValueType;
 export type TimeSeriesValueUnit = AttributeValueUnit;
 export type TimeSeriesMeta = {
   type: TimeSeriesValueType;
@@ -44,7 +44,7 @@ export type TimeSeries = {
 
 export type TabularValueType = AttributeValueType;
 export type TabularValueUnit = AttributeValueUnit;
-export type TabularMeta<TFields extends string = string> = {
+type TabularMeta<TFields extends string = string> = {
   fields: Record<TFields, TabularValueType>;
   units: Record<TFields, TabularValueUnit>;
 };
@@ -59,7 +59,7 @@ export type TabularData<TFields extends string = string> = {
   meta: TabularMeta<TFields>;
 };
 
-export type ErrorProp = Error | string;
+type ErrorProp = Error | string;
 export interface ErrorPropWithResponseJSON extends Error {
   responseJSON?: {detail: string};
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -32,7 +32,7 @@ type ValidSampleRow = {
   timestamp: string;
 };
 
-export type SamplesConfig = {
+type SamplesConfig = {
   /**
    * The name of the data attribute to plot. This should be one of the keys in the data that's available in the `samples` parameter that's passed to the constructor.
    */
@@ -63,7 +63,7 @@ export type SamplesConfig = {
   onHighlight?: (datum: ValidSampleRow) => void;
 };
 
-export type SamplesPlottingOptions = {
+type SamplesPlottingOptions = {
   /**
    * The current theme.
    */

--- a/static/app/views/deprecatedAsyncView.tsx
+++ b/static/app/views/deprecatedAsyncView.tsx
@@ -1,8 +1,8 @@
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 
-export type AsyncViewState = DeprecatedAsyncComponent['state'];
-export type AsyncViewProps = DeprecatedAsyncComponent['props'];
+type AsyncViewState = DeprecatedAsyncComponent['state'];
+type AsyncViewProps = DeprecatedAsyncComponent['props'];
 
 /**
  * @deprecated use useApiQuery instead.

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -72,7 +72,7 @@ import TableActions from './tableActions';
 import {TopResultsIndicator} from './topResultsIndicator';
 import type {TableColumn} from './types';
 
-export type TableViewProps = {
+type TableViewProps = {
   error: string | null;
   eventView: EventView;
   isFirstPage: boolean;

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -12,7 +12,7 @@ import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
-export type TraceItemSearchQueryBuilderProps = {
+type TraceItemSearchQueryBuilderProps = {
   itemType: TraceItemDataset.LOGS; // This should include TraceItemDataset.SPANS etc.
   numberAttributes: TagCollection;
   stringAttributes: TagCollection;

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -47,7 +47,7 @@ interface LogsPageParams {
   readonly projectIds?: number[];
 }
 
-export type LogPageParamsUpdate = Partial<LogsPageParams>;
+type LogPageParamsUpdate = Partial<LogsPageParams>;
 
 const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
   createDefinedContext<LogsPageParams>({

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -51,7 +51,7 @@ interface ReadablePageParams {
   title?: string;
 }
 
-export interface WritablePageParams {
+interface WritablePageParams {
   dataset?: DiscoverDatasets | null;
   fields?: string[] | null;
   groupBys?: string[] | null;

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -18,7 +18,7 @@ const HIGH_SAMPLING_MODE_QUERY_EXTRAS = {
   samplingMode: SAMPLING_MODE.BEST_EFFORT,
 } as const;
 
-export type QueryMode = (typeof QUERY_MODE)[keyof typeof QUERY_MODE];
+type QueryMode = (typeof QUERY_MODE)[keyof typeof QUERY_MODE];
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type SpansRPCQueryExtras = {
   samplingMode?: SamplingMode;

--- a/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeValues.tsx
@@ -12,7 +12,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 
-export interface TraceItemAttributeValue {
+interface TraceItemAttributeValue {
   first_seen: null;
   key: string;
   last_seen: null;

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -17,7 +17,7 @@ import {
 
 const DEFAULT_HOVER_TIMEOUT = 200;
 
-export interface UseTraceItemDetailsProps {
+interface UseTraceItemDetailsProps {
   /**
    * Every trace item belongs to a project.
    */

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -48,7 +48,7 @@ export interface TraceResult {
   trace: string;
 }
 
-export type TraceBreakdownResult = TraceBreakdownProject | TraceBreakdownMissing;
+type TraceBreakdownResult = TraceBreakdownProject | TraceBreakdownMissing;
 
 interface TraceResults {
   data: TraceResult[];

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -46,7 +46,7 @@ import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
-export type LogsTabProps = {
+type LogsTabProps = {
   defaultPeriod: DefaultPeriod;
   maxPickableDays: MaxPickableDays;
   relativeOptions: Record<string, React.ReactNode>;

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -40,7 +40,7 @@ import {getLogBodySearchTerms, getTableHeaderLabel, logsFieldAlignment} from './
 
 const LOGS_INSTRUCTIONS_URL = 'https://github.com/getsentry/sentry/discussions/86804';
 
-export type LogsTableProps = {
+type LogsTableProps = {
   tableData: UseExploreLogsTableResult;
   allowPagination?: boolean;
   numberAttributes?: TagCollection;

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -30,7 +30,7 @@ export enum OurLogKnownFieldKey {
 
 export type OurLogFieldKey = OurLogCustomFieldKey | OurLogKnownFieldKey;
 
-export type OurLogsKnownFieldResponseMap = {
+type OurLogsKnownFieldResponseMap = {
   [OurLogKnownFieldKey.MESSAGE]: string;
   [OurLogKnownFieldKey.SEVERITY_NUMBER]: number;
   [OurLogKnownFieldKey.SEVERITY_TEXT]: string;

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -23,7 +23,7 @@ interface UseMultiQueryTimeseriesOptions {
   queryExtras?: SpansRPCQueryExtras;
 }
 
-export interface UseMultiQueryTimeseriesResults {
+interface UseMultiQueryTimeseriesResults {
   canUsePreviousResults: boolean;
   result: ReturnType<typeof useSortedTimeSeries>;
 }

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -121,7 +121,7 @@ export function useReadQueriesFromLocation(): ReadableExploreQueryParts[] {
 
 // Write utils begin
 
-export type WritableExploreQueryParts = {
+type WritableExploreQueryParts = {
   chartType?: ChartType;
   fields?: string[];
   groupBys?: string[];

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -44,7 +44,7 @@ import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/use
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 const CHART_HEIGHT = 260;
-export interface MultiQueryChartProps {
+interface MultiQueryChartProps {
   canUsePreviousResults: boolean;
   index: number;
   mode: Mode;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -76,7 +76,7 @@ import {Onboarding} from 'sentry/views/performance/onboarding';
 // eslint-disable-next-line no-restricted-imports
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
 
-export type SpanTabProps = {
+type SpanTabProps = {
   defaultPeriod: DefaultPeriod;
   maxPickableDays: MaxPickableDays;
   relativeOptions: Record<string, React.ReactNode>;

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -57,7 +57,7 @@ export function FieldRenderer({data, meta, unit, column}: FieldProps) {
   );
 }
 
-export interface MultiQueryFieldProps extends FieldProps {
+interface MultiQueryFieldProps extends FieldProps {
   index: number;
 }
 

--- a/static/app/views/explore/tables/tracesTable/data.tsx
+++ b/static/app/views/explore/tables/tracesTable/data.tsx
@@ -16,6 +16,6 @@ export const FIELDS = [
 
 export type Field = (typeof FIELDS)[number];
 
-export type Sort = Field | `-${Field}`;
+type Sort = Field | `-${Field}`;
 
 export const SORTS: Sort[] = ['-is_transaction', '-span.self_time'];

--- a/static/app/views/insights/browser/resources/utils/useResourceSummarySort.ts
+++ b/static/app/views/insights/browser/resources/utils/useResourceSummarySort.ts
@@ -16,7 +16,7 @@ const SORTABLE_FIELDS = [
   `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
 ] as const;
 
-export type ValidSort = Sort & {
+type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];
 };
 

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -13,7 +13,7 @@ export type Row = {
   transaction: string;
 };
 
-export type TransactionSampleRow = {
+type TransactionSampleRow = {
   id: string;
   'profile.id': string;
   project: string;
@@ -40,7 +40,7 @@ export type Score = {
   ttfbScore: number;
 };
 
-export type SpanSampleRow = {
+type SpanSampleRow = {
   id: string;
   'profile.id': string;
   project: string;

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -43,7 +43,7 @@ import {
 } from 'sentry/views/insights/types';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-export enum LandingDisplayField {
+enum LandingDisplayField {
   OVERVIEW = 'overview',
   SPANS = 'spans',
 }

--- a/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
@@ -37,7 +37,7 @@ type ColumnKeys =
   | SpanIndexedField.CACHE_ITEM_SIZE
   | 'transaction.duration';
 
-export type DataRow = Pick<SpanIndexedResponse, DataRowKeys> & {
+type DataRow = Pick<SpanIndexedResponse, DataRowKeys> & {
   'transaction.duration': number;
 };
 

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -63,7 +63,7 @@ export enum ChartType {
   AREA = 2,
 }
 
-export interface ChartRenderingProps {
+interface ChartRenderingProps {
   height: number;
   isFullscreen: boolean;
 }

--- a/static/app/views/insights/common/views/spans/types.tsx
+++ b/static/app/views/insights/common/views/spans/types.tsx
@@ -11,7 +11,7 @@ export type ModuleFilters = {
   [SpanMetricsField.USER_GEO_SUBREGION]?: SubregionCode[];
 };
 
-export type DataKey =
+type DataKey =
   | 'change'
   | 'timeSpent'
   | 'p50p95'

--- a/static/app/views/insights/crons/components/statusToggleButton.tsx
+++ b/static/app/views/insights/crons/components/statusToggleButton.tsx
@@ -7,7 +7,7 @@ import type {ObjectStatus} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Monitor} from 'sentry/views/insights/crons/types';
 
-export interface StatusToggleButtonProps extends Omit<BaseButtonProps, 'onClick'> {
+interface StatusToggleButtonProps extends Omit<BaseButtonProps, 'onClick'> {
   monitor: Monitor;
   onToggleStatus: (status: ObjectStatus) => Promise<void>;
 }

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -65,7 +65,7 @@ interface BaseConfig {
 /**
  * The configuration object used when the schedule is a CRONTAB
  */
-export interface CrontabConfig extends BaseConfig {
+interface CrontabConfig extends BaseConfig {
   /**
    * The crontab schedule
    */
@@ -89,12 +89,12 @@ export interface IntervalConfig extends BaseConfig {
 
 export type MonitorConfig = CrontabConfig | IntervalConfig;
 
-export interface MonitorEnvBrokenDetection {
+interface MonitorEnvBrokenDetection {
   environmentMutedTimestamp: string;
   userNotifiedTimestamp: string;
 }
 
-export interface MonitorIncident {
+interface MonitorIncident {
   brokenNotice: MonitorEnvBrokenDetection | null;
   resolvingTimestamp: string;
   startingTimestamp: string;

--- a/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
@@ -23,7 +23,7 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {LoadingScreen} from 'sentry/views/insights/common/components/chart';
 import MiniChartPanel from 'sentry/views/insights/common/components/miniChartPanel';
 
-export type ChartSelectOptions = {
+type ChartSelectOptions = {
   title: string;
   yAxis: string;
   series?: Series[];

--- a/static/app/views/insights/mobile/screens/utils.ts
+++ b/static/app/views/insights/mobile/screens/utils.ts
@@ -50,7 +50,7 @@ export type VitalStatus = {
   value: MetricValue | undefined;
 };
 
-export type GenericVitalItem<
+type GenericVitalItem<
   T extends DiscoverDatasets.SPANS_METRICS | DiscoverDatasets.METRICS,
 > = {
   dataset: T;

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -44,7 +44,7 @@ const defaultProps = {
   useTintRow: true,
 };
 
-export type GroupListColumn =
+type GroupListColumn =
   | 'graph'
   | 'event'
   | 'users'

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -79,12 +79,12 @@ export enum SpanFields {
   IS_STARRED_TRANSACTION = 'is_starred_transaction',
 }
 
-export type SpanBooleanFields =
+type SpanBooleanFields =
   | SpanFields.CACHE_HIT
   | SpanFields.IS_TRANSACTION
   | SpanFields.IS_STARRED_TRANSACTION;
 
-export type SpanNumberFields =
+type SpanNumberFields =
   | SpanMetricsField.AI_TOTAL_COST
   | SpanMetricsField.AI_TOTAL_TOKENS_USED
   | SpanMetricsField.SPAN_SELF_TIME
@@ -102,7 +102,7 @@ export type SpanNumberFields =
   | SpanMetricsField.MOBILE_SLOW_FRAMES
   | DiscoverNumberFields;
 
-export type SpanStringFields =
+type SpanStringFields =
   | SpanMetricsField.RESOURCE_RENDER_BLOCKING_STATUS
   | 'id'
   | 'span_id'
@@ -147,7 +147,7 @@ export type SpanIndexedQueryFilters = Partial<Record<SpanStringFields, string>> 
   [SpanIndexedField.PROJECT_ID]?: string;
 };
 
-export type SpanStringArrayFields = 'span.domain';
+type SpanStringArrayFields = 'span.domain';
 
 export const COUNTER_AGGREGATES = ['sum', 'avg', 'min', 'max', 'p100'] as const;
 export const DISTRIBUTION_AGGREGATES = ['p50', 'p75', 'p90', 'p95', 'p99'] as const;
@@ -156,7 +156,7 @@ export const AGGREGATES = [...COUNTER_AGGREGATES, ...DISTRIBUTION_AGGREGATES] as
 
 export type Aggregate = (typeof AGGREGATES)[number];
 
-export type ConditionalAggregate =
+type ConditionalAggregate =
   | `avg_if`
   | `count_op`
   | 'trace_status_rate'
@@ -488,7 +488,7 @@ export enum MetricsFields {
   RELEASE = 'release',
 }
 
-export type MetricsNumberFields =
+type MetricsNumberFields =
   | MetricsFields.TRANSACTION_DURATION
   | MetricsFields.SPAN_DURATION
   | MetricsFields.LCP_SCORE
@@ -513,7 +513,7 @@ export type MetricsNumberFields =
   | MetricsFields.TIME_TO_INITIAL_DISPLAY
   | MetricsFields.TIME_TO_FULL_DISPLAY;
 
-export type MetricsStringFields =
+type MetricsStringFields =
   | MetricsFields.TRANSACTION
   | MetricsFields.PROJECT
   | MetricsFields.ID
@@ -523,7 +523,7 @@ export type MetricsStringFields =
   | MetricsFields.RELEASE
   | MetricsFields.TIMESTAMP;
 
-export type MetricsFunctions = (typeof METRICS_FUNCTIONS)[number];
+type MetricsFunctions = (typeof METRICS_FUNCTIONS)[number];
 
 export type MetricsResponse = {
   [Property in MetricsNumberFields as `${Aggregate}(${Property})`]: number;
@@ -539,7 +539,7 @@ export type MetricsResponse = {
   ['project.id']: number;
 };
 
-export enum DiscoverFields {
+enum DiscoverFields {
   ID = 'id',
   TRACE = 'trace',
   USER_DISPLAY = 'user.display',
@@ -574,7 +574,7 @@ export enum DiscoverFields {
 
 export type MetricsProperty = keyof MetricsResponse;
 
-export type DiscoverNumberFields =
+type DiscoverNumberFields =
   | DiscoverFields.CLS
   | DiscoverFields.FCP
   | DiscoverFields.LCP
@@ -598,7 +598,7 @@ export type DiscoverNumberFields =
   | DiscoverFields.SCORE_RATIO_TTFB
   | DiscoverFields.SCORE_RATIO_INP;
 
-export type DiscoverStringFields =
+type DiscoverStringFields =
   | DiscoverFields.ID
   | DiscoverFields.TRACE
   | DiscoverFields.USER_DISPLAY

--- a/static/app/views/issueDetails/groupActivity.tsx
+++ b/static/app/views/issueDetails/groupActivity.tsx
@@ -35,7 +35,7 @@ import {
   useHasStreamlinedUI,
 } from 'sentry/views/issueDetails/utils';
 
-export type MutateActivityOptions = MutateOptions<TData, TError, TVariables, TContext>;
+type MutateActivityOptions = MutateOptions<TData, TError, TVariables, TContext>;
 
 interface GroupActivityProps {
   group: Group;

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -30,7 +30,7 @@ interface MetricEventStatsParams {
   timePeriod: TimePeriodType;
 }
 
-export interface EventRequestQueryParams {
+interface EventRequestQueryParams {
   comparisonDelta?: number;
   dataset?: DiscoverDatasets;
   end?: string;

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -94,7 +94,7 @@ export interface SectionConfig {
   initialCollapse?: boolean;
 }
 
-export interface IssueDetailsContextType extends IssueDetailsState {
+interface IssueDetailsContextType extends IssueDetailsState {
   dispatch: Dispatch<IssueDetailsActions>;
 }
 
@@ -115,7 +115,7 @@ export function useIssueDetails() {
   return useContext(IssueDetailsContext);
 }
 
-export interface IssueDetailsState {
+interface IssueDetailsState {
   /**
    * Detector details for the current issue
    */
@@ -155,7 +155,7 @@ type UpdateDetectorDetailsAction = {
   type: 'UPDATE_DETECTOR_DETAILS';
 };
 
-export type IssueDetailsActions =
+type IssueDetailsActions =
   | UpdateEventSectionAction
   | UpdateNavScrollMarginAction
   | UpdateEventCountAction

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -147,7 +147,7 @@ type SyncViewsToBackendAction = {
   type: 'SYNC_VIEWS_TO_BACKEND';
 };
 
-export type IssueViewsActions =
+type IssueViewsActions =
   | ReorderTabsAction
   | SaveChangesAction
   | DiscardChangesAction
@@ -175,12 +175,12 @@ const ACTION_ANALYTICS_MAP: Partial<Record<IssueViewsActions['type'], string>> =
   CREATE_NEW_VIEW: 'issue_views.add_view.clicked',
 };
 
-export interface IssueViewsState {
+interface IssueViewsState {
   views: IssueView[];
   tempView?: IssueView;
 }
 
-export interface IssueViewsContextType extends TabContext {
+interface IssueViewsContextType extends TabContext {
   defaultProject: number[];
   dispatch: Dispatch<IssueViewsActions>;
   state: IssueViewsState;

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -162,7 +162,7 @@ export function isForReviewQuery(query: string | undefined) {
 // the tab counts will look like 99+
 export const TAB_MAX_COUNT = 99;
 
-export type QueryCount = {
+type QueryCount = {
   count: number;
   hasMore: boolean;
 };
@@ -225,7 +225,7 @@ export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];
 export const SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY =
   'issue-stream-saved-searches-sidebar-open';
 
-export enum IssueGroup {
+enum IssueGroup {
   ALL = 'all',
   ERROR_OUTAGE = 'error_outage',
   TREND = 'trend',

--- a/static/app/views/nav/context.tsx
+++ b/static/app/views/nav/context.tsx
@@ -6,7 +6,7 @@ import useMedia from 'sentry/utils/useMedia';
 import {NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY} from 'sentry/views/nav/constants';
 import {NavLayout} from 'sentry/views/nav/types';
 
-export interface NavContext {
+interface NavContext {
   endInteraction: () => void;
   isCollapsed: boolean;
   isInteractingRef: React.RefObject<boolean | null>;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -25,7 +25,7 @@ import {
 } from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewNavQueryCount';
 
-export interface IssueViewNavItemContentProps {
+interface IssueViewNavItemContentProps {
   /**
    * Whether the item is active.
    */

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -49,7 +49,7 @@ type Props = {
 
 const MAX_ROWS_USAGE_TABLE = 25;
 
-export enum SortBy {
+enum SortBy {
   PROJECT = 'project',
   TOTAL = 'total',
   ACCEPTED = 'accepted',

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -80,7 +80,7 @@ export enum PerformanceTerm {
   HIGHEST_CACHE_MISS_RATE_TRANSACTIONS = 'highestCacheMissRateTransactions',
 }
 
-export type TooltipOption = SelectValue<string> & {
+type TooltipOption = SelectValue<string> & {
   tooltip: string;
 };
 

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -10,7 +10,7 @@ import type EventView from 'sentry/utils/discover/eventView';
 import type {PerformanceWidgetContainerTypes} from './components/performanceWidgetContainer';
 import type {ChartDefinition, PerformanceWidgetSetting} from './widgetDefinitions';
 
-export enum VisualizationDataState {
+enum VisualizationDataState {
   ERROR = 'error',
   LOADING = 'loading',
   EMPTY = 'empty',
@@ -59,10 +59,10 @@ export interface WidgetDataResult {
 }
 export type WidgetDataConstraint = Record<string, WidgetDataResult | undefined>;
 
-export type QueryChildren = {
+type QueryChildren = {
   children: (props: any) => React.ReactNode; // TODO(k-fish): Fix any type.
 };
-export type QueryFC<T extends WidgetDataConstraint> = React.ComponentType<
+type QueryFC<T extends WidgetDataConstraint> = React.ComponentType<
   QueryChildren & {
     eventView: EventView;
     orgSlug: string;
@@ -94,7 +94,7 @@ export type QueryDefinition<
   ) => S; // TODO(k-fish): Fix any type.
   enabled?: (data: T) => boolean;
 };
-export type Queries<T extends WidgetDataConstraint> = Record<
+type Queries<T extends WidgetDataConstraint> = Record<
   string,
   QueryDefinition<T, T[string]>
 >;

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -19,7 +19,7 @@ import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
 
-export type UseTraceViewLogsDataProps = {
+type UseTraceViewLogsDataProps = {
   children: React.ReactNode;
   traceSlug: string;
 };

--- a/static/app/views/performance/newTraceDetails/traceState/traceRovingTabIndex.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceRovingTabIndex.tsx
@@ -2,13 +2,13 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {traceReducerExhaustiveActionCheck} from 'sentry/views/performance/newTraceDetails/traceState';
 
-export interface TraceRovingTabIndexState {
+interface TraceRovingTabIndexState {
   index: number | null;
   items: number | null;
   node: TraceTreeNode<TraceTree.NodeValue> | null;
 }
 
-export type TraceRovingTabIndexAction =
+type TraceRovingTabIndexAction =
   | {
       index: number | null;
       items: number;

--- a/static/app/views/performance/newTraceDetails/traceState/traceSearch.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceSearch.tsx
@@ -3,7 +3,7 @@ import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/trace
 import type {TraceSearchResult} from 'sentry/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator';
 import {traceReducerExhaustiveActionCheck} from 'sentry/views/performance/newTraceDetails/traceState';
 
-export type TraceSearchAction =
+type TraceSearchAction =
   | {query: string; type: 'set query'; source?: 'external'}
   | {type: 'go to first match'}
   | {type: 'go to last match'}

--- a/static/app/views/performance/newTraceDetails/traceState/traceTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceTabs.tsx
@@ -62,7 +62,7 @@ export type TraceTabsReducerState = {
   tabs: Tab[];
 };
 
-export type TraceTabsReducerAction =
+type TraceTabsReducerAction =
   | {payload: TraceTabsReducerState; type: 'initialize tabs reducer'}
   | {
       payload: Tab['node'] | number;

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceUsageStats.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceUsageStats.tsx
@@ -5,7 +5,7 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 // 1 hour in milliseconds
 const ONE_HOUR = 60 * 60 * 1000;
 
-export type PerformanceStatsGroup = {
+type PerformanceStatsGroup = {
   by: {
     reason: string;
   };

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -22,18 +22,18 @@ export enum EventsDisplayFilterName {
   P100 = 'p100',
 }
 
-export type PercentileValues = Record<EventsDisplayFilterName, number>;
+type PercentileValues = Record<EventsDisplayFilterName, number>;
 
-export type EventsDisplayFilter = {
+type EventsDisplayFilter = {
   label: string;
   name: EventsDisplayFilterName;
   query?: string[][];
   sort?: {field: string; kind: 'desc' | 'asc'};
 };
 
-export type EventsFilterOptions = Record<EventsDisplayFilterName, EventsDisplayFilter>;
+type EventsFilterOptions = Record<EventsDisplayFilterName, EventsDisplayFilter>;
 
-export type EventsFilterPercentileValues = Record<
+type EventsFilterPercentileValues = Record<
   Exclude<EventsDisplayFilterName, EventsDisplayFilterName.P100>,
   number
 >;

--- a/static/app/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext.tsx
@@ -11,7 +11,7 @@ type TransactionListTableData =
     }
   | undefined;
 
-export type PerformanceAtScaleContextProps = {
+type PerformanceAtScaleContextProps = {
   metricsSeriesDataEmpty: boolean | undefined;
   setMetricsSeriesDataEmpty: (data: boolean | undefined) => void;
   setTransactionListTableData: (data: TransactionListTableData) => void;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort.tsx
@@ -13,7 +13,7 @@ const SORTABLE_FIELDS = [
   SpanIndexedField.SPAN_DURATION,
 ] as const;
 
-export type ValidSort = Sort & {
+type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];
 };
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/useSpansTabTableSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/useSpansTabTableSort.tsx
@@ -14,7 +14,7 @@ const SORTABLE_FIELDS = [
   `avg(${SpanMetricsField.SPAN_DURATION})`,
 ] as const;
 
-export type ValidSort = Sort & {
+type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];
 };
 

--- a/static/app/views/performance/trends/types.tsx
+++ b/static/app/views/performance/trends/types.tsx
@@ -72,7 +72,7 @@ export enum TrendParameterLabel {
   SPANS_RESOURCE = 'Spans (resource)',
 }
 
-export type TrendStat = {
+type TrendStat = {
   data: EventsStatsData;
   order: number;
 };

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -39,7 +39,7 @@ interface SpanFieldEntry {
   key: string;
   name: string;
 }
-export type SpanFieldsResponse = SpanFieldEntry[];
+type SpanFieldsResponse = SpanFieldEntry[];
 
 const getDynamicSpanFieldsEndpoint = (
   orgSlug: string,

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -186,7 +186,7 @@ function VitalChart({
 
 export default VitalChart;
 
-export type VitalChartInnerProps = {
+type VitalChartInnerProps = {
   field: string;
   grid: LineChartProps['grid'];
   loading: boolean;

--- a/static/app/views/profiling/landing/landingWidgetSelector.tsx
+++ b/static/app/views/profiling/landing/landingWidgetSelector.tsx
@@ -12,7 +12,7 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 import {FunctionTrendsWidget} from './functionTrendsWidget';
 import {SlowestFunctionsWidget} from './slowestFunctionsWidget';
 
-export type WidgetOption =
+type WidgetOption =
   | 'slowest functions avg'
   | 'slowest functions p50'
   | 'slowest functions' // kept for backwards compatibility as the p75

--- a/static/app/views/profiling/profilesProvider.tsx
+++ b/static/app/views/profiling/profilesProvider.tsx
@@ -162,7 +162,7 @@ export function TransactionProfileProvider({
   return <ProfileContext value={profile}>{children}</ProfileContext>;
 }
 
-export interface ContinuousProfileQueryParams {
+interface ContinuousProfileQueryParams {
   end: string;
   profiler_id: string;
   start: string;

--- a/static/app/views/projects/gettingStartedWithProjectContext.tsx
+++ b/static/app/views/projects/gettingStartedWithProjectContext.tsx
@@ -11,7 +11,7 @@ type GettingStartedWithProject = Pick<Project, 'name' | 'id'> & {
   teamSlug?: Project['team']['slug'];
 };
 
-export type ProjectsContextProps = {
+type ProjectsContextProps = {
   setProject: (project: GettingStartedWithProject) => void;
   project?: GettingStartedWithProject;
 };

--- a/static/app/views/releases/detail/commitsAndFiles/releaseCommit.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/releaseCommit.tsx
@@ -25,7 +25,7 @@ function formatCommitMessage(message: string | null) {
   return message.split(/\n/)[0];
 }
 
-export interface ReleaseCommitProps {
+interface ReleaseCommitProps {
   commit: Commit;
 }
 

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -9,7 +9,7 @@ import type {ReplayFrame} from 'sentry/utils/replays/types';
 import {getFrameOpOrCategory} from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/replays/detail/utils';
 
-export type FilterFields = {
+type FilterFields = {
   f_b_search: string;
   f_b_type: string[];
 };

--- a/static/app/views/replays/detail/trace/replayTransactionContext.tsx
+++ b/static/app/views/replays/detail/trace/replayTransactionContext.tsx
@@ -48,7 +48,7 @@ type InternalState = {
   orphanErrors?: TraceError[];
 };
 
-export type ExternalState = {
+type ExternalState = {
   didInit: boolean;
   errors: Error[];
   isFetching: boolean;

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -1,7 +1,7 @@
 export const SUPPORTED_PROVIDERS = ['email', 'slack', 'msteams'] as const;
 export type SupportedProviders = (typeof SUPPORTED_PROVIDERS)[number];
 
-export type ProviderValue = 'always' | 'never';
+type ProviderValue = 'always' | 'never';
 
 type NotificationBaseObject = {
   id: string;

--- a/static/app/views/settings/components/dataScrubbing/types.tsx
+++ b/static/app/views/settings/components/dataScrubbing/types.tsx
@@ -66,20 +66,19 @@ export type RuleDefault = RuleBase & {
     | RuleType.ANYTHING;
 };
 
-export type RulePattern = RuleBase & {
+type RulePattern = RuleBase & {
   pattern: string;
   type: RuleType.PATTERN;
 } & Pick<RuleDefault, 'method'>;
 
-export type RuleReplace = RuleBase & {
+type RuleReplace = RuleBase & {
   method: MethodType.REPLACE;
   placeholder?: string;
 } & Pick<RuleDefault, 'type'>;
 
 export type KeysOfUnion<T> = T extends any ? keyof T : never;
 
-export type RuleReplaceAndPattern = Omit<RulePattern, 'method'> &
-  Omit<RuleReplace, 'type'>;
+type RuleReplaceAndPattern = Omit<RulePattern, 'method'> & Omit<RuleReplace, 'type'>;
 
 export type Rule = RuleDefault | RuleReplace | RulePattern | RuleReplaceAndPattern;
 

--- a/static/app/views/settings/dynamicSampling/utils/formContext.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/formContext.tsx
@@ -50,7 +50,7 @@ interface PlainObject {
 interface PlainArray extends Array<PlainValue> {}
 type AtomicValue = string | number | boolean | null | undefined;
 
-export type FormValidators<
+type FormValidators<
   FormFields extends Record<string, PlainValue>,
   FieldErrors extends Record<keyof FormFields, any>,
 > = {

--- a/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
@@ -28,12 +28,12 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFetchSecretQueryKey} from 'sentry/views/settings/featureFlags/changeTracking';
 
-export type CreateSecretQueryVariables = {
+type CreateSecretQueryVariables = {
   provider: string;
   secret: string;
 };
 
-export type CreateSecretResponse = string;
+type CreateSecretResponse = string;
 
 export default function NewProviderForm({
   onCreatedSecret,

--- a/static/app/views/settings/organization/organizationPermissionAlert.tsx
+++ b/static/app/views/settings/organization/organizationPermissionAlert.tsx
@@ -5,7 +5,7 @@ import {Alert, type AlertProps} from 'sentry/components/core/alert';
 import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
 
-export interface OrganizationPermissionAlertProps extends Omit<AlertProps, 'type'> {
+interface OrganizationPermissionAlertProps extends Omit<AlertProps, 'type'> {
   access?: Scope[];
   message?: ReactNode;
 }

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -3,7 +3,7 @@ import {createContext} from 'react';
 import type {IntegrationProvider, IntegrationType} from 'sentry/types/integrations';
 import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
-export type IntegrationContextProps = {
+type IntegrationContextProps = {
   analyticsParams: {
     already_installed: boolean;
     view:

--- a/static/app/views/settings/projectProguard/index.tsx
+++ b/static/app/views/settings/projectProguard/index.tsx
@@ -20,7 +20,7 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import ProjectProguardRow from './projectProguardRow';
 
-export type ProjectProguardProps = RouteComponentProps<{projectId: string}> & {
+type ProjectProguardProps = RouteComponentProps<{projectId: string}> & {
   organization: Organization;
   project: Project;
 };

--- a/static/app/views/traces/data.tsx
+++ b/static/app/views/traces/data.tsx
@@ -16,6 +16,6 @@ export const FIELDS = [
 
 export type Field = (typeof FIELDS)[number];
 
-export type Sort = Field | `-${Field}`;
+type Sort = Field | `-${Field}`;
 
 export const SORTS: Sort[] = ['-is_transaction', '-span.self_time'];

--- a/static/app/views/traces/hooks/useTraces.tsx
+++ b/static/app/views/traces/hooks/useTraces.tsx
@@ -46,7 +46,7 @@ export interface TraceResult {
   trace: string;
 }
 
-export type TraceBreakdownResult = TraceBreakdownProject | TraceBreakdownMissing;
+type TraceBreakdownResult = TraceBreakdownProject | TraceBreakdownMissing;
 
 interface TraceResults {
   data: TraceResult[];

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -50,7 +50,7 @@ const PRODUCT_URLS = {
     'https://docs.sentry.io/product/explore/profiling/getting-started/#continuous-profiling',
 };
 
-export interface ProductTrialAlertProps {
+interface ProductTrialAlertProps {
   api: Client;
   organization: Organization;
   subscription: Subscription;

--- a/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
+++ b/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
@@ -3,7 +3,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
-export type PerformanceStatsGroup = {
+type PerformanceStatsGroup = {
   by: {
     reason: string;
   };

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -868,7 +868,7 @@ export interface MonitorCountResponse {
   overQuotaMonitorCount: number;
 }
 
-export type PendingReservedBudget = {
+type PendingReservedBudget = {
   categories: Partial<Record<DataCategories, boolean | null>>;
   reservedBudget: number;
 };


### PR DESCRIPTION
This PR removes the `export` keyword from `types`, `interfaces` and `enums` if those declarations are only used within the same file.

This was mostly done with knip’s [auto-fix feature](https://knip.dev/features/auto-fix): `knip --fix-type types`

Unnecessarily exporting types has a couple of disadvantages:

- they could be accidentally auto-imported
- when reading that something is exported, we have to check where it’s used before changing it. If something is not exported, it’s local to the current file, thus impact of changing it is contained.
- TypeScript will give us an error if a declaration that is local to a file is unused, but it won’t error if it’s exported. We will see in a follow-up PR that there are about 40 additional types that will be marked for removal by TypeScript after `export` is removed.