### PR TITLE
fix(nextj-insights): Hide http method column

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
@@ -135,12 +135,22 @@ function useTableSortParams() {
 interface PathsTableProps {
   handleAddTransactionFilter: (value: string) => void;
   query?: string;
+  showHttpMethodColumn?: boolean;
 }
 
-export function PathsTable({query, handleAddTransactionFilter}: PathsTableProps) {
+export function PathsTable({
+  query,
+  handleAddTransactionFilter,
+  showHttpMethodColumn = true,
+}: PathsTableProps) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
-  const [columnOrder, setColumnOrder] = useState(defaultColumnOrder);
+  const [columnOrder, setColumnOrder] = useState(() => {
+    if (!showHttpMethodColumn) {
+      return defaultColumnOrder.filter(column => column.key !== 'http.method');
+    }
+    return defaultColumnOrder;
+  });
   const {sortField, sortOrder} = useTableSortParams();
 
   const transactionsRequest = useApiQuery<DiscoverQueryResponse>(

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -57,7 +57,11 @@ export function NextJsOverviewPage({headerTitle}: {headerTitle: React.ReactNode}
           <PlaceholderWidget />
         </CachesContainer>
       </WidgetGrid>
-      <PathsTable handleAddTransactionFilter={setTransactionFilter} query={query} />
+      <PathsTable
+        handleAddTransactionFilter={setTransactionFilter}
+        query={query}
+        showHttpMethodColumn={false}
+      />
     </PlatformLandingPageLayout>
   );
 }


### PR DESCRIPTION
As for NextJS all span descriptions include the http method and the `http_method` in only set for a few we hide the respective column and just show the span description.

### Before
<img width="1055" alt="Screenshot 2025-04-23 at 08 32 05" src="https://github.com/user-attachments/assets/829d3ba4-a1e0-4564-ad1f-ef9e043f5280" />


### After
<img width="1053" alt="Screenshot 2025-04-23 at 08 17 13" src="https://github.com/user-attachments/assets/b082bd65-7a63-4628-8c29-d25396611e64" />