### PR TITLE
feat(schema-hints): Make slideout transparent when search dropdown open

### DIFF
--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -98,12 +98,14 @@ interface DrawerContextType {
     renderer: DrawerConfig['renderer'],
     options: DrawerConfig['options']
   ) => void;
+  panelRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const DrawerContext = createContext<DrawerContextType>({
   openDrawer: () => {},
   isDrawerOpen: false,
   closeDrawer: () => {},
+  panelRef: {current: null},
 });
 
 export function GlobalDrawer({children}: any) {
@@ -198,7 +200,7 @@ export function GlobalDrawer({children}: any) {
     : null;
 
   return (
-    <DrawerContext value={{closeDrawer, isDrawerOpen, openDrawer}}>
+    <DrawerContext value={{closeDrawer, isDrawerOpen, openDrawer, panelRef}}>
       <ErrorBoundary mini message={t('There was a problem rendering the drawer.')}>
         <AnimatePresence>
           {isDrawerOpen && (

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -102,8 +102,36 @@ function SchemaHintsList({
   const schemaHintsContainerRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   const organization = useOrganization();
-  const {openDrawer, isDrawerOpen} = useDrawer();
-  const {dispatch, query} = useSearchQueryBuilder();
+  const {openDrawer, isDrawerOpen, panelRef: schemaHintsDrawerRef} = useDrawer();
+  const {dispatch, query, focusOverride} = useSearchQueryBuilder();
+
+  // Control opacity of the schema hints drawer.
+  // When the search bar dropdown is open, the schema hints drawer should be transparent
+  // to allow users to see their search bar input.
+  useEffect(() => {
+    const observer = new MutationObserver(_mutations => {
+      const searchBarDropdown = document.querySelector(
+        '[aria-label="Edit filter value"]'
+      );
+      if (searchBarDropdown && schemaHintsDrawerRef.current) {
+        schemaHintsDrawerRef.current.style.opacity = '0.5';
+      } else if (
+        !searchBarDropdown &&
+        focusOverride === null &&
+        schemaHintsDrawerRef.current
+      ) {
+        schemaHintsDrawerRef.current.style.opacity = '1';
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // cleanup observer
+    return () => observer.disconnect();
+  }, [schemaHintsDrawerRef, focusOverride]);
 
   // Create a ref to hold the latest query for the drawer
   const queryRef = useRef(query);


### PR DESCRIPTION
Got feedback expressing the slideout covering the search bar is not great for visibility. I've adjusted the logic to ensure that when the dropdown is open, the slideout it translucent. This way users can see their query. This is what it looks like:


https://github.com/user-attachments/assets/bd623069-f10b-42fd-a64a-ea1e80f25bd9

