### PR TITLE
debug(onboarding): add sentry instrumentation to catch errors during project creation

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -1,6 +1,7 @@
 import time
 from typing import TypedDict
 
+import sentry_sdk
 from django.db import IntegrityError, router, transaction
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
@@ -210,7 +211,8 @@ class TeamProjectsEndpoint(TeamEndpoint):
                         organization=team.organization,
                         platform=result.get("platform"),
                     )
-            except (IntegrityError, MaxSnowflakeRetryError):
+            except (IntegrityError, MaxSnowflakeRetryError) as e:
+                sentry_sdk.capture_exception(e)
                 return Response({"detail": "A project with this slug already exists."}, status=409)
             else:
                 project.add_team(team)

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -4,6 +4,7 @@ from collections.abc import Container
 from typing import TYPE_CHECKING, Any, Generic, Self, overload
 from uuid import uuid4
 
+import sentry_sdk
 from django.db.models import Field, Model
 from django.utils.crypto import get_random_string
 from django.utils.text import slugify
@@ -63,6 +64,11 @@ def unique_db_instance(
             setattr(inst, field_name, value)
             if not base_qs.filter(**{f"{field_name}__iexact": value}).exists():
                 return
+
+    # xxx (vgrozdanic): temporary logging to debug the issue
+    sentry_sdk.capture_message(
+        f"Failed to generate a unique {field_name} for the model", level="error"
+    )
 
     # If at this point, we've exhausted all possibilities, we'll just end up hitting
     # an IntegrityError from database, which is ok, and unlikely to happen


### PR DESCRIPTION
Currently few times per week, when users try to create a project during onboarding, 409 error is happening.

This PR adds more sentry instrumentation to get a better understanding and more context around errors that occur during project creation 

Part of [TET-277: RequestError: POST /teams/{orgSlug}/{teamSlug}/projects/ 409](https://linear.app/getsentry/issue/TET-277/requesterror-post-teamsorgslugteamslugprojects-409) 