### PR TITLE
ref(billing): FE constant cleanup, pt. 1

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -3544,9 +3544,8 @@ describe('Customer Details', function () {
       })[0]!
     );
 
-    const item = screen.getByTestId(`gift-${DataCategory.SPANS_INDEXED}`);
-    expect(item).toBeInTheDocument();
-    expect(item).toHaveAttribute('aria-disabled', 'true');
+    const item = screen.queryByTestId(`gift-${DataCategory.SPANS_INDEXED}`);
+    expect(item).not.toBeInTheDocument();
   });
 
   it('can gift events - MONITOR SEATS', async function () {
@@ -4022,7 +4021,11 @@ describe('Gift Categories Availability', function () {
       organization,
       planDetails: {
         ...SubscriptionFixture({organization}).planDetails,
-        checkoutCategories: [DataCategory.ERRORS, DataCategory.REPLAYS],
+        checkoutCategories: [
+          DataCategory.ERRORS,
+          DataCategory.REPLAYS,
+          DataCategory.SPANS,
+        ],
         onDemandCategories: [DataCategory.ERRORS, DataCategory.PROFILE_DURATION],
         categories: [
           DataCategory.ERRORS,
@@ -4106,9 +4109,9 @@ describe('Gift Categories Availability', function () {
     expect(giftCategories[DataCategory.SPANS]?.disabled).toBe(true);
   });
 
-  it('disables categories in neither checkoutCategories nor onDemandCategories', function () {
+  it('filters out categories in neither checkoutCategories nor onDemandCategories', function () {
     const giftCategories = customerDetails.giftCategories;
     // PROFILE_DURATION_UI is not in either checkoutCategories or onDemandCategories
-    expect(giftCategories[DataCategory.PROFILE_DURATION_UI]?.disabled).toBe(true);
+    expect(Object.keys(giftCategories)).not.toContain(DataCategory.PROFILE_DURATION_UI);
   });
 });

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -57,13 +57,13 @@ import testVercelApiEndpoint from 'admin/components/testVCApiEndpoints';
 import toggleSpendAllocationModal from 'admin/components/toggleSpendAllocationModal';
 import TrialSubscriptionAction from 'admin/components/trialSubscriptionAction';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
-import type {BillingConfig, Subscription} from 'getsentry/types';
+import type {BillingConfig, DataCategories, Subscription} from 'getsentry/types';
 import {
   hasActiveVCFeature,
   isBizPlanFamily,
   isUnlimitedReserved,
 } from 'getsentry/utils/billing';
-import {getPlanCategoryName, GIFT_CATEGORIES} from 'getsentry/utils/dataCategory';
+import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 
 const DEFAULT_ERROR_MESSAGE = 'Unable to update the customer account';
 
@@ -129,41 +129,39 @@ class CustomerDetails extends DeprecatedAsyncComponent<Props, State> {
     if (!data?.planDetails) {
       return {};
     }
-    // Can only gift for checkout categories
+    // We display all categories that are in either checkoutCategories or onDemandCategories,
+    // then disable the button if the category cannot be gifted to on this particular subscription (ie. unlimited quota).
+    // Categories that are not giftable in any state for the subscription are excluded (ie. plan does not include category).
     return Object.fromEntries(
-      GIFT_CATEGORIES.map(category => {
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        const reserved = data.categories?.[category]?.reserved;
-        const isUnlimited = isUnlimitedReserved(reserved);
-        const isReservedBudgetQuota = reserved === RESERVED_BUDGET_QUOTA;
+      data.planDetails.categories
+        .filter(
+          category =>
+            data.planDetails.checkoutCategories.includes(category) ||
+            data.planDetails.onDemandCategories.includes(category)
+        )
+        .map(category => {
+          const reserved = data.categories?.[category as DataCategories]?.reserved;
+          const isUnlimited = isUnlimitedReserved(reserved);
+          const isReservedBudgetQuota = reserved === RESERVED_BUDGET_QUOTA;
 
-        // Check why categories are disabled
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        const categoryNotExists = !data.categories?.[category];
-        const notInCheckoutCategories =
-          !data.planDetails?.checkoutCategories?.includes(category);
-        const notInOnDemandCategories =
-          !data.planDetails?.onDemandCategories?.includes(category);
+          // Check why categories are disabled
+          const categoryNotExists = !data.categories?.[category as DataCategories];
 
-        return [
-          category,
-          {
-            disabled:
-              categoryNotExists ||
-              (notInCheckoutCategories && notInOnDemandCategories) ||
-              isUnlimited ||
+          return [
+            category,
+            {
+              disabled: categoryNotExists || isUnlimited || isReservedBudgetQuota,
+              displayName: getPlanCategoryName({
+                plan: data.planDetails,
+                category,
+                capitalize: false,
+                hadCustomDynamicSampling: isReservedBudgetQuota,
+              }),
+              isUnlimited,
               isReservedBudgetQuota,
-            displayName: getPlanCategoryName({
-              plan: data.planDetails,
-              category,
-              capitalize: false,
-              hadCustomDynamicSampling: isReservedBudgetQuota,
-            }),
-            isUnlimited,
-            isReservedBudgetQuota,
-          },
-        ];
-      })
+            },
+          ];
+        })
     );
   }
 

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -1,4 +1,4 @@
-import {DataCategory, DataCategoryExact} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 
 import {PlanTier} from 'getsentry/types';
 
@@ -51,10 +51,10 @@ export enum AllocationTargetTypes {
   ORGANIZATION = 'Organization',
 }
 
-export const ALLOCATION_SUPPORTED_CATEGORIES: DataCategoryExact[] = [
-  DataCategoryExact.ERROR,
-  DataCategoryExact.TRANSACTION,
-  DataCategoryExact.ATTACHMENT,
+export const ALLOCATION_SUPPORTED_CATEGORIES: DataCategory[] = [
+  DataCategory.ERRORS,
+  DataCategory.TRANSACTIONS,
+  DataCategory.ATTACHMENTS,
 ];
 
 export const PRODUCT_TRIAL_CATEGORIES: DataCategory[] = [

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -13,7 +13,6 @@ import type {
   RecurringCredit,
   Subscription,
 } from 'getsentry/types';
-import titleCase from 'getsentry/utils/titleCase';
 
 const DATA_CATEGORY_FEATURES: Record<string, string | null> = {
   [DataCategory.ERRORS]: null, // All plans have access to errors
@@ -91,7 +90,7 @@ export function getSingularCategoryName({
         ? displayNames.singular
         : category.substring(0, category.length - 1);
   return title
-    ? titleCase(categoryName)
+    ? toTitleCase(categoryName, {allowInnerUpperCase: true})
     : capitalize
       ? upperFirst(categoryName)
       : categoryName;

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -1,5 +1,7 @@
 import upperFirst from 'lodash/upperFirst';
 
+import {DATA_CATEGORY_INFO} from 'sentry/constants';
+import type {DataCategoryExact} from 'sentry/types/core';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
@@ -11,21 +13,7 @@ import type {
   RecurringCredit,
   Subscription,
 } from 'getsentry/types';
-import {CreditType} from 'getsentry/types';
 import titleCase from 'getsentry/utils/titleCase';
-
-export const GIFT_CATEGORIES: string[] = [
-  DataCategory.ERRORS,
-  DataCategory.TRANSACTIONS,
-  DataCategory.REPLAYS,
-  DataCategory.ATTACHMENTS,
-  DataCategory.MONITOR_SEATS,
-  DataCategory.SPANS,
-  DataCategory.SPANS_INDEXED,
-  DataCategory.PROFILE_DURATION,
-  DataCategory.PROFILE_DURATION_UI,
-  DataCategory.UPTIME,
-];
 
 const DATA_CATEGORY_FEATURES: Record<string, string | null> = {
   [DataCategory.ERRORS]: null, // All plans have access to errors
@@ -37,37 +25,18 @@ const DATA_CATEGORY_FEATURES: Record<string, string | null> = {
   [DataCategory.UPTIME]: 'uptime',
 };
 
-const CREDIT_TYPE_TO_DATA_CATEGORY = {
-  [CreditType.ERROR]: DataCategory.ERRORS,
-  [CreditType.TRANSACTION]: DataCategory.TRANSACTIONS,
-  [CreditType.SPAN]: DataCategory.SPANS,
-  [CreditType.PROFILE_DURATION]: DataCategory.PROFILE_DURATION,
-  [CreditType.PROFILE_DURATION_UI]: DataCategory.PROFILE_DURATION_UI,
-  [CreditType.ATTACHMENT]: DataCategory.ATTACHMENTS,
-  [CreditType.REPLAY]: DataCategory.REPLAYS,
-  [CreditType.MONITOR_SEAT]: DataCategory.MONITOR_SEATS,
-  [CreditType.UPTIME]: DataCategory.UPTIME,
-};
-
-export const SINGULAR_DATA_CATEGORY = {
-  default: 'default',
-  errors: 'error',
-  transactions: 'transaction',
-  profiles: 'profile',
-  attachments: 'attachment',
-  replays: 'replay',
-  monitorSeats: 'monitorSeat',
-  spans: 'span',
-  uptime: 'uptime',
-};
-
 /**
  *
  * Get the data category for a recurring credit type
  */
-export function getCreditDataCategory(credit: RecurringCredit) {
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  return CREDIT_TYPE_TO_DATA_CATEGORY[credit.type];
+export function getCreditDataCategory(credit: RecurringCredit): DataCategory | null {
+  const category =
+    (DATA_CATEGORY_INFO[credit.type as string as DataCategoryExact]
+      ?.plural as DataCategory) || null;
+  if (!category) {
+    return null;
+  }
+  return category;
 }
 
 type CategoryNameProps = {

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import capitalize from 'lodash/capitalize';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -15,7 +14,6 @@ import NewBooleanField from 'sentry/components/forms/fields/booleanField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {PanelTable} from 'sentry/components/panels/panelTable';
-import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -64,12 +62,12 @@ function AllocationForm({
   const [allocationVolume, setAllocationVolume] = useState<number>(0);
   const [errorFields, setErrorFields] = useState<string[]>([]);
   const [showPrice, setShowPrice] = useState<boolean>(false);
-  const [selectedMetric, setSelectedMetric] = useState<DataCategory | null>(
+  const [selectedMetric, setSelectedMetric] = useState<DataCategory>(
     initializedData
       ? (initializedData.billingMetric as DataCategory)
       : initialMetric && ALLOCATION_SUPPORTED_CATEGORIES.includes(initialMetric)
         ? initialMetric
-        : (ALLOCATION_SUPPORTED_CATEGORIES[0] ?? null)
+        : ALLOCATION_SUPPORTED_CATEGORIES[0]!
   );
   const [targetId, setTargetId] = useState<string | undefined>(
     initializedData && String(initializedData.targetId)
@@ -232,8 +230,11 @@ function AllocationForm({
         <Title>
           <span>
             {tct('Allocate [category] by [displayType]', {
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              category: capitalize(DATA_CATEGORY_INFO[selectedMetric].plural),
+              category: getPlanCategoryName({
+                plan: subscription.planDetails,
+                category: selectedMetric,
+                title: true,
+              }),
               displayType: showPrice ? t('Spend') : t('Volume'),
             })}
           </span>

--- a/static/gsApp/views/spendAllocations/index.spec.tsx
+++ b/static/gsApp/views/spendAllocations/index.spec.tsx
@@ -596,7 +596,7 @@ describe('DELETE spend allocation', () => {
       statusCode: 200,
       match: [
         MockApiClient.matchQuery({
-          billing_metric: 'error',
+          billing_metric: 'errors',
           target_id: 1,
           target_type: 'Project',
         }),

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -13,11 +13,10 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconAdd, IconBroadcast} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {DataCategory, DataCategoryExact} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -32,8 +31,12 @@ import {
   AllocationTargetTypes,
 } from 'getsentry/constants';
 import type {Subscription} from 'getsentry/types';
-import {displayPlanName, isAmEnterprisePlan} from 'getsentry/utils/billing';
-import {SINGULAR_DATA_CATEGORY} from 'getsentry/utils/dataCategory';
+import {
+  displayPlanName,
+  getCategoryInfoFromPlural,
+  isAmEnterprisePlan,
+} from 'getsentry/utils/billing';
+import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 import {isDisabledByPartner} from 'getsentry/utils/partnerships';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import PartnershipNote from 'getsentry/views/subscriptionPage/partnershipNote';
@@ -56,9 +59,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
   const [errors, setErrors] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [orgEnabledFlag, setOrgEnabledFlag] = useState<boolean>(true);
-  const [selectedMetric, setSelectedMetric] = useState<string>(
-    DATA_CATEGORY_INFO[DataCategoryExact.ERROR].plural
-  ); // NOTE: plural lowercase datacategories ex. errors
+  const [selectedMetric, setSelectedMetric] = useState<DataCategory>(DataCategory.ERRORS);
   const [shouldRetry, setShouldRetry] = useState<boolean>(true);
   const [rootAllocations, setRootAllocations] = useState<SpendAllocation[]>([]);
   const [spendAllocations, setSpendAllocations] = useState<SpendAllocation[]>([]); // NOTE: we default to fetching 1 period
@@ -77,7 +78,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
   }, [selectedMetric]);
 
   const supportedCategories = ALLOCATION_SUPPORTED_CATEGORIES.filter(category =>
-    planDetails.categories.includes(DATA_CATEGORY_INFO[category].plural)
+    planDetails.categories.includes(category)
   );
 
   const period = useMemo<Date[]>(() => {
@@ -126,8 +127,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
 
   const rootAllocationForMetric: SpendAllocation | undefined = useMemo(() => {
     const root = currentRootAllocations.find(
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      a => a.billingMetric === SINGULAR_DATA_CATEGORY[selectedMetric]
+      a => a.billingMetric === getCategoryInfoFromPlural(selectedMetric)?.name
     );
     return root;
   }, [currentRootAllocations, selectedMetric]);
@@ -167,8 +167,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
               periods,
               target_type: 'Project',
               cursor: currentCursor,
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              billing_metric: SINGULAR_DATA_CATEGORY[selectedMetric],
+              billing_metric: getCategoryInfoFromPlural(selectedMetric)?.name,
             },
           }
         );
@@ -198,7 +197,12 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
   );
 
   const deleteSpendAllocation =
-    (billingMetric: string, targetId: number, targetType: string, timestamp: number) =>
+    (
+      billingMetric: DataCategory | null,
+      targetId: number,
+      targetType: string,
+      timestamp: number
+    ) =>
     async (e: React.MouseEvent) => {
       e.preventDefault();
       setErrors(null);
@@ -227,8 +231,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
       await api.requestPromise(PATH, {
         method: 'POST',
         data: {
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          billing_metric: SINGULAR_DATA_CATEGORY[selectedMetric],
+          billing_metric: getCategoryInfoFromPlural(selectedMetric)?.name,
           target_id: organization.id,
           target_type: AllocationTargetTypes.ORGANIZATION,
           desired_quantity: 1,
@@ -427,17 +430,17 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
             triggerProps={{prefix: t('Category')}}
             value={selectedMetric}
             options={supportedCategories
-              .filter(category =>
-                subscription.planDetails.categories.includes(
-                  DATA_CATEGORY_INFO[category].plural
-                )
-              )
+              .filter(category => subscription.planDetails.categories.includes(category))
               .map(category => ({
-                value: DATA_CATEGORY_INFO[category].plural,
-                label: DATA_CATEGORY_INFO[category].titleName,
+                value: category,
+                label: getPlanCategoryName({
+                  plan: subscription.planDetails,
+                  category,
+                  title: true,
+                }),
               }))}
             onChange={opt => {
-              setSelectedMetric(String(opt?.value));
+              setSelectedMetric(opt?.value as DataCategory);
               setCurrentCursor('');
             }}
           />

--- a/static/gsApp/views/spendAllocations/projectAllocationsTable.tsx
+++ b/static/gsApp/views/spendAllocations/projectAllocationsTable.tsx
@@ -4,8 +4,9 @@ import styled from '@emotion/styled';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {DataCategory} from 'sentry/types/core';
 
-import {SINGULAR_DATA_CATEGORY} from 'getsentry/utils/dataCategory';
+import {getCategoryInfoFromPlural} from 'getsentry/utils/billing';
 
 import AllocationRow from './components/allocationRow';
 import {Centered, Divider, HalvedWithDivider} from './components/styles';
@@ -15,14 +16,14 @@ import {midPeriod} from './utils';
 
 type Props = {
   deleteSpendAllocation: (
-    selectedMetric: string,
+    selectedMetric: DataCategory | null,
     targetId: number,
     targetType: string,
     timestamp: number
   ) => (e: React.MouseEvent) => void;
   metricUnit: BigNumUnits;
   openForm: (formData?: SpendAllocation) => (e: React.MouseEvent) => void;
-  selectedMetric: string;
+  selectedMetric: DataCategory;
   spendAllocations?: SpendAllocation[];
 };
 
@@ -36,8 +37,7 @@ function ProjectAllocationsTable({
   const filteredMetrics: SpendAllocation[] = useMemo(() => {
     const filtered = spendAllocations.filter(
       allocation =>
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        allocation.billingMetric === SINGULAR_DATA_CATEGORY[selectedMetric] &&
+        allocation.billingMetric === getCategoryInfoFromPlural(selectedMetric)?.name &&
         allocation.targetType === 'Project'
     );
     // NOTE: This will NOT work once we include multiple layers. We'll need to construct a tree
@@ -93,8 +93,7 @@ function ProjectAllocationsTable({
               key={a.id}
               allocation={a}
               deleteAction={deleteSpendAllocation(
-                // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                SINGULAR_DATA_CATEGORY[selectedMetric],
+                selectedMetric,
                 a.targetId,
                 a.targetType,
                 midPeriod(a.period)

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import capitalize from 'lodash/capitalize';
 
 import {Button} from 'sentry/components/core/button';
 import type {TooltipProps} from 'sentry/components/core/tooltip';
@@ -16,8 +15,8 @@ import type {BillingStatTotal, Subscription} from 'getsentry/types';
 import {formatUsageWithUnits} from 'getsentry/utils/billing';
 import {
   getPlanCategoryName,
+  getSingularCategoryName,
   isContinuousProfiling,
-  SINGULAR_DATA_CATEGORY,
 } from 'getsentry/utils/dataCategory';
 import {StripedTable} from 'getsentry/views/subscriptionPage/styles';
 import {displayPercentage} from 'getsentry/views/subscriptionPage/usageTotals';
@@ -166,8 +165,11 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
               <TextOverflow>
                 {isEventBreakdown
                   ? tct('[singularName] Events', {
-                      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                      singularName: capitalize(SINGULAR_DATA_CATEGORY[category]),
+                      singularName: getSingularCategoryName({
+                        plan: subscription.planDetails,
+                        category,
+                        title: true,
+                      }),
                     })
                   : categoryName}
               </TextOverflow>

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -9,15 +9,12 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {IconStack} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {DataCategory} from 'sentry/types/core';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import type {BillingStatTotal, Subscription} from 'getsentry/types';
-import {formatUsageWithUnits} from 'getsentry/utils/billing';
-import {
-  getPlanCategoryName,
-  getSingularCategoryName,
-  isContinuousProfiling,
-} from 'getsentry/utils/dataCategory';
+import {formatUsageWithUnits, getCategoryInfoFromPlural} from 'getsentry/utils/billing';
+import {getPlanCategoryName, isContinuousProfiling} from 'getsentry/utils/dataCategory';
 import {StripedTable} from 'getsentry/views/subscriptionPage/styles';
 import {displayPercentage} from 'getsentry/views/subscriptionPage/usageTotals';
 
@@ -165,11 +162,11 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
               <TextOverflow>
                 {isEventBreakdown
                   ? tct('[singularName] Events', {
-                      singularName: getSingularCategoryName({
-                        plan: subscription.planDetails,
-                        category,
-                        title: true,
-                      }),
+                      singularName: toTitleCase(
+                        getCategoryInfoFromPlural(category as DataCategory)
+                          ?.displayName ?? category,
+                        {allowInnerUpperCase: true}
+                      ),
                     })
                   : categoryName}
               </TextOverflow>


### PR DESCRIPTION
First effort at https://linear.app/getsentry/issue/BIL-481/reduce-fe-category-constants, tackling constants living in `dataCategory.tsx`

