### PR TITLE
fix(billing): Check for canSelfServe before showing the RequestUpdate button

### DIFF
--- a/static/gsApp/components/addEventsCTA.spec.tsx
+++ b/static/gsApp/components/addEventsCTA.spec.tsx
@@ -1,0 +1,167 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {sendAddEventsRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
+import AddEventsCTA from 'getsentry/components/addEventsCTA';
+import {PlanTier} from 'getsentry/types';
+import {
+  getBestActionToIncreaseEventLimits,
+  type UsageAction,
+} from 'getsentry/utils/billing';
+import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
+
+jest.mock('getsentry/actionCreators/upsell', () => ({
+  sendUpgradeRequest: jest.fn(),
+  sendAddEventsRequest: jest.fn(),
+}));
+
+jest.mock('getsentry/utils/billing', () => {
+  const actual = jest.requireActual('getsentry/utils/billing');
+  return {
+    ...actual,
+    displayBudgetName: jest.fn(() => 'On-Demand Budget'),
+    getBestActionToIncreaseEventLimits: jest.fn(),
+    getTrialLength: jest.fn(),
+  };
+});
+
+jest.mock('getsentry/views/onDemandBudgets/editOnDemandButton', () => ({
+  openOnDemandBudgetEditModal: jest.fn(),
+}));
+
+describe('AddEventsCTA', function () {
+  const mockSendUpgradeRequest = sendUpgradeRequest as jest.MockedFunction<
+    typeof sendUpgradeRequest
+  >;
+  const _mockSendAddEventsRequest = sendAddEventsRequest as jest.MockedFunction<
+    typeof sendAddEventsRequest
+  >;
+  const mockGetBestActionToIncreaseEventLimits =
+    getBestActionToIncreaseEventLimits as jest.MockedFunction<
+      typeof getBestActionToIncreaseEventLimits
+    >;
+  const _mockOpenOnDemandBudgetEditModal =
+    openOnDemandBudgetEditModal as jest.MockedFunction<
+      typeof openOnDemandBudgetEditModal
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({
+    organization,
+    planTier: PlanTier.AM1,
+    canSelfServe: true,
+    isManaged: false,
+  });
+
+  const defaultProps = {
+    api: new MockApiClient(),
+    organization,
+    subscription,
+    source: 'test',
+    referrer: 'test-referrer',
+  };
+
+  it('renders request upgrade button when action is request_upgrade and subscription is self-serve and not managed', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'request_upgrade' as UsageAction
+    );
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    expect(screen.getByText('Request Upgrade')).toBeInTheDocument();
+  });
+
+  it('does not render request upgrade button when action is request_upgrade but subscription is not self-serve', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'request_upgrade' as UsageAction
+    );
+
+    const nonSelfServeSubscription = {
+      ...subscription,
+      canSelfServe: false,
+    };
+
+    const {container} = render(
+      <AddEventsCTA {...defaultProps} subscription={nonSelfServeSubscription} />
+    );
+
+    expect(screen.queryByText('Request Upgrade')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render request upgrade button when action is request_upgrade but subscription is managed', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'request_upgrade' as UsageAction
+    );
+
+    const managedSubscription = {
+      ...subscription,
+      isManaged: true,
+    };
+
+    const {container} = render(
+      <AddEventsCTA {...defaultProps} subscription={managedSubscription} />
+    );
+
+    expect(screen.queryByText('Request Upgrade')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls sendUpgradeRequest when request upgrade button is clicked', async function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'request_upgrade' as UsageAction
+    );
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    await userEvent.click(screen.getByText('Request Upgrade'));
+
+    expect(mockSendUpgradeRequest).toHaveBeenCalledTimes(1);
+    expect(mockSendUpgradeRequest).toHaveBeenCalledWith({
+      api: expect.any(Object),
+      organization,
+    });
+  });
+
+  it('renders add events button when action is add_events', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue('add_events' as UsageAction);
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    expect(screen.getByText(/On-Demand Budget/)).toBeInTheDocument();
+  });
+
+  it('renders request additional quota button when action is request_add_events', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'request_add_events' as UsageAction
+    );
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    expect(screen.getByText('Request Additional Quota')).toBeInTheDocument();
+  });
+
+  it('renders start trial button when action is start_trial', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue('start_trial' as UsageAction);
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    expect(screen.getByText('Start Trial')).toBeInTheDocument();
+  });
+
+  it('renders upgrade plan button when action is send_to_checkout', function () {
+    mockGetBestActionToIncreaseEventLimits.mockReturnValue(
+      'send_to_checkout' as UsageAction
+    );
+
+    render(<AddEventsCTA {...defaultProps} />);
+
+    expect(screen.getByText('Upgrade Plan')).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -153,6 +153,10 @@ function AddEventsCTA(props: Props) {
         </StartTrialButton>
       );
     case 'request_upgrade':
+      if (!subscription.canSelfServe || subscription.isManaged) {
+        return null;
+      }
+
       return (
         <Button
           onClick={async () => {

--- a/static/gsApp/components/crons/cronsBannerUpgradeCTA.spec.tsx
+++ b/static/gsApp/components/crons/cronsBannerUpgradeCTA.spec.tsx
@@ -1,0 +1,122 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
+import {
+  CronsBannerOnDemandCTA,
+  CronsBannerUpgradeCTA,
+} from 'getsentry/components/crons/cronsBannerUpgradeCTA';
+
+jest.mock('getsentry/actionCreators/upsell', () => ({
+  sendUpgradeRequest: jest.fn(),
+}));
+
+jest.mock('sentry/actionCreators/modal', () => ({
+  openModal: jest.fn(),
+}));
+
+describe('CronsBannerUpgradeCTA', function () {
+  const mockSendUpgradeRequest = sendUpgradeRequest as jest.MockedFunction<
+    typeof sendUpgradeRequest
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const organization = OrganizationFixture();
+
+  // Standard subscription that is self-serve and not managed
+  const subscription = SubscriptionFixture({
+    organization,
+    canSelfServe: true,
+    isManaged: false,
+  });
+
+  it('renders upgrade now button for users with billing access', function () {
+    render(<CronsBannerUpgradeCTA hasBillingAccess subscription={subscription} />);
+
+    expect(screen.getByText('Upgrade Now')).toBeInTheDocument();
+  });
+
+  it('renders request upgrade button for users without billing access', function () {
+    render(
+      <CronsBannerUpgradeCTA hasBillingAccess={false} subscription={subscription} />
+    );
+
+    expect(screen.getByText('Request Upgrade')).toBeInTheDocument();
+  });
+
+  it('calls sendUpgradeRequest when request upgrade button is clicked', async function () {
+    render(
+      <CronsBannerUpgradeCTA hasBillingAccess={false} subscription={subscription} />
+    );
+
+    await userEvent.click(screen.getByText('Request Upgrade'));
+
+    expect(mockSendUpgradeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides request upgrade button for non-self-serve plans', function () {
+    const nonSelfServeSubscription = SubscriptionFixture({
+      organization,
+      canSelfServe: false,
+      isManaged: false,
+    });
+
+    const {container} = render(
+      <CronsBannerUpgradeCTA
+        hasBillingAccess={false}
+        subscription={nonSelfServeSubscription}
+      />
+    );
+
+    expect(screen.queryByText('Request Upgrade')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('hides request upgrade button for managed plans', function () {
+    const managedSubscription = SubscriptionFixture({
+      organization,
+      canSelfServe: true,
+      isManaged: true,
+    });
+
+    const {container} = render(
+      <CronsBannerUpgradeCTA
+        hasBillingAccess={false}
+        subscription={managedSubscription}
+      />
+    );
+
+    expect(screen.queryByText('Request Upgrade')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('CronsBannerOnDemandCTA', function () {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({
+    organization,
+  });
+
+  it('renders update plan button for users with billing access', function () {
+    render(<CronsBannerOnDemandCTA hasBillingAccess subscription={subscription} />);
+
+    expect(screen.getByText('Update Plan')).toBeInTheDocument();
+  });
+
+  it('renders nothing for users without billing access', function () {
+    const {container} = render(
+      <CronsBannerOnDemandCTA hasBillingAccess={false} subscription={subscription} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
+++ b/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
@@ -6,6 +6,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import type {Subscription} from 'getsentry/types';
 import OnDemandBudgetEditModal from 'getsentry/views/onDemandBudgets/onDemandBudgetEditModal';
 
@@ -16,6 +17,10 @@ interface UpgradeCTAProps {
 export function CronsBannerUpgradeCTA({hasBillingAccess}: UpgradeCTAProps) {
   const organization = useOrganization();
   const api = useApi();
+
+  // Check if subscription is self-serve
+  const subscription = SubscriptionStore.getState()[organization.slug];
+  const canSelfServe = subscription?.canSelfServe !== false; // Default to true if unknown
 
   if (hasBillingAccess) {
     return (
@@ -29,6 +34,11 @@ export function CronsBannerUpgradeCTA({hasBillingAccess}: UpgradeCTAProps) {
         {t('Upgrade Now')}
       </LinkButton>
     );
+  }
+
+  // Don't show request upgrade button for non-self-serve or managed plans
+  if (!canSelfServe || subscription?.isManaged) {
+    return null;
   }
 
   return (

--- a/static/gsApp/components/crons/cronsBillingBanner.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.tsx
@@ -90,7 +90,9 @@ export function CronsBillingBanner({organization, subscription}: Props) {
     daysSinceTrial <= 7 &&
     !subscription.planDetails.allowOnDemand
   ) {
-    return <TrialEndedBanner hasBillingAccess={hasBillingAccess} />;
+    return (
+      <TrialEndedBanner hasBillingAccess={hasBillingAccess} subscription={subscription} />
+    );
   }
 
   return null;
@@ -98,10 +100,12 @@ export function CronsBillingBanner({organization, subscription}: Props) {
 
 interface BannerProps {
   hasBillingAccess: boolean;
+  subscription?: Subscription;
 }
 
 interface TrialEndingBannerProps extends BannerProps {
   currentUsage: number;
+  subscription: Subscription;
   trialDaysLeft: number;
 }
 
@@ -110,10 +114,10 @@ function TrialEndingBanner({
   currentUsage,
   trialDaysLeft,
   subscription,
-}: TrialEndingBannerProps & {subscription: Subscription}) {
+}: TrialEndingBannerProps) {
   const budgetType = subscription.planDetails.budgetTerm;
   return (
-    <TrialBanner hasBillingAccess={hasBillingAccess}>
+    <TrialBanner hasBillingAccess={hasBillingAccess} subscription={subscription}>
       {hasBillingAccess
         ? tct(
             "Your organization's free business trial ends in [trialDaysLeft]. To continue monitoring your cron jobs, make sure your [budgetType] budget is set to a minimum of $[currentUsage].",
@@ -131,9 +135,12 @@ function TrialEndingBanner({
   );
 }
 
-function TrialEndedBanner({hasBillingAccess}: BannerProps) {
+function TrialEndedBanner({
+  hasBillingAccess,
+  subscription,
+}: BannerProps & {subscription: Subscription}) {
   return (
-    <TrialBanner hasBillingAccess={hasBillingAccess}>
+    <TrialBanner hasBillingAccess={hasBillingAccess} subscription={subscription}>
       {hasBillingAccess
         ? t(
             'Your free business trial has ended. One cron job monitor is included in your current plan. If you want to monitor more than one cron job, please increase your on-demand budget.'
@@ -147,14 +154,20 @@ function TrialEndedBanner({hasBillingAccess}: BannerProps) {
 
 function TrialBanner({
   hasBillingAccess,
+  subscription,
   children,
-}: BannerProps & {children?: React.ReactNode}) {
+}: BannerProps & {subscription: Subscription; children?: React.ReactNode}) {
   return (
     <Alert.Container>
       <NoBorderRadiusAlert
         type="warning"
         showIcon
-        trailingItems={<CronsBannerUpgradeCTA hasBillingAccess={hasBillingAccess} />}
+        trailingItems={
+          <CronsBannerUpgradeCTA
+            hasBillingAccess={hasBillingAccess}
+            subscription={subscription}
+          />
+        }
       >
         {children}
       </NoBorderRadiusAlert>

--- a/static/gsApp/components/partnerPlanEndingModal.spec.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.spec.tsx
@@ -54,6 +54,48 @@ describe('PartnerPlanEndingModal', function () {
     expect(mockCall).toHaveBeenCalled();
   });
 
+  it('does not show request upgrade button when canSelfServe is false', function () {
+    const org = OrganizationFixture({access: []});
+    const sub = SubscriptionFixture({
+      organization: org,
+      contractPeriodEnd: '2024-08-08',
+      canSelfServe: false,
+    });
+    SubscriptionStore.set(org.slug, sub);
+
+    render(
+      <PartnerPlanEndingModal
+        closeModal={jest.fn()}
+        organization={org}
+        subscription={sub}
+      />
+    );
+
+    expect(screen.getByTestId('partner-plan-ending-modal')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Request to Upgrade')).not.toBeInTheDocument();
+  });
+
+  it('does not show request upgrade button when subscription is managed', function () {
+    const org = OrganizationFixture({access: []});
+    const sub = SubscriptionFixture({
+      organization: org,
+      contractPeriodEnd: '2024-08-08',
+      isManaged: true,
+    });
+    SubscriptionStore.set(org.slug, sub);
+
+    render(
+      <PartnerPlanEndingModal
+        closeModal={jest.fn()}
+        organization={org}
+        subscription={sub}
+      />
+    );
+
+    expect(screen.getByTestId('partner-plan-ending-modal')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Request to Upgrade')).not.toBeInTheDocument();
+  });
+
   it('shows an upgrade now button with billing permission', function () {
     const org = OrganizationFixture({access: ['org:billing']});
     const sub = SubscriptionFixture({organization: org, contractPeriodEnd: '2024-08-08'});

--- a/static/gsApp/components/partnerPlanEndingModal.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.tsx
@@ -69,6 +69,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
 
   const isTeam = isTeamPlanFamily(subscription.planDetails);
   const hasBillingAccess = organization.access?.includes('org:billing');
+  const canRequestUpgrade = subscription.canSelfServe && !subscription.isManaged;
 
   const endDate = moment(subscription.contractPeriodEnd).add(1, 'days').format('ll');
   const lastDay = daysLeft === 0;
@@ -170,7 +171,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
               >
                 {t('Upgrade Now')}
               </LinkButton>
-            ) : (
+            ) : canRequestUpgrade ? (
               <Button
                 size="md"
                 aria-label="Request to Upgrade"
@@ -179,7 +180,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
               >
                 {t('Request to Upgrade')}
               </Button>
-            )}
+            ) : null}
           </StyledButtonBar>
         </div>
       </div>

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -72,6 +72,7 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
 
   const isPaid = subscription.planDetails?.price > 0;
   const hasBillingRole = organization.access?.includes('org:billing');
+  const canRequestUpgrade = subscription.canSelfServe && !subscription.isManaged;
 
   let alertText: string | null = null;
   let alertHeader: string | null = null;
@@ -134,19 +135,21 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
 
     alertButton =
       isPaid && !hasBillingRole ? (
-        <Button
-          size="sm"
-          disabled={isUpgradeSent}
-          onClick={() => {
-            sendUpgradeRequest({
-              api,
-              organization,
-              handleSuccess: () => setIsUpgradeSent(true),
-            });
-          }}
-        >
-          {t('Request Upgrade')}
-        </Button>
+        canRequestUpgrade ? (
+          <Button
+            size="sm"
+            disabled={isUpgradeSent}
+            onClick={() => {
+              sendUpgradeRequest({
+                api,
+                organization,
+                handleSuccess: () => setIsUpgradeSent(true),
+              });
+            }}
+          >
+            {t('Request Upgrade')}
+          </Button>
+        ) : null
       ) : (
         <Button
           priority="primary"
@@ -168,19 +171,21 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
 
     alertButton =
       isPaid && !hasBillingRole ? (
-        <Button
-          size="sm"
-          disabled={isUpgradeSent}
-          onClick={() => {
-            sendUpgradeRequest({
-              api,
-              organization,
-              handleSuccess: () => setIsUpgradeSent(true),
-            });
-          }}
-        >
-          {t('Request Upgrade')}
-        </Button>
+        canRequestUpgrade ? (
+          <Button
+            size="sm"
+            disabled={isUpgradeSent}
+            onClick={() => {
+              sendUpgradeRequest({
+                api,
+                organization,
+                handleSuccess: () => setIsUpgradeSent(true),
+              });
+            }}
+          >
+            {t('Request Upgrade')}
+          </Button>
+        ) : null
       ) : (
         <Button
           priority="primary"

--- a/static/gsApp/components/productUnavailableCTA.tsx
+++ b/static/gsApp/components/productUnavailableCTA.tsx
@@ -73,12 +73,14 @@ function RequestUpdateAlert({
   isAncientPlan,
   hasPerformanceView,
   hasSessionReplay,
+  subscription,
 }: {
   children: React.ReactNode;
   hasPerformanceView: boolean;
   hasSessionReplay: boolean;
   isAncientPlan: boolean;
   organization: Organization;
+  subscription: Subscription;
 }) {
   const api = useApi();
   const [loading, setLoading] = useState(false);
@@ -129,20 +131,25 @@ function RequestUpdateAlert({
     setLoading(false);
   }, [api, isAncientPlan, organization, analyticsCommonProps]);
 
+  // Don't show request upgrade button for non-self-serve or managed plans
+  const showRequestButton = subscription.canSelfServe && !subscription.isManaged;
+
   return (
     <AlertWithCustomMargin
       system
       type="info"
       trailingItems={
-        <Button
-          size="xs"
-          onClick={handleClick}
-          busy={loading}
-          disabled={requestSent}
-          title={requestSent ? t('Request sent!') : undefined}
-        >
-          {t('Request Update')}
-        </Button>
+        showRequestButton ? (
+          <Button
+            size="xs"
+            onClick={handleClick}
+            busy={loading}
+            disabled={requestSent}
+            title={requestSent ? t('Request sent!') : undefined}
+          >
+            {t('Request Update')}
+          </Button>
+        ) : null
       }
     >
       {children}
@@ -272,6 +279,7 @@ function ProductUnavailableCTAContainer({
       hasPerformanceView={hasPerformanceView}
       organization={organization}
       isAncientPlan={isAncientPlan}
+      subscription={subscription}
     >
       {getRequestUpdateLabel({hasSessionReplay, hasPerformanceView})}
     </RequestUpdateAlert>

--- a/static/gsApp/components/upgradeOrTrialButton.spec.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.spec.tsx
@@ -1,0 +1,201 @@
+import userEvent from '@testing-library/user-event'; // eslint-disable-line no-restricted-imports
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {sendTrialRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
+import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
+
+jest.mock('getsentry/actionCreators/upsell', () => ({
+  sendTrialRequest: jest.fn(),
+  sendUpgradeRequest: jest.fn(),
+}));
+
+describe('UpgradeOrTrialButton', function () {
+  const mockSendTrialRequest = sendTrialRequest as jest.MockedFunction<
+    typeof sendTrialRequest
+  >;
+  const mockSendUpgradeRequest = sendUpgradeRequest as jest.MockedFunction<
+    typeof sendUpgradeRequest
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const organization = OrganizationFixture();
+  const adminOrganization = OrganizationFixture({
+    access: ['org:billing'],
+  });
+
+  it('renders upgrade now button for admins', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: false,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={adminOrganization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(screen.getByText('Upgrade now')).toBeInTheDocument();
+  });
+
+  it('renders request upgrade button for non-admins', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: false,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(screen.getByText('Request Upgrade')).toBeInTheDocument();
+  });
+
+  it('hides button for non-self-serve customers without billing access', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: false,
+      canSelfServe: false,
+    });
+
+    const {container} = render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders start trial button for admins when trial is available', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: true,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={adminOrganization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(screen.getByText(/Start \d+-Day Trial/)).toBeInTheDocument();
+  });
+
+  it('renders request trial button for non-admins when trial is available', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: true,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(screen.getByText('Request Trial')).toBeInTheDocument();
+  });
+
+  it('calls sendTrialRequest when request trial button is clicked', async function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: true,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Request Trial'));
+
+    expect(mockSendTrialRequest).toHaveBeenCalledTimes(1);
+    expect(mockSendTrialRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        api: expect.any(Object),
+        organization,
+      })
+    );
+  });
+
+  it('calls sendUpgradeRequest when request upgrade button is clicked', async function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: false,
+      canSelfServe: true,
+    });
+
+    render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Request Upgrade'));
+
+    expect(mockSendUpgradeRequest).toHaveBeenCalledTimes(1);
+    expect(mockSendUpgradeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        api: expect.any(Object),
+        organization,
+      })
+    );
+  });
+
+  it('hides request upgrade button for managed plans', function () {
+    const subscription = SubscriptionFixture({
+      organization,
+      canTrial: false,
+      canSelfServe: true,
+      isManaged: true,
+    });
+
+    const {container} = render(
+      <UpgradeOrTrialButton
+        api={new MockApiClient()}
+        organization={organization}
+        source="test"
+        subscription={subscription}
+      />
+    );
+
+    expect(screen.queryByText('Request Upgrade')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -118,6 +118,11 @@ function UpgradeOrTrialButton({
     return null;
   }
 
+  // Additionally, don't show request upgrade CTAs to managed plans
+  if (!subscription.canSelfServe && action === 'upgrade') {
+    return null;
+  }
+
   if (action === 'trial') {
     if (hasAccess) {
       // admin with trial available
@@ -159,6 +164,12 @@ function UpgradeOrTrialButton({
       </Button>
     );
   }
+
+  // Hide the Request Upgrade button for managed plans
+  if (subscription.isManaged) {
+    return null;
+  }
+
   return (
     <Button onClick={handleRequest} busy={busy} priority={buttonPriority} {...props}>
       {childComponent || t('Request Upgrade')}

--- a/static/gsApp/components/upsellProvider.spec.tsx
+++ b/static/gsApp/components/upsellProvider.spec.tsx
@@ -175,6 +175,50 @@ describe('UpsellProvider', function () {
     expect(requestTrialMock).toHaveBeenCalled();
   });
 
+  it('does not request plan upgrade for non-self-serve plans', async function () {
+    populateOrg(undefined, {canTrial: false, canSelfServe: false});
+    const renderer = createRenderer();
+
+    const requestUpgradeMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/plan-upgrade-request/`,
+      method: 'POST',
+    });
+
+    render(
+      <UpsellProvider source="test-abc" triggerMemberRequests>
+        {renderer}
+      </UpsellProvider>,
+      {router, organization: org}
+    );
+
+    expect(screen.getByText('Request Upgrade')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('test-render'));
+    // The upgrade request should not be made
+    expect(requestUpgradeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not request plan upgrade for managed plans', async function () {
+    populateOrg(undefined, {canTrial: false, canSelfServe: true, isManaged: true});
+    const renderer = createRenderer();
+
+    const requestUpgradeMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/plan-upgrade-request/`,
+      method: 'POST',
+    });
+
+    render(
+      <UpsellProvider source="test-abc" triggerMemberRequests>
+        {renderer}
+      </UpsellProvider>,
+      {router, organization: org}
+    );
+
+    expect(screen.getByText('Request Upgrade')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('test-render'));
+    // The upgrade request should not be made
+    expect(requestUpgradeMock).not.toHaveBeenCalled();
+  });
+
   it('opens modal with showConfirmation', async function () {
     populateOrg(
       {

--- a/static/gsApp/hooks/disabledMemberView.tsx
+++ b/static/gsApp/hooks/disabledMemberView.tsx
@@ -117,9 +117,10 @@ function DisabledMemberView(props: Props) {
 
   const totalLicenses = subscription.totalLicenses;
   const orgName = organization?.name;
+  const canRequestUpgrade = subscription.canSelfServe && !subscription.isManaged;
   const requestButton = requested ? (
     <strong>{t('Requested!')}</strong>
-  ) : (
+  ) : canRequestUpgrade ? (
     <Button
       onClick={() => handleUpgradeRequestMutation.mutate()}
       size="sm"
@@ -127,7 +128,7 @@ function DisabledMemberView(props: Props) {
     >
       {t('Request Upgrade')}
     </Button>
-  );
+  ) : null;
   return (
     <PageContainer>
       {prefersStackedNav ? (


### PR DESCRIPTION
Hide the RequestUpdate CTA for enterprise customers