### PR TITLE
chore(aci milestone 3): remove resolution action filter to unblock dual write

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -341,9 +341,9 @@ def get_resolve_threshold(detector_data_condition_group: DataConditionGroup) -> 
     return resolve_threshold
 
 
-def migrate_resolve_threshold_data_conditions(
+def migrate_resolve_threshold_data_condition(
     alert_rule: AlertRule,
-) -> tuple[DataCondition, DataCondition]:
+) -> DataCondition:
     """
     Create data conditions for the old world's "resolve" threshold. If a resolve threshold
     has been explicitly set on the alert rule, then use this as our comparison value. Otherwise,
@@ -382,22 +382,7 @@ def migrate_resolve_threshold_data_conditions(
         condition_group=detector_data_condition_group,
     )
 
-    data_condition_group = DataConditionGroup.objects.create(
-        organization_id=alert_rule.organization_id
-    )
-    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
-    WorkflowDataConditionGroup.objects.create(
-        condition_group=data_condition_group,
-        workflow=alert_rule_workflow.workflow,
-    )
-
-    action_filter = DataCondition.objects.create(
-        comparison=DetectorPriorityLevel.OK,
-        condition_result=True,
-        type=Condition.ISSUE_PRIORITY_EQUALS,
-        condition_group=data_condition_group,
-    )
-    return detector_trigger, action_filter
+    return detector_trigger
 
 
 def create_metric_alert_lookup_tables(
@@ -586,7 +571,7 @@ def dual_write_alert_rule(alert_rule: AlertRule, user: RpcUser | None = None) ->
             for trigger_action in trigger_actions:
                 migrate_metric_action(trigger_action)
         # step 4: migrate alert rule resolution
-        migrate_resolve_threshold_data_conditions(alert_rule)
+        migrate_resolve_threshold_data_condition(alert_rule)
 
 
 def dual_update_alert_rule(alert_rule: AlertRule) -> None:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -42,7 +42,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_alert_rule,
     migrate_metric_action,
     migrate_metric_data_conditions,
-    migrate_resolve_threshold_data_conditions,
+    migrate_resolve_threshold_data_condition,
 )
 from sentry.workflow_engine.migration_helpers.utils import get_workflow_name
 from sentry.workflow_engine.models import (
@@ -120,21 +120,6 @@ def assert_alert_rule_resolve_trigger_migrated(alert_rule):
     assert detector_trigger.type == Condition.LESS_OR_EQUAL
     assert detector_trigger.condition_result == DetectorPriorityLevel.OK
     assert detector_trigger.condition_group == detector.workflow_condition_group
-
-    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
-    workflow = alert_rule_workflow.workflow
-    workflow_dcgs = DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow=workflow)
-
-    data_condition = DataCondition.objects.get(
-        comparison=DetectorPriorityLevel.OK, condition_group__in=workflow_dcgs
-    )
-
-    assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
-    assert data_condition.comparison == DetectorPriorityLevel.OK
-    assert data_condition.condition_result is True
-    assert WorkflowDataConditionGroup.objects.filter(
-        condition_group=data_condition.condition_group
-    ).exists()
 
 
 def assert_dual_written_resolution_threshold_equals(alert_rule, threshold):
@@ -679,7 +664,7 @@ class DualWriteAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
         """
         migrate_metric_data_conditions(self.alert_rule_trigger_warning)
         migrate_metric_data_conditions(self.alert_rule_trigger_critical)
-        migrate_resolve_threshold_data_conditions(self.metric_alert)
+        migrate_resolve_threshold_data_condition(self.metric_alert)
 
         assert_alert_rule_trigger_migrated(self.alert_rule_trigger_warning)
         assert_alert_rule_trigger_migrated(self.alert_rule_trigger_critical)
@@ -694,7 +679,7 @@ class DualWriteAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
         )
 
         migrate_metric_data_conditions(critical_trigger)
