### PR TITLE
chore(rollbacks): Remove options for EnvironmentProject model

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2815,13 +2815,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch for EnvironmentProject.get_or_create refactor
-register(
-    "environmentproject.new_add_project.rollout",
-    default=0.0,
-    type=Float,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # TODO: remove once removed from options
 register(


### PR DESCRIPTION
Time to fully clean up after the refactor.

Refactored code, and the only usage of the option was deployed in https://github.com/getsentry/sentry/pull/90042, also an option from option automator has been cleaned in https://github.com/getsentry/sentry-options-automator/pull/3621.
