### PR TITLE
fix: re-add accountNotificationSettings.tsx

### DIFF
--- a/static/app/data/forms/accountNotificationSettings.tsx
+++ b/static/app/data/forms/accountNotificationSettings.tsx
@@ -1,0 +1,20 @@
+import type {Field} from 'sentry/components/forms/types';
+import {t} from 'sentry/locale';
+
+// Export route to make these forms searchable by label/help
+export const route = '/settings/account/notifications/';
+
+export const fields = {
+  personalActivityNotifications: {
+    name: 'personalActivityNotifications',
+    type: 'boolean',
+    label: t('Notify Me About My Own Activity'),
+    help: t('Enable this to receive notifications about your own actions on Sentry.'),
+  },
+  selfAssignOnResolve: {
+    name: 'selfAssignOnResolve',
+    type: 'boolean',
+    label: t("Claim Unassigned Issues I've Resolved"),
+    help: t("You'll receive notifications about any changes that happen afterwards."),
+  },
+} satisfies Record<string, Field>;


### PR DESCRIPTION
This restores the file `static/app/data/forms/accountNotificationSettings.tsx` as everything under `static/app/data/forms` is dynamically imported:

https://github.com/getsentry/sentry/blob/19478d9922d3aa417dbca27318b89d0e8f85e044/static/app/components/search/sources/formSource.tsx#L59-L61