### PR TITLE
fix(nav): Fix more pathnames pointing to old route structure

### DIFF
--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -17,12 +17,12 @@ import type {Organization} from 'sentry/types/organization';
 import {escape} from 'sentry/utils';
 import {getFormattedDate, getUtcDateString} from 'sentry/utils/dates';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 type ReleaseMetaBasic = {
   date: string;
@@ -264,14 +264,13 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
         value: formatVersion(release.version, true),
 
         onClick: () => {
-          router.push(
-            normalizeUrl({
-              pathname: `/organizations/${
-                organization.slug
-              }/releases/${encodeURIComponent(release.version)}/`,
-              query,
-            })
-          );
+          router.push({
+            pathname: makeReleasesPathname({
+              organization,
+              path: `/${encodeURIComponent(release.version)}/`,
+            }),
+            query,
+          });
         },
 
         label: {

--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -2,12 +2,13 @@ import type {Crumb} from 'sentry/components/breadcrumbs';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 function ExploreBreadcrumb() {
   const organization = useOrganization();
   const crumbs: Crumb[] = [];
   crumbs.push({
-    to: `/organizations/${organization.slug}/traces/`,
+    to: makeTracesPathname({organization, path: '/'}),
     label: t('Traces'),
   });
   crumbs.push({

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -4,6 +4,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SavedQueriesLandingContent} from 'sentry/views/explore/savedQueries/savedQueriesLandingContent';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 export default function SavedQueriesView() {
   const organization = useOrganization();
@@ -17,7 +18,7 @@ export default function SavedQueriesView() {
               crumbs={[
                 {
                   label: t('Explore'),
-                  to: `/organizations/${organization.slug}/traces/`,
+                  to: makeTracesPathname({organization, path: '/'}),
                 },
                 {
                   label: t('All Queries'),

--- a/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
@@ -22,6 +22,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {
   formatUsageWithUnits,
   getFormatUsageOptions,
@@ -158,7 +159,10 @@ class SpikeProtectionHistoryTable extends Component<Props> {
             })
           }
           to={{
-            pathname: `/organizations/${organization.slug}/discover/homepage/`,
+            pathname: makeDiscoverPathname({
+              organization,
+              path: '/homepage/',
+            }),
             query: {
               project: [project.id],
               start: decodeScalar(spike.start),


### PR DESCRIPTION
Found a few more references to the old route structure. Using the pathname utils to point to the correct page based on the nav preference.