### PR TITLE
fix(nav): Fix links to /settings/stats/ pages

### DIFF
--- a/static/app/utils/url/normalizeUrl.spec.tsx
+++ b/static/app/utils/url/normalizeUrl.spec.tsx
@@ -69,6 +69,11 @@ describe('normalizeUrl', function () {
       ['/settings/account/security/', '/settings/account/security/'],
       ['/settings/account/details/', '/settings/account/details/'],
 
+      // Stats views should stay the same
+      ['/settings/stats/', '/settings/stats/'],
+      ['/settings/stats/issues/', '/settings/stats/issues/'],
+      ['/settings/stats/health/', '/settings/stats/health/'],
+
       ['/join-request/acme', '/join-request/'],
       ['/join-request/acme/', '/join-request/'],
       ['/onboarding/acme/', '/onboarding/'],

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -8,13 +8,13 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/\/organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
   [
-    /\/settings\/(?!account\/|billing\/|projects\/|teams\/)[^\/]+\/?$/,
+    /\/settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/)[^\/]+\/?$/,
     '/settings/organization/',
   ],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
   [
-    /^\/?settings\/(?!account\/|billing\/|projects\/|teams\/)[^\/]+\/(.*)/,
+    /^\/?settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/)[^\/]+\/(.*)/,
     '/settings/$1',
   ],
   [/^\/?join-request\/[^\/]+\/?.*/, '/join-request/'],


### PR DESCRIPTION
`normalizeUrl` was taking `/settings/stats/` and converting it to `/settings/organization/`. Stats needs to be treated like `account`, `billing`, etc which are explicitly ignored in `normalizeUrl`.