### PR TITLE
chore(slos): Re-classify opsgenie APIUnauthorized to halts

### DIFF
--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -12,7 +12,7 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
 from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.shared_integrations.exceptions import ApiError
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api
@@ -120,7 +120,7 @@ class OpsgenieClient(ApiClient):
         with record_event(OnCallInteractionType.CREATE).capture() as lifecycle:
             try:
                 return self.post("/alerts", data=data, headers=headers)
-            except (ApiUnauthorized, ApiError) as e:
+            except ApiError as e:
                 record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                 raise
 
@@ -139,7 +139,7 @@ class OpsgenieClient(ApiClient):
                         params={"identifierType": "alias"},
                         headers=headers,
                     )
-                except (ApiUnauthorized, ApiError) as e:
+                except ApiError as e:
                     record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                     raise
 
@@ -147,6 +147,6 @@ class OpsgenieClient(ApiClient):
         with record_event(OnCallInteractionType.CREATE).capture() as lifecycle:
             try:
                 return self.post("/alerts", data=data, headers=headers)
-            except (ApiUnauthorized, ApiError) as e:
+            except ApiError as e:
                 record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                 raise

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -144,7 +144,6 @@ class OpsgenieClient(ApiClient):
                     raise
 
         # Creating a metric alert
-
         with record_event(OnCallInteractionType.CREATE).capture() as lifecycle:
             try:
                 return self.post("/alerts", data=data, headers=headers)

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -12,6 +12,7 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
 from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.links import create_link_to_workflow
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api
@@ -116,9 +117,12 @@ class OpsgenieClient(ApiClient):
 
     def send_notification(self, data):
         headers = self._get_auth_headers()
-        with record_event(OnCallInteractionType.CREATE).capture():
-            resp = self.post("/alerts", data=data, headers=headers)
-        return resp
+        with record_event(OnCallInteractionType.CREATE).capture() as lifecycle:
+            try:
+                return self.post("/alerts", data=data, headers=headers)
+            except (ApiUnauthorized, ApiError) as e:
+                lifecycle.record_halt(halt_reason=e)
+                raise
 
     # TODO(iamrajjoshi): We need to delete this method during notification platform
     def send_metric_alert_notification(self, data):
@@ -127,14 +131,23 @@ class OpsgenieClient(ApiClient):
         # If closing an alert (when Sentry alert was resolved)
         if data.get("identifier"):
             alias = data["identifier"]
-            with record_event(OnCallInteractionType.RESOLVE).capture():
-                return self.post(
-                    f"/alerts/{alias}/close",
-                    data={},
-                    params={"identifierType": "alias"},
-                    headers=headers,
-                )
+            with record_event(OnCallInteractionType.RESOLVE).capture() as lifecycle:
+                try:
+                    return self.post(
+                        f"/alerts/{alias}/close",
+                        data={},
+                        params={"identifierType": "alias"},
+                        headers=headers,
+                    )
+                except (ApiUnauthorized, ApiError) as e:
+                    lifecycle.record_halt(halt_reason=e)
+                    raise
 
         # Creating a metric alert
-        with record_event(OnCallInteractionType.CREATE).capture():
-            return self.post("/alerts", data=data, headers=headers)
+
+        with record_event(OnCallInteractionType.CREATE).capture() as lifecycle:
+            try:
+                return self.post("/alerts", data=data, headers=headers)
+            except (ApiUnauthorized, ApiError) as e:
+                lifecycle.record_halt(halt_reason=e)
+                raise

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -7,7 +7,7 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.on_call.metrics import OnCallInteractionType
-from sentry.integrations.opsgenie.metrics import record_event
+from sentry.integrations.opsgenie.metrics import record_event, record_lifecycle_termination_level
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
 from sentry.notifications.notifications.rules import get_key_from_rule_data
@@ -121,7 +121,7 @@ class OpsgenieClient(ApiClient):
             try:
                 return self.post("/alerts", data=data, headers=headers)
             except (ApiUnauthorized, ApiError) as e:
-                lifecycle.record_halt(halt_reason=e)
+                record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                 raise
 
     # TODO(iamrajjoshi): We need to delete this method during notification platform
@@ -140,7 +140,7 @@ class OpsgenieClient(ApiClient):
                         headers=headers,
                     )
                 except (ApiUnauthorized, ApiError) as e:
-                    lifecycle.record_halt(halt_reason=e)
+                    record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                     raise
 
         # Creating a metric alert
@@ -148,5 +148,5 @@ class OpsgenieClient(ApiClient):
             try:
                 return self.post("/alerts", data=data, headers=headers)
             except (ApiUnauthorized, ApiError) as e:
-                lifecycle.record_halt(halt_reason=e)
+                record_lifecycle_termination_level(lifecycle=lifecycle, error=e)
                 raise

--- a/src/sentry/integrations/opsgenie/metrics.py
+++ b/src/sentry/integrations/opsgenie/metrics.py
@@ -1,6 +1,24 @@
 from sentry.integrations.on_call.metrics import OnCallInteractionEvent, OnCallInteractionType
 from sentry.integrations.on_call.spec import OpsgenieOnCallSpec
+from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError, ApiUnauthorized
 
 
 def record_event(event: OnCallInteractionType):
     return OnCallInteractionEvent(event, OpsgenieOnCallSpec())
