### PR TITLE
:wrench: chore(aci): support digest notifications during dual write

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -73,7 +73,7 @@ def event_to_record(
     # TODO(iamrajjoshi): This will only work during the dual write period of the rollout!
     if features.has("organizations:workflow-engine-trigger-actions", event.organization):
         for rule in rules:
-            rule_ids.append(get_key_from_rule_data(rule, "legacy_rule_id"))
+            rule_ids.append(int(get_key_from_rule_data(rule, "legacy_rule_id")))
     else:
         for rule in rules:
             rule_ids.append(rule.id)

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -11,8 +11,8 @@ from sentry.eventstore.models import Event
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.tsdb.base import TSDBModel
 
 logger = logging.getLogger("sentry.digests")

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -177,15 +177,7 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
     # TODO(iamrajjoshi): This will only work during the dual write period of the rollout!
     if features.has("organizations:workflow-engine-trigger-actions", project.organization):
         for rule in rules.values():
-            try:
-                rule.data["actions"][0]["legacy_rule_id"] = get_key_from_rule_data(
-                    rule, "legacy_rule_id"
-                )
-            except Exception:
-                logger.warning("Failed to get legacy rule id for rule %s", rule.id)
-                # This means that this is an "old" rule that hasn't been flushed from redis yet
-                # We manually set the legacy rule id because we are under the feature flag
-                rule.data["actions"][0]["legacy_rule_id"] = rule.id
+            rule.data["actions"][0]["legacy_rule_id"] = rule.id
 
     for group_id, g in groups.items():
         assert g.project_id == project.id, "Group must belong to Project"

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -16,7 +16,7 @@ from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import Feature, with_feature
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.actor import ActorType
 
 
@@ -217,23 +217,6 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         rule.data["actions"][0]["legacy_rule_id"] = rule.id
         records = [event_to_record(event, (rule,)) for event in self.team1_events]
         digest = build_digest(self.project, sort_records(records))[0]
-
-        expected_result = {self.user1.id: set(self.team1_events)}
-        assert_get_personalized_digests(
-            self.project, digest, expected_result, ActionTargetType.MEMBER, self.user1.id
-        )
-        assert_rule_ids(digest, [rule.id])
-
-    def test_direct_email_with_legacy_rule_id_during_rollout(self):
-        """When the action type is not Issue Owners, then the target actor gets a digest."""
-        self.project_ownership.update(fallthrough=False)
-        rule = self.project.rule_set.all()[0]
-        # Simulate don't update the Rule object with the legacy rule id
-        records = [event_to_record(event, (rule,)) for event in self.team1_events]
-
-        # Simulate the rollout of the feature flag
-        with Feature("organizations:workflow-engine-trigger-actions"):
-            digest = build_digest(self.project, sort_records(records))[0]
 
         expected_result = {self.user1.id: set(self.team1_events)}
         assert_get_personalized_digests(

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -16,6 +16,7 @@ from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import Feature, with_feature
 from sentry.types.actor import ActorType
 
 
@@ -59,6 +60,11 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
         assert {e.event_id for e in get_event_from_groups_in_digest(digest)} == {
             e.event_id for e in events
         }
+
+
+def assert_rule_ids(digest: Digest, expected_rule_ids: list[str]):
+    for rule, groups in digest.items():
+        assert rule.id in expected_rule_ids
 
 
 def assert_get_personalized_digests(
@@ -201,6 +207,39 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         assert_get_personalized_digests(
             self.project, digest, expected_result, ActionTargetType.MEMBER, self.user1.id
         )
+
+    @with_feature("organizations:workflow-engine-trigger-actions")
+    def test_direct_email_with_legacy_rule_id(self):
+        """When the action type is not Issue Owners, then the target actor gets a digest."""
+        self.project_ownership.update(fallthrough=False)
+        rule = self.project.rule_set.all()[0]
+
+        rule.data["actions"][0]["legacy_rule_id"] = rule.id
+        records = [event_to_record(event, (rule,)) for event in self.team1_events]
+        digest = build_digest(self.project, sort_records(records))[0]
+
+        expected_result = {self.user1.id: set(self.team1_events)}
+        assert_get_personalized_digests(
+            self.project, digest, expected_result, ActionTargetType.MEMBER, self.user1.id
+        )
+        assert_rule_ids(digest, [rule.id])
+
+    def test_direct_email_with_legacy_rule_id_during_rollout(self):
+        """When the action type is not Issue Owners, then the target actor gets a digest."""
+        self.project_ownership.update(fallthrough=False)
+        rule = self.project.rule_set.all()[0]
+        # Simulate don't update the Rule object with the legacy rule id
+        records = [event_to_record(event, (rule,)) for event in self.team1_events]
+
+        # Simulate the rollout of the feature flag
+        with Feature("organizations:workflow-engine-trigger-actions"):
+            digest = build_digest(self.project, sort_records(records))[0]
+
+        expected_result = {self.user1.id: set(self.team1_events)}
+        assert_get_personalized_digests(
+            self.project, digest, expected_result, ActionTargetType.MEMBER, self.user1.id
+        )
+        assert_rule_ids(digest, [rule.id])
 
     def test_team_without_members(self):
         team = self.create_team()


### PR DESCRIPTION
this is a temporary solution to support issue digest notifications within workflow engine while we are dual writing.

there is still work required to port the system so it works when the new UI has been rolled out

i have a pr that builds upon this https://github.com/getsentry/sentry/pull/90268, which will support us in the medium term as well