### PR TITLE
chore(issues): Remove fallback

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -9,7 +9,6 @@ from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.utils import metrics
 
 from ..base import (
     DetectorType,
@@ -49,14 +48,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if not data:
             return
 
-        # TODO(nar): `Encoded Body Size` can be removed once SDK adoption has increased and
-        # we are receiving `http.response_content_length` consistently, likely beyond October 2023
         encoded_body_size = data.get("http.response_content_length", None)
-        if not encoded_body_size:
-            encoded_body_size = data.get("Encoded Body Size")
-            if encoded_body_size:
-                metrics.incr("performance.performance_issue.encoded_body_size_fallback")
-
         if not encoded_body_size:
             return
 


### PR DESCRIPTION
Zero hits on this metric in the past few hours.

Note: there are two others I missed earlier which can be removed in future PRs but I'd like to check them with metrics as well first just to be safe:
- `src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py`
- `src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py`