### PR TITLE
fix(code-mappings): Pass extra parameters when calling repo-path-parsing

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -128,6 +128,9 @@ function StacktraceLinkModal({
         data: {
           sourceUrl: sourceCodeInput,
           stackPath: filename,
+          module,
+          absPath,
+          platform,
         },
       });
 


### PR DESCRIPTION
In Java, `filename` does not contain all the required information to determine the values of a code mapping.

This will require an API change to support taking these extra parameters.

This is a follow-up to #88676.