### PR TITLE
fix(autofix): Display last started time in start over

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -54,7 +54,7 @@ describe('AutofixChanges', () => {
           repos: [],
         },
         codebases: {},
-        created_at: '2024-01-01T00:00:00Z',
+        last_triggered_at: '2024-01-01T00:00:00Z',
         run_id: '456',
         status: AutofixStatus.COMPLETED,
       },

--- a/static/app/components/events/autofix/autofixSteps.spec.tsx
+++ b/static/app/components/events/autofix/autofixSteps.spec.tsx
@@ -53,7 +53,7 @@ describe('AutofixSteps', () => {
         repos: [],
       },
       codebases: {},
-      created_at: '2023-01-01T00:00:00Z',
+      last_triggered_at: '2023-01-01T00:00:00Z',
       run_id: '1',
       status: AutofixStatus.PROCESSING,
     }),

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -47,7 +47,7 @@ type CodebaseState = {
 
 export type AutofixData = {
   codebases: Record<string, CodebaseState>;
-  created_at: string;
+  last_triggered_at: string;
   request: {
     repos: SeerRepoDefinition[];
   };

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -48,7 +48,7 @@ const makeInitialAutofixData = (): AutofixResponse => ({
         ],
       },
     ],
-    created_at: new Date().toISOString(),
+    last_triggered_at: new Date().toISOString(),
     request: {
       repos: [],
     },

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -41,7 +41,7 @@ describe('useCopyIssueDetails', () => {
 
   // Create a mock AutofixData with steps that includes root cause and solution steps
   const mockAutofixData: AutofixData = {
-    created_at: '2023-01-01T00:00:00Z',
+    last_triggered_at: '2023-01-01T00:00:00Z',
     request: {
       repos: [],
     },

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -9,6 +9,7 @@ import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {DateTime} from 'sentry/components/dateTime';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import {AutofixProgressBar} from 'sentry/components/events/autofix/autofixProgressBar';
 import {AutofixStartBox} from 'sentry/components/events/autofix/autofixStartBox';
@@ -160,8 +161,10 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
                   size="xs"
                   onClick={reset}
                   title={
-                    autofixData?.created_at
-                      ? `Last run at ${autofixData.created_at.split('T')[0]}`
+                    autofixData?.last_triggered_at
+                      ? tct('Last run at [date]', {
+                          date: <DateTime date={autofixData.last_triggered_at} />,
+                        })
                       : null
                   }
                   disabled={!autofixData}

--- a/tests/js/fixtures/autofixData.ts
+++ b/tests/js/fixtures/autofixData.ts
@@ -5,7 +5,7 @@ export function AutofixDataFixture(params: Partial<AutofixData>): AutofixData {
     run_id: '1',
     status: AutofixStatus.PROCESSING,
     completed_at: '',
-    created_at: '',
+    last_triggered_at: '',
     steps: [],
     request: {
       repos: [],


### PR DESCRIPTION
created_at doesn't exist in the response, instead use last_triggered_at

![image](https://github.com/user-attachments/assets/1c283ce4-5f17-4ddd-ba5a-f7714ebfe2a7)
