### PR TITLE
button: remove buttonlabel from button

### DIFF
--- a/static/app/components/acl/featureDisabled.stories.tsx
+++ b/static/app/components/acl/featureDisabled.stories.tsx
@@ -1,0 +1,26 @@
+import {Fragment} from 'react';
+
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import storyBook from 'sentry/stories/storyBook';
+
+export default storyBook('FeatureDisabled', story => {
+  story('Default', () => {
+    return (
+      <Fragment>
+        <p>
+          The FeatureDisabled component is used to display a warning message when a user
+          attempts to access a feature that is not available to them. It can show both a
+          simple alert-style message as well as an expandable help section with more
+          detailed information. The component supports customization of the message,
+          feature name, and whether to show the help toggle. It's commonly used throughout
+          the application to gracefully handle feature access restrictions and provide
+          clear feedback to users about why certain functionality may be unavailable.
+        </p>
+        <FeatureDisabled
+          features={['this-feature-does-not-exist']}
+          featureName="Feature"
+        />
+      </Fragment>
+    );
+  });
+});

--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import type {AlertProps} from 'sentry/components/core/alert';
 import {Alert} from 'sentry/components/core/alert';
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {CONFIG_DOCS_URL} from 'sentry/constants';
 import {IconChevron, IconCopy} from 'sentry/icons';
@@ -106,7 +106,7 @@ function FeatureDisabled({
               onClick={() => setShowHelp(!showHelp)}
             >
               {t('Help')}
-              <IconChevron direction={showDescription ? 'up' : 'down'} />
+              <StyledIconChevron direction={showDescription ? 'up' : 'down'} />
             </ToggleButton>
           )}
         </FeatureDisabledMessage>
@@ -149,6 +149,10 @@ const HelpText = styled('p')`
   margin-bottom: ${space(1)};
 `;
 
+const StyledIconChevron = styled(IconChevron)`
+  margin-left: ${space(1)};
+`;
+
 const ToggleButton = styled(Button)`
   color: ${p => p.theme.active};
   height: ${p => p.theme.text.lineHeightBody}em;
@@ -156,12 +160,6 @@ const ToggleButton = styled(Button)`
 
   &:hover {
     color: ${p => p.theme.activeHover};
-  }
-
-  ${ButtonLabel} {
-    display: grid;
-    grid-auto-flow: column;
-    gap: ${space(1)};
   }
 `;
 

--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -586,7 +586,7 @@ function getButtonStyles(p: StyledButtonProps & {theme: Theme}): SerializedStyle
   `;
 }
 
-export const ButtonLabel = styled('span', {
+const ButtonLabel = styled('span', {
   shouldForwardProp: prop =>
     typeof prop === 'string' &&
     isPropValid(prop) &&

--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -81,11 +81,12 @@ const StyledButton = styled(Button)`
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-right: none;
+    ${p => p.theme.overflowEllipsis};
 
-    ${ButtonLabel} {
+    > span {
+      ${p => p.theme.overflowEllipsis};
       height: auto;
       display: block;
-      ${p => p.theme.overflowEllipsis};
     }
   }
 `;

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -5,7 +5,7 @@ import orderBy from 'lodash/orderBy';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import LoadingError from 'sentry/components/loadingError';
@@ -327,10 +327,6 @@ const StyledItemButton = styled(Button)`
   line-height: ${p => p.theme.text.lineHeightBody};
 
   padding: ${space(1)} ${space(2)};
-
-  ${ButtonLabel} {
-    justify-content: start;
-  }
 `;
 
 const OverflowMenu = styled(DropdownMenu)`
@@ -376,6 +372,9 @@ const SearchListItem = styled('li')<{hasMenu?: boolean}>`
 
 const TitleDescriptionWrapper = styled('div')`
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: start;
 `;
 
 const SavedSearchItemTitle = styled('div')`

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -164,6 +164,7 @@ export function SidebarButton({
   onClick,
   label,
 }: SidebarButtonProps) {
+  const theme = useTheme();
   const organization = useOrganization();
   const {layout} = useNavContext();
   const showLabel = layout === NavLayout.MOBILE;
@@ -180,7 +181,7 @@ export function SidebarButton({
           onClick?.(e);
         }}
       >
-        <InteractionStateLayer />
+        {theme.isChonk ? null : <InteractionStateLayer />}
         {children}
         {showLabel ? label : null}
       </NavButton>

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -2,7 +2,7 @@ import {Fragment, type MouseEventHandler} from 'react';
 import {css, type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Button, ButtonLabel} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -429,13 +429,13 @@ const ChonkNavButton = styled(Button, {
   width: ${p => (p.isMobile ? '100%' : '44px')};
   padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : undefined)};
 
-  ${ButtonLabel} {
-    gap: ${space(1)};
+  svg {
+    margin-right: ${p => (p.isMobile ? space(1) : undefined)};
+  }
 
-    /* Disable interactionstatelayer hover */
-    [data-isl] {
-      display: none;
-    }
+  /* Disable interactionstatelayer hover */
+  [data-isl] {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
Precursor to removing ButtonLabel, which is an annoying wrapper that in some cases requires sub selectors