### PR TITLE
fix(aci): skip migrating rule in issue alert migration if environment is invalid

### DIFF
--- a/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
@@ -17,7 +17,7 @@ from jsonschema import ValidationError, validate
 from sentry.new_migrations.migrations import CheckedMigration
 from sentry.utils import redis
 from sentry.utils.iterators import chunked
-from sentry.utils.query import RangeQuerySetWrapperWithProgressBarApprox
+from sentry.utils.query import RangeQuerySetWrapper, RangeQuerySetWrapperWithProgressBarApprox
 
 logger = logging.getLogger(__name__)
 
@@ -2189,7 +2189,7 @@ def migrate_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) ->
                 with transaction.atomic(router.db_for_write(Rule)):
                     rules = Rule.objects.select_for_update().filter(project_id=project_id)
 
-                    for rule in RangeQuerySetWrapperWithProgressBarApprox(rules):
+                    for rule in RangeQuerySetWrapper(rules):
                         try:
                             with transaction.atomic(router.db_for_write(Workflow)):
                                 # make sure rule is not already migrated

--- a/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0047_migrate_issue_alerts.py
@@ -2185,53 +2185,61 @@ def migrate_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) ->
                 project_id=project_id,
                 defaults={"config": {}, "name": "Error Detector"},
             )
+            try:
+                with transaction.atomic(router.db_for_write(Rule)):
+                    rules = Rule.objects.select_for_update().filter(project_id=project_id)
 
-            with transaction.atomic(router.db_for_write(Rule)):
-                rules = Rule.objects.select_for_update().filter(project_id=project_id)
+                    for rule in RangeQuerySetWrapperWithProgressBarApprox(rules):
+                        try:
+                            with transaction.atomic(router.db_for_write(Workflow)):
+                                # make sure rule is not already migrated
+                                _, created = AlertRuleDetector.objects.get_or_create(
+                                    detector_id=error_detector.id, rule_id=rule.id
+                                )
+                                if not created:
+                                    raise Exception("Rule already migrated")
 
-                for rule in RangeQuerySetWrapperWithProgressBarApprox(rules):
-                    try:
-                        with transaction.atomic(router.db_for_write(Workflow)):
-                            # make sure rule is not already migrated
-                            _, created = AlertRuleDetector.objects.get_or_create(
-                                detector_id=error_detector.id, rule_id=rule.id
+                                data = rule.data
+                                user_id = None
+                                created_activity = RuleActivity.objects.filter(
+                                    rule=rule, type=1  # created
+                                ).first()
+                                if created_activity:
+                                    user_id = getattr(created_activity, "user_id")
+
+                                conditions, filters = split_conditions_and_filters(
+                                    data["conditions"]
+                                )
+                                action_match = data.get("action_match") or "all"
+                                workflow = _create_workflow_and_lookup(
+                                    rule=rule,
+                                    user_id=int(user_id) if user_id else None,
+                                    conditions=conditions,
+                                    filters=filters,
+                                    action_match=action_match,
+                                    detector=error_detector,
+                                )
+                                filter_match = data.get("filter_match") or "all"
+                                if_dcg = _create_if_dcg(
+                                    rule=rule,
+                                    filter_match=filter_match,
+                                    workflow=workflow,
+                                    conditions=conditions,
+                                    filters=filters,
+                                )
+                                _create_workflow_actions(if_dcg=if_dcg, actions=data["actions"])
+                        except Exception as e:
+                            logger.exception(
+                                "Error migrating issue alert",
+                                extra={"rule_id": rule.id, "error": str(e)},
                             )
-                            if not created:
-                                raise Exception("Rule already migrated")
-
-                            data = rule.data
-                            user_id = None
-                            created_activity = RuleActivity.objects.filter(
-                                rule=rule, type=1  # created
-                            ).first()
-                            if created_activity:
-                                user_id = getattr(created_activity, "user_id")
-
-                            conditions, filters = split_conditions_and_filters(data["conditions"])
-                            action_match = data.get("action_match") or "all"
-                            workflow = _create_workflow_and_lookup(
-                                rule=rule,
-                                user_id=int(user_id) if user_id else None,
-                                conditions=conditions,
-                                filters=filters,
-                                action_match=action_match,
-                                detector=error_detector,
-                            )
-                            filter_match = data.get("filter_match") or "all"
-                            if_dcg = _create_if_dcg(
-                                rule=rule,
-                                filter_match=filter_match,
-                                workflow=workflow,
-                                conditions=conditions,
-                                filters=filters,
-                            )
-                            _create_workflow_actions(if_dcg=if_dcg, actions=data["actions"])
-                    except Exception as e:
-                        logger.exception(
-                            "Error migrating issue alert",
-                            extra={"rule_id": rule.id, "error": str(e)},
-                        )
-                        sentry_sdk.capture_exception(e)
+                            sentry_sdk.capture_exception(e)
+            except Exception as e:
+                logger.exception(
+                    "Error migrating issue alert",
+                    extra={"rule_id": rule.id, "error": str(e)},
+                )
+                sentry_sdk.capture_exception(e)
 
     for projects in chunked(
         RangeQuerySetWrapperWithProgressBarApprox(


### PR DESCRIPTION
An `IntegrityError` from an uncaught invalid environment id when migrating is stopping the migration. We should catch this case and prevent the rule from being migrated, but it shouldn't block migrating other rules in the project.