### PR TITLE
nit(aci milestone 3): dual write name fix

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -448,7 +448,7 @@ def get_detector_field_values(
     user: RpcUser | None = None,
 ) -> dict[str, Any]:
     detector_field_values = {
-        "name": alert_rule.name,
+        "name": alert_rule.name if len(alert_rule.name) < 200 else alert_rule.name[:197] + "...",
         "description": alert_rule.description,
         "workflow_condition_group": data_condition_group,
         "owner_user_id": alert_rule.user_id,


### PR DESCRIPTION
Pull this off the migration and into its own PR. We should get this merged before turning dual write on for all orgs, but the chances of someone making an alert rule with name >200 characters is pretty small.