### PR TITLE
feat(code-mapping): Support Java

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -12,7 +12,10 @@ from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.services.integration import RpcIntegration, integration_service
-from sentry.issues.auto_source_code_config.code_mapping import FrameInfo, find_roots
+from sentry.issues.auto_source_code_config.code_mapping import find_roots
+from sentry.issues.auto_source_code_config.derived_code_mappings_endpoint import (
+    get_frame_info_from_request,
+)
 from sentry.models.repository import Repository
 
 
@@ -111,7 +114,7 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
 
         data = serializer.validated_data
         source_url = data["source_url"]
-        stack_path = data["stack_path"]
+        frame_info = get_frame_info_from_request(request)
 
         repo = serializer.repo
         integration = serializer.integration
@@ -119,7 +122,7 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
 
         branch = installation.extract_branch_from_source_url(repo, source_url)
         source_path = installation.extract_source_path_from_source_url(repo, source_url)
-        stack_root, source_root = find_roots(FrameInfo({"filename": stack_path}), source_path)
+        stack_root, source_root = find_roots(frame_info, source_path)
 
         return self.respond(
             {

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -12,10 +12,7 @@ from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.services.integration import RpcIntegration, integration_service
-from sentry.issues.auto_source_code_config.code_mapping import find_roots
-from sentry.issues.auto_source_code_config.derived_code_mappings_endpoint import (
-    get_frame_info_from_request,
-)
+from sentry.issues.auto_source_code_config.code_mapping import FrameInfo, find_roots
 from sentry.models.repository import Repository
 
 
@@ -134,3 +131,12 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
                 "defaultBranch": branch,
             }
         )
+
+
+def get_frame_info_from_request(request: Request) -> FrameInfo:
+    frame = {
+        "abs_path": request.data.get("absPath"),
+        "filename": request.data["stackPath"],
+        "module": request.data.get("module"),
+    }
+    return FrameInfo(frame, request.data.get("platform"))

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -26,12 +26,11 @@ def get_file_and_repo_matches(request: Request, organization: Organization) -> l
 
 def get_frame_info_from_request(request: Request) -> FrameInfo:
     frame = {
-        "abs_path": request.GET.get("absPath"),
-        # Currently, the only required parameter, thus, avoiding the `get` method
-        "filename": request.GET["stacktraceFilename"],
-        "module": request.GET.get("module"),
+        "abs_path": request.data.get("absPath"),
+        "filename": request.data.get("stacktraceFilename") or request.data.get("stackPath"),
+        "module": request.data.get("module"),
     }
-    return FrameInfo(frame, request.GET.get("platform"))
+    return FrameInfo(frame, request.data.get("platform"))
 
 
 def get_code_mapping_from_request(request: Request) -> CodeMapping:

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -26,11 +26,11 @@ def get_file_and_repo_matches(request: Request, organization: Organization) -> l
 
 def get_frame_info_from_request(request: Request) -> FrameInfo:
     frame = {
-        "abs_path": request.data.get("absPath"),
-        "filename": request.data.get("stacktraceFilename") or request.data.get("stackPath"),
-        "module": request.data.get("module"),
+        "abs_path": request.GET.get("absPath"),
+        "filename": request.GET["stacktraceFilename"],
+        "module": request.GET.get("module"),
     }
-    return FrameInfo(frame, request.data.get("platform"))
+    return FrameInfo(frame, request.GET.get("platform"))
 
 
 def get_code_mapping_from_request(request: Request) -> CodeMapping:

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -13,7 +13,16 @@ class BaseStacktraceLinkTest(APITestCase):
             name="foo", organization=self.org, teams=[self.create_team(organization=self.org)]
         )
 
-    def make_post(self, source_url, stack_path, project=None, user=None):
+    def make_post(
+        self,
+        source_url,
+        stack_path,
+        module=None,
+        abs_path=None,
+        platform=None,
+        project=None,
+        user=None,
+    ):
         self.login_as(user=user or self.user)
         if not project:
             project = self.project
@@ -26,7 +35,16 @@ class BaseStacktraceLinkTest(APITestCase):
             },
         )
 
-        return self.client.post(url, data={"sourceUrl": source_url, "stackPath": stack_path})
+        return self.client.post(
+            url,
+            data={
+                "sourceUrl": source_url,
+                "stackPath": stack_path,
+                "module": module,
+                "absPath": abs_path,
+                "platform": platform,
+            },
+        )
 
 
 class PathMappingSerializerTest(TestCase):
@@ -202,6 +220,28 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
             "stackRoot": "sentry/",
             "sourceRoot": "src/sentry/",
             "defaultBranch": "master",
+        }
+
+    def test_java_path(self):
+        src_file = "src/com/example/foo/Bar.kt"
+        source_url = f"https://github.com/getsentry/sentry/blob/master/{src_file}"
+        filename = "Bar.kt"  # The filename in Java does not contain the package name
+        resp = self.make_post(
+            source_url,
+            filename,
+            module="com.example.foo.Bar",  # The module misses the extension
+            abs_path="Bar.kt",  # abs_path includes the extension
+            platform="java",
+        )
+        assert resp.status_code == 200, resp.content
+
+        assert resp.data == {
+            "defaultBranch": "master",
+            "integrationId": self.integration.id,
+            "repositoryId": self.repo.id,
+            "provider": "github",
+            "sourceRoot": "src/com/example/",
+            "stackRoot": "com/example/",
         }
 
     def test_short_path(self):


### PR DESCRIPTION
For Java, the `filename` is not enough to determine the stack and source code roots to save the code mapping.

This is a follow-up to https://github.com/getsentry/sentry/pull/90176.