### PR TITLE
fix(nav): Prevent secondary nav links from resetting page filters

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -8,6 +8,7 @@ import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link from 'sentry/components/links/link';
 import {linkStyles} from 'sentry/components/links/styles';
+import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -19,7 +20,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useNavContext} from 'sentry/views/nav/context';
 import {NavLayout} from 'sentry/views/nav/types';
-import {isLinkActive, makeLinkPropsFromTo} from 'sentry/views/nav/utils';
+import {isLinkActive} from 'sentry/views/nav/utils';
 
 interface SidebarItemLinkProps {
   analyticsKey: string;
@@ -127,14 +128,13 @@ export function SidebarLink({
   const organization = useOrganization();
   const location = useLocation();
   const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
-  const linkProps = makeLinkPropsFromTo(to);
-
   const {layout} = useNavContext();
 
   return (
     <SidebarItem label={label} showLabel>
       <NavLink
-        {...linkProps}
+        to={to}
+        state={{source: SIDEBAR_NAVIGATION_SOURCE}}
         onClick={() => recordPrimaryItemClick(analyticsKey, organization)}
         aria-selected={isActive}
         aria-current={isActive ? 'page' : undefined}

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link, {type LinkProps} from 'sentry/components/links/link';
+import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -126,6 +127,7 @@ SecondaryNav.Item = function SecondaryNavItem({
 
   return (
     <Item
+      state={{source: SIDEBAR_NAVIGATION_SOURCE}}
       {...linkProps}
       to={to}
       aria-current={isActive ? 'page' : undefined}

--- a/static/app/views/nav/utils.tsx
+++ b/static/app/views/nav/utils.tsx
@@ -1,7 +1,5 @@
 import type {To} from '@remix-run/router';
-import type {LocationDescriptor} from 'history';
 
-import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
 export function isLinkActive(
@@ -16,17 +14,4 @@ export function isLinkActive(
   }
 
   return pathname.startsWith(toPathname);
-}
-
-/**
- * Creates a `LocationDescriptor` from a URL string that may contain search params
- */
-export function makeLinkPropsFromTo(to: string): {
-  state: Record<PropertyKey, unknown>;
-  to: LocationDescriptor;
-} {
-  return {
-    to,
-    state: {source: SIDEBAR_NAVIGATION_SOURCE},
-  };
 }


### PR DESCRIPTION
To reproduce the issue, you could:

- Go to /issues/ and select a project
- Click "Feed"

Prior to this change, the page filters would be reset. Adding the `SIDEBAR_NAVIGATION_SOURCE` router state prevents this (with existing logic in page filters). This was already applied to the primary nav items, but not the secondary ones.