### PR TITLE
fix(aci): add dual delete pre-delete receiver for issue alerts

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -21,7 +21,10 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors.workflow import WorkflowDataConditionGroupType
+from sentry.workflow_engine.processors.workflow import (
+    WorkflowDataConditionGroupType,
+    delete_workflow,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -183,32 +186,6 @@ def update_dcg(
         bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=dcg)
 
     return dcg
-
-
-def delete_workflow(workflow: Workflow) -> None:
-    # delete all associated IF DCGs and their conditions
-    workflow_dcgs = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
-    for workflow_dcg in workflow_dcgs:
-        if_dcg = workflow_dcg.condition_group
-        if_dcg.conditions.all().delete()
-        delete_workflow_actions(if_dcg=if_dcg)
-        if_dcg.delete()
-
-    if not workflow.when_condition_group:
-        # OK, this shouldn't happen but should not prevent deletion
-        logger.error(
-            "workflow_engine.issue_alert.deleted.error",
-            extra={
-                "workflow_id": workflow.id,
-                "error": "Workflow does not have a when_condition_group",
-            },
-        )
-    else:
-        when_dcg = workflow.when_condition_group
-        when_dcg.conditions.all().delete()
-        when_dcg.delete()
-
-    workflow.delete()
 
 
 def delete_migrated_issue_alert(rule: Rule) -> int | None:


### PR DESCRIPTION
If a project or org is deleted, the related workflow engine objects should also be deleted.

For a Rule (issue alert) this is currently not the case. All related workflow engine objects are only correctly deleted via the API (which uses `delete_migrated_issue_alert` + `RuleDeletionTask`).

We need a pre-delete signal on the `Rule` for the case where the `Rule` is deleted via cascade because the org/project is deleted.

As a followup I'll be making a script to clean up unwanted rows in all regions.