+
+
+# 40301 - To perform this action, use an API key from an API integration.
+OPSGENIE_HALT_ERRORS = (40301,)
+
+
+def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
+    if isinstance(error, (ApiUnauthorized, ApiRateLimitedError)):
+        lifecycle.record_halt(halt_reason=error)
+    elif error.json:
+        if error.json.get("code") in OPSGENIE_HALT_ERRORS:
+            lifecycle.record_halt(error)
+        else:
+            lifecycle.record_failure(error)
+    else:
+        lifecycle.record_failure(error)

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -7,7 +7,12 @@ import responses
 from sentry.integrations.opsgenie.client import OpsgenieClient
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.rule import Rule
-from sentry.testutils.asserts import assert_slo_metric
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.testutils.asserts import (
+    assert_count_of_metric,
+    assert_many_halt_metrics,
+    assert_slo_metric,
+)
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.skips import requires_snuba
@@ -241,3 +246,149 @@ class OpsgenieClientTest(APITestCase):
             "source": "Sentry",
         }
         assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_notification_unauthorized_errors(self, mock_record):
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/alerts",
+            status=401,
+            json={"message": "Unauthorized"},
+        )
+
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/alerts",
+            status=403,
+            json={"message": ":bufo-riot:"},
+        )
+
+        event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "warning",
+                "platform": "python",
+                "culprit": "foo.bar",
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
+        assert group is not None
+
+        rule = Rule.objects.create(project=self.project, label="my rule")
+        client: OpsgenieClient = self.installation.get_keyring_client("team-123")
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            payload = client.build_issue_alert_payload(
+                data=event,
+                rules=[rule],
+                event=event,
+                group=group,
+                priority="P2",
+            )
+            with pytest.raises(ApiUnauthorized):
+                client.send_notification(payload)
+
+            with pytest.raises(ApiError):
+                client.send_notification(payload)
+
+        # CREATE (halt)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=2
+        )
+        assert_many_halt_metrics(
+            mock_record=mock_record,
+            messages_or_errors=[ApiUnauthorized("something"), ApiError("something")],
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_metric_alert_notification_unauthorized_errors(self, mock_record):
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/alerts",
+            status=401,
+            json={"message": "Unauthorized"},
+        )
+
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/alerts",
+            status=403,
+            json={"message": ":bufo-riot:"},
+        )
+        client: OpsgenieClient = self.installation.get_keyring_client("team-123")
+
+        # Test critical alert (P1)
+        critical_payload = {
+            "message": "Critical Alert Rule",
+            "alias": "incident_123_456",
+            "description": "This is a critical alert",
+            "source": "Sentry",
+            "priority": "P1",
+            "details": {
+                "URL": "http://example.com/alert/1",
+            },
+        }
+
+        with pytest.raises(ApiUnauthorized):
+            client.send_metric_alert_notification(critical_payload)
+
+        with pytest.raises(ApiError):
+            client.send_metric_alert_notification(critical_payload)
+
+        # CREATE (halt)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=2
+        )
+        assert_many_halt_metrics(
+            mock_record=mock_record,
+            messages_or_errors=[ApiUnauthorized("something"), ApiError("something")],
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_metric_alert_notification_closed_unauthorized_errors(self, mock_record):
+        identifier = "poggers"
+        closed_payload = {
+            "identifier": identifier,
+        }
+        responses.add(
+            responses.POST,
+            url=f"https://api.opsgenie.com/v2/alerts/{identifier}/close?identifierType=alias",
+            status=401,
+            json={"message": "Unauthorized"},
+        )
+
+        responses.add(
+            responses.POST,
+            url=f"https://api.opsgenie.com/v2/alerts/{identifier}/close?identifierType=alias",
+            status=403,
+            json={"message": ":bufo-riot:"},
+        )
+        client: OpsgenieClient = self.installation.get_keyring_client("team-123")
+
+        with pytest.raises(ApiUnauthorized):
+            client.send_metric_alert_notification(closed_payload)
+
+        with pytest.raises(ApiError):
+            client.send_metric_alert_notification(closed_payload)
+
+        # CREATE (halt)
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=2
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=2
+        )
+        assert_many_halt_metrics(
+            mock_record=mock_record,
+            messages_or_errors=[ApiUnauthorized("something"), ApiError("something")],
+        )


### PR DESCRIPTION
### Important context!!! 
Opsgenie as an integration does not have an auth flow. Users manually give us their `apiKey` which in turn we use to contact Opsgenie

### Okay, now onto the PR...
The Opsgenie errors that are tanking our SLOs take some form of the below 2:

1. [APIUnauthorized, Could not authenticate](https://sentry.sentry.io/issues/5644977127/?query=has%3Ainteraction_type%20integration_name%3Aopsgenie%20interaction_type%3Aresolve&referrer=issue-stream&sort=date&stream_index=0). This is because either the `apiKey` is invalid or the integraton is disabled. I assume the `apiKey` is invalid in this case because `apiKey` is a user supplied field

2. [ApiError, 40301 error code](https://sentry.sentry.io/issues/6503108928/?query=has%3Ainteraction_type%20integration_name%3Aopsgenie%20interaction_type%3Aresolve&referrer=issue-stream&sort=date&stream_index=1) . According to [Atlassian 40301 error code means](https://docs.opsgenie.com/docs/response#response-codes) the `apiKey` is valid but the action is not allowed because of permissions. For this one, I assume the failure reason is because the user gave us an `apiKey` with the incorrect permissions
