### PR TITLE
chore(aci): Remove MetricAlertFire class

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -88,8 +88,3 @@ class MetricIssue(GroupType):
     @classmethod
     def allow_post_process_group(cls, organization: Organization) -> bool:
         return features.has("organizations:workflow-engine-metric-alert-processing", organization)
-
-
-# This needs to be removed once the import in getsentry is updated to use MetricIssue
-class MetricAlertFire:
-    slug = "metric_alert_fire"


### PR DESCRIPTION
Last PR to rename `MetricAlertFire` -> `MetricIssue`