### PR TITLE
chore(ACI): Rename alert rule serializer to detector serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -5,7 +5,7 @@ from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerialize
 from sentry.workflow_engine.models import Detector
 
 
-class WorkflowEngineAlertRuleSerializer(Serializer):
+class WorkflowEngineDetectorSerializer(Serializer):
     def serialize(self, obj: Detector, attrs, user, **kwargs) -> AlertRuleSerializerResponse:
         # TODO: Implement this
         return {

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
@@ -4,8 +4,8 @@ from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializerResponse,
     IncidentSerializerResponse,
 )
-from sentry.incidents.endpoints.serializers.workflow_engine_alert_rule import (
-    WorkflowEngineAlertRuleSerializer,
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models import Detector
 
 
 def get_alert_rule_serializer(detector: Detector) -> AlertRuleSerializerResponse:
-    return serialize(detector, None, WorkflowEngineAlertRuleSerializer())
+    return serialize(detector, None, WorkflowEngineDetectorSerializer())
 
 
 def get_detailed_incident_serializer(


### PR DESCRIPTION
The other workflow engine serializers are named for the new models they're serializing so let's rename this one (mostly to make the diff in https://github.com/getsentry/sentry/pull/90255/files smaller)