### PR TITLE
ref(grouping): Small enhancements refactors

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -178,9 +178,10 @@ class Enhancements:
         """
         # TODO: Fix this type to list[MatchFrame] once it's fixed in ophio
         match_frames: list[Any] = [create_match_frame(frame, platform) for frame in frames]
+        rust_exception_data = make_rust_exception_data(exception_data)
 
         category_and_in_app_results = self.rust_enhancements.apply_modifications_to_frames(
-            match_frames, make_rust_exception_data(exception_data)
+            match_frames, rust_exception_data
         )
 
         for frame, (category, in_app) in zip(frames, category_and_in_app_results):
@@ -209,13 +210,14 @@ class Enhancements:
         match_frames: list[Any] = [create_match_frame(frame, platform) for frame in frames]
 
         rust_frames = [RustFrame(contributes=c.contributes) for c in frame_components]
+        rust_exception_data = make_rust_exception_data(exception_data)
 
         # Modify the rust frames by applying +group/-group rules and getting hints for both those
         # changes and the `in_app` changes applied by earlier in the ingestion process by
         # `apply_category_and_updated_in_app_to_frames`. Also, get `hint` and `contributes` values
         # for the overall stacktrace (returned in `rust_results`).
         rust_stacktrace_results = self.rust_enhancements.assemble_stacktrace_component(
-            match_frames, make_rust_exception_data(exception_data), rust_frames
+            match_frames, rust_exception_data, rust_frames
         )
 
         # Tally the number of each type of frame in the stacktrace. Later on, this will allow us to

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -7,7 +7,7 @@ import zlib
 from collections import Counter
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Any, Literal
 
 import msgpack
 import sentry_sdk
@@ -16,7 +16,6 @@ from sentry_ophio.enhancers import Cache as RustCache
 from sentry_ophio.enhancers import Component as RustFrame
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
-from sentry import projectoptions
 from sentry.grouping.component import FrameGroupingComponent, StacktraceGroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils.safe import get_path, set_path
@@ -24,7 +23,7 @@ from sentry.utils.safe import get_path, set_path
 from .exceptions import InvalidEnhancerConfig
 from .matchers import create_match_frame
 from .parser import parse_enhancements
-from .rules import EnhancementRule, EnhancementRuleDict
+from .rules import EnhancementRule
 
 logger = logging.getLogger(__name__)
 
@@ -132,13 +131,6 @@ def keep_profiling_rules(config: str) -> str:
         if is_valid_profiling_matcher(matchers) and is_valid_profiling_action(action):
             filtered_rules.append(rule)
     return "\n".join(filtered_rules)
-
-
-class EnhancementsDict(TypedDict):
-    id: str | None
-    bases: list[str]
-    latest: bool
-    rules: NotRequired[list[EnhancementRuleDict]]
 
 
 class Enhancements:
@@ -293,19 +285,6 @@ class Enhancements:
         )
 
         return stacktrace_component
-
-    def as_dict(self, with_rules: bool = False) -> EnhancementsDict:
-        rv: EnhancementsDict = {
-            "id": self.id,
-            "bases": self.bases,
-            "latest": projectoptions.lookup_well_known_key(
-                "sentry:grouping_enhancements_base"
-            ).get_default(epoch=projectoptions.LATEST_EPOCH)
-            == self.id,
-        }
-        if with_rules:
-            rv["rules"] = [x.as_dict() for x in self.rules]
-        return rv
 
     def _to_config_structure(self) -> list[Any]:
         # TODO: Can we switch this to a tuple so we can type it more exactly?

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -318,7 +318,7 @@ class Enhancements:
         """A base64 string representation of the enhancements object"""
         pickled = msgpack.dumps(self._to_config_structure())
         compressed_pickle = zstandard.compress(pickled)
-        return base64.urlsafe_b64encode(compressed_pickle).decode("ascii").strip("=")
+        return base64.urlsafe_b64encode(compressed_pickle).strip(b"=").decode("ascii")
 
     @classmethod
     def _from_config_structure(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -341,9 +341,12 @@ class Enhancements:
     @classmethod
     def from_base64_string(cls, base64_string: str | bytes) -> Enhancements:
         """Convert a base64 string into an `Enhancements` object"""
-        if isinstance(base64_string, str):
-            base64_string = base64_string.encode("ascii", "ignore")
-        padded_bytes = base64_string + b"=" * (4 - (len(base64_string) % 4))
+        bytes_str = (
+            base64_string.encode("ascii", "ignore")
+            if isinstance(base64_string, str)
+            else base64_string
+        )
+        padded_bytes = bytes_str + b"=" * (4 - (len(bytes_str) % 4))
         try:
             compressed_pickle = base64.urlsafe_b64decode(padded_bytes)
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -353,8 +353,9 @@ class Enhancements:
                 pickled = zlib.decompress(compressed_pickle)
 
             rust_enhancements = get_rust_enhancements("config_structure", pickled)
+            config_structure = msgpack.loads(pickled, raw=False)
 
-            return cls._from_config_structure(msgpack.loads(pickled, raw=False), rust_enhancements)
+            return cls._from_config_structure(config_structure, rust_enhancements)
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid stack trace rule config: %s" % e)
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -318,7 +318,9 @@ class Enhancements:
         """A base64 string representation of the enhancements object"""
         pickled = msgpack.dumps(self._to_config_structure())
         compressed_pickle = zstandard.compress(pickled)
-        return base64.urlsafe_b64encode(compressed_pickle).strip(b"=").decode("ascii")
+        base64_bytes = base64.urlsafe_b64encode(compressed_pickle).strip(b"=")
+        base64_str = base64_bytes.decode("ascii")
+        return base64_str
 
     @classmethod
     def _from_config_structure(

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -14,16 +14,19 @@ from sentry.grouping.enhancer import (
     is_valid_profiling_matcher,
     keep_profiling_rules,
 )
+from sentry.grouping.enhancer.actions import EnhancementAction
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import ReturnValueCache, _cached, create_match_frame
 from sentry.grouping.enhancer.parser import parse_enhancements
+from sentry.grouping.enhancer.rules import EnhancementRule
 from sentry.testutils.cases import TestCase
 
 
-def dump_obj(obj):
+def convert_to_dict(obj: object) -> object | dict[str, Any]:
     if not isinstance(getattr(obj, "__dict__", None), dict):
         return obj
-    rv: dict[str, Any] = {}
+
+    d: dict[str, Any] = {}
     for key, value in obj.__dict__.items():
         if key.startswith("_"):
             continue
@@ -36,37 +39,84 @@ def dump_obj(obj):
         ]:
             continue
         elif isinstance(value, list):
-            rv[key] = [dump_obj(x) for x in value]
+            d[key] = [convert_to_dict(x) for x in value]
         elif isinstance(value, dict):
-            rv[key] = {k: dump_obj(v) for k, v in value.items()}
+            d[key] = {k: convert_to_dict(v) for k, v in value.items()}
         else:
-            rv[key] = value
-    return rv
+            d[key] = value
+    return d
+
+
+def get_matching_frame_actions(
+    rule: EnhancementRule,
+    frames: list[dict[str, Any]],
+    platform: str,
+    exception_data: dict[str, Any] | None = None,
+    cache: ReturnValueCache | None = None,
+) -> list[tuple[int, EnhancementAction]]:
+    cache = cache or {}
+    exception_data = exception_data or {}
+
+    match_frames = [create_match_frame(frame, platform) for frame in frames]
+
+    return rule.get_matching_frame_actions(match_frames, exception_data, cache)
+
+
+def get_matching_frame_indices(
+    rule: EnhancementRule,
+    frames: list[dict[str, Any]],
+    platform: str,
+    exception_data: dict[str, Any] | None = None,
+    cache: ReturnValueCache | None = None,
+) -> list[int]:
+    matching_frame_actions = get_matching_frame_actions(
+        rule, frames, platform, exception_data, cache
+    )
+    matching_frame_indices = sorted(mfa[0] for mfa in matching_frame_actions)
+    return matching_frame_indices
+
+
+def assert_matching_frame_found(
+    rule: EnhancementRule,
+    frames: list[dict[str, Any]],
+    platform: str,
+    exception_data: dict[str, Any] | None = None,
+    cache: ReturnValueCache | None = None,
+) -> None:
+    assert bool(get_matching_frame_actions(rule, frames, platform, exception_data, cache))
+
+
+def assert_no_matching_frame_found(
+    rule: EnhancementRule,
+    frames: list[dict[str, Any]],
+    platform: str,
+    exception_data: dict[str, Any] | None = None,
+    cache: ReturnValueCache | None = None,
+) -> None:
+    assert not bool(get_matching_frame_actions(rule, frames, platform, exception_data, cache))
 
 
 @pytest.mark.parametrize("version", [2])
 def test_basic_parsing(insta_snapshot, version):
     enhancements = Enhancements.from_rules_text(
         """
