### PR TITLE
feat(explore): Update Explore All Queries view to show/hide query attributes based on container size

### DIFF
--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -13,7 +13,6 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
 import {Switch} from 'sentry/components/core/switch';
-import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
@@ -21,13 +20,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
-import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-
-type SingleQueryProps = {
-  query: string;
-  visualizes: BaseVisualize[];
-  groupBys?: string[]; // This needs to be passed in because saveQuery relies on being within the Explore PageParamsContext to fetch params
-};
 
 export type SaveQueryModalProps = {
   organization: Organization;
@@ -140,46 +132,6 @@ function SaveQueryModal({
   );
 }
 
-export function ExploreParams({
-  query,
-  visualizes,
-  groupBys,
-  className,
-}: SingleQueryProps & {className?: string}) {
-  const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
-
-  return (
-    <ExploreParamsContainer className={className}>
-      <ExploreParamSection>
-        <ExploreParamTitle>{t('Visualize')}</ExploreParamTitle>
-        <ExploreParamSection>
-          {yAxes.map(yAxis => (
-            <ExploreVisualizes key={yAxis}>{yAxis}</ExploreVisualizes>
-          ))}
-        </ExploreParamSection>
-      </ExploreParamSection>
-      {query && (
-        <ExploreParamSection>
-          <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
-          <FormattedQueryWrapper>
-            <ProvidedFormattedQuery query={query} />
-          </FormattedQueryWrapper>
-        </ExploreParamSection>
-      )}
-      {groupBys && groupBys.length > 0 && (
-        <ExploreParamSection>
-          <ExploreParamTitle>{t('Group By')}</ExploreParamTitle>
-          <ExploreParamSection>
-            {groupBys.map(groupBy => (
-              <ExploreGroupBys key={groupBy}>{groupBy}</ExploreGroupBys>
-            ))}
-          </ExploreParamSection>
-        </ExploreParamSection>
-      )}
-    </ExploreParamsContainer>
-  );
-}
-
 export default SaveQueryModal;
 
 const Wrapper = styled('div')`
@@ -217,45 +169,4 @@ export const modalCss = css`
 const SectionHeader = styled('h6')`
   font-size: ${p => p.theme.form.md.fontSize};
   margin-bottom: ${space(0.5)};
-`;
-
-const ExploreParamsContainer = styled('span')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(1)};
-  flex-wrap: wrap;
-  margin-bottom: ${space(2)};
-`;
-
-const ExploreParamSection = styled('span')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(0.5)};
-  overflow: hidden;
-  flex-wrap: wrap;
-`;
-
-const ExploreParamTitle = styled('span')`
-  font-size: ${p => p.theme.form.sm.fontSize};
-  color: ${p => p.theme.subText};
-  white-space: nowrap;
-  padding-top: 3px;
-`;
-
-const ExploreVisualizes = styled('span')`
-  font-size: ${p => p.theme.form.sm.fontSize};
-  background: ${p => p.theme.background};
-  padding: ${space(0.25)} ${space(0.5)};
-  border: 1px solid ${p => p.theme.innerBorder};
-  border-radius: ${p => p.theme.borderRadius};
-  height: 24px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`;
-
-const ExploreGroupBys = ExploreVisualizes;
-
-const FormattedQueryWrapper = styled('span')`
-  display: inline-block;
 `;

