### PR TITLE
feat(aci): WorkflowStats endpoint

### DIFF
--- a/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
+++ b/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
@@ -108,4 +108,5 @@ SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY = {
     "UserSubscriptionsEndpoint",
     "UserUserRolesEndpoint",
     "VstsSearchEndpoint",
+    "OrganizationWorkflowStatsEndpoint",
 }

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_stats.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_stats.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.serializers import serialize
+from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, WorkflowParams
+from sentry.models.organization import Organization
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowEndpoint,
+)
+from sentry.workflow_engine.endpoints.serializers import TimeSeriesValueSerializer
+from sentry.workflow_engine.models import Workflow
+from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_hourly_stats
+
+
+@region_silo_endpoint
+class OrganizationWorkflowStatsEndpoint(OrganizationWorkflowEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    @extend_schema(
+        operation_id="Retrieve Firing Stats for a Workflow for a Given Time Range.",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            WorkflowParams.WORKFLOW_ID,
+        ],
+        responses={
+            200: TimeSeriesValueSerializer,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, organization: Organization, workflow: Workflow) -> Response:
+        """
+        Note that results are returned in hourly buckets.
+        """
+        start, end = get_date_range_from_params(request.GET)
+        results = fetch_workflow_hourly_stats(workflow, start, end)
+        return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -10,6 +10,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
 from sentry.rules.actions.notify_event_service import PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS
+from sentry.rules.history.base import TimeSeriesValue
 from sentry.workflow_engine.models import (
     Action,
     DataCondition,
@@ -433,6 +434,21 @@ class WorkflowGroupHistorySerializer(Serializer):
             "count": obj.count,
             "lastTriggered": obj.last_triggered,
             "eventId": obj.event_id,
+        }
+
+
+class TimeSeriesValueResponse(TypedDict):
+    date: datetime
+    count: int
+
+
+class TimeSeriesValueSerializer(Serializer):
+    def serialize(
+        self, obj: TimeSeriesValue, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
+    ) -> TimeSeriesValueResponse:
+        return {
+            "date": obj.bucket,
+            "count": obj.count,
         }
 
 

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,9 +1,5 @@
 from django.urls import re_path
 
-from sentry.workflow_engine.endpoints.organization_workflow_group_history import (
-    OrganizationWorkflowGroupHistoryEndpoint,
-)
-
 from .organization_available_action_index import OrganizationAvailableActionIndexEndpoint
 from .organization_data_condition_index import OrganizationDataConditionIndexEndpoint
 from .organization_detector_details import OrganizationDetectorDetailsEndpoint
@@ -13,7 +9,9 @@ from .organization_detector_workflow_details import OrganizationDetectorWorkflow
 from .organization_detector_workflow_index import OrganizationDetectorWorkflowIndexEndpoint
 from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
+from .organization_workflow_group_history import OrganizationWorkflowGroupHistoryEndpoint
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
+from .organization_workflow_stats import OrganizationWorkflowStatsEndpoint
 
 # TODO @saponifi3d - Add the remaining API endpoints
 
@@ -51,6 +49,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>\d+)/group-history$",
         OrganizationWorkflowGroupHistoryEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-group-history",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/stats$",
+        OrganizationWorkflowStatsEndpoint.as_view(),
+        name="sentry-api-0-organization-workflow-stats",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/data-conditions/$",

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import TypedDict, cast
 
 from django.db.models import Count, Max, OuterRef, Subquery
+from django.db.models.functions import TruncHour
 
 from sentry.api.paginator import OffsetPaginator
 from sentry.models.group import Group
+from sentry.rules.history.base import TimeSeriesValue
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.workflow_engine.endpoints.serializers import WorkflowGroupHistory
 from sentry.workflow_engine.models import Workflow, WorkflowFireHistory
@@ -59,3 +61,29 @@ def fetch_workflow_groups_paginated(
             qs, order_by=("-count", "-last_triggered"), on_results=convert_results
         ).get_result(per_page, cursor),
     )