-# This is a config
-path:*/code/game/whatever/*                     +app
-function:panic_handler                          ^-group -group
-function:ThreadStartWin32                       v-group
-function:ThreadStartLinux                       v-group
-function:ThreadStartMac                         v-group
-family:native module:std::*                     -app
-module:core::*                                  -app
-family:javascript path:*/test.js                -app
-family:javascript app:1 path:*/test.js          -app
-family:native                                   max-frames=3
-
-error.value:"*something*"                       max-frames=12
-""",
+            path:*/code/game/whatever/*                     +app
+            function:panic_handler                          ^-group -group
+            function:ThreadStartWin32                       v-group
+            function:ThreadStartLinux                       v-group
+            function:ThreadStartMac                         v-group
+            family:native module:std::*                     -app
+            module:core::*                                  -app
+            family:javascript path:*/test.js                -app
+            family:javascript app:1 path:*/test.js          -app
+            family:native                                   max-frames=3
+            error.value:"*something*"                       max-frames=12
+        """,
         bases=["common:v1"],
     )
     enhancements.version = version
 
-    insta_snapshot(dump_obj(enhancements))
+    insta_snapshot(convert_to_dict(enhancements))
 
     enhancements_str = enhancements.base64_string
     assert Enhancements.from_base64_string(enhancements_str).base64_string == enhancements_str
