### PR TITLE
ref(✂️): simplify dynamic import

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -56,8 +56,9 @@ export async function openEmailVerification({
   onClose,
   ...args
 }: EmailVerificationModalOptions = {}) {
-  const mod = await import('sentry/components/modals/emailVerificationModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/emailVerificationModal'
+  );
 
   openModal(deps => <Modal {...deps} {...args} />, {onClose});
 }
@@ -74,8 +75,7 @@ type OpenDiffModalOptions = {
 };
 
 export async function openDiffModal(options: OpenDiffModalOptions) {
-  const mod = await import('sentry/components/modals/diffModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import('sentry/components/modals/diffModal');
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -93,8 +93,7 @@ type CreateTeamModalOptions = {
 };
 
 export async function openCreateTeamModal(options: CreateTeamModalOptions) {
-  const mod = await import('sentry/components/modals/createTeamModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import('sentry/components/modals/createTeamModal');
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
@@ -125,8 +124,9 @@ type CreateOwnershipRuleModalOptions = {
 export async function openIssueOwnershipRuleModal(
   options: CreateOwnershipRuleModalOptions
 ) {
-  const mod = await import('sentry/components/modals/issueOwnershipRuleModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/issueOwnershipRuleModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     modalCss: modalCss(options.theme),
@@ -142,8 +142,9 @@ export type EditOwnershipRulesModalOptions = {
 };
 
 export async function openEditOwnershipRules(options: EditOwnershipRulesModalOptions) {
-  const mod = await import('sentry/components/modals/editOwnershipRulesModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/editOwnershipRulesModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
@@ -152,8 +153,9 @@ export async function openEditOwnershipRules(options: EditOwnershipRulesModalOpt
 }
 
 export async function openCommandPalette(options: ModalOptions = {}) {
-  const mod = await import('sentry/components/modals/commandPalette');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/commandPalette'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -163,8 +165,7 @@ type RecoveryModalOptions = {
 };
 
 export async function openRecoveryOptions(options: RecoveryModalOptions) {
-  const mod = await import('sentry/components/modals/recoveryOptionsModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import('sentry/components/modals/recoveryOptionsModal');
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
@@ -176,8 +177,9 @@ export type TeamAccessRequestModalOptions = {
 };
 
 export async function openTeamAccessRequestModal(options: TeamAccessRequestModalOptions) {
-  const mod = await import('sentry/components/modals/teamAccessRequestModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/teamAccessRequestModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
@@ -188,8 +190,9 @@ type HelpSearchModalOptions = {
 };
 
 export async function openHelpSearchModal(options?: HelpSearchModalOptions) {
-  const mod = await import('sentry/components/modals/helpSearchModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/helpSearchModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -206,9 +209,10 @@ export async function openDebugFileSourceModal({
   onClose,
   ...restOptions
 }: DebugFileSourceModalOptions) {
-  const mod = await import('sentry/components/modals/debugFileCustomRepository');
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/debugFileCustomRepository'
+  );
 
-  const {default: Modal, modalCss} = mod;
   openModal(deps => <Modal {...deps} {...restOptions} />, {
     modalCss,
     onClose,
@@ -219,8 +223,9 @@ export async function openInviteMembersModal({
   onClose,
   ...args
 }: InviteMembersModalOptions = {}) {
-  const mod = await import('sentry/components/modals/inviteMembersModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/inviteMembersModal'
+  );
 
   openModal(deps => <Modal {...deps} {...args} />, {modalCss, onClose});
 }
@@ -249,8 +254,9 @@ export async function openInviteMissingMembersModal({
 export async function openWidgetBuilderOverwriteModal(
   options: OverwriteWidgetModalProps
 ) {
-  const mod = await import('sentry/components/modals/widgetBuilder/overwriteWidgetModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/widgetBuilder/overwriteWidgetModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
@@ -259,8 +265,9 @@ export async function openWidgetBuilderOverwriteModal(
 }
 
 export async function openAddToDashboardModal(options: AddToDashboardModalProps) {
-  const mod = await import('sentry/components/modals/widgetBuilder/addToDashboardModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/widgetBuilder/addToDashboardModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
@@ -271,8 +278,9 @@ export async function openAddToDashboardModal(options: AddToDashboardModalProps)
 export async function openImportDashboardFromFileModal(
   options: ImportDashboardFromFileModalProps
 ) {
-  const mod = await import('sentry/components/modals/importDashboardFromFileModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/importDashboardFromFileModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
@@ -292,8 +300,7 @@ export async function openReprocessEventModal({
 }
 
 export async function demoSignupModal(options: ModalOptions = {}) {
-  const mod = await import('sentry/components/modals/demoSignUp');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import('sentry/components/modals/demoSignUp');
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -303,8 +310,9 @@ export type DemoEndModalOptions = {
 };
 
 export async function demoEndModal(options: DemoEndModalOptions) {
-  const mod = await import('sentry/components/modals/demoEndModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/demoEndModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -312,8 +320,9 @@ export async function demoEndModal(options: DemoEndModalOptions) {
 export async function openDashboardWidgetQuerySelectorModal(
   options: DashboardWidgetQuerySelectorModalOptions
 ) {
-  const mod = await import('sentry/components/modals/dashboardWidgetQuerySelectorModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/dashboardWidgetQuerySelectorModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
@@ -325,9 +334,9 @@ export async function openWidgetViewerModal({
   onClose,
   ...options
 }: WidgetViewerModalOptions & {onClose?: () => void}) {
-  const mod = await import('sentry/components/modals/widgetViewerModal');
-
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/widgetViewerModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'none',
@@ -337,8 +346,9 @@ export async function openWidgetViewerModal({
 }
 
 export async function openCreateNewIntegrationModal() {
-  const mod = await import('sentry/components/modals/createNewIntegrationModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/createNewIntegrationModal'
+  );
 
   openModal(deps => <Modal {...deps} />);
 }
@@ -346,8 +356,9 @@ export async function openCreateNewIntegrationModal() {
 export async function openCreateReleaseIntegration(
   options: CreateReleaseIntegrationModalOptions
 ) {
-  const mod = await import('sentry/components/modals/createReleaseIntegrationModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/createReleaseIntegrationModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
@@ -359,15 +370,17 @@ export type NavigateToExternalLinkModalOptions = {
 export async function openNavigateToExternalLinkModal(
   options: NavigateToExternalLinkModalOptions
 ) {
-  const mod = await import('sentry/components/modals/navigateToExternalLinkModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/navigateToExternalLinkModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
 
 export async function openProjectCreationModal(options: {defaultCategory: Category}) {
-  const mod = await import('sentry/components/modals/projectCreationModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/projectCreationModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -384,8 +397,9 @@ export async function openBulkEditMonitorsModal({onClose, ...options}: ModalOpti
 }
 
 export async function openInsightChartModal(options: InsightChartModalOptions) {
-  const mod = await import('sentry/components/modals/insightChartModal');
-  const {default: Modal, modalCss} = mod;
+  const {default: Modal, modalCss} = await import(
+    'sentry/components/modals/insightChartModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
@@ -394,15 +408,17 @@ export async function openAddTempestCredentialsModal(options: {
   organization: Organization;
   project: Project;
 }) {
-  const mod = await import('sentry/components/modals/addTempestCredentialsModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/addTempestCredentialsModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
 
 export async function openSaveQueryModal(options: SaveQueryModalProps) {
-  const mod = await import('sentry/components/modals/explore/saveQueryModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import(
+    'sentry/components/modals/explore/saveQueryModal'
+  );
 
   openModal(deps => <Modal {...deps} {...options} />);
 }

--- a/static/app/actionCreators/redirectToProject.tsx
+++ b/static/app/actionCreators/redirectToProject.tsx
@@ -1,8 +1,7 @@
 import ModalStore from 'sentry/stores/modalStore';
 
 export async function redirectToProject(newProjectSlug: string) {
-  const mod = await import('sentry/components/modals/redirectToProject');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import('sentry/components/modals/redirectToProject');
 
   ModalStore.openModal(deps => <Modal {...deps} slug={newProjectSlug} />, {});
 }

--- a/static/app/actionCreators/sudoModal.tsx
+++ b/static/app/actionCreators/sudoModal.tsx
@@ -15,8 +15,7 @@ export async function openSudo({
   closeEvents,
   ...args
 }: OpenSudoModalOptions = {}) {
-  const mod = await import('sentry/components/modals/sudoModal');
-  const {default: Modal} = mod;
+  const {default: Modal} = await import('sentry/components/modals/sudoModal');
 
   ModalStore.openModal(deps => <Modal {...deps} {...args} />, {onClose, closeEvents});
 }


### PR DESCRIPTION
by removing the extra variable and destruct

`knip` only sees things as "used" when they are directly destructed from a dynamic import; also, the extra layer seems unnecessary
