### PR TITLE
feat(nav): Separate org and user dropdowns

### DIFF
--- a/static/app/views/nav/orgDropdown.spec.tsx
+++ b/static/app/views/nav/orgDropdown.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
@@ -36,59 +36,6 @@ describe('OrgDropdown', function () {
       'href',
       `/organizations/${organization.slug}/settings/teams/`
     );
-  });
-
-  it('displays user info and links', async function () {
-    render(<OrgDropdown />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
-
-    expect(screen.getByText('Foo Bar')).toBeInTheDocument();
-    expect(screen.getByText('foo@example.com')).toBeInTheDocument();
-
-    expect(screen.getByRole('link', {name: 'User Settings'})).toHaveAttribute(
-      'href',
-      '/settings/account/'
-    );
-    expect(screen.getByRole('link', {name: 'User Auth Tokens'})).toHaveAttribute(
-      'href',
-      '/settings/account/api/'
-    );
-  });
-
-  it('can sign out', async function () {
-    const mockLogout = MockApiClient.addMockResponse({
-      url: '/auth/',
-      method: 'DELETE',
-    });
-
-    render(<OrgDropdown />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
-
-    await userEvent.click(screen.getByText('Sign Out'));
-
-    await waitFor(() => {
-      expect(mockLogout).toHaveBeenCalled();
-    });
-  });
-
-  it('hides admin link if user is not admin', async function () {
-    render(<OrgDropdown />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
-
-    expect(screen.queryByRole('link', {name: 'Admin'})).not.toBeInTheDocument();
-  });
-
-  it('shows admin link if user is admin', async function () {
-    ConfigStore.set('user', UserFixture({isSuperuser: true}));
-
-    render(<OrgDropdown />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
-
-    expect(screen.getByRole('link', {name: 'Admin'})).toHaveAttribute('href', `/manage/`);
   });
 
   it('can switch orgs', async function () {

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -2,12 +2,10 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import orderBy from 'lodash/orderBy';
 
-import {logout} from 'sentry/actionCreators/account';
 import {OrganizationAvatar} from 'sentry/components/core/avatar/organizationAvatar';
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import OrganizationBadge from 'sentry/components/idBadge/organizationBadge';
-import UserBadge from 'sentry/components/idBadge/userBadge';
 import {IconAdd} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -15,12 +13,11 @@ import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {localizeDomain, resolveRoute} from 'sentry/utils/resolveRoute';
-import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {useUser} from 'sentry/utils/useUser';
 import {useNavContext} from 'sentry/views/nav/context';
 import {NavLayout} from 'sentry/views/nav/types';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 function createOrganizationMenuItem(): MenuItemProps {
   const configFeatures = ConfigStore.get('features');
@@ -54,12 +51,10 @@ export function OrgDropdown({
   className?: string;
   hideOrgLinks?: boolean;
 }) {
-  const api = useApi();
   const theme = useTheme();
 
   const config = useLegacyStore(ConfigStore);
   const organization = useOrganization();
-  const user = useUser();
 
   // It's possible we do not have an org in context (e.g. RouteNotFound)
   // Otherwise, we should have the full org
@@ -74,10 +69,6 @@ export function OrgDropdown({
 
   const {layout} = useNavContext();
   const isMobile = layout === NavLayout.MOBILE;
-
-  function handleLogout() {
-    logout(api);
-  }
 
   return (
     <DropdownMenu
@@ -96,6 +87,7 @@ export function OrgDropdown({
           />
         </OrgDropdownTrigger>
       )}
+      position="right-start"
       minMenuWidth={200}
       items={[
         {
@@ -115,6 +107,12 @@ export function OrgDropdown({
               label: t('Organization Settings'),
               to: `/organizations/${organization.slug}/settings/`,
               hidden: !hasOrgRead || hideOrgLinks,
+            },
+            {
+              key: 'projects',
+              label: t('Projects'),
+              to: makeProjectsPathname({path: '/', orgSlug: organization.slug}),
+              hidden: hideOrgLinks,
             },
             {
               key: 'members',
@@ -158,38 +156,6 @@ export function OrgDropdown({
                 }),
                 createOrganizationMenuItem(),
               ],
-            },
-          ],
-        },
-        {
-          key: 'user',
-          label: (
-            <SectionTitleWrapper>
-              <UserBadge user={user} avatarSize={32} />
-            </SectionTitleWrapper>
-          ),
-          textValue: t('User Summary'),
-          children: [
-            {
-              key: 'user-settings',
-              label: t('User Settings'),
-              to: '/settings/account/',
-            },
-            {
-              key: 'user-auth-tokens',
-              label: t('User Auth Tokens'),
-              to: '/settings/account/api/',
-            },
-            {
-              key: 'admin',
-              label: t('Admin'),
-              to: '/manage/',
-              hidden: !user?.isSuperuser,
-            },
-            {
-              key: 'signout',
-              label: t('Sign Out'),
-              onAction: handleLogout,
             },
           ],
         },

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -63,7 +63,7 @@ interface SidebarItemProps extends React.HTMLAttributes<HTMLLIElement> {
 export function SidebarItem({children, label, showLabel, ...props}: SidebarItemProps) {
   const {layout} = useNavContext();
   return (
-    <IconDefaultsProvider legacySize={layout === NavLayout.MOBILE ? '14px' : '21px'}>
+    <IconDefaultsProvider legacySize={layout === NavLayout.MOBILE ? '16px' : '21px'}>
       <Tooltip title={label} disabled={showLabel} position="right" skipWrapper delay={0}>
         <SidebarListItem {...props}>{children}</SidebarListItem>
       </Tooltip>
@@ -89,6 +89,7 @@ export function SidebarMenu({
     <DropdownMenu
       position={layout === NavLayout.MOBILE ? 'bottom' : 'right-end'}
       shouldApplyMinWidth={false}
+      minMenuWidth={200}
       trigger={(props, isOpen) => {
         return (
           <SidebarItem label={label} showLabel={showLabel}>
@@ -188,9 +189,15 @@ export function SidebarButton({
   );
 }
 
-export function SeparatorItem() {
+export function SeparatorItem({
+  className,
+  hasMargin,
+}: {
+  className?: string;
+  hasMargin?: boolean;
+}) {
   return (
-    <SeparatorListItem aria-hidden>
+    <SeparatorListItem aria-hidden className={className} hasMargin={hasMargin}>
       <Separator />
     </SeparatorListItem>
   );
@@ -202,10 +209,15 @@ const SidebarListItem = styled('li')`
   justify-content: center;
 `;
 
-const SeparatorListItem = styled('li')`
+const SeparatorListItem = styled('li')<{hasMargin?: boolean}>`
   list-style: none;
   width: 100%;
   padding: 0 ${space(1.5)};
+  ${p =>
+    p.hasMargin &&
+    css`
+      margin: ${space(0.5)} 0;
+    `}
 `;
 
 const Separator = styled('hr')`

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -29,6 +29,7 @@ import {PrimaryNavigationServiceIncidents} from 'sentry/views/nav/primary/servic
 import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew';
 import {NavTourElement, StackedNavigationTour} from 'sentry/views/nav/tour/tour';
 import {NavLayout, PrimaryNavGroup} from 'sentry/views/nav/types';
+import {UserDropdown} from 'sentry/views/nav/userDropdown';
 
 function SidebarBody({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
@@ -151,9 +152,6 @@ export function PrimaryNavigationItems() {
       <SidebarFooter>
         <ChonkOptInBanner collapsed="never" />
         <PrimaryNavigationHelp />
-
-        <SeparatorItem />
-
         <PrimaryNavigationWhatsNew />
         <Hook
           name="sidebar:try-business"
@@ -165,6 +163,8 @@ export function PrimaryNavigationItems() {
         <ErrorBoundary customComponent={null}>
           <PrimaryNavigationOnboarding />
         </ErrorBoundary>
+        <SeparatorItem hasMargin />
+        <UserDropdown />
       </SidebarFooter>
     </Fragment>
   );

--- a/static/app/views/nav/userDropdown.spec.tsx
+++ b/static/app/views/nav/userDropdown.spec.tsx
@@ -1,0 +1,61 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import {UserDropdown} from 'sentry/views/nav/userDropdown';
+
+describe('UserDropdown', function () {
+  beforeEach(() => {
+    ConfigStore.set('user', UserFixture());
+  });
+
+  it('displays user info and links', async function () {
+    render(<UserDropdown />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'foo@example.com'}));
+
+    expect(screen.getByText('Foo Bar')).toBeInTheDocument();
+    expect(screen.getByText('foo@example.com')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', {name: 'User Settings'})).toHaveAttribute(
+      'href',
+      '/settings/account/'
+    );
+  });
+
+  it('can sign out', async function () {
+    const mockLogout = MockApiClient.addMockResponse({
+      url: '/auth/',
+      method: 'DELETE',
+    });
+
+    render(<UserDropdown />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'foo@example.com'}));
+
+    await userEvent.click(screen.getByText('Sign Out'));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
+  });
+
+  it('hides admin link if user is not admin', async function () {
+    render(<UserDropdown />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'foo@example.com'}));
+
+    expect(screen.queryByRole('link', {name: 'Admin'})).not.toBeInTheDocument();
+  });
+
+  it('shows admin link if user is admin', async function () {
+    ConfigStore.set('user', UserFixture({isSuperuser: true}));
+
+    render(<UserDropdown />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'foo@example.com'}));
+
+    expect(screen.getByRole('link', {name: 'Admin'})).toHaveAttribute('href', `/manage/`);
+  });
+});

--- a/static/app/views/nav/userDropdown.tsx
+++ b/static/app/views/nav/userDropdown.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+
+import {logout} from 'sentry/actionCreators/account';
+import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
+import UserBadge from 'sentry/components/idBadge/userBadge';
+import {t} from 'sentry/locale';
+import useApi from 'sentry/utils/useApi';
+import {useUser} from 'sentry/utils/useUser';
+import {useNavContext} from 'sentry/views/nav/context';
+import {SidebarMenu} from 'sentry/views/nav/primary/components';
+import {NavLayout} from 'sentry/views/nav/types';
+
+export function UserDropdown() {
+  const api = useApi();
+  const user = useUser();
+  const {layout} = useNavContext();
+  const isMobile = layout === NavLayout.MOBILE;
+
+  function handleLogout() {
+    logout(api);
+  }
+
+  return (
+    <SidebarMenu
+      label={user.email}
+      analyticsKey="account"
+      items={[
+        {
+          key: 'user',
+          label: (
+            <SectionTitleWrapper>
+              <UserBadge user={user} avatarSize={32} />
+            </SectionTitleWrapper>
+          ),
+          textValue: t('User Summary'),
+          children: [
+            {
+              key: 'user-settings',
+              label: t('User Settings'),
+              to: '/settings/account/',
+            },
+            {
+              key: 'admin',
+              label: t('Admin'),
+              to: '/manage/',
+              hidden: !user?.isSuperuser,
+            },
+            {
+              key: 'signout',
+              label: t('Sign Out'),
+              onAction: handleLogout,
+            },
+          ],
+        },
+      ]}
+    >
+      <UserAvatar size={isMobile ? 20 : 28} user={user} />
+    </SidebarMenu>
+  );
+}
+
+const SectionTitleWrapper = styled('div')`
+  text-transform: none;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  color: ${p => p.theme.textColor};
+`;

--- a/static/gsApp/hooks/disabledMemberView.tsx
+++ b/static/gsApp/hooks/disabledMemberView.tsx
@@ -20,6 +20,7 @@ import useApi from 'sentry/utils/useApi';
 import {useParams} from 'sentry/utils/useParams';
 import {OrgDropdown} from 'sentry/views/nav/orgDropdown';
 import {usePrefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
+import {UserDropdown} from 'sentry/views/nav/userDropdown';
 
 import {sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
 import DeactivatedMember from 'getsentry/components/features/illustrations/deactivatedMember';
@@ -133,6 +134,7 @@ function DisabledMemberView(props: Props) {
       {prefersStackedNav ? (
         <MinimalistSidebar>
           {organization ? <OrgDropdown hideOrgLinks /> : null}
+          {<UserDropdown />}
         </MinimalistSidebar>
       ) : (
         <MinimalistSidebarLegacy collapsed={false}>
@@ -224,6 +226,7 @@ const MinimalistSidebar = styled('div')`
   background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface300)};
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding: 0 ${space(2)};
 `;
 


### PR DESCRIPTION
Removes user-specific items from the org dropdown and moves them into a user dropdown at the bottom of the primary nav.

Also:

- Adds a link to "Projects" from the org dropdown
- Removes "Auth User Tokens" from the user dropdown

Before:

<img src="https://github.com/user-attachments/assets/c253a25d-1e0d-476b-82fc-a4787a84d80e" width="200" />

After:

<img src="https://github.com/user-attachments/assets/ea03172e-5d60-4e31-bc5a-9a9bc95cec78" width="200" />

<img src="https://github.com/user-attachments/assets/99650104-bf95-4500-a4eb-b86c82bca76f" width="500" />