### PR TITLE
fix(priority): Fix bug with priority updates

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -278,7 +278,11 @@ def save_issue_from_occurrence(
         group_event.occurrence = occurrence
         is_regression = _process_existing_aggregate(group, group_event, issue_kwargs, release)
         group_info = GroupInfo(group=group, is_new=False, is_regression=is_regression)
-        if issue_kwargs["priority"] and group.priority != issue_kwargs["priority"]:
+        if (
+            issue_kwargs["priority"]
+            and group.priority != issue_kwargs["priority"]
+            and group.priority_locked_at is None
+        ):
             update_priority(
                 group=group,
                 priority=PriorityLevel(issue_kwargs["priority"]),

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -47,9 +47,6 @@ def update_priority(
     if priority is None or group.priority == priority:
         return
 
-    if group.priority_locked_at is not None:
-        return
-
     previous_priority = PriorityLevel(group.priority) if group.priority is not None else None
     group.update(priority=priority)
     Activity.objects.create_group_activity(

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
+from sentry.api.helpers.group_index.update import handle_priority
 from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import (
@@ -485,7 +486,13 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert group.priority == PriorityLevel.HIGH
         assert group.priority_locked_at is None
 
-        group_info.group.update(priority_locked_at=timezone.now(), priority=PriorityLevel.LOW)
+        handle_priority(
+            priority=PriorityLevel.LOW.to_str(),
+            group_list=[group],
+            acting_user=None,
+            project_lookup={self.project.id: self.project},
+        )
+
         occurrence = self.build_occurrence(priority=PriorityLevel.HIGH)
         event = self.store_event(data={}, project_id=self.project.id)
         save_issue_from_occurrence(occurrence, event, None)


### PR DESCRIPTION
Checking the priority lock in the update method is too generic and prevents users from making multiple updates. Moving the check to the caller in `save_issue_from_occurrence` instead.

