### PR TITLE
fix(quota alert): copy change

### DIFF
--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -31,7 +31,11 @@ import {
   type Subscription,
 } from 'getsentry/types';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/billing';
-import {listDisplayNames, sortCategoriesWithKeys} from 'getsentry/utils/dataCategory';
+import {
+  getSingularCategoryName,
+  listDisplayNames,
+  sortCategoriesWithKeys,
+} from 'getsentry/utils/dataCategory';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
 const ANIMATE_PROPS: MotionProps = {
@@ -80,7 +84,18 @@ function QuotaExceededContent({
         <HeaderTitle>{t('Billing Status')}</HeaderTitle>
       </Header>
       <Body>
-        <Title>{t('Quota Exceeded')}</Title>
+        <Title>
+          {exceededCategories.length === 1
+            ? tct('[category] Quota Exceeded', {
+                category: getSingularCategoryName({
+                  plan: subscription.planDetails,
+                  category: exceededCategories[0] as DataCategory,
+                  hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+                  title: true,
+                }),
+              })
+            : t('Quotas Exceeded')}
+        </Title>
         <Description>
           {tct(
             'You’ve run out of [exceededCategories] for this billing cycle. This means we are no longer monitoring or ingesting events and showing them in Sentry.',


### PR DESCRIPTION
"Quota Exceeded" -> "[category] Quota Exceeded" if only one category is exceeded, else "Quotas Exceeded"

![Screenshot 2025-04-23 at 11 35 09 AM](https://github.com/user-attachments/assets/4726d099-a1b5-4c63-9ed0-88f35f8eb1c3)
![Screenshot 2025-04-23 at 11 35 37 AM](https://github.com/user-attachments/assets/e34bb1a1-601b-4933-950a-ed2cbae8187a)

If a non-PAYG only category and any PAYG only categories (ie. crons, profiling hours) are exceeded, we still render the singular title (ie. "[non-PAYG only category] Quota Exceeded") if the customer doesn't have PAYG, otherwise we'd render "Quotas Exceeded"