### PR TITLE
feat(aci): Only update open periods if the initial one exists

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -31,13 +31,14 @@ from sentry.issues.status_change import handle_status_update, infer_substatus
 from sentry.issues.update_inbox import update_inbox
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.commit import Commit
-from sentry.models.group import STATUS_UPDATE_CHOICES, Group, GroupStatus, update_group_open_period
+from sentry.models.group import STATUS_UPDATE_CHOICES, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.grouplink import GroupLink
+from sentry.models.groupopenperiod import update_group_open_period
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -88,7 +88,7 @@ from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.grouplink import GroupLink
-from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.models.groupopenperiod import GroupOpenPeriod, has_initial_open_period
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
@@ -1715,7 +1715,9 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
         kick_off_status_syncs.apply_async(
             kwargs={"project_id": group.project_id, "group_id": group.id}
         )
-        if features.has("organizations:issue-open-periods", group.project.organization):
+        if features.has(
+            "organizations:issue-open-periods", group.project.organization
+        ) and has_initial_open_period(group):
             GroupOpenPeriod.objects.create(
                 group=group,
                 project_id=group.project_id,

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -31,9 +31,10 @@ from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
-from sentry.models.group import Group, get_open_periods_for_group
+from sentry.models.group import Group
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.grouplink import GroupLink
+from sentry.models.groupopenperiod import get_open_periods_for_group
 from sentry.models.groupowner import get_owner_details
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupsubscription import GroupSubscriptionManager

--- a/src/sentry/issues/endpoints/group_open_periods.py
+++ b/src/sentry/issues/endpoints/group_open_periods.py
@@ -13,7 +13,7 @@ from sentry.api.bases import GroupEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
-from sentry.models.group import get_open_periods_for_group
+from sentry.models.groupopenperiod import get_open_periods_for_group
 
 if TYPE_CHECKING:
     from sentry.models.group import Group

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -13,8 +13,9 @@ from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_sync
 from sentry.issues.ignored import IGNORED_CONDITION_FIELDS
 from sentry.issues.ongoing import TRANSITION_AFTER_DAYS
 from sentry.models.activity import Activity
-from sentry.models.group import Group, GroupStatus, update_group_open_period
+from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import record_group_history_from_activity_type
+from sentry.models.groupopenperiod import update_group_open_period
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.project import Project
 from sentry.notifications.types import GroupSubscriptionReason

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -21,7 +21,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
-from sentry import eventstore, eventtypes, features, options, tagstore
+from sentry import eventstore, eventtypes, options, tagstore
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
@@ -42,10 +42,8 @@ from sentry.issues.priority import (
     PriorityChangeReason,
     get_priority_for_ongoing_group,
 )
-from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.grouphistory import record_group_history, record_group_history_from_activity_type
-from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -62,7 +60,6 @@ from sentry.utils.numbers import base32_decode, base32_encode
 from sentry.utils.strings import strip, truncatechars
 
 if TYPE_CHECKING:
-    from sentry.incidents.utils.metric_issue_poc import OpenPeriod
     from sentry.integrations.services.integration import RpcIntegration
     from sentry.models.environment import Environment
     from sentry.models.team import Team
@@ -448,6 +445,7 @@ class GroupManager(BaseManager["Group"]):
     ) -> None:
         """For each groups, update status to `status` and create an Activity."""
         from sentry.models.activity import Activity
+        from sentry.models.groupopenperiod import update_group_open_period
 
         modified_groups_list = []
         selected_groups = Group.objects.filter(id__in=[g.id for g in groups]).exclude(
@@ -1063,185 +1061,3 @@ def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
                 "No substatus allowed for group",
                 extra={"status": instance.status, "substatus": instance.substatus},
             )
