### PR TITLE
fix(sentryapps) Eager load api_token relation for sentryapps

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -103,7 +103,7 @@ class DatabaseBackedAppService(AppService):
     ) -> list[RpcSentryAppInstallation]:
         installations = SentryAppInstallation.objects.get_installed_for_organization(
             organization_id
-        ).select_related("sentry_app")
+        ).select_related("sentry_app", "api_token")
         fq = self._AppServiceFilterQuery()
         return [fq.serialize_rpc(i) for i in installations]
 


### PR DESCRIPTION
If we don't eager load this relation, we get an n+1 query.

Fixes SENTRY-3F25