### PR TITLE
chore(explore): conditionalize functions by multiple group bys

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -618,8 +618,8 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getByLabelText('Remove Column'));
     expect(groupBys).toEqual(['']);
 
-    // last one and it's empty
-    expect(within(section).getByLabelText('Remove Column')).toBeDisabled();
+    // last one so remove column button is hidden
+    expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
   });
 
   it('switches to aggregates mode when modifying group bys', async function () {

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -158,14 +158,16 @@ function ColumnEditorRow({
       style={{transform: CSS.Transform.toString(transform), transition}}
       {...attributes}
     >
-      <Button
-        aria-label={t('Drag to reorder')}
-        borderless
-        size="zero"
-        disabled={disabled}
-        icon={<IconGrabbable size="sm" />}
-        {...listeners}
-      />
+      {canDelete ? (
+        <Button
+          aria-label={t('Drag to reorder')}
+          borderless
+          size="zero"
+          disabled={disabled}
+          icon={<IconGrabbable size="sm" />}
+          {...listeners}
+        />
+      ) : null}
       <StyledCompactSelect
         data-test-id="editor-column"
         options={options}

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -178,14 +178,15 @@ function ColumnEditorRow({
         searchable
         triggerProps={{style: {width: '100%'}}}
       />
-      <Button
-        aria-label={t('Remove Column')}
-        borderless
-        disabled={!canDelete || disabled}
-        size="zero"
-        icon={<IconDelete size="sm" />}
-        onClick={() => onColumnDelete()}
-      />
+      {canDelete ? (
+        <Button
+          aria-label={t('Remove Column')}
+          borderless
+          size="zero"
+          icon={<IconDelete size="sm" />}
+          onClick={() => onColumnDelete()}
+        />
+      ) : null}
     </ToolbarRow>
   );
 }


### PR DESCRIPTION
- Hide draggable and delete functionality when there is only one group present
<img width="372" alt="Screenshot 2025-04-22 at 7 45 07 AM" src="https://github.com/user-attachments/assets/b63ad263-e3b5-464c-bc21-9cf6e1aef65b" />
<img width="363" alt="Screenshot 2025-04-22 at 7 45 18 AM" src="https://github.com/user-attachments/assets/957d8233-314e-4eb4-a8c8-2ee160b5447f" />

Closes EXP-172