### PR TITLE
feat(gen-ai): Use gen-ai-consent flag

### DIFF
--- a/static/gsApp/hooks/genAiAccess.spec.tsx
+++ b/static/gsApp/hooks/genAiAccess.spec.tsx
@@ -34,33 +34,11 @@ describe('useGenAiConsentButtonAccess', function () {
     mockGetRegionData.mockReset();
   });
 
-  describe('Region-based access', function () {
-    it('disables access for non-US regions', function () {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization});
-
-      mockGetRegionData.mockReturnValue({
-        name: 'de',
-        displayName: 'Germany',
-        url: 'https://sentry.io',
-      });
-      mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
-
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
-
-      expect(result.current).toEqual(
-        expect.objectContaining({
-          isDisabled: true,
-          message: 'This feature is not available in your region.',
-        })
-      );
-    });
-
-    it('enables access for US region with proper permissions', function () {
+  describe('Flag-based access', function () {
+    it('enables access for US region when flag is present', function () {
       const organization = OrganizationFixture({
         access: ['org:billing'],
+        features: ['gen-ai-consent'],
       });
       const subscription = SubscriptionFixture({
         organization,
@@ -91,6 +69,7 @@ describe('useGenAiConsentButtonAccess', function () {
     it('disables access for users without billing access', function () {
       const organization = OrganizationFixture({
         access: [],
+        features: ['gen-ai-consent'],
       });
       const subscription = SubscriptionFixture({
         organization,
@@ -121,6 +100,7 @@ describe('useGenAiConsentButtonAccess', function () {
     it('enables access for superusers regardless of billing access', function () {
       const organization = OrganizationFixture({
         access: [],
+        features: ['gen-ai-consent'],
       });
       const subscription = SubscriptionFixture({
         organization,
@@ -151,6 +131,7 @@ describe('useGenAiConsentButtonAccess', function () {
     it('enables access for users with billing access', function () {
       const organization = OrganizationFixture({
         access: ['org:billing'],
+        features: ['gen-ai-consent'],
       });
       const subscription = SubscriptionFixture({
         organization,
@@ -180,9 +161,10 @@ describe('useGenAiConsentButtonAccess', function () {
   });
 
   describe('Combined Conditions', function () {
-    it('shows region restriction for EU region', function () {
+    it('shows region restriction when feature flag is off', function () {
       const organization = OrganizationFixture({
         access: ['org:billing'],
+        features: [],
       });
       const subscription = SubscriptionFixture({
         organization,
@@ -210,39 +192,10 @@ describe('useGenAiConsentButtonAccess', function () {
       );
     });
 
-    it('shows region restriction for other ST region', function () {
-      const organization = OrganizationFixture({
-        access: ['org:billing'],
-      });
-      const subscription = SubscriptionFixture({
-        organization,
-        type: BillingType.INVOICED,
-        msaUpdatedForDataConsent: false,
-      });
-
-      mockGetRegionData.mockReturnValue({
-        name: 'customer1',
-        displayName: 'Customer 1',
-        url: 'https://sentry.io',
-      });
-      mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
-
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
-
-      expect(result.current).toEqual(
-        expect.objectContaining({
-          isDisabled: true,
-          message: 'This feature is not available in your region.',
-          isTouchCustomerAndNeedsMsaUpdate: true,
-        })
-      );
-    });
-
     it('allows access for invoiced customers with undefined msaUpdatedForDataConsent', function () {
       const organization = OrganizationFixture({
         access: ['org:billing'],
+        features: ['gen-ai-consent'],
       });
       const subscription = SubscriptionFixture({
         organization,

--- a/static/gsApp/hooks/genAiAccess.tsx
+++ b/static/gsApp/hooks/genAiAccess.tsx
@@ -1,6 +1,5 @@
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
@@ -13,8 +12,6 @@ export function useGenAiConsentButtonAccess({
 }) {
   const user = useUser();
   const organization = useOrganization();
-
-  const regionData = getRegionDataFromOrganization(organization);
 
   const isTouchCustomer = subscription.type === BillingType.INVOICED;
   const hasMsaUpdated =
@@ -33,7 +30,7 @@ export function useGenAiConsentButtonAccess({
 
   const conditions = [
     {
-      check: !regionData?.name || !['us', 'sentry4sentry'].includes(regionData.name),
+      check: !organization.features.includes('gen-ai-consent'),
       message: t('This feature is not available in your region.'),
     },
     {


### PR DESCRIPTION
Instead of relying on hard coded region checks, we use the gen ai consent flag and set region in flagpole
