### PR TITLE
feat(dashboards): Allow hiding the X axis in `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -400,6 +400,27 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
+  story('X Axis', () => {
+    return (
+      <Fragment>
+        <p>
+          In a <JSXNode name="TimeSeriesWidgetVisualization" />, the X axis is by
+          definition always time. The ticks and labels are automatically determined based
+          on the domain of the data set. You can, however, use the <code>showXAxis</code>{' '}
+          prop to hide the X axis in contexts where it would be too busy or distracting.
+          This might be the case in small sidebar charts, for example. Setting the{' '}
+          <code>showXAxis</code> prop to <code>"never"</code> will hide the X axis.
+        </p>
+
+        <SmallWidget>
+          <TimeSeriesWidgetVisualization
+            plottables={[new Line(sampleDurationTimeSeries)]}
+          />
+        </SmallWidget>
+      </Fragment>
+    );
+  });
+
   story('Unit Alignment', () => {
     const millisecondsSeries = sampleDurationTimeSeries;
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -415,6 +415,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         <SmallWidget>
           <TimeSeriesWidgetVisualization
             plottables={[new Line(sampleDurationTimeSeries)]}
+            showXAxis="never"
           />
         </SmallWidget>
       </Fragment>


### PR DESCRIPTION
This was requested for Performance sidebars, where we show small charts. The X axis there is not really needed because they're small charts just meant to give an idea. The tooltip still appears on hover. Closes [DAIN-184: Allow turning off `TimeSeriesWidgetVisualization` X axis](https://linear.app/getsentry/issue/DAIN-184/allow-turning-off-timeserieswidgetvisualization-x-axis)

**e.g.,**
<img width="415" alt="Screenshot 2025-04-23 at 2 04 53 PM" src="https://github.com/user-attachments/assets/5b6fc3fd-b7e2-40cb-ac89-21689acfcf5e" />
