### PR TITLE
♻️ ref(aci): add support for aci for `AlertRuleNotification`

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -258,6 +258,9 @@ class AlertRuleNotification(ProjectNotification):
                 context["snooze_alert_url"] = get_snooze_url(
                     self.rules[0], self.organization, self.project, sentry_query_params
                 )
+        else:
+            context["snooze_alert"] = False
+            context["snooze_alert_url"] = None
 
         if isinstance(self.event, GroupEvent) and self.event.occurrence:
             context["issue_title"] = self.event.occurrence.issue_title

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -146,7 +146,7 @@ def get_workflow_links(
         workflow_id = get_key_from_rule_data(rule, "workflow_id")
         workflow_links.append(
             NotificationRuleDetails(
-                workflow_id,
+                int(workflow_id),
                 rule.label,
                 create_link_to_workflow(organization.id, workflow_id),
                 # TODO(iamrajjoshi): Add status url (whatever it is)

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -106,7 +106,9 @@ def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project
 ) -> Sequence[NotificationRuleDetails]:
-    if features.has("organizations:workflow-engine-trigger-actions", organization):
+    if features.has("organizations:workflow-engine-ui-links", organization):
+        return get_workflow_links(rules, organization, project)
+    elif features.has("organizations:workflow-engine-trigger-actions", organization):
         return get_rules_with_legacy_ids(rules, organization, project)
     return [
         NotificationRuleDetails(
@@ -134,6 +136,24 @@ def get_rules_with_legacy_ids(
             )
         )
     return rules_with_legacy_ids
+
+
+def get_workflow_links(
+    rules: Sequence[Rule], organization: Organization, project: Project
+) -> Sequence[NotificationRuleDetails]:
+    workflow_links = []
+    for rule in rules:
+        workflow_id = get_key_from_rule_data(rule, "workflow_id")
+        workflow_links.append(
+            NotificationRuleDetails(
+                workflow_id,
+                rule.label,
+                create_link_to_workflow(organization.id, workflow_id),
+                # TODO(iamrajjoshi): Add status url (whatever it is)
+                create_link_to_workflow(organization.id, workflow_id),
+            )
+        )
+    return workflow_links
 
 
 def get_snooze_url(

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -234,9 +234,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         group_event = event.for_group(event.groups[0])
 
+        # Create a rule with the legacy rule id being another rule
         rule = self.create_project_rule(
             project=self.project,
-            action_data=[{"legacy_rule_id": "1234567890"}],
+            action_data=[{"legacy_rule_id": self.rule.id}],
             name="ja rule",
         )
 
@@ -251,7 +252,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # Assert we are using the legacy rule id
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/1234567890/details/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
 
@@ -262,7 +263,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             event.group,
             "issue_alert-slack",
             alert_type="alerts",
-            issue_link_extra_params="&alert_rule_id=1234567890&alert_type=issue",
+            issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
         )
 
     @patch(

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -29,6 +29,7 @@ from sentry.plugins.base import Notification
 from sentry.silo.base import SiloMode
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -216,6 +217,52 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             "issue_alert-slack",
             alert_type="alerts",
             issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
+        )
+
+    @patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @with_feature("organizations:workflow-engine-trigger-actions")
+    def test_generic_issue_alert_user_block_workflow_engine_dual_write(self, occurrence):
+        """
+        Tests that we build links correctly when dual writing
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        group_event = event.for_group(event.groups[0])
+
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[{"legacy_rule_id": "1234567890"}],
+            name="ja rule",
+        )
+
+        notification = AlertRuleNotification(
+            Notification(event=group_event, rule=rule), ActionTargetType.MEMBER, self.user.id
+        )
+        with self.tasks():
+            notification.send()
+
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+        # Assert we are using the legacy rule id
+        assert (
+            fallback_text
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/1234567890/details/|ja rule>"
+        )
+        assert blocks[0]["text"]["text"] == fallback_text
+
+        self.assert_generic_issue_blocks(
+            blocks,
+            group_event.organization,
+            event.project.slug,
+            event.group,
+            "issue_alert-slack",
+            alert_type="alerts",
+            issue_link_extra_params="&alert_rule_id=1234567890&alert_type=issue",
         )
 
     def test_disabled_org_integration_for_user(self):

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -265,6 +265,52 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             issue_link_extra_params="&alert_rule_id=1234567890&alert_type=issue",
         )
 
+    @patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @with_feature("organizations:workflow-engine-ui-links")
+    def test_generic_issue_alert_user_block_workflow_engine_ui_links(self, occurrence):
+        """
+        Tests that we build links correctly when dual writing
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        group_event = event.for_group(event.groups[0])
+
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[{"workflow_id": "1234567890"}],
+            name="ja rule",
+        )
+
+        notification = AlertRuleNotification(
+            Notification(event=group_event, rule=rule), ActionTargetType.MEMBER, self.user.id
+        )
+        with self.tasks():
+            notification.send()
+
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+        # Assert we are using the workflow id and created a link to the workflow
+        assert (
+            fallback_text
+            == f"Alert triggered <http://testserver/organizations/{event.organization.id}/issues/automations/1234567890/|ja rule>"
+        )
+        assert blocks[0]["text"]["text"] == fallback_text
+
+        self.assert_generic_issue_blocks(
+            blocks,
+            group_event.organization,
+            event.project.slug,
+            event.group,
+            "issue_alert-slack",
+            alert_type="alerts",
+            issue_link_extra_params="&workflow_id=1234567890&alert_type=issue",
+        )
+
     def test_disabled_org_integration_for_user(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.get(integration=self.integration).update(

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -598,6 +598,8 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         self.assertEqual(notification.reference, group)
         assert notification.get_subject() == "BAR-1 - hello world"
 
+        # Because we are using the workflow engine, the snooze_alert context should be False
+        # This is because a user cannot snooze a workflow for themselves
         assert notification.get_context()["snooze_alert"] is False
 
         assert group

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -576,7 +576,9 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             value="never",
         )
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-        rule = self.create_project_rule(project=self.project)
+        rule = self.create_project_rule(
+            project=self.project, action_data=[{"workflow_id": "1234567890"}]
+        )
         with self.tasks():
             AlertRuleNotification(
                 Notification(event=event, rules=[rule]),

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -60,10 +60,6 @@ pytestmark = requires_snuba
 
 
 class BaseMailAdapterTest(TestCase, PerformanceIssueTestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule = self.create_project_rule(project=self.project)
-
     @cached_property
     def adapter(self):
         return mail_adapter
@@ -520,10 +516,10 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             value="never",
         )
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-
+        rule = self.create_project_rule(project=self.project)
         with self.tasks():
             AlertRuleNotification(
-                Notification(event=event, rules=[self.rule]),
+                Notification(event=event, rules=[rule]),
                 ActionTargetType.ISSUE_OWNERS,
                 fallthrough_choice=FallthroughChoiceType.ACTIVE_MEMBERS,
             ).send()
@@ -580,10 +576,10 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             value="never",
         )
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-
+        rule = self.create_project_rule(project=self.project)
         with self.tasks():
             AlertRuleNotification(
-                Notification(event=event, rules=[self.rule]),
+                Notification(event=event, rules=[rule]),
                 ActionTargetType.ISSUE_OWNERS,
                 fallthrough_choice=FallthroughChoiceType.ACTIVE_MEMBERS,
             ).send()


### PR DESCRIPTION
adds ACI/NOA support for emails that end up being sent as `AlertRuleNotification` notifications