### PR TITLE
feat(sandbox): don't set activeorg session var for sandbox orgs

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -20,6 +20,7 @@ from sentry.api.utils import get_date_range_from_params, is_member_disabled_from
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.exceptions import InvalidParams
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.environment import Environment
@@ -305,7 +306,8 @@ class ControlSiloOrganizationEndpoint(Endpoint):
         # Never track any org (regardless of whether the user does or doesn't have
         # membership in that org) when the user is in active superuser mode
         if request.auth is None and request.user and not is_active_superuser(request):
-            auth.set_active_org(request, organization_context.organization.slug)
+            if not is_demo_mode_enabled() or not is_demo_org(organization_context.organization):
+                auth.set_active_org(request, organization_context.organization.slug)
 
         kwargs["organization_context"] = organization_context
         kwargs["organization"] = organization_context.organization
@@ -638,7 +640,8 @@ class OrganizationEndpoint(Endpoint):
         # Never track any org (regardless of whether the user does or doesn't have
         # membership in that org) when the user is in active superuser mode
         if request.auth is None and request.user and not is_active_superuser(request):
-            auth.set_active_org(request, organization.slug)
+            if not is_demo_mode_enabled() or not is_demo_org(organization):
+                auth.set_active_org(request, organization.slug)
 
         kwargs["organization"] = organization
         return (args, kwargs)

--- a/src/sentry/demo_mode/utils.py
+++ b/src/sentry/demo_mode/utils.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from sentry import options
 from sentry.models.organization import Organization
+from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.users.models.user import User
 
 READONLY_SCOPES = frozenset(
@@ -29,7 +30,7 @@ def is_demo_user(user: User | AnonymousUser | None) -> bool:
     return user.id in options.get("demo-mode.users")
 
 
-def is_demo_org(organization: Organization | None):
+def is_demo_org(organization: Organization | RpcOrganization | None):
 
     if not organization:
         return False

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -11,8 +11,10 @@ from django.http.response import HttpResponseBase
 from django.urls import resolve, reverse
 
 from sentry import features
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import organization_service
+from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.types.region import subdomain_is_region
 from sentry.utils import auth
 from sentry.utils.http import absolute_uri
@@ -20,12 +22,10 @@ from sentry.utils.http import absolute_uri
 logger = logging.getLogger(__name__)
 
 
-def _org_exists(slug):
+def _get_org_id(slug: str | None) -> int | None:
     if not slug:
-        return False
-    return (
-        organization_service.check_organization_by_slug(slug=slug, only_visible=False) is not None
-    )
+        return None
+    return organization_service.check_organization_by_slug(slug=slug, only_visible=False)
 
 
 def _query_string(request):
@@ -35,15 +35,15 @@ def _query_string(request):
     return qs
 
 
-def _resolve_activeorg(request):
+def _resolve_activeorg(request: HttpRequest) -> tuple[int | None, str | None]:
     subdomain = request.subdomain
     session = getattr(request, "session", None)
-    if _org_exists(subdomain):
+    if org_id := _get_org_id(subdomain):
         # Assume subdomain is an org slug being accessed
-        return subdomain
-    elif session and "activeorg" in session and _org_exists(session["activeorg"]):
-        return session["activeorg"]
-    return None
+        return org_id, subdomain
+    elif session and (org_id := _get_org_id(session.get("activeorg"))):
+        return org_id, session["activeorg"]
+    return None, None
 
 
 def _resolve_redirect_url(request, activeorg):
@@ -107,15 +107,21 @@ class CustomerDomainMiddleware:
             logger.info("customer_domain.redirect.logout", extra={"location": redirect_url})
             return HttpResponseRedirect(redirect_url)
 
-        activeorg = _resolve_activeorg(request)
+        org_id, activeorg = _resolve_activeorg(request)
+
         if not activeorg:
             session = getattr(request, "session", None)
             if session and "activeorg" in session:
                 del session["activeorg"]
             return self.get_response(request)
-        auth.set_active_org(request, activeorg)
+
+        if not is_demo_mode_enabled() or not is_demo_org(RpcOrganization(id=org_id)):
+            # we explicitly do not set the active org for demo orgs
+            auth.set_active_org(request, activeorg)
+
         redirect_url = _resolve_redirect_url(request, activeorg)
         if redirect_url is not None and len(redirect_url) > 0:
             logger.info("customer_domain.redirect", extra={"location": redirect_url})
             return HttpResponseRedirect(redirect_url)
+
         return self.get_response(request)

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -30,6 +30,7 @@ from sentry.api.utils import is_member_disabled_from_limit
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ObjectStatus
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
 from sentry.middleware.placeholder import placeholder_get_response
 from sentry.models.avatars.base import AvatarBase
@@ -221,7 +222,8 @@ def determine_active_organization(
         )
 
     if active_organization and active_organization.member:
-        auth.set_active_org(request, active_organization.organization.slug)
+        if not is_demo_mode_enabled() or not is_demo_org(active_organization.organization):
+            auth.set_active_org(request, active_organization.organization.slug)
 
     return active_organization
 

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -174,28 +174,28 @@ class CustomerDomainMiddlewareTest(TestCase):
         ]
 
     @with_feature("system:multi-region")
-    @override_options({"demo-mode.enabled": True, "demo-mode.orgs": [2]})
     def test_no_activeorg_when_demo_org(self):
-        self.create_organization(name="sandbox", id=2)
-        request = RequestFactory().get("/")
-        request.subdomain = "sandbox"
-        request.session = _session({})
-        response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
+        org = self.create_organization(name="sandbox")
+        with override_options({"demo-mode.enabled": True, "demo-mode.orgs": [org.id]}):
+            request = RequestFactory().get("/")
+            request.subdomain = "sandbox"
+            request.session = _session({})
+            response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
 
-        assert "activeorg" not in request.session
-        assert response == mock.sentinel.response
+            assert "activeorg" not in request.session
+            assert response == mock.sentinel.response
 
     @with_feature("system:multi-region")
-    @override_options({"demo-mode.enabled": True, "demo-mode.orgs": [2]})
     def test_activeorg_when_not_demo_org(self):
-        self.create_organization(name="other", id=3)
-        request = RequestFactory().get("/")
-        request.subdomain = "other"
-        request.session = _session({})
-        response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
+        org = self.create_organization(name="other")
+        with override_options({"demo-mode.enabled": True, "demo-mode.orgs": [org.id + 1]}):
+            request = RequestFactory().get("/")
+            request.subdomain = "other"
+            request.session = _session({})
+            response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
 
-        assert request.session["activeorg"] == "other"
-        assert response == mock.sentinel.response
+            assert request.session["activeorg"] == "other"
+            assert response == mock.sentinel.response
 
 
 class OrganizationTestEndpoint(Endpoint):

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -12,8 +12,9 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.middleware.customer_domain import CustomerDomainMiddleware
-from sentry.testutils.cases import APITestCase, TestCase, override_options
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import all_silo_test, create_test_regions, no_silo_test
 from sentry.web.frontend.auth_logout import AuthLogoutView
 


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-87/remove-sentryio-sandbox-redirect

We don't want to redirect to the sandbox after trying it out. This is handled by the `activeorg` session variable. In this PR, we check first whether the org we are dealing with is a demo org before commiting it to the `activeorg` variable.