### PR TITLE
chore(explore): Remove beta badge from explore traces

### DIFF
--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -2,7 +2,6 @@ import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import DropdownButton from 'sentry/components/dropdownButton';
@@ -74,14 +73,6 @@ function ExploreContentImpl() {
                     'Find problematic spans/traces or compute real-time metrics via aggregation.'
                   )}
                   linkLabel={t('Read the Discussion')}
-                />
-                <FeatureBadge
-                  tooltipProps={{
-                    title: t(
-                      'This feature is available for early adopters and the UX may change'
-                    ),
-                  }}
-                  type="beta"
                 />
               </Layout.Title>
             </Layout.HeaderContent>


### PR DESCRIPTION
As we start the rollout, we dont need this badge anymore.