-
-
-def get_last_checked_for_open_period(group: Group) -> datetime:
-    from sentry.incidents.models.alert_rule import AlertRule
-    from sentry.issues.grouptype import MetricIssuePOC
-
-    event = group.get_latest_event()
-    last_checked = group.last_seen
-    if event and group.type == MetricIssuePOC.type_id:
-        alert_rule_id = event.data.get("contexts", {}).get("metric_alert", {}).get("alert_rule_id")
-        if alert_rule_id:
-            try:
-                alert_rule = AlertRule.objects.get(id=alert_rule_id)
-                now = timezone.now()
-                last_checked = now - timedelta(seconds=alert_rule.snuba_query.time_window)
-            except AlertRule.DoesNotExist:
-                pass
-
-    return last_checked
-
-
-def get_open_periods_for_group(
-    group: Group,
-    query_start: datetime | None = None,
-    query_end: datetime | None = None,
-    offset: int | None = None,
-    limit: int | None = None,
-) -> list[OpenPeriod]:
-    from sentry.incidents.utils.metric_issue_poc import OpenPeriod
-    from sentry.models.groupopenperiod import GroupOpenPeriod
-
-    if not features.has("organizations:issue-open-periods", group.organization):
-        return []
-
-    # Try to get open periods from the GroupOpenPeriod table first
-    group_open_periods = GroupOpenPeriod.objects.filter(group=group)
-    if group_open_periods.exists() and query_start:
-        group_open_periods = group_open_periods.filter(
-            date_started__gte=query_start, date_ended__lte=query_end, id__gte=offset or 0
-        ).order_by("-date_started")[:limit]
-
-        return [
-            OpenPeriod(
-                start=period.date_started,
-                end=period.date_ended,
-                duration=period.date_ended - period.date_started if period.date_ended else None,
-                is_open=period.date_ended is None,
-                last_checked=get_last_checked_for_open_period(group),
-            )
-            for period in group_open_periods
-        ]
-
-    # If there are no open periods in the table, we need to calculate them
-    # from the activity log.
-    # TODO(snigdha): This is temporary until we have backfilled the GroupOpenPeriod table
-
-    if query_start is None or query_end is None:
-        query_start = timezone.now() - timedelta(days=90)
-        query_end = timezone.now()
-
-    query_limit = limit * 2 if limit else None
-    # Filter to REGRESSION and RESOLVED activties to find the bounds of each open period.
-    # The only UNRESOLVED activity we would care about is the first UNRESOLVED activity for the group creation,
-    # but we don't create an entry for that .
-    activities = Activity.objects.filter(
-        group=group,
-        type__in=[ActivityType.SET_REGRESSION.value, ActivityType.SET_RESOLVED.value],
-        datetime__gte=query_start,
-        datetime__lte=query_end,
-    ).order_by("-datetime")[:query_limit]
-
-    open_periods = []
-    start: datetime | None = None
-    end: datetime | None = None
-    last_checked = get_last_checked_for_open_period(group)
-
-    # Handle currently open period
-    if group.status == GroupStatus.UNRESOLVED and len(activities) > 0:
-        open_periods.append(
-            OpenPeriod(
-                start=activities[0].datetime,
-                end=None,
-                duration=None,
-                is_open=True,
-                last_checked=last_checked,
-            )
-        )
-        activities = activities[1:]
-
-    for activity in activities:
-        if activity.type == ActivityType.SET_RESOLVED.value:
-            end = activity.datetime
-        elif activity.type == ActivityType.SET_REGRESSION.value:
-            start = activity.datetime
-            if end is not None:
-                open_periods.append(
-                    OpenPeriod(
-                        start=start,
-                        end=end,
-                        duration=end - start,
-                        is_open=False,
-                        last_checked=end,
-                    )
-                )
-                end = None
-
-    # Add the very first open period, which has no UNRESOLVED activity for the group creation
-    open_periods.append(
-        OpenPeriod(
-            start=group.first_seen,
-            end=end if end else None,
-            duration=end - group.first_seen if end else None,
-            is_open=False if end else True,
-            last_checked=end if end else last_checked,
-        )
-    )
-
-    if offset and limit:
-        return open_periods[offset : offset + limit]
-
-    if limit:
-        return open_periods[:limit]
-
-    return open_periods
-
-
-def update_group_open_period(
-    group: Group,
-    new_status: int,
-    activity: Activity | None,
-    should_reopen_open_period: bool,
-) -> None:
-    """
-    Update an existing open period when the group is resolved or unresolved.
-
-    On resolution, we set the date_ended to the resolution time and link the activity to the open period.
-    On unresolved, we clear the date_ended and resolution_activity fields. This is only done if the group
-    is unresolved manually without a regression. If the group is unresolved due to a regression, the
-    open periods will be updated during ingestion.
-    """
-    if not features.has("organizations:issue-open-periods", group.project.organization):
-        return
-
-    if new_status not in (GroupStatus.RESOLVED, GroupStatus.UNRESOLVED):
-        return
-
-    find_open = new_status != GroupStatus.UNRESOLVED
-    open_period = (
-        GroupOpenPeriod.objects.filter(group=group, date_ended__isnull=find_open)
-        .order_by("-date_started")
-        .first()
-    )
-    if not open_period:
-        logger.error(
-            "Unable to update open period, no open period found",
-            extra={"group_id": group.id},
-        )
-        return
-
-    if new_status == GroupStatus.RESOLVED:
-        if activity is None:
-            logger.warning(
-                "Missing activity for group resolution, querying for it",
-                extra={"group_id": group.id},
-            )
-            activity = (
-                Activity.objects.filter(
-                    group=group,
-                    type=ActivityType.SET_RESOLVED.value,
-                )
-                .order_by("-datetime")
-                .first()
-            )
-
-        end_time = group.resolved_at or (activity.datetime if activity else None)
-        open_period.update(
-            date_ended=end_time,
-            resolution_activity=activity,
-            user_id=activity.user_id if activity else None,
-        )
-    elif new_status == GroupStatus.UNRESOLVED and should_reopen_open_period:
-        open_period.update(date_ended=None, resolution_activity=None, user_id=None)

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -1,11 +1,21 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
 from django.conf import settings
 from django.contrib.postgres.fields import DateTimeRangeField
 from django.db import models
 from django.utils import timezone
 
