### PR TITLE
:wrench: chore: update log to get group count correctly

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -211,7 +211,7 @@ class DigestNotification(ProjectNotification):
                 "user_ids": user_ids,
                 "notification_uuid": self.notification_uuid,
                 "number_of_rules": len(shared_context.get("rules_details", [])),
-                "group_count": shared_context.get("event_counts", 0),
+                "group_count": shared_context.get("counts", 0),
             },
         )
 


### PR DESCRIPTION
updating log to get the actual `group_count`