### PR TITLE
fix(dashboards-eap): Open in Explore passing aggregates as fields

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -9,7 +9,7 @@ describe('getWidgetExploreUrl', () => {
   const organization = OrganizationFixture();
   const selection = PageFiltersFixture();
 
-  it('returns the correct url for table widgets', () => {
+  it('returns the correct aggregate mode url for table widgets with aggregation', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.TABLE,
       queries: [
@@ -28,7 +28,30 @@ describe('getWidgetExploreUrl', () => {
 
     // Note: for table widgets the mode is set to samples and the fields are propagated
     expect(url).toBe(
-      '/organizations/org-slug/traces/?dataset=spansRpc&field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=samples&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+      '/organizations/org-slug/traces/?dataset=spansRpc&groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+    );
+  });
+
+  it('returns the correct samples mode url for table widgets without aggregation', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          fields: ['span.description', 'span.duration'],
+          aggregates: [],
+          columns: [],
+          conditions: '',
+          orderby: '',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, selection, organization);
+
+    // Note: for table widgets the mode is set to samples and the fields are propagated
+    expect(url).toBe(
+      '/organizations/org-slug/traces/?dataset=spansRpc&field=span.description&field=span.duration&interval=30m&mode=samples&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%5D%7D'
     );
   });
 
@@ -52,7 +75,7 @@ describe('getWidgetExploreUrl', () => {
     // Note: for line widgets the mode is set to aggregate
     // The chart type is set to 1 for area charts
     expect(url).toBe(
-      '/organizations/org-slug/traces/?dataset=spansRpc&field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+      '/organizations/org-slug/traces/?dataset=spansRpc&groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
     );
   });
 
@@ -76,7 +99,7 @@ describe('getWidgetExploreUrl', () => {
     // Note: for line widgets the mode is set to aggregate
     // The chart type is set to 1 for area charts
     expect(url).toBe(
-      '/organizations/org-slug/traces/?dataset=spansRpc&field=avg%28span.duration%29&groupBy=&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+      '/organizations/org-slug/traces/?dataset=spansRpc&groupBy=&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
     );
   });
 
@@ -100,7 +123,7 @@ describe('getWidgetExploreUrl', () => {
 
     // The URL should have the sort and another visualize to plot the sort
     expect(url).toBe(
-      '/organizations/org-slug/traces/?dataset=spansRpc&field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=aggregate&sort=-count%28span.duration%29&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D'
+      '/organizations/org-slug/traces/?dataset=spansRpc&groupBy=span.description&interval=30m&mode=aggregate&sort=-count%28span.duration%29&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D'
     );
   });
 });


### PR DESCRIPTION
Fixes the Open in Explore flows from Dashboards. The main issue is that `field` shouldn't be populated in the query params unless we're setting columns for the sample mode, and they should not contain aggregates. The consequence of the previous behaviour is that aggregates would appear for individual samples in the samples view, which is not a valid state.

The following test cases have been updated

- Table with aggregates
  - Produces a URL to Aggregate Mode with the columns in the group by and aggregates in a `visualize` object
- Tables without aggregates
  - Produces a URL to Samples Mode with no grouping set and columns set in the `field` query params
- Charts do not add `field` to the query params
  - Charts by definition are plotting an aggregate, so put the chart in aggregate mode and the only columns that apply are in the `groupBy` param

Fixes EXP-177; The sorting is resolved because the user cannot get into a state in the samples table where the columns are not valid and therefore not properly triggering a request when the columns are clicked.