@@ -129,353 +179,257 @@ def test_flipflop_inapp():
     assert frames[0]["in_app"] is False
 
 
-def _get_matching_frame_actions(rule, frames, platform, exception_data=None, cache=None):
-    """Convenience function for rule tests"""
-    if cache is None:
-        cache = {}
-
-    match_frames = [create_match_frame(frame, platform) for frame in frames]
-
-    return rule.get_matching_frame_actions(match_frames, exception_data, cache)
-
-
 def test_basic_path_matching():
-    enhancements = Enhancements.from_rules_text(
-        """
-        path:**/test.js              +app
-    """
-    )
-    js_rule = enhancements.rules[0]
+    js_rule = Enhancements.from_rules_text("path:**/test.js +app").rules[0]
 
-    assert bool(
-        _get_matching_frame_actions(
-            js_rule,
-            [{"abs_path": "http://example.com/foo/test.js", "filename": "/foo/test.js"}],
-            "javascript",
-        )
+    assert_matching_frame_found(
+        js_rule,
+        [{"abs_path": "http://example.com/foo/test.js", "filename": "/foo/test.js"}],
+        "javascript",
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            js_rule,
-            [{"abs_path": "http://example.com/foo/bar.js", "filename": "/foo/bar.js"}],
-            "javascript",
-        )
+    assert_no_matching_frame_found(
+        js_rule,
+        [{"abs_path": "http://example.com/foo/bar.js", "filename": "/foo/bar.js"}],
+        "javascript",
     )
 
-    assert bool(
-        _get_matching_frame_actions(
-            js_rule, [{"abs_path": "http://example.com/foo/test.js"}], "javascript"
-        )
+    assert_matching_frame_found(
+        js_rule,
+        [{"abs_path": "http://example.com/foo/test.js"}],
+        "javascript",
     )
 
-    assert not bool(
-        _get_matching_frame_actions(js_rule, [{"filename": "/foo/bar.js"}], "javascript")
+    assert_no_matching_frame_found(
+        js_rule,
+        [{"filename": "/foo/bar.js"}],
+        "javascript",
     )
 
-    assert bool(
-        _get_matching_frame_actions(
-            js_rule, [{"abs_path": "http://example.com/foo/TEST.js"}], "javascript"
-        )
+    assert_matching_frame_found(
+        js_rule,
+        [{"abs_path": "http://example.com/foo/TEST.js"}],
+        "javascript",
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            js_rule, [{"abs_path": "http://example.com/foo/bar.js"}], "javascript"
-        )
+    assert_no_matching_frame_found(
+        js_rule,
+        [{"abs_path": "http://example.com/foo/bar.js"}],
+        "javascript",
     )
 
 
 def test_family_matching():
-    enhancements = Enhancements.from_rules_text(
+    js_rule, native_rule = Enhancements.from_rules_text(
         """
         family:javascript path:**/test.js              +app
         family:native function:std::*                  -app
-    """
-    )
-    js_rule, native_rule = enhancements.rules
+        """
+    ).rules
 
-    assert bool(
-        _get_matching_frame_actions(
-            js_rule, [{"abs_path": "http://example.com/foo/TEST.js"}], "javascript"
-        )
+    assert_matching_frame_found(
+        js_rule, [{"abs_path": "http://example.com/foo/TEST.js"}], "javascript"
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            js_rule, [{"abs_path": "http://example.com/foo/TEST.js"}], "native"
-        )
+    assert_no_matching_frame_found(
+        js_rule, [{"abs_path": "http://example.com/foo/TEST.js"}], "native"
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            native_rule,
-            [{"abs_path": "http://example.com/foo/TEST.js", "function": "std::whatever"}],
-            "javascript",
-        )
+    assert_no_matching_frame_found(
+        native_rule,
+        [{"abs_path": "http://example.com/foo/TEST.js", "function": "std::whatever"}],
+        "javascript",
     )
 
-    assert bool(_get_matching_frame_actions(native_rule, [{"function": "std::whatever"}], "native"))
+    assert_matching_frame_found(native_rule, [{"function": "std::whatever"}], "native")
 
 
 def test_app_matching():
-    enhancements = Enhancements.from_rules_text(
+    app_yes_rule, app_no_rule = Enhancements.from_rules_text(
         """
         family:javascript path:**/test.js app:yes       +app
         family:native path:**/test.c app:no            -group
-    """
-    )
-    app_yes_rule, app_no_rule = enhancements.rules
+        """
+    ).rules
 
-    assert bool(
-        _get_matching_frame_actions(
-            app_yes_rule,
-            [{"abs_path": "http://example.com/foo/TEST.js", "in_app": True}],
-            "javascript",
-        )
-    )
-    assert not bool(
-        _get_matching_frame_actions(
-            app_yes_rule,
-            [{"abs_path": "http://example.com/foo/TEST.js", "in_app": False}],
-            "javascript",
-        )
+    assert_matching_frame_found(
+        app_yes_rule,
+        [{"abs_path": "http://example.com/foo/TEST.js", "in_app": True}],
+        "javascript",
     )
 
-    assert bool(
-        _get_matching_frame_actions(
-            app_no_rule, [{"abs_path": "/test.c", "in_app": False}], "native"
-        )
+    assert_no_matching_frame_found(
+        app_yes_rule,
+        [{"abs_path": "http://example.com/foo/TEST.js", "in_app": False}],
+        "javascript",
     )
-    assert not bool(
-        _get_matching_frame_actions(
-            app_no_rule, [{"abs_path": "/test.c", "in_app": True}], "native"
-        )
-    )
+
+    assert_matching_frame_found(app_no_rule, [{"abs_path": "/test.c", "in_app": False}], "native")
+
+    assert_no_matching_frame_found(app_no_rule, [{"abs_path": "/test.c", "in_app": True}], "native")
 
 
 def test_invalid_app_matcher():
-    enhancements = Enhancements.from_rules_text("app://../../src/some-file.ts -app")
-    (rule,) = enhancements.rules
+    rule = Enhancements.from_rules_text("app://../../src/some-file.ts -app").rules[0]
 
-    assert not bool(_get_matching_frame_actions(rule, [{}], "javascript"))
-    assert not bool(_get_matching_frame_actions(rule, [{"in_app": True}], "javascript"))
-    assert not bool(_get_matching_frame_actions(rule, [{"in_app": False}], "javascript"))
+    assert_no_matching_frame_found(rule, [{}], "javascript")
+    assert_no_matching_frame_found(rule, [{"in_app": True}], "javascript")
+    assert_no_matching_frame_found(rule, [{"in_app": False}], "javascript")
 
 
 def test_package_matching():
     # This tests a bunch of different rules from the default in-app logic that
     # was ported from the former native plugin.
-    enhancements = Enhancements.from_rules_text(
+    bundled_rule, macos_rule, linux_rule, windows_rule = Enhancements.from_rules_text(
         """
         family:native package:/var/**/Frameworks/**                  -app
         family:native package:**/*.app/Contents/**                   +app
         family:native package:linux-gate.so                          -app
         family:native package:?:/Windows/**                          -app
-    """
+        """
+    ).rules
+
+    assert_matching_frame_found(
+        bundled_rule, [{"package": "/var/containers/MyApp/Frameworks/libsomething"}], "native"
     )
 
-    bundled_rule, macos_rule, linux_rule, windows_rule = enhancements.rules
-
-    assert bool(
-        _get_matching_frame_actions(
-            bundled_rule, [{"package": "/var/containers/MyApp/Frameworks/libsomething"}], "native"
-        )
+    assert_matching_frame_found(
+        macos_rule, [{"package": "/Applications/MyStuff.app/Contents/MacOS/MyStuff"}], "native"
     )
 
-    assert bool(
-        _get_matching_frame_actions(
-            macos_rule, [{"package": "/Applications/MyStuff.app/Contents/MacOS/MyStuff"}], "native"
-        )
+    assert_matching_frame_found(linux_rule, [{"package": "linux-gate.so"}], "native")
+
+    assert_matching_frame_found(
+        windows_rule, [{"package": "D:\\Windows\\System32\\kernel32.dll"}], "native"
     )
 
-    assert bool(_get_matching_frame_actions(linux_rule, [{"package": "linux-gate.so"}], "native"))
-
-    assert bool(
-        _get_matching_frame_actions(
-            windows_rule, [{"package": "D:\\Windows\\System32\\kernel32.dll"}], "native"
-        )
+    assert_matching_frame_found(
+        windows_rule, [{"package": "d:\\windows\\System32\\kernel32.dll"}], "native"
     )
 
-    assert bool(
-        _get_matching_frame_actions(
-            windows_rule, [{"package": "d:\\windows\\System32\\kernel32.dll"}], "native"
-        )
+    assert_no_matching_frame_found(
+        bundled_rule, [{"package": "/var2/containers/MyApp/Frameworks/libsomething"}], "native"
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            bundled_rule, [{"package": "/var2/containers/MyApp/Frameworks/libsomething"}], "native"
-        )
+    assert_no_matching_frame_found(
+        bundled_rule, [{"package": "/var/containers/MyApp/MacOs/MyApp"}], "native"
     )
 
-    assert not bool(
-        _get_matching_frame_actions(
-            bundled_rule, [{"package": "/var/containers/MyApp/MacOs/MyApp"}], "native"
-        )
-    )
-
-    assert not bool(
-        _get_matching_frame_actions(bundled_rule, [{"package": "/usr/lib/linux-gate.so"}], "native")
-    )
+    assert_no_matching_frame_found(bundled_rule, [{"package": "/usr/lib/linux-gate.so"}], "native")
 
 
 def test_type_matching():
-    enhancements = Enhancements.from_rules_text(
+    zero_rule, error_rule = Enhancements.from_rules_text(
         """
         family:other error.type:ZeroDivisionError -app
         family:other error.type:*Error -app
-    """
-    )
+        """
+    ).rules
 
-    zero_rule, error_rule = enhancements.rules
+    assert_no_matching_frame_found(zero_rule, [{"function": "foo"}], "python")
+    assert_no_matching_frame_found(error_rule, [{"function": "foo"}], "python")
 
-    assert not _get_matching_frame_actions(zero_rule, [{"function": "foo"}], "python")
-    assert not _get_matching_frame_actions(zero_rule, [{"function": "foo"}], "python", None)
-    assert not _get_matching_frame_actions(error_rule, [{"function": "foo"}], "python")
-    assert not _get_matching_frame_actions(error_rule, [{"function": "foo"}], "python", None)
-
-    assert _get_matching_frame_actions(
+    assert_matching_frame_found(
         zero_rule, [{"function": "foo"}], "python", {"type": "ZeroDivisionError"}
     )
 
-    assert not _get_matching_frame_actions(
-        zero_rule, [{"function": "foo"}], "native", {"type": "FooError"}
-    )
+    assert_no_matching_frame_found(zero_rule, [{"function": "foo"}], "native", {"type": "FooError"})
 
-    assert _get_matching_frame_actions(
+    assert_matching_frame_found(
         error_rule, [{"function": "foo"}], "python", {"type": "ZeroDivisionError"}
     )
 
-    assert _get_matching_frame_actions(
-        error_rule, [{"function": "foo"}], "python", {"type": "FooError"}
-    )
+    assert_matching_frame_found(error_rule, [{"function": "foo"}], "python", {"type": "FooError"})
 
 
 def test_value_matching():
-    enhancements = Enhancements.from_rules_text(
+    foo_rule, failed_rule = Enhancements.from_rules_text(
         """
         family:other error.value:foo -app
         family:other error.value:Failed* -app
-    """
-    )
+        """
+    ).rules
 
-    foo_rule, failed_rule = enhancements.rules
+    assert_no_matching_frame_found(foo_rule, [{"function": "foo"}], "python")
+    assert_no_matching_frame_found(failed_rule, [{"function": "foo"}], "python")
 
-    assert not _get_matching_frame_actions(foo_rule, [{"function": "foo"}], "python")
-    assert not _get_matching_frame_actions(foo_rule, [{"function": "foo"}], "python", None)
-    assert not _get_matching_frame_actions(failed_rule, [{"function": "foo"}], "python")
-    assert not _get_matching_frame_actions(failed_rule, [{"function": "foo"}], "python", None)
+    assert_matching_frame_found(foo_rule, [{"function": "foo"}], "python", {"value": "foo"})
 
-    assert _get_matching_frame_actions(foo_rule, [{"function": "foo"}], "python", {"value": "foo"})
-
-    assert not _get_matching_frame_actions(
+    assert_no_matching_frame_found(
         foo_rule, [{"function": "foo"}], "native", {"value": "Failed to download"}
     )
 
-    assert not _get_matching_frame_actions(
-        failed_rule, [{"function": "foo"}], "python", {"value": "foo"}
-    )
+    assert_no_matching_frame_found(failed_rule, [{"function": "foo"}], "python", {"value": "foo"})
 
-    assert _get_matching_frame_actions(
+    assert_matching_frame_found(
         failed_rule, [{"function": "foo"}], "python", {"value": "Failed to download"}
     )
 
 
 def test_mechanism_matching():
-    enhancements = Enhancements.from_rules_text(
-        """
-        family:other error.mechanism:NSError -app
-    """
-    )
+    rule = Enhancements.from_rules_text("family:other error.mechanism:NSError -app").rules[0]
 
-    (rule,) = enhancements.rules
+    assert_no_matching_frame_found(rule, [{"function": "foo"}], "python")
 
-    assert not _get_matching_frame_actions(rule, [{"function": "foo"}], "python")
-    assert not _get_matching_frame_actions(rule, [{"function": "foo"}], "python", None)
-
-    assert _get_matching_frame_actions(
+    assert_matching_frame_found(
         rule, [{"function": "foo"}], "python", {"mechanism": {"type": "NSError"}}
     )
 
-    assert not _get_matching_frame_actions(
+    assert_no_matching_frame_found(
         rule, [{"function": "foo"}], "native", {"mechanism": {"type": "NSError"}}
     )
 
-    assert not _get_matching_frame_actions(
+    assert_no_matching_frame_found(
         rule, [{"function": "foo"}], "python", {"mechanism": {"type": "fooerror"}}
     )
 
 
 def test_mechanism_matching_no_frames():
-    enhancements = Enhancements.from_rules_text(
-        """
-        error.mechanism:NSError -app
-    """
-    )
-    (rule,) = enhancements.rules
+    rule = Enhancements.from_rules_text("error.mechanism:NSError -app").rules[0]
     exception_data = {"mechanism": {"type": "NSError"}}
 
     # Does not crash:
-    assert [] == _get_matching_frame_actions(rule, [], "python", exception_data)
+    assert [] == get_matching_frame_actions(rule, [], "python", exception_data)
 
     # Matcher matches:
-    (matcher,) = rule._exception_matchers
+    matcher = rule._exception_matchers[0]
     assert matcher.matches_frame([], None, exception_data, {})
 
 
 def test_range_matching():
-    enhancements = Enhancements.from_rules_text(
-        """
-        [ function:foo ] | function:* | [ function:baz ] category=bar
-    """
-    )
+    rule = Enhancements.from_rules_text(
+        "[ function:foo ] | function:* | [ function:baz ] category=bar"
+    ).rules[0]
 
-    (rule,) = enhancements.rules
-
-    assert sorted(
-        dict(
-            _get_matching_frame_actions(
-                rule,
-                [
-                    {"function": "main"},
-                    {"function": "foo"},
-                    {"function": "bar"},
-                    {"function": "baz"},
-                    {"function": "abort"},
-                ],
-                "python",
-            )
-        )
+    assert get_matching_frame_indices(
+        rule,
+        [
+            {"function": "main"},
+            {"function": "foo"},
+            {"function": "bar"},
+            {"function": "baz"},
+            {"function": "abort"},
+        ],
+        "python",
     ) == [2]
 
 
 def test_range_matching_direct():
-    enhancements = Enhancements.from_rules_text(
-        """
-        function:bar | [ function:baz ] -group
-    """
-    )
+    rule = Enhancements.from_rules_text("function:bar | [ function:baz ] -group").rules[0]
 
-    (rule,) = enhancements.rules
-
-    assert sorted(
-        dict(
-            _get_matching_frame_actions(
-                rule,
-                [
-                    {"function": "main"},
-                    {"function": "foo"},
-                    {"function": "bar"},
-                    {"function": "baz"},
-                    {"function": "abort"},
-                ],
-                "python",
-            )
-        )
+    assert get_matching_frame_indices(
+        rule,
+        [
+            {"function": "main"},
+            {"function": "foo"},
+            {"function": "bar"},
+            {"function": "baz"},
+            {"function": "abort"},
+        ],
+        "python",
     ) == [2]
 
-    assert not _get_matching_frame_actions(
+    assert_no_matching_frame_found(
         rule,
         [
             {"function": "main"},
@@ -498,7 +452,7 @@ def test_range_matching_direct():
 def test_app_no_matches(frame):
     enhancements = Enhancements.from_rules_text("app:no +app")
     enhancements.apply_category_and_updated_in_app_to_frames([frame], "native", {})
-    assert frame.get("in_app")
+    assert frame.get("in_app") is True
 
 
 def test_cached_with_kwargs():
@@ -625,57 +579,55 @@ class EnhancementsTest(TestCase):
             assert contributes_rule_actions == expected_as_contributes_rule_actions
 
 
-@dataclass
-class DummyRustComponent:
-    contributes: bool | None
-    hint: str | None
-
-
-@dataclass
-class DummyRustAssembleResult:
-    contributes: bool | None
-    hint: str | None
-
-
-DummyRustExceptionData = dict[str, bytes | None]
-DummyRustFrame = dict[str, Any]
-
-
-class MockRustEnhancements:
-    def __init__(
-        self,
-        frame_results: Sequence[tuple[bool, str | None]],
-        stacktrace_results: tuple[bool, str | None] = (True, None),
-    ):
-        self.frame_results = frame_results
-        self.stacktrace_results = stacktrace_results
-
-    def assemble_stacktrace_component(
-        self,
-        _match_frames: list[DummyRustFrame],
-        _exception_data: DummyRustExceptionData,
-        rust_components: list[DummyRustComponent],
-    ) -> DummyRustAssembleResult:
-        # The real (rust) version of this function modifies the components in
-        # `rust_components` in place, but that's not possible from python, so instead we
-        # replace the contents of the list with our own components
-        dummy_rust_components = [
-            DummyRustComponent(contributes, hint) for contributes, hint in self.frame_results
-        ]
-        rust_components[:] = dummy_rust_components
-
-        return DummyRustAssembleResult(*self.stacktrace_results)
-
-
-def in_app_frame(contributes: bool, hint: str | None) -> FrameGroupingComponent:
-    return FrameGroupingComponent(values=[], in_app=True, contributes=contributes, hint=hint)
-
-
-def system_frame(contributes: bool, hint: str | None) -> FrameGroupingComponent:
-    return FrameGroupingComponent(values=[], in_app=False, contributes=contributes, hint=hint)
-
-
 class AssembleStacktraceComponentTest(TestCase):
+
+    @dataclass
+    class DummyRustFrame:
+        contributes: bool | None
+        hint: str | None
+
+    @dataclass
+    class DummyRustStacktraceResult:
+        contributes: bool | None
+        hint: str | None
+
+    DummyRustExceptionData = dict[str, bytes | None]
+    DummyMatchFrame = dict[str, Any]
+
+    class MockRustEnhancements:
+        def __init__(
+            self,
+            frame_results: Sequence[tuple[bool, str | None]],
+            stacktrace_results: tuple[bool, str | None] = (True, None),
+        ):
+            self.frame_results = frame_results
+            self.stacktrace_results = stacktrace_results
+
+        def assemble_stacktrace_component(
+            self,
+            _match_frames: list[AssembleStacktraceComponentTest.DummyMatchFrame],
+            _exception_data: AssembleStacktraceComponentTest.DummyRustExceptionData,
+            rust_frames: list[AssembleStacktraceComponentTest.DummyRustFrame],
+        ) -> AssembleStacktraceComponentTest.DummyRustStacktraceResult:
+            # The real (rust) version of this function modifies the RustFrames in `rust_frames` in
+            # place, but that's not possible from python, so instead we replace the contents of the
+            # list with our own RustFrames
+            dummy_rust_frames = [
+                AssembleStacktraceComponentTest.DummyRustFrame(contributes, hint)
+                for contributes, hint in self.frame_results
+            ]
+            rust_frames[:] = dummy_rust_frames
+
+            return AssembleStacktraceComponentTest.DummyRustStacktraceResult(
+                *self.stacktrace_results
+            )
+
+    def in_app_frame(self, contributes: bool, hint: str | None) -> FrameGroupingComponent:
+        return FrameGroupingComponent(values=[], in_app=True, contributes=contributes, hint=hint)
+
+    def system_frame(self, contributes: bool, hint: str | None) -> FrameGroupingComponent:
+        return FrameGroupingComponent(values=[], in_app=False, contributes=contributes, hint=hint)
+
     def assert_frame_values_match_expected(
         self,
         stacktrace_component: StacktraceGroupingComponent,
@@ -707,32 +659,32 @@ class AssembleStacktraceComponentTest(TestCase):
               `test_marks_app_stacktrace_non_contributing_if_no_in_app_frames` below.)
         """
         app_variant_frame_components = [
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            system_frame(contributes=False, hint="non app frame"),
-            system_frame(contributes=False, hint="non app frame"),
-            system_frame(contributes=False, hint="non app frame"),
-            system_frame(contributes=False, hint="non app frame"),
-            system_frame(contributes=False, hint="non app frame"),
-            system_frame(contributes=False, hint="non app frame"),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="non app frame"),
         ]
         system_variant_frame_components = [
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            in_app_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
-            system_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
         ]
 
         # Notes:
@@ -799,7 +751,7 @@ class AssembleStacktraceComponentTest(TestCase):
         ]
 
         enhancements = Enhancements.from_rules_text("")
-        mock_rust_enhancements = MockRustEnhancements(
+        mock_rust_enhancements = self.MockRustEnhancements(
             frame_results=rust_frame_results,
             stacktrace_results=(True, "some stacktrace hint"),
         )
@@ -841,9 +793,9 @@ class AssembleStacktraceComponentTest(TestCase):
             # All possibilities (all combos of app vs system, contributing vs not) except a
             # contributing system frame, since that will never be passed to
             # `assemble_stacktrace_component` when dealing with the app variant
-            system_frame(contributes=False, hint="non app frame"),
-            in_app_frame(contributes=False, hint="ignored due to recursion"),
-            in_app_frame(contributes=True, hint=None),
+            self.system_frame(contributes=False, hint="non app frame"),
+            self.in_app_frame(contributes=False, hint="ignored due to recursion"),
+            self.in_app_frame(contributes=True, hint=None),
         ]
 
         # With these results, there will still be a contributing frame in the end
@@ -873,11 +825,11 @@ class AssembleStacktraceComponentTest(TestCase):
         ]
 
         enhancements1 = Enhancements.from_rules_text("")
-        mock_rust_enhancements1 = MockRustEnhancements(
+        mock_rust_enhancements1 = self.MockRustEnhancements(
             frame_results=rust_frame_results1, stacktrace_results=(True, None)
         )
         enhancements2 = Enhancements.from_rules_text("")
-        mock_rust_enhancements2 = MockRustEnhancements(
+        mock_rust_enhancements2 = self.MockRustEnhancements(
             frame_results=rust_frame_results2, stacktrace_results=(True, None)
         )
 


### PR DESCRIPTION
This is a series of small refactors to enhancements code, extracted from upcoming PRs in order to make them easier to review. No behavior changes.

- Break the base64 helper functions up into more steps.
- Pull the rust exception data into its own variable before passing it to the rust enhancer.
- Remove `Enhancements.as_dict` and the `EnhancementsDict` type. These used to be used in the `/grouping-enhancements` endpoint, but it was removed 4 years ago in https://github.com/getsentry/sentry/pull/24854.
- Clean up enhancement tests (mostly adding/organizing helper functions and fixtures).