### PR TITLE
fix(issue summary): handle line breaks messing up slack alert title rendering

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -465,7 +465,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title = summary_headline or build_attachment_title(event_or_group)
         title_emoji = self.get_title_emoji(has_action)
 
-        title_text = title_emoji + f"<{title_link}|*{escape_slack_text(title)}*>"
+        title_text = f"{title_emoji}<{title_link}|*{escape_slack_text(title)}*>"
         return self.get_markdown_block(title_text)
 
     def get_title_emoji(self, has_action: bool) -> str | None:

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1125,6 +1125,47 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             expected_truncated = long_text[:MAX_SUMMARY_HEADLINE_LENGTH] + "..."
             assert expected_truncated in title_text
 
+        # Test cases for other line breaks
+        line_break_test_cases = [
+            ("crlf", "CRLF Line1\r\nCRLF Line2", "CRLF Line1..."),
+            ("ls", "LS Line1\u2028LS Line2", "LS Line1..."),
+            ("ps", "PS Line1\u2029PS Line2", "PS Line1..."),
+            ("strip_before_ellipsis", "Space Line1  \r\nSpace Line2", "Space Line1..."),
+        ]
+
+        for name, text_with_break, expected_headline_part in line_break_test_cases:
+            event_lb = self.store_event(
+                data={
+                    "event_id": "c" * 32,
+                    "message": "IntegrationError",
+                    "fingerprint": [f"group-lb-{name}"],
+                    "exception": {
+                        "values": [
+                            {
+                                "type": "IntegrationError",
+                                "value": text_with_break,
+                            }
+                        ]
+                    },
+                    "level": "error",
+                    "timestamp": before_now(minutes=1).isoformat(),
+                },
+                project_id=self.project.id,
+            )
+            assert event_lb.group
+            group_lb = event_lb.group
+            group_lb.type = ErrorGroupType.type_id
+            group_lb.save()
+
+            with (
+                patch(patch_path) as mock_get_summary,
+                patch(serializer_path, serializer_mock),
+            ):
+                mock_get_summary.return_value = (mock_summary, 200)
+                blocks = SlackIssuesMessageBuilder(group_lb, event_lb.for_group(group_lb)).build()
+                title_block = blocks["blocks"][0]["text"]["text"]
+                assert f": {expected_headline_part}*>" in title_block, f"Failed for {name}"
+
 
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")


### PR DESCRIPTION
The issue was that we handled `\n` properly, but not `\r\n`, `\u2028`, and `\u2029`, which are other ways to add line breaks and could be returned in some HTML-ish error messages.

Before and after:
<img width="809" alt="Screenshot 2025-04-22 at 8 30 40 PM" src="https://github.com/user-attachments/assets/6d469bb5-ff5e-44c6-bf41-07331a94de38" />
