### PR TITLE
chore(ourlogs): Ensure frontend aliases are things that actually work

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -22,7 +22,7 @@ const COMMON_HINT_KEYS = [
 
 const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.MESSAGE,
-  OurLogKnownFieldKey.SEVERITY_TEXT,
+  OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.PROJECT_ID,

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -48,11 +48,7 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
   OurLogKnownFieldKey.TRACE_ID,
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.MESSAGE,
-  OurLogKnownFieldKey.SEVERITY_TEXT,
-  OurLogKnownFieldKey.ORGANIZATION_ID,
-  OurLogKnownFieldKey.PROJECT_ID,
-  OurLogKnownFieldKey.TIMESTAMP,
-  OurLogKnownFieldKey.ITEM_TYPE,
+  OurLogKnownFieldKey.SEVERITY,
 ];
 
 export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NUMBER];

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -8,7 +8,7 @@ import {type OurLogFieldKey, OurLogKnownFieldKey} from 'sentry/views/explore/log
 
 export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = {
   [OurLogKnownFieldKey.TIMESTAMP]: t('Timestamp'),
-  [OurLogKnownFieldKey.SEVERITY_TEXT]: t('Severity'),
+  [OurLogKnownFieldKey.SEVERITY]: t('Severity'),
   [OurLogKnownFieldKey.MESSAGE]: t('Message'),
   [OurLogKnownFieldKey.TRACE_ID]: t('Trace'),
 };
@@ -21,7 +21,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.PROJECT_ID,
   OurLogKnownFieldKey.TRACE_ID,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
-  OurLogKnownFieldKey.SEVERITY_TEXT,
+  OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.TIMESTAMP,
 ];
 

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -94,7 +94,7 @@ export function SeverityCircleRenderer(props: Omit<LogFieldRendererProps, 'item'
   if (!props.tableResultLogRow) {
     return null;
   }
-  const attribute_value = props.tableResultLogRow?.[OurLogKnownFieldKey.SEVERITY_TEXT];
+  const attribute_value = props.tableResultLogRow?.[OurLogKnownFieldKey.SEVERITY];
   const _severityNumber = props.tableResultLogRow?.[OurLogKnownFieldKey.SEVERITY_NUMBER];
 
   const severityNumber = _severityNumber ? Number(_severityNumber) : null;
@@ -193,7 +193,7 @@ export const LogAttributesRendererMap: Record<
   [OurLogKnownFieldKey.TIMESTAMP]: props => {
     return TimestampRenderer(props);
   },
-  [OurLogKnownFieldKey.SEVERITY_TEXT]: SeverityTextRenderer,
+  [OurLogKnownFieldKey.SEVERITY]: SeverityTextRenderer,
   [OurLogKnownFieldKey.MESSAGE]: LogBodyRenderer,
   [OurLogKnownFieldKey.TRACE_ID]: TraceIDRenderer,
 };

--- a/static/app/views/explore/logs/logFieldsTree.spec.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.spec.tsx
@@ -79,7 +79,7 @@ describe('logFieldsTree', () => {
             [OurLogKnownFieldKey.ORGANIZATION_ID]: 1,
             [OurLogKnownFieldKey.MESSAGE]: 'test log body',
             [OurLogKnownFieldKey.SEVERITY_NUMBER]: 456,
-            [OurLogKnownFieldKey.SEVERITY_TEXT]: 'error',
+            [OurLogKnownFieldKey.SEVERITY]: 'error',
             [OurLogKnownFieldKey.TIMESTAMP]: '2025-04-03T15:50:10+00:00',
           }}
         />

--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -106,7 +106,7 @@ export function LogRowContent({
   const theme = useTheme();
 
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
-  const severityText = dataRow[OurLogKnownFieldKey.SEVERITY_TEXT];
+  const severityText = dataRow[OurLogKnownFieldKey.SEVERITY];
 
   const level = getLogSeverityLevel(
     typeof severityNumber === 'number' ? severityNumber : null,
@@ -225,7 +225,7 @@ function LogRowDetails({
   const organization = useOrganization();
   const fields = useLogsFields();
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
-  const severityText = dataRow[OurLogKnownFieldKey.SEVERITY_TEXT];
+  const severityText = dataRow[OurLogKnownFieldKey.SEVERITY];
 
   const level = getLogSeverityLevel(
     typeof severityNumber === 'number' ? severityNumber : null,

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -17,7 +17,7 @@ export enum OurLogKnownFieldKey {
   ID = 'sentry.item_id',
   MESSAGE = 'message',
   SEVERITY_NUMBER = 'severity_number',
-  SEVERITY_TEXT = 'severity_text',
+  SEVERITY = 'severity',
   ORGANIZATION_ID = 'organization.id',
   PROJECT_ID = 'project.id',
   PROJECT = 'project',
@@ -33,7 +33,7 @@ export type OurLogFieldKey = OurLogCustomFieldKey | OurLogKnownFieldKey;
 type OurLogsKnownFieldResponseMap = {
   [OurLogKnownFieldKey.MESSAGE]: string;
   [OurLogKnownFieldKey.SEVERITY_NUMBER]: number;
-  [OurLogKnownFieldKey.SEVERITY_TEXT]: string;
+  [OurLogKnownFieldKey.SEVERITY]: string;
   [OurLogKnownFieldKey.ORGANIZATION_ID]: number;
   [OurLogKnownFieldKey.PROJECT_ID]: number;
   [OurLogKnownFieldKey.TIMESTAMP]: string;

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -35,7 +35,7 @@ function getTitle(event: TraceTree.TraceEvent | OurLogsResponseItem | null): {
   }
 
   // Handle log events
-  if (OurLogKnownFieldKey.SEVERITY_TEXT in event) {
+  if (OurLogKnownFieldKey.SEVERITY in event) {
     return {
       title: t('Trace'),
       subtitle: event[OurLogKnownFieldKey.MESSAGE],


### PR DESCRIPTION
- severity_text -> severity rename for consistency
- do not include organization.id in possible searchable tags
- do not include project.id as a searchable tag (it should be done with project selector)
- do not include item_type as a searchable tag
- do not include timestamp as a string tag (it's impossible to use it this way, users can filter timestamps via the graph)