### PR TITLE
chore(explore): conditionalize delete by multiple visualizes

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -415,8 +415,8 @@ describe('ExploreToolbar', function () {
       },
     ]);
 
-    // only one left so cant be deleted
-    expect(within(section).getByLabelText('Remove Overlay')).toBeDisabled();
+    // only one left so we hide the delete button
+    expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
   it('allows changing visualizes equations', async function () {

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -254,14 +254,15 @@ function VisualizeDropdown({
         onChange={setChartField}
         disabled={lockOptions}
       />
-      <Button
-        borderless
-        icon={<IconDelete />}
-        size="zero"
-        disabled={!canDelete}
-        onClick={() => deleteOverlay(group, index)}
-        aria-label={t('Remove Overlay')}
-      />
+      {canDelete ? (
+        <Button
+          borderless
+          icon={<IconDelete />}
+          size="zero"
+          onClick={() => deleteOverlay(group, index)}
+          aria-label={t('Remove Overlay')}
+        />
+      ) : null}
     </ToolbarRow>
   );
 }


### PR DESCRIPTION
- Hide delete functionality when there's only one visualize present

<img width="361" alt="Screenshot 2025-04-22 at 8 05 11 AM" src="https://github.com/user-attachments/assets/6729c42c-36a6-4e63-bb7c-eaeaa726ef6d" />
<img width="358" alt="Screenshot 2025-04-22 at 8 05 22 AM" src="https://github.com/user-attachments/assets/dcede090-cf1e-4759-aa2e-4df500fae0c7" />