### PR TITLE
ref: upgrade reportlab to 4.4.0 round 2

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -169,7 +169,7 @@ redis==3.4.1
 redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
-reportlab==4.2.5
+reportlab==4.4.0
 requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -114,7 +114,7 @@ redis==3.4.1
 redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
-reportlab==4.2.5
+reportlab==4.4.0
 requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -10,5 +10,5 @@ Avalara==20.9.0
 iso3166
 pycountry==17.5.14
 pyvat==1.3.15
-reportlab==4.2.5
+reportlab==4.4.0
 stripe==4.2.0


### PR DESCRIPTION
Revert "Revert "ref: upgrade reportlab to 4.4.0 (#90049)""

This reverts commit ec521cd8a46a34ec2be6142dfb192ace38706986.

We reverted this commit as part of an incident, as it was in a suspect release, but these changes were not the problem.
