### PR TITLE
✨  feat(aci): refactor issue digests for ACI

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -166,7 +166,7 @@ def _build_digest_impl(
 
 
 def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[int, Rule]:
-    rules = {}
+    rules: dict[int, Rule] = {}
     if not workflow_ids:
         return rules
 

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -189,7 +189,7 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
 
     groups = Group.objects.in_bulk(record.value.event.group_id for record in records)
     group_ids = list(groups)
-    rules = Rule.objects.in_bulk(rule_id for record in records for rule_id in record.value.rules)
+    rules = Rule.objects.in_bulk(rule_ids)
 
     if features.has("organizations:workflow-engine-trigger-actions", project.organization):
         for rule in rules.values():
@@ -230,7 +230,6 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
         end,
         tenant_ids=tenant_ids,
     )
-
     digest = _build_digest_impl(records, groups, rules, event_counts, user_counts)
 
     return DigestInfo(digest, event_counts, user_counts)

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -72,14 +72,13 @@ def event_to_record(
 
     rule_ids = []
     identifier_key = IdentifierKey.RULE
-    # TODO(iamrajjoshi): This will only work during the dual write period of the rollout!
-    if features.has("organizations:workflow-engine-trigger-actions", event.organization):
-        for rule in rules:
-            rule_ids.append(int(get_key_from_rule_data(rule, "legacy_rule_id")))
-    elif features.has("organizations:workflow-engine-ui-links", event.organization):
+    if features.has("organizations:workflow-engine-ui-links", event.organization):
         identifier_key = IdentifierKey.WORKFLOW
         for rule in rules:
             rule_ids.append(int(get_key_from_rule_data(rule, "workflow_id")))
+    elif features.has("organizations:workflow-engine-trigger-actions", event.organization):
+        for rule in rules:
+            rule_ids.append(int(get_key_from_rule_data(rule, "legacy_rule_id")))
     else:
         for rule in rules:
             rule_ids.append(rule.id)

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -171,9 +171,9 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
         return rules
 
     # Fetch all workflows in bulk
-    workflows = Workflow.objects.filter(
-        id__in=workflow_ids, organization_id=project.organization_id
-    ).in_bulk(workflow_ids)
+    workflows = Workflow.objects.filter(organization_id=project.organization_id).in_bulk(
+        workflow_ids
+    )
 
     # We are only processing the workflows in the digest if under the new flag
     # This should be ok since we should only add workflow_ids to redis when under this flag
@@ -192,9 +192,7 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
     # This is if we had workflows in the digest but the flag is not enabled
     # This can happen if we rollback the flag, but the records in the digest aren't flushed
     else:
-        alert_rule_workflows = AlertRuleWorkflow.objects.filter(
-            workflow_id__in=workflow_ids
-        ).select_related("workflow")
+        alert_rule_workflows = AlertRuleWorkflow.objects.filter(workflow_id__in=workflow_ids)
         alert_rule_workflows_map = {awf.workflow_id: awf for awf in alert_rule_workflows}
 
         rule_ids_to_fetch = {awf.rule_id for awf in alert_rule_workflows}

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -176,13 +176,13 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
     start = records[-1].datetime
     end = records[0].datetime
 
-    rule_ids = set()
-    workflow_ids = set()
+    rule_ids: set[int] = set()
+    workflow_ids: set[int] = set()
 
     for record in records:
         identifier_key = getattr(record.value, "identifier_key", IdentifierKey.RULE)
         # record.value is Notification, record.value.rules is Sequence[int]
-        ids_to_add = getattr(record.value, "rules", [])
+        ids_to_add = record.value.rules
         if identifier_key == IdentifierKey.RULE:
             rule_ids.update(ids_to_add)
         elif identifier_key == IdentifierKey.WORKFLOW:
@@ -207,7 +207,6 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
                 label=workflow.name,
                 id=workflow_id,
                 project_id=project.id,
-                organization_id=project.organization_id,
                 # We need to do this so that the links are built correctly downstream
                 data={"actions": [{"workflow_id": workflow_id}]},
             )

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -197,9 +197,7 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
 
         rule_ids_to_fetch = {awf.rule_id for awf in alert_rule_workflows}
 
-        bulk_rules = Rule.objects.filter(id__in=rule_ids_to_fetch, project_id=project.id).in_bulk(
-            rule_ids_to_fetch
-        )
+        bulk_rules = Rule.objects.filter(project_id=project.id).in_bulk(rule_ids_to_fetch)
 
         for workflow_id in workflow_ids:
             alert_workflow = alert_rule_workflows_map.get(workflow_id)