+
+
+def fetch_workflow_hourly_stats(
+    workflow: Workflow, start: datetime, end: datetime
+) -> Sequence[TimeSeriesValue]:
+    start = start.replace(tzinfo=timezone.utc)
+    end = end.replace(tzinfo=timezone.utc)
+    qs = (
+        WorkflowFireHistory.objects.filter(
+            workflow=workflow,
+            date_added__gte=start,
+            date_added__lt=end,
+        )
+        .annotate(bucket=TruncHour("date_added"))
+        .order_by("bucket")
+        .values("bucket")
+        .annotate(count=Count("id"))
+    )
+    existing_data = {row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs}
+
+    results = []
+    current = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    while current <= end.replace(minute=0, second=0, microsecond=0):
+        results.append(existing_data.get(current, TimeSeriesValue(current, 0)))
+        current += timedelta(hours=1)
+    return results

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
@@ -9,6 +10,7 @@ from sentry.workflow_engine.endpoints.serializers import (
     WorkflowGroupHistorySerializer,
 )
 from sentry.workflow_engine.models import WorkflowFireHistory
+from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_groups_paginated
 
 pytestmark = [requires_snuba]
 
@@ -34,16 +36,149 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.history.append(
             WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
         )
+        self.group_3 = self.create_group()
+        for i in range(2):
+            self.history.append(
+                WorkflowFireHistory(
+                    workflow=self.workflow,
+                    group=self.group_3,
+                    event_id=uuid4().hex,
+                )
+            )
+        self.workflow_2 = self.create_workflow(organization=self.organization)
+        self.history.append(
+            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
+        )
+
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 
         # manually update date_added
         for i in range(3):
             histories[i].update(date_added=before_now(days=i + 1))
-        histories[-1].update(date_added=before_now(days=1))
+        histories[3].update(date_added=before_now(days=1))
+        for i in range(2):
+            histories[i + 4].update(date_added=before_now(days=i + 1))
+        histories[-1].update(date_added=before_now(days=0))
 
         self.base_triggered_date = before_now(days=1)
 
         self.login_as(self.user)
+
+    def assert_correct_pagination(self, rule, start, end, expected, cursor=None, per_page=25):
+        result = fetch_workflow_groups_paginated(rule, start, end, cursor, per_page)
+        assert result.results == expected, (result.results, expected)
+        return result
+
+    def test_workflow_groups_paginated(self):
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+        )
+        result = self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=3,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+            ],
+            per_page=1,
+        )
+        result = self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=2,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+            ],
+            cursor=result.next,
+            per_page=1,
+        )
+
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=1),
+            before_now(days=0),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[0].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_2,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[3].event_id,
+                ),
+                WorkflowGroupHistory(
+                    self.group_3,
+                    count=1,
+                    last_triggered=self.base_triggered_date,
+                    event_id=self.history[4].event_id,
+                ),
+            ],
+        )
+
+        self.assert_correct_pagination(
+            self.workflow,
+            before_now(days=3),
+            before_now(days=2),
+            [
+                WorkflowGroupHistory(
+                    self.group,
+                    count=1,
+                    last_triggered=self.base_triggered_date - timedelta(days=2),
+                    event_id=self.history[2].event_id,
+                ),
+            ],
+        )
 
     def test_simple(self):
         resp = self.get_success_response(
@@ -58,7 +193,10 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                     self.group, 3, self.base_triggered_date, self.history[0].event_id
                 ),
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
+                ),
+                WorkflowGroupHistory(
+                    self.group_2, 1, self.base_triggered_date, self.history[3].event_id
                 ),
             ],
             self.user,
@@ -94,8 +232,8 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
-                )
+                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
+                ),
             ],
             self.user,
             WorkflowGroupHistorySerializer(),

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
@@ -36,149 +35,16 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.history.append(
             WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
         )
-        self.group_3 = self.create_group()
-        for i in range(2):
-            self.history.append(
-                WorkflowFireHistory(
-                    workflow=self.workflow,
-                    group=self.group_3,
-                    event_id=uuid4().hex,
-                )
-            )
-        self.workflow_2 = self.create_workflow(organization=self.organization)
-        self.history.append(
-            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
-        )
-
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 
         # manually update date_added
         for i in range(3):
             histories[i].update(date_added=before_now(days=i + 1))
-        histories[3].update(date_added=before_now(days=1))
-        for i in range(2):
-            histories[i + 4].update(date_added=before_now(days=i + 1))
-        histories[-1].update(date_added=before_now(days=0))
+        histories[-1].update(date_added=before_now(days=1))
 
         self.base_triggered_date = before_now(days=1)
 
         self.login_as(self.user)
