### PR TITLE
ref(useCreateProject): Remove debug instrumentation in project creation

### DIFF
--- a/static/app/components/onboarding/useCreateProject.tsx
+++ b/static/app/components/onboarding/useCreateProject.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Project} from 'sentry/types/project';
@@ -24,11 +22,6 @@ export function useCreateProject() {
   return useMutation<Project, RequestError, Variables>({
     mutationKey: [MUTATION_KEY],
     mutationFn: ({firstTeamSlug, name, platform, default_rules}) => {
-      // A default team should always be created for a new organization.
-      // If teams are loaded but no first team is found, fallback to the experimental project.
-      if (!firstTeamSlug) {
-        Sentry.captureException('No team slug found for new org during onboarding');
-      }
       return api.requestPromise(
         firstTeamSlug
           ? `/teams/${organization.slug}/${firstTeamSlug}/projects/`


### PR DESCRIPTION
**TL;DR**
Removes debug instrumentation from the useCreateProject hook.

**Context**
After reviewing the behavior, it turns out that it's valid for a user without a team to create a project:

- It's possible for all projects within an organization to be deleted.
- A new member may not be assigned to any team but can still create a project ([example](https://pri-project-experiment.sentry.io/insights/projects/javascript/?project=4509202554814545)). In this case, the `/experimental/projects/` endpoint is fired. [Notion Doc](https://www.notion.so/sentry/24Q2-Project-Creation-for-All-5ed58b658f28464b8582252836de5394) (Sorry, internal only)

![Screenshot 2025-04-24 at 09 08 26](https://github.com/user-attachments/assets/4ad8d3d4-31b1-4a1a-bcc7-4565f7b5c133)

While a bug was observed post-project creation, it will be fixed in [PR #89568](https://github.com/getsentry/sentry/pull/89568).

closes TET-345