### PR TITLE
fix(autofix): Dedupe repos in prefs dropdown

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -23,7 +23,16 @@ export function useOrganizationRepositories() {
   });
 
   return {
-    data: useMemo(() => pages.flat(), [pages]),
+    data: useMemo(() => {
+      const flattenedRepos = pages.flat();
+      const uniqueReposMap = new Map<string, Repository>();
+      flattenedRepos.forEach(repo => {
+        if (repo.externalId && !uniqueReposMap.has(repo.externalId)) {
+          uniqueReposMap.set(repo.externalId, repo);
+        }
+      });
+      return Array.from(uniqueReposMap.values());
+    }, [pages]),
     isFetching,
   };
 }


### PR DESCRIPTION
The endpoint was returning several duplicate repos. This was also causing rendering problems. Simply de-duplicating them by external ID seems to solve it.