-
-    def assert_correct_pagination(self, rule, start, end, expected, cursor=None, per_page=25):
-        result = fetch_workflow_groups_paginated(rule, start, end, cursor, per_page)
-        assert result.results == expected, (result.results, expected)
-        return result
-
-    def test_workflow_groups_paginated(self):
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=3,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=2,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-            ],
-        )
-        result = self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=3,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-            ],
-            per_page=1,
-        )
-        result = self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=2,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-            ],
-            cursor=result.next,
-            per_page=1,
-        )
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=6),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-            ],
-            cursor=result.next,
-            per_page=1,
-        )
-
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=1),
-            before_now(days=0),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[0].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_2,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[3].event_id,
-                ),
-                WorkflowGroupHistory(
-                    self.group_3,
-                    count=1,
-                    last_triggered=self.base_triggered_date,
-                    event_id=self.history[4].event_id,
-                ),
-            ],
-        )
-
-        self.assert_correct_pagination(
-            self.workflow,
-            before_now(days=3),
-            before_now(days=2),
-            [
-                WorkflowGroupHistory(
-                    self.group,
-                    count=1,
-                    last_triggered=self.base_triggered_date - timedelta(days=2),
-                    event_id=self.history[2].event_id,
-                ),
-            ],
-        )
 
     def test_simple(self):
         resp = self.get_success_response(
@@ -193,10 +59,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                     self.group, 3, self.base_triggered_date, self.history[0].event_id
                 ),
                 WorkflowGroupHistory(
-                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
-                ),
-                WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[3].event_id
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
                 ),
             ],
             self.user,
@@ -232,8 +95,8 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group_3, 2, self.base_triggered_date, self.history[4].event_id
-                ),
+                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                )
             ],
             self.user,
             WorkflowGroupHistorySerializer(),

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -9,7 +9,6 @@ from sentry.workflow_engine.endpoints.serializers import (
     WorkflowGroupHistorySerializer,
 )
 from sentry.workflow_engine.models import WorkflowFireHistory
-from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_groups_paginated
 
 pytestmark = [requires_snuba]
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
@@ -43,12 +43,14 @@ class WorkflowStatsEndpointTest(APITestCase):
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 
         # manually update date_added
+        index = 0
         for i in range(3):
-            for j in range(i + 1):
-                histories[i + j].update(date_added=before_now(hours=i + 1))
+            for _ in range(i + 1):
+                histories[index].update(date_added=before_now(hours=i + 1))
+                index += 1
 
         for i in range(2):
-            histories[-i].update(date_added=before_now(hours=i + 1))
+            histories[i + 6].update(date_added=before_now(hours=i + 4))
 
         self.login_as(self.user)
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import WorkflowFireHistory
+
+pytestmark = [requires_snuba]
+
+
+@freeze_time()
+class WorkflowStatsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-workflow-stats"
+
+    def setUp(self):
+        super().setUp()
+
+        self.workflow = self.create_workflow(organization=self.organization)
+        self.workflow_2 = self.create_workflow(organization=self.organization)
+
+        self.history: list[WorkflowFireHistory] = []
+        for i in range(3):
+            for _ in range(i + 1):
+                self.history.append(
+                    WorkflowFireHistory(
+                        workflow=self.workflow,
+                        group=self.group,
+                        date_added=before_now(hours=i + 1),
+                    )
+                )
+
+        for i in range(2):
+            self.history.append(
+                WorkflowFireHistory(
+                    workflow=self.workflow_2,
+                    group=self.group,
+                    date_added=before_now(hours=i + 1),
+                )
+            )
+
+        histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
+
+        # manually update date_added
+        for i in range(3):
+            for j in range(i + 1):
+                histories[i + j].update(date_added=before_now(hours=i + 1))
+
+        for i in range(2):
+            histories[-i].update(date_added=before_now(hours=i + 1))
+
+        self.login_as(self.user)
+
+    def test(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            start=before_now(days=6),
+            end=before_now(days=0),
+        )
+        assert len(resp.data) == 144
+        now = timezone.now().replace(minute=0, second=0, microsecond=0)
+        assert [r for r in resp.data[-4:]] == [
+            {"date": now - timedelta(hours=3), "count": 3},
+            {"date": now - timedelta(hours=2), "count": 2},
+            {"date": now - timedelta(hours=1), "count": 1},
+            {"date": now, "count": 0},
+        ]

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -1,14 +1,16 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.rules.history.base import TimeSeriesValue
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import default_detector_config_data
+from sentry.workflow_engine.endpoints.serializers import TimeSeriesValueSerializer
 from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import data_source_type_registry
