### PR TITLE
🔧 chore(aci): add new notification utils and clean up circular imports

### DIFF
--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -23,7 +23,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.notifications.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data
 
 from ..message_builder.base.component import DiscordComponentCustomIds as CustomIds
 

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -15,8 +15,9 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.notifications.notifications.base import BaseNotification
-from sentry.notifications.notifications.rules import AlertRuleNotification, get_key_from_rule_data
+from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.users.services.user import RpcUser
 from sentry.utils.http import absolute_uri
 

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -10,9 +10,8 @@ from sentry.integrations.on_call.metrics import OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event, record_lifecycle_termination_level
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
-from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.links import create_link_to_workflow
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.notifications.utils.rules import get_key_from_rule_data
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -12,6 +12,7 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.shared_integrations.exceptions import ApiError
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -53,12 +53,12 @@ from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
     get_suspect_commit_users,
 )
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
 from sentry.types.group import SUBSTATUS_TO_STR

--- a/src/sentry/integrations/slack/message_builder/util.py
+++ b/src/sentry/integrations/slack/message_builder/util.py
@@ -6,8 +6,8 @@ from sentry.integrations.slack.message_builder.types import SLACK_URL_FORMAT
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.notifications.rules import get_key_from_rule_data
 from sentry.notifications.utils.links import create_link_to_workflow
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.utils.http import absolute_uri
 
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -20,13 +20,17 @@ from sentry.integrations.types import ExternalProviders
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.notify import notify
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType, UnsubscribeContext
-from sentry.notifications.utils import get_rules, has_alert_integration
+from sentry.notifications.utils import has_alert_integration
 from sentry.notifications.utils.digest import (
     get_digest_subject,
     send_as_alert_notification,
     should_send_as_alert_notification,
 )
-from sentry.notifications.utils.links import get_email_link_extra_params, get_integration_link
+from sentry.notifications.utils.links import (
+    get_email_link_extra_params,
+    get_integration_link,
+    get_rules,
+)
 from sentry.types.actor import Actor
 from sentry.types.rules import NotificationRuleDetails
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -5,7 +5,6 @@ import zoneinfo
 from collections.abc import Iterable, Mapping, MutableMapping
 from datetime import UTC, tzinfo
 from typing import Any
-from urllib.parse import urlencode
 
 from sentry import analytics, features
 from sentry.db.models import Model
@@ -19,7 +18,6 @@ from sentry.issues.grouptype import (
     ProfileFunctionRegressionType,
 )
 from sentry.models.group import Group
