### PR TITLE
feat(issue-details): Introduce godot changes to view hierarchy

### DIFF
--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -4,8 +4,11 @@ import * as Sentry from '@sentry/react';
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
+import {
+  getPlatform,
+  getPlatformViewConfig,
+} from 'sentry/components/events/viewHierarchy/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {IssueAttachment} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
@@ -86,14 +89,23 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
     return <LoadingIndicator />;
   }
 
+  const platform = getPlatform({event, project});
+  const platformViewConfig = getPlatformViewConfig(platform);
+
   return (
     <InterimSection
-      title={t('View Hierarchy')}
+      title={platformViewConfig.title}
       type={SectionKey.VIEW_HIERARCHY}
       disableCollapsePersistence={disableCollapsePersistence}
     >
       <ErrorBoundary mini>
-        <ViewHierarchy viewHierarchy={hierarchy} project={project} />
+        <ViewHierarchy
+          viewHierarchy={hierarchy}
+          platform={platform}
+          emptyMessage={platformViewConfig.emptyMessage}
+          showWireframe={platformViewConfig.showWireframe}
+          nodeField={platformViewConfig.nodeField}
+        />
       </ErrorBoundary>
     </InterimSection>
   );

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -15,6 +15,7 @@ import {
 } from 'sentry/components/events/viewHierarchy/utils';
 import type {Project} from 'sentry/types/project';
 
+import type {ViewHierarchyData} from './index';
 import {ViewHierarchy} from './index';
 
 // Mocks for useVirtualizedTree hook
