### PR TITLE
fix(grouping): Remove grouping metadata from test inputs

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/bugly.json
+++ b/tests/sentry/grouping/grouping_inputs/bugly.json
@@ -26,8 +26,6 @@
               "package": "[vdso]",
               "in_app": false,
               "data": {
-                "orig_in_app": -1,
-                "min_grouping_level": 2,
                 "symbolicator_status": "unknown_image"
               },
               "symbol_addr": "0x7a715f363c"

--- a/tests/sentry/grouping/grouping_inputs/cocoa_dispatch_client_callout.json
+++ b/tests/sentry/grouping/grouping_inputs/cocoa_dispatch_client_callout.json
@@ -9,10 +9,7 @@
             {
               "function": "unicorn",
               "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
-              "in_app": false,
-              "data": {
-                "orig_in_app": 1
-              }
+              "in_app": false
             },
             {
               "function": "UIApplicationMain",
@@ -65,26 +62,17 @@
             {
               "function": "FudgeLogTaggedError",
               "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
-              "in_app": false,
-              "data": {
-                "orig_in_app": 1
-              }
+              "in_app": false
             },
             {
               "function": "thunk for closure",
               "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
-              "in_app": false,
-              "data": {
-                "orig_in_app": 1
-              }
+              "in_app": false
             },
             {
               "function": "SentrySetupInteractor.setupSentry",
               "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
-              "in_app": false,
-              "data": {
-                "orig_in_app": 1
-              }
+              "in_app": false
             },
             {
               "function": "_dispatch_lane_barrier_sync_invoke_and_complete",
@@ -101,10 +89,7 @@
             {
               "function": "thunk for closure",
               "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
-              "in_app": false,
-              "data": {
-                "orig_in_app": 1
-              }
+              "in_app": false
             }
           ]
         }

--- a/tests/sentry/grouping/grouping_inputs/native-driver-crash1.json
+++ b/tests/sentry/grouping/grouping_inputs/native-driver-crash1.json
@@ -12,7 +12,6 @@
           "frames": [
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "CUseCountedObject<T>::UCDestroy",
@@ -25,7 +24,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "destructor'",
@@ -38,7 +36,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "CD3D11LayeredChild<T>::LUCBeginLayerDestruction",
@@ -51,7 +48,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "CContext::LUCBeginLayerDestruction",
@@ -64,7 +60,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "NDXGI::CDevice::DestroyDriverInstance",
@@ -77,7 +72,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "OpenAdapter10",
@@ -89,7 +83,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing_symbol"
               },
               "in_app": false,

--- a/tests/sentry/grouping/grouping_inputs/native-driver-crash2.json
+++ b/tests/sentry/grouping/grouping_inputs/native-driver-crash2.json
@@ -13,8 +13,7 @@
               "symbol": "?UCDestroy@?$CUseCountedObject@VCDeviceChild@NOutermost@@@@UEAAXXZ",
               "package": "C:\\WINDOWS\\SYSTEM32\\d3d11.dll",
               "data": {
-                "symbolicator_status": "symbolicated",
-                "orig_in_app": -1
+                "symbolicator_status": "symbolicated"
               },
               "instruction_addr": "0x7ff8151f7639",
               "trust": "cfi",
@@ -26,8 +25,7 @@
               "symbol": "?LUCBeginLayerDestruction@CContext@@QEAAXXZ",
               "package": "C:\\WINDOWS\\SYSTEM32\\d3d11.dll",
               "data": {
-                "symbolicator_status": "symbolicated",
-                "orig_in_app": -1
+                "symbolicator_status": "symbolicated"
               },
               "instruction_addr": "0x7ff8152033b7",
               "trust": "cfi",
@@ -39,8 +37,7 @@
               "symbol": "?DestroyDriverInstance@CDevice@NDXGI@@UEAAXXZ",
               "package": "C:\\WINDOWS\\SYSTEM32\\d3d11.dll",
               "data": {
-                "symbolicator_status": "symbolicated",
-                "orig_in_app": -1
+                "symbolicator_status": "symbolicated"
               },
               "instruction_addr": "0x7ff815200b7b",
               "trust": "cfi",
@@ -51,8 +48,7 @@
               "symbol": "OpenAdapter10",
               "package": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvblwi.inf_amd64_ce1b980000216c78\\nvwgf2umx.dll",
               "data": {
-                "symbolicator_status": "symbolicated",
-                "orig_in_app": -1
+                "symbolicator_status": "symbolicated"
               },
               "instruction_addr": "0x7fff971991ce",
               "trust": "cfi",
