### PR TITLE
fix(issue-stream): Fix responsive styles at certain widths

### DIFF
--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -120,10 +120,6 @@ const FirstSeenLabel = styled(IssueStreamHeaderLabel)`
 
 const EventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
   width: 60px;
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    display: none;
-  }
 `;
 
 const PriorityLabel = styled(IssueStreamHeaderLabel)`


### PR DESCRIPTION
I noticed that at small widths, the headers on the issue stream were being removed when not meant to. Located a media query which wasn't deleted when we GA'd the new table styles.