--- a/src/sentry/digests/types.py
+++ b/src/sentry/digests/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as datetime_mod
 from collections.abc import Sequence
+from enum import StrEnum
 from typing import TYPE_CHECKING, NamedTuple
 
 from sentry.utils.dates import to_datetime
@@ -11,16 +12,23 @@ if TYPE_CHECKING:
     from sentry.models.rule import Rule
 
 
+class IdentifierKey(StrEnum):
+    RULE = "rule"
+    WORKFLOW = "workflow"
+
+
 class Notification(NamedTuple):
     event: Event
     rules: Sequence[int] = ()
     notification_uuid: str | None = None
+    identifier_key: IdentifierKey = IdentifierKey.RULE
 
     def with_rules(self, rules: list[Rule]) -> NotificationWithRuleObjects:
         return NotificationWithRuleObjects(
             event=self.event,
             rules=rules,
             notification_uuid=self.notification_uuid,
+            # We don't really worry about identifier_key here since this method is not used after we pop record from redis
         )
 
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -117,14 +117,17 @@ class DigestNotification(ProjectNotification):
 
         sentry_query_params = self.get_sentry_query_params(ExternalProviders.EMAIL)
 
-        snooze_alert = len(rule_details) > 0
-        snooze_alert_urls = {
-            rule.id: f"{rule.status_url}{sentry_query_params}&{urlencode({'mute': '1'})}"
-            for rule in rule_details
-        }
+        if not features.has("organizations:workflow-engine-ui-links", self.project.organization):
+            # TODO(iamrajjoshi): This actually mutes a rule for a user, something we have not ported over in the new system
+            # By not including this context, the template will not show the mute button
+            snooze_alert = len(rule_details) > 0
+            snooze_alert_urls = {
+                rule.id: f"{rule.status_url}{sentry_query_params}&{urlencode({'mute': '1'})}"
+                for rule in rule_details
+            }
 
-        context["snooze_alert"] = snooze_alert
-        context["snooze_alert_urls"] = snooze_alert_urls
+            context["snooze_alert"] = snooze_alert
+            context["snooze_alert_urls"] = snooze_alert_urls
 
         return context
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -128,6 +128,9 @@ class DigestNotification(ProjectNotification):
 
             context["snooze_alert"] = snooze_alert
             context["snooze_alert_urls"] = snooze_alert_urls
+        else:
+            context["snooze_alert"] = False
+            context["snooze_alert_urls"] = None
 
         return context
 

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -12,6 +12,7 @@ from django.db.models import Count
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
+from sentry import features
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.base import IntegrationFeatures, IntegrationProvider
 from sentry.integrations.manager import default_manager as integrations
@@ -34,6 +35,8 @@ from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
+from sentry.notifications.notifications.rules import get_key_from_rule_data
+from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.silo.base import region_silo_function
 from sentry.types.rules import NotificationRuleDetails
 from sentry.users.services.user import RpcUser
@@ -117,9 +120,133 @@ def get_environment_for_deploy(deploy: Deploy | None) -> str:
     return "Default Environment"
 
 
+def get_email_link_extra_params(
+    referrer: str = "alert_email",
+    environment: str | None = None,
+    rule_details: Sequence[NotificationRuleDetails] | None = None,
+    alert_timestamp: int | None = None,
+    notification_uuid: str | None = None,
+    **kwargs: Any,
+) -> dict[int, str]:
+    alert_timestamp_str = (
+        str(round(time.time() * 1000)) if not alert_timestamp else str(alert_timestamp)
+    )
+    return {
+        rule_detail.id: "?"
+        + str(
+            urlencode(
+                {
+                    "referrer": referrer,
+                    "alert_type": str(AlertRuleTriggerAction.Type.EMAIL.name).lower(),
+                    "alert_timestamp": alert_timestamp_str,
+                    # TODO(iamrajjoshi): This will be workflow_id in the new UI, might need to update analytics
+                    "alert_rule_id": rule_detail.id,
+                    **dict(
+                        []
+                        if notification_uuid is None
+                        else [("notification_uuid", str(notification_uuid))]
+                    ),
+                    **dict([] if environment is None else [("environment", environment)]),
+                    **kwargs,
+                }
+            )
+        )
+        for rule_detail in (rule_details or [])
+    }
+
+
+def get_group_settings_link(
+    group: Group,
+    environment: str | None,
+    rule_details: Sequence[NotificationRuleDetails] | None = None,
+    alert_timestamp: int | None = None,
+    referrer: str = "alert_email",
+    notification_uuid: str | None = None,
+    **kwargs: Any,
+) -> str:
+    alert_rule_id = rule_details[0].id if rule_details and rule_details[0].id else None
+    extra_params = ""
+    if alert_rule_id:
+        extra_params = get_email_link_extra_params(
+            referrer,
+            environment,
+            rule_details,
+            alert_timestamp,
+            notification_uuid=notification_uuid,
+            **kwargs,
+        )[alert_rule_id]
+    elif not alert_rule_id and notification_uuid:
+        extra_params = "?" + str(urlencode({"notification_uuid": notification_uuid}))
+    return str(group.get_absolute_url() + extra_params)
+
+
+def get_integration_link(
+    organization: Organization, integration_slug: str, notification_uuid: str | None = None
+) -> str:
+    query_params = {"referrer": "alert_email"}
+    if notification_uuid:
+        query_params.update({"notification_uuid": notification_uuid})
+
+    return organization.absolute_url(
+        f"/settings/{organization.slug}/integrations/{integration_slug}/",
+        query=urlencode(query_params),
+    )
+
+
+def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
+    return str(group.get_absolute_url() + "replays/" + sentry_query_params)
+
+
+@dataclass
+class NotificationRuleDetails:
+    id: int
+    label: str
+    url: str
+    status_url: str
+
+
+def get_rules_with_legacy_ids(
+    rules: Sequence[Rule], organization: Organization, project: Project
+) -> Sequence[NotificationRuleDetails]:
+    rules_with_legacy_ids = []
+    for rule in rules:
+        rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
+        rules_with_legacy_ids.append(
+            NotificationRuleDetails(
+                rule_id,
+                rule.label,
+                f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/",
+                f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/details/",
+            )
+        )
+    return rules_with_legacy_ids
+
+
+def get_workflow_links(
+    rules: Sequence[Rule], organization: Organization, project: Project
+) -> Sequence[NotificationRuleDetails]:
+    workflow_links = []
+    for rule in rules:
+        workflow_id = get_key_from_rule_data(rule, "workflow_id")
+        workflow_links.append(
+            NotificationRuleDetails(
+                workflow_id,
+                rule.label,
+                create_link_to_workflow(organization.id, workflow_id),
+                # TODO(iamrajjoshi): Add status url (whatever it is)
+                create_link_to_workflow(organization.id, workflow_id),
+            )
+        )
+    return workflow_links
+
+
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project
 ) -> Sequence[NotificationRuleDetails]:
+    if features.has("organizations:workflow-engine-trigger-actions", organization):
+        return get_rules_with_legacy_ids(rules, organization, project)
+    elif features.has("organizations:workflow-engine-ui-links", organization):
+        return get_workflow_links(rules, organization, project)
     return [
         NotificationRuleDetails(
             rule.id,

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -94,7 +94,7 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
         assert record.value.rules == [123]
 
 
-def assert_rule_ids(digest: Digest, expected_rule_ids: list[str]):
+def assert_rule_ids(digest: Digest, expected_rule_ids: list[int]):
     for rule, groups in digest.items():
         assert rule.id in expected_rule_ids
 
@@ -271,6 +271,7 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         }
 
         assert_get_personalized_digests(self.project, digest, expected_result)
+        assert_rule_ids(digest, [self.shadow_rule.id])
 
     def test_direct_email(self):
         """When the action type is not Issue Owners, then the target actor gets a digest."""
@@ -387,6 +388,7 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         assert not {
             actor for actors in participants_by_provider_by_event.values() for actor in actors
         }  # no users in this team no digests should be processed
+        assert_rule_ids(digest, [self.shadow_rule.id])
 
     def test_only_everyone(self):
         events = self.create_events_from_filenames(


### PR DESCRIPTION
this is a refactor so issue digests works with workflow engine.

this is a temporary solution that should get us over the line for ACI, but we need to spec out some work here to completely remove the dependence on rules for digests.

In this refactor, we do the following:
1. When adding records to redis, we add an identifier key (Rule or Workflow) so we know what type of id we are throwing into the buffer.
2. When fetching records to build a digest form, we check the key and if its a workflow, we fake a rule (similar to what we do inside the NOA)
3. Rest of the logic doesn't change much since i already have handled a chunk of the logic in my earlier refactors

The thing to note here is that when we show the new UI, we will not be including the ability to snooze the workflow via the notification. this is because in the old system, the snooze would would are the user level, which we don't support in the new UI. 

we should probably think through this more because a user muting a workflow in its entirety might have a broader implication. for now, lets just remove the this ability. (by removing it from the context, it won't render in the template)