### PR TITLE
feat(trace-eap-waterfall): Adding opsbreakdown to span description

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -15,7 +15,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import ResourceSize from 'sentry/views/insights/browser/resources/components/resourceSize';
 import {
   DisabledImages,
@@ -135,7 +135,7 @@ export function SpanDescription({
                 organization,
                 transaction: node.event?.title ?? '',
                 query: location.query,
-                spanSlug: {op: span.op!, group: group ?? ''},
+                spanSlug: {op: span.op, group: group ?? ''},
                 projectID: node.event?.projectID,
               })
         }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useMemo} from 'react';
-import {Theme, useTheme} from '@emotion/react';
+import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -537,16 +537,16 @@ function HighLightEAPOpsBreakdown({node}: {node: TraceTreeNode<TraceTree.EAPSpan
     return null;
   }
 
-  breakdown.sort((a, b) => b.count - a.count);
-  const totalCount = breakdown.reduce((acc, curr) => acc + curr.count, 0);
+  const sortedBreakdown = breakdown.toSorted((a, b) => b.count - a.count);
+  const totalCount = sortedBreakdown.reduce((acc, curr) => acc + curr.count, 0);
 
   const TOP_N = 3;
-  const displayOps = breakdown.slice(0, TOP_N).map(op => ({
+  const displayOps = sortedBreakdown.slice(0, TOP_N).map(op => ({
     op: op.op,
     percentage: (op.count / totalCount) * 100,
   }));
 
-  if (breakdown.length > TOP_N) {
+  if (sortedBreakdown.length > TOP_N) {
     const topNPercentage = displayOps.reduce((acc, curr) => acc + curr.percentage, 0);
     displayOps.push({
       op: t('Other'),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -483,10 +483,10 @@ function Highlights({
             <StyledPanelHeader>{headerContent}</StyledPanelHeader>
             <PanelBody>{bodyContent}</PanelBody>
           </StyledPanel>
-          {event ? (
-            <HighLightsOpsBreakdown event={event} />
-          ) : isEAPSpanNode(node) ? (
+          {isEAPSpanNode(node) ? (
             <HighLightEAPOpsBreakdown node={node} />
+          ) : event ? (
+            <HighLightsOpsBreakdown event={event} />
           ) : null}
         </HighlightsRightColumn>
       </HighlightsWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -5,7 +5,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 export function getProfileMeta(event: EventTransaction | null) {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -612,6 +612,62 @@ describe('TraceTree', () => {
       expect(eapSpan?.occurrences.size).toBe(1);
     });
 
+    it('initializes eap span ops breakdown', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'eap-span-1',
+            is_transaction: true,
+            op: 'op-1',
+            occurrences: [],
+            children: [
+              makeEAPSpan({
+                event_id: 'eap-span-2',
+                is_transaction: false,
+                op: 'op-2',
+                children: [
+                  makeEAPSpan({
+                    event_id: 'eap-span-4',
+                    is_transaction: false,
+                    op: 'op-3',
+                    occurrences: [],
+                    children: [],
+                  }),
+                ],
+              }),
+              makeEAPSpan({
+                event_id: 'eap-span-3',
+                is_transaction: true,
+                op: 'op-2',
+                occurrences: [],
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        traceMetadata
+      );
+
+      const eapSpan1 = findEAPSpanByEventId(tree, 'eap-span-1');
+      expect(eapSpan1?.eapSpanOpsBreakdown).toEqual(
+        expect.arrayContaining([
+          {op: 'op-2', count: 2},
+          {op: 'op-3', count: 1},
+        ])
+      );
+
+      const eapSpan2 = findEAPSpanByEventId(tree, 'eap-span-2');
+      expect(eapSpan2?.eapSpanOpsBreakdown).toEqual(
+        expect.arrayContaining([{op: 'op-3', count: 1}])
+      );
+
+      const eapSpan3 = findEAPSpanByEventId(tree, 'eap-span-3');
+      expect(eapSpan3?.eapSpanOpsBreakdown).toEqual([]);
+
+      const eapSpan4 = findEAPSpanByEventId(tree, 'eap-span-4');
+      expect(eapSpan4?.eapSpanOpsBreakdown).toEqual([]);
+    });
+
     it('initializes expanded based on is_transaction property', () => {
       const tree = TraceTree.FromTrace(
         makeEAPTrace([

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -465,7 +465,10 @@ export class TraceTree extends TraceTreeEventDispatcher {
           }
         }
 
-        function updateAncestorOps(node: TraceTreeNode<TraceTree.EAPSpan>, op: string) {
+        function updateAncestorOpsBreakdown(
+          node: TraceTreeNode<TraceTree.EAPSpan>,
+          op: string
+        ) {
           let current = node.parent;
           while (current) {
             const existing = current.eapSpanOpsBreakdown.find(b => b.op === op);
@@ -479,7 +482,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         }
 
         if (isEAPSpanNode(c)) {
-          updateAncestorOps(c, c.value.op);
+          updateAncestorOpsBreakdown(c, c.value.op);
         }
       }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -253,6 +253,11 @@ export declare namespace TraceTree {
     spans?: number;
   };
 
+  type OpsBreakdown = Array<{
+    count: number;
+    op: string;
+  }>;
+
   type Indicator = {
     duration: number;
     label: string;
@@ -458,6 +463,23 @@ export class TraceTree extends TraceTreeEventDispatcher {
           if (closestEAPTransaction) {
             closestEAPTransaction.occurrences.add(occurence);
           }
+        }
+
+        function updateAncestorOps(node: TraceTreeNode<TraceTree.EAPSpan>, op: string) {
+          let current = node.parent;
+          while (current) {
+            const existing = current.eapSpanOpsBreakdown.find(b => b.op === op);
+            if (existing) {
+              existing.count++;
+            } else {
+              current.eapSpanOpsBreakdown.push({op, count: 1});
+            }
+            current = current.parent;
+          }
+        }
+
+        if (isEAPSpanNode(c)) {
+          updateAncestorOps(c, c.value.op);
         }
       }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -65,6 +65,8 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
     spans: undefined,
   };
 
+  eapSpanOpsBreakdown: TraceTree.OpsBreakdown = [];
+
   event: EventTransaction | null = null;
 
   // Events associated with the node, these are inferred from the node value.


### PR DESCRIPTION
<img width="1229" alt="Screenshot 2025-04-22 at 12 33 37 PM" src="https://github.com/user-attachments/assets/fce9344c-7c1b-4586-83a9-9cad8f6a4d79" />
