### PR TITLE
fix(shared-views): Fix absolute dates not registering unsaved changes

### DIFF
--- a/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
@@ -1,5 +1,6 @@
 import type {Query} from 'history';
 
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {
   decodeBoolean,
@@ -11,6 +12,8 @@ import type {IssueViewParams} from 'sentry/views/issueList/issueViews/issueViews
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 export function createIssueViewFromUrl({query}: {query: Query}): IssueViewParams {
+  const normalizedTimeFilters = normalizeDateTimeParams(query);
+
   return {
     query: typeof query.query === 'string' ? query.query : '',
     querySort:
@@ -20,10 +23,10 @@ export function createIssueViewFromUrl({query}: {query: Query}): IssueViewParams
     projects: decodeList(query[URL_PARAM.PROJECT]).map(decodeInteger),
     environments: decodeList(query[URL_PARAM.ENVIRONMENT]),
     timeFilters: {
-      start: decodeScalar(query[URL_PARAM.START]) ?? null,
-      end: decodeScalar(query[URL_PARAM.END]) ?? null,
-      period: decodeScalar(query[URL_PARAM.PERIOD]) ?? null,
-      utc: decodeBoolean(query[URL_PARAM.UTC]) ?? null,
+      start: decodeScalar(normalizedTimeFilters.start) ?? null,
+      end: decodeScalar(normalizedTimeFilters.end) ?? null,
+      period: decodeScalar(normalizedTimeFilters.period) ?? null,
+      utc: decodeBoolean(normalizedTimeFilters.utc) ?? null,
     },
   };
 }


### PR DESCRIPTION
Fixes an issue where absolute time filters were not correctly dismissing the Save prompt.

This was because we were not normalizing date time params before saving them to the view, but we were normalizing them when we populated the url query with the view.  

You can see the slight difference in precision here: 

![image](https://github.com/user-attachments/assets/c4862421-da3e-40c1-8392-38a093984512)