@@ -325,29 +326,31 @@ describe('View Hierarchy', function () {
     const mockData = getMockData(ProjectFixture({platform: 'godot'}));
     render(
       <ViewHierarchy
-        viewHierarchy={{
-          rendering_system: 'Godot',
-          windows: [
-            {
-              name: 'root',
-              class: 'Window',
-              children: [
-                {
-                  name: 'SentryConfigurationScript',
-                  class: 'SentryConfiguration',
-                  script: 'res://example_configuration.gd',
-                  children: [
-                    {
-                      name: 'Header - Output',
-                      class: 'Label',
-                      children: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        }}
+        viewHierarchy={
+          {
+            rendering_system: 'Godot',
+            windows: [
+              {
+                name: 'root',
+                class: 'Window',
+                children: [
+                  {
+                    name: 'SentryConfigurationScript',
+                    class: 'SentryConfiguration',
+                    script: 'res://example_configuration.gd',
+                    children: [
+                      {
+                        name: 'Header - Output',
+                        class: 'Label',
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          } as unknown as ViewHierarchyData
+        }
         emptyMessage={mockData.emptyMessage}
         nodeField={mockData.nodeField}
         showWireframe={mockData.showWireframe}

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -61,17 +61,19 @@ function onScrollToNode(
 }
 
 export type ViewHierarchyWindow = {
-  alpha: number;
-  height: number;
-  visible: boolean;
-  width: number;
-  x: number;
-  y: number;
+  // there can be many other properties, but we only care about a few
+  [key: string]: unknown;
+  alpha?: number;
   children?: ViewHierarchyWindow[];
   depth?: number;
+  height?: number;
   identifier?: string;
   name?: string;
   type?: string;
+  visible?: boolean;
+  width?: number;
+  x?: number;
+  y?: number;
 };
 
 export type ViewHierarchyData = {

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -60,9 +60,8 @@ function onScrollToNode(
   }
 }
 
+// there can be many other properties, but we only care about a few
 export type ViewHierarchyWindow = {
-  // there can be many other properties, but we only care about a few
-  [key: string]: unknown;
   alpha?: number;
   children?: ViewHierarchyWindow[];
   depth?: number;

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -4,9 +4,7 @@ import styled from '@emotion/styled';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {Node} from 'sentry/components/events/viewHierarchy/node';
 import {Wireframe} from 'sentry/components/events/viewHierarchy/wireframe';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {UseVirtualizedTreeProps} from 'sentry/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree';
@@ -18,8 +16,16 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 import {DetailsPanel} from './detailsPanel';
 import {RenderingSystem} from './renderingSystem';
 
-function getNodeLabel({identifier, type}: ViewHierarchyWindow) {
-  return identifier ? `${type} - ${identifier}` : type;
+function getNodeLabel({
+  node,
+  nodeField,
+}: {
+  node: ViewHierarchyWindow;
+  nodeField: ViewHierarchyNodeField;
+}) {
+  const label = node[nodeField] ?? 'type';
+  const {identifier} = node;
+  return identifier ? `${label} - ${identifier}` : label;
 }
 
 function onScrollToNode(
@@ -57,7 +63,6 @@ function onScrollToNode(
 export type ViewHierarchyWindow = {
   alpha: number;
   height: number;
-  type: string;
   visible: boolean;
   width: number;
   x: number;
@@ -65,6 +70,8 @@ export type ViewHierarchyWindow = {
   children?: ViewHierarchyWindow[];
   depth?: number;
   identifier?: string;
+  name?: string;
+  type?: string;
 };
 
 export type ViewHierarchyData = {
@@ -72,12 +79,23 @@ export type ViewHierarchyData = {
   windows: ViewHierarchyWindow[];
 };
 
+export type ViewHierarchyNodeField = 'type' | 'name';
+
 type ViewHierarchyProps = {
-  project: Project;
+  emptyMessage: string;
+  nodeField: ViewHierarchyNodeField;
+  showWireframe: boolean;
   viewHierarchy: ViewHierarchyData;
+  platform?: string;
 };
 
-function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
+function ViewHierarchy({
+  viewHierarchy,
+  emptyMessage,
+  showWireframe,
+  platform,
+  nodeField,
+}: ViewHierarchyProps) {
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(
@@ -125,7 +143,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
           handleRowClick(e);
           trackAnalytics('issue_details.view_hierarchy.select_from_tree', {
             organization,
-            platform: project.platform,
+            platform,
             user_org_role: organization.orgRole,
           });
         }}
@@ -133,7 +151,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
         {r.item.depth !== 0 && <DepthMarker depth={r.item.depth} />}
         <Node
           id={key}
-          label={getNodeLabel(r.item.node)}
+          label={getNodeLabel({node: r.item.node, nodeField})}
           onExpandClick={() =>
             handleExpandTreeNode(r.item, !r.item.expanded, {expandChildren: false})
           }
@@ -171,31 +189,24 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
       handleScrollTo(item => item === node);
       trackAnalytics('issue_details.view_hierarchy.select_from_wireframe', {
         organization,
-        platform: project.platform,
+        platform,
         user_org_role: organization.orgRole,
       });
     },
-    [handleScrollTo, organization, project.platform]
+    [handleScrollTo, organization, platform]
   );
-
-  const showWireframe = project?.platform !== 'unity';
 
   if (!hierarchy.length) {
     return (
       <EmptyStateContainer>
-        <EmptyStateWarning small>
-          {t('There is no view hierarchy data to visualize')}
-        </EmptyStateWarning>
+        <EmptyStateWarning small>{emptyMessage}</EmptyStateWarning>
       </EmptyStateContainer>
     );
   }
 
   const viewHierarchyContent = (
     <Fragment>
-      <RenderingSystem
-        platform={project?.platform}
-        system={viewHierarchy.rendering_system}
-      />
+      <RenderingSystem platform={platform} system={viewHierarchy.rendering_system} />
       <Content>
         <Left hasRight={showWireframe}>
           <TreeContainer>
@@ -209,7 +220,10 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
           </TreeContainer>
           {defined(selectedNode) && (
             <DetailsContainer>
-              <DetailsPanel data={selectedNode} getTitle={getNodeLabel} />
+              <DetailsPanel
+                data={selectedNode}
+                getTitle={node => getNodeLabel({node, nodeField})}
+              />
             </DetailsContainer>
           )}
         </Left>
@@ -219,7 +233,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
               hierarchy={hierarchy}
               selectedNode={userHasSelected ? selectedNode : undefined}
               onNodeSelect={onWireframeNodeSelect}
-              project={project}
+              platform={platform}
             />
           </Right>
         )}

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -14,7 +14,6 @@ import {
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Project} from 'sentry/types/project';
 import {getCenterScaleMatrixFromConfigPosition} from 'sentry/utils/profiling/gl/utils';
 import type {Rect} from 'sentry/utils/profiling/speedscope';
 
@@ -29,11 +28,11 @@ export interface ViewNode {
 type WireframeProps = {
   hierarchy: ViewHierarchyWindow[];
   onNodeSelect: (node?: ViewHierarchyWindow) => void;
-  project: Project;
+  platform?: string;
   selectedNode?: ViewHierarchyWindow;
 };
 
-function Wireframe({hierarchy, selectedNode, onNodeSelect, project}: WireframeProps) {
+function Wireframe({hierarchy, selectedNode, onNodeSelect, platform}: WireframeProps) {
   const theme = useTheme();
   const [canvasRef, setCanvasRef] = useState<HTMLCanvasElement | null>(null);
   const [overlayRef, setOverlayRef] = useState<HTMLCanvasElement | null>(null);
@@ -50,9 +49,9 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect, project}: WireframePr
     () =>
       getHierarchyDimensions(
         hierarchy,
-        ['flutter', 'dart-flutter'].includes(project?.platform ?? '')
+        ['flutter', 'dart-flutter'].includes(platform ?? '')
       ),
-    [hierarchy, project.platform]
+    [hierarchy, platform]
   );
   const nodeLookupMap = useMemo(() => {
     const map = new Map<ViewHierarchyWindow, ViewNode>();


### PR DESCRIPTION
**Changes**

- Change header from "View Hierarchy" to "Scene Tree".
- Does not render the right section since it's not needed for our use-case.
- Use the name attribute from the JSON attachment for hierarchy item text.
- Show icon of the Godot Engine on the left side.

**Preview**


https://github.com/user-attachments/assets/6bc0996c-bfef-4a6d-bb7c-56ff410de71f



closes TET-271