@@ -61,8 +57,7 @@
             {
               "package": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvblwi.inf_amd64_ce1b980000216c78\\nvwgf2umx.dll",
               "data": {
-                "symbolicator_status": "missing_symbol",
-                "orig_in_app": -1
+                "symbolicator_status": "missing_symbol"
               },
               "instruction_addr": "0x7fff96573450",
               "trust": "cfi",
@@ -71,8 +66,7 @@
             {
               "package": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvblwi.inf_amd64_ce1b980000216c78\\nvwgf2umx.dll",
               "data": {
-                "symbolicator_status": "missing_symbol",
-                "orig_in_app": -1
+                "symbolicator_status": "missing_symbol"
               },
               "instruction_addr": "0x7fff9669dea0",
               "trust": "context",

--- a/tests/sentry/grouping/grouping_inputs/native-driver-crash3.json
+++ b/tests/sentry/grouping/grouping_inputs/native-driver-crash3.json
@@ -12,7 +12,6 @@
           "frames": [
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "CUseCountedObject<T>::UCDestroy",
@@ -25,7 +24,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "destructor'",
@@ -38,7 +36,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "NOutermost::CDeviceChild::LUCBeginLayerDestruction",
@@ -51,7 +48,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "CContext::LUCBeginLayerDestruction",
@@ -64,7 +60,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "NDXGI::CDevice::DestroyDriverInstance",
@@ -77,7 +72,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing_symbol"
               },
               "in_app": false,
@@ -87,7 +81,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "OpenAdapter12",
@@ -99,7 +92,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing_symbol"
               },
               "in_app": false,

--- a/tests/sentry/grouping/grouping_inputs/native-malloc-chain.json
+++ b/tests/sentry/grouping/grouping_inputs/native-malloc-chain.json
@@ -15,7 +15,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "malloc_zone_malloc",
@@ -27,7 +26,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "nanov2_malloc",
@@ -39,7 +37,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "nanov2_allocate",
@@ -51,7 +48,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "nanov2_allocate_from_block",
@@ -63,7 +59,6 @@
             },
             {
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               },
               "function": "nanov2_allocate_from_block.cold.1",

--- a/tests/sentry/grouping/grouping_inputs/unreal_assert_mac.json
+++ b/tests/sentry/grouping/grouping_inputs/unreal_assert_mac.json
@@ -10,19 +10,12 @@
             {
               "function": "_pthread_start",
               "symbol": "_pthread_start",
-              "package": "/usr/lib/system/libsystem_pthread.dylib",
-              "data": {
-                "category": "threadbase"
-              }
+              "package": "/usr/lib/system/libsystem_pthread.dylib"
             },
             {
               "function": "__NSThread__start__",
               "symbol": "__NSThread__start__",
-              "package": "/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation",
-              "data": {
-                "orig_in_app": 0,
-                "category": "internals"
-              }
+              "package": "/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation"
             },
             {
               "function": "-[FCocoaGameThread main]",
@@ -146,10 +139,7 @@
               "function": "ProcessLocalFunction::lambda::operator()",
               "raw_function": "ProcessLocalFunction(UObject*, UFunction*, FFrame&, void*)::$_48::operator()() const",
               "symbol": "_ZZ20ProcessLocalFunctionP7UObjectP9UFunctionR6FFramePvENK4$_48clEv",
-              "package": "/Users/username/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
-              "data": {
-                "category": "indirection"
-              }
+              "package": "/Users/username/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground"
             },
             {
               "function": "ProcessScriptFunction<T>",

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:31:44.063306+00:00'
+created: '2025-04-23T19:15:05.776111+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "FudgeLogTaggedError"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "closure"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "SentrySetupInteractor.setupSentry"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "closure"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:03.546142+00:00'
+created: '2025-04-23T19:16:09.526442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,16 +30,16 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "FudgeLogTaggedError"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "SentrySetupInteractor.setupSentry"
   system*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:38.326987+00:00'
+created: '2025-04-23T19:06:00.383739+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (logentry takes precedence)
       threads
         stacktrace
-          frame
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "unicorn"
           frame (non app frame)
@@ -37,13 +37,13 @@ app:
           frame
             function (function name is not used if module or filename are available)
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "FudgeLogTaggedError"
-          frame
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "thunk for closure"
-          frame
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "SentrySetupInteractor.setupSentry"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -52,7 +52,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function (function name is not used if module or filename are available)
               "_dispatch_client_callout"
-          frame
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "thunk for closure"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:17.988231+00:00'
+created: '2025-04-23T19:07:03.263727+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
           frame (non app frame)
@@ -37,13 +37,13 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "FudgeLogTaggedError"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "closure"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -52,7 +52,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_client_callout"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "closure"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:57.364760+00:00'
+created: '2025-04-23T19:08:06.988108+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
           frame (marked out of app by stack trace rule (category:system -app))
@@ -37,13 +37,13 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "FudgeLogTaggedError"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "closure"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:16.189781+00:00'
+created: '2025-04-23T19:09:01.325342+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))


### PR DESCRIPTION
Some of our test grouping inputs contain data that would never exist in an incoming event, because it's metadata we add during grouping. This removes it so the inputs are more realistic, and so our logic relying on that metadata isn't confused by the incoming values.