### PR TITLE
feat(onboarding): add uv to python framework onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
@@ -14,11 +14,6 @@ describe('aiohttp onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -19,7 +18,6 @@ import {t, tct} from 'sentry/locale';
 import {
   getPythonAiocontextvarsConfig,
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -71,7 +69,7 @@ const onboarding: OnboardingConfig = {
         link: <ExternalLink href="https://docs.aiohttp.org/en/stable/web.html" />,
       }
     ),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
@@ -80,10 +78,6 @@ const onboarding: OnboardingConfig = {
       configurations: [
         ...getPythonInstallConfig({
           packageName: "'sentry-sdk'",
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? getPythonProfilingMinVersionMessage()
-              : undefined,
         }),
         ...getPythonAiocontextvarsConfig(),
       ],

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -18,13 +18,12 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonAiocontextvarsConfig,
+  getPythonInstallConfig,
   getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from aiohttp import web
@@ -79,15 +78,14 @@ const onboarding: OnboardingConfig = {
         code: <code />,
       }),
       configurations: [
-        {
+        ...getPythonInstallConfig({
+          packageName: "'sentry-sdk'",
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? getPythonProfilingMinVersionMessage()
               : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-        getPythonAiocontextvarsConfig(),
+        }),
+        ...getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
+  getPythonAiocontextvarsConfig,
   getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
@@ -86,16 +87,7 @@ const onboarding: OnboardingConfig = {
           language: 'bash',
           code: getInstallSnippet(),
         },
-        {
-          description: tct(
-            "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
-            {
-              code: <code />,
-            }
-          ),
-          language: 'bash',
-          code: 'pip install --upgrade aiocontextvars',
-        },
+        getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -75,12 +75,7 @@ const onboarding: OnboardingConfig = {
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: [
-        ...getPythonInstallConfig({
-          packageName: "'sentry-sdk'",
-        }),
-        ...getPythonAiocontextvarsConfig(),
-      ],
+      configurations: [...getPythonInstallConfig(), ...getPythonAiocontextvarsConfig()],
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -16,7 +16,10 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonProfilingMinVersionMessage,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -78,12 +81,7 @@ const onboarding: OnboardingConfig = {
         {
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
+              ? getPythonProfilingMinVersionMessage()
               : undefined,
           language: 'bash',
           code: getInstallSnippet(),

--- a/static/app/gettingStartedDocs/python/asgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.spec.tsx
@@ -14,11 +14,6 @@ describe('asgi onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -4,7 +4,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -15,7 +14,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -94,18 +92,13 @@ const onboarding: OnboardingConfig = {
         link: <ExternalLink href="https://asgi.readthedocs.io/en/latest/" />,
       }
     ),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig(),
     },
   ],
 

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -13,11 +13,12 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -98,23 +99,20 @@ const onboarding: OnboardingConfig = {
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
+
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -15,6 +15,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -102,12 +103,7 @@ const onboarding: OnboardingConfig = {
       configurations: getPythonInstallConfig({
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.spec.tsx
@@ -14,11 +14,6 @@ describe('awslambda onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Timeout Warning'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -74,24 +74,19 @@ sentry_sdk.init(
   ],
 )`;
 
-const installStep = (params: Params) => [
-  {
-    type: StepType.INSTALL,
-    description: tct(
-      'Install [code:sentry-sdk] from PyPI with the [code:django] extra:',
-      {
-        code: <code />,
-      }
-    ),
-    configurations: getPythonInstallConfig({
-      packageName: "'sentry-sdk'",
-      description:
-        params.docsLocation === DocsPageLocation.PROFILING_PAGE
-          ? getPythonProfilingMinVersionMessage()
-          : undefined,
-    }),
-  },
-];
+const installStep = (params: Params): StepProps => ({
+  type: StepType.INSTALL,
+  description: tct('Install [code:sentry-sdk] from PyPI with the [code:django] extra:', {
+    code: <code />,
+  }),
+  configurations: getPythonInstallConfig({
+    packageName: "'sentry-sdk'",
+    description:
+      params.docsLocation === DocsPageLocation.PROFILING_PAGE
+        ? getPythonProfilingMinVersionMessage()
+        : undefined,
+  }),
+});
 
 const configureStep = (params: Params): StepProps => ({
   type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -19,10 +19,9 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -72,11 +71,17 @@ sentry_sdk.init(
   ],
 )`;
 
-const installStep = (params: Params): StepProps => ({
-  type: StepType.INSTALL,
-  description: tct('Install our Python SDK using [code:pip]:', {code: <code />}),
-  configurations: [
-    {
+const installStep = (params: Params) => [
+  {
+    type: StepType.INSTALL,
+    description: tct(
+      'Install [code:sentry-sdk] from PyPI with the [code:django] extra:',
+      {
+        code: <code />,
+      }
+    ),
+    configurations: getPythonInstallConfig({
+      packageName: "'sentry-sdk'",
       description:
         params.docsLocation === DocsPageLocation.PROFILING_PAGE
           ? tct(
@@ -86,11 +91,9 @@ const installStep = (params: Params): StepProps => ({
               }
             )
           : undefined,
-      language: 'bash',
-      code: getInstallSnippet(),
-    },
-  ],
-});
+    }),
+  },
+];
 
 const configureStep = (params: Params): StepProps => ({
   type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -19,7 +19,10 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -84,12 +87,7 @@ const installStep = (params: Params) => [
       packageName: "'sentry-sdk'",
       description:
         params.docsLocation === DocsPageLocation.PROFILING_PAGE
-          ? tct(
-              'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-              {
-                code: <code />,
-              }
-            )
+          ? getPythonProfilingMinVersionMessage()
           : undefined,
     }),
   },

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -9,7 +9,6 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -19,10 +18,7 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {
-  getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
-} from 'sentry/utils/gettingStartedDocs/python';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -74,18 +70,12 @@ sentry_sdk.init(
   ],
 )`;
 
-const installStep = (params: Params): StepProps => ({
+const installStep = (): StepProps => ({
   type: StepType.INSTALL,
   description: tct('Install [code:sentry-sdk] from PyPI with the [code:django] extra:', {
     code: <code />,
   }),
-  configurations: getPythonInstallConfig({
-    packageName: "'sentry-sdk'",
-    description:
-      params.docsLocation === DocsPageLocation.PROFILING_PAGE
-        ? getPythonProfilingMinVersionMessage()
-        : undefined,
-  }),
+  configurations: getPythonInstallConfig(),
 });
 
 const configureStep = (params: Params): StepProps => ({
@@ -125,7 +115,7 @@ const onboarding: OnboardingConfig = {
         ),
       }
     ),
-  install: (params: Params) => [installStep(params)],
+  install: () => [installStep()],
   configure: (params: Params) => [
     configureStep(params),
     {
@@ -171,7 +161,7 @@ const onboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding: OnboardingConfig = {
-  install: (params: Params) => [installStep(params)],
+  install: () => [installStep()],
   configure: (params: Params) => [configureStep(params)],
   verify: () => [],
 };

--- a/static/app/gettingStartedDocs/python/bottle.spec.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.spec.tsx
@@ -14,13 +14,6 @@ describe('bottle onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[bottle\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -83,7 +83,6 @@ const onboarding: OnboardingConfig = {
       }),
     },
   ],
-
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -65,7 +63,7 @@ const onboarding: OnboardingConfig = {
     tct('The Bottle integration adds support for the [link:Bottle Web Framework].', {
       link: <ExternalLink href="https://bottlepy.org/docs/dev/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -74,13 +72,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[bottle]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[bottle]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -18,6 +18,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -77,12 +78,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[bottle]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -16,11 +16,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[bottle]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -72,23 +73,21 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[bottle]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
+
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/celery.spec.tsx
+++ b/static/app/gettingStartedDocs/python/celery.spec.tsx
@@ -16,13 +16,6 @@ describe('celery onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Standalone Setup'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Setup With Django'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[celery\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -6,7 +6,6 @@ import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStarted
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -65,7 +63,7 @@ const onboarding: OnboardingConfig = {
     tct('The celery integration adds support for the [link:Celery Task Queue System].', {
       link: <ExternalLink href="https://docs.celeryq.dev/en/stable/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -74,13 +72,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[celery]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[celery]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -18,6 +18,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -77,12 +78,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[celery]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -16,11 +16,12 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[celery]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -72,21 +73,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[celery]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/chalice.spec.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.spec.tsx
@@ -14,13 +14,6 @@ describe('chalice onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[chalice\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -88,7 +88,6 @@ const onboarding: OnboardingConfig = {
       }),
     },
   ],
-
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -1,7 +1,6 @@
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -12,7 +11,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -70,7 +68,7 @@ def index():
     return {"hello": "world"}`;
 
 const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -79,13 +77,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[chalice]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[chalice]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -12,6 +12,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -82,12 +83,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[chalice]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -10,11 +10,12 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[chalice]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -77,23 +78,21 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[chalice]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
+
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/django.spec.tsx
+++ b/static/app/gettingStartedDocs/python/django.spec.tsx
@@ -14,13 +14,6 @@ describe('django onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher("pip install --upgrade 'sentry-sdk[django]'")
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -18,6 +18,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -73,12 +74,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[django]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -16,11 +16,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[django]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -68,21 +69,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[django]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -61,7 +59,7 @@ sentry_sdk.init(
 `;
 
 const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -70,13 +68,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[django]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[django]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/falcon.spec.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.spec.tsx
@@ -14,13 +14,6 @@ describe('falcon onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[falcon\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -18,6 +18,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -78,12 +79,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[falcon]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -16,11 +16,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[falcon]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import falcon
@@ -73,21 +74,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[falcon]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -66,7 +64,7 @@ const onboarding: OnboardingConfig = {
     tct('The Falcon integration adds support for the [link:Falcon Web Framework].', {
       link: <ExternalLink href="https://falconframework.org/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -75,13 +73,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[falcon]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[falcon]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/fastapi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.spec.tsx
@@ -14,13 +14,6 @@ describe('flask onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[fastapi\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -4,7 +4,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -20,7 +19,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -68,7 +66,7 @@ const onboarding: OnboardingConfig = {
     tct('The FastAPI integration adds support for the [link:FastAPI Framework].', {
       link: <ExternalLink href="https://fastapi.tiangolo.com/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -77,13 +75,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[fastapi]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[fastapi]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -18,11 +18,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[fastapi]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from fastapi import FastAPI
@@ -75,21 +76,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[fastapi]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -20,6 +20,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -80,12 +81,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[fastapi]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -14,13 +14,6 @@ describe('flask onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[flask\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -18,11 +18,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[flask]'`;
 
 const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
 from flask import Flask
@@ -74,21 +75,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[flask]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -20,6 +20,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -79,12 +80,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[flask]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -4,7 +4,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -20,7 +19,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -67,7 +65,7 @@ const onboarding: OnboardingConfig = {
     tct('The Flask integration adds support for the [link:Flask Framework].', {
       link: <ExternalLink href="https://flask.palletsprojects.com" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -76,13 +74,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[flask]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[flask]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
@@ -14,11 +14,6 @@ describe('gcpfunctions onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Timeout Warning'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -6,7 +6,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -73,18 +71,13 @@ sentry_sdk.init(
 )`;
 
 const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig(),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -16,11 +16,12 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -74,24 +75,20 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: (
-        <p>{tct('Install our Python SDK using [code:pip]:', {code: <code />})}</p>
-      ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      description: tct('Install [code:sentry-sdk] from PyPI:', {
+        code: <code />,
+      }),
+      configurations: getPythonInstallConfig({
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -18,6 +18,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -81,12 +82,7 @@ const onboarding: OnboardingConfig = {
       configurations: getPythonInstallConfig({
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/mongo.spec.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.spec.tsx
@@ -1,6 +1,5 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs from './mongo';
 
@@ -11,12 +10,5 @@ describe('mongo onboarding docs', function () {
     // Renders main headings
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[pymongo\]'/)
-      )
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -60,7 +60,6 @@ const onboarding: OnboardingConfig = {
       }),
     },
   ],
-
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -2,16 +2,12 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {
-  getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
-} from 'sentry/utils/gettingStartedDocs/python';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -42,7 +38,7 @@ const onboarding: OnboardingConfig = {
         link: <ExternalLink href="https://www.mongodb.com/docs/drivers/pymongo/" />,
       }
     ),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -51,13 +47,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[pymongo]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[pymongo]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -8,6 +8,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -30,8 +31,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
 )`;
 
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[pymongo]'`;
-
 const onboarding: OnboardingConfig = {
   introduction: () =>
     tct(
@@ -49,23 +48,21 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[pymongo]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
+
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -8,7 +8,10 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -52,12 +55,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[pymongo]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/pyramid.spec.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.spec.tsx
@@ -1,6 +1,5 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs from './pyramid';
 
@@ -12,10 +11,5 @@ describe('aiohttp onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -47,7 +47,6 @@ const onboarding: OnboardingConfig = {
       configurations: getPythonInstallConfig(),
     },
   ],
-
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -14,11 +14,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from pyramid.config import Configurator
@@ -40,15 +41,13 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct('Install [code:sentry-sdk] from PyPI:', {code: <code />}),
-      configurations: [
-        {
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      description: tct('Install [code:sentry-sdk] from PyPI:', {
+        code: <code />,
+      }),
+      configurations: getPythonInstallConfig(),
     },
   ],
+
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/python.spec.tsx
+++ b/static/app/gettingStartedDocs/python/python.spec.tsx
@@ -14,11 +14,6 @@ describe('python onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -204,7 +204,7 @@ const onboarding: OnboardingConfig = {
       description: tct('Install our Python SDK:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({packageName: "'sentry-sdk'"}),
+      configurations: getPythonInstallConfig(),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -3,7 +3,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -13,7 +12,10 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -136,13 +138,6 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))`,
   },
 };
 
-const getInstallSnippet = (packageManager?: 'pip' | 'uv') => {
-  if (packageManager === 'uv') {
-    return `uv add sentry-sdk`;
-  }
-  return `pip install --upgrade sentry-sdk`;
-};
-
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
@@ -203,40 +198,15 @@ sentry_sdk.profiler.stop_profiler()`
 }`;
 
 const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install our Python SDK:', {
         code: <code />,
       }),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: [
-            {
-              label: 'pip',
-              value: 'pip',
-              language: 'bash',
-              code: getInstallSnippet('pip'),
-            },
-            {
-              label: 'uv',
-              value: 'uv',
-              language: 'bash',
-              code: getInstallSnippet('uv'),
-            },
-          ],
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: 'sentry-sdk',
+      }),
     },
   ],
   configure: (params: Params) => [
@@ -391,25 +361,9 @@ export const featureFlagOnboarding: OnboardingConfig = {
           featureFlagOptions.integration === FeatureFlagProviderEnum.GENERIC
             ? t('Install the Sentry SDK.')
             : t('Install the Sentry SDK with an extra.'),
-        configurations: [
-          {
-            language: 'bash',
-            code: [
-              {
-                label: 'pip',
-                value: 'pip',
-                language: 'bash',
-                code: `pip install --upgrade ${packageName}`,
-              },
-              {
-                label: 'uv',
-                value: 'uv',
-                language: 'bash',
-                code: `uv pip install --upgrade ${packageName}`,
-              },
-            ],
-          },
-        ],
+        configurations: getPythonInstallConfig({
+          packageName,
+        }),
       },
       {
         type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -3,6 +3,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
+  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -14,6 +15,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -198,7 +200,7 @@ sentry_sdk.profiler.stop_profiler()`
 }`;
 
 const onboarding: OnboardingConfig = {
-  install: () => [
+  install: (params: Params) => [
     {
       type: StepType.INSTALL,
       description: tct('Install our Python SDK:', {
@@ -206,6 +208,10 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: getPythonInstallConfig({
         packageName: 'sentry-sdk',
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? getPythonProfilingMinVersionMessage()
+            : undefined,
       }),
     },
   ],

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -3,7 +3,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -15,7 +14,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -200,19 +198,13 @@ sentry_sdk.profiler.stop_profiler()`
 }`;
 
 const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install our Python SDK:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({
-        packageName: 'sentry-sdk',
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/quart.spec.tsx
+++ b/static/app/gettingStartedDocs/python/quart.spec.tsx
@@ -14,13 +14,6 @@ describe('quart onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[quart\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -68,7 +66,7 @@ const onboarding: OnboardingConfig = {
     tct('The Quart integration adds support for the [link:Quart Web Framework].', {
       link: <ExternalLink href="https://quart.palletsprojects.com/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -77,13 +75,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[quart]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[quart]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -18,6 +18,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -80,12 +81,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[quart]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -16,11 +16,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[quart]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -75,21 +76,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[quart]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/rq.spec.tsx
+++ b/static/app/gettingStartedDocs/python/rq.spec.tsx
@@ -19,11 +19,6 @@ describe('rq onboarding docs', function () {
       screen.getByRole('heading', {name: 'Settings for worker'})
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Main Python Script'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[rq\]'/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -12,11 +12,12 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[rq]'`;
 
 const getInitCallSnippet = (params: Params) => `
 sentry_sdk.init(
@@ -100,12 +101,7 @@ const onboarding: OnboardingConfig = {
       description: tct('Install [code:sentry-sdk] from PyPI with the [code:rq] extra:', {
         code: <code />,
       }),
-      configurations: [
-        {
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[rq]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/sanic.spec.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.spec.tsx
@@ -1,6 +1,5 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs from './sanic';
 
@@ -12,12 +11,5 @@ describe('sanic onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[sanic\]'/)
-      )
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -14,11 +14,13 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonAiocontextvarsConfig,
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[sanic]'`;
 
 const getSdkSetupSnippet = (params: Params) => `from sanic import Sanic
 import sentry_sdk
@@ -46,24 +48,8 @@ const onboarding: OnboardingConfig = {
         }
       ),
       configurations: [
-        {
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-        {
-          description: (
-            <p>
-              {tct(
-                "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
-                {
-                  code: <code />,
-                }
-              )}
-            </p>
-          ),
-          language: 'bash',
-          code: 'pip install --upgrade aiocontextvars',
-        },
+        ...getPythonInstallConfig({packageName: "'sentry-sdk[sanic]'"}),
+        getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -49,7 +49,7 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         ...getPythonInstallConfig({packageName: "'sentry-sdk[sanic]'"}),
-        getPythonAiocontextvarsConfig(),
+        ...getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/serverless.spec.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.spec.tsx
@@ -14,11 +14,6 @@ describe('serverless onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -4,7 +4,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -15,7 +14,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -89,18 +87,13 @@ const onboarding: OnboardingConfig = {
       </p>
     </Fragment>
   ),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig(),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -15,6 +15,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -97,12 +98,7 @@ const onboarding: OnboardingConfig = {
       configurations: getPythonInstallConfig({
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -13,11 +13,12 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -90,24 +91,20 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Python SDK using [code:pip]:', {
+      description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/starlette.spec.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.spec.tsx
@@ -14,13 +14,6 @@ describe('starlette onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[starlette\]'/)
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -18,6 +18,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -78,12 +79,7 @@ const onboarding: OnboardingConfig = {
         packageName: "'sentry-sdk[starlette]'",
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -66,7 +64,7 @@ const onboarding: OnboardingConfig = {
     tct('The Starlette integration adds support for the Starlette Framework.', {
       link: <ExternalLink href="https://www.starlette.io/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -75,13 +73,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[starlette]'",
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig({packageName: "'sentry-sdk[starlette]'"}),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -16,11 +16,12 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[starlette]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from starlette.applications import Starlette
@@ -73,21 +74,18 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[starlette]'",
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/tornado.spec.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.spec.tsx
@@ -14,11 +14,6 @@ describe('tornado onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -2,7 +2,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -19,7 +18,6 @@ import {t, tct} from 'sentry/locale';
 import {
   getPythonAiocontextvarsConfig,
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -66,7 +64,7 @@ const onboarding: OnboardingConfig = {
     tct('The Tornado integration adds support for the [link:Tornado Web Framework].', {
       link: <ExternalLink href="https://www.tornadoweb.org/en/stable/" />,
     }),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct(
@@ -75,15 +73,7 @@ const onboarding: OnboardingConfig = {
           code: <code />,
         }
       ),
-      configurations: [
-        ...getPythonInstallConfig({
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? getPythonProfilingMinVersionMessage()
-              : undefined,
-        }),
-        ...getPythonAiocontextvarsConfig(),
-      ],
+      configurations: [...getPythonInstallConfig(), ...getPythonAiocontextvarsConfig()],
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -18,13 +18,12 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonAiocontextvarsConfig,
+  getPythonInstallConfig,
   getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -77,15 +76,14 @@ const onboarding: OnboardingConfig = {
         }
       ),
       configurations: [
-        {
+        ...getPythonInstallConfig({
+          packageName: "'sentry-sdk[tornado]'",
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? getPythonProfilingMinVersionMessage()
               : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-        getPythonAiocontextvarsConfig(),
+        }),
+        ...getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -16,7 +16,10 @@ import {
   featureFlagOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonProfilingMinVersionMessage,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -76,12 +79,7 @@ const onboarding: OnboardingConfig = {
         {
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
+              ? getPythonProfilingMinVersionMessage()
               : undefined,
           language: 'bash',
           code: getInstallSnippet(),

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
+  getPythonAiocontextvarsConfig,
   getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
@@ -84,16 +85,7 @@ const onboarding: OnboardingConfig = {
           language: 'bash',
           code: getInstallSnippet(),
         },
-        {
-          description: tct(
-            "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
-            {
-              code: <code />,
-            }
-          ),
-          language: 'bash',
-          code: 'pip install --upgrade aiocontextvars',
-        },
+        getPythonAiocontextvarsConfig(),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -77,7 +77,6 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         ...getPythonInstallConfig({
-          packageName: "'sentry-sdk[tornado]'",
           description:
             params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? getPythonProfilingMinVersionMessage()

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -10,6 +10,7 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
 
@@ -69,8 +70,6 @@ def _(app, request, e):
         data = UserError('Custom message', f'{event_id}{e}')
         return app.make_response(request, data)`;
 
-const getInstallSnippet = () => `pip install 'sentry-sdk'`;
-
 const onboarding: OnboardingConfig = {
   introduction: () =>
     tct('The Tryton integration adds support for the [link:Tryton Framework Server].', {
@@ -79,13 +78,15 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: t('Install the Sentry Python SDK package:'),
-      configurations: [
+      description: tct(
+        'Install [code:sentry-sdk] from PyPI with the [code:tryton] extra:',
         {
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+          code: <code />,
+        }
+      ),
+      configurations: getPythonInstallConfig({
+        packageName: "'sentry-sdk[tryton]'",
+      }),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -78,15 +78,10 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Install [code:sentry-sdk] from PyPI with the [code:tryton] extra:',
-        {
-          code: <code />,
-        }
-      ),
-      configurations: getPythonInstallConfig({
-        packageName: "'sentry-sdk[tryton]'",
+      description: tct('Install [code:sentry-sdk] from PyPI:', {
+        code: <code />,
       }),
+      configurations: getPythonInstallConfig(),
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/python/wsgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.spec.tsx
@@ -14,11 +14,6 @@ describe('wsgi onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Renders install instructions
-    expect(
-      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
-    ).toBeInTheDocument();
   });
 
   it('renders without tracing', function () {

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -13,11 +13,12 @@ import {
   crashReportOnboardingPython,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
-import {getPythonProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/python';
+import {
+  getPythonInstallConfig,
+  getPythonProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/python';
 
 type Params = DocsParams;
-
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -100,24 +101,20 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Python SDK using [code:pip]:', {
+      description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: [
-        {
-          description:
-            params.docsLocation === DocsPageLocation.PROFILING_PAGE
-              ? tct(
-                  'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                  {
-                    code: <code />,
-                  }
-                )
-              : undefined,
-          language: 'bash',
-          code: getInstallSnippet(),
-        },
-      ],
+      configurations: getPythonInstallConfig({
+        description:
+          params.docsLocation === DocsPageLocation.PROFILING_PAGE
+            ? tct(
+                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+                {
+                  code: <code />,
+                }
+              )
+            : undefined,
+      }),
     },
   ],
   configure: params => [

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -4,7 +4,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type Docs,
-  DocsPageLocation,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -15,7 +14,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
-  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -99,18 +97,13 @@ const onboarding: OnboardingConfig = {
       </p>
     </Fragment>
   ),
-  install: (params: Params) => [
+  install: () => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
         code: <code />,
       }),
-      configurations: getPythonInstallConfig({
-        description:
-          params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? getPythonProfilingMinVersionMessage()
-            : undefined,
-      }),
+      configurations: getPythonInstallConfig(),
     },
   ],
   configure: params => [

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -15,6 +15,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {
   getPythonInstallConfig,
+  getPythonProfilingMinVersionMessage,
   getPythonProfilingOnboarding,
 } from 'sentry/utils/gettingStartedDocs/python';
 
@@ -107,12 +108,7 @@ const onboarding: OnboardingConfig = {
       configurations: getPythonInstallConfig({
         description:
           params.docsLocation === DocsPageLocation.PROFILING_PAGE
-            ? tct(
-                'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-                {
-                  code: <code />,
-                }
-              )
+            ? getPythonProfilingMinVersionMessage()
             : undefined,
       }),
     },

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -27,7 +27,7 @@ export function getPythonInstallSnippet({
 }
 
 export function getPythonInstallConfig({
-  packageName = 'sentry-sdk',
+  packageName = "'sentry-sdk'",
   description,
 }: {
   description?: React.ReactNode;

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -1,14 +1,68 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  type DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {AlternativeConfiguration} from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
 const getProfilingInstallSnippet = (basePackage: string, minimumVersion?: string) =>
   `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
-import type {
-  DocsParams,
-  OnboardingConfig,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+/**
+ * Creates install snippets for various Python package managers
+ */
+export function getPythonInstallSnippet({
+  packageName,
+  packageManager,
+}: {
+  packageManager: 'pip' | 'uv';
+  packageName: string;
+}) {
+  if (packageManager === 'uv') {
+    return `uv add ${packageName}`;
+  }
+  return `pip install --upgrade ${packageName}`;
+}
+
+/**
+ * Creates a configuration object for installation instructions that supports multiple package managers
+ */
+export function getPythonInstallConfig({
+  packageName = 'sentry-sdk',
+  description,
+}: {
+  description?: React.ReactNode;
+  packageName?: string;
+} = {}) {
+  return [
+    {
+      description,
+      language: 'bash',
+      code: [
+        {
+          label: 'pip',
+          value: 'pip',
+          language: 'bash',
+          code: getPythonInstallSnippet({
+            packageName,
+            packageManager: 'pip',
+          }),
+        },
+        {
+          label: 'uv',
+          value: 'uv',
+          language: 'bash',
+          code: getPythonInstallSnippet({
+            packageName,
+            packageManager: 'uv',
+          }),
+        },
+      ],
+    },
+  ];
+}
 
 export const getPythonProfilingOnboarding = ({
   basePackage = 'sentry-sdk',

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -58,6 +58,15 @@ export function getPythonInstallConfig({
   ];
 }
 
+export function getPythonProfilingMinVersionMessage() {
+  return tct(
+    'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
+    {
+      code: <code />,
+    }
+  );
+}
+
 export const getPythonProfilingOnboarding = ({
   basePackage = 'sentry-sdk',
   traceLifecycle = 'trace',

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -66,6 +66,18 @@ export function getPythonProfilingMinVersionMessage() {
     }
   );
 }
+export function getPythonAiocontextvarsConfig() {
+  return {
+    description: tct(
+      "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
+      {
+        code: <code />,
+      }
+    ),
+    language: 'bash',
+    code: 'pip install --upgrade aiocontextvars',
+  };
+}
 
 export const getPythonProfilingOnboarding = ({
   basePackage = 'sentry-sdk',

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -1,5 +1,8 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  Configuration,
+  StepType,
+} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   type DocsParams,
   OnboardingConfig,
@@ -29,7 +32,7 @@ export function getPythonInstallConfig({
 }: {
   description?: React.ReactNode;
   packageName?: string;
-} = {}) {
+} = {}): Configuration[] {
   return [
     {
       description,
@@ -66,17 +69,38 @@ export function getPythonProfilingMinVersionMessage() {
     }
   );
 }
-export function getPythonAiocontextvarsConfig() {
-  return {
-    description: tct(
-      "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
-      {
-        code: <code />,
-      }
-    ),
-    language: 'bash',
-    code: 'pip install --upgrade aiocontextvars',
-  };
+export function getPythonAiocontextvarsConfig({
+  description,
+}: {
+  description?: React.ReactNode;
+} = {}): Configuration[] {
+  const defaultDescription = tct(
+    "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
+    {
+      code: <code />,
+    }
+  );
+
+  return [
+    {
+      description: description ?? defaultDescription,
+      language: 'bash',
+      code: [
+        {
+          label: 'pip',
+          value: 'pip',
+          language: 'bash',
+          code: "pip install --upgrade 'aiocontextvars'",
+        },
+        {
+          label: 'uv',
+          value: 'uv',
+          language: 'bash',
+          code: "uv add 'aiocontextvars'",
+        },
+      ],
+    },
+  ];
 }
 
 export const getPythonProfilingOnboarding = ({

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -81,26 +81,10 @@ export function getPythonAiocontextvarsConfig({
     }
   );
 
-  return [
-    {
-      description: description ?? defaultDescription,
-      language: 'bash',
-      code: [
-        {
-          label: 'pip',
-          value: 'pip',
-          language: 'bash',
-          code: "pip install --upgrade 'aiocontextvars'",
-        },
-        {
-          label: 'uv',
-          value: 'uv',
-          language: 'bash',
-          code: "uv add 'aiocontextvars'",
-        },
-      ],
-    },
-  ];
+  return getPythonInstallConfig({
+    packageName: "'aiocontextvars'",
+    description: description ?? defaultDescription,
+  });
 }
 
 export const getPythonProfilingOnboarding = ({

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -1,10 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {
-  Configuration,
+  type Configuration,
   StepType,
 } from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {
-  type DocsParams,
+import type {
+  DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {AlternativeConfiguration} from 'sentry/gettingStartedDocs/python/python';

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -21,7 +21,7 @@ export function getPythonInstallSnippet({
   packageName: string;
 }) {
   if (packageManager === 'uv') {
-    return `uv add ${packageName}`;
+    return `uv add --upgrade ${packageName}`;
   }
   return `pip install --upgrade ${packageName}`;
 }

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -10,9 +10,6 @@ import {t, tct} from 'sentry/locale';
 const getProfilingInstallSnippet = (basePackage: string, minimumVersion?: string) =>
   `pip install --upgrade ${minimumVersion ? `${basePackage}>=${minimumVersion}` : basePackage}`;
 
-/**
- * Creates install snippets for various Python package managers
- */
 export function getPythonInstallSnippet({
   packageName,
   packageManager,
@@ -26,9 +23,6 @@ export function getPythonInstallSnippet({
   return `pip install --upgrade ${packageName}`;
 }
 
-/**
- * Creates a configuration object for installation instructions that supports multiple package managers
- */
 export function getPythonInstallConfig({
   packageName = 'sentry-sdk',
   description,


### PR DESCRIPTION
- Move the install snippet to utils and adds uv as an option
- Add utility function for the aiocontextvars additional install (which can also be done using uv) 
- Remove the minimum profiling version message - this code was inactive since the upgrade of the profiling onboarding empty state
- Remove the rigid installation tests that check for presence of a fixed pip install string (these were also removed for javascript platforms)

- Closes TET-350


| Type | Before | After |
| ------ | ------ | ------ |
| With extra | <img width="631" alt="Screenshot 2025-04-24 at 11 04 09" src="https://github.com/user-attachments/assets/95f8f127-6f63-42cf-90a6-15f9ea37ccd0" /> | <img width="635" alt="Screenshot 2025-04-24 at 11 04 16" src="https://github.com/user-attachments/assets/6c442961-7858-4e8a-9615-eac73ef6116d" /> |
| Without extra & with aiocontextvars | <img width="638" alt="Screenshot 2025-04-24 at 10 56 29" src="https://github.com/user-attachments/assets/23862ad0-1575-41e9-aaf4-74ed5fee9978" /> | <img width="645" alt="Screenshot 2025-04-24 at 10 56 39" src="https://github.com/user-attachments/assets/3b887e7f-8631-4d9c-b1af-ab3da2a3b0b3" />|