### PR TITLE
feat(issue-taxonomy): Update group serializer to return updated category mapping

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -323,6 +323,11 @@ class GroupSerializerBase(Serializer, ABC):
         is_subscribed, subscription_details = get_subscription_from_attributes(attrs)
         share_id = attrs["share_id"]
         priority_label = PriorityLevel(obj.priority).to_str() if obj.priority else None
+        issue_category = (
+            obj.issue_category_v2.name.lower()
+            if features.has("organizations:issue-taxonomy", obj.project.organization, actor=user)
+            else obj.issue_category.name.lower()
+        )
         group_dict: BaseGroupSerializerResponse = {
             "id": str(obj.id),
             "shareId": share_id,
@@ -353,7 +358,7 @@ class GroupSerializerBase(Serializer, ABC):
             "hasSeen": attrs["has_seen"],
             "annotations": attrs["annotations"],
             "issueType": obj.issue_type.slug,
-            "issueCategory": obj.issue_category.name.lower(),
+            "issueCategory": issue_category,
             "priority": priority_label,
             "priorityLockedAt": obj.priority_locked_at,
         }

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1039,6 +1039,10 @@ class Group(Model):
     def issue_category(self):
         return GroupCategory(self.issue_type.category)
 
+    @property
+    def issue_category_v2(self):
+        return GroupCategory(self.issue_type.category_v2)
+
 
 @receiver(pre_save, sender=Group, dispatch_uid="pre_save_group_default_substatus", weak=False)
 def pre_save_group_default_substatus(instance, sender, *args, **kwargs):

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -6,7 +6,11 @@ from django.utils import timezone
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializerSnuba
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
+from sentry.issues.grouptype import (
+    GroupCategory,
+    PerformanceNPlusOneGroupType,
+    ProfileFileIOGroupType,
+)
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouplink import GroupLink
@@ -18,6 +22,7 @@ from sentry.notifications.types import NotificationSettingsOptionEnum
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.group import PriorityLevel
 from sentry.users.models.user_option import UserOption
@@ -470,6 +475,19 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert not serializer.conditions
         result = serialize(group, self.user, serializer=serializer)
         assert result["id"] == str(group.id)
+
+    def test_issue_category(self):
+        group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
+        result = serialize(group, self.user, serializer=GroupSerializerSnuba())
+
+        assert result["issueCategory"] == GroupCategory.PERFORMANCE.name.lower()
+
+    @with_feature("organizations:issue-taxonomy")
+    def test_issue_category_v2(self):
+        group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
+        result = serialize(group, self.user, serializer=GroupSerializerSnuba())
+
+        assert result["issueCategory"] == GroupCategory.PERFORMANCE_BEST_PRACTICE.name.lower()
 
 
 class PerformanceGroupSerializerSnubaTest(


### PR DESCRIPTION
Calls to fetch group details, when `issue-taxonomy` is enabled, should return the new category mapping for `issueCategory`.