### PR TITLE
feat(ourlogs): Use a custom chart component with the highest granularity

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -1,0 +1,75 @@
+import {t} from 'sentry/locale';
+import usePrevious from 'sentry/utils/usePrevious';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {INGESTION_DELAY} from 'sentry/views/explore/settings';
+import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+const CHART_HEIGHT = 175;
+
+export interface LogsGraphProps {
+  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
+}
+
+export function LogsGraph({timeseriesResult}: LogsGraphProps) {
+  const previousTimeseriesResult = usePrevious(timeseriesResult);
+  const usePreviousData =
+    timeseriesResult.isPending && !!previousTimeseriesResult?.data?.length;
+  const {
+    data: dataMap,
+    isPending,
+    error,
+  } = usePreviousData ? previousTimeseriesResult : timeseriesResult;
+  const data = Object.values(dataMap)?.[0];
+
+  const Title = <Widget.WidgetTitle title={t('count(logs)')} />;
+
+  if (isPending) {
+    return (
+      <Widget
+        height={CHART_HEIGHT}
+        Title={Title}
+        Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Widget
+        height={CHART_HEIGHT}
+        Title={Title}
+        Visualization={<Widget.WidgetError error={error} />}
+      />
+    );
+  }
+
+  if (!data || data?.length === 0) {
+    return (
+      <Widget
+        height={CHART_HEIGHT}
+        Title={Title}
+        Visualization={<Widget.WidgetError error={t('No data')} />}
+      />
+    );
+  }
+
+  return (
+    <Widget
+      height={CHART_HEIGHT}
+      Title={Title}
+      Visualization={
+        <TimeSeriesWidgetVisualization
+          plottables={data.map(
+            timeSeries =>
+              new Bars(timeSeries, {
+                delay: INGESTION_DELAY,
+                stack: 'all',
+              })
+          )}
+        />
+      }
+    />
+  );
+}

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -6,8 +6,6 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {INGESTION_DELAY} from 'sentry/views/explore/settings';
 import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
-const CHART_HEIGHT = 175;
-
 export interface LogsGraphProps {
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
 }
@@ -28,7 +26,6 @@ export function LogsGraph({timeseriesResult}: LogsGraphProps) {
   if (isPending) {
     return (
       <Widget
-        height={CHART_HEIGHT}
         Title={Title}
         Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
       />
@@ -36,28 +33,17 @@ export function LogsGraph({timeseriesResult}: LogsGraphProps) {
   }
 
   if (error) {
-    return (
-      <Widget
-        height={CHART_HEIGHT}
-        Title={Title}
-        Visualization={<Widget.WidgetError error={error} />}
-      />
-    );
+    return <Widget Title={Title} Visualization={<Widget.WidgetError error={error} />} />;
   }
 
   if (!data || data?.length === 0) {
     return (
-      <Widget
-        height={CHART_HEIGHT}
-        Title={Title}
-        Visualization={<Widget.WidgetError error={t('No data')} />}
-      />
+      <Widget Title={Title} Visualization={<Widget.WidgetError error={t('No data')} />} />
     );
   }
 
   return (
     <Widget
-      height={CHART_HEIGHT}
       Title={Title}
       Visualization={
         <TimeSeriesWidgetVisualization

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -163,9 +163,9 @@ export function LogsTabContent({
             </SchemaHintsSection>
           </Feature>
           <Feature features="organizations:ourlogs-graph">
-            <LogsItemContainer>
+            <LogsGraphContainer>
               <LogsGraph timeseriesResult={timeseriesResult} />
-            </LogsItemContainer>
+            </LogsGraphContainer>
           </Feature>
           <LogsItemContainer>
             <LogsTable
@@ -189,4 +189,8 @@ const FilterBarContainer = styled('div')`
 const LogsItemContainer = styled('div')`
   flex: 1 1 auto;
   margin-top: ${space(2)};
+`;
+
+const LogsGraphContainer = styled(LogsItemContainer)`
+  height: 175px;
 `;

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -16,7 +16,7 @@ import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {ExploreCharts} from 'sentry/views/explore/charts';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import SchemaHintsList, {
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHints/schemaHintsList';
@@ -32,18 +32,17 @@ import {
   useSetLogsFields,
   useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
-import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useLogAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
-import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {getIntervalOptionsForPageFilter} from 'sentry/views/explore/hooks/useChartInterval';
 import {HiddenColumnEditorLogFields} from 'sentry/views/explore/logs/constants';
+import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
-import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
 type LogsTabProps = {
@@ -62,9 +61,11 @@ export function LogsTabContent({
   const setFields = useSetLogsFields();
   const setLogsPageParams = useSetLogsPageParams();
   const tableData = useExploreLogsTable({});
+  const pageFilters = usePageFilters();
 
-  const [interval] = useChartInterval();
-
+  // always use the smallest interval possible (the most bars)
+  const interval = getIntervalOptionsForPageFilter(pageFilters.selection.datetime)?.[0]
+    ?.value;
   const timeseriesResult = useSortedTimeSeries(
     {
       search: logsSearch,
@@ -74,13 +75,6 @@ export function LogsTabContent({
     'explore.ourlogs.main-chart',
     DiscoverDatasets.OURLOGS
   );
-  const [visualizes, setVisualizes] = useState<Visualize[]>([
-    {
-      chartType: ChartType.BAR,
-      yAxes: [`count(${OurLogKnownFieldKey.MESSAGE})`],
-      label: 'A',
-    },
-  ]);
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
     useTraceItemAttributes('string');
@@ -170,17 +164,7 @@ export function LogsTabContent({
           </Feature>
           <Feature features="organizations:ourlogs-graph">
             <LogsItemContainer>
-              <ExploreCharts
-                canUsePreviousResults
-                confidences={['high']}
-                query={logsSearch.formatString()}
-                timeseriesResult={timeseriesResult}
-                visualizes={visualizes}
-                setVisualizes={setVisualizes}
-                // TODO: we do not support log alerts nor adding to dashboards yet
-                hideContextMenu
-                dataset={DiscoverDatasets.OURLOGS}
-              />
+              <LogsGraph timeseriesResult={timeseriesResult} />
             </LogsItemContainer>
           </Feature>
           <LogsItemContainer>


### PR DESCRIPTION
Instead of using the explore chart (which constantly changes, and has features like sampling and a footer), use a custom chart component.

It has:
- No loading on data changes (like the explore chart)
- Always uses the highest granularity (no controls)
- Always a bar chart (no controls)
- A fixed title
- A smaller height (175px vs 260px)