@@ -476,3 +478,15 @@ class TestWorkflowSerializer(TestCase):
             "environment": self.environment.name,
             "detectorIds": [str(detector.id)],
         }
+
+
+class TimeSeriesValueSerializerTest(TestCase):
+    def test(self):
+        time_series_value = TimeSeriesValue(datetime.now(), 30)
+        result = serialize([time_series_value], self.user, TimeSeriesValueSerializer())
+        assert result == [
+            {
+                "date": time_series_value.bucket,
+                "count": time_series_value.count,
+            }
+        ]

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -188,7 +188,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
 
 
 @freeze_time()
-class FetchRuleHourlyStatsTest(TestCase):
+class WorkflowHourlyStatsTest(TestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -6,13 +6,16 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.endpoints.serializers import WorkflowGroupHistory
 from sentry.workflow_engine.models import WorkflowFireHistory
-from sentry.workflow_engine.processors.workflow_fire_history import fetch_workflow_groups_paginated
+from sentry.workflow_engine.processors.workflow_fire_history import (
+    fetch_workflow_groups_paginated,
+    fetch_workflow_hourly_stats,
+)
 
 pytestmark = [requires_snuba]
 
 
 @freeze_time()
-class WorkflowFireHistoryProcessorTest(TestCase):
+class WorkflowGroupsPaginatedTest(TestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
@@ -182,3 +185,69 @@ class WorkflowFireHistoryProcessorTest(TestCase):
                 ),
             ],
         )
+
+
+@freeze_time()
+class FetchRuleHourlyStatsTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.group = self.create_group()
+        self.project = self.group.project
+        self.organization = self.project.organization
+
+        self.history: list[WorkflowFireHistory] = []
+        self.workflow = self.create_workflow(organization=self.organization)
+
+        for i in range(3):
+            for _ in range(i + 1):
+                self.history.append(
+                    WorkflowFireHistory(
+                        workflow=self.workflow,
+                        group=self.group,
+                    )
+                )
+
+        self.workflow_2 = self.create_workflow(organization=self.organization)
+        for i in range(2):
+            self.history.append(
+                WorkflowFireHistory(
+                    workflow=self.workflow_2,
+                    group=self.group,
+                )
+            )
+
+        histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
+
+        # manually update date_added
+        index = 0
+        for i in range(3):
+            for _ in range(i + 1):
+                histories[index].update(date_added=before_now(hours=i + 1))
+                index += 1
+
+        for i in range(2):
+            histories[i + 6].update(date_added=before_now(hours=i + 4))
+
+        self.base_triggered_date = before_now(days=1)
+
+        self.login_as(self.user)
+
+    def test_workflow_hourly_stats(self):
+        results = fetch_workflow_hourly_stats(self.workflow, before_now(hours=6), before_now())
+        assert len(results) == 6
+        assert [result.count for result in results] == [
+            0,
+            0,
+            3,
+            2,
+            1,
+            0,
+        ]  # last zero is for the current hour
+
+    def test_workflow_hourly_stats__past_date_range(self):
+        results = fetch_workflow_hourly_stats(
+            self.workflow_2, before_now(hours=6), before_now(hours=2)
+        )
+        assert len(results) == 4
+        assert [result.count for result in results] == [1, 1, 0, 0]


### PR DESCRIPTION
Create the workflow equivalent of `ProjectRuleStatsEndpoint`.

This is used to power the chart showing how many times the workflow was triggered within some past time period. The difference between workflows and rules is that we will show how many times the workflow trigger conditions were met, whereas the rule chart currently shows how many times the rule trigger + filter conditions were met (and thus fired an action).

Response data looks like
```
[
    {'date': datetime.datetime(2025, 4, 24, 22, 0, tzinfo=datetime.timezone.utc), 'count': 3},
    {'date': datetime.datetime(2025, 4, 24, 23, 0, tzinfo=datetime.timezone.utc), 'count': 1}
]
```