### PR TITLE
ref: upgrade reportlab to 4.4.0

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -169,7 +169,7 @@ redis==3.4.1
 redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
-reportlab==4.2.5
+reportlab==4.4.0
 requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -114,7 +114,7 @@ redis==3.4.1
 redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
-reportlab==4.2.5
+reportlab==4.4.0
 requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -10,5 +10,5 @@ Avalara==20.9.0
 iso3166
 pycountry==17.5.14
 pyvat==1.3.15
-reportlab==4.2.5
+reportlab==4.4.0
 stripe==4.2.0


### PR DESCRIPTION
fixes an annoying warning (that would also prevent us from upgrading to python 3.14)

<!-- Describe your PR here. -->