### PR TITLE
fix(warmup) Add HTTP_HOST to warmup request

### DIFF
--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -20,15 +20,20 @@ from django.core.handlers.wsgi import WSGIHandler
 # Run WSGI handler for the application
 application = WSGIHandler()
 
+params = {
+    "PATH_INFO": reverse("sentry-warmup"),
+    "REQUEST_METHOD": "GET",
+    "SERVER_NAME": "127.0.0.1",
+    "SERVER_PORT": "9001",
+    "wsgi.input": io.BytesIO(),
+    "wsgi.url_scheme": "https",
+}
+if settings.ALLOWED_HOSTS:
+    # ALLOWED_HOSTS items can start with a dot to match subdomains
+    params["HTTP_HOST"] = settings.ALLOWED_HOSTS[0].lstrip(".")
+
 # trigger a warmup of the application
 application(
-    {
-        "PATH_INFO": reverse("sentry-warmup"),
-        "REQUEST_METHOD": "GET",
-        "SERVER_NAME": "127.0.0.1",
-        "SERVER_PORT": "9001",
-        "wsgi.input": io.BytesIO(),
-        "wsgi.url_scheme": "https",
-    },
+    params,
     lambda status, response_headers, exc_info=None: lambda bts: None,
 )

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -28,7 +28,7 @@ params = {
     "wsgi.input": io.BytesIO(),
     "wsgi.url_scheme": "https",
 }
-if settings.ALLOWED_HOSTS:
+if settings.ALLOWED_HOSTS and "*" not in settings.ALLOWED_HOSTS[0]:
     # ALLOWED_HOSTS items can start with a dot to match subdomains
     params["HTTP_HOST"] = settings.ALLOWED_HOSTS[0].lstrip(".")
 

--- a/tests/sentry/api/endpoints/test_warmup.py
+++ b/tests/sentry/api/endpoints/test_warmup.py
@@ -1,3 +1,4 @@
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -9,4 +10,22 @@ class WarmupEndpointTest(APITestCase):
         url = reverse("sentry-warmup")
         response = self.client.get(url)
 
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_warmup_endpoint_with_incorrect_basehost(self):
+        url = reverse("sentry-warmup")
+        with (
+            override_settings(ALLOWED_HOSTS=[".sentry.io"]),
+            self.options({"system.base-hostname": "sentry.io"}),
+        ):
+            response = self.client.get(url, HTTP_HOST="example.com")
+        assert response.status_code == status.HTTP_302_FOUND
+
+    def test_warmup_endpoint_with_basehost(self):
+        url = reverse("sentry-warmup")
+        with (
+            override_settings(ALLOWED_HOSTS=[".sentry.io"]),
+            self.options({"system.base-hostname": "sentry.io"}),
+        ):
+            response = self.client.get(url, HTTP_HOST="sentry.io")
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
We're seeing warmup requests getting short circuited by the subdomain middleware. By emulating an allowed host we should be able to reach the warmup logic more reliably.