--- a/static/app/views/explore/savedQueries/exploreParams.spec.tsx
+++ b/static/app/views/explore/savedQueries/exploreParams.spec.tsx
@@ -1,0 +1,19 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import * as useDimensions from 'sentry/utils/useDimensions';
+
+import {ExploreParams} from './exploreParams';
+
+describe('ExploreParams', () => {
+  it('should render', () => {
+    jest.spyOn(useDimensions, 'useDimensions').mockReturnValue({width: 900, height: 100});
+    render(<ExploreParams query="test" visualizes={[]} groupBys={[]} />);
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+
+  it('should render overflow indicator when dimensions are small', () => {
+    jest.spyOn(useDimensions, 'useDimensions').mockReturnValue({width: 36, height: 100});
+    render(<ExploreParams query="test" visualizes={[]} groupBys={[]} />);
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/savedQueries/exploreParams.tsx
+++ b/static/app/views/explore/savedQueries/exploreParams.tsx
@@ -1,0 +1,189 @@
+import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
+
+import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {getFieldDefinition} from 'sentry/utils/fields';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+
+const MORE_TOKENS_WIDTH = 32;
+
+type SingleQueryProps = {
+  query: string;
+  visualizes: BaseVisualize[];
+  groupBys?: string[]; // This needs to be passed in because saveQuery relies on being within the Explore PageParamsContext to fetch params
+};
+
+export function ExploreParams({
+  query,
+  visualizes,
+  groupBys,
+  className,
+}: SingleQueryProps & {className?: string}) {
+  const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  const {width} = useDimensions({elementRef: containerRef});
+  const [childWidths, setChildWidths] = useState<number[]>([]);
+  const [containerWidth, setContainerWidth] = useState<number>(0);
+
+  const debouncedSetContainerWidth = useMemo(
+    () =>
+      debounce((newWidth: number) => {
+        setContainerWidth(newWidth);
+      }, 30),
+    []
+  );
+
+  useLayoutEffect(() => {
+    debouncedSetContainerWidth(width - MORE_TOKENS_WIDTH);
+  }, [debouncedSetContainerWidth, width]);
+
+  useLayoutEffect(() => {
+    if (containerRef.current?.children) {
+      const children = Array.from(containerRef.current.children);
+      setChildWidths(children.map(child => child.getBoundingClientRect().width));
+    }
+  }, [containerRef]);
+
+  // Calculates the index of the last token that is safe to show without overflowing
+  const calculateTokensToShow = useCallback(() => {
+    if (childWidths.length > 0) {
+      let totalWidth = 0;
+      let lastVisibleIndex = childWidths.length - 1;
+
+      childWidths.some((childWidth, index) => {
+        const newTotalWidth = totalWidth + childWidth + (index > 0 ? 8 : 0);
+
+        if (newTotalWidth > containerWidth) {
+          lastVisibleIndex = Math.max(0, index - 1);
+          return true;
+        }
+
+        totalWidth = newTotalWidth;
+        return false;
+      });
+
+      return lastVisibleIndex;
+    }
+    return null;
+  }, [childWidths, containerWidth]);
+
+  const tokens = [];
+  if (visualizes.length > 0) {
+    tokens.push(
+      <Token key="visualize">
+        <ExploreParamTitle>{t('Visualize')}</ExploreParamTitle>
+      </Token>
+    );
+    yAxes.forEach((yAxis, index) => {
+      tokens.push(
+        <Token key={`visualize-${index}`}>
+          <ExploreVisualizes>{yAxis}</ExploreVisualizes>
+        </Token>
+      );
+    });
+  }
+  const parsedQuery = useMemo(() => {
+    return parseQueryBuilderValue(query, getFieldDefinition);
+  }, [query]);
+  if (query) {
+    tokens.push(
+      <Token>
+        <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
+      </Token>
+    );
+    parsedQuery
+      ?.filter(({text}) => text.trim() !== '')
+      .forEach(({text}, index) => {
+        tokens.push(
+          <Token key={`filter-${index}`}>
+            <FormattedQueryWrapper>
+              <ProvidedFormattedQuery query={text} />
+            </FormattedQueryWrapper>
+          </Token>
+        );
+      });
+  }
+  if (groupBys && groupBys.length > 0) {
+    tokens.push(
+      <Token>
+        <ExploreParamTitle>{t('Group By')}</ExploreParamTitle>
+      </Token>
+    );
+    groupBys.forEach((groupBy, index) => {
+      tokens.push(
+        <Token key={`groupBy-${index}`}>
+          <ExploreGroupBys key={groupBy}>{groupBy}</ExploreGroupBys>
+        </Token>
+      );
+    });
+  }
+
+  const tokensToShow = calculateTokensToShow();
+  const visibleTokens = defined(tokensToShow)
+    ? tokens.slice(0, tokensToShow + 1)
+    : tokens;
+
+  if (defined(tokensToShow) && tokensToShow + 1 < tokens.length) {
+    visibleTokens.push(
+      <Token key="more">
+        <ExploreMoreTokens>{'+' + (tokens.length - tokensToShow - 1)}</ExploreMoreTokens>
+      </Token>
+    );
+  }
+
+  return (
+    <ExploreParamsContainer className={className} ref={containerRef}>
+      {visibleTokens}
+    </ExploreParamsContainer>
+  );
+}
+
+const ExploreParamsContainer = styled('span')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(1)};
+  flex-wrap: wrap;
+  margin-bottom: ${space(2)};
+  width: 100%;
+`;
+
+const Token = styled('span')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+  overflow: hidden;
+  flex-wrap: wrap;
+`;
+
+const ExploreParamTitle = styled('span')`
+  font-size: ${p => p.theme.form.sm.fontSize};
+  color: ${p => p.theme.subText};
+  white-space: nowrap;
+  padding-top: 3px;
+`;
+
+const ExploreVisualizes = styled('span')`
+  font-size: ${p => p.theme.form.sm.fontSize};
+  background: ${p => p.theme.background};
+  padding: ${space(0.25)} ${space(0.5)};
+  border: 1px solid ${p => p.theme.innerBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const ExploreGroupBys = ExploreVisualizes;
+const ExploreMoreTokens = ExploreVisualizes;
+
+const FormattedQueryWrapper = styled('span')`
+  display: inline-block;
+`;

--- a/static/app/views/explore/savedQueries/exploreParams.tsx
+++ b/static/app/views/explore/savedQueries/exploreParams.tsx
@@ -94,7 +94,7 @@ export function ExploreParams({
   }, [query]);
   if (query) {
     tokens.push(
-      <Token>
+      <Token key="filter">
         <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
       </Token>
     );
@@ -112,7 +112,7 @@ export function ExploreParams({
   }
   if (groupBys && groupBys.length > 0) {
     tokens.push(
-      <Token>
+      <Token key="groupBy">
         <ExploreParamTitle>{t('Group By')}</ExploreParamTitle>
       </Token>
     );

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -9,7 +9,6 @@ import {
 } from 'sentry/actionCreators/indicator';
 import {openSaveQueryModal} from 'sentry/actionCreators/modal';
 import Avatar from 'sentry/components/core/avatar';
-import {ExploreParams} from 'sentry/components/modals/explore/saveQueryModal';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
 import {SavedEntityTable} from 'sentry/components/savedEntityTable';
 import {t} from 'sentry/locale';
@@ -27,6 +26,7 @@ import {
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {useStarQuery} from 'sentry/views/explore/hooks/useStarQuery';
+import {ExploreParams} from 'sentry/views/explore/savedQueries/exploreParams';
 import {getExploreUrlFromSavedQueryUrl} from 'sentry/views/explore/utils';
 
 type Props = {


### PR DESCRIPTION
Updates the `Query` column in the All Queries view tables to hide tokens based on container size to prevent overflow.
- Moves `ExploreParams` out of `saveQueryModal.tsx` and into its own file
- Calculates how many tokens to show by getting the widths of the container and children via refs
<img width="482" alt="image" src="https://github.com/user-attachments/assets/1699856f-8792-4722-a1f4-c2585abcf5eb" />
