### PR TITLE
feat(trace-eap-waterfall): Cleaning up trace context sections

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -122,6 +122,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                   tree={tree}
                   rootEvent={rootEvent}
                   onScrollToNode={traceWaterfallScroll.onScrollToNode}
+                  logs={logsTableData.logsData?.data}
                 />
               )}
             </TraceInnerLayout>

--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -126,5 +126,8 @@ const TraceLinksNavigationContainer = styled('div')`
   display: flex;
   justify-content: space-between;
   flex-direction: row;
-  margin: ${space(1)} 0;
+
+  &:not(:empty) {
+    margin-top: ${space(1)};
+  }
 `;

--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -8,7 +8,7 @@ import type {EventTransaction} from 'sentry/types/event';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
-import {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceContextProfiles} from 'sentry/views/performance/newTraceDetails/traceContextProfiles';

--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -18,6 +18,7 @@ import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetail
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceViewLogsSection} from 'sentry/views/performance/newTraceDetails/traceOurlogs';
+import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
 
 type Props = {
   logs: OurLogsResponseItem[] | undefined;
@@ -27,12 +28,11 @@ type Props = {
 };
 
 export function TraceContextPanel({tree, rootEvent, onScrollToNode, logs}: Props) {
-  const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
-  const hasLogs = logs && logs?.length > 0;
-  const hasTags =
-    rootEvent.data &&
-    rootEvent.data.tags.length > 0 &&
-    !(tree.type === 'empty' && hasLogs); // We don't show tags for only logs trace views
+  const {hasProfiles, hasLogs, hasTags} = useTraceContextSections({
+    tree,
+    rootEvent,
+    logs,
+  });
 
   const organization = useOrganization();
   const showLinkedTraces = organization?.features.includes('trace-view-linked-traces');
@@ -64,9 +64,9 @@ export function TraceContextPanel({tree, rootEvent, onScrollToNode, logs}: Props
       )}
 
       <VitalMetersContainer id={TraceContextSectionKeys.WEB_VITALS}>
-        <TraceContextVitals tree={tree} />
+        <TraceContextVitals rootEvent={rootEvent} tree={tree} logs={logs} />
       </VitalMetersContainer>
-      {hasTags && (
+      {hasTags && rootEvent.data && (
         <ContextRow>
           <FoldSection
             sectionKey={TraceContextSectionKeys.TAGS as string as SectionKey}

--- a/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextProfiles.tsx
@@ -1,5 +1,3 @@
-import EmptyStateWarning from 'sentry/components/emptyStateWarning';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
@@ -7,7 +5,6 @@ import {TraceProfiles} from 'sentry/views/performance/newTraceDetails/traceDrawe
 import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
-import {EmptyStateText} from 'sentry/views/traces/styles';
 
 export function TraceContextProfiles({
   tree,
@@ -16,24 +13,13 @@ export function TraceContextProfiles({
   onScrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
   tree: TraceTree;
 }) {
-  const hasProfiles = tree.profiled_events.size > 0;
-
   return (
     <FoldSection
       sectionKey={TraceContextSectionKeys.PROFILES as string as SectionKey}
       title={t('Profiles')}
+      disableCollapsePersistence
     >
-      {tree.type === 'loading' ? (
-        <LoadingIndicator />
-      ) : tree.type === 'trace' && hasProfiles ? (
-        <TraceProfiles tree={tree} onScrollToNode={onScrollToNode} />
-      ) : (
-        <EmptyStateWarning withIcon>
-          <EmptyStateText size="fontSizeExtraLarge">
-            {t('No profiles found')}
-          </EmptyStateText>
-        </EmptyStateWarning>
-      )}
+      <TraceProfiles tree={tree} onScrollToNode={onScrollToNode} />
     </FoldSection>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -2,9 +2,13 @@ import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {space} from 'sentry/styles/space';
+import {EventTransaction} from 'sentry/types/event';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import type {Vital} from 'sentry/utils/performance/vitals/types';
+import {UseApiQueryResult} from 'sentry/utils/queryClient';
+import RequestError from 'sentry/utils/requestError/requestError';
+import {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {VITAL_DESCRIPTIONS} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
 import {WEB_VITALS_METERS_CONFIG} from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
@@ -17,22 +21,18 @@ import {
   STATUS_TEXT,
 } from 'sentry/views/insights/browser/webVitals/utils/scoreToStatus';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
 
 type Props = {
+  logs: OurLogsResponseItem[] | undefined;
+  rootEvent: UseApiQueryResult<EventTransaction, RequestError>;
   tree: TraceTree;
 };
 
-export function treeHasValidVitals(tree: TraceTree) {
-  const allowedVitals = Object.keys(VITAL_DETAILS);
-  return Array.from(tree.vitals.values()).some(vitalGroup =>
-    vitalGroup.some(vital => allowedVitals.includes(`measurements.${vital.key}`))
-  );
-}
+export function TraceContextVitals({rootEvent, tree, logs}: Props) {
+  const {hasVitals} = useTraceContextSections({tree, rootEvent, logs});
 
-export function TraceContextVitals({tree}: Props) {
-  const hasValidVitals = treeHasValidVitals(tree);
-
-  if (!hasValidVitals) {
+  if (!hasVitals) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -16,10 +16,10 @@ import {generateStats} from 'sentry/components/events/opsBreakdown';
 import {DataSection} from 'sentry/components/events/styles';
 import FileSize from 'sentry/components/fileSize';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import {
+import type {
   CardPanel,
   KeyValueData,
-  type KeyValueDataContentProps,
+  KeyValueDataContentProps,
   Subject,
   ValueSection,
 } from 'sentry/components/keyValueData';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -16,10 +16,10 @@ import {generateStats} from 'sentry/components/events/opsBreakdown';
 import {DataSection} from 'sentry/components/events/styles';
 import FileSize from 'sentry/components/fileSize';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import type {
+import {
   CardPanel,
   KeyValueData,
-  KeyValueDataContentProps,
+  type KeyValueDataContentProps,
   Subject,
   ValueSection,
 } from 'sentry/components/keyValueData';

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -241,7 +241,11 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             organization={props.organization}
           />
           <Flex>
-            <ScrollToSectionLinks tree={props.tree} />
+            <ScrollToSectionLinks
+              rootEvent={props.rootEventResults}
+              tree={props.tree}
+              logs={props.logs}
+            />
             <Projects projects={projects} logs={props.logs} tree={props.tree} />
           </Flex>
         </TraceHeaderComponents.HeaderRow>

--- a/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
@@ -10,8 +10,8 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
-import {treeHasValidVitals} from 'sentry/views/performance/newTraceDetails/traceContextVitals';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
 
 export const enum TraceContextSectionKeys {
   TAGS = 'trace-context-tags',
@@ -68,18 +68,16 @@ function ScrollToSectionLinks({
   tree: TraceTree;
 }) {
   const location = useLocation();
-  const hasValidVitals = treeHasValidVitals(tree);
-  const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
-  const hasLogs = logs && logs.length > 0;
-  const hasTags =
-    rootEvent.data &&
-    rootEvent.data.tags.length > 0 &&
-    !(tree.type === 'empty' && hasLogs); // We don't show tags for only logs trace views
+  const {hasVitals, hasProfiles, hasLogs, hasTags} = useTraceContextSections({
+    tree,
+    rootEvent,
+    logs,
+  });
 
-  return hasValidVitals || hasTags || hasProfiles || hasLogs ? (
+  return hasVitals || hasTags || hasProfiles || hasLogs ? (
     <Wrapper>
       <div aria-hidden>{t('Jump to:')}</div>
-      {hasValidVitals && (
+      {hasVitals && (
         <SectionLink
           sectionKey={TraceContextSectionKeys.WEB_VITALS}
           location={location}

--- a/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks.tsx
@@ -5,11 +5,11 @@ import Feature from 'sentry/components/acl/feature';
 import {LinkButton} from 'sentry/components/core/button';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EventTransaction} from 'sentry/types/event';
-import {UseApiQueryResult} from 'sentry/utils/queryClient';
-import RequestError from 'sentry/utils/requestError/requestError';
+import type {EventTransaction} from 'sentry/types/event';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
-import {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {treeHasValidVitals} from 'sentry/views/performance/newTraceDetails/traceContextVitals';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -16,7 +16,9 @@ import {
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
-import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
 
 type UseTraceViewLogsDataProps = {
@@ -40,26 +42,27 @@ export function TraceViewLogsDataProvider({
 }
 
 export function TraceViewLogsSection() {
+  const tableData = useLogsPageData();
+  if (!tableData?.logsData || tableData.logsData.data.length === 0) {
+    return null;
+  }
   return (
-    <InterimSection
-      key="logs"
-      type={TraceContextSectionKeys.LOGS}
+    <FoldSection
+      sectionKey={TraceContextSectionKeys.LOGS as string as SectionKey}
       title={t('Logs')}
       data-test-id="logs-data-section"
       initialCollapse={false}
+      disableCollapsePersistence
     >
-      <LogsSectionContent />
-    </InterimSection>
+      <LogsSectionContent tableData={tableData.logsData} />
+    </FoldSection>
   );
 }
 
-function LogsSectionContent() {
+function LogsSectionContent({tableData}: {tableData: UseExploreLogsTableResult}) {
   const setLogsQuery = useSetLogsQuery();
   const logsSearch = useLogsSearch();
-  const tableData = useLogsPageData();
-  if (!tableData?.logsData) {
-    return null;
-  }
+
   return (
     <Fragment>
       <SearchQueryBuilder
@@ -71,7 +74,7 @@ function LogsSectionContent() {
         onSearch={setLogsQuery}
       />
       <TableContainer>
-        <LogsTable tableData={tableData.logsData} showHeader={false} />
+        <LogsTable tableData={tableData} showHeader={false} />
       </TableContainer>
     </Fragment>
   );

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -16,8 +16,8 @@ import {
   useSetLogsQuery,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
-import {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
-import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import type {UseExploreLogsTableResult} from 'sentry/views/explore/logs/useLogsQuery';
+import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceContextSectionKeys} from 'sentry/views/performance/newTraceDetails/traceHeader/scrollToSectionLinks';
 

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
@@ -1,0 +1,35 @@
+import {EventTransaction} from 'sentry/types/event';
+import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
+import {UseApiQueryResult} from 'sentry/utils/queryClient';
+import RequestError from 'sentry/utils/requestError/requestError';
+import {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+export function useTraceContextSections({
+  tree,
+  rootEvent,
+  logs,
+}: {
+  logs: OurLogsResponseItem[] | undefined;
+  rootEvent: UseApiQueryResult<EventTransaction, RequestError>;
+  tree: TraceTree;
+}) {
+  const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
+  const hasLogs = logs && logs?.length > 0;
+  const hasTags =
+    rootEvent.data &&
+    rootEvent.data.tags.length > 0 &&
+    !(tree.type === 'empty' && hasLogs); // We don't show tags for only logs trace views
+
+  const allowedVitals = Object.keys(VITAL_DETAILS);
+  const hasVitals = Array.from(tree.vitals.values()).some(vitalGroup =>
+    vitalGroup.some(vital => allowedVitals.includes(`measurements.${vital.key}`))
+  );
+
+  return {
+    hasProfiles,
+    hasLogs,
+    hasTags,
+    hasVitals,
+  };
+}


### PR DESCRIPTION
- Only rendering contexts when we have data to populate them with. 
- Disabled collapse persistence for the context sections.
 
