### PR TITLE
chore(trace-view): spacing between entries'

### DIFF
--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -5,7 +5,7 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 
 export const ToolbarSection = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(3)};
 `;
 
 export const ToolbarHeader = styled('div')`

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -305,7 +305,7 @@ const DisabledText = styled('span')`
 
 const StyledToolbarSection = styled(ToolbarSection)`
   border-top: 1px solid ${p => p.theme.border};
-  padding-top: ${space(2)};
+  padding-top: ${space(3)};
 `;
 
 const SaveAsButton = styled(Button)`

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -11,6 +11,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {
@@ -86,7 +87,7 @@ export function ToolbarVisualize({equationSupport}: ToolbarVisualizeProps) {
   const shouldRenderLabel = visualizes.length > 1;
 
   return (
-    <ToolbarSection data-test-id="section-visualizes">
+    <StyledToolbarSection data-test-id="section-visualizes">
       <ToolbarHeader>
         <Tooltip
           position="right"
@@ -154,7 +155,7 @@ export function ToolbarVisualize({equationSupport}: ToolbarVisualizeProps) {
           );
         })}
       </div>
-    </ToolbarSection>
+    </StyledToolbarSection>
   );
 }
 
@@ -372,4 +373,8 @@ const AggregateCompactSelect = styled(CompactSelect)`
   > button {
     width: 100%;
   }
+`;
+
+const StyledToolbarSection = styled(ToolbarSection)`
+  margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
- Tightened spacing around visualize with more breathing room for others

**Before:**
<img width="368" alt="Screenshot 2025-04-22 at 7 26 21 AM" src="https://github.com/user-attachments/assets/5b2086c7-98d1-4e61-916d-365d861888d6" />

**After:**
<img width="364" alt="Screenshot 2025-04-22 at 7 27 06 AM" src="https://github.com/user-attachments/assets/ff97e7b9-bda5-4b57-84b2-3ec3e11451ac" />