### PR TITLE
feat(aci): Deprecate `initial_issue_priority` in favor of `priority`

### DIFF
--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -147,7 +147,7 @@ class MetricIssueContext:
     def _get_new_status(cls, group: Group, occurrence: IssueOccurrence) -> IncidentStatus:
         if group.status == GroupStatus.RESOLVED:
             return IncidentStatus.CLOSED
-        elif occurrence.initial_issue_priority == PriorityLevel.MEDIUM.value:
+        elif occurrence.priority == PriorityLevel.MEDIUM.value:
             return IncidentStatus.WARNING
         else:
             return IncidentStatus.CRITICAL

--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -104,7 +104,7 @@ def _build_occurrence_from_incident(
     event_data: dict[str, str | int],
     metric_value: float,
 ) -> IssueOccurrence:
-    initial_issue_priority = (
+    priority = (
         PriorityLevel.HIGH
         if incident.status == IncidentStatus.CRITICAL.value
         else PriorityLevel.MEDIUM
@@ -123,7 +123,7 @@ def _build_occurrence_from_incident(
         detection_time=incident.date_started,
         level="error",
         culprit="",
-        initial_issue_priority=initial_issue_priority,
+        priority=priority,
         # TODO(snigdha): Add more data here as needed
         evidence_data={"metric_value": metric_value, "alert_rule_id": incident.alert_rule.id},
         evidence_display=[],

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -261,7 +261,8 @@ def save_issue_from_occurrence(
         return None
     else:
         group = primary_grouphash.group
-        group.update(priority=issue_kwargs["priority"])
+        if issue_kwargs["priority"] and group.priority != issue_kwargs["priority"]:
+            group.update(priority=issue_kwargs["priority"])
 
         if group.issue_category.value != occurrence.type.category:
             logger.error(

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -100,6 +100,8 @@ class IssueArgs(TypedDict):
 def _create_issue_kwargs(
     occurrence: IssueOccurrence, event: Event, release: Release | None
 ) -> IssueArgs:
+    priority = occurrence.priority or occurrence.type.default_priority
+
     kwargs: IssueArgs = {
         "platform": event.platform,
         # TODO: Figure out what message should be. Or maybe we just implement a platform event and
@@ -113,11 +115,7 @@ def _create_issue_kwargs(
         "type": occurrence.type.type_id,
         "first_release": release,
         "data": materialize_metadata(occurrence, event),
-        "priority": (
-            occurrence.initial_issue_priority
-            if occurrence.initial_issue_priority is not None
-            else occurrence.type.default_priority
-        ),
+        "priority": priority,
     }
     kwargs["data"]["last_received"] = json.datetime_to_str(event.datetime)
     return kwargs
@@ -145,7 +143,7 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
     event_metadata.update(event.get_event_metadata())
     event_metadata["title"] = occurrence.issue_title
     event_metadata["value"] = occurrence.subtitle
-    event_metadata["initial_priority"] = occurrence.initial_issue_priority
+    event_metadata["priority"] = occurrence.priority
 
     if occurrence.type == FeedbackGroup:
         # TODO: Should feedbacks be their own event type, so above call to event.get_event_medata
@@ -262,7 +260,6 @@ def save_issue_from_occurrence(
     elif primary_grouphash.group is None:
         return None
     else:
-        group = primary_grouphash.group
         if group.issue_category.value != occurrence.type.category:
             logger.error(
                 "save_issue_from_occurrence.category_mismatch",

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -143,7 +143,7 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
     event_metadata.update(event.get_event_metadata())
     event_metadata["title"] = occurrence.issue_title
     event_metadata["value"] = occurrence.subtitle
-    event_metadata["priority"] = occurrence.priority
+    event_metadata["initial_priority"] = occurrence.priority
 
     if occurrence.type == FeedbackGroup:
         # TODO: Should feedbacks be their own event type, so above call to event.get_event_medata
@@ -261,9 +261,6 @@ def save_issue_from_occurrence(
         return None
     else:
         group = primary_grouphash.group
-        if issue_kwargs["priority"] and group.priority != issue_kwargs["priority"]:
-            group.update(priority=issue_kwargs["priority"])
-
         if group.issue_category.value != occurrence.type.category:
             logger.error(
                 "save_issue_from_occurrence.category_mismatch",
@@ -279,6 +276,8 @@ def save_issue_from_occurrence(
         group_event.occurrence = occurrence
         is_regression = _process_existing_aggregate(group, group_event, issue_kwargs, release)
         group_info = GroupInfo(group=group, is_new=False, is_regression=is_regression)
+        if issue_kwargs["priority"] and group.priority != issue_kwargs["priority"]:
+            group.update(priority=issue_kwargs["priority"])
 
     additional_hashes = [f for f in occurrence.fingerprint if f != primary_grouphash.hash]
     for fingerprint_hash in additional_hashes:

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -260,6 +260,9 @@ def save_issue_from_occurrence(
     elif primary_grouphash.group is None:
         return None
     else:
+        group = primary_grouphash.group
+        group.update(priority=issue_kwargs["priority"])
+
         if group.issue_category.value != occurrence.type.category:
             logger.error(
                 "save_issue_from_occurrence.category_mismatch",

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -136,6 +136,12 @@ class IssueOccurrence:
         if not culprit:
             culprit = ""
 
+        # When getting the priority, we fallback to the deprecated initial_issue_priority if specified.
+        # This ensures we don't break existing uses of the `initial_issue_priority` field.
+        priority = data.get("priority")
+        if not priority:
+            priority = data.get("initial_issue_priority")
+
         assignee = None
         try:
             # Note that this can cause IO, but in practice this will happen only the first time that
@@ -165,9 +171,7 @@ class IssueOccurrence:
             cast(datetime, parse_timestamp(data["detection_time"])),
             level,
             culprit,
-            # When getting the priority, we fallback to the deprecated initial_issue_priority if specified.
-            # This ensures we don't break existing uses of the `initial_issue_priority` field.
-            data.get("priority", data.get("initial_issue_priority")),
+            priority,
             assignee,
         )
 

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -37,8 +37,8 @@ class IssueOccurrenceData(TypedDict):
     detection_time: float
     level: str | None
     culprit: str | None
-    initial_issue_priority: NotRequired[int | None]
     assignee: NotRequired[str | None]
+    priority: NotRequired[int | None]
     """
     Who to assign the issue to when creating a new issue. Has no effect on existing issues.
     In the format of an Actor identifier, as defined in `Actor.from_identifier`
@@ -94,8 +94,10 @@ class IssueOccurrence:
     detection_time: datetime
     level: str
     culprit: str
-    initial_issue_priority: int | None = None
+    priority: int | None = None
     assignee: Actor | None = None
+    # `initial_issue_priority` is deprecated, use `priority` instead
+    initial_issue_priority: int | None = None
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -118,7 +120,7 @@ class IssueOccurrence:
             "detection_time": self.detection_time.timestamp(),
             "level": self.level,
             "culprit": self.culprit,
-            "initial_issue_priority": self.initial_issue_priority,
+            "priority": self.priority,
             "assignee": self.assignee.identifier if self.assignee else None,
         }
 
@@ -163,7 +165,9 @@ class IssueOccurrence:
             cast(datetime, parse_timestamp(data["detection_time"])),
             level,
             culprit,
-            data.get("initial_issue_priority"),
+            # When getting the priority, we fallback to the deprecated initial_issue_priority if specified.
+            # This ensures we don't break existing uses of the `initial_issue_priority` field.
+            data.get("priority", data.get("initial_issue_priority")),
             assignee,
         )
 

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -138,9 +138,7 @@ class IssueOccurrence:
 
         # When getting the priority, we fallback to the deprecated initial_issue_priority if specified.
         # This ensures we don't break existing uses of the `initial_issue_priority` field.
-        priority = data.get("priority")
-        if not priority:
-            priority = data.get("initial_issue_priority")
+        priority = cast(int | None, data.get("priority", data.get("initial_issue_priority", None)))
 
         assignee = None
         try:

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -226,11 +226,11 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
             if payload.get("culprit"):
                 occurrence_data["culprit"] = payload["culprit"]
 
-            if payload.get("initial_issue_priority") is not None:
-                occurrence_data["initial_issue_priority"] = payload["initial_issue_priority"]
+            if payload.get("priority") is not None:
+                occurrence_data["priority"] = payload["priority"]
             else:
                 group_type = get_group_type_by_type_id(occurrence_data["type"])
-                occurrence_data["initial_issue_priority"] = group_type.default_priority
+                occurrence_data["priority"] = group_type.default_priority
 
             if "event" in payload:
                 event_payload = payload["event"]
@@ -388,7 +388,7 @@ def process_occurrence_message(
 @sentry_sdk.tracing.trace
 @metrics.wraps("occurrence_consumer.process_message")
 def _process_message(
-    message: Mapping[str, Any]
+    message: Mapping[str, Any],
 ) -> tuple[IssueOccurrence | None, GroupInfo | None] | None:
     """
     :raises InvalidEventPayloadError: when the message is invalid

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -26,7 +26,7 @@ class DetectorOccurrence:
     type: type[GroupType]
     level: str
     culprit: str
-    initial_issue_priority: int | None = None
+    priority: int | None = None
     assignee: Actor | None = None
 
     def to_issue_occurrence(
@@ -53,7 +53,7 @@ class DetectorOccurrence:
             detection_time=detection_time,
             level=self.level,
             culprit=self.culprit,
-            initial_issue_priority=self.initial_issue_priority or status,
+            priority=self.priority or status,
             assignee=self.assignee,
         )
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -3760,7 +3760,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         occurrence = mock_produce_occurrence_to_kafka.call_args.kwargs["occurrence"]
         assert occurrence.type == MetricIssuePOC
         assert occurrence.issue_title == incident.title
-        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+        assert occurrence.priority == PriorityLevel.HIGH
         assert occurrence.evidence_data["metric_value"] == trigger.alert_threshold + 1
 
     @with_feature("organizations:metric-issue-poc")
@@ -3795,7 +3795,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert mock_produce_occurrence_to_kafka.call_count == 1
         occurrence = mock_produce_occurrence_to_kafka.call_args.kwargs["occurrence"]
         assert occurrence.type == MetricIssuePOC
-        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+        assert occurrence.priority == PriorityLevel.HIGH
         assert occurrence.evidence_data["metric_value"] == trigger.alert_threshold + 1
         mock_produce_occurrence_to_kafka.reset_mock()
 
@@ -3823,7 +3823,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert mock_produce_occurrence_to_kafka.call_count == 2
         occurrence = mock_produce_occurrence_to_kafka.call_args_list[0][1]["occurrence"]
         assert occurrence.type == MetricIssuePOC
-        assert occurrence.initial_issue_priority == PriorityLevel.MEDIUM
+        assert occurrence.priority == PriorityLevel.MEDIUM
         assert occurrence.evidence_data["metric_value"] == rule.resolve_threshold - 1
 
         status_change = mock_produce_occurrence_to_kafka.call_args_list[1][1]["status_change"]

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -57,7 +57,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
         assert stored_occurrence
         assert occurrence.event_id == stored_occurrence.event_id
         assert occurrence.type == MetricIssuePOC
-        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+        assert occurrence.priority == PriorityLevel.HIGH
 
         assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 1
         group = Group.objects.get(type=MetricIssuePOC.type_id)
@@ -81,7 +81,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
         stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
         assert stored_occurrence
         assert stored_occurrence.type == MetricIssuePOC
-        assert stored_occurrence.initial_issue_priority == PriorityLevel.MEDIUM
+        assert stored_occurrence.priority == PriorityLevel.MEDIUM
 
         assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 1
         group = Group.objects.get(type=MetricIssuePOC.type_id)

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -506,7 +506,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "metadata": {
                 "title": occurrence.issue_title,
                 "value": occurrence.subtitle,
-                "priority": occurrence.priority,
+                "initial_priority": occurrence.priority,
             },
             "title": occurrence.issue_title,
             "location": event.location,
@@ -524,7 +524,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "title": occurrence.issue_title,
             "value": occurrence.subtitle,
             "dogs": "are great",
-            "priority": occurrence.priority,
+            "initial_priority": occurrence.priority,
         }
 
     def test_populates_feedback_metadata(self) -> None:
@@ -550,7 +550,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "message": "test",
             "name": "Name Test",
             "source": "crash report widget",
-            "priority": occurrence.priority,
+            "initial_priority": occurrence.priority,
         }
 
 

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -164,6 +164,32 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         assignee = GroupAssignee.objects.get(group=group_info.group)
         assert assignee.team_id == self.team.id
 
+    def test_issue_platform_handles_deprecated_initial_priority(self) -> None:
+        # test initial_issue_priority is handled
+        event = self.store_event(data={}, project_id=self.project.id)
+        occurrence = self.build_occurrence(
+            event_id=event.event_id,
+            assignee=f"team:{self.team.id}",
+            initial_issue_priority=PriorityLevel.MEDIUM,
+        )
+        _, group_info = save_issue_occurrence(occurrence.to_dict(), event)
+        assert group_info is not None
+        group = group_info.group
+        assert group.priority == PriorityLevel.MEDIUM
+
+        # test that the priority overrides the initial_issue_priority
+        Group.objects.all().delete()
+        occurrence = self.build_occurrence(
+            event_id=event.event_id,
+            assignee=f"team:{self.team.id}",
+            initial_issue_priority=PriorityLevel.MEDIUM,
+            priority=PriorityLevel.HIGH,
+        )
+        _, group_info = save_issue_occurrence(occurrence.to_dict(), event)
+        assert group_info is not None
+        group = group_info.group
+        assert group.priority == PriorityLevel.HIGH
+
 
 class ProcessOccurrenceDataTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -141,7 +141,7 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         occurrence = self.build_occurrence(
             event_id=event.event_id,
-            initial_issue_priority=PriorityLevel.HIGH,
+            priority=PriorityLevel.HIGH,
         )
         _, group_info = save_issue_occurrence(occurrence.to_dict(), event)
         assert group_info is not None
@@ -443,7 +443,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert group_info.group.priority == PriorityLevel.LOW
 
     def test_new_group_with_priority(self) -> None:
-        occurrence = self.build_occurrence(initial_issue_priority=PriorityLevel.HIGH)
+        occurrence = self.build_occurrence(priority=PriorityLevel.HIGH)
         event = self.store_event(data={}, project_id=self.project.id)
         group_info = save_issue_from_occurrence(occurrence, event, None)
         assert group_info is not None
@@ -480,7 +480,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "metadata": {
                 "title": occurrence.issue_title,
                 "value": occurrence.subtitle,
-                "initial_priority": occurrence.initial_issue_priority,
+                "priority": occurrence.priority,
             },
             "title": occurrence.issue_title,
             "location": event.location,
@@ -498,7 +498,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "title": occurrence.issue_title,
             "value": occurrence.subtitle,
             "dogs": "are great",
-            "initial_priority": occurrence.initial_issue_priority,
+            "priority": occurrence.priority,
         }
 
     def test_populates_feedback_metadata(self) -> None:
@@ -524,7 +524,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "message": "test",
             "name": "Name Test",
             "source": "crash report widget",
-            "initial_priority": occurrence.initial_issue_priority,
+            "priority": occurrence.priority,
         }
 
 

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -1,7 +1,7 @@
-from sentry.issues.grouptype import PriorityLevel
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueEvidence, IssueOccurrence
 from sentry.testutils.cases import TestCase
 from sentry.types.actor import Actor, ActorType
+from sentry.types.group import PriorityLevel
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
@@ -52,14 +52,6 @@ class IssueOccurrenceSerializeTest(OccurrenceTestMixin, TestCase):
         occurrence_data["priority"] = PriorityLevel.HIGH.value
         occurrence = IssueOccurrence.from_dict(occurrence_data)
         assert occurrence.priority == PriorityLevel.HIGH
-
-        occurrence_data["initial_issue_priority"] = PriorityLevel.MEDIUM.value
-        occurrence = IssueOccurrence.from_dict(occurrence_data)
-        assert occurrence.priority == PriorityLevel.HIGH
-
-        occurrence_data["priority"] = None
-        occurrence = IssueOccurrence.from_dict(occurrence_data)
-        assert occurrence.priority == PriorityLevel.MEDIUM
 
 
 class IssueOccurrenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -1,3 +1,4 @@
+from sentry.issues.grouptype import PriorityLevel
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueEvidence, IssueOccurrence
 from sentry.testutils.cases import TestCase
 from sentry.types.actor import Actor, ActorType
@@ -45,6 +46,20 @@ class IssueOccurrenceSerializeTest(OccurrenceTestMixin, TestCase):
         occurrence_data["assignee"] = ""
         occurrence = IssueOccurrence.from_dict(occurrence_data)
         assert occurrence.assignee is None
+
+    def test_priority(self) -> None:
+        occurrence_data = self.build_occurrence_data()
+        occurrence_data["priority"] = PriorityLevel.HIGH.value
+        occurrence = IssueOccurrence.from_dict(occurrence_data)
+        assert occurrence.priority == PriorityLevel.HIGH
+
+        occurrence_data["initial_issue_priority"] = PriorityLevel.MEDIUM.value
+        occurrence = IssueOccurrence.from_dict(occurrence_data)
+        assert occurrence.priority == PriorityLevel.HIGH
+
+        occurrence_data["priority"] = None
+        occurrence = IssueOccurrence.from_dict(occurrence_data)
+        assert occurrence.priority == PriorityLevel.MEDIUM
 
 
 class IssueOccurrenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -205,7 +205,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
     ) -> None:
         # test explicitly set priority of HIGH
         message = get_test_message(self.project.id)
-        message["initial_issue_priority"] = PriorityLevel.HIGH.value
+        message["priority"] = PriorityLevel.HIGH.value
         with self.feature("organizations:profile-file-io-main-thread-ingest"):
             result = _process_message(message)
         assert result is not None
@@ -528,19 +528,19 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
     def test_priority(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         kwargs = _get_kwargs(message)
-        assert kwargs["occurrence_data"]["initial_issue_priority"] == PriorityLevel.LOW
+        assert kwargs["occurrence_data"]["priority"] == PriorityLevel.LOW
 
     def test_priority_defaults_to_grouptype(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
-        message["initial_issue_priority"] = None
+        message["priority"] = None
         kwargs = _get_kwargs(message)
-        assert kwargs["occurrence_data"]["initial_issue_priority"] == PriorityLevel.LOW
+        assert kwargs["occurrence_data"]["priority"] == PriorityLevel.LOW
 
     def test_priority_overrides_defaults(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
-        message["initial_issue_priority"] = PriorityLevel.HIGH
+        message["priority"] = PriorityLevel.HIGH
         kwargs = _get_kwargs(message)
-        assert kwargs["occurrence_data"]["initial_issue_priority"] == PriorityLevel.HIGH
+        assert kwargs["occurrence_data"]["priority"] == PriorityLevel.HIGH
 
     def test_assignee(self) -> None:
         message = deepcopy(get_test_message(self.project.id))

--- a/tests/sentry/issues/test_run.py
+++ b/tests/sentry/issues/test_run.py
@@ -112,7 +112,7 @@ class TestOccurrenceConsumer(TestCase, OccurrenceTestMixin):
         assert mock_save_issue_occurrence.call_count == 2
         occurrence_data = occurrence.to_dict()
         # need to modify some fields because they get mutated
-        occurrence_data["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data["priority"] = PriorityLevel.LOW
         occurrence_data["fingerprint"] = ["cdfb5fbc0959e8e2f27a6e6027c6335b"]
         mock_save_issue_occurrence.assert_called_with(occurrence_data, mock.ANY)
 
@@ -289,11 +289,11 @@ class TestBatchedOccurrenceConsumer(
         occurrence_data2 = occurrence2.to_dict()
         occurrence_data3 = occurrence3.to_dict()
         # need to modify some fields because they get mutated
-        occurrence_data1["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data1["priority"] = PriorityLevel.LOW
         occurrence_data1["fingerprint"] = ["28c8edde3d61a0411511d3b1866f0636"]
-        occurrence_data2["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data2["priority"] = PriorityLevel.LOW
         occurrence_data2["fingerprint"] = ["665f644e43731ff9db3d341da5c827e1"]
-        occurrence_data3["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data3["priority"] = PriorityLevel.LOW
         occurrence_data3["fingerprint"] = ["665f644e43731ff9db3d341da5c827e1"]
         assert any(
             call.args[0] == occurrence_data1 for call in mock_save_issue_occurrence.mock_calls
@@ -420,9 +420,9 @@ class TestBatchedOccurrenceConsumer(
         occurrence_data2 = occurrence2.to_dict()
 
         # need to modify some fields because they get mutated
-        occurrence_data1["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data1["priority"] = PriorityLevel.LOW
         occurrence_data1["fingerprint"] = ["28c8edde3d61a0411511d3b1866f0636"]
-        occurrence_data2["initial_issue_priority"] = PriorityLevel.LOW
+        occurrence_data2["priority"] = PriorityLevel.LOW
         occurrence_data2["fingerprint"] = ["665f644e43731ff9db3d341da5c827e1"]
 
         assert any(

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -35,7 +35,7 @@ class OccurrenceTestMixin:
         assert o1.evidence_display == o2.evidence_display
         assert o1.type == o2.type
         assert o1.detection_time == o2.detection_time
-        assert o1.initial_issue_priority == o2.initial_issue_priority
+        assert o1.priority == o2.priority
 
     def build_occurrence_data(self, **overrides: Any) -> IssueOccurrenceData:
         kwargs: IssueOccurrenceData = {

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -63,7 +63,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
 
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.HIGH.value,
+                priority=PriorityLevel.HIGH.value,
                 level="error",
                 evidence_data={
                     "snuba_query_id": self.snuba_query.id,
@@ -87,7 +87,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
 
     def create_issue_occurrence(
         self,
-        initial_issue_priority: int | None = None,
+        priority: int | None = None,
         level: str = "error",
         evidence_data: Mapping[str, Any] | None = None,
     ):
@@ -108,7 +108,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
             detection_time=timezone.now(),
             level=level,
             culprit="test_culprit",
-            initial_issue_priority=initial_issue_priority,
+            priority=priority,
             assignee=None,
         )
 
@@ -222,7 +222,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         self.group, self.event, self.group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.HIGH.value,
+                priority=PriorityLevel.HIGH.value,
                 level="error",
                 evidence_data={
                     "snuba_query_id": self.snuba_query.id,
@@ -244,7 +244,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         group, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.HIGH.value,
+                priority=PriorityLevel.HIGH.value,
                 level="error",
             ),
         )
@@ -258,7 +258,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         group, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                priority=PriorityLevel.MEDIUM.value,
                 level="warning",
             ),
         )
@@ -272,7 +272,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         group, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                priority=PriorityLevel.MEDIUM.value,
                 level="warning",
             ),
         )
@@ -304,7 +304,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         _, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.HIGH.value,
+                priority=PriorityLevel.HIGH.value,
                 level="error",
                 evidence_data={"snuba_query_id": self.snuba_query.id},
             ),
@@ -323,7 +323,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         _, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                priority=PriorityLevel.MEDIUM.value,
                 level="warning",
                 evidence_data={"snuba_query_id": self.snuba_query.id},
             ),
@@ -336,7 +336,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         _, _, group_event = self.create_group_event(
             group_type_id=MetricIssuePOC.type_id,
             occurrence=self.create_issue_occurrence(
-                initial_issue_priority=PriorityLevel.MEDIUM.value,
+                priority=PriorityLevel.MEDIUM.value,
                 level="warning",
                 evidence_data={"metric_value": 123.45},
             ),

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -68,7 +68,7 @@ class BuildOccurrenceFromResultTest(UptimeTestCase):
             detection_time=datetime.datetime.now(datetime.UTC),
             level="error",
             culprit="",
-            initial_issue_priority=None,
+            priority=None,
             assignee=None,
         )
 


### PR DESCRIPTION
We need a way to update `Group.priority` with new occurrences for metric issues. This PR deprecates `initial_issue_priority` in favor of the new `priority` field on `IssueOccurrence`. This field will be used to set the priority of a group on creation as well as update the group priority for new occurrences if applicable.

The old `initial_issue_priority` will still be used as a fallback for the priority if specified. 

[Decision log](https://www.notion.so/sentry/Updating-issue-priority-via-issue-platform-1dd8b10e4b5d80c59bfbf99ffab52de9)