### PR TITLE
fix(aci): Respect priority locks when updating group priority

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -276,7 +276,11 @@ def save_issue_from_occurrence(
         group_event.occurrence = occurrence
         is_regression = _process_existing_aggregate(group, group_event, issue_kwargs, release)
         group_info = GroupInfo(group=group, is_new=False, is_regression=is_regression)
-        if issue_kwargs["priority"] and group.priority != issue_kwargs["priority"]:
+        if (
+            issue_kwargs["priority"]
+            and group.priority != issue_kwargs["priority"]
+            and not group.priority_locked_at
+        ):
             group.update(priority=issue_kwargs["priority"])
 
     additional_hashes = [f for f in occurrence.fingerprint if f != primary_grouphash.hash]

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 class PriorityChangeReason(Enum):
     ESCALATING = "escalating"
     ONGOING = "ongoing"
+    ISSUE_PLATFORM = "issue_platform"
 
 
 PRIORITY_TO_GROUP_HISTORY_STATUS = {
@@ -44,6 +45,9 @@ def update_priority(
     """
 
     if priority is None or group.priority == priority:
+        return
+
+    if group.priority_locked_at is not None:
         return
 
     previous_priority = PriorityLevel(group.priority) if group.priority is not None else None

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -476,6 +476,25 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert group_info is not None
         assert group_info.group.priority == PriorityLevel.HIGH
 
+    def test_group_with_priority_locked(self) -> None:
+        occurrence = self.build_occurrence(priority=PriorityLevel.HIGH)
+        event = self.store_event(data={}, project_id=self.project.id)
+        group_info = save_issue_from_occurrence(occurrence, event, None)
+        assert group_info is not None
+        assert group_info.group.priority == PriorityLevel.HIGH
+        assert group_info.group.priority_locked_at is None
+
+        group_info.group.update(priority_locked_at=timezone.now(), priority=PriorityLevel.LOW)
+        assert group_info.group.priority == PriorityLevel.LOW
+        assert group_info.group.priority_locked_at is not None
+
+        occurrence = self.build_occurrence(priority=PriorityLevel.HIGH)
+        event = self.store_event(data={}, project_id=self.project.id)
+        group_info = save_issue_from_occurrence(occurrence, event, None)
+        assert group_info is not None
+        assert group_info.group.priority == PriorityLevel.LOW
+        assert group_info.group.priority_locked_at is not None
+
 
 class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -481,19 +481,17 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         group_info = save_issue_from_occurrence(occurrence, event, None)
         assert group_info is not None
-        assert group_info.group.priority == PriorityLevel.HIGH
-        assert group_info.group.priority_locked_at is None
+        group = group_info.group
+        assert group.priority == PriorityLevel.HIGH
+        assert group.priority_locked_at is None
 
         group_info.group.update(priority_locked_at=timezone.now(), priority=PriorityLevel.LOW)
-        assert group_info.group.priority == PriorityLevel.LOW
-        assert group_info.group.priority_locked_at is not None
-
         occurrence = self.build_occurrence(priority=PriorityLevel.HIGH)
         event = self.store_event(data={}, project_id=self.project.id)
-        group_info = save_issue_from_occurrence(occurrence, event, None)
-        assert group_info is not None
-        assert group_info.group.priority == PriorityLevel.LOW
-        assert group_info.group.priority_locked_at is not None
+        save_issue_from_occurrence(occurrence, event, None)
+        group.refresh_from_db()
+        assert group.priority == PriorityLevel.LOW
+        assert group.priority_locked_at is not None
 
 
 class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):


### PR DESCRIPTION
Sentry should not be overwriting the group priority if it's set by a user. We check this using the `priority_locked_at` field and should check this when saving issue occurrences.