-from sentry.models.rule import Rule
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import (
     ActionTargetType,
@@ -32,7 +30,6 @@ from sentry.notifications.utils import (
     get_interface_list,
     get_performance_issue_alert_subtitle,
     get_replay_id,
-    get_rules,
     get_transaction_data,
     has_alert_integration,
     has_integrations,
@@ -41,6 +38,8 @@ from sentry.notifications.utils.links import (
     get_group_settings_link,
     get_integration_link,
     get_issue_replay_link,
+    get_rules,
+    get_snooze_url,
 )
 from sentry.notifications.utils.participants import get_owner_reason, get_send_to
 from sentry.plugins.base.structs import Notification
@@ -65,12 +64,6 @@ def get_group_substatus_text(group: Group) -> str:
 
 
 GENERIC_TEMPLATE_NAME = "generic"
-
-
-def get_key_from_rule_data(rule: Rule, key: str) -> str:
-    value = rule.data.get("actions", [{}])[0].get(key)
-    assert value is not None
-    return value
 
 
 class AlertRuleNotification(ProjectNotification):
@@ -257,8 +250,8 @@ class AlertRuleNotification(ProjectNotification):
 
         if len(self.rules) > 0:
             context["snooze_alert"] = True
-            context["snooze_alert_url"] = (
-                f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/{sentry_query_params}&{urlencode({'mute': '1'})}"
+            context["snooze_alert_url"] = get_snooze_url(
+                self.rules[0], self.organization, self.project, sentry_query_params
             )
 
         if isinstance(self.event, GroupEvent) and self.event.occurrence:

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -1,5 +1,6 @@
 import time
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from django.utils.http import urlencode
 

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -1,19 +1,22 @@
+import time
+from typing import Any, Sequence
+
+from django.utils.http import urlencode
+
+from sentry import features
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.rule import Rule
+from sentry.notifications.utils.rules import get_key_from_rule_data
+from sentry.types.rules import NotificationRuleDetails
+
 """
 This file contains simple functions to generate links to Sentry pages
 
 We can use this as a basepoint to build out our templating system in the future
 """
-
-import time
-from collections.abc import Sequence
-from typing import Any
-
-from django.utils.http import urlencode
-
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.models.group import Group
-from sentry.models.organization import Organization
-from sentry.types.rules import NotificationRuleDetails
 
 
 def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
@@ -97,3 +100,49 @@ def get_integration_link(
 
 def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
     return str(group.get_absolute_url() + "replays/" + sentry_query_params)
+
+
+def get_rules(
+    rules: Sequence[Rule], organization: Organization, project: Project
+) -> Sequence[NotificationRuleDetails]:
+    if features.has("organizations:workflow-engine-trigger-actions", organization):
+        return get_rules_with_legacy_ids(rules, organization, project)
+    return [
+        NotificationRuleDetails(
+            rule.id,
+            rule.label,
+            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/",
+            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/details/",
+        )
+        for rule in rules
+    ]
+
+
+def get_rules_with_legacy_ids(
+    rules: Sequence[Rule], organization: Organization, project: Project
+) -> Sequence[NotificationRuleDetails]:
+    rules_with_legacy_ids = []
+    for rule in rules:
+        rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
+        rules_with_legacy_ids.append(
+            NotificationRuleDetails(
+                rule_id,
+                rule.label,
+                f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/",
+                f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/details/",
+            )
+        )
+    return rules_with_legacy_ids
+
+
+def get_snooze_url(
+    rule: Rule,
+    organization: Organization,
+    project: Project,
+    sentry_query_params: str,
+) -> str:
+    if features.has("organizations:workflow-engine-trigger-actions", organization):
+        rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
+    else:
+        rule_id = rule.id
+    return f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule_id}/details/{sentry_query_params}&{urlencode({'mute': '1'})}"

--- a/src/sentry/notifications/utils/rules.py
+++ b/src/sentry/notifications/utils/rules.py
@@ -1,0 +1,7 @@
+from sentry.models.rule import Rule
+
+
+def get_key_from_rule_data(rule: Rule, key: str) -> str:
+    value = rule.data.get("actions", [{}])[0].get(key)
+    assert value is not None
+    return value

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -20,7 +20,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
-from sentry.notifications.notifications.rules import get_key_from_rule_data
+from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,

--- a/src/sentry/types/rules.py
+++ b/src/sentry/types/rules.py
@@ -6,6 +6,10 @@ RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 @dataclass
 class NotificationRuleDetails:
+    """
+    Dataclass to pass around rule details.
+    """
+
     id: int
     label: str
     url: str

--- a/src/sentry/web/frontend/debug/debug_feedback_issue.py
+++ b/src/sentry/web/frontend/debug/debug_feedback_issue.py
@@ -5,8 +5,8 @@ from django.views.generic import View
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils import get_generic_data, get_rules
-from sentry.notifications.utils.links import get_group_settings_link
+from sentry.notifications.utils import get_generic_data
+from sentry.notifications.utils.links import get_group_settings_link, get_rules
 from sentry.utils import json
 
 from .mail import COMMIT_EXAMPLE, MailPreview, make_feedback_issue

--- a/src/sentry/web/frontend/debug/debug_generic_issue.py
+++ b/src/sentry/web/frontend/debug/debug_generic_issue.py
@@ -6,8 +6,8 @@ from django.views.generic import View
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.utils import get_generic_data, get_rules
-from sentry.notifications.utils.links import get_group_settings_link
+from sentry.notifications.utils import get_generic_data
+from sentry.notifications.utils.links import get_group_settings_link, get_rules
 from sentry.utils import json
 
 from .mail import COMMIT_EXAMPLE, MailPreview, make_generic_event

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -46,8 +46,12 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.digest import DigestNotification
 from sentry.notifications.notifications.rules import get_group_substatus_text
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.notifications.utils import get_interface_list, get_rules
-from sentry.notifications.utils.links import get_group_settings_link, get_issue_replay_link
+from sentry.notifications.utils import get_interface_list
+from sentry.notifications.utils.links import (
+    get_group_settings_link,
+    get_issue_replay_link,
+    get_rules,
+)
 from sentry.testutils.helpers.datetime import before_now  # NOQA:S007
 from sentry.testutils.helpers.notifications import (  # NOQA:S007
     SAMPLE_TO_OCCURRENCE_MAP,

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -12,8 +12,11 @@ from sentry.notifications.helpers import (
 )
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.types import NotificationSettingEnum, NotificationSettingsOptionEnum
-from sentry.notifications.utils import get_rules
-from sentry.notifications.utils.links import get_email_link_extra_params, get_group_settings_link
+from sentry.notifications.utils.links import (
+    get_email_link_extra_params,
+    get_group_settings_link,
+    get_rules,
+)
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of


### PR DESCRIPTION
introduced a couple new utils to create links for NOA and ACI and moved some functions around to better, more logic places to prevent circular imports