### PR TITLE
fix(jira-server): Adds new webhook URL, version checks for newer datacenter installations

### DIFF
--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -14,6 +14,11 @@ from sentry.identity.services.identity.model import RpcIdentity
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.utils.metrics import (
+    IntegrationDomain,
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import control_silo_function
 from sentry.utils import jwt
@@ -226,6 +231,9 @@ class JiraServerSetupClient(ApiClient):
     access_token_url = "{}/plugins/servlet/oauth/access-token"
     authorize_url = "{}/plugins/servlet/oauth/authorize?oauth_token={}"
     integration_name = "jira_server_setup"
+    SERVER_INFO_URL = "/rest/api/2/serverInfo"
+    WEBHOOK_URL = "/rest/jira-webhook/1.0/webhooks"
+    LEGACY_WEBHOOK_URL = "/rest/webhooks/1.0/webhook"
 
     @control_silo_function
     def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
@@ -291,7 +299,27 @@ class JiraServerSetupClient(ApiClient):
             "url": absolute_uri(path),
             "events": ["jira:issue_created", "jira:issue_updated"],
         }
-        return self.post("/rest/webhooks/1.0/webhook", auth=auth, data=data)
+
+        with IntegrationPipelineViewEvent(
+            interaction_type=IntegrationPipelineViewType.WEBHOOK_CREATION,
+            domain=IntegrationDomain.PROJECT_MANAGEMENT,
+            provider_key=self.integration_name,
+        ).capture() as lifecycle:
+            webhook_url = self.WEBHOOK_URL
+
+            # Query the server version to determine which webhook endpoint to use
+            server_info = self.get(self.SERVER_INFO_URL, auth=auth)
+            server_version = server_info.get("version")
+            server_major_version = server_version.split(".")[0] if server_version else None
+            lifecycle.add_extra("server_major_version", server_major_version)
+
+            if server_major_version and int(server_major_version) >= 10:
+                webhook_url = self.WEBHOOK_URL
+            else:
+                # Fallback to legacy webhook endpoint if we encounter an error
+                webhook_url = self.LEGACY_WEBHOOK_URL
+
+            return self.post(webhook_url, auth=auth, data=data)
 
     def request(self, *args, **kwargs):
         """

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -11,11 +11,11 @@ from requests import PreparedRequest
 from requests_oauthlib import OAuth1
 
 from sentry.identity.services.identity.model import RpcIdentity
+from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.utils.metrics import (
-    IntegrationDomain,
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -277,6 +277,9 @@ class IntegrationPipelineViewType(StrEnum):
     # Azure DevOps
     ACCOUNT_CONFIG = "account_config"
 
+    # Jira Server
+    WEBHOOK_CREATION = "webhook_creation"
+
 
 class IntegrationPipelineErrorReason(StrEnum):
     # OAuth identity


### PR DESCRIPTION
As of v10.0.0, the webhook URL for Jira Datacenter has changed: https://developer.atlassian.com/server/jira/platform/webhooks/

This does a version check via the `server_info` endpoint, and selects the correct webhook URL for the given Jira Server/Datacenter instance.

Fixes RTC-442
