### PR TITLE
chore: update issue-workflow team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -522,23 +522,23 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 
 ## Issues
 # Catch-all
-**/issues/**                                                @getsentry/issue-detection-backend @getsentry/issue-detection-frontend @getsentry/issues-workflow
+**/issues/**                                                @getsentry/issue-detection-backend @getsentry/issue-detection-frontend @getsentry/issue-workflow
 # Overrides
 /src/sentry/api/helpers/actionable_items_helper.py          @getsentry/issues
 /src/sentry/api/helpers/events.py                           @getsentry/issues
 /src/sentry/api/helpers/group_index/                        @getsentry/issues
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issues
-/src/sentry/api/issue_search.py                             @getsentry/issues-workflow
-/src/sentry/api/endpoints/organization_pinned_searches.py   @getsentry/issues-workflow
+/src/sentry/api/issue_search.py                             @getsentry/issue-workflow
+/src/sentry/api/endpoints/organization_pinned_searches.py   @getsentry/issue-workflow
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend
 /src/sentry/event_manager.py                                @getsentry/issue-detection-backend
 /src/sentry/eventstore/models.py                            @getsentry/issue-detection-backend
 /src/sentry/grouping/                                       @getsentry/issue-detection-backend
 /src/sentry/mediators/                                      @getsentry/issues
-/src/sentry/search/events/builder/issue_platform.py         @getsentry/issues-workflow
-/src/sentry/search/events/builder/errors.py                 @getsentry/issues-workflow
-/src/sentry/search/snuba/                                   @getsentry/issues-workflow
+/src/sentry/search/events/builder/issue_platform.py         @getsentry/issue-workflow
+/src/sentry/search/events/builder/errors.py                 @getsentry/issue-workflow
+/src/sentry/search/snuba/                                   @getsentry/issue-workflow
 /src/sentry/seer/similarity/                                @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_ongoing_issues.py                    @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_remove_inbox.py                      @getsentry/issue-detection-backend
@@ -558,17 +558,17 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/tasks/post_process.py                           @getsentry/issue-detection-backend
 /src/sentry/tasks/unmerge.py                                @getsentry/issue-detection-backend
 /src/sentry/tasks/weekly_escalating_forecast.py             @getsentry/issue-detection-backend
-/static/app/components/events/contexts/                     @getsentry/issues-workflow
-/static/app/components/events/eventTags/                    @getsentry/issues-workflow
-/static/app/components/events/highlights/                   @getsentry/issues-workflow
-/static/app/views/issueList                                 @getsentry/issues-workflow
-/static/app/views/issueDetails/                             @getsentry/issues-workflow
-/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx   @getsentry/issues-workflow
-/tests/sentry/api/test_issue_search.py                      @getsentry/issues-workflow
+/static/app/components/events/contexts/                     @getsentry/issue-workflow
+/static/app/components/events/eventTags/                    @getsentry/issue-workflow
+/static/app/components/events/highlights/                   @getsentry/issue-workflow
+/static/app/views/issueList                                 @getsentry/issue-workflow
+/static/app/views/issueDetails/                             @getsentry/issue-workflow
+/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx   @getsentry/issue-workflow
+/tests/sentry/api/test_issue_search.py                      @getsentry/issue-workflow
 /tests/sentry/deletions/test_group.py                       @getsentry/issue-detection-backend
 /tests/sentry/event_manager/                                @getsentry/issue-detection-backend
 /tests/sentry/grouping/                                     @getsentry/issue-detection-backend
-/tests/sentry/search/                                       @getsentry/issues-workflow
+/tests/sentry/search/                                       @getsentry/issue-workflow
 /tests/sentry/tasks/test_auto_ongoing_issues.py             @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_remove_inbox.py               @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_resolve_issues.py             @getsentry/issue-detection-backend
@@ -586,7 +586,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/tasks/test_merge.py                           @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_post_process.py                    @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_weekly_escalating_forecast.py      @getsentry/issue-detection-backend
-/tests/snuba/search/                                        @getsentry/issues-workflow
+/tests/snuba/search/                                        @getsentry/issue-workflow
 ## End of Issues
 
 ## Billing


### PR DESCRIPTION
The `issues-workflow` team is now the `issue-workflow` team. Requires https://github.com/getsentry/security-as-code/pull/1430 to be merged first.