### PR TITLE
feat(ourlogs): Add context menu to all attributes except timestamp

### DIFF
--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -148,7 +148,7 @@ export function LogRowContent({
             />
           </LogFirstCellContent>
         </LogsTableBodyFirstCell>
-        {fields.map(field => {
+        {fields?.map(field => {
           const value = dataRow[field];
 
           if (!defined(value)) {
@@ -191,7 +191,7 @@ export function LogRowContent({
                   }
                 }}
                 allowActions={
-                  field === OurLogKnownFieldKey.MESSAGE ? ALLOWED_CELL_ACTIONS : []
+                  field === OurLogKnownFieldKey.TIMESTAMP ? [] : ALLOWED_CELL_ACTIONS
                 }
               >
                 <LogFieldRenderer


### PR DESCRIPTION
Currently, when you mouse over a column in the logs table, it shows a context menu only for the 'message' attribute - this lets you add a column and then filter on its values.