### PR TITLE
chore(codecov): Add in tests for VirtualDiffRenderer

### DIFF
--- a/static/app/components/codecov/virtualRenderers/lineNumber.tsx
+++ b/static/app/components/codecov/virtualRenderers/lineNumber.tsx
@@ -9,6 +9,7 @@ import {
 import {space} from 'sentry/styles/space';
 
 interface LineNumberProps {
+  ariaLabel: string | undefined;
   coverage: CoverageValue | undefined;
   isHighlighted: boolean;
   lineNumber: number | string | null | undefined;
@@ -33,6 +34,7 @@ export function LineNumber({
   virtualItem,
   virtualizer,
   isHighlighted,
+  ariaLabel,
 }: LineNumberProps) {
   return (
     <LineNumberWrapper
@@ -45,7 +47,7 @@ export function LineNumber({
       isHighlighted={isHighlighted}
       hasLineNumber={!!lineNumber}
     >
-      <StyledLineNumber onClick={onClick}>
+      <StyledLineNumber onClick={onClick} aria-label={ariaLabel}>
         {isHighlighted ? '#' : null}
         {lineNumber}
       </StyledLineNumber>

--- a/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.spec.tsx
+++ b/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.spec.tsx
@@ -20,12 +20,6 @@ jest.mock('@sentry/react', () => {
   };
 });
 
-window.requestAnimationFrame = cb => {
-  cb(1);
-  return 1;
-};
-window.cancelAnimationFrame = () => {};
-
 const scrollToMock = jest.fn();
 window.scrollTo = scrollToMock;
 window.scrollY = 100;

--- a/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.spec.tsx
+++ b/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.spec.tsx
@@ -1,0 +1,491 @@
+import * as Sentry from '@sentry/react';
+
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {type LineData, VirtualDiffRenderer} from './virtualDiffRenderer';
+
+jest.mock('@sentry/react', () => {
+  const originalModule = jest.requireActual('@sentry/react');
+  return {
+    ...originalModule,
+    withProfiler: (component: any) => component,
+    captureMessage: jest.fn(),
+  };
+});
+
+window.requestAnimationFrame = cb => {
+  cb(1);
+  return 1;
+};
+window.cancelAnimationFrame = () => {};
+
+const scrollToMock = jest.fn();
+window.scrollTo = scrollToMock;
+window.scrollY = 100;
+
+class ResizeObserverMock {
+  callback = (_x: any) => null;
+
+  constructor(callback: any) {
+    this.callback = callback;
+  }
+
+  observe() {
+    this.callback([
+      {
+        contentRect: {width: 100},
+        target: {
+          scrollWidth: 100,
+          clientWidth: 100,
+          getAttribute: () => ({scrollWidth: 100}),
+          getBoundingClientRect: () => ({top: 100}),
+        },
+      },
+    ]);
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+}
+global.window.ResizeObserver = ResizeObserverMock;
+
+const code = `<Breadcrumb
+    paths={[
+    { pageName: 'owner', text: owner },
+    { pageName: 'repo', text: repo },
+    ...treePaths,
+    {..props}
+    ]}
+/>`;
+
+const lineData: LineData[] = [
+  {headNumber: '1', baseNumber: '2', headCoverage: 'H', baseCoverage: 'H'},
+  {headNumber: '3', baseNumber: '4', headCoverage: 'M', baseCoverage: 'M'},
+  {headNumber: '5', baseNumber: '6', headCoverage: 'P', baseCoverage: 'P'},
+  {headNumber: '7', baseNumber: '8', headCoverage: null, baseCoverage: null},
+  {headNumber: '9', baseNumber: '10', headCoverage: null, baseCoverage: null},
+  {headNumber: '11', baseNumber: '12', headCoverage: null, baseCoverage: null},
+  {headNumber: '13', baseNumber: '14', headCoverage: null, baseCoverage: null},
+  {headNumber: '15', baseNumber: '16', headCoverage: null, baseCoverage: null},
+];
+
+describe('VirtualFileRenderer', () => {
+  let requestAnimationFrameSpy: jest.SpyInstance;
+  let cancelAnimationFrameSpy: jest.SpyInstance;
+  let dateNowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => {
+          cb(1);
+        }, 50);
+        return 1;
+      });
+    cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementationOnce(() => 1000)
+      .mockImplementationOnce(() => 2000);
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+    dateNowSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  function setup() {
+    const user = userEvent.setup();
+
+    return {user};
+  }
+
+  it('renders the text-area', () => {
+    render(
+      <VirtualDiffRenderer
+        content={code}
+        lineData={lineData}
+        fileName="tsx"
+        hashedPath="hashedPath"
+      />,
+      {}
+    );
+
+    const textArea = screen.getByTestId('virtual-diff-renderer-text-area');
+    expect(textArea).toBeInTheDocument();
+
+    const codeBlock = within(textArea).getByText(/Breadcrumb/);
+    expect(codeBlock).toBeInTheDocument();
+  });
+
+  describe('virtualized list', () => {
+    describe('valid language', () => {
+      it('renders code in virtualized list', () => {
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {}
+        );
+
+        const virtualOverlay = screen.getByTestId('virtual-diff-renderer-overlay');
+        expect(virtualOverlay).toBeInTheDocument();
+
+        const codeBlock = within(virtualOverlay).getByText(/Breadcrumb/);
+        expect(codeBlock).toBeInTheDocument();
+      });
+    });
+
+    describe('invalid language', () => {
+      it('renders code in virtualized list', () => {
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="random-file-type"
+            hashedPath="hashedPath"
+          />,
+          {}
+        );
+
+        const virtualOverlay = screen.getByTestId('virtual-diff-renderer-overlay');
+        expect(virtualOverlay).toBeInTheDocument();
+
+        const codeBlock = within(virtualOverlay).getByText(/Breadcrumb/);
+        expect(codeBlock).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('renders line numbers', () => {
+    render(
+      <VirtualDiffRenderer
+        content={code}
+        lineData={lineData}
+        fileName="tsx"
+        hashedPath="hashedPath"
+      />,
+      {}
+    );
+
+    const lineNumbers = screen.getAllByText(/\d+/);
+    // 2 * total lines
+    expect(lineNumbers).toHaveLength(16);
+  });
+
+  describe('covered lines', () => {
+    it('applies hit coverage labels', () => {
+      render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const coverageHitBaseLineNumber = screen.getByLabelText('hit base line');
+      expect(coverageHitBaseLineNumber).toBeInTheDocument();
+
+      const coverageHitHeadLineNumber = screen.getByLabelText('hit head line');
+      expect(coverageHitHeadLineNumber).toBeInTheDocument();
+    });
+  });
+
+  describe('uncovered lines', () => {
+    it('applies missing coverage labels', () => {
+      render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const coverageMissedBaseLineNumber = screen.getByLabelText('missed base line');
+      expect(coverageMissedBaseLineNumber).toBeInTheDocument();
+
+      const coverageMissedHeadLineNumber = screen.getByLabelText('missed head line');
+      expect(coverageMissedHeadLineNumber).toBeInTheDocument();
+    });
+  });
+
+  describe('partial lines', () => {
+    it('applies partial coverage labels', () => {
+      render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const coveragePartialBaseLineNumber = screen.getByLabelText('partial base line');
+      expect(coveragePartialBaseLineNumber).toBeInTheDocument();
+
+      const coveragePartialHeadLineNumber = screen.getByLabelText('partial head line');
+      expect(coveragePartialHeadLineNumber).toBeInTheDocument();
+    });
+  });
+
+  describe('toggling pointer events', () => {
+    it('disables pointer events on scroll and resets after timeout', async () => {
+      render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const lines = await screen.findAllByText(/{ pageName: 'repo', text: repo },/);
+      expect(lines[0]).toBeInTheDocument();
+
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      const codeRenderer = screen.getByTestId('virtual-diff-renderer');
+      await waitFor(() => expect(codeRenderer).toHaveStyle('pointer-events: none'));
+      await waitFor(() => expect(codeRenderer).toHaveStyle('pointer-events: auto'));
+    });
+
+    it('calls cancelAnimationFrame', async () => {
+      const {container} = render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const lines = await screen.findAllByText(/{ pageName: 'repo', text: repo },/);
+      expect(lines[0]).toBeInTheDocument();
+
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      // eslint-disable-next-line testing-library/no-container
+      container.remove();
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+      fireEvent.scroll(window, {target: {scrollX: 100}});
+
+      await waitFor(() => expect(cancelAnimationFrameSpy).toHaveBeenCalled());
+    });
+  });
+
+  describe('highlighted line', () => {
+    describe('user clicks on base number', () => {
+      it('updates the URL', async () => {
+        const {user} = setup();
+        const {router} = render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(2);
+        await user.click(line);
+
+        await waitFor(() => expect(router.location.hash).toBe('#hashedPath-L2'));
+      });
+
+      it('highlights the line on click', async () => {
+        const {user} = setup();
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(2);
+        await user.click(line);
+
+        const bar = await screen.findByLabelText('highlighted base line');
+        expect(bar).toBeInTheDocument();
+      });
+
+      it('removes highlighting when clicking on highlighted line', async () => {
+        const {user} = setup();
+        const {router} = render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(1);
+        await user.click(line);
+        await waitFor(() => expect(router.location.hash).toBe('#hashedPath-R1'));
+        await user.click(line);
+        await waitFor(() => expect(router.location.hash).toBe(''));
+      });
+    });
+
+    describe('user clicks on head number', () => {
+      it('updates the URL', async () => {
+        const {user} = setup();
+        const {router} = render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(1);
+        await user.click(line);
+
+        await waitFor(() => expect(router.location.hash).toBe('#hashedPath-R1'));
+      });
+
+      it('highlights the line on click', async () => {
+        const {user} = setup();
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(1);
+        await user.click(line);
+
+        const bar = await screen.findByLabelText('highlighted head line');
+        expect(bar).toBeInTheDocument();
+      });
+
+      it('removes highlighting when clicking on highlighted line', async () => {
+        const {user} = setup();
+        const {router} = render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {enableRouterMocks: false}
+        );
+
+        const line = screen.getByText(1);
+        await user.click(line);
+        await waitFor(() => expect(router.location.hash).toBe('#hashedPath-R1'));
+        await user.click(line);
+        await waitFor(() => expect(router.location.hash).toBe(''));
+      });
+    });
+  });
+
+  describe('scroll to line', () => {
+    describe('valid line number', () => {
+      it('calls scrollTo', async () => {
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {
+            enableRouterMocks: false,
+            initialRouterConfig: {
+              location: {
+                pathname: '/#hashedPath-L4',
+              },
+            },
+          }
+        );
+
+        await waitFor(() => expect(scrollToMock).toHaveBeenCalled());
+      });
+    });
+
+    describe('invalid line number', () => {
+      it('captures message to sentry', async () => {
+        render(
+          <VirtualDiffRenderer
+            content={code}
+            lineData={lineData}
+            fileName="tsx"
+            hashedPath="hashedPath"
+          />,
+          {
+            enableRouterMocks: false,
+            initialRouterConfig: {
+              location: {
+                pathname: '/#hashedPath-RRandomNumber',
+              },
+            },
+          }
+        );
+
+        await waitFor(() => {
+          expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            'Invalid line number in diff renderer hash: #hashedPath-RRandomNumber',
+            {fingerprint: ['diff-renderer-invalid-line-number']}
+          );
+        });
+      });
+    });
+  });
+
+  describe('horizontal scroll', () => {
+    it('syncs code display with text area scroll', async () => {
+      render(
+        <VirtualDiffRenderer
+          content={code}
+          lineData={lineData}
+          fileName="tsx"
+          hashedPath="hashedPath"
+        />,
+        {}
+      );
+
+      const textArea = screen.getByTestId('virtual-diff-renderer-text-area');
+      fireEvent.scroll(textArea, {
+        target: {scrollLeft: 100},
+      });
+
+      const virtualOverlay = screen.getByTestId('virtual-diff-renderer-overlay');
+      await waitFor(() => expect(virtualOverlay.scrollLeft).toBe(100));
+    });
+  });
+});

--- a/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.tsx
+++ b/static/app/components/codecov/virtualRenderers/virtualDiffRenderer.tsx
@@ -94,9 +94,16 @@ function CodeBody({
           const lineNumber = line?.baseNumber;
           const hash = `#${hashedPath}-L${lineNumber}`;
 
-          let coverageValue = undefined;
-          if (lineNumber && line?.baseCoverage) {
-            coverageValue = line?.baseCoverage;
+          const isHighlighted = location.hash === hash;
+          let label = 'base line';
+          if (isHighlighted) {
+            label = 'highlighted base line';
+          } else if (line?.baseCoverage === 'H') {
+            label = 'hit base line';
+          } else if (line?.baseCoverage === 'M') {
+            label = 'missed base line';
+          } else if (line?.baseCoverage === 'P') {
+            label = 'partial base line';
           }
 
           return (
@@ -106,8 +113,9 @@ function CodeBody({
               virtualizer={virtualizer}
               lineNumber={lineNumber}
               virtualItem={virtualItem}
-              coverage={coverageValue}
-              isHighlighted={location.hash === hash}
+              coverage={line?.baseCoverage ?? undefined}
+              isHighlighted={isHighlighted}
+              ariaLabel={label}
               onClick={() => {
                 if (lineNumber) {
                   location.hash = location.hash === hash ? '' : hash;
@@ -124,9 +132,16 @@ function CodeBody({
           const lineNumber = line?.headNumber;
           const hash = `#${hashedPath}-R${lineNumber}`;
 
-          let coverageValue = undefined;
-          if (lineNumber && line?.headCoverage) {
-            coverageValue = line?.headCoverage;
+          const isHighlighted = location.hash === hash;
+          let label = 'head line';
+          if (isHighlighted) {
+            label = 'highlighted head line';
+          } else if (line?.headCoverage === 'H') {
+            label = 'hit head line';
+          } else if (line?.headCoverage === 'M') {
+            label = 'missed head line';
+          } else if (line?.headCoverage === 'P') {
+            label = 'partial head line';
           }
 
           return (
@@ -136,8 +151,9 @@ function CodeBody({
               virtualizer={virtualizer}
               lineNumber={lineNumber}
               virtualItem={virtualItem}
-              coverage={coverageValue}
-              isHighlighted={location.hash === hash}
+              coverage={line?.headCoverage ?? undefined}
+              isHighlighted={isHighlighted}
+              ariaLabel={label}
               onClick={() => {
                 if (lineNumber) {
                   location.hash = location.hash === hash ? '' : hash;
@@ -272,7 +288,10 @@ export function VirtualDiffRenderer({
   });
 
   return (
-    <VirtualCodeRenderer ref={virtualCodeRendererRef}>
+    <VirtualCodeRenderer
+      ref={virtualCodeRendererRef}
+      data-test-id="virtual-diff-renderer"
+    >
       <TextArea
         ref={textAreaRef}
         value={content}
@@ -287,10 +306,12 @@ export function VirtualDiffRenderer({
         tabIndex={0}
         aria-multiline="true"
         aria-haspopup="false"
+        data-test-id="virtual-diff-renderer-text-area"
       />
       <CodeDisplayOverlay
         ref={codeDisplayOverlayRef}
         styleHeight={virtualizer.getTotalSize()}
+        data-test-id="virtual-diff-renderer-overlay"
       >
         <CodePreWrapper
           ref={widthDivRef}

--- a/static/app/components/codecov/virtualRenderers/virtualFileRenderer.tsx
+++ b/static/app/components/codecov/virtualRenderers/virtualFileRenderer.tsx
@@ -69,15 +69,28 @@ function CodeBody({
       <LineNumberColumn>
         {virtualizer.getVirtualItems().map(virtualItem => {
           const lineNumber = virtualItem.index + 1;
+          const isHighlighted = location.hash === `#L${lineNumber}`;
+
+          let label = 'line';
+          if (isHighlighted) {
+            label = 'highlighted line';
+          } else if (coverage.get(lineNumber)?.coverage === 'H') {
+            label = 'covered line';
+          } else if (coverage.get(lineNumber)?.coverage === 'M') {
+            label = 'missed line';
+          } else if (coverage.get(lineNumber)?.coverage === 'P') {
+            label = 'partial line';
+          }
 
           return (
             <LineNumber
+              ariaLabel={label}
               key={virtualItem.key}
               coverage={coverage.get(lineNumber)?.coverage}
               lineNumber={lineNumber}
               virtualItem={virtualItem}
               virtualizer={virtualizer}
-              isHighlighted={location.hash === `#L${lineNumber}`}
+              isHighlighted={isHighlighted}
               onClick={() => {
                 location.hash =
                   location.hash === `#L${lineNumber}` ? '' : `#L${lineNumber}`;


### PR DESCRIPTION
This PR adds in tests for the `VirtualDiffRenderer` component, as well as a couple of tweaks to get all of the tests passing happily.

Some of these tweaks include:

- Adding `aria-label` to `LineNumber`
- Adding in test id's
- Passing `ariaLabel`'s through to `LineNumber`
