### PR TITLE
fix(autofix): Use org-prefixed urls for autofix

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -65,7 +65,7 @@ describe('AutofixChanges', () => {
 
   it('passes correct analytics props for Create PR button when write access is enabled', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
@@ -78,7 +78,7 @@ describe('AutofixChanges', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
       body: {ok: true},
     });
@@ -121,7 +121,7 @@ describe('AutofixChanges', () => {
 
   it('passes correct analytics props for Create PR Setup button when write access is not enabled', () => {
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
@@ -176,7 +176,7 @@ describe('AutofixChanges', () => {
 
   it('passes correct analytics props for Create Branch button when write access is enabled', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
@@ -192,7 +192,7 @@ describe('AutofixChanges', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
       body: {ok: true},
     });
@@ -236,7 +236,7 @@ describe('AutofixChanges', () => {
 
   it('passes correct analytics props for Create Branch Setup button when write access is not enabled', () => {
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
         setupAcknowledgement: {

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -34,6 +34,7 @@ import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type AutofixChangesProps = {
   groupId: string;
@@ -468,6 +469,7 @@ function CreatePRsButton({
   const api = useApi();
   const queryClient = useQueryClient();
   const [hasClicked, setHasClicked] = useState(false);
+  const orgSlug = useOrganization().slug;
 
   // Reset hasClicked state and notify parent when isBusy goes from true to false
   useEffect(() => {
@@ -479,19 +481,22 @@ function CreatePRsButton({
 
   const {mutate: createPr} = useMutation({
     mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'create_pr',
-            repo_external_id: change.repo_external_id,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'create_pr',
+              repo_external_id: change.repo_external_id,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
       setHasClicked(true);
     },
     onError: () => {
@@ -542,6 +547,7 @@ function CreateBranchButton({
   const api = useApi();
   const queryClient = useQueryClient();
   const [hasClicked, setHasClicked] = useState(false);
+  const orgSlug = useOrganization().slug;
 
   // Reset hasClicked state and notify parent when isBusy goes from true to false
   useEffect(() => {
@@ -553,19 +559,22 @@ function CreateBranchButton({
 
   const {mutate: createBranch} = useMutation({
     mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'create_branch',
-            repo_external_id: change.repo_external_id,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'create_branch',
+              repo_external_id: change.repo_external_id,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
     },
     onError: () => {
       addErrorMessage(t('Failed to push to branches.'));

--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -105,7 +105,7 @@ describe('AutofixDiff', function () {
     await userEvent.type(textarea!, 'New content');
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
     });
 
@@ -123,7 +123,7 @@ describe('AutofixDiff', function () {
     render(<AutofixDiff {...defaultProps} />);
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
     });
 
@@ -145,7 +145,7 @@ describe('AutofixDiff', function () {
     await userEvent.type(textarea!, 'New content');
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
       statusCode: 500,
     });

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -28,6 +28,7 @@ import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
 import type {CommentThreadMessage} from './types';
@@ -52,6 +53,7 @@ const MIN_LEFT_MARGIN = 8;
 function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   return useMutation({
     mutationFn: (params: {
@@ -62,24 +64,27 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
       step_index: number;
       thread_id: string;
     }) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'comment_thread',
-            message: params.message,
-            thread_id: params.thread_id,
-            selected_text: params.selected_text,
-            step_index: params.step_index,
-            retain_insight_card_index: params.retain_insight_card_index,
-            is_agent_comment: params.is_agent_comment,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'comment_thread',
+              message: params.message,
+              thread_id: params.thread_id,
+              selected_text: params.selected_text,
+              step_index: params.step_index,
+              retain_insight_card_index: params.retain_insight_card_index,
+              is_agent_comment: params.is_agent_comment,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when sending your comment.'));
@@ -90,6 +95,7 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
 function useCloseCommentThread({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   return useMutation({
     mutationFn: (params: {
@@ -97,21 +103,24 @@ function useCloseCommentThread({groupId, runId}: {groupId: string; runId: string
       step_index: number;
       thread_id: string;
     }) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'resolve_comment_thread',
-            thread_id: params.thread_id,
-            step_index: params.step_index,
-            is_agent_comment: params.is_agent_comment,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'resolve_comment_thread',
+              thread_id: params.thread_id,
+              step_index: params.step_index,
+              is_agent_comment: params.is_agent_comment,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when resolving the thread.'));

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -110,7 +110,7 @@ describe('AutofixInsightCards', () => {
 
   it('submits edit request when form is submitted', async () => {
     const mockApi = MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
     });
 
@@ -125,7 +125,7 @@ describe('AutofixInsightCards', () => {
     await userEvent.click(submitButton);
 
     expect(mockApi).toHaveBeenCalledWith(
-      '/issues/1/autofix/update/',
+      '/organizations/org-slug/issues/1/autofix/update/',
       expect.objectContaining({
         method: 'POST',
         data: expect.objectContaining({
@@ -143,7 +143,7 @@ describe('AutofixInsightCards', () => {
 
   it('shows success message after successful edit submission', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
     });
 
@@ -164,7 +164,7 @@ describe('AutofixInsightCards', () => {
 
   it('shows error message after failed edit submission', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
       statusCode: 500,
     });

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -16,7 +16,7 @@ describe('AutofixOutputStream', () => {
     (addSuccessMessage as jest.Mock).mockClear();
     (addErrorMessage as jest.Mock).mockClear();
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
   });
@@ -105,7 +105,7 @@ describe('AutofixOutputStream', () => {
 
   it('shows error message when user interruption fails', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
       statusCode: 500,
     });

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -9,7 +9,7 @@ describe('AutofixRootCause', function () {
 
   beforeEach(function () {
     mockApi = MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/update/',
+      url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
       body: {success: true},
     });
@@ -114,7 +114,7 @@ describe('AutofixRootCause', function () {
     await waitFor(
       () => {
         expect(mockApi).toHaveBeenCalledWith(
-          '/issues/1/autofix/update/',
+          '/organizations/org-slug/issues/1/autofix/update/',
           expect.objectContaining({
             method: 'POST',
             data: {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -29,6 +29,7 @@ import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {Divider} from 'sentry/views/issueDetails/divider';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
@@ -71,6 +72,7 @@ const cardAnimationProps: AnimationProps = {
 function useSelectCause({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   return useMutation({
     mutationFn: (
@@ -83,31 +85,34 @@ function useSelectCause({groupId, runId}: {groupId: string; runId: string}) {
             customRootCause: string;
           }
     ) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data:
-          'customRootCause' in params
-            ? {
-                run_id: runId,
-                payload: {
-                  type: 'select_root_cause',
-                  custom_root_cause: params.customRootCause,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data:
+            'customRootCause' in params
+              ? {
+                  run_id: runId,
+                  payload: {
+                    type: 'select_root_cause',
+                    custom_root_cause: params.customRootCause,
+                  },
+                }
+              : {
+                  run_id: runId,
+                  payload: {
+                    type: 'select_root_cause',
+                    cause_id: params.causeId,
+                    instruction: params.instruction,
+                  },
                 },
-              }
-            : {
-                run_id: runId,
-                payload: {
-                  type: 'select_root_cause',
-                  cause_id: params.causeId,
-                  instruction: params.instruction,
-                },
-              },
-      });
+        }
+      );
     },
     onSuccess: (_, params) => {
       setApiQueryData<AutofixResponse>(
         queryClient,
-        makeAutofixQueryKey(groupId),
+        makeAutofixQueryKey(orgSlug, groupId),
         data => {
           if (!data?.autofix) {
             return data;

--- a/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
@@ -8,7 +8,7 @@ import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/aut
 describe('AutofixSetupWriteAccessModal', function () {
   it('displays help text when repos are not all installed', async function () {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/1/autofix/setup/?check_write_access=true',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,
@@ -59,7 +59,7 @@ describe('AutofixSetupWriteAccessModal', function () {
 
   it('displays success text when installed repos for github app text', async function () {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/?check_write_access=true',
+      url: '/organizations/org-slug/issues/1/autofix/setup/?check_write_access=true',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -35,7 +35,7 @@ describe('AutofixSolution', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
     jest.mocked(useAutofixRepos).mockReset();
@@ -221,7 +221,7 @@ describe('AutofixSolution', () => {
   it('passes the solution array when Code It Up button is clicked', async () => {
     // Mock the API directly before the test
     const mockApi = MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
 
@@ -253,7 +253,7 @@ describe('AutofixSolution', () => {
 
     // Verify payload
     expect(mockApi).toHaveBeenCalledWith(
-      '/issues/123/autofix/update/',
+      '/organizations/org-slug/issues/123/autofix/update/',
       expect.objectContaining({
         data: {
           run_id: 'run-123',
@@ -275,7 +275,7 @@ describe('AutofixSolution', () => {
   it('allows toggling solution items active/inactive', async () => {
     // Mock the API directly before the test
     const mockApi = MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
 
@@ -318,7 +318,7 @@ describe('AutofixSolution', () => {
 
     // Verify payload
     expect(mockApi).toHaveBeenCalledWith(
-      '/issues/123/autofix/update/',
+      '/organizations/org-slug/issues/123/autofix/update/',
       expect.objectContaining({
         data: {
           run_id: 'run-123',
@@ -340,7 +340,7 @@ describe('AutofixSolution', () => {
   it('allows adding custom instructions', async () => {
     // Mock the API directly before the test
     const mockApi = MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
 
@@ -386,7 +386,7 @@ describe('AutofixSolution', () => {
 
     // Verify payload
     expect(mockApi).toHaveBeenCalledWith(
-      '/issues/123/autofix/update/',
+      '/organizations/org-slug/issues/123/autofix/update/',
       expect.objectContaining({
         data: {
           run_id: 'run-123',
@@ -510,7 +510,7 @@ describe('AutofixSolution', () => {
 
     // Mock the API directly before the test
     const mockApi = MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/update/',
+      url: '/organizations/org-slug/issues/123/autofix/update/',
       method: 'POST',
     });
 
@@ -541,7 +541,7 @@ describe('AutofixSolution', () => {
 
     // Verify payload
     expect(mockApi).toHaveBeenCalledWith(
-      '/issues/123/autofix/update/',
+      '/organizations/org-slug/issues/123/autofix/update/',
       expect.objectContaining({
         data: {
           run_id: 'run-123',

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -32,6 +32,7 @@ import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {Divider} from 'sentry/views/issueDetails/divider';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
@@ -39,28 +40,32 @@ import AutofixHighlightPopup from './autofixHighlightPopup';
 function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   return useMutation({
     mutationFn: (params: {
       mode: 'all' | 'fix' | 'test';
       solution: AutofixSolutionTimelineEvent[];
     }) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'select_solution',
-            mode: params.mode,
-            solution: params.solution,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'select_solution',
+              mode: params.mode,
+              solution: params.solution,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onSuccess: (_, params) => {
       setApiQueryData<AutofixResponse>(
         queryClient,
-        makeAutofixQueryKey(groupId),
+        makeAutofixQueryKey(orgSlug, groupId),
         data => {
           if (!data?.autofix) {
             return data;

--- a/static/app/components/events/autofix/autofixThumbsUpDownButtons.tsx
+++ b/static/app/components/events/autofix/autofixThumbsUpDownButtons.tsx
@@ -11,10 +11,12 @@ import {t} from 'sentry/locale';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import useOrganization from 'sentry/utils/useOrganization';
 
 function useUpdateAutofixFeedback({groupId, runId}: {groupId: string; runId: string}) {
   const api = useApi();
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   return useMutation({
     mutationFn: (params: {
@@ -24,45 +26,51 @@ function useUpdateAutofixFeedback({groupId, runId}: {groupId: string; runId: str
         | 'solution_thumbs_up'
         | 'solution_thumbs_down';
     }) => {
-      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
-        method: 'POST',
-        data: {
-          run_id: runId,
-          payload: {
-            type: 'feedback',
-            action: params.action,
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'feedback',
+              action: params.action,
+            },
           },
-        },
-      });
+        }
+      );
     },
     onMutate: params => {
-      queryClient.setQueryData(makeAutofixQueryKey(groupId), (data: AutofixResponse) => {
-        if (!data?.autofix) {
-          return data;
-        }
+      queryClient.setQueryData(
+        makeAutofixQueryKey(orgSlug, groupId),
+        (data: AutofixResponse) => {
+          if (!data?.autofix) {
+            return data;
+          }
 
-        return {
-          ...data,
-          autofix: {
-            ...data.autofix,
-            feedback: params.action.includes('solution')
-              ? {
-                  ...data.autofix.feedback,
-                  solution_thumbs_up: params.action === 'solution_thumbs_up',
-                  solution_thumbs_down: params.action === 'solution_thumbs_down',
-                }
-              : {
-                  ...data.autofix.feedback,
-                  root_cause_thumbs_up: params.action === 'root_cause_thumbs_up',
-                  root_cause_thumbs_down: params.action === 'root_cause_thumbs_down',
-                },
-          },
-        };
-      });
+          return {
+            ...data,
+            autofix: {
+              ...data.autofix,
+              feedback: params.action.includes('solution')
+                ? {
+                    ...data.autofix.feedback,
+                    solution_thumbs_up: params.action === 'solution_thumbs_up',
+                    solution_thumbs_down: params.action === 'solution_thumbs_down',
+                  }
+                : {
+                    ...data.autofix.feedback,
+                    root_cause_thumbs_up: params.action === 'root_cause_thumbs_up',
+                    root_cause_thumbs_down: params.action === 'root_cause_thumbs_down',
+                  },
+            },
+          };
+        }
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: makeAutofixQueryKey(groupId),
+        queryKey: makeAutofixQueryKey(orgSlug, groupId),
       });
     },
     onError: () => {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export type AutofixResponse = {
   autofix: AutofixData | null;
@@ -23,8 +24,8 @@ export type AutofixResponse = {
 
 const POLL_INTERVAL = 500;
 
-export const makeAutofixQueryKey = (groupId: string): ApiQueryKey => [
-  `/issues/${groupId}/autofix/`,
+export const makeAutofixQueryKey = (orgSlug: string, groupId: string): ApiQueryKey => [
+  `/organizations/${orgSlug}/issues/${groupId}/autofix/`,
 ];
 
 const makeInitialAutofixData = (): AutofixResponse => ({
@@ -154,11 +155,16 @@ export const useAutofixRepos = (groupId: string) => {
 };
 
 export const useAutofixData = ({groupId}: {groupId: string}) => {
-  const {data, isPending} = useApiQuery<AutofixResponse>(makeAutofixQueryKey(groupId), {
-    staleTime: Infinity,
-    enabled: false,
-    notifyOnChangeProps: ['data'],
-  });
+  const orgSlug = useOrganization().slug;
+
+  const {data, isPending} = useApiQuery<AutofixResponse>(
+    makeAutofixQueryKey(orgSlug, groupId),
+    {
+      staleTime: Infinity,
+      enabled: false,
+      notifyOnChangeProps: ['data'],
+    }
+  );
 
   return {data: data?.autofix ?? null, isPending};
 };
@@ -173,27 +179,31 @@ export const useAiAutofix = (
 ) => {
   const api = useApi();
   const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
 
   const [isReset, setIsReset] = useState<boolean>(false);
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [waitingForNextRun, setWaitingForNextRun] = useState<boolean>(false);
 
-  const {data: apiData} = useApiQuery<AutofixResponse>(makeAutofixQueryKey(group.id), {
-    staleTime: 0,
-    retry: false,
-    refetchInterval: query => {
-      if (
-        isPolling(
-          query.state.data?.[0]?.autofix || null,
-          !!currentRunId || waitingForNextRun,
-          options.isSidebar
-        )
-      ) {
-        return options.pollInterval ?? POLL_INTERVAL;
-      }
-      return false;
-    },
-  } as UseApiQueryOptions<AutofixResponse, RequestError>);
+  const {data: apiData} = useApiQuery<AutofixResponse>(
+    makeAutofixQueryKey(orgSlug, group.id),
+    {
+      staleTime: 0,
+      retry: false,
+      refetchInterval: query => {
+        if (
+          isPolling(
+            query.state.data?.[0]?.autofix || null,
+            !!currentRunId || waitingForNextRun,
+            options.isSidebar
+          )
+        ) {
+          return options.pollInterval ?? POLL_INTERVAL;
+        }
+        return false;
+      },
+    } as UseApiQueryOptions<AutofixResponse, RequestError>
+  );
 
   const triggerAutofix = useCallback(
     async (instruction: string) => {
@@ -202,7 +212,7 @@ export const useAiAutofix = (
       setWaitingForNextRun(true);
       setApiQueryData<AutofixResponse>(
         queryClient,
-        makeAutofixQueryKey(group.id),
+        makeAutofixQueryKey(orgSlug, group.id),
         makeInitialAutofixData()
       );
 
@@ -215,17 +225,17 @@ export const useAiAutofix = (
           },
         });
         setCurrentRunId(response.run_id ?? null);
-        queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(group.id)});
+        queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, group.id)});
       } catch (e) {
         setWaitingForNextRun(false);
         setApiQueryData<AutofixResponse>(
           queryClient,
-          makeAutofixQueryKey(group.id),
+          makeAutofixQueryKey(orgSlug, group.id),
           makeErrorAutofixData(e?.responseJSON?.detail ?? 'An error occurred')
         );
       }
     },
-    [queryClient, group.id, api, event.id]
+    [queryClient, group.id, api, event.id, orgSlug]
   );
 
   const reset = useCallback(() => {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -217,13 +217,16 @@ export const useAiAutofix = (
       );
 
       try {
-        const response = await api.requestPromise(`/issues/${group.id}/autofix/`, {
-          method: 'POST',
-          data: {
-            event_id: event.id,
-            instruction,
-          },
-        });
+        const response = await api.requestPromise(
+          `/organizations/${orgSlug}/issues/${group.id}/autofix/`,
+          {
+            method: 'POST',
+            data: {
+              event_id: event.id,
+              instruction,
+            },
+          }
+        );
         setCurrentRunId(response.run_id ?? null);
         queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, group.id)});
       } catch (e) {

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -5,6 +5,7 @@ import {
   type UseApiQueryOptions,
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
   ok: boolean;
@@ -26,11 +27,12 @@ export interface AutofixSetupResponse {
 }
 
 function makeAutofixSetupQueryKey(
+  orgSlug: string,
   groupId: string,
   checkWriteAccess?: boolean
 ): ApiQueryKey {
   return [
-    `/issues/${groupId}/autofix/setup/${checkWriteAccess ? '?check_write_access=true' : ''}`,
+    `/organizations/${orgSlug}/issues/${groupId}/autofix/setup/${checkWriteAccess ? '?check_write_access=true' : ''}`,
   ];
 }
 
@@ -38,8 +40,10 @@ export function useAutofixSetup(
   {groupId, checkWriteAccess}: {groupId: string; checkWriteAccess?: boolean},
   options: Omit<UseApiQueryOptions<AutofixSetupResponse, RequestError>, 'staleTime'> = {}
 ) {
+  const orgSlug = useOrganization().slug;
+
   const queryData = useApiQuery<AutofixSetupResponse>(
-    makeAutofixSetupQueryKey(groupId, checkWriteAccess),
+    makeAutofixSetupQueryKey(orgSlug, groupId, checkWriteAccess),
     {
       enabled: Boolean(groupId),
       staleTime: 0,

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -54,7 +54,7 @@ describe('GroupSummary', function () {
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       method: 'GET',
       body: AutofixSetupFixture({
         setupAcknowledgement: {

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -90,7 +90,7 @@ export function useGroupSummary(
 
   const refresh = () => {
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${organization.slug}/issues/${group.id}/summarize/`],
+      queryKey: makeGroupSummaryQueryKey(organization.slug, group.id),
       exact: false,
     });
     refetch();
@@ -140,10 +140,17 @@ export function GroupSummary({
   useEffect(() => {
     if (isFixable && !isPending && aiConfig.hasAutofix) {
       queryClient.invalidateQueries({
-        queryKey: makeAutofixQueryKey(group.id),
+        queryKey: makeAutofixQueryKey(organization.slug, group.id),
       });
     }
-  }, [isFixable, isPending, aiConfig.hasAutofix, group.id, queryClient]);
+  }, [
+    isFixable,
+    isPending,
+    aiConfig.hasAutofix,
+    group.id,
+    queryClient,
+    organization.slug,
+  ]);
 
   const eventDetailsItems = [
     {

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -86,7 +86,7 @@ describe('GroupSidebar', function () {
       method: 'GET',
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/autofix/setup/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -88,7 +88,7 @@ describe('GroupDetailsLayout', () => {
       body: {committers: []},
     });
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -105,7 +105,7 @@ describe('SeerDrawer', () => {
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -136,7 +136,7 @@ describe('SeerDrawer', () => {
 
   it('renders consent state if not consented', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,
@@ -193,7 +193,7 @@ describe('SeerDrawer', () => {
 
   it('renders GitHub integration setup notice when missing GitHub integration', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -253,7 +253,7 @@ describe('SeerDrawer', () => {
 
   it('hides ButtonBarWrapper when AI consent is needed', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,
@@ -284,7 +284,7 @@ describe('SeerDrawer', () => {
   it('shows ButtonBarWrapper but hides Start Over button when hasAutofix is false', async () => {
     // Mock AI consent as okay but no autofix capability
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -328,7 +328,7 @@ describe('SeerDrawer', () => {
   it('shows ButtonBarWrapper with disabled Start Over button when hasAutofix is true but no autofixData', async () => {
     // Mock everything as ready for autofix but no data
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -361,7 +361,7 @@ describe('SeerDrawer', () => {
   it('shows ButtonBarWrapper with enabled Start Over button when hasAutofix and autofixData are both true', async () => {
     // Mock everything as ready with existing autofix data
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -442,7 +442,7 @@ describe('SeerDrawer', () => {
 
   it('shows setup instructions when GitHub integration setup is needed', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -481,7 +481,7 @@ describe('SeerDrawer', () => {
 
   it('does not render SeerNotices when all repositories are readable', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -510,7 +510,7 @@ describe('SeerDrawer', () => {
 
   it('renders warning for unreadable GitHub repository', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -540,7 +540,7 @@ describe('SeerDrawer', () => {
 
   it('renders warning for unreadable non-GitHub repository', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -147,7 +147,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -170,7 +170,7 @@ describe('SeerDrawer', () => {
 
   it('renders initial state with Start Autofix button', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -204,7 +204,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -225,12 +225,12 @@ describe('SeerDrawer', () => {
 
   it('triggers autofix on clicking the Start button', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       method: 'POST',
       body: {autofix: null},
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       method: 'GET',
       body: {autofix: null},
     });
@@ -264,7 +264,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -295,7 +295,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -339,7 +339,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -372,7 +372,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixData},
     });
 
@@ -393,7 +393,7 @@ describe('SeerDrawer', () => {
 
   it('displays Start Over button with autofix data', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixData},
     });
 
@@ -406,7 +406,7 @@ describe('SeerDrawer', () => {
 
   it('displays Start Over button even without autofix data', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
 
@@ -423,7 +423,7 @@ describe('SeerDrawer', () => {
 
   it('resets autofix on clicking the start over button', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixData},
     });
 
@@ -453,7 +453,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
     });
     MockApiClient.addMockResponse({
@@ -492,7 +492,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixWithReadableRepos},
     });
 
@@ -521,7 +521,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixWithUnreadableGithubRepos},
     });
 
@@ -551,7 +551,7 @@ describe('SeerDrawer', () => {
       }),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixWithUnreadableNonGithubRepos},
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -35,7 +35,7 @@ describe('SeerSection', () => {
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,
@@ -47,7 +47,7 @@ describe('SeerSection', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/issues/${mockGroup.id}/autofix/`,
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {steps: []},
     });
   });
@@ -108,7 +108,7 @@ describe('SeerSection', () => {
       });
 
       MockApiClient.addMockResponse({
-        url: `/issues/${mockGroup.id}/autofix/setup/`,
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
           setupAcknowledgement: {
             orgHasAcknowledged: false,
@@ -135,7 +135,7 @@ describe('SeerSection', () => {
 
     it('shows "Find Root Cause" even when autofix needs setup', async () => {
       MockApiClient.addMockResponse({
-        url: `/issues/${mockGroup.id}/autofix/setup/`,
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
           setupAcknowledgement: {
             orgHasAcknowledged: true,
@@ -165,7 +165,7 @@ describe('SeerSection', () => {
     it('shows "Find Root Cause" when autofix is available', async () => {
       // Mock successful autofix setup but disable resources
       MockApiClient.addMockResponse({
-        url: `/issues/${mockGroup.id}/autofix/setup/`,
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
           setupAcknowledgement: {
             orgHasAcknowledged: true,
@@ -203,7 +203,7 @@ describe('SeerSection', () => {
 
       // Mock config with autofix disabled
       MockApiClient.addMockResponse({
-        url: `/issues/${mockGroup.id}/autofix/setup/`,
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
           setupAcknowledgement: {
             orgHasAcknowledged: true,

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -64,7 +64,7 @@ describe('StreamlinedSidebar', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/autofix/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
       body: {steps: []},
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -52,7 +52,7 @@ describe('StreamlinedSidebar', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -35,7 +35,11 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
     },
     onSuccess: () => {
       // Make sure this query key doesn't go out of date with the one on the Sentry side!
-      queryClient.invalidateQueries({queryKey: [`/issues/${groupId}/autofix/setup/`]});
+      queryClient.invalidateQueries({
+        queryKey: [
+          `/organizations/${organization.slug}/issues/${groupId}/autofix/setup/`,
+        ],
+      });
     },
   });
 

--- a/static/gsApp/components/ai/aiSetupDataConsent.spec.tsx
+++ b/static/gsApp/components/ai/aiSetupDataConsent.spec.tsx
@@ -10,7 +10,7 @@ describe('AiSetupDataConsent', () => {
 
   it('renders Enable Seer button if nobody in org has acknowledged', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
+      url: '/organizations/org-slug/issues/1/autofix/setup/',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: false,
@@ -46,7 +46,7 @@ describe('AiSetupDataConsent', () => {
 
   it('renders Try Seer button if org has acknowledged but not the user', async () => {
     MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
+      url: '/organizations/org-slug/issues/1/autofix/setup/',
       body: AutofixSetupFixture({
         setupAcknowledgement: {
           orgHasAcknowledged: true,


### PR DESCRIPTION
Changes all calls to all autofix endpoints to be prefixed by `/organizations/{orgSlug}/`
