### PR TITLE
ref(uptime): Simplify consumer with one-to-one proj_sub <-> sub

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -266,13 +266,11 @@ def get_top_hosting_provider_names(limit: int) -> set[str]:
     recalculate=False,
     cache_ttl=timedelta(hours=4),
 )
-def get_project_subscriptions_for_uptime_subscription(
+def get_project_subscription_for_uptime_subscription(
     uptime_subscription_id: int,
-) -> list[ProjectUptimeSubscription]:
-    return list(
-        ProjectUptimeSubscription.objects.filter(
-            uptime_subscription_id=uptime_subscription_id
-        ).select_related("project", "project__organization")
+) -> ProjectUptimeSubscription:
+    return ProjectUptimeSubscription.objects.select_related("project", "project__organization").get(
+        uptime_subscription_id=uptime_subscription_id
     )
 
 


### PR DESCRIPTION
This merges the handle_result_for_project into handler_result, since we
can now assume there's a single ProjectUptimeSubscription for every
UptimeSubscription, thus we don't need to fan out