+from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.models.activity import Activity
+from sentry.models.group import Group, GroupStatus
+from sentry.types.activity import ActivityType
+
+logger = logging.getLogger(__name__)
 
 
 class TsTzRange(models.Func):
@@ -60,3 +70,184 @@ class GroupOpenPeriod(DefaultFieldsModel):
         # )
 
     __repr__ = sane_repr("project_id", "group_id", "date_started", "date_ended", "user_id")
+
+
+def get_last_checked_for_open_period(group: Group) -> datetime:
+    from sentry.incidents.models.alert_rule import AlertRule
+    from sentry.issues.grouptype import MetricIssuePOC
+
+    event = group.get_latest_event()
+    last_checked = group.last_seen
+    if event and group.type == MetricIssuePOC.type_id:
+        alert_rule_id = event.data.get("contexts", {}).get("metric_alert", {}).get("alert_rule_id")
+        if alert_rule_id:
+            try:
+                alert_rule = AlertRule.objects.get(id=alert_rule_id)
+                now = timezone.now()
+                last_checked = now - timedelta(seconds=alert_rule.snuba_query.time_window)
+            except AlertRule.DoesNotExist:
+                pass
+
+    return last_checked
+
+
+def get_open_periods_for_group(
+    group: Group,
+    query_start: datetime | None = None,
+    query_end: datetime | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> list[Any]:
+    from sentry.incidents.utils.metric_issue_poc import OpenPeriod
+
+    if not features.has("organizations:issue-open-periods", group.organization):
+        return []
+
+    # Try to get open periods from the GroupOpenPeriod table first
+    group_open_periods = GroupOpenPeriod.objects.filter(group=group)
+    if group_open_periods.exists() and query_start:
+        group_open_periods = group_open_periods.filter(
+            date_started__gte=query_start, date_ended__lte=query_end, id__gte=offset or 0
+        ).order_by("-date_started")[:limit]
+
+        return [
+            OpenPeriod(
+                start=period.date_started,
+                end=period.date_ended,
+                duration=period.date_ended - period.date_started if period.date_ended else None,
+                is_open=period.date_ended is None,
+                last_checked=get_last_checked_for_open_period(group),
+            )
+            for period in group_open_periods
+        ]
+
+    # If there are no open periods in the table, we need to calculate them
+    # from the activity log.
+    # TODO(snigdha): This is temporary until we have backfilled the GroupOpenPeriod table
+
+    if query_start is None or query_end is None:
+        query_start = timezone.now() - timedelta(days=90)
+        query_end = timezone.now()
+
+    query_limit = limit * 2 if limit else None
+    # Filter to REGRESSION and RESOLVED activties to find the bounds of each open period.
+    # The only UNRESOLVED activity we would care about is the first UNRESOLVED activity for the group creation,
+    # but we don't create an entry for that .
+    activities = Activity.objects.filter(
+        group=group,
+        type__in=[ActivityType.SET_REGRESSION.value, ActivityType.SET_RESOLVED.value],
+        datetime__gte=query_start,
+        datetime__lte=query_end,
+    ).order_by("-datetime")[:query_limit]
+
+    open_periods = []
+    start: datetime | None = None
+    end: datetime | None = None
+    last_checked = get_last_checked_for_open_period(group)
+
+    # Handle currently open period
+    if group.status == GroupStatus.UNRESOLVED and len(activities) > 0:
+        open_periods.append(
+            OpenPeriod(
+                start=activities[0].datetime,
+                end=None,
+                duration=None,
+                is_open=True,
+                last_checked=last_checked,
+            )
+        )
+        activities = activities[1:]
+
+    for activity in activities:
+        if activity.type == ActivityType.SET_RESOLVED.value:
+            end = activity.datetime
+        elif activity.type == ActivityType.SET_REGRESSION.value:
+            start = activity.datetime
+            if end is not None:
+                open_periods.append(
+                    OpenPeriod(
+                        start=start,
+                        end=end,
+                        duration=end - start,
+                        is_open=False,
+                        last_checked=end,
+                    )
+                )
+                end = None
+
+    # Add the very first open period, which has no UNRESOLVED activity for the group creation
+    open_periods.append(
+        OpenPeriod(
+            start=group.first_seen,
+            end=end if end else None,
+            duration=end - group.first_seen if end else None,
+            is_open=False if end else True,
+            last_checked=end if end else last_checked,
+        )
+    )
+
+    if offset and limit:
+        return open_periods[offset : offset + limit]
+
+    if limit:
+        return open_periods[:limit]
+
+    return open_periods
+
+
+def update_group_open_period(
+    group: Group,
+    new_status: int,
+    activity: Activity | None,
+    should_reopen_open_period: bool,
+) -> None:
+    """
+    Update an existing open period when the group is resolved or unresolved.
+
+    On resolution, we set the date_ended to the resolution time and link the activity to the open period.
+    On unresolved, we clear the date_ended and resolution_activity fields. This is only done if the group
+    is unresolved manually without a regression. If the group is unresolved due to a regression, the
+    open periods will be updated during ingestion.
+    """
+    if not features.has("organizations:issue-open-periods", group.project.organization):
+        return
+
+    if new_status not in (GroupStatus.RESOLVED, GroupStatus.UNRESOLVED):
+        return
+
+    find_open = new_status != GroupStatus.UNRESOLVED
+    open_period = (
+        GroupOpenPeriod.objects.filter(group=group, date_ended__isnull=find_open)
+        .order_by("-date_started")
+        .first()
+    )
+    if not open_period:
+        logger.error(
+            "Unable to update open period, no open period found",
+            extra={"group_id": group.id},
+        )
+        return
+
+    if new_status == GroupStatus.RESOLVED:
+        if activity is None:
+            logger.warning(
+                "Missing activity for group resolution, querying for it",
+                extra={"group_id": group.id},
+            )
+            activity = (
+                Activity.objects.filter(
+                    group=group,
+                    type=ActivityType.SET_RESOLVED.value,
+                )
+                .order_by("-datetime")
+                .first()
+            )
+
+        end_time = group.resolved_at or (activity.datetime if activity else None)
+        open_period.update(
+            date_ended=end_time,
+            resolution_activity=activity,
+            user_id=activity.user_id if activity else None,
+        )
+    elif new_status == GroupStatus.UNRESOLVED and should_reopen_open_period:
+        open_period.update(date_ended=None, resolution_activity=None, user_id=None)

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -11,9 +11,10 @@ from sentry import analytics
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues import grouptype
 from sentry.models.activity import Activity
-from sentry.models.group import Group, GroupStatus, update_group_open_period
+from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.models.groupopenperiod import update_group_open_period
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.signals import issue_resolved

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -146,6 +146,29 @@ class UpdateGroupsTest(TestCase):
         open_period.refresh_from_db()
         assert open_period.date_ended is not None
 
+    @patch("sentry.signals.issue_resolved.send_robust")
+    @with_feature("organizations:issue-open-periods")
+    def test_resolving_unresolved_group_without_open_period(self, send_robust: Mock) -> None:
+        unresolved_group = self.create_group(status=GroupStatus.UNRESOLVED)
+        add_group_to_inbox(unresolved_group, GroupInboxReason.NEW)
+        assert unresolved_group.status == GroupStatus.UNRESOLVED
+        GroupOpenPeriod.objects.all().delete()
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "resolved", "substatus": None}
+        request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        update_groups(request, group_list)
+
+        unresolved_group.refresh_from_db()
+
+        assert unresolved_group.status == GroupStatus.RESOLVED
+        assert not GroupInbox.objects.filter(group=unresolved_group).exists()
+        assert send_robust.called
+        assert GroupOpenPeriod.objects.filter(group=unresolved_group).count() == 0
+
     @patch("sentry.signals.issue_ignored.send_robust")
     @patch("sentry.issues.status_change.post_save")
     def test_ignoring_group_archived_forever(self, post_save: Mock, send_robust: Mock) -> None:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -288,6 +288,38 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert open_period.date_started == group.first_seen
         assert open_period.date_ended == resolved_at
 
+    @mock.patch("sentry.signals.issue_unresolved.send_robust")
+    @with_feature("organizations:issue-open-periods")
+    def test_unresolves_group_without_open_period(self, send_robust: mock.MagicMock) -> None:
+        ts = before_now(minutes=5).isoformat()
+
+        # N.B. EventManager won't unresolve the group unless the event2 has a
+        # later timestamp than event1.
+        manager = EventManager(make_event(event_id="a" * 32, checksum="a" * 32, timestamp=ts))
+        with self.tasks():
+            event = manager.save(self.project.id)
+
+        group = Group.objects.get(id=event.group_id)
+        group.status = GroupStatus.RESOLVED
+        group.substatus = None
+        group.save()
+        assert group.is_resolved()
+
+        GroupOpenPeriod.objects.all().delete()
+        manager = EventManager(
+            make_event(
+                event_id="b" * 32, checksum="a" * 32, timestamp=before_now(minutes=3).isoformat()
+            )
+        )
+        event2 = manager.save(self.project.id)
+        assert event.group_id == event2.group_id
+
+        group = Group.objects.get(id=group.id)
+        assert not group.is_resolved()
+        assert send_robust.called
+
+        assert GroupOpenPeriod.objects.filter(group=group).count() == 0
+
     @mock.patch("sentry.event_manager.plugin_is_regression")
     def test_does_not_unresolve_group(self, plugin_is_regression: mock.MagicMock) -> None:
         # N.B. EventManager won't unresolve the group unless the event2 has a

--- a/tests/sentry/issues/endpoints/test_group_open_periods.py
+++ b/tests/sentry/issues/endpoints/test_group_open_periods.py
@@ -4,7 +4,8 @@ from django.utils import timezone
 
 from sentry.issues.grouptype import MetricIssuePOC, ProfileFileIOGroupType
 from sentry.models.activity import Activity
-from sentry.models.group import GroupStatus, get_open_periods_for_group
+from sentry.models.group import GroupStatus
+from sentry.models.groupopenperiod import get_open_periods_for_group
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType


### PR DESCRIPTION
Step 1 to get us ready for the [open period backfill](https://www.notion.so/sentry/Backfilling-open-periods-1dd8b10e4b5d8081b283d6f05e9abd93?pvs=25)

In order to cleanly backfill open periods, we need to change the existing open period logic to only update an open period for a group if the group has the initial open period (from group creation). If it doesn't, then do nothing. If it does, handle the open periods as usual.

This PR makes that change, using `has_initial_open_period` to check for an open period that matches the `group.first_seen ` time. 

I've also relocated all the open period methods to `groupopenperiod.py` instead of `group.py`.