### PR TITLE
feat(gen-ai): Add gen-ai-consent flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -130,6 +130,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:failure-rate-metric-alert-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GenAI features such as Autofix and Issue Summary
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable GenAI consent
+    manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable increased issue_owners rate limit for auto-assignment


### PR DESCRIPTION
This allows us to control the consent showing via flagpole instead of hard coded region checks. This addresses a limitation we have on the frontend consent component of only having the us and de regions...

This flag would not be used anywhere yet, but serve only for debugging purposes to ensure service uptime.