### PR TITLE
ref(insights): Remove `location.query` spread in Session queries

### DIFF
--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -321,3 +321,15 @@ export function getDatetimeFromState(state: PageFiltersState) {
     Object.entries(state).filter(([key]) => DATE_TIME_KEYS.includes(key))
   ) as PageFilters['datetime'];
 }
+
+/**
+ * Translates a pageFilters object to a location query object using our
+ * standard query params.
+ */
+export function pageFiltersToQueryParams(pageFilters: PageFilters) {
+  return {
+    [URL_PARAM.PROJECT]: pageFilters.projects ?? [],
+    [URL_PARAM.ENVIRONMENT]: pageFilters.environments ?? [],
+    ...normalizeDateTimeParams(pageFilters.datetime),
+  };
+}

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -1,30 +1,17 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {percent} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useSessionProjectTotal from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useCrashFreeSessions({pageFilters}: {pageFilters?: PageFilters}) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: sessionData,
@@ -35,8 +22,10 @@ export default function useCrashFreeSessions({pageFilters}: {pageFilters?: PageF
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['session.status', 'release'],
         },

--- a/static/app/views/insights/sessions/queries/useErroredSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErroredSessions.tsx
@@ -1,25 +1,15 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useErroredSessions({pageFilters}: {pageFilters?: PageFilters}) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location.query,
-    query: undefined,
-    width: undefined,
-    cursor: undefined,
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: sessionData,
@@ -30,8 +20,10 @@ export default function useErroredSessions({pageFilters}: {pageFilters?: PageFil
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['session.status'],
         },

--- a/static/app/views/insights/sessions/queries/useNewAndResolvedIssues.tsx
+++ b/static/app/views/insights/sessions/queries/useNewAndResolvedIssues.tsx
@@ -1,8 +1,8 @@
 import {getInterval} from 'sentry/components/charts/utils';
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {IssuesMetricsApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -13,21 +13,8 @@ export default function useNewAndResolvedIssues({
   type: 'issue' | 'feedback';
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: issueData,
@@ -38,10 +25,10 @@ export default function useNewAndResolvedIssues({
       `/organizations/${organization.slug}/issues-metrics/`,
       {
         query: {
-          ...locationQuery.query,
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
           category: type,
           interval: getInterval(
-            pageFilters ? pageFilters.datetime : datetime,
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime,
             'issues-metrics'
           ),
         },

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -1,28 +1,22 @@
-import type {PageFiltersStringified} from 'sentry/components/organizations/pageFilters/types';
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {PageFilters} from 'sentry/types/core';
 import type {Release} from 'sentry/types/release';
 import {FieldKey} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 export default function useOrganizationReleases({
-  dateRange,
   filters,
+  pageFilters,
 }: {
   filters: string[];
-  dateRange?: Pick<PageFiltersStringified, 'start' | 'end' | 'statsPeriod'>;
+  pageFilters?: PageFilters;
 }) {
   const location = useLocation();
   const organization = useOrganization();
-
-  const locationWithoutWidth = {
-    ...location,
-    query: {
-      ...location.query,
-      ...dateRange,
-      width: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   let finalizedQuery;
   const hasFinalized = filters.includes('Finalized');
@@ -74,7 +68,7 @@ export default function useOrganizationReleases({
       `/organizations/${organization.slug}/releases/`,
       {
         query: {
-          ...locationWithoutWidth.query,
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
           query: queryString,
           adoptionStages: 1,
           health: 1,

--- a/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseNewIssues.tsx
@@ -1,27 +1,14 @@
 import {getInterval} from 'sentry/components/charts/utils';
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {IssuesMetricsApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 export default function useReleaseNewIssues({pageFilters}: {pageFilters?: PageFilters}) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: issueData,
@@ -32,10 +19,10 @@ export default function useReleaseNewIssues({pageFilters}: {pageFilters?: PageFi
       `/organizations/${organization.slug}/issues-metrics/`,
       {
         query: {
-          ...locationQuery.query,
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
           category: 'issue',
           interval: getInterval(
-            pageFilters ? pageFilters.datetime : datetime,
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime,
             'issues-metrics'
           ),
         },

--- a/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseSessionCounts.tsx
@@ -1,8 +1,8 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -11,21 +11,8 @@ export default function useReleaseSessionCounts({
 }: {
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: sessionData,
@@ -36,8 +23,10 @@ export default function useReleaseSessionCounts({
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['release'],
           per_page: 5,

--- a/static/app/views/insights/sessions/queries/useReleaseSessionPercentage.tsx
+++ b/static/app/views/insights/sessions/queries/useReleaseSessionPercentage.tsx
@@ -1,8 +1,8 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -11,21 +11,8 @@ export default function useReleaseSessionPercentage({
 }: {
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: sessionData,
@@ -36,8 +23,10 @@ export default function useReleaseSessionPercentage({
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['release'],
           per_page: 5,
@@ -135,5 +124,10 @@ export default function useReleaseSessionPercentage({
     };
   });
 
-  return {series, releases: Array.from(releaseGroupMap.keys()), isPending, error};
+  return {
+    series,
+    releases: Array.from(releaseGroupMap.keys()),
+    isPending,
+    error,
+  };
 }

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -1,8 +1,8 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
@@ -14,21 +14,8 @@ export default function useSessionHealthBreakdown({
   type: 'count' | 'rate';
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: sessionData,
@@ -39,8 +26,10 @@ export default function useSessionHealthBreakdown({
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['session.status'],
         },

--- a/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
@@ -1,8 +1,8 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -11,21 +11,8 @@ export default function useSessionProjectTotal({
 }: {
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: projSessionData,
@@ -36,8 +23,10 @@ export default function useSessionProjectTotal({
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['sum(session)'],
           groupBy: ['project'],
         },

--- a/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useUserHealthBreakdown.tsx
@@ -1,8 +1,8 @@
+import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getSessionsInterval} from 'sentry/utils/sessions';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getCountStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
@@ -14,21 +14,8 @@ export default function useUserHealthBreakdown({
   type: 'count' | 'rate';
   pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  const locationQuery = {
-    ...location,
-    query: {
-      ...location.query,
-      query: undefined,
-      width: undefined,
-      cursor: undefined,
-    },
-  };
+  const {selection: defaultPageFilters} = usePageFilters();
 
   const {
     data: userData,
@@ -39,8 +26,10 @@ export default function useUserHealthBreakdown({
       `/organizations/${organization.slug}/sessions/`,
       {
         query: {
-          ...locationQuery.query,
-          interval: getSessionsInterval(pageFilters ? pageFilters.datetime : datetime),
+          ...pageFiltersToQueryParams(pageFilters || defaultPageFilters),
+          interval: getSessionsInterval(
+            pageFilters ? pageFilters.datetime : defaultPageFilters.datetime
+          ),
           field: ['count_unique(user)'],
           groupBy: ['session.status'],
         },


### PR DESCRIPTION
These hooks are using `useLocation` to spread the entire `location.query` object (less a few fields) to the API request. Instead, directly use pageFilters instead of the current location query object.

Required for https://github.com/getsentry/sentry/pull/88562
