### PR TITLE
feat(taskworker): make seer taskworker compatible

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1435,7 +1435,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.snuba.tasks",
     "sentry.tasks.auth.auth",
     "sentry.tasks.auth.check_auth",
-    "sentry.tasks.autofix.trigger_autofix_from_issue_summary",
+    "sentry.tasks.autofix",
     "sentry.tasks.auto_enable_codecov",
     "sentry.tasks.delete_seer_grouping_records",
     "sentry.tasks.digests",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,7 +31,6 @@ from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
 from sentry.conf.types.taskworker import ScheduleConfigMap
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import make_split_task_queues
 
 
@@ -1436,8 +1435,11 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.snuba.tasks",
     "sentry.tasks.auth.auth",
     "sentry.tasks.auth.check_auth",
+    "sentry.tasks.autofix.trigger_autofix_from_issue_summary",
     "sentry.tasks.auto_enable_codecov",
+    "sentry.tasks.delete_seer_grouping_records",
     "sentry.tasks.digests",
+    "sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project",
     "sentry.tasks.email",
     "sentry.tasks.release_registry",
     "sentry.tempest.tasks",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,6 +31,7 @@ from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
 from sentry.conf.types.taskworker import ScheduleConfigMap
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import make_split_task_queues
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3313,3 +3313,8 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "taskworker.seer.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -22,6 +22,9 @@ from sentry.seer.autofix import trigger_autofix
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import seer_tasks
+from sentry.taskworker.retry import Retry
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -35,6 +38,13 @@ logger = logging.getLogger(__name__)
     max_retries=1,
     soft_time_limit=60,  # 1 minute
     time_limit=65,
+    taskworker_config=TaskworkerConfig(
+        namespace=seer_tasks,
+        processing_deadline_duration=65,
+        retry=Retry(
+            times=1,
+        ),
+    ),
 )
 def _trigger_autofix_task(group_id: int, event_id: str, user_id: int | None, auto_run_source: str):
     """

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -11,6 +11,8 @@ from sentry.seer.similarity.grouping_records import (
 from sentry.seer.similarity.utils import ReferrerOptions, killswitch_enabled
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import seer_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +24,10 @@ logger = logging.getLogger(__name__)
     silo_mode=SiloMode.REGION,
     soft_time_limit=60 * 15,
     time_limit=60 * (15 + 5),
+    taskworker_config=TaskworkerConfig(
+        namespace=seer_tasks,
+        processing_deadline_duration=60 * (15 + 5),
+    ),
 )
 def delete_seer_grouping_records_by_hash(
     project_id: int,
@@ -80,6 +86,10 @@ def call_delete_seer_grouping_records_by_hash(
     silo_mode=SiloMode.REGION,
     soft_time_limit=60 * 15,
     time_limit=60 * (15 + 5),
+    taskworker_config=TaskworkerConfig(
+        namespace=seer_tasks,
+        processing_deadline_duration=60 * (15 + 5),
+    ),
 )
 def call_seer_delete_project_grouping_records(
     project_id: int,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -46,6 +46,8 @@ sdk_tasks = taskregistry.create_namespace("sdk")
 
 sdk_control_tasks = taskregistry.create_namespace("sdk.control")
 
+seer_tasks = taskregistry.create_namespace("seer")
+
 selfhosted_tasks = taskregistry.create_namespace("selfhosted")
 
 tempest_tasks = taskregistry.create_namespace("tempest")


### PR DESCRIPTION
This work is required to migrate tasks from celery to the new taskbroker system. The sentry option will be used to control the rollout of these tasks. The full migration plan is describe in this [document](https://www.notion.so/sentry/Rollout-Planning-1bd8b10e4b5d80aeaaa7dba0efca83bc).