### PR TITLE
sdkcd: ignore function `FlutterErrorIntegration.call.<fn>`

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -365,6 +365,9 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 # However every custom implementation is try/catch guarded so no exception can be thrown.
                 "SentryWidgetsBindingMixin.handleDrawFrame",
                 "SentryWidgetsBindingMixin.handleBeginFrame",
+                # This is the integration responsible for reporting unhandled errors.
+                # For certain errors the frame is sometimes included in the stacktrace which leads to false positives.
+                "FlutterErrorIntegration.call.<fn>",
             },
         )
         configs.append(dart_config)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -257,7 +257,9 @@ def test_ignore_handle_draw_frame(mock_sdk_crash_reporter, mock_random, store_ev
 
 
 @decorators
-def test_ignore_flutter_error_integration(mock_sdk_crash_reporter, mock_random, store_event, configs):
+def test_ignore_flutter_error_integration(
+    mock_sdk_crash_reporter, mock_random, store_event, configs
+):
     event_data = get_crash_event(sdk_function="FlutterErrorIntegration.call.<fn>")
     event = store_event(data=event_data)
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -254,3 +254,18 @@ def test_ignore_handle_draw_frame(mock_sdk_crash_reporter, mock_random, store_ev
     )
 
     assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@decorators
+def test_ignore_flutter_error_integration(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="FlutterErrorIntegration.call.<fn>")
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 0


### PR DESCRIPTION
For certain errors the function is sometimes included in the stacktrace which leads to false positives of the crash detection.

Example: The stacktrace is made up of system flutter frames + 1 flutter on error function frame.
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/245e5065-78e9-4914-b3e8-4268f586ffbb" />