-        migrate_resolve_threshold_data_conditions(self.metric_alert_no_resolve)
+        migrate_resolve_threshold_data_condition(self.metric_alert_no_resolve)
 
         detector = AlertRuleDetector.objects.get(
             alert_rule_id=self.metric_alert_no_resolve.id
@@ -709,15 +694,6 @@ class DualWriteAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
         assert resolve_detector_trigger.condition_result == DetectorPriorityLevel.OK
         assert resolve_detector_trigger.condition_group == detector.workflow_condition_group
 
-        resolve_data_condition = DataCondition.objects.get(comparison=DetectorPriorityLevel.OK)
-
-        assert resolve_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
-        assert resolve_data_condition.condition_result is True
-        assert resolve_data_condition.condition_group == resolve_data_condition.condition_group
-        assert WorkflowDataConditionGroup.objects.filter(
-            condition_group=resolve_data_condition.condition_group
-        ).exists()
-
     def test_create_metric_alert_trigger_auto_resolve_less_than(self):
         """
         Test that we assign the resolve detector trigger the correct type if the threshold type is BELOW
@@ -728,7 +704,7 @@ class DualWriteAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
         )
 
         migrate_metric_data_conditions(critical_trigger)
-        migrate_resolve_threshold_data_conditions(self.metric_alert_no_resolve)
+        migrate_resolve_threshold_data_condition(self.metric_alert_no_resolve)
 
         detector = AlertRuleDetector.objects.get(
             alert_rule_id=self.metric_alert_no_resolve.id

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -365,14 +365,13 @@ class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
 
     def create_migrated_metric_alert_rule_resolve_objects(
         self, alert_rule: AlertRule, resolve_threshold, detector_trigger_type: Condition
-    ) -> tuple[DataCondition, DataCondition]:
+    ) -> DataCondition:
         """
         Set up all the necessary ACI objects for a dual written metric alert resolution threshold.
         """
         detector = AlertRuleDetector.objects.get(alert_rule_id=alert_rule.id).detector
         detector_dcg = detector.workflow_condition_group
         assert detector_dcg  # to appease mypy
-        workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id).workflow
 
         detector_trigger = self.create_data_condition(
             comparison=resolve_threshold,
@@ -380,18 +379,8 @@ class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
             type=detector_trigger_type,
             condition_group=detector_dcg,
         )
-        data_condition_group = self.create_data_condition_group(organization=self.organization)
-        self.create_workflow_data_condition_group(
-            condition_group=data_condition_group, workflow=workflow
-        )
-        action_filter = self.create_data_condition(
-            comparison=DetectorPriorityLevel.OK,
-            condition_result=True,
-            type=Condition.ISSUE_PRIORITY_EQUALS,
-            condition_group=data_condition_group,
-        )
 
-        return detector_trigger, action_filter
+        return detector_trigger
 
     def create_migrated_metric_alert_rule_action_objects(
         self, alert_rule_trigger_action: AlertRuleTriggerAction
@@ -473,12 +462,10 @@ class DualDeleteAlertRuleTest(BaseMetricAlertMigrationTest):
             self.detector_workflow,
             self.data_source_detector,
         ) = self.create_migrated_metric_alert_objects(self.metric_alert)
-        # we need to set up the resolve conditions here, because the dual delete helper expects them
-        # their contents don't matter, they just need to exist
-        self.resolve_detector_trigger, self.resolve_action_filter = (
-            self.create_migrated_metric_alert_rule_resolve_objects(
-                self.metric_alert, 67, Condition.LESS_OR_EQUAL
-            )
+        # we need to set up the resolve condition here, because the dual delete helper expects it
+        # its content doesn't matter, it just needs to exist
+        self.resolve_detector_trigger = self.create_migrated_metric_alert_rule_resolve_objects(
+            self.metric_alert, 67, Condition.LESS_OR_EQUAL
         )
 
     def test_dual_delete_metric_alert_workflow(self):
@@ -523,7 +510,6 @@ class DualDeleteAlertRuleTest(BaseMetricAlertMigrationTest):
             alert_rule_trigger, DetectorPriorityLevel.HIGH, Condition.GREATER
         )
         action_filter_dcg = action_filter.condition_group
-        resolve_action_filter_dcg = self.resolve_action_filter.condition_group
         action, data_condition_group_action, aarta = (
             self.create_migrated_metric_alert_rule_action_objects(alert_rule_trigger_action)
         )
@@ -538,9 +524,7 @@ class DualDeleteAlertRuleTest(BaseMetricAlertMigrationTest):
         assert not ActionAlertRuleTriggerAction.objects.filter(id=aarta.id).exists()
 
         # check resolution objects
-        assert not DataConditionGroup.objects.filter(id=resolve_action_filter_dcg.id).exists()
         assert not DataCondition.objects.filter(id=self.resolve_detector_trigger.id).exists()
-        assert not DataCondition.objects.filter(id=self.resolve_action_filter.id).exists()
 
         # check trigger objects
         assert not DataConditionGroup.objects.filter(id=action_filter_dcg.id).exists()
@@ -588,10 +572,8 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
                 self.alert_rule_trigger, DetectorPriorityLevel.HIGH, Condition.GREATER
             )
         )
-        self.resolve_detector_trigger, self.resolve_action_filter = (
-            self.create_migrated_metric_alert_rule_resolve_objects(
-                self.metric_alert, 200, Condition.LESS_OR_EQUAL
-            )
+        self.resolve_detector_trigger = self.create_migrated_metric_alert_rule_resolve_objects(
+            self.metric_alert, 200, Condition.LESS_OR_EQUAL
         )
 
     def test_dual_update_metric_alert(self):
@@ -788,10 +770,8 @@ class DualUpdateAlertRuleTriggerTest(BaseMetricAlertMigrationTest):
                 self.alert_rule_trigger, DetectorPriorityLevel.HIGH, Condition.GREATER
             )
         )
-        self.resolve_detector_trigger, self.resolve_action_filter = (
-            self.create_migrated_metric_alert_rule_resolve_objects(
-                self.metric_alert, 200, Condition.LESS_OR_EQUAL
-            )
+        self.resolve_detector_trigger = self.create_migrated_metric_alert_rule_resolve_objects(
+            self.metric_alert, 200, Condition.LESS_OR_EQUAL
         )
 
     def test_dual_update_metric_alert_threshold_type(self):


### PR DESCRIPTION
We need to have some larger product discussions regarding metric issue resolution + how we fire actions. To unblock the migration, remove the references to the resolution action filter in the dual write helper (and later, the migration).