### PR TITLE
ref(issues): don't auto resolve issues if not enabled on grouptype

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -419,8 +419,10 @@ class GroupSerializerBase(Serializer, ABC):
                 status = GroupStatus.UNRESOLVED
         if status == GroupStatus.UNRESOLVED and obj.is_over_resolve_age():
             # When an issue is over the auto-resolve age but the task has not yet run
-            status = GroupStatus.RESOLVED
-            status_details["autoResolved"] = True
+            # Only show as auto-resolved if this group type has auto-resolve enabled
+            if obj.issue_type.enable_auto_resolve:
+                status = GroupStatus.RESOLVED
+                status_details["autoResolved"] = True
         if status == GroupStatus.RESOLVED:
             status_label = "resolved"
             if attrs["resolution_type"] == "release":

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -776,7 +776,9 @@ class Group(Model):
                     status = GroupStatus.UNRESOLVED
 
         if status == GroupStatus.UNRESOLVED and self.is_over_resolve_age():
-            return GroupStatus.RESOLVED
+            # Only auto-resolve if this group type has auto-resolve enabled
+            if self.issue_type.enable_auto_resolve:
+                return GroupStatus.RESOLVED
         return status
 
     def get_share_id(self):


### PR DESCRIPTION
i think we were missing a spot where auto resolve was happening regardless of whether the group type had `enable_auto_resolve` set or not

relates to https://github.com/getsentry/team-replay/issues/571