### PR TITLE
feat(nextjs-insights): Add UI toggle

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -57,7 +57,8 @@ import {
 import {LaravelOverviewPage} from 'sentry/views/insights/pages/platform/laravel';
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
-import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 import {
@@ -102,12 +103,12 @@ export const BACKEND_COLUMN_TITLES = [
 function BackendOverviewPage() {
   useOverviewPageTrackPageload();
   const isLaravelPageAvailable = useIsLaravelInsightsAvailable();
-  const isNextJsPageAvailable = useIsNextJsInsightsAvailable();
+  const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
   if (isLaravelPageAvailable) {
     return <LaravelOverviewPage />;
   }
-  if (isNextJsPageAvailable) {
+  if (isNextJsPageEnabled) {
     return <NextJsOverviewPage headerTitle={BACKEND_LANDING_TITLE} />;
   }
   if (useEap) {
@@ -290,7 +291,10 @@ function EAPBackendOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <BackendHeader headerTitle={BACKEND_LANDING_TITLE} />
+      <BackendHeader
+        headerTitle={BACKEND_LANDING_TITLE}
+        headerActions={<NewNextJsExperienceButton />}
+      />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
@@ -346,14 +350,14 @@ function EAPBackendOverviewPage() {
 function BackendOverviewPageWithProviders() {
   const organization = useOrganization();
   const isLaravelPageAvailable = useIsLaravelInsightsAvailable();
-  const isNextJsPageAvailable = useIsNextJsInsightsAvailable();
+  const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
 
   const {maxPickableDays} = limitMaxPickableDays(organization);
 
   return (
     <DomainOverviewPageProviders
       maxPickableDays={
-        isLaravelPageAvailable || isNextJsPageAvailable ? maxPickableDays : undefined
+        isLaravelPageAvailable || isNextJsPageEnabled ? maxPickableDays : undefined
       }
     >
       <BackendOverviewPage />

--- a/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
@@ -45,6 +45,7 @@ import {
   MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {
   generateBackendPerformanceEventView,
   USER_MISERY_TOOLTIP,
@@ -229,7 +230,10 @@ export function OldBackendOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <BackendHeader headerTitle={BACKEND_LANDING_TITLE} />
+      <BackendHeader
+        headerTitle={BACKEND_LANDING_TITLE}
+        headerActions={<NewNextJsExperienceButton />}
+      />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -24,6 +24,7 @@ import {
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
+import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   isModuleConsideredNew,
@@ -64,6 +65,7 @@ export function DomainViewHeader({
   const navigate = useNavigate();
   const moduleURLBuilder = useModuleURLBuilder();
   const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
+  const [isNextJsInsightsEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
   const hasEapFlag = organization.features.includes('insights-modules-use-eap');
 
@@ -139,10 +141,12 @@ export function DomainViewHeader({
             ) : (
               <FeedbackWidgetButton
                 optionOverrides={
-                  isLaravelInsightsAvailable
+                  isLaravelInsightsAvailable || isNextJsInsightsEnabled
                     ? {
                         tags: {
-                          ['feedback.source']: 'laravel-insights',
+                          ['feedback.source']: isLaravelInsightsAvailable
+                            ? 'laravel-insights'
+                            : 'nextjs-insights',
                           ['feedback.owner']: 'telemetry-experience',
                         },
                       }

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -49,7 +49,8 @@ import {
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
-import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 import {
@@ -241,7 +242,10 @@ function EAPOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <FrontendHeader headerTitle={FRONTEND_LANDING_TITLE} />
+      <FrontendHeader
+        headerTitle={FRONTEND_LANDING_TITLE}
+        headerActions={<NewNextJsExperienceButton />}
+      />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
@@ -296,14 +300,14 @@ function EAPOverviewPage() {
 
 function FrontendOverviewPageWithProviders() {
   const organization = useOrganization();
-  const isNextJsPageAvailable = useIsNextJsInsightsAvailable();
+  const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
 
   const {maxPickableDays} = limitMaxPickableDays(organization);
 
   return (
     <DomainOverviewPageProviders maxPickableDays={maxPickableDays}>
-      {isNextJsPageAvailable ? (
+      {isNextJsPageEnabled ? (
         <NextJsOverviewPage headerTitle={FRONTEND_LANDING_TITLE} />
       ) : useEap ? (
         <EAPOverviewPage />

--- a/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
@@ -39,6 +39,7 @@ import {
   FRONTEND_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
+import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import {
   generateFrontendOtherPerformanceEventView,
@@ -205,7 +206,10 @@ export function OldFrontendOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <FrontendHeader headerTitle={FRONTEND_LANDING_TITLE} />
+      <FrontendHeader
+        headerTitle={FRONTEND_LANDING_TITLE}
+        headerActions={<NewNextJsExperienceButton />}
+      />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>

--- a/static/app/views/insights/pages/platform/nextjs/features.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/features.tsx
@@ -1,8 +1,12 @@
+import {useCallback} from 'react';
+
 import type {Organization} from 'sentry/types/organization';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
+import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 
 export function hasNextJsInsightsFeature(organization: Organization) {
   return organization.features.includes('nextjs-insights');
@@ -20,4 +24,31 @@ export function useIsNextJsInsightsAvailable() {
   );
 
   return hasNextJsInsightsFeature(organization) && isOnlyNextJsSelected;
+}
+
+export function useIsNextJsInsightsEnabled() {
+  const organization = useOrganization();
+  const user = useUser();
+  const isAvailable = useIsNextJsInsightsAvailable();
+
+  const isEnabled = Boolean(
+    isAvailable && (user.options.prefersNextjsInsightsOverview ?? true)
+  );
+
+  const {mutate: mutateUserOptions} = useMutateUserOptions();
+
+  const setIsEnabled = useCallback(
+    (enabled: boolean) => {
+      if (!hasNextJsInsightsFeature(organization)) {
+        return;
+      }
+
+      mutateUserOptions({
+        prefersNextjsInsightsOverview: enabled,
+      });
+    },
+    [mutateUserOptions, organization]
+  );
+
+  return [isEnabled, setIsEnabled] as const;
 }

--- a/static/app/views/insights/pages/platform/nextjs/features.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/features.tsx
@@ -31,9 +31,7 @@ export function useIsNextJsInsightsEnabled() {
   const user = useUser();
   const isAvailable = useIsNextJsInsightsAvailable();
 
-  const isEnabled = Boolean(
-    isAvailable && (user.options.prefersNextjsInsightsOverview ?? true)
-  );
+  const isEnabled = isAvailable && (user.options.prefersNextjsInsightsOverview ?? true);
 
   const {mutate: mutateUserOptions} = useMutateUserOptions();
 

--- a/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
@@ -84,7 +84,7 @@ export function NewNextJsExperienceButton() {
                 'Excluding bribes, what would make you excited to use the new UI?'
               ),
               tags: {
-                ['feedback.source']: 'NextJs-insights',
+                ['feedback.source']: 'nextjs-insights',
                 ['feedback.owner']: 'telemetry-experience',
               },
             });

--- a/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
@@ -43,7 +43,6 @@ export function NewNextJsExperienceButton() {
 
     return (
       <ToggleButton
-        enabled={isNextJsInsightsEnabled}
         size="sm"
         icon={<IconLab isSolid={isNextJsInsightsEnabled} />}
         title={label}
@@ -60,7 +59,6 @@ export function NewNextJsExperienceButton() {
       trigger={triggerProps => (
         <StyledDropdownButton
           {...triggerProps}
-          enabled={isNextJsInsightsEnabled}
           size="sm"
           aria-label={t('Switch issue experience')}
         >
@@ -96,18 +94,17 @@ export function NewNextJsExperienceButton() {
   );
 }
 
-const StyledDropdownButton = styled(DropdownButton)<{enabled: boolean}>`
-  color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+const StyledDropdownButton = styled(DropdownButton)`
+  color: ${p => p.theme.button.primary.background};
   :hover {
-    color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+    color: ${p => p.theme.button.primary.background};
   }
 `;
 
-const ToggleButton = styled(Button)<{enabled: boolean}>`
-  color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
-  background: ${p =>
-    p.enabled ? 'inherit' : `linear-gradient(90deg, #3468D8, #248574)`};
+const ToggleButton = styled(Button)`
+  color: ${p => p.theme.white};
+  background: linear-gradient(90deg, #3468d8, #248574);
   :hover {
-    color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
+    color: ${p => p.theme.white};
   }
 `;

--- a/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/newNextjsExperienceToggle.tsx
@@ -1,0 +1,113 @@
+import {useCallback} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import DropdownButton from 'sentry/components/dropdownButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconLab} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  useIsNextJsInsightsAvailable,
+  useIsNextJsInsightsEnabled,
+} from 'sentry/views/insights/pages/platform/nextjs/features';
+
+export function NewNextJsExperienceButton() {
+  const organization = useOrganization();
+  const [isNextJsInsightsEnabled, setIsNextJsInsightsEnabled] =
+    useIsNextJsInsightsEnabled();
+
+  const isNextJsInsightsAvailable = useIsNextJsInsightsAvailable();
+
+  const openForm = useFeedbackForm();
+
+  const handleToggle = useCallback(() => {
+    setIsNextJsInsightsEnabled(!isNextJsInsightsEnabled);
+    trackAnalytics('nextjs-insights.ui_toggle', {
+      isEnabled: !isNextJsInsightsEnabled,
+      organization,
+    });
+  }, [setIsNextJsInsightsEnabled, isNextJsInsightsEnabled, organization]);
+
+  if (!isNextJsInsightsAvailable) {
+    return null;
+  }
+
+  if (!openForm || !isNextJsInsightsEnabled) {
+    const label = isNextJsInsightsEnabled
+      ? t('Switch to the old experience')
+      : t('Switch to the new experience');
+    const text = isNextJsInsightsEnabled ? null : t('Try New UI');
+
+    return (
+      <ToggleButton
+        enabled={isNextJsInsightsEnabled}
+        size="sm"
+        icon={<IconLab isSolid={isNextJsInsightsEnabled} />}
+        title={label}
+        aria-label={label}
+        onClick={handleToggle}
+      >
+        {text}
+      </ToggleButton>
+    );
+  }
+
+  return (
+    <DropdownMenu
+      trigger={triggerProps => (
+        <StyledDropdownButton
+          {...triggerProps}
+          enabled={isNextJsInsightsEnabled}
+          size="sm"
+          aria-label={t('Switch issue experience')}
+        >
+          {/* Passing icon as child to avoid extra icon margin */}
+          <IconLab isSolid={isNextJsInsightsEnabled} />
+        </StyledDropdownButton>
+      )}
+      items={[
+        {
+          key: 'switch-to-old-ui',
+          label: t('Switch to the old experience'),
+          onAction: handleToggle,
+        },
+        {
+          key: 'give-feedback',
+          label: t('Give feedback on new UI'),
+          hidden: !openForm,
+          onAction: () => {
+            openForm({
+              messagePlaceholder: t(
+                'Excluding bribes, what would make you excited to use the new UI?'
+              ),
+              tags: {
+                ['feedback.source']: 'NextJs-insights',
+                ['feedback.owner']: 'telemetry-experience',
+              },
+            });
+          },
+        },
+      ]}
+      position="bottom-end"
+    />
+  );
+}
+
+const StyledDropdownButton = styled(DropdownButton)<{enabled: boolean}>`
+  color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+  :hover {
+    color: ${p => (p.enabled ? p.theme.button.primary.background : 'inherit')};
+  }
+`;
+
+const ToggleButton = styled(Button)<{enabled: boolean}>`
+  color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
+  background: ${p =>
+    p.enabled ? 'inherit' : `linear-gradient(90deg, #3468D8, #248574)`};
+  :hover {
+    color: ${p => (p.enabled ? p.theme.button.primary.background : p.theme.white)};
+  }
+`;

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -19,6 +19,7 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
+import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 import {ProjectPerformanceType} from 'sentry/views/performance/utils';
@@ -71,6 +72,7 @@ export function PlatformLandingPageLayout({
         headerActions={
           <Fragment>
             <ViewTrendsButton />
+            <NewNextJsExperienceButton />
           </Fragment>
         }
       />

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -118,7 +118,10 @@ export function InsightsSecondaryNav() {
           {projectsToDisplay.map(project => (
             <SecondaryNav.Item
               key={project.id}
-              to={`${baseUrl}/projects/${project.slug}/`}
+              to={{
+                pathname: `${baseUrl}/projects/${project.slug}/`,
+                search: '?source=sidebar',
+              }}
               isActive={
                 isProjectDetailsRedirectActive
                   ? isProjectSelectedExclusively(project)

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,9 +1,8 @@
 import Redirect from 'sentry/components/redirect';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
-import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
-import {getProjectDetailsRedirect} from 'sentry/views/insights/pages/platform/shared/projectDetailsRedirect';
+import {useProjectDetailsRedirect} from 'sentry/views/insights/pages/platform/shared/projectDetailsRedirect';
 
 import ProjectDetail from './projectDetail';
 
@@ -13,7 +12,6 @@ function ProjectDetailContainer(
     'projects' | 'loadingProjects' | 'selection'
   >
 ) {
-  const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === props.params.projectId);
 
@@ -26,8 +24,8 @@ function ProjectDetailContainer(
       : {}
   );
 
-  const redirect = project && getProjectDetailsRedirect(organization, project);
-  if (redirect) {
+  const redirect = useProjectDetailsRedirect(project);
+  if (project && redirect) {
     return <Redirect to={redirect} />;
   }
 


### PR DESCRIPTION
<img width="1426" alt="Screenshot 2025-04-23 at 21 37 34" src="https://github.com/user-attachments/assets/c01d4649-3a44-4fe9-894f-25dfe1b09f1d" />

<img width="1426" alt="Screenshot 2025-04-23 at 21 37 42" src="https://github.com/user-attachments/assets/ed2caa5c-c16d-4018-9be5-8e72c9e37a44" />

- closes [TET-296: Add opt-out button to NextJS insights](https://linear.app/getsentry/issue/TET-296/add-opt-out-button-to-nextjs-insights)