### PR TITLE
Add a GitHub Account ID to the integration metadata

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -227,6 +227,12 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
         """
         return self.get_cached(f"/repos/{repo}/commits/{sha}")
 
+    def get_installation_info(self, installation_id: int) -> Any:
+        """
+        https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-installation-for-the-authenticated-app
+        """
+        return self.get(f"/app/installations/{installation_id}")
+
     def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         """
         Get the merge commit sha from a commit sha.


### PR DESCRIPTION
This id is associated with the GitHub Organization id, which will be used when Codecov tries to resolve the integration with the Codecov Organization that the user is looking at.

We are going to lazy backfill the id. If the id is missing from the metadata object, we will look it up and backfill it that way.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
