### PR TITLE
chore(ourlogs): Make the chevron toggle details

### DIFF
--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -90,18 +90,22 @@ export function LogRowContent({
   const search = useLogsSearch();
   const setLogsSearch = useSetLogsSearch();
 
+  function toggleExpanded() {
+    setExpanded(e => !e);
+    trackAnalytics('logs.table.row_expanded', {
+      log_id: String(dataRow[OurLogKnownFieldKey.ID]),
+      page_source: analyticsPageSource,
+      organization,
+    });
+  }
+
   function onPointerUp(event: SyntheticEvent) {
     if (event.target instanceof Element && isInsideButton(event.target)) {
       // do not expand the context menu if you clicked a button
       return;
     }
     if (window.getSelection()?.toString() === '') {
-      setExpanded(e => !e);
-      trackAnalytics('logs.table.row_expanded', {
-        log_id: String(dataRow[OurLogKnownFieldKey.ID]),
-        page_source: analyticsPageSource,
-        organization,
-      });
+      toggleExpanded();
     }
   }
 
@@ -160,6 +164,7 @@ export function LogRowContent({
               aria-expanded={expanded}
               size="zero"
               borderless
+              onClick={() => toggleExpanded()}
             />
             <SeverityCircleRenderer
               extra={rendererExtra}


### PR DESCRIPTION
In previous PRs, we made it so:
- clicking the chevron would toggle the context menu
- clicking anywhere in the log would toggle the context menu
- clicking the chevron would *not* toggle the context menu (due to double toggling with second trigger)
- clicking anywhere in the log (but not a button) would toggle the context menu

This finalizes the behavior we want - clicking anywhere in the log except for a button will toggle the context menu, and clicking the chevron explicitly will toggle the context menu.