### PR TITLE
ref(✂️): remove unused exports keyword from functions and consts

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -246,7 +246,7 @@ type FetchEventAttachmentParameters = {
 
 type FetchEventAttachmentResponse = IssueAttachment[];
 
-export const makeFetchEventAttachmentsQueryKey = ({
+const makeFetchEventAttachmentsQueryKey = ({
   orgSlug,
   projectSlug,
   eventId,

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -93,7 +93,7 @@ type RemoveParams = {
   successMessage?: string;
 };
 
-export function remove(api: Client, {successMessage, errorMessage, orgId}: RemoveParams) {
+function remove(api: Client, {successMessage, errorMessage, orgId}: RemoveParams) {
   const endpoint = `/organizations/${orgId}/`;
   return api
     .requestPromise(endpoint, {

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -88,7 +88,7 @@ export function fetchRecentSearches(
   return promise;
 }
 
-export function makeRecentSearchesQueryKey({
+function makeRecentSearchesQueryKey({
   limit,
   orgSlug,
   savedSearchType,

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -286,7 +286,7 @@ export type FetchOrganizationTagsParams = {
   useFlagsBackend?: boolean;
 };
 
-export const makeFetchOrganizationTags = ({
+const makeFetchOrganizationTags = ({
   orgSlug,
   dataset,
   projectIds,

--- a/static/app/components/arithmeticInput/parser.tsx
+++ b/static/app/components/arithmeticInput/parser.tsx
@@ -39,7 +39,7 @@ class Term {
   }
 }
 
-export class TokenConverter {
+class TokenConverter {
   numOperations: number;
   errors: string[];
   fields: Term[];

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -112,7 +112,7 @@ interface AssigneeSelectorDropdownProps {
   ) => React.ReactNode;
 }
 
-export function AssigneeAvatar({
+function AssigneeAvatar({
   assignedTo,
   suggestedActors = [],
 }: {

--- a/static/app/components/charts/areaChart.tsx
+++ b/static/app/components/charts/areaChart.tsx
@@ -16,7 +16,7 @@ export interface AreaChartProps extends Omit<BaseChartProps, 'series'> {
   stacked?: boolean;
 }
 
-export function transformToAreaSeries({
+function transformToAreaSeries({
   series,
   stacked,
   colors,

--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -19,7 +19,7 @@ export interface BarChartProps extends BaseChartProps {
   stacked?: boolean;
 }
 
-export function transformToBarSeries({
+function transformToBarSeries({
   barOpacity = 1,
   series,
   stacked,

--- a/static/app/components/checkInTimeline/utils/getTimeRangeFromEvent.tsx
+++ b/static/app/components/checkInTimeline/utils/getTimeRangeFromEvent.tsx
@@ -4,7 +4,7 @@ import type {TimeWindow} from 'sentry/components/checkInTimeline/types';
 import type {Event} from 'sentry/types/event';
 
 // Stores the elapsed minutes for each selectable resolution
-export const resolutionElapsedMinutes: Record<TimeWindow, number> = {
+const resolutionElapsedMinutes: Record<TimeWindow, number> = {
   '1h': 60,
   '24h': 60 * 24,
   '7d': 60 * 24 * 7,

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -308,7 +308,7 @@ const Title = styled('h5')`
   margin-bottom: ${space(1)};
 `;
 
-export const ClipFade = styled('div')`
+const ClipFade = styled('div')`
   position: absolute;
   left: 0;
   right: 0;

--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -436,7 +436,7 @@ const StyledOverlay = styled(Overlay)<{width?: string}>`
   width: ${p => p.width ?? 'auto'};
 `;
 
-export const EmptyMessage = styled('p')`
+const EmptyMessage = styled('p')`
   text-align: center;
   color: ${p => p.theme.subText};
   padding: ${space(1)} ${space(1.5)} ${space(1)};

--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -156,7 +156,7 @@ function AvatarList({
 export default AvatarList;
 
 // used in releases list page to do some alignment
-export const AvatarListWrapper = styled('div')`
+const AvatarListWrapper = styled('div')`
   display: flex;
   align-items: center;
   flex-direction: row-reverse;

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -186,7 +186,7 @@ export function getHiddenOptions<Value extends SelectKey>(
  * selected, then this function selects all of them. If all of the options are selected,
  * then this function unselects all of them.
  */
-export function toggleOptions<Value extends SelectKey>(
+function toggleOptions<Value extends SelectKey>(
   optionKeys: Value[],
   selectionManager: SelectionManager
 ) {

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -43,7 +43,7 @@ interface InputContext {
    */
   trailingWidth?: number;
 }
-export const InputGroupContext = createContext<InputContext>({inputProps: {}});
+const InputGroupContext = createContext<InputContext>({inputProps: {}});
 
 /**
  * Wrapper for input group. To be used alongisde `Input`, `InputGroup.LeadingItems`,
@@ -219,7 +219,7 @@ InputGroup.TrailingItems = TrailingItems;
 
 export type {InputProps, TextAreaProps};
 
-export const InputGroupWrap = styled('div')<{disabled?: boolean}>`
+const InputGroupWrap = styled('div')<{disabled?: boolean}>`
   position: relative;
   ${p => p.disabled && `color: ${p.theme.disabled};`};
 `;

--- a/static/app/components/core/select/async.tsx
+++ b/static/app/components/core/select/async.tsx
@@ -35,7 +35,7 @@ type State = {
 /**
  * Performs an API request to `url` to fetch the options
  */
-export class SelectAsyncControl extends Component<SelectAsyncControlProps> {
+class SelectAsyncControl extends Component<SelectAsyncControlProps> {
   static defaultProps = {
     placeholder: '--',
     defaultOptions: true,

--- a/static/app/components/core/slider/index.tsx
+++ b/static/app/components/core/slider/index.tsx
@@ -28,7 +28,7 @@ interface UncontrolledProps extends BaseProps {
 
 export type SliderProps = ControlledProps | UncontrolledProps;
 
-export function LegacySlider({ref, ...props}: SliderProps) {
+function LegacySlider({ref, ...props}: SliderProps) {
   return (
     <StyledSlider
       ref={ref}

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -18,7 +18,7 @@ import {
 import {initDemoMode} from 'sentry/utils/demoMode/utils';
 import useApi from 'sentry/utils/useApi';
 
-export const DEMO_HEADER_HEIGHT_PX = 70;
+const DEMO_HEADER_HEIGHT_PX = 70;
 
 export default function DemoHeader() {
   const api = useApi();

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -474,7 +474,7 @@ const EmptyMessage = styled('div')`
   text-transform: none;
 `;
 
-export const AutoCompleteRoot = styled('div')<{disabled?: boolean}>`
+const AutoCompleteRoot = styled('div')<{disabled?: boolean}>`
   position: relative;
   display: inline-block;
   ${p => p.disabled && 'pointer-events: none;'}

--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -181,7 +181,7 @@ function EditableText({
 
 export default EditableText;
 
-export const Label = styled('div')<{isDisabled: boolean}>`
+const Label = styled('div')<{isDisabled: boolean}>`
   display: grid;
   grid-auto-flow: column;
   align-items: center;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -68,7 +68,7 @@ const cardAnimationProps: AnimationProps = {
   }),
 };
 
-export function useSelectCause({groupId, runId}: {groupId: string; runId: string}) {
+function useSelectCause({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
 

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -48,7 +48,7 @@ import {Divider} from 'sentry/views/issueDetails/divider';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 
-export function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
+function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
 

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -57,7 +57,7 @@ function isProgressLog(
   return 'message' in item && 'timestamp' in item;
 }
 
-export function Step({
+function Step({
   step,
   groupId,
   runId,

--- a/static/app/components/events/autofix/autofixThumbsUpDownButtons.tsx
+++ b/static/app/components/events/autofix/autofixThumbsUpDownButtons.tsx
@@ -12,13 +12,7 @@ import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
-export function useUpdateAutofixFeedback({
-  groupId,
-  runId,
-}: {
-  groupId: string;
-  runId: string;
-}) {
+function useUpdateAutofixFeedback({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
 

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -24,7 +24,7 @@ type AutofixSetupResponse = {
   } | null;
 };
 
-export function makeAutofixSetupQueryKey(
+function makeAutofixSetupQueryKey(
   groupId: string,
   checkWriteAccess?: boolean
 ): ApiQueryKey {

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -367,7 +367,7 @@ function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
   }
 }
 
-export const BreadcrumbLevel = styled('div')<{level: BreadcrumbLevelType}>`
+const BreadcrumbLevel = styled('div')<{level: BreadcrumbLevelType}>`
   margin: 0 ${space(1)};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -106,7 +106,7 @@ export function getFieldTypeFromUnit(unit: any) {
   return 'number';
 }
 
-export function EventCustomPerformanceMetric({
+function EventCustomPerformanceMetric({
   event,
   name,
   location,

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -180,7 +180,7 @@ const SectionHeader = styled('div')`
   }
 `;
 
-export const SectionContents = styled('div')`
+const SectionContents = styled('div')`
   position: relative;
 `;
 

--- a/static/app/components/events/eventProcessingErrors.tsx
+++ b/static/app/components/events/eventProcessingErrors.tsx
@@ -23,7 +23,7 @@ const keyMapping = {
   image_path: 'File Path',
 };
 
-export default function EventErrorCard({
+function EventErrorCard({
   title,
   data,
 }: {

--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -129,7 +129,7 @@ const ReplaySectionMinHeight = styled(InterimSection)`
   min-height: 557px;
 `;
 
-export const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`
+const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`
   height: ${REPLAY_LOADING_HEIGHT}px;
   margin-bottom: ${space(2)};
 `;

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -240,7 +240,7 @@ export const TreeColumn = styled('div')`
   }
 `;
 
-export const TreeLoadingIndicator = styled(LoadingIndicator)`
+const TreeLoadingIndicator = styled(LoadingIndicator)`
   grid-column: 1 /-1;
 `;
 

--- a/static/app/components/events/eventVitals.tsx
+++ b/static/app/components/events/eventVitals.tsx
@@ -200,4 +200,4 @@ const Value = styled('span')<{failedThreshold: boolean}>`
   ${p => p.failedThreshold && `color: ${p.theme.errorText};`}
 `;
 
-export const EventVitalContainer = styled('div')``;
+const EventVitalContainer = styled('div')``;

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -23,7 +23,7 @@ export const MOCK_FLAGS: Array<Required<FeatureFlag>> = [
   },
 ];
 
-export const MOCK_FLAGS_MANY: Array<Required<FeatureFlag>> = [
+const MOCK_FLAGS_MANY: Array<Required<FeatureFlag>> = [
   {
     flag: 'mobile-replay-ui',
     result: false,

--- a/static/app/components/events/featureFlags/utils.tsx
+++ b/static/app/components/events/featureFlags/utils.tsx
@@ -101,7 +101,7 @@ export const enum FlagControlOptions {
   SORT = 'sort',
 }
 
-export const handleSortAlphabetical = (flags: KeyValueDataContentProps[]) => {
+const handleSortAlphabetical = (flags: KeyValueDataContentProps[]) => {
   return [...flags].sort((a, b) => {
     return a.item.key.localeCompare(b.item.key);
   });

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -339,7 +339,7 @@ const HighlightContextContent = styled(ContextCardContent)`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-export const highlightModalCss = (theme: Theme) => css`
+const highlightModalCss = (theme: Theme) => css`
   width: 850px;
   padding: 0 ${space(2)};
   margin: ${space(2)} 0;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -27,7 +27,7 @@ import type {BreadcrumbProps} from './breadcrumb';
 import {Breadcrumb} from './breadcrumb';
 
 const PANEL_MIN_HEIGHT = 200;
-export const PANEL_INITIAL_HEIGHT = 400;
+const PANEL_INITIAL_HEIGHT = 400;
 
 const noop = () => void 0;
 

--- a/static/app/components/events/interfaces/breadcrumbs/utils.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/utils.tsx
@@ -50,7 +50,7 @@ export function convertCrumbType(breadcrumb: RawCrumb): RawCrumb {
   return breadcrumb;
 }
 
-export function getCrumbDescriptionAndColor(
+function getCrumbDescriptionAndColor(
   type: BreadcrumbType
 ): Pick<Crumb, 'color' | 'description'> {
   switch (type) {

--- a/static/app/components/events/interfaces/crashContent/exception/banners/addIntegrationBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/banners/addIntegrationBanner.tsx
@@ -49,7 +49,7 @@ export function AddIntegrationBanner({orgSlug, onDismiss}: AddIntegrationBannerP
   );
 }
 
-export const StacktraceIntegrationBannerWrapper = styled('div')`
+const StacktraceIntegrationBannerWrapper = styled('div')`
   position: relative;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
@@ -63,18 +63,18 @@ export const StacktraceIntegrationBannerWrapper = styled('div')`
   );
 `;
 
-export const IntegationBannerTitle = styled('div')`
+const IntegationBannerTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   margin-bottom: ${space(1)};
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 
-export const IntegationBannerDescription = styled('div')`
+const IntegationBannerDescription = styled('div')`
   margin-bottom: ${space(1.5)};
   max-width: 340px;
 `;
 
-export const CloseBannerButton = styled(Button)`
+const CloseBannerButton = styled(Button)`
   position: absolute;
   display: block;
   top: ${space(2)};

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -256,6 +256,6 @@ const ContentPanel = styled(Panel)<{hideIcon?: boolean}>`
   overflow: hidden;
 `;
 
-export const Frames = styled('ul')`
+const Frames = styled('ul')`
   list-style: none;
 `;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -46,12 +46,12 @@ function getRubyFrame(frame: Frame): string {
   return result;
 }
 
-export function getPHPFrame(frame: Frame, idx: number): string {
+function getPHPFrame(frame: Frame, idx: number): string {
   const funcName = frame.function === 'null' ? '{main}' : frame.function;
   return `#${idx} ${frame.filename || frame.module}(${frame.lineNo}): ${funcName}`;
 }
 
-export function getPythonFrame(frame: Frame): string {
+function getPythonFrame(frame: Frame): string {
   let result = '';
   if (defined(frame.filename)) {
     result += '  File "' + frame.filename + '"';
@@ -98,7 +98,7 @@ export function getJavaFrame(frame: Frame): string {
   return result;
 }
 
-export function getDartFrame(frame: Frame, frameIdxFromEnd: number): string {
+function getDartFrame(frame: Frame, frameIdxFromEnd: number): string {
   let result = `  #${frameIdxFromEnd}`;
 
   if (frame.function === '<asynchronous suspension>') {
@@ -129,7 +129,7 @@ function ljust(str: string, len: number) {
   return str + new Array(Math.max(0, len - str.length) + 1).join(' ');
 }
 
-export function getNativeFrame(frame: Frame): string {
+function getNativeFrame(frame: Frame): string {
   let result = '  ';
   if (defined(frame.package)) {
     result += ljust(trimPackage(frame.package), 20);

--- a/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
@@ -107,7 +107,7 @@ function AggregateSpanDetail({span, organization}: Props) {
 
 export default AggregateSpanDetail;
 
-export function Row({
+function Row({
   title,
   keep,
   children,
@@ -144,7 +144,7 @@ export function Row({
   );
 }
 
-export const SpanDetailContainer = styled('div')`
+const SpanDetailContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
   cursor: auto;
 `;
@@ -177,7 +177,7 @@ const ButtonContainer = styled('div')`
   padding: 8px 10px;
 `;
 
-export const SpanDetails = styled('div')`
+const SpanDetails = styled('div')`
   padding: ${space(2)};
 
   table.table.key-value td.key {

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -802,7 +802,7 @@ const DurationGuideBox = styled('div')<{alignLeft: boolean}>`
   }};
 `;
 
-export const HeaderContainer = styled('div')<{
+const HeaderContainer = styled('div')<{
   hasProfileMeasurementsChart: boolean;
   isEmbedded: boolean;
 }>`

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
@@ -93,7 +93,7 @@ import {
   unwrapTreeDepth,
 } from './utils';
 
-export const MARGIN_LEFT = 0;
+const MARGIN_LEFT = 0;
 const SPAN_BAR_HEIGHT = 24;
 
 type NewTraceDetailsSpanBarProps = SpanBarProps & {

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -687,7 +687,7 @@ const SpanIdTitle = styled('a')`
   }
 `;
 
-export function Row({
+function Row({
   title,
   keep,
   children,
@@ -727,7 +727,7 @@ export function Row({
   );
 }
 
-export function Tags({span}: {span: RawSpanType}) {
+function Tags({span}: {span: RawSpanType}) {
   const tags: Record<string, string> | undefined = span?.tags;
 
   if (!tags) {
@@ -765,13 +765,13 @@ const Flex = styled('div')`
   display: flex;
   align-items: center;
 `;
-export const ButtonGroup = styled('div')`
+const ButtonGroup = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
 `;
 
-export const ValueRow = styled('div')`
+const ValueRow = styled('div')`
   display: grid;
   grid-template-columns: auto min-content;
   gap: ${space(1)};
@@ -786,7 +786,7 @@ const StyledPre = styled('pre')`
   background-color: transparent !important;
 `;
 
-export const ButtonContainer = styled('div')`
+const ButtonContainer = styled('div')`
   padding: 8px 10px;
 `;
 

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -120,7 +120,7 @@ const INTERSECTION_THRESHOLDS: number[] = [
   0.9, 0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98, 0.99, 1.0,
 ];
 
-export const MARGIN_LEFT = 0;
+const MARGIN_LEFT = 0;
 
 export type SpanBarProps = ScrollbarManagerChildrenProps & {
   addContentSpanBarRef: (instance: HTMLDivElement | null) => void;

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -708,7 +708,7 @@ export function Row({
   );
 }
 
-export function Tags({span}: {span: RawSpanType}) {
+function Tags({span}: {span: RawSpanType}) {
   const tags: Record<string, string> | undefined = span?.tags;
 
   if (!tags) {

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -33,7 +33,7 @@ import {
   subTimingMarkToTime,
 } from './utils';
 
-export const MIN_SIBLING_GROUP_SIZE = 5;
+const MIN_SIBLING_GROUP_SIZE = 5;
 
 class SpanTreeModel {
   api: Client;

--- a/static/app/components/events/interfaces/stackTraceContext.tsx
+++ b/static/app/components/events/interfaces/stackTraceContext.tsx
@@ -74,7 +74,7 @@ interface StacktraceContextType {
   stackView: StackView;
 }
 
-export const IssueStacktraceContext = createContext<StacktraceContextType>({
+const IssueStacktraceContext = createContext<StacktraceContextType>({
   stackView: StackView.APP,
   stackType: StackType.ORIGINAL,
   displayOptions: [],

--- a/static/app/components/events/interfaces/threads/threadSelector/threadStates.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/threadStates.tsx
@@ -12,7 +12,7 @@ export enum ThreadStates {
 
 type ThreadStatesMap = Record<string, ThreadStates>;
 
-export const javaThreadStatesMap: ThreadStatesMap = {
+const javaThreadStatesMap: ThreadStatesMap = {
   RUNNABLE: ThreadStates.RUNNABLE,
   TIMED_WAITING: ThreadStates.TIMED_WAITING,
   BLOCKED: ThreadStates.BLOCKED,

--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -54,7 +54,7 @@ const DOWNTIME_START_TYPES = [
 
 const DOWNTIME_TERMINAL_TYPES = [GroupActivityType.SET_RESOLVED];
 
-export function useDowntimeDuration({group}: {group: Group}): {
+function useDowntimeDuration({group}: {group: Group}): {
   durationMs: number;
   endDate: Date;
   startDate: Date;

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -63,7 +63,7 @@ export function isRepeatedFrame(frame: Frame, nextFrame?: Frame) {
   );
 }
 
-export function getRepeatedFrameIndices(data: StacktraceType) {
+function getRepeatedFrameIndices(data: StacktraceType) {
   const repeats: number[] = [];
   (data.frames ?? []).forEach((frame, frameIdx) => {
     const nextFrame = (data.frames ?? [])[frameIdx + 1];

--- a/static/app/components/events/packageData.tsx
+++ b/static/app/components/events/packageData.tsx
@@ -87,13 +87,13 @@ export function EventPackageData({event}: Props) {
   );
 }
 
-export const ColumnsContainer = styled('div')<{columnCount: number}>`
+const ColumnsContainer = styled('div')<{columnCount: number}>`
   display: grid;
   align-items: start;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
 `;
 
-export const Column = styled('div')`
+const Column = styled('div')`
   display: grid;
   grid-template-columns: fit-content(65%) 1fr;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -151,7 +151,7 @@ export function SuspectCommits({
   );
 }
 
-export const StyledPanel = styled(Panel)`
+const StyledPanel = styled(Panel)`
   margin: 0;
 `;
 

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -7,7 +7,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export const CRASH_REPORT_HASH = '#crashreport-sidequest';
-export const FEEDBACK_HASH = '#feedback-sidequest';
+const FEEDBACK_HASH = '#feedback-sidequest';
 
 export default function useHaveSelectedProjectsSetupFeedback() {
   const {hasField: hasSetupOneFeedback, fetching} =

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -105,7 +105,7 @@ const Container = styled('div')`
 const shouldForwardProp = (p: PropertyKey) =>
   typeof p === 'string' && !['disabled', 'animate'].includes(p) && isPropValid(p);
 
-export const RadioItem = styled('label', {shouldForwardProp})<{
+const RadioItem = styled('label', {shouldForwardProp})<{
   index: number;
   disabled?: boolean;
 }>`

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -45,7 +45,7 @@ interface DrawerPanelProps {
   transitionProps?: AnimationProps['transition'];
 }
 
-export function DrawerPanel({
+function DrawerPanel({
   ref,
   ariaLabel,
   children,

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -4,9 +4,9 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {space} from 'sentry/styles/space';
 
-export const GRID_HEAD_ROW_HEIGHT = 45;
+const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 42;
-export const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
+const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
 /**
  * Local z-index stacking context

--- a/static/app/components/group/pluginActions.tsx
+++ b/static/app/components/group/pluginActions.tsx
@@ -232,6 +232,4 @@ const TabsContainer = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-export {PluginActions};
-
 export default withApi(withOrganization(PluginActions));

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -123,7 +123,7 @@ function IssueSyncListElement({
   );
 }
 
-export const IssueSyncListElementContainer = styled('div')`
+const IssueSyncListElementContainer = styled('div')`
   line-height: 0;
   display: flex;
   align-items: center;

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -347,8 +347,6 @@ class GroupList extends Component<Props, State> {
   }
 }
 
-export {GroupList};
-
 export default withOrganization(withApi(withSentryRouter(GroupList)));
 
 const GroupPlaceholder = styled('div')`

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -195,7 +195,7 @@ const filterChildren = (children: ReactNode): ReactNode[] => {
 // Note: When conditionally rendering children, instead of returning
 // if(!condition) return null inside Component, we should render  {condition ? <Component/> : null}
 // where Component returns a <Card/>. {null} is ignored when distributing cards into columns.
-export function Container({children}: {children: React.ReactNode}) {
+function Container({children}: {children: React.ReactNode}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
 

--- a/static/app/components/modals/emailVerificationModal.tsx
+++ b/static/app/components/modals/emailVerificationModal.tsx
@@ -36,4 +36,3 @@ function EmailVerificationModal({
 }
 
 export default EmailVerificationModal;
-export {EmailVerificationModal};

--- a/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
@@ -112,7 +112,7 @@ export const StatusMessage = styled('div')<{
     p.status === 'error' && !p.isNewInviteModal ? p.theme.errorText : p.theme.textColor};
 `;
 
-export const BoldCount = styled('div')`
+const BoldCount = styled('div')`
   display: inline;
   font-weight: bold;
 `;

--- a/static/app/components/modals/navigateToExternalLinkModal.tsx
+++ b/static/app/components/modals/navigateToExternalLinkModal.tsx
@@ -41,7 +41,6 @@ function NavigateToExternalLinkModal({Body, closeModal, Header, linkText}: Props
 }
 
 export default NavigateToExternalLinkModal;
-export {NavigateToExternalLinkModal};
 
 const ButtonContainer = styled('div')`
   display: flex;

--- a/static/app/components/notificationActions/notificationActionItem.tsx
+++ b/static/app/components/notificationActions/notificationActionItem.tsx
@@ -375,14 +375,14 @@ const NotificationActionContainer = styled('div')`
   width: 100%;
 `;
 
-export const NotificationActionCell = styled('div')`
+const NotificationActionCell = styled('div')`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: ${space(0.5)};
 `;
 
-export const NotificationActionFormContainer = styled('div')`
+const NotificationActionFormContainer = styled('div')`
   display: flex;
   justify-content: space-between;
   width: 100%;

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -11,7 +11,7 @@ type OnboardingContextProps = {
 /**
  * Prefer using `useOnboardingContext` hook instead of directly using this context.
  */
-export const OnboardingContext = createContext<OnboardingContextProps>({
+const OnboardingContext = createContext<OnboardingContextProps>({
   selectedPlatform: undefined,
   setSelectedPlatform: () => {},
 });

--- a/static/app/components/onboardingWizard/filterSupportedTasks.tsx
+++ b/static/app/components/onboardingWizard/filterSupportedTasks.tsx
@@ -36,7 +36,7 @@ export function shouldShowPerformanceTasks(projects: Project[]): boolean {
   );
 }
 
-export function shouldShowReplayTasks(projects: Project[]): boolean {
+function shouldShowReplayTasks(projects: Project[]): boolean {
   return projects?.some(
     project => project.platform && replayOnboardingPlatforms.includes(project.platform)
   );

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -59,7 +59,7 @@ function getSpanFieldDefinitionFunction(tags: TagCollection) {
   };
 }
 
-export function useSpanSearchQueryBuilderProps({
+function useSpanSearchQueryBuilderProps({
   initialQuery,
   searchSource,
   datetime,

--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -49,7 +49,7 @@ export const DividerLineGhostContainer = styled('div')`
   height: 100%;
 `;
 
-export const BadgeBorder = styled('div')<{
+const BadgeBorder = styled('div')<{
   color: Color | keyof Aliases;
   fillBackground?: boolean;
 }>`

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
@@ -332,7 +332,7 @@ const Separator = styled('li')`
   transform: translateY(29%);
 `;
 
-export const ProfilingDetailsFrameTabs = styled('ul')`
+const ProfilingDetailsFrameTabs = styled('ul')`
   display: flex;
   list-style-type: none;
   padding: 0 ${space(1)};
@@ -343,7 +343,7 @@ export const ProfilingDetailsFrameTabs = styled('ul')`
   grid-area: tabs;
 `;
 
-export const ProfilingDetailsListItem = styled('li')<{
+const ProfilingDetailsListItem = styled('li')<{
   margin?: 'none';
   size?: 'sm';
 }>`

--- a/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
@@ -16,10 +16,7 @@ import {
   FlamegraphTooltipTimelineInfo,
 } from './flamegraphTooltip';
 
-export function formatWeightToTransactionDuration(
-  span: SpanChartNode,
-  spanChart: SpanChart
-) {
+function formatWeightToTransactionDuration(span: SpanChartNode, spanChart: SpanChart) {
   return `(${Math.round((span.duration / spanChart.root.duration) * 100)}%)`;
 }
 

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/differentialFlamegraphToolbar.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/differentialFlamegraphToolbar.tsx
@@ -48,7 +48,7 @@ export function DifferentialFlamegraphToolbar(props: DifferentialFlamegraphProps
   );
 }
 
-export const DifferentialFlamegraphToolbarContainer = styled('div')`
+const DifferentialFlamegraphToolbarContainer = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -42,7 +42,7 @@ export function searchFrameFzf(
   return match;
 }
 
-export function searchSpanFzf(
+function searchSpanFzf(
   span: SpanChartNode,
   matches: FlamegraphSearchResults['results']['spans'],
   query: string
@@ -86,7 +86,7 @@ export function searchFrameRegExp(
   return match;
 }
 
-export function searchSpanRegExp(
+function searchSpanRegExp(
   span: SpanChartNode,
   matches: FlamegraphSearchResults['results']['spans'],
   query: string,

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -19,14 +19,11 @@ import type {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegra
 import {Rect} from 'sentry/utils/profiling/speedscope';
 import {relativeChange} from 'sentry/utils/profiling/units/units';
 
-export const PROFILING_SAMPLES_FORMATTER = Intl.NumberFormat(undefined, {
+const PROFILING_SAMPLES_FORMATTER = Intl.NumberFormat(undefined, {
   notation: 'compact',
 });
 
-export function formatWeightToProfileDuration(
-  frame: CallTreeNode,
-  flamegraph: Flamegraph
-) {
+function formatWeightToProfileDuration(frame: CallTreeNode, flamegraph: Flamegraph) {
   const weight = (frame.totalWeight / flamegraph.profile.duration) * 100;
 
   return `${Math.round(weight * 100) / 100}%`;

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -143,12 +143,12 @@ const Title = styled('h4')`
   gap: ${space(1)};
 `;
 
-export const Before = styled('span')`
+const Before = styled('span')`
   color: ${p => p.theme.red300};
   font-weight: bold;
 `;
 
-export const After = styled('span')`
+const After = styled('span')`
   color: ${p => p.theme.green300};
   font-weight: bold;
 `;

--- a/static/app/components/resultGrid.tsx
+++ b/static/app/components/resultGrid.tsx
@@ -389,6 +389,4 @@ class ResultGrid extends Component<Props, State> {
   }
 }
 
-export {ResultGrid};
-
 export default withApi(ResultGrid);

--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -82,7 +82,7 @@ export const ScorePanel = styled(Panel)`
   min-height: 96px;
 `;
 
-export const HeaderTitle = styled('div')`
+const HeaderTitle = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
   gap: ${space(1)};

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -176,7 +176,7 @@ function ActionButtons({
   );
 }
 
-export function SearchQueryBuilderUI({
+function SearchQueryBuilderUI({
   className,
   disabled = false,
   label,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -40,7 +40,7 @@ export function createRecentFilterOptionKey(filter: string) {
   return getEscapedKey(`${RECENT_FILTER_KEY_PREFIX}${filter}`);
 }
 
-export function createRecentQueryOptionKey(filter: string) {
+function createRecentQueryOptionKey(filter: string) {
   return getEscapedKey(`${RECENT_QUERY_KEY_PREFIX}${filter}`);
 }
 

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -82,7 +82,7 @@ function InnerWrap({
   );
 }
 
-export function BaseTab({
+function BaseTab({
   to,
   children,
   ref,

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -26,7 +26,7 @@ import {tabsShouldForwardProp} from './utils';
  * Uses IntersectionObserver API to detect overflowing tabs. Returns an array
  * containing of keys of overflowing tabs.
  */
-export function useOverflowTabs({
+function useOverflowTabs({
   tabListRef,
   tabItemsRef,
   tabItems,
@@ -95,7 +95,7 @@ export function useOverflowTabs({
   return overflowTabs.filter(tabKey => !tabItemKeyToHiddenMap[tabKey]);
 }
 
-export function OverflowMenu({state, overflowMenuItems, disabled}: any) {
+function OverflowMenu({state, overflowMenuItems, disabled}: any) {
   return (
     <TabListOverflowWrap>
       <CompactSelect

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -25,7 +25,7 @@ export interface TimelineItemProps {
   timestamp?: React.ReactNode;
 }
 
-export function Item({
+function Item({
   title,
   children,
   icon,
@@ -121,7 +121,7 @@ const Content = styled('div')`
   word-wrap: break-word;
 `;
 
-export const Text = styled('div')`
+const Text = styled('div')`
   text-align: left;
   font-size: ${p => p.theme.fontSizeSmall};
   &:only-child {
@@ -129,7 +129,7 @@ export const Text = styled('div')`
   }
 `;
 
-export const Data = styled('div')`
+const Data = styled('div')`
   border-radius: ${space(0.5)};
   padding: ${space(0.25)} ${space(0.75)};
   border: 1px solid ${p => p.theme.translucentInnerBorder};
@@ -143,7 +143,7 @@ export const Data = styled('div')`
   }
 `;
 
-export const Container = styled('div')`
+const Container = styled('div')`
   position: relative;
   /* vertical line connecting items */
   &::before {

--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -92,7 +92,7 @@ const Wrapper = styled('span')`
   position: relative;
 `;
 
-export const FullValue = styled('span')<{
+const FullValue = styled('span')<{
   expandDirection: 'left' | 'right';
   expanded: boolean;
 }>`

--- a/static/app/components/workflowEngine/layout/breadcrumbs.tsx
+++ b/static/app/components/workflowEngine/layout/breadcrumbs.tsx
@@ -7,7 +7,7 @@ import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 interface BreadcrumbsContextValue {
   crumbs: Array<Crumb | CrumbDropdown>;
 }
-export const BreadcrumbsContext = createContext<BreadcrumbsContextValue>({
+const BreadcrumbsContext = createContext<BreadcrumbsContextValue>({
   crumbs: [],
 });
 

--- a/static/app/components/workflowEngine/ui/collapsibleSection.tsx
+++ b/static/app/components/workflowEngine/ui/collapsibleSection.tsx
@@ -32,7 +32,7 @@ export default function CollapsibleSection({
   );
 }
 
-export const Body = styled('details')`
+const Body = styled('details')`
   display: flex;
   flex-direction: column;
   background-color: ${p => p.theme.backgroundElevated};
@@ -57,12 +57,12 @@ export const Body = styled('details')`
   }
 `;
 
-export const Heading = styled('h2')`
+const Heading = styled('h2')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   margin: 0;
 `;
 
-export const HeadingWrapper = styled('summary')`
+const HeadingWrapper = styled('summary')`
   display: flex;
   justify-content: space-between;
   position: relative;
@@ -73,7 +73,7 @@ export const HeadingWrapper = styled('summary')`
   cursor: pointer;
 `;
 
-export const Description = styled('span')`
+const Description = styled('span')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.subText};
   margin: 0;

--- a/static/app/components/workflowEngine/ui/section.tsx
+++ b/static/app/components/workflowEngine/ui/section.tsx
@@ -17,7 +17,7 @@ export default function Section({children, title}: SectionProps) {
   );
 }
 
-export const SectionHeading = styled('h4')`
+const SectionHeading = styled('h4')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
 `;

--- a/static/app/constants/pageFilters.tsx
+++ b/static/app/constants/pageFilters.tsx
@@ -14,7 +14,7 @@ export const PAGE_URL_PARAM = {
   PAGE_PERIOD: 'pageStatsPeriod',
 };
 
-export const DATE_TIME = {
+const DATE_TIME = {
   START: 'start',
   END: 'end',
   PERIOD: 'period',

--- a/static/app/data/timezones.tsx
+++ b/static/app/data/timezones.tsx
@@ -491,4 +491,4 @@ const timezoneOptions: Array<SelectValue<string>> = groupedTimezones.map(
   })
 );
 
-export {timezones, timezoneOptions};
+export {timezoneOptions};

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -22,7 +22,7 @@ export const DEFAULT_LOCALE_DATA = {
   },
 };
 
-export function setLocaleDebug(value: boolean) {
+function setLocaleDebug(value: boolean) {
   localStorage.setItem('localeDebug', value ? '1' : '0');
   // eslint-disable-next-line no-console
   console.log(`Locale debug is: ${value ? 'on' : 'off'}. Reload page to apply changes!`);
@@ -176,7 +176,7 @@ type ComponentMap = Record<string, React.ReactNode>;
  * The top level group will be keyed as `root`. All other group names will have
  * been extracted from the template string.
  */
-export function parseComponentTemplate(template: string): ParsedTemplate {
+function parseComponentTemplate(template: string): ParsedTemplate {
   const parsed: ParsedTemplate = {};
   let groupId = 1;
 
@@ -241,7 +241,7 @@ export function parseComponentTemplate(template: string): ParsedTemplate {
  * Renders a parsed template into a React tree given a ComponentMap to use for
  * the parsed groups.
  */
-export function renderTemplate(
+function renderTemplate(
   template: ParsedTemplate,
   components: ComponentMap
 ): React.ReactNode {
@@ -317,7 +317,7 @@ function mark<T extends React.ReactNode>(node: T): T {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function format(formatString: string, args: FormatArg[]): React.ReactNode {
+function format(formatString: string, args: FormatArg[]): React.ReactNode {
   if (argsInvolveReact(args)) {
     return formatForReact(formatString, args);
   }
@@ -333,7 +333,7 @@ export function format(formatString: string, args: FormatArg[]): React.ReactNode
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function gettext(string: string, ...args: FormatArg[]): string {
+function gettext(string: string, ...args: FormatArg[]): string {
   const val: string = getClient().gettext(string);
 
   if (args.length === 0) {
@@ -357,7 +357,7 @@ export function gettext(string: string, ...args: FormatArg[]): string {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function ngettext(singular: string, plural: string, ...args: FormatArg[]): string {
+function ngettext(singular: string, plural: string, ...args: FormatArg[]): string {
   let countArg = 0;
 
   if (args.length > 0) {
@@ -401,7 +401,7 @@ export function ngettext(singular: string, plural: string, ...args: FormatArg[])
  *
  * You may recursively nest additional groups within the grouped string values.
  */
-export function gettextComponentTemplate(
+function gettextComponentTemplate(
   template: string,
   components: ComponentMap
 ): React.JSX.Element {

--- a/static/app/plugins/index.tsx
+++ b/static/app/plugins/index.tsx
@@ -18,8 +18,6 @@ contexts.sessionstack = SessionStackContextType;
 // Jira
 registry.add('jira', Jira);
 
-export {BasePlugin, DefaultIssuePlugin, registry};
-
 const add: typeof registry.add = registry.add.bind(registry);
 const get: typeof registry.get = registry.get.bind(registry);
 const isLoaded: typeof registry.isLoaded = registry.isLoaded.bind(registry);

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -45,5 +45,4 @@ const storeConfig: StoreDefinition & DebugMetaStoreInterface & Internals = {
 
 const DebugMetaStore = createStore(storeConfig);
 
-export {DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -6,7 +6,7 @@ import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 
 import type {StrictStoreDefinition} from './types';
 
-export function datetimeHasSameValue(
+function datetimeHasSameValue(
   a: PageFilters['datetime'],
   b: PageFilters['datetime']
 ): boolean {

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -144,7 +144,7 @@ export function getLocalToSystem(dateObj: moment.MomentInput): Date {
 /**
  * Get the beginning of day (e.g. midnight)
  */
-export function getStartOfDay(date: moment.MomentInput): Date {
+function getStartOfDay(date: moment.MomentInput): Date {
   return moment(date)
     .startOf('day')
     .startOf('hour')
@@ -197,7 +197,7 @@ export function shouldUse24Hours() {
 /**
  * Get a common date format
  */
-export function getDateFormat({year}: {year?: boolean}) {
+function getDateFormat({year}: {year?: boolean}) {
   // "Jan 1, 2022" or "Jan 1"
   return year ? 'MMM D, YYYY' : 'MMM D';
 }

--- a/static/app/utils/demoMode/utils.tsx
+++ b/static/app/utils/demoMode/utils.tsx
@@ -12,7 +12,7 @@ const SIGN_UP_MODAL_DELAY = 2 * 60 * 1000;
 
 const DEMO_MODE_EMAIL_KEY = 'demo-mode:email';
 
-export function openDemoSignupModal() {
+function openDemoSignupModal() {
   if (!isDemoModeActive()) {
     return;
   }

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -173,7 +173,7 @@ function hasProfile(event: Event) {
  * Function to determine if an event has source maps
  * by ensuring that every inApp frame has a valid sourcemap
  */
-export function eventHasSourceMaps(event: Event) {
+function eventHasSourceMaps(event: Event) {
   const inAppFrames = getExceptionFrames(event, true);
 
   // the map field tells us if it's sourcemapped
@@ -185,7 +185,7 @@ export function eventHasSourceMaps(event: Event) {
  * goes through symbolicator and has in-app frames, it looks for at least one in-app frame
  * to be successfully symbolicated. Otherwise falls back to checking for `rawStacktrace` field presence.
  */
-export function eventIsSymbolicated(event: Event) {
+function eventIsSymbolicated(event: Event) {
   const frames = getAllFrames(event, false);
   const fromSymbolicator = frames.some(frame => defined(frame.symbolicatorStatus));
 
@@ -221,7 +221,7 @@ export function eventIsSymbolicated(event: Event) {
 /**
  * Function to determine if an event has source context
  */
-export function eventHasSourceContext(event: Event) {
+function eventHasSourceContext(event: Event) {
   const frames = getAllFrames(event, false);
 
   return frames.some(frame => defined(frame.context) && !!frame.context.length);
@@ -230,7 +230,7 @@ export function eventHasSourceContext(event: Event) {
 /**
  * Function to determine if an event has local variables
  */
-export function eventHasLocalVariables(event: Event) {
+function eventHasLocalVariables(event: Event) {
   const frames = getAllFrames(event, false);
 
   return frames.some(frame => defined(frame.vars));
@@ -239,7 +239,7 @@ export function eventHasLocalVariables(event: Event) {
 /**
  * Function to get status about how many frames have source maps
  */
-export function getFrameBreakdownOfSourcemaps(event?: Event | null) {
+function getFrameBreakdownOfSourcemaps(event?: Event | null) {
   if (!event) {
     // return undefined if there is no event
     return {};
@@ -271,7 +271,7 @@ function getExceptionFrames(event: Event, inAppOnly: boolean) {
 /**
  * Returns all entries of type 'exception' of this event
  */
-export function getExceptionEntries(event: Event) {
+function getExceptionEntries(event: Event) {
   return (event.entries?.filter(entry => entry.type === EntryType.EXCEPTION) ||
     []) as EntryException[];
 }
@@ -346,14 +346,14 @@ function getNumberOfThreadsWithNames(event: Event) {
   return Math.max(...threadLengths);
 }
 
-export function eventHasExceptionGroup(event: Event) {
+function eventHasExceptionGroup(event: Event) {
   const exceptionEntries = getExceptionEntries(event);
   return exceptionEntries.some(entry =>
     entry.data.values?.some(({mechanism}) => mechanism?.is_exception_group)
   );
 }
 
-export function eventExceptionGroupHeight(event: Event) {
+function eventExceptionGroupHeight(event: Event) {
   try {
     const exceptionEntry = getExceptionEntries(event)[0];
 
@@ -368,7 +368,7 @@ export function eventExceptionGroupHeight(event: Event) {
   }
 }
 
-export function eventExceptionGroupWidth(event: Event) {
+function eventExceptionGroupWidth(event: Event) {
   try {
     const exceptionEntry = getExceptionEntries(event)[0];
 
@@ -383,7 +383,7 @@ export function eventExceptionGroupWidth(event: Event) {
   }
 }
 
-export function eventHasGraphQlRequest(event: Event) {
+function eventHasGraphQlRequest(event: Event) {
   const requestEntry = event.entries?.find(entry => entry.type === EntryType.REQUEST) as
     | EntryRequest
     | undefined;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -840,7 +840,7 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.MAX,
 ];
 
-export const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
+const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   ...AGGREGATION_FIELDS,
   [AggregationKey.COUNT]: {
     ...AGGREGATION_FIELDS[AggregationKey.COUNT],
@@ -1135,7 +1135,7 @@ export const MEASUREMENT_FIELDS: Record<WebVital | MobileVital, FieldDefinition>
   },
 };
 
-export const SPAN_OP_FIELDS: Record<SpanOpBreakdown, FieldDefinition> = {
+const SPAN_OP_FIELDS: Record<SpanOpBreakdown, FieldDefinition> = {
   [SpanOpBreakdown.SPANS_BROWSER]: {
     desc: t('Cumulative time based on the browser operation'),
     kind: FieldKind.METRICS,
@@ -1179,7 +1179,7 @@ type TraceFields =
   | SpanIndexedField.RESPONSE_CODE
   | SpanIndexedField.CACHE_HIT;
 
-export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
+const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   /** Indexed Fields */
   [SpanIndexedField.SPAN_ACTION]: {
     desc: t(

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-export function getInstallSnippet({
+function getInstallSnippet({
   params,
   packageManager,
   additionalPackages = [],

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -280,7 +280,7 @@ export function getCodeOwnerIcon(
       return <IconSentry size={iconSize} />;
   }
 }
-export const isSlackIntegrationUpToDate = (integrations: Integration[]): boolean => {
+const isSlackIntegrationUpToDate = (integrations: Integration[]): boolean => {
   return integrations.every(
     integration =>
       integration.provider.key !== 'slack' || integration.scopes?.includes('commands')

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -48,7 +48,7 @@ export enum MEPState {
   TRANSACTIONS_ONLY = 'transactionsOnly',
 }
 
-export const METRIC_SETTING_PARAM = 'metricSetting';
+const METRIC_SETTING_PARAM = 'metricSetting';
 export const METRIC_SEARCH_SETTING_PARAM = 'metricSearchSetting'; // TODO: Clean this up since we don't need multiple params in practice.
 
 const storageKey = 'performance.metrics-enhanced-setting';
@@ -71,7 +71,7 @@ export const MEPSetting = {
   },
 };
 
-export function canUseMetricsDevUI(organization: Organization) {
+function canUseMetricsDevUI(organization: Organization) {
   return organization.features.includes('performance-use-metrics');
 }
 

--- a/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -49,7 +49,7 @@ type FacetQuery = LocationQuery &
     tagKey?: string;
   };
 
-export function getRequestFunction(_props: QueryProps) {
+function getRequestFunction(_props: QueryProps) {
   const {aggregateColumn} = _props;
   function getTagExplorerRequestPayload(props: DiscoverQueryProps) {
     const {eventView} = props;

--- a/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
@@ -50,7 +50,7 @@ type FacetQuery = LocationQuery &
     tagKey?: string;
   };
 
-export function getRequestFunction(_props: QueryProps) {
+function getRequestFunction(_props: QueryProps) {
   const {aggregateColumn} = _props;
   function getTagExplorerRequestPayload(props: DiscoverQueryProps) {
     const {eventView} = props;

--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -49,7 +49,7 @@ type EventProps = RequestProps & {
   children: (props: EventChildrenProps) => React.ReactNode;
 };
 
-export function getTrendsRequestPayload(props: RequestProps) {
+function getTrendsRequestPayload(props: RequestProps) {
   const {eventView, projects} = props;
   const apiPayload: TrendsQuery = eventView?.getEventsAPIPayload(props.location);
   const trendFunction = getCurrentTrendFunction(props.location, props.trendFunctionField);

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -83,7 +83,7 @@ export function makeColorBufferForNodes(
   return colorBuffer;
 }
 
-export function makeColorBuffer(
+function makeColorBuffer(
   frames: readonly FlamegraphFrame[],
   colorMap: Map<any, ColorChannels>,
   fallbackColor: ColorChannels
@@ -132,7 +132,7 @@ export const makeStackToColor = (
   };
 };
 
-export function isNumber(input: unknown): input is number {
+function isNumber(input: unknown): input is number {
   return typeof input === 'number' && !isNaN(input);
 }
 
@@ -168,7 +168,7 @@ function frameLibraryKey(frame: FlamegraphFrame): string {
   return frame.frame.package ?? frame.frame.module ?? '';
 }
 
-export function defaultFrameKey(frame: FlamegraphFrame): string {
+function defaultFrameKey(frame: FlamegraphFrame): string {
   return `${frame.frame.name}:${frame.frame.package}:${frame.frame.module}`;
 }
 

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -156,7 +156,7 @@ export class DifferentialFlamegraph extends Flamegraph {
   }
 }
 
-export function diffFlamegraphTreeRecursive(
+function diffFlamegraphTreeRecursive(
   beforeFlamegraph: Flamegraph,
   afterFlamegraph: Flamegraph,
   negated: any

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
@@ -126,7 +126,7 @@ export function decodeFlamegraphStateFromQueryParams(
   return decoded;
 }
 
-export function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
+function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
   const highlightFrameToEncode: Record<string, string> = {};
 
   // For some frames we do not have a package (or name) if that happens we want to omit

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -5,11 +5,7 @@ import {Rect} from 'sentry/utils/profiling/speedscope';
 
 import {useKeyboardNavigation} from './useKeyboardNavigation';
 
-export function computeBestContextMenuPosition(
-  mouse: Rect,
-  container: Rect,
-  target: Rect
-) {
+function computeBestContextMenuPosition(mouse: Rect, container: Rect, target: Rect) {
   const maxY = Math.floor(container.height - target.height);
   const minY = container.top;
 

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 
-export function useRovingTabIndex(items: any[]) {
+function useRovingTabIndex(items: any[]) {
   const [tabIndex, setTabIndex] = useState<number | null>(null);
 
   const onKeyDown = useCallback(

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
@@ -9,7 +9,7 @@ import type {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtuali
 
 import type {VirtualizedState} from './useVirtualizedTreeReducer';
 
-export function updateGhostRow({
+function updateGhostRow({
   element,
   selectedNodeIndex,
   rowHeight,
@@ -156,7 +156,7 @@ export function cancelAnimationTimeout(frame: AnimationTimeoutId) {
   window.cancelAnimationFrame(frame.id);
 }
 
-export function findOptimisticStartIndex<T extends TreeLike>({
+function findOptimisticStartIndex<T extends TreeLike>({
   items,
   overscroll,
   rowHeight,

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -220,7 +220,7 @@ function importSentrySampledProfile(
   };
 }
 
-export function importSchema(
+function importSchema(
   input: Readonly<Profiling.Schema>,
   traceID: string,
   options: ImportOptions
@@ -440,7 +440,7 @@ export function importAndroidContinuousProfileChunk(
   };
 }
 
-export function importSentryContinuousProfileChunk(
+function importSentryContinuousProfileChunk(
   input: Readonly<Profiling.SentryContinousProfileChunk>,
   traceID: string,
   options: ImportOptions

--- a/static/app/utils/profiling/speedscope.tsx
+++ b/static/app/utils/profiling/speedscope.tsx
@@ -319,9 +319,9 @@ export function findRangeBinarySearch(
   }
 }
 
-export const fract = (x: number): number => x - Math.floor(x);
-export const triangle = (x: number): number => 2.0 * Math.abs(fract(x) - 0.5) - 1.0;
-export function fromLumaChromaHue(L: number, C: number, H: number): ColorChannels {
+const fract = (x: number): number => x - Math.floor(x);
+const triangle = (x: number): number => 2.0 * Math.abs(fract(x) - 0.5) - 1.0;
+function fromLumaChromaHue(L: number, C: number, H: number): ColorChannels {
   const hPrime = H / 60;
   const X = C * (1 - Math.abs((hPrime % 2) - 1));
   const [R1, G1, B1] =

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -5,7 +5,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {safeURL} from 'sentry/utils/url/safeURL';
 
 // remove leading and trailing whitespace and remove double spaces
-export function formatQueryString(query: string): string {
+function formatQueryString(query: string): string {
   return query.trim().replace(/\s+/g, ' ');
 }
 

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -20,11 +20,11 @@ interface RegionData {
   flag?: RegionFlagIndicator;
 }
 
-export function getRegionDisplayName(region: Region): string {
+function getRegionDisplayName(region: Region): string {
   return RegionDisplayName[region.name.toUpperCase()] ?? region.name;
 }
 
-export function getRegionFlagIndicator(region: Region): RegionFlagIndicator | undefined {
+function getRegionFlagIndicator(region: Region): RegionFlagIndicator | undefined {
   const regionName = region.name.toUpperCase();
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return RegionFlagIndicator[regionName];

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -12,4 +12,3 @@ import {darkTheme, lightTheme} from './theme';
 
 export {lightTheme, darkTheme};
 // @deprecated use useTheme hook instead of directly importing the theme. If you require a theme for your tests, use ThemeFixture.
-export default lightTheme;

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,6 +1,6 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
-export const ALLOWED_WILDCARD_FIELDS = [
+const ALLOWED_WILDCARD_FIELDS = [
   'span.description',
   'span.domain',
   'span.status_code',

--- a/static/app/utils/useBreakpoints.tsx
+++ b/static/app/utils/useBreakpoints.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@emotion/react';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
-export function useInstantRef<T>(value: T) {
+function useInstantRef<T>(value: T) {
   const ref = useRef(value);
   ref.current = value;
   return ref;

--- a/static/app/utils/useMutateApiToken.tsx
+++ b/static/app/utils/useMutateApiToken.tsx
@@ -17,7 +17,7 @@ type UpdateTokenQueryVariables = {
 type FetchApiTokenParameters = {
   tokenId: string;
 };
-export const makeFetchApiTokenKey = ({tokenId}: FetchApiTokenParameters): ApiQueryKey => [
+const makeFetchApiTokenKey = ({tokenId}: FetchApiTokenParameters): ApiQueryKey => [
   `/api-tokens/${tokenId}/`,
 ];
 

--- a/static/app/views/admin/adminRelays.tsx
+++ b/static/app/views/admin/adminRelays.tsx
@@ -103,6 +103,4 @@ class AdminRelays extends Component<Props, State> {
   }
 }
 
-export {AdminRelays};
-
 export default withApi(AdminRelays);

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -15,9 +15,9 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-export const DEFAULT_EAP_AGGREGATION = 'count';
-export const DEFAULT_EAP_FIELD = 'span.duration';
-export const DEFAULT_EAP_METRICS_ALERT_FIELD = `${DEFAULT_EAP_AGGREGATION}(${DEFAULT_EAP_FIELD})`;
+const DEFAULT_EAP_AGGREGATION = 'count';
+const DEFAULT_EAP_FIELD = 'span.duration';
+const DEFAULT_EAP_METRICS_ALERT_FIELD = `${DEFAULT_EAP_AGGREGATION}(${DEFAULT_EAP_FIELD})`;
 
 interface Props {
   aggregate: string;

--- a/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
+++ b/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
@@ -76,7 +76,7 @@ function incompatibleYAxis(eventView: EventView): boolean {
   return invalidFunction || invalidParameter;
 }
 
-export function checkMetricAlertCompatiablity(
+function checkMetricAlertCompatiablity(
   eventView: EventView
 ): IncompatibleQueryProperties {
   // Must have exactly one project selected and not -1 (all projects)

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -127,7 +127,7 @@ const MOST_TIME_PERIODS: readonly TimePeriod[] = [
  * TimeWindow determines data available in TimePeriod
  * If TimeWindow is small, lower TimePeriod to limit data points
  */
-export const AVAILABLE_TIME_PERIODS: Record<TimeWindow, readonly TimePeriod[]> = {
+const AVAILABLE_TIME_PERIODS: Record<TimeWindow, readonly TimePeriod[]> = {
   [TimeWindow.ONE_MINUTE]: [
     TimePeriod.SIX_HOURS,
     TimePeriod.ONE_DAY,

--- a/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.tsx
@@ -105,7 +105,7 @@ export function determineMultiSeriesConfidence(
   );
 }
 
-export function combineConfidence(a: Confidence, b: Confidence): Confidence {
+function combineConfidence(a: Confidence, b: Confidence): Confidence {
   if (!defined(a)) {
     return b;
   }

--- a/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
+++ b/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
@@ -13,11 +13,7 @@ interface MetricRuleParams {
   };
 }
 
-export function makeMetricRuleQueryKey({
-  orgSlug,
-  ruleId,
-  query,
-}: MetricRuleParams): ApiQueryKey {
+function makeMetricRuleQueryKey({orgSlug, ruleId, query}: MetricRuleParams): ApiQueryKey {
   return [`/organizations/${orgSlug}/alert-rules/${ruleId}/`, {query}];
 }
 

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -328,7 +328,7 @@ function transactionSupportedTags(org: Organization) {
 
 // Some data sets support all tags except some. For these cases, define the
 // omissions only
-export function datasetOmittedTags(
+function datasetOmittedTags(
   dataset: Dataset,
   org: Organization
 ):

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -116,7 +116,7 @@ function Actions() {
   );
 }
 
-export const SectionHeading = styled('h4')`
+const SectionHeading = styled('h4')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
 `;

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -5,7 +5,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {space} from 'sentry/styles/space';
 
-export const DEFAULT_CODECOV_DATETIME_SELECTION = {
+const DEFAULT_CODECOV_DATETIME_SELECTION = {
   start: null,
   end: null,
   utc: false,

--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -42,8 +42,6 @@ export function WidgetSyncContextProvider({
   );
 }
 
-export {WidgetSyncContext};
-
 export function useWidgetSyncContext(): WidgetSyncContext {
   const context = _useWidgetSyncContext();
 

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -135,11 +135,7 @@ function getEventsTableFieldOptions(
   });
 }
 
-export function getCustomEventsFieldRenderer(
-  field: string,
-  meta: MetaType,
-  widget?: Widget
-) {
+function getCustomEventsFieldRenderer(field: string, meta: MetaType, widget?: Widget) {
   if (field === 'id') {
     return renderEventIdAsLinkable;
   }
@@ -151,7 +147,7 @@ export function getCustomEventsFieldRenderer(
   return getFieldRenderer(field, meta, false);
 }
 
-export function getEventsRequest(
+function getEventsRequest(
   api: Client,
   query: WidgetQuery,
   organization: Organization,
@@ -192,7 +188,7 @@ export function getEventsRequest(
 }
 
 // The y-axis options are a strict set of available aggregates
-export function filterYAxisOptions(_displayType: DisplayType) {
+function filterYAxisOptions(_displayType: DisplayType) {
   return (option: FieldValueOption) => {
     return ERRORS_AGGREGATION_FUNCTIONS.includes(
       option.value.meta.name as AggregationKey

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -457,7 +457,7 @@ export function getCustomEventsFieldRenderer(
   return getFieldRenderer(field, meta, false);
 }
 
-export function getEventsRequest(
+function getEventsRequest(
   url: string,
   api: Client,
   query: WidgetQuery,

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -309,7 +309,7 @@ function getSeriesRequest(
 }
 
 // Filters the primary options in the sort by selector
-export function filterSeriesSortOptions(columns: Set<string>) {
+function filterSeriesSortOptions(columns: Set<string>) {
   return (option: FieldValueOption) => {
     if (option.value.kind === FieldValueKind.FUNCTION) {
       return true;

--- a/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
@@ -9,7 +9,7 @@ import {
   resolveDerivedStatusFields,
 } from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 
-export function getSeriesName(
+function getSeriesName(
   field: string,
   group: SessionApiResponse['groups'][number],
   queryAlias?: string

--- a/static/app/views/dashboards/widgetBuilder/components/common/draggableUtils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/draggableUtils.tsx
@@ -13,10 +13,10 @@ export const WIDGET_PREVIEW_DRAG_ID = 'widget-preview-draggable';
 
 export const SIDEBAR_HEIGHT = 54;
 
-export const DEFAULT_TRANSLATE_COORDINATES = {x: 0, y: 0};
+const DEFAULT_TRANSLATE_COORDINATES = {x: 0, y: 0};
 const DEFAULT_SPACING = parseInt(space(2).replace('px', ''), 10);
-export const DEFAULT_LEFT = DEFAULT_SPACING;
-export const DEFAULT_TOP = SIDEBAR_HEIGHT + DEFAULT_SPACING; // 54px sidebar + 16px space
+const DEFAULT_LEFT = DEFAULT_SPACING;
+const DEFAULT_TOP = SIDEBAR_HEIGHT + DEFAULT_SPACING; // 54px sidebar + 16px space
 
 export const DEFAULT_WIDGET_DRAG_POSITIONING: WidgetDragPositioning = {
   initialTranslate: DEFAULT_TRANSLATE_COORDINATES,
@@ -25,9 +25,9 @@ export const DEFAULT_WIDGET_DRAG_POSITIONING: WidgetDragPositioning = {
   top: DEFAULT_TOP,
 };
 
-export const DRAGGABLE_PREVIEW_HEIGHT = 200;
-export const DRAGGABLE_PREVIEW_WIDTH = 300;
-export const PREVIEW_HEIGHT = 400;
+const DRAGGABLE_PREVIEW_HEIGHT = 200;
+const DRAGGABLE_PREVIEW_WIDTH = 300;
+const PREVIEW_HEIGHT = 400;
 
 export const DRAGGABLE_PREVIEW_HEIGHT_PX = `${DRAGGABLE_PREVIEW_HEIGHT}px`;
 export const DRAGGABLE_PREVIEW_WIDTH_PX = `${DRAGGABLE_PREVIEW_WIDTH}px`;

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -257,7 +257,7 @@ function WidgetBuilderQueryFilterBuilder({
 
 export default WidgetBuilderQueryFilterBuilder;
 
-export function DeleteButton({onDelete}: {onDelete: () => void}) {
+function DeleteButton({onDelete}: {onDelete: () => void}) {
   return (
     <Button
       size="zero"

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -57,7 +57,7 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 export const NONE = 'none';
 
-export const NONE_AGGREGATE = {
+const NONE_AGGREGATE = {
   textValue: t('field'),
   label: tct('[emphasis:field]', {emphasis: <em />}),
   value: NONE,
@@ -834,7 +834,7 @@ function Visualize({error, setError}: VisualizeProps) {
 
 export default Visualize;
 
-export function renderTag(kind: FieldValueKind, label: string, dataType?: string) {
+function renderTag(kind: FieldValueKind, label: string, dataType?: string) {
   if (dataType) {
     switch (dataType) {
       case 'boolean':

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -190,7 +190,7 @@ const StyledTransparentLoadingMask = styled((props: any) => (
   align-items: center;
 `;
 
-export function LoadingScreen({loading}: {loading: boolean}) {
+function LoadingScreen({loading}: {loading: boolean}) {
   if (!loading) {
     return null;
   }

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -10,7 +10,7 @@ export type WidgetTemplate = Widget & {
   description: string;
 };
 
-export const getDefaultWidgets = (organization: Organization) => {
+const getDefaultWidgets = (organization: Organization) => {
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const transactionsWidgets = [
     {

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -110,7 +110,7 @@ const getMeasurementTags = (
   }, measurementsWithKind);
 };
 
-export const getHasTag = (tags: TagCollection) => ({
+const getHasTag = (tags: TagCollection) => ({
   key: FieldKey.HAS,
   name: 'Has property',
   values: Object.keys(tags).sort((a, b) => {

--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -22,7 +22,7 @@ export function NoContext({isLoading}: NoContextProps) {
   );
 }
 
-export const HoverWrapper = styled('div')`
+const HoverWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.75)};

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -747,7 +747,7 @@ const StyledTooltip = styled(Tooltip)`
   max-width: max-content;
 `;
 
-export const StyledLink = styled(Link)`
+const StyledLink = styled(Link)`
   & div {
     display: inline;
   }

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -62,7 +62,7 @@ export const EXPLORE_CHART_TYPE_OPTIONS = [
   },
 ];
 
-export const EXPLORE_CHART_GROUP = 'explore-charts_group';
+const EXPLORE_CHART_GROUP = 'explore-charts_group';
 
 export function ExploreCharts({
   canUsePreviousResults,

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -37,7 +37,7 @@ import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
-export const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
+const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
 
 interface SchemaHintsListProps extends SchemaHintsPageParams {
   numberTags: TagCollection;

--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -50,7 +50,7 @@ const SCHEMA_HINTS_HIDDEN_KEYS_LOGS = [
 ];
 
 // Unlike ORDER_KEYS, hidden keys are completely omitted from the schema hints list.
-export const SCHEMA_HINTS_HIDDEN_KEYS: string[] = [
+const SCHEMA_HINTS_HIDDEN_KEYS: string[] = [
   ...new Set([...SCHEMA_HINTS_HIDDEN_KEYS_LOGS]),
 ];
 

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -18,7 +18,7 @@ type TraceItemSearchQueryBuilderProps = {
   stringAttributes: TagCollection;
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
-export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
+const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
   if (!supportedAggregates?.length) {
     return {};
   }

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -114,7 +114,7 @@ export function LogsPageParamsProvider({
   );
 }
 
-export const useLogsPageParams = _useLogsPageParams;
+const useLogsPageParams = _useLogsPageParams;
 
 const decodeLogsQuery = (location: Location): string => {
   if (!location.query?.[LOGS_QUERY_KEY]) {

--- a/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
@@ -13,7 +13,7 @@ export function getDatasetFromLocation(location: Location): DiscoverDatasets | u
   return parseDataset(rawDataset);
 }
 
-export function parseDataset(rawDataset: string | undefined) {
+function parseDataset(rawDataset: string | undefined) {
   if (rawDataset === 'spansIndexed') {
     return DiscoverDatasets.SPANS_INDEXED;
   }

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -50,7 +50,7 @@ interface UseTrackAnalyticsProps {
   tracesTableResult?: TracesTableResult;
 }
 
-export function useTrackAnalytics({
+function useTrackAnalytics({
   queryType,
   aggregatesTableResult,
   spansTableResult,
@@ -480,7 +480,7 @@ function computeTotals(
   });
 }
 
-export function computeEmptyBucketsForSeries(series: Pick<TimeSeries, 'data'>): number {
+function computeEmptyBucketsForSeries(series: Pick<TimeSeries, 'data'>): number {
   let emptyBucketsForSeries = 0;
   for (const item of series.data) {
     if (item.value === 0 || item.value === null) {

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -75,7 +75,7 @@ function SeverityCircle(props: {
   );
 }
 
-export function SeverityTextRenderer(props: LogFieldRendererProps) {
+function SeverityTextRenderer(props: LogFieldRendererProps) {
   const attribute_value = props.item.value as string;
   const _severityNumber = props.tableResultLogRow?.[OurLogKnownFieldKey.SEVERITY_NUMBER];
   const severityNumber = _severityNumber ? Number(_severityNumber) : null;
@@ -113,7 +113,7 @@ export function SeverityCircleRenderer(props: Omit<LogFieldRendererProps, 'item'
   );
 }
 
-export function TimestampRenderer(props: LogFieldRendererProps) {
+function TimestampRenderer(props: LogFieldRendererProps) {
   return (
     <LogDate align={props.extra.align}>
       <DateTime seconds date={props.item.value} />
@@ -198,7 +198,7 @@ export const LogAttributesRendererMap: Record<
   [OurLogKnownFieldKey.TRACE_ID]: TraceIDRenderer,
 };
 
-export function getLogFieldRenderer(field: OurLogFieldKey) {
+function getLogFieldRenderer(field: OurLogFieldKey) {
   return LogAttributesRendererMap[field];
 }
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -82,7 +82,7 @@ type SpanTabProps = {
   relativeOptions: Record<string, React.ReactNode>;
 };
 
-export function SpansTabContentImpl({
+function SpansTabContentImpl({
   defaultPeriod,
   maxPickableDays,
   relativeOptions,

--- a/static/app/views/explore/spans/tour.tsx
+++ b/static/app/views/explore/spans/tour.tsx
@@ -46,7 +46,7 @@ interface ExploreSpansTourModalProps {
   handleStartTour: () => void;
 }
 
-export function ExploreSpansTourModal({
+function ExploreSpansTourModal({
   closeModal,
   handleDismissTour,
   handleStartTour,

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -127,7 +127,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
   );
 }
 
-export const SpanTimeChartsContainer = styled('div')`
+const SpanTimeChartsContainer = styled('div')`
   margin-bottom: ${space(2)};
 `;
 

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -192,6 +192,3 @@ const RingBar = styled('circle')<{
 `;
 
 export default PerformanceScoreRing;
-
-// We export components to allow for css selectors
-export {RingBackground, RingBar, Text as RingText};

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -117,7 +117,7 @@ type VitalMeterProps = {
   onClick?: (webVital: WebVitals) => void;
 };
 
-export function VitalMeter({
+function VitalMeter({
   webVital,
   showTooltip,
   score,

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -75,7 +75,7 @@ export type RowWithScoreAndOpportunity = Row & Score & Opportunity;
 export type WebVitals = 'lcp' | 'fcp' | 'cls' | 'ttfb' | 'inp';
 
 // TODO: Refactor once stored scores are GA'd
-export const SORTABLE_SCORE_FIELDS = [
+const SORTABLE_SCORE_FIELDS = [
   'totalScore',
   'opportunity',
   'avg(measurements.score.total)',
@@ -92,7 +92,7 @@ export const SORTABLE_FIELDS = [
   ...SORTABLE_SCORE_FIELDS,
 ] as const;
 
-export const SORTABLE_INDEXED_SCORE_FIELDS = [
+const SORTABLE_INDEXED_SCORE_FIELDS = [
   'totalScore',
   'measurements.score.total',
   'inpScore',

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -56,7 +56,7 @@ function getCurrentTabSelection(selectedTab: any) {
   return LandingDisplayField.OVERVIEW;
 }
 
-export function PageOverview() {
+function PageOverview() {
   const navigate = useNavigate();
   const moduleURL = useModuleURL('vital');
   const organization = useOrganization();

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -202,6 +202,6 @@ const ChartContainer = styled('div')<{height?: string | number}>`
     p.height ? (typeof p.height === 'string' ? p.height : `${p.height}px`) : '220px'};
 `;
 
-export const ModalChartContainer = styled('div')`
+const ModalChartContainer = styled('div')`
   height: 360px;
 `;

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -134,7 +134,7 @@ const StyledIconBuisness = styled(IconBusiness)`
   margin-left: auto;
 `;
 
-export const UpsellFooterHook = HookOrDefault({
+const UpsellFooterHook = HookOrDefault({
   hookName: 'component:insights-date-range-query-limit-footer',
   defaultComponent: () => undefined,
 });

--- a/static/app/views/insights/common/components/releaseSelector.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.tsx
@@ -39,7 +39,7 @@ type Props = {
   triggerLabelPrefix?: string;
 };
 
-export function ReleaseSelector({
+function ReleaseSelector({
   selectorKey,
   selectorValue,
   triggerLabelPrefix,

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -37,7 +37,7 @@ const {
   CACHE_MISS_RATE,
 } = SpanFunction;
 
-export const SORTABLE_FIELDS = new Set([
+const SORTABLE_FIELDS = new Set([
   `avg(${SPAN_SELF_TIME})`,
   `avg(${SPAN_DURATION})`,
   `sum(${SPAN_SELF_TIME})`,
@@ -121,7 +121,7 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
   );
 };
 
-export const getAlignment = (key: string): Alignments => {
+const getAlignment = (key: string): Alignments => {
   const result = parseFunction(key);
 
   if (result) {

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -173,7 +173,7 @@ export const useDiscover = <
   };
 };
 
-export function getEventView(
+function getEventView(
   search: MutableSearch | string | undefined,
   fields: string[] = [],
   sorts: Sort[] = [],

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/views/insights/common/utils/retryHandlers';
 import {TrackResponse} from 'sentry/views/insights/common/utils/trackResponse';
 
-export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
+const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 
 const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
 const FOURTEEN_DAYS = 14 * 24 * 60 * 60 * 1000;
@@ -82,7 +82,7 @@ export function useSpansQuery<T = any[]>({
   throw new Error('eventView argument must be defined when Starfish useDiscover is true');
 }
 
-export function useWrappedDiscoverTimeseriesQuery<T>({
+function useWrappedDiscoverTimeseriesQuery<T>({
   eventView,
   enabled,
   initialData,

--- a/static/app/views/insights/common/utils/centerTruncate.ts
+++ b/static/app/views/insights/common/utils/centerTruncate.ts
@@ -2,7 +2,7 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 
 export const ELLIPSIS = '\u2026';
 
-export function centerTruncate(value: string, maxLength = 20) {
+function centerTruncate(value: string, maxLength = 20) {
   const divider = Math.floor(maxLength / 2);
   if (value?.length > maxLength) {
     return `${value.slice(0, divider)}${ELLIPSIS}${value.slice(value.length - divider)}`;

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -34,7 +34,7 @@ type Props = {
   monitorEnvs: MonitorEnvironment[];
 };
 
-export const checkStatusToIndicatorStatus: Record<
+const checkStatusToIndicatorStatus: Record<
   CheckInStatus,
   StatusIndicatorProps['status']
 > = {

--- a/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
@@ -22,7 +22,7 @@ interface Props {
   monitorEnv: MonitorEnvironment;
 }
 
-export const statusIconColorMap: Record<MonitorStatus, StatusNotice> = {
+const statusIconColorMap: Record<MonitorStatus, StatusNotice> = {
   ok: {
     icon: <IconCheckmark color="successText" />,
     color: 'successText',

--- a/static/app/views/insights/crons/utils/useMonitorCheckIns.tsx
+++ b/static/app/views/insights/crons/utils/useMonitorCheckIns.tsx
@@ -17,7 +17,7 @@ interface MonitorChecksParameters {
   queryParams?: Record<string, string | string[] | null | undefined>;
 }
 
-export function makeMonitorCheckInsQueryKey({
+function makeMonitorCheckInsQueryKey({
   orgSlug,
   projectSlug,
   monitorIdOrSlug,

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelineSpansTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelineSpansTable.tsx
@@ -70,7 +70,7 @@ type ValidSort = Sort & {
     | SpanIndexedField.TIMESTAMP;
 };
 
-export function isAValidSort(sort: Sort): sort is ValidSort {
+function isAValidSort(sort: Sort): sort is ValidSort {
   return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
 }
 

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -86,7 +86,7 @@ type ValidSort = Sort & {
   field: 'epm()' | 'avg(span.duration)';
 };
 
-export function isAValidSort(sort: Sort): sort is ValidSort {
+function isAValidSort(sort: Sort): sort is ValidSort {
   return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
 }
 export function PipelinesTable() {

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -42,7 +42,7 @@ type Query = {
   'span.description'?: string;
 };
 
-export function LLMMonitoringPage({params}: Props) {
+function LLMMonitoringPage({params}: Props) {
   const location = useLocation<Query>();
 
   const organization = useOrganization();

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -13,7 +13,7 @@ import {PipelinesTable} from 'sentry/views/insights/llmMonitoring/components/tab
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export function LLMMonitoringPage() {
+function LLMMonitoringPage() {
   return (
     <Layout.Page>
       <AiHeader module={ModuleName.AI} />

--- a/static/app/views/insights/mobile/appStarts/components/breakdown.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/breakdown.tsx
@@ -14,7 +14,7 @@ interface BreakdownGroup {
   name: string;
 }
 
-export function TooltipContents({
+function TooltipContents({
   row,
   total,
   breakdownGroups,

--- a/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
@@ -9,7 +9,7 @@ import {
 import ScreensTemplate from 'sentry/views/insights/mobile/common/components/screensTemplate';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export function InitializationModule() {
+function InitializationModule() {
   return (
     <ScreensTemplate
       additionalSelectors={<StartTypeSelector />}

--- a/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
@@ -16,7 +16,7 @@ import {MODULE_TITLE} from 'sentry/views/insights/mobile/screenRendering/setting
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export function ScreenRenderingModule() {
+function ScreenRenderingModule() {
   const {isProjectCrossPlatform} = useCrossPlatformProject();
 
   return (

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
@@ -26,7 +26,7 @@ import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader'
 import {ModuleName} from 'sentry/views/insights/types';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 
-export function PageloadModule() {
+function PageloadModule() {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const {isProjectCrossPlatform} = useCrossPlatformProject();

--- a/static/app/views/insights/mobile/ui/views/uiLandingPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/uiLandingPage.tsx
@@ -8,7 +8,7 @@ import {
 } from 'sentry/views/insights/mobile/ui/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export function ResponsivenessModule() {
+function ResponsivenessModule() {
   return (
     <ScreensTemplate
       content={<UIScreens />}

--- a/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
@@ -71,7 +71,7 @@ const APDEX_TOOLTIP = tct(
   }
 );
 
-export const BACKEND_COLUMN_TITLES = [
+const BACKEND_COLUMN_TITLES = [
   {title: 'http method'},
   {title: 'transaction'},
   {title: 'operation'},

--- a/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
@@ -66,7 +66,7 @@ const DURATION_TOOLTIP = tct(
   }
 );
 
-export const FRONTEND_COLUMN_TITLES = [
+const FRONTEND_COLUMN_TITLES = [
   {title: 'transaction'},
   {title: 'operation'},
   {title: 'project'},

--- a/static/app/views/insights/pages/platform/nextjs/features.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/features.tsx
@@ -4,7 +4,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 
-export function hasNextJsInsightsFeature(organization: Organization) {
+function hasNextJsInsightsFeature(organization: Organization) {
   return organization.features.includes('nextjs-insights');
 }
 

--- a/static/app/views/insights/queues/components/tables/transactionsTable.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.tsx
@@ -94,7 +94,7 @@ type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];
 };
 
-export function isAValidSort(sort: Sort): sort is ValidSort {
+function isAValidSort(sort: Sort): sort is ValidSort {
   return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
 }
 

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -26,7 +26,7 @@ import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/rele
 import useProjectHasSessions from 'sentry/views/insights/sessions/queries/useProjectHasSessions';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export function SessionsOverview() {
+function SessionsOverview() {
   const {view = ''} = useDomainViewFilters();
   const [filters, setFilters] = useState<string[]>(['']);
 

--- a/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
@@ -16,7 +16,7 @@ interface UptimeChecksParameters {
   statsPeriod?: string;
 }
 
-export function makeUptimeChecksQueryKey({
+function makeUptimeChecksQueryKey({
   orgSlug,
   projectSlug,
   uptimeAlertId,

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -36,7 +36,7 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
  *
  * Returns a function that can be used to reset the modal.
  */
-export function useIssueDetailsPromoModal() {
+function useIssueDetailsPromoModal() {
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
   const {mutate: mutateAssistant} = useMutateAssistant();

--- a/static/app/views/issueDetails/actions/publishModal.tsx
+++ b/static/app/views/issueDetails/actions/publishModal.tsx
@@ -28,7 +28,7 @@ interface PublishIssueModalProps extends ModalRenderProps {
 
 type UrlRef = React.ElementRef<typeof AutoSelectText>;
 
-export function getShareUrl(group: Group) {
+function getShareUrl(group: Group) {
   const path = `/share/issue/${group.shareId}/`;
   const {host, protocol} = window.location;
   return `${protocol}//${host}${path}`;

--- a/static/app/views/issueDetails/groupActivity.tsx
+++ b/static/app/views/issueDetails/groupActivity.tsx
@@ -41,7 +41,7 @@ interface GroupActivityProps {
   group: Group;
 }
 
-export function GroupActivity({group}: GroupActivityProps) {
+function GroupActivity({group}: GroupActivityProps) {
   const organization = useOrganization();
   const {activity: activities, count, id: groupId} = group;
   const groupCount = Number(count);

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -51,7 +51,7 @@ interface GroupHeaderTabsProps extends Pick<Props, 'baseUrl' | 'group' | 'projec
   eventRoute: LocationDescriptor;
 }
 
-export function GroupHeaderTabs({
+function GroupHeaderTabs({
   baseUrl,
   disabledTabs,
   eventRoute,

--- a/static/app/views/issueDetails/metricIssues/useMetricAnomalies.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricAnomalies.tsx
@@ -14,7 +14,7 @@ interface MetricAnomaliesParams {
   };
 }
 
-export function makeMetricAnomaliesQueryKey(params: MetricAnomaliesParams): ApiQueryKey {
+function makeMetricAnomaliesQueryKey(params: MetricAnomaliesParams): ApiQueryKey {
   const {orgSlug, ruleId, query} = params;
   return [`/organizations/${orgSlug}/alert-rules/${ruleId}/anomalies/`, {query}];
 }

--- a/static/app/views/issueDetails/metricIssues/useMetricIncidents.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricIncidents.tsx
@@ -17,7 +17,7 @@ interface MetricIncidentsParams {
   };
 }
 
-export function makeMetricIncidentsQueryKey(params: MetricIncidentsParams): ApiQueryKey {
+function makeMetricIncidentsQueryKey(params: MetricIncidentsParams): ApiQueryKey {
   const {orgSlug, query} = params;
   return [
     `/organizations/${orgSlug}/incidents/`,

--- a/static/app/views/issueDetails/streamline/eventListTable.tsx
+++ b/static/app/views/issueDetails/streamline/eventListTable.tsx
@@ -156,7 +156,7 @@ export const HeaderItem = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-export const StreamlineGridEditable = styled('div')`
+const StreamlineGridEditable = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -406,7 +406,7 @@ interface IssueViewsStateProviderProps extends Omit<TabsProps<any>, 'children'> 
   router: InjectedRouter;
 }
 
-export function IssueViewsStateProvider({
+function IssueViewsStateProvider({
   children,
   initialViews,
   router,

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -486,7 +486,7 @@ export default IssueViewsIssueListHeader;
  * If project/environemnts is undefined, it equates to an empty array. If it is a single value,
  * it is converted to single element array.
  */
-export const normalizeProjectsEnvironments = (
+const normalizeProjectsEnvironments = (
   project: string[] | string | undefined,
   env: string[] | string | undefined
 ): {queryEnvs: string[] | undefined; queryProjects: number[] | undefined} => {

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -14,7 +14,7 @@ interface FetchIssueCountsParameters {
   useGroupSnubaDataset?: boolean;
 }
 
-export const makeFetchIssueCounts = ({
+const makeFetchIssueCounts = ({
   orgSlug,
   ...requestParams
 }: FetchIssueCountsParameters): ApiQueryKey => [

--- a/static/app/views/lastKnownRouteContextProvider.tsx
+++ b/static/app/views/lastKnownRouteContextProvider.tsx
@@ -7,7 +7,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export const LastKnownRouteContext = createContext<string>('<unknown>');
+const LastKnownRouteContext = createContext<string>('<unknown>');
 
 export function useLastKnownRoute() {
   return useContext(LastKnownRouteContext);

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -412,7 +412,7 @@ const StyledNavLink = styled(Link, {
     `}
 `;
 
-export const NavLink = withChonk(StyledNavLink, ChonkNavLink);
+const NavLink = withChonk(StyledNavLink, ChonkNavLink);
 
 const ChonkNavButton = styled(Button, {
   shouldForwardProp: prop => prop !== 'isMobile',

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -313,7 +313,7 @@ const StyledNavItem = styled(Link)<ItemProps>`
     `}
 `;
 
-export const Item = withChonk(StyledNavItem, ChonkItem);
+const Item = withChonk(StyledNavItem, ChonkItem);
 
 const ItemText = styled('span')`
   ${p => p.theme.overflowEllipsis}

--- a/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews.tsx
@@ -53,7 +53,7 @@ export const convertGSVtoIssueView = (gsv: StarredGroupSearchView): NavIssueView
   };
 };
 
-export const convertIssueViewToGSV = (view: NavIssueView): StarredGroupSearchView => {
+const convertIssueViewToGSV = (view: NavIssueView): StarredGroupSearchView => {
   return {
     id: view.id,
     name: view.label,

--- a/static/app/views/nav/tour/tour.tsx
+++ b/static/app/views/nav/tour/tour.tsx
@@ -29,7 +29,7 @@ export const enum StackedNavigationTour {
   SETTINGS = 'settings',
 }
 
-export const ORDERED_STACKED_NAVIGATION_TOUR = [
+const ORDERED_STACKED_NAVIGATION_TOUR = [
   StackedNavigationTour.ISSUES,
   StackedNavigationTour.EXPLORE,
   StackedNavigationTour.DASHBOARDS,
@@ -70,9 +70,9 @@ export const STACKED_NAVIGATION_TOUR_CONTENT = {
   },
 };
 
-export const STACKED_NAVIGATION_TOUR_GUIDE_KEY = 'tour.stacked_navigation';
+const STACKED_NAVIGATION_TOUR_GUIDE_KEY = 'tour.stacked_navigation';
 
-export const StackedNavigationTourContext =
+const StackedNavigationTourContext =
   createContext<TourContextType<StackedNavigationTour> | null>(null);
 
 export function useStackedNavigationTour(): TourContextType<StackedNavigationTour> {
@@ -291,7 +291,7 @@ export function useTourModal() {
   }, [shouldShowTourModal, startTour, mutateAssistant, endTour]);
 }
 
-export const NAV_REFERRER = 'nav-tour';
+const NAV_REFERRER = 'nav-tour';
 
 export function useIsNavTourActive() {
   const location = useLocation();

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -90,7 +90,7 @@ export function getFormatUsageOptions(
  * If you are not displaying usage numbers, it might be better to use
  * `formatAbbreviatedNumber` in 'sentry/utils/formatters'
  */
-export function abbreviateUsageNumber(n: number) {
+function abbreviateUsageNumber(n: number) {
   if (n >= BILLION) {
     return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
   }

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -33,7 +33,7 @@ type Props = {
 };
 
 // adapted from https://stackoverflow.com/questions/11397239/rounding-up-for-a-graph-maximum
-export function computeAxisMax(data: Series[]) {
+function computeAxisMax(data: Series[]) {
   // assumes min is 0
   const valuesDict = data.map(value => value.data.map(point => point.value));
   const maxValue = max(valuesDict.map(max)) as number;

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -102,7 +102,7 @@ function trackDataComponentClicks(
   });
 }
 
-export function DataDisplay<T extends WidgetDataConstraint>(
+function DataDisplay<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> &
     WidgetDataProps<T> & {
       containerType: PerformanceWidgetContainerTypes;

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -221,7 +221,7 @@ function WidgetContainerInner(props: Props) {
   }
 }
 
-export function WidgetInteractiveTitle({
+function WidgetInteractiveTitle({
   chartSetting,
   eventView,
   setChartSetting,
@@ -287,7 +287,7 @@ const StyledCompactSelect = styled(CompactSelect)`
   }
 `;
 
-export function WidgetContainerActions({
+function WidgetContainerActions({
   chartSetting,
   eventView,
   setChartSetting,

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -68,7 +68,7 @@ type ComponentData = React.ComponentProps<
   GenericPerformanceWidgetProps<DataType>['Visualizations'][0]['component']
 >;
 
-export function transformEventsChartRequest<T extends WidgetDataConstraint>(
+function transformEventsChartRequest<T extends WidgetDataConstraint>(
   widgetProps: WidgetPropUnion<T>,
   results: RenderProps,
   _: QueryDefinitionWithKey<T>

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -191,7 +191,7 @@ export const Subtitle = styled('span')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-export const HighlightNumber = styled('div')<{color?: string}>`
+const HighlightNumber = styled('div')<{color?: string}>`
   color: ${p => p.color};
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -301,4 +301,4 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   );
 }
 
-export const TrendsChart = withProjects(Chart);
+const TrendsChart = withProjects(Chart);

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -83,7 +83,7 @@ function getVitalFields(baseField: string) {
   return vitalFields;
 }
 
-export function transformFieldsWithStops(props: {
+function transformFieldsWithStops(props: {
   field: string;
   fields: string[];
   vitalStops: ChartDefinition['vitalStops'];
@@ -462,7 +462,7 @@ function getVitalDataForListItem(
   return vitalData;
 }
 
-export const VitalBarCell = styled(RightAlignedCell)`
+const VitalBarCell = styled(RightAlignedCell)`
   width: 120px;
   margin-left: ${space(1)};
   margin-right: ${space(1)};

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -69,7 +69,7 @@ type VitalPillProps = {
   vital: Vital;
 };
 
-export function VitalPill({vital, score, meterValue}: VitalPillProps) {
+function VitalPill({vital, score, meterValue}: VitalPillProps) {
   const status = score === undefined || isNaN(score) ? 'none' : scoreToStatus(score);
   const webVitalsConfig = WEB_VITALS_METERS_CONFIG;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -49,7 +49,7 @@ import {usePerformanceGeneralProjectSettings} from 'sentry/views/performance/uti
 
 const formatter = new SQLishFormatter();
 
-export function hasFormattedSpanDescription(node: TraceTreeNode<TraceTree.Span>) {
+function hasFormattedSpanDescription(node: TraceTreeNode<TraceTree.Span>) {
   const span = node.value;
   const resolvedModule: ModuleName = resolveSpanModule(
     span.sentry_tags?.op,

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -345,7 +345,7 @@ function findRenderedItems({
   return {rendered, virtualized};
 }
 
-export function findOptimisticStartIndex({
+function findOptimisticStartIndex({
   items,
   overscroll,
   rowHeight,

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
@@ -118,7 +118,7 @@ const BOOLEAN_KEYS = new Set([
   ...withPrefixedPermutation('span', SPAN_BOOLEAN_KEYS),
 ]);
 
-export const TRACE_SEARCH_CONFIG: SearchConfig = {
+const TRACE_SEARCH_CONFIG: SearchConfig = {
   ...defaultConfig,
   textOperatorKeys: TEXT_KEYS,
   durationKeys: DURATION_KEYS,

--- a/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
@@ -14,10 +14,10 @@ import {storeTraceViewPreferences, type TracePreferencesState} from './tracePref
 
 interface TraceStateContext {}
 
-export const TraceStateContext = createContext<TraceReducerState | null>(null);
-export const TraceStateDispatchContext =
+const TraceStateContext = createContext<TraceReducerState | null>(null);
+const TraceStateDispatchContext =
   createContext<React.Dispatch<TraceReducerAction> | null>(null);
-export const TraceStateEmitterContext = createContext<DispatchingReducerEmitter<
+const TraceStateEmitterContext = createContext<DispatchingReducerEmitter<
   typeof TraceReducer
 > | null>(null);
 

--- a/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
@@ -510,7 +510,7 @@ function NewTraceView({
 }
 export default memo(NewTraceView);
 
-export const StyledTracePanel = styled(Panel)`
+const StyledTracePanel = styled(Panel)`
   height: 100%;
   overflow-x: visible;
 

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -510,9 +510,7 @@ function SpanDetailsBody({
   );
 }
 
-export function isEventDetail(
-  detail: EventDetail | SpanDetailProps
-): detail is EventDetail {
+function isEventDetail(detail: EventDetail | SpanDetailProps): detail is EventDetail {
   return !('span' in detail);
 }
 

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -262,7 +262,7 @@ type EventDetailHeaderProps = {
   type?: 'transaction' | 'event';
 };
 
-export function getEventDetailHeaderCols({
+function getEventDetailHeaderCols({
   hasReplay,
   isBackendProject,
   type,

--- a/static/app/views/performance/transactionDetails/styles.tsx
+++ b/static/app/views/performance/transactionDetails/styles.tsx
@@ -59,7 +59,7 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin: 0;
 `;
 
-export const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
+const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
   color: ${p => (p.type === 'error' ? p.theme.error : p.theme.subText)};
   font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -56,7 +56,7 @@ type Props = {
   webVital?: WebVital;
 };
 
-export const TRANSACTIONS_LIST_TITLES: readonly string[] = [
+const TRANSACTIONS_LIST_TITLES: readonly string[] = [
   t('event id'),
   t('user'),
   t('operation duration'),

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -60,7 +60,7 @@ type TagColumn = GridColumnOrder<ColumnKeys> & {
   field: string;
   canSort?: boolean;
 };
-export const TAG_EXPLORER_COLUMN_ORDER: TagColumn[] = [
+const TAG_EXPLORER_COLUMN_ORDER: TagColumn[] = [
   {
     key: 'key',
     field: 'key',

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
@@ -115,7 +115,7 @@ type ChartProps = {
   disableChartPadding?: boolean;
 };
 
-export function Chart(props: ChartProps) {
+function Chart(props: ChartProps) {
   const theme = useTheme();
   const {chartData, zoomProps, spanSlug} = props;
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsHeader.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsHeader.tsx
@@ -152,7 +152,7 @@ const PercentileHeaderBodyWrapper = styled('div')`
   gap: ${space(3)};
 `;
 
-export const SpanLabelContainer = styled('div')`
+const SpanLabelContainer = styled('div')`
   ${p => p.theme.overflowEllipsis};
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -53,13 +53,7 @@ export function spanDetailsRouteWithQuery({
   };
 }
 
-export function generateQuerySummaryRoute({
-  base,
-  group,
-}: {
-  base: string;
-  group: string;
-}): string {
+function generateQuerySummaryRoute({base, group}: {base: string; group: string}): string {
   return `${base}/spans/span/${group}/`;
 }
 
@@ -91,7 +85,7 @@ export function querySummaryRouteWithQuery({
   };
 }
 
-export function generateResourceSummaryRoute({
+function generateResourceSummaryRoute({
   baseUrl,
   group,
 }: {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
@@ -101,7 +101,7 @@ const SectionSubtext = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-export const SpanLabelContainer = styled('div')`
+const SpanLabelContainer = styled('div')`
   ${p => p.theme.overflowEllipsis};
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -16,7 +16,7 @@ import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transaction
 import type {SpanSort, SpanSortOption} from './types';
 import {SpanSortOthers, SpanSortPercentiles} from './types';
 
-export function generateSpansRoute({
+function generateSpansRoute({
   organization,
   view,
 }: {

--- a/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
@@ -6,7 +6,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
-export function generateTagsRoute({
+function generateTagsRoute({
   organization,
   view,
 }: {

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -29,7 +29,7 @@ export enum TransactionThresholdMetric {
   LARGEST_CONTENTFUL_PAINT = 'lcp',
 }
 
-export const METRIC_CHOICES = [
+const METRIC_CHOICES = [
   {label: t('Transaction Duration'), value: 'duration'},
   {label: t('Largest Contentful Paint'), value: 'lcp'},
 ];

--- a/static/app/views/performance/transactionSummary/transactionVitals/styles.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/styles.tsx
@@ -10,7 +10,7 @@ export const Card = styled(PanelItem)`
   padding: 0;
 `;
 
-export const CardSection = styled('div')`
+const CardSection = styled('div')`
   padding: ${space(3)};
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -10,11 +10,7 @@ import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transaction
 
 import type {Point, Rectangle} from './types';
 
-export function generateVitalsRoute({
-  organization,
-}: {
-  organization: Organization;
-}): string {
+function generateVitalsRoute({organization}: {organization: Organization}): string {
   return `${getTransactionSummaryBaseUrl(organization)}/vitals/`;
 }
 

--- a/static/app/views/performance/trends/utils/getSelectedQueryKey.tsx
+++ b/static/app/views/performance/trends/utils/getSelectedQueryKey.tsx
@@ -1,6 +1,6 @@
 import {TrendChangeType} from 'sentry/views/performance/trends/types';
 
-export const trendSelectedQueryKeys = {
+const trendSelectedQueryKeys = {
   [TrendChangeType.IMPROVED]: 'improvedSelected',
   [TrendChangeType.REGRESSION]: 'regressionSelected',
 };

--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -15,7 +15,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import type {Color} from 'sentry/utils/theme';
 import type {AlertType} from 'sentry/views/alerts/wizard/options';
 
-export function generateVitalDetailRoute({orgSlug}: {orgSlug: string}): string {
+function generateVitalDetailRoute({orgSlug}: {orgSlug: string}): string {
   return `/organizations/${orgSlug}/performance/vitaldetail/`;
 }
 

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -348,5 +348,5 @@ function ReleasesDetailContainer(props: ReleasesDetailContainerProps) {
     </PageFiltersContainer>
   );
 }
-export {ReleaseContext, ReleasesDetailContainer};
+export {ReleaseContext};
 export default ReleasesDetailContainer;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -1032,7 +1032,7 @@ const DescriptionCell = styled(Cell)`
   overflow: visible;
 `;
 
-export const Change = styled('div')<{color?: Color}>`
+const Change = styled('div')<{color?: Color}>`
   font-size: ${p => p.theme.fontSizeMedium};
   ${p => p.color && `color: ${p.theme[p.color]}`}
 `;

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -360,7 +360,7 @@ const FinalizeWrapper = styled('div')`
   }
 `;
 
-export const PackageName = styled('div')`
+const PackageName = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.textColor};
   display: flex;

--- a/static/app/views/releases/list/releasesRequest.tsx
+++ b/static/app/views/releases/list/releasesRequest.tsx
@@ -55,7 +55,7 @@ function getInterval(datetimeObj: DateTimeObject) {
   // TODO(sessions): sub-hour session resolution is still not possible
   return '1h';
 }
-export function reduceTimeSeriesGroups(
+function reduceTimeSeriesGroups(
   acc: number[],
   group: SessionApiResponse['groups'][number],
   field: 'count_unique(user)' | 'sum(session)'

--- a/static/app/views/settings/account/accountNotificationFineTuningController.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningController.tsx
@@ -11,7 +11,7 @@ interface AccountNotificationFineTuningControllerProps
   organizationsLoading?: boolean;
 }
 
-export function AccountNotificationFineTuningController({
+function AccountNotificationFineTuningController({
   organizationsLoading,
   ...props
 }: AccountNotificationFineTuningControllerProps) {

--- a/static/app/views/settings/account/apiTokenDetails.tsx
+++ b/static/app/views/settings/account/apiTokenDetails.tsx
@@ -35,7 +35,7 @@ type FetchApiTokenParameters = {
 };
 type FetchApiTokenResponse = InternalAppApiToken;
 
-export const makeFetchApiTokenKey = ({tokenId}: FetchApiTokenParameters) =>
+const makeFetchApiTokenKey = ({tokenId}: FetchApiTokenParameters) =>
   [`/api-tokens/${tokenId}/`] as const;
 
 function ApiTokenDetailsForm({token}: {token: InternalAppApiToken}) {

--- a/static/app/views/settings/account/notifications/notificationSettingsController.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsController.tsx
@@ -10,7 +10,7 @@ interface NotificationSettingsControllerProps extends RouteComponentProps {
   organizationsLoading?: boolean;
 }
 
-export function NotificationSettingsController({
+function NotificationSettingsController({
   organizationsLoading,
 }: NotificationSettingsControllerProps) {
   if (organizationsLoading) {

--- a/static/app/views/settings/dynamicSampling/utils/formContext.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/formContext.tsx
@@ -82,7 +82,7 @@ type FormStateConfig<
 /**
  * Creates a form state object with fields and validation for a given set of form fields.
  */
-export const useFormState = <
+const useFormState = <
   FormFields extends Record<string, PlainValue>,
   FieldErrors extends Record<keyof FormFields, any>,
 >(

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -51,10 +51,7 @@ type UpdateTokenQueryVariables = {
   name: string;
 };
 
-export const makeFetchOrgAuthTokenKey = ({
-  orgSlug,
-  tokenId,
-}: FetchOrgAuthTokenParameters) =>
+const makeFetchOrgAuthTokenKey = ({orgSlug, tokenId}: FetchOrgAuthTokenParameters) =>
   [`/organizations/${orgSlug}/org-auth-tokens/${tokenId}/`] as const;
 
 function AuthTokenDetailsForm({
@@ -185,7 +182,7 @@ function AuthTokenDetailsForm({
   );
 }
 
-export function OrganizationAuthTokensDetails({params, organization}: Props) {
+function OrganizationAuthTokensDetails({params, organization}: Props) {
   const {tokenId} = params;
 
   const {

--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -3,7 +3,7 @@ export const NOT_INSTALLED = 'Not Installed';
 export const PENDING = 'Pending';
 export const DISABLED = 'Disabled';
 export const PENDING_DELETION = 'Pending Deletion';
-export const LEARN_MORE = 'Learn More';
+const LEARN_MORE = 'Learn More';
 
 export const COLORS = {
   [INSTALLED]: 'success',

--- a/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
@@ -33,7 +33,7 @@ type Props = {
   className?: string;
 };
 
-export class InstalledPlugin extends Component<Props> {
+class InstalledPlugin extends Component<Props> {
   get projectId() {
     return this.props.projectItem.projectId;
   }

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -88,7 +88,7 @@ type Props = {
  *
  *  See (#28465) for more details.
  */
-export class SentryAppExternalForm extends Component<Props, State> {
+class SentryAppExternalForm extends Component<Props, State> {
   state: State = {optionsByField: new Map(), selectedOptions: {}};
 
   componentDidMount() {

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -272,7 +272,6 @@ const TeamLink = styled(Link)`
   }
 `;
 
-export {AllTeamsRow};
 export default withApi(AllTeamsRow);
 
 export const GRID_TEMPLATE = `

--- a/static/app/views/settings/organizationTeams/roleOverwriteWarning.tsx
+++ b/static/app/views/settings/organizationTeams/roleOverwriteWarning.tsx
@@ -51,7 +51,7 @@ export function hasOrgRoleOverwrite(props: Props) {
 /**
  * Standardize string so situations where org-level vs team-level roles is easier to recognize
  */
-export function getOverwriteString(props: Props) {
+function getOverwriteString(props: Props) {
   const {orgRole, orgRoleList, teamRoleList, isSelf} = props;
   const orgRoleObj = orgRoleList.find(r => r.id === orgRole);
   const teamRoleObj = teamRoleList.find(r => r.id === orgRoleObj?.minimumTeamRole);

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -278,5 +278,4 @@ const EnvironmentButton = styled(Button)`
   margin-left: ${space(0.5)};
 `;
 
-export {ProjectEnvironments};
 export default withApi(ProjectEnvironments);

--- a/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
@@ -205,7 +205,7 @@ interface SourceMapUploadsListProps {
   sourceMapUploads?: SourceMapUpload[];
 }
 
-export function SourceMapUploadsList({
+function SourceMapUploadsList({
   isLoading,
   sourceMapUploads,
   emptyMessage,
@@ -258,11 +258,7 @@ export function SourceMapUploadsList({
   );
 }
 
-export function SourceMapUploadDetails({
-  sourceMapUpload,
-}: {
-  sourceMapUpload: SourceMapUpload;
-}) {
+function SourceMapUploadDetails({sourceMapUpload}: {sourceMapUpload: SourceMapUpload}) {
   const [showAll, setShowAll] = useState(false);
   const detailsData = useMemo<KeyValueListData>(() => {
     const rows = sourceMapUpload.associations;
@@ -317,9 +313,7 @@ interface SourceMapUploadDeleteButtonProps {
   size?: ButtonProps['size'];
 }
 
-export function SourceMapUploadDeleteButton({
-  onDelete,
-}: SourceMapUploadDeleteButtonProps) {
+function SourceMapUploadDeleteButton({onDelete}: SourceMapUploadDeleteButtonProps) {
   const tooltipTitle = useCallback((hasAccess: boolean, canDelete: boolean) => {
     if (hasAccess) {
       if (canDelete) {

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -503,7 +503,7 @@ const OMITTED_SPAN_STATUS = ['unknown'];
 /**
  * This display a tag for the status (not to be confused with 'status_code' which has values like '200', '429').
  */
-export function StatusTag({status, onClick}: {status: string; onClick?: () => void}) {
+function StatusTag({status, onClick}: {status: string; onClick?: () => void}) {
   const tagType = statusToTagType(status);
 
   if (!tagType) {

--- a/static/gsApp/hooks/organizationRoles.tsx
+++ b/static/gsApp/hooks/organizationRoles.tsx
@@ -1,6 +1,6 @@
 import type {Organization, OrgRole} from 'sentry/types/organization';
 
-export const ORG_ROLES: OrgRole[] = [
+const ORG_ROLES: OrgRole[] = [
   {
     id: 'billing',
     name: 'Billing',

--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
@@ -293,7 +293,7 @@ function ReviewAndConfirmItems({previewData}: Pick<State, 'previewData'>) {
   );
 }
 
-export function ReviewAndConfirmBody({
+function ReviewAndConfirmBody({
   cardActionError,
   loading,
   loadError,

--- a/tests/js/sentry-test/charts.tsx
+++ b/tests/js/sentry-test/charts.tsx
@@ -24,7 +24,7 @@ const model = {
   ],
 };
 
-export const chart = {
+const chart = {
   getModel: jest.fn(() => ({...model})),
 };
 

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -9,7 +9,7 @@ export enum ProblemSpan {
   CAUSE = 'cause',
 }
 
-export const EXAMPLE_TRANSACTION_TITLE = '/api/0/transaction-test-endpoint/';
+const EXAMPLE_TRANSACTION_TITLE = '/api/0/transaction-test-endpoint/';
 
 type AddSpanOpts = {
   endTimestamp: number;


### PR DESCRIPTION
This PR removes the `export` from functions and consts that are only used within the same file; This again reduces the risk of accidental auto-imports, and helps TypeScript understand which things are actually unused.

This was mainly done with `knip --fix-type exports`