### PR TITLE
:wrench: chore(notifs): move notif utils out of __init__.py to prevent circular deps

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -20,17 +20,16 @@ from sentry.integrations.types import ExternalProviders
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.notify import notify
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType, UnsubscribeContext
-from sentry.notifications.utils import (
-    NotificationRuleDetails,
-    get_email_link_extra_params,
-    get_integration_link,
-    get_rules,
-    has_alert_integration,
-)
+from sentry.notifications.utils import get_rules, has_alert_integration
 from sentry.notifications.utils.digest import (
     get_digest_subject,
     send_as_alert_notification,
     should_send_as_alert_notification,
+)
+from sentry.notifications.utils.links import (
+    NotificationRuleDetails,
+    get_email_link_extra_params,
+    get_integration_link,
 )
 from sentry.types.actor import Actor
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -27,8 +27,8 @@ from sentry.notifications.utils.digest import (
     should_send_as_alert_notification,
 )
 from sentry.notifications.utils.links import get_email_link_extra_params, get_integration_link
-from sentry.notifications.utils.types import NotificationRuleDetails
 from sentry.types.actor import Actor
+from sentry.types.rules import NotificationRuleDetails
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -26,11 +26,8 @@ from sentry.notifications.utils.digest import (
     send_as_alert_notification,
     should_send_as_alert_notification,
 )
-from sentry.notifications.utils.links import (
-    NotificationRuleDetails,
-    get_email_link_extra_params,
-    get_integration_link,
-)
+from sentry.notifications.utils.links import get_email_link_extra_params, get_integration_link
+from sentry.notifications.utils.types import NotificationRuleDetails
 from sentry.types.actor import Actor
 
 if TYPE_CHECKING:

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -29,16 +29,18 @@ from sentry.notifications.types import (
 from sentry.notifications.utils import (
     get_commits,
     get_generic_data,
-    get_group_settings_link,
-    get_integration_link,
     get_interface_list,
-    get_issue_replay_link,
     get_performance_issue_alert_subtitle,
     get_replay_id,
     get_rules,
     get_transaction_data,
     has_alert_integration,
     has_integrations,
+)
+from sentry.notifications.utils.links import (
+    get_group_settings_link,
+    get_integration_link,
+    get_issue_replay_link,
 )
 from sentry.notifications.utils.participants import get_owner_reason, get_send_to
 from sentry.plugins.base.structs import Notification

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
@@ -10,12 +9,10 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
 from urllib.parse import parse_qs, urlparse
 
 from django.db.models import Count
-from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.base import IntegrationFeatures, IntegrationProvider
 from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.services.integration import integration_service
@@ -42,6 +39,8 @@ from sentry.utils.committers import get_serialized_event_file_committers
 from sentry.utils.performance_issues.base import get_url_from_span
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 from sentry.web.helpers import render_to_string
+
+from .types import NotificationRuleDetails
 
 if TYPE_CHECKING:
     from sentry.notifications.notifications.activity.base import ActivityNotification
@@ -116,90 +115,6 @@ def get_environment_for_deploy(deploy: Deploy | None) -> str:
         if environment and environment.name:
             return str(environment.name)
     return "Default Environment"
-
-
-def get_email_link_extra_params(
-    referrer: str = "alert_email",
-    environment: str | None = None,
-    rule_details: Sequence[NotificationRuleDetails] | None = None,
-    alert_timestamp: int | None = None,
-    notification_uuid: str | None = None,
-    **kwargs: Any,
-) -> dict[int, str]:
-    alert_timestamp_str = (
-        str(round(time.time() * 1000)) if not alert_timestamp else str(alert_timestamp)
-    )
-    return {
-        rule_detail.id: "?"
-        + str(
-            urlencode(
-                {
-                    "referrer": referrer,
-                    "alert_type": str(AlertRuleTriggerAction.Type.EMAIL.name).lower(),
-                    "alert_timestamp": alert_timestamp_str,
-                    "alert_rule_id": rule_detail.id,
-                    **dict(
-                        []
-                        if notification_uuid is None
-                        else [("notification_uuid", str(notification_uuid))]
-                    ),
-                    **dict([] if environment is None else [("environment", environment)]),
-                    **kwargs,
-                }
-            )
-        )
-        for rule_detail in (rule_details or [])
-    }
-
-
-def get_group_settings_link(
-    group: Group,
-    environment: str | None,
-    rule_details: Sequence[NotificationRuleDetails] | None = None,
-    alert_timestamp: int | None = None,
-    referrer: str = "alert_email",
-    notification_uuid: str | None = None,
-    **kwargs: Any,
-) -> str:
-    alert_rule_id = rule_details[0].id if rule_details and rule_details[0].id else None
-    extra_params = ""
-    if alert_rule_id:
-        extra_params = get_email_link_extra_params(
-            referrer,
-            environment,
-            rule_details,
-            alert_timestamp,
-            notification_uuid=notification_uuid,
-            **kwargs,
-        )[alert_rule_id]
-    elif not alert_rule_id and notification_uuid:
-        extra_params = "?" + str(urlencode({"notification_uuid": notification_uuid}))
-    return str(group.get_absolute_url() + extra_params)
-
-
-def get_integration_link(
-    organization: Organization, integration_slug: str, notification_uuid: str | None = None
-) -> str:
-    query_params = {"referrer": "alert_email"}
-    if notification_uuid:
-        query_params.update({"notification_uuid": notification_uuid})
-
-    return organization.absolute_url(
-        f"/settings/{organization.slug}/integrations/{integration_slug}/",
-        query=urlencode(query_params),
-    )
-
-
-def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
-    return str(group.get_absolute_url() + "replays/" + sentry_query_params)
-
-
-@dataclass
-class NotificationRuleDetails:
-    id: int
-    label: str
-    url: str
-    status_url: str
 
 
 def get_rules(
@@ -336,7 +251,7 @@ def occurrence_perf_to_email_html(context: Any) -> str:
 
 
 def get_spans(
-    entries: list[dict[str, list[dict[str, str | float]] | str]]
+    entries: list[dict[str, list[dict[str, str | float]] | str]],
 ) -> list[dict[str, str | float]] | None:
     """Get the given event's spans"""
     if not len(entries):

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -34,13 +34,12 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.silo.base import region_silo_function
+from sentry.types.rules import NotificationRuleDetails
 from sentry.users.services.user import RpcUser
 from sentry.utils.committers import get_serialized_event_file_committers
 from sentry.utils.performance_issues.base import get_url_from_span
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 from sentry.web.helpers import render_to_string
-
-from .types import NotificationRuleDetails
 
 if TYPE_CHECKING:
     from sentry.notifications.notifications.activity.base import ActivityNotification

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -4,9 +4,97 @@ This file contains simple functions to generate links to Sentry pages
 We can use this as a basepoint to build out our templating system in the future
 """
 
+import time
+from collections.abc import Sequence
+from typing import Any
+
+from django.utils.http import urlencode
+
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+
+from .types import NotificationRuleDetails
+
 
 def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """
     return f"/organizations/{organization_id}/issues/automations/{workflow_id}/"
+
+
+def get_email_link_extra_params(
+    referrer: str = "alert_email",
+    environment: str | None = None,
+    rule_details: Sequence[NotificationRuleDetails] | None = None,
+    alert_timestamp: int | None = None,
+    notification_uuid: str | None = None,
+    **kwargs: Any,
+) -> dict[int, str]:
+    alert_timestamp_str = (
+        str(round(time.time() * 1000)) if not alert_timestamp else str(alert_timestamp)
+    )
+    return {
+        rule_detail.id: "?"
+        + str(
+            urlencode(
+                {
+                    "referrer": referrer,
+                    "alert_type": str(AlertRuleTriggerAction.Type.EMAIL.name).lower(),
+                    "alert_timestamp": alert_timestamp_str,
+                    "alert_rule_id": rule_detail.id,
+                    **dict(
+                        []
+                        if notification_uuid is None
+                        else [("notification_uuid", str(notification_uuid))]
+                    ),
+                    **dict([] if environment is None else [("environment", environment)]),
+                    **kwargs,
+                }
+            )
+        )
+        for rule_detail in (rule_details or [])
+    }
+
+
+def get_group_settings_link(
+    group: Group,
+    environment: str | None,
+    rule_details: Sequence[NotificationRuleDetails] | None = None,
+    alert_timestamp: int | None = None,
+    referrer: str = "alert_email",
+    notification_uuid: str | None = None,
+    **kwargs: Any,
+) -> str:
+    alert_rule_id = rule_details[0].id if rule_details and rule_details[0].id else None
+    extra_params = ""
+    if alert_rule_id:
+        extra_params = get_email_link_extra_params(
+            referrer,
+            environment,
+            rule_details,
+            alert_timestamp,
+            notification_uuid=notification_uuid,
+            **kwargs,
+        )[alert_rule_id]
+    elif not alert_rule_id and notification_uuid:
+        extra_params = "?" + str(urlencode({"notification_uuid": notification_uuid}))
+    return str(group.get_absolute_url() + extra_params)
+
+
+def get_integration_link(
+    organization: Organization, integration_slug: str, notification_uuid: str | None = None
+) -> str:
+    query_params = {"referrer": "alert_email"}
+    if notification_uuid:
+        query_params.update({"notification_uuid": notification_uuid})
+
+    return organization.absolute_url(
+        f"/settings/{organization.slug}/integrations/{integration_slug}/",
+        query=urlencode(query_params),
+    )
+
+
+def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
+    return str(group.get_absolute_url() + "replays/" + sentry_query_params)

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -13,8 +13,7 @@ from django.utils.http import urlencode
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.models.group import Group
 from sentry.models.organization import Organization
-
-from .types import NotificationRuleDetails
+from sentry.types.rules import NotificationRuleDetails
 
 
 def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:

--- a/src/sentry/notifications/utils/types.py
+++ b/src/sentry/notifications/utils/types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class NotificationRuleDetails:
+    id: int
+    label: str
+    url: str
+    status_url: str

--- a/src/sentry/notifications/utils/types.py
+++ b/src/sentry/notifications/utils/types.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class NotificationRuleDetails:
-    id: int
-    label: str
-    url: str
-    status_url: str

--- a/src/sentry/types/rules.py
+++ b/src/sentry/types/rules.py
@@ -1,3 +1,12 @@
 from collections import namedtuple
+from dataclasses import dataclass
 
 RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
+
+
+@dataclass
+class NotificationRuleDetails:
+    id: int
+    label: str
+    url: str
+    status_url: str

--- a/src/sentry/web/frontend/debug/debug_feedback_issue.py
+++ b/src/sentry/web/frontend/debug/debug_feedback_issue.py
@@ -5,7 +5,8 @@ from django.views.generic import View
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils import get_generic_data, get_group_settings_link, get_rules
+from sentry.notifications.utils import get_generic_data, get_rules
+from sentry.notifications.utils.links import get_group_settings_link
 from sentry.utils import json
 
 from .mail import COMMIT_EXAMPLE, MailPreview, make_feedback_issue

--- a/src/sentry/web/frontend/debug/debug_generic_issue.py
+++ b/src/sentry/web/frontend/debug/debug_generic_issue.py
@@ -6,7 +6,8 @@ from django.views.generic import View
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils import get_generic_data, get_group_settings_link, get_rules
+from sentry.notifications.utils import get_generic_data, get_rules
+from sentry.notifications.utils.links import get_group_settings_link
 from sentry.utils import json
 
 from .mail import COMMIT_EXAMPLE, MailPreview, make_generic_event

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -46,12 +46,8 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.digest import DigestNotification
 from sentry.notifications.notifications.rules import get_group_substatus_text
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.notifications.utils import (
-    get_group_settings_link,
-    get_interface_list,
-    get_issue_replay_link,
-    get_rules,
-)
+from sentry.notifications.utils import get_interface_list, get_rules
+from sentry.notifications.utils.links import get_group_settings_link, get_issue_replay_link
 from sentry.testutils.helpers.datetime import before_now  # NOQA:S007
 from sentry.testutils.helpers.notifications import (  # NOQA:S007
     SAMPLE_TO_OCCURRENCE_MAP,

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -12,11 +12,8 @@ from sentry.notifications.helpers import (
 )
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.types import NotificationSettingEnum, NotificationSettingsOptionEnum
-from sentry.notifications.utils import (
-    get_email_link_extra_params,
-    get_group_settings_link,
-    get_rules,
-)
+from sentry.notifications.utils import get_rules
+from sentry.notifications.utils.links import get_email_link_extra_params, get_group_settings_link
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of


### PR DESCRIPTION
i need to do this for https://github.com/getsentry/sentry/pull/90268 since import everything from `__init__.py` causes a bunch of circular imports