### PR TITLE
fix(ourlogs): Make the alias for 'severity_text' be 'severity'

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -28,7 +28,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="integer",
         ),
         ResolvedAttribute(
-            public_alias="severity_text",
+            public_alias="severity",
             internal_name="sentry.severity_text",
             search_type="string",
         ),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -67,6 +67,12 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
         # Deprecated
         ResolvedAttribute(
+            public_alias="severity_text",
+            internal_name="sentry.severity_text",
+            search_type="string",
+            secondary_alias=True,
+        ),
+        ResolvedAttribute(
             public_alias="log.severity_text",
             internal_name="sentry.severity_text",
             search_type="string",

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -180,7 +180,7 @@ class SearchResolverQueryTest(TestCase):
 
     def test_query_with_or_and_brackets(self):
         where, having, _ = self.resolver.resolve_query(
-            "(message:123 and severity_text:345) or (message:foo and severity_text:bar)"
+            "(message:123 and severity_text:345) or (message:foo and severity:bar)"
         )
         assert where == TraceItemFilter(
             or_filter=OrFilter(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -78,7 +78,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
         assert "test.attribute3" in keys
         assert "another.attribute" in keys
         assert "different.attr" in keys
-        assert "severity_text" in keys
+        assert "severity" in keys
 
         # With a prefix only match the attributes that start with "tes"
         response = self.do_request(query={"substring_match": "tes"})
@@ -111,7 +111,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
         assert len(keys) >= 3
         assert "test.attribute1" in keys
         assert "test.attribute2" in keys
-        assert "severity_text" in keys
+        assert "severity" in keys
 
     def test_body_attribute(self):
         logs = [
@@ -129,7 +129,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
-        assert keys == {"severity_text", "message", "project"}
+        assert keys == {"severity", "message", "project"}
 
     def test_disallowed_attributes(self):
         logs = [
@@ -149,7 +149,7 @@ class OrganizationTraceItemAttributesEndpointTest(OrganizationEventsEndpointTest
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
-        assert keys == {"severity_text", "message", "project", "sentry.item_type2"}
+        assert keys == {"severity", "message", "project", "sentry.item_type2"}
 
 
 class OrganizationTraceItemAttributeValuesEndpointTest(OrganizationEventsEndpointTestBase):

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -105,7 +105,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                 "value": str(timestamp_nanos),
             },
             {"name": "message", "type": "str", "value": "foo"},
-            {"name": "severity_text", "type": "str", "value": "INFO"},
+            {"name": "severity", "type": "str", "value": "INFO"},
             {"name": "str_attr", "type": "str", "value": "1"},
             {"name": "trace", "type": "str", "value": self.trace_uuid},
         ]
@@ -186,7 +186,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                     "value": str(timestamp_nanos),
                 },
                 {"name": "message", "type": "str", "value": "foo"},
-                {"name": "severity_text", "type": "str", "value": "INFO"},
+                {"name": "severity", "type": "str", "value": "INFO"},
                 {"name": "str_attr", "type": "str", "value": "1"},
                 {"name": "trace", "type": "str", "value": self.trace_uuid},
             ],


### PR DESCRIPTION
This aligns the alias with the displayed column.