### PR TITLE
fix(dashboards): Escape release versions in release health widgets

### DIFF
--- a/static/app/utils/queryString.spec.tsx
+++ b/static/app/utils/queryString.spec.tsx
@@ -61,6 +61,11 @@ describe('appendTagCondition', function () {
     expect(result).toBe('color:"id:red"');
   });
 
+  it('wraps values with a backslash', function () {
+    const result = utils.appendTagCondition(null, 'color', 'id\\red');
+    expect(result).toBe('color:"id\\red"');
+  });
+
   it('handles user tag values', function () {
     let result = utils.appendTagCondition('', 'user', 'something');
     expect(result).toBe('user:something');

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -4,7 +4,9 @@ import {escapeDoubleQuotes} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {safeURL} from 'sentry/utils/url/safeURL';
 
-export const TAG_VALUE_ESCAPE_CHARS = /[:\s\(\)\\"]/g;
+// Create a string representation of the regex so we need to create a new regex
+// for each use to avoid carrying over state
+export const TAG_VALUE_ESCAPE_PATTERN = '[:\\s\\(\\)\\"]';
 
 // remove leading and trailing whitespace and remove double spaces
 function formatQueryString(query: string): string {
@@ -48,7 +50,10 @@ export function appendTagCondition(
       ? query
       : '';
 
-  if (typeof value === 'string' && TAG_VALUE_ESCAPE_CHARS.test(value)) {
+  if (
+    typeof value === 'string' &&
+    new RegExp(TAG_VALUE_ESCAPE_PATTERN, 'g').test(value)
+  ) {
     value = `"${escapeDoubleQuotes(value)}"`;
   }
   if (currentQuery) {

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -4,6 +4,8 @@ import {escapeDoubleQuotes} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {safeURL} from 'sentry/utils/url/safeURL';
 
+export const TAG_VALUE_ESCAPE_CHARS = /[:\s\(\)\\"]/g;
+
 // remove leading and trailing whitespace and remove double spaces
 function formatQueryString(query: string): string {
   return query.trim().replace(/\s+/g, ' ');
@@ -46,7 +48,7 @@ export function appendTagCondition(
       ? query
       : '';
 
-  if (typeof value === 'string' && /[:\s\(\)\\"]/g.test(value)) {
+  if (typeof value === 'string' && TAG_VALUE_ESCAPE_CHARS.test(value)) {
     value = `"${escapeDoubleQuotes(value)}"`;
   }
   if (currentQuery) {

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -6,7 +6,7 @@ import {safeURL} from 'sentry/utils/url/safeURL';
 
 // Create a string representation of the regex so we need to create a new regex
 // for each use to avoid carrying over state
-export const TAG_VALUE_ESCAPE_PATTERN = '[:\\s\\(\\)\\"]';
+export const TAG_VALUE_ESCAPE_PATTERN = '[:\\s\\(\\)\\\\"]';
 
 // remove leading and trailing whitespace and remove double spaces
 function formatQueryString(query: string): string {

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -919,6 +919,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
         {id: 1, version: 'this release has spaces'},
         {id: 2, version: 'this_release_has_no_spaces'},
         {id: 3, version: 'this release has (parens)'},
+        {id: 3, version: 'this_release_has_(parens)'},
       ],
     });
     const queries = [
@@ -954,7 +955,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           query:
-            ' release:["this release has spaces",this_release_has_no_spaces,"this release has (parens)"]',
+            ' release:["this release has spaces",this_release_has_no_spaces,"this release has (parens)","this_release_has_(parens)"]',
         }),
       })
     );

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -13,11 +13,11 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
-import {defined} from 'sentry/utils';
+import {defined, escapeDoubleQuotes} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {stripDerivedMetricsPrefix} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
-import {appendTagCondition} from 'sentry/utils/queryString';
+import {TAG_VALUE_ESCAPE_CHARS} from 'sentry/utils/queryString';
 import {ReleasesConfig} from 'sentry/views/dashboards/datasetConfig/releases';
 import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
@@ -64,17 +64,12 @@ function getReleasesQuery(releases: Release[]): {
   releaseQueryString: string;
   releasesUsed: string[];
 } {
-  let releaseCondition = '';
   const releasesArray: string[] = [];
-  releaseCondition +=
-    'release:[' + appendTagCondition('', '', releases[0]!.version).replace(/^:/, '');
   releasesArray.push(releases[0]!.version);
   for (let i = 1; i < releases.length; i++) {
-    releaseCondition +=
-      ',' + appendTagCondition('', '', releases[i]!.version).replace(/^:/, '');
     releasesArray.push(releases[i]!.version);
   }
-  releaseCondition += ']';
+  const releaseCondition = `release:[${releasesArray.map(v => (TAG_VALUE_ESCAPE_CHARS.test(v) ? `"${escapeDoubleQuotes(v)}"` : v))}]`;
   if (releases.length < 10) {
     return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
   }

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -17,6 +17,7 @@ import {defined} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {stripDerivedMetricsPrefix} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
+import {appendTagCondition} from 'sentry/utils/queryString';
 import {ReleasesConfig} from 'sentry/views/dashboards/datasetConfig/releases';
 import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
@@ -65,10 +66,12 @@ function getReleasesQuery(releases: Release[]): {
 } {
   let releaseCondition = '';
   const releasesArray: string[] = [];
-  releaseCondition += 'release:[' + releases[0]!.version;
+  releaseCondition +=
+    'release:[' + appendTagCondition('', '', releases[0]!.version).replace(/^:/, '');
   releasesArray.push(releases[0]!.version);
   for (let i = 1; i < releases.length; i++) {
-    releaseCondition += ',' + releases[i]!.version;
+    releaseCondition +=
+      ',' + appendTagCondition('', '', releases[i]!.version).replace(/^:/, '');
     releasesArray.push(releases[i]!.version);
   }
   releaseCondition += ']';

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -17,7 +17,7 @@ import {defined, escapeDoubleQuotes} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {stripDerivedMetricsPrefix} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
-import {TAG_VALUE_ESCAPE_CHARS} from 'sentry/utils/queryString';
+import {TAG_VALUE_ESCAPE_PATTERN} from 'sentry/utils/queryString';
 import {ReleasesConfig} from 'sentry/views/dashboards/datasetConfig/releases';
 import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
@@ -69,7 +69,7 @@ function getReleasesQuery(releases: Release[]): {
   for (let i = 1; i < releases.length; i++) {
     releasesArray.push(releases[i]!.version);
   }
-  const releaseCondition = `release:[${releasesArray.map(v => (TAG_VALUE_ESCAPE_CHARS.test(v) ? `"${escapeDoubleQuotes(v)}"` : v))}]`;
+  const releaseCondition = `release:[${releasesArray.map(v => (new RegExp(TAG_VALUE_ESCAPE_PATTERN, 'g').test(v) ? `"${escapeDoubleQuotes(v)}"` : v))}]`;
   if (releases.length < 10) {
     return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
   }


### PR DESCRIPTION
Release health widgets concats together a bunch of release versions to sort by release. We weren't escaping them, so if the release versions had spaces, it would break the `x:[value1,value2]` syntax and get interpreted as free text search. This exposes a regex we use to determine if a tag value needs escaping and wraps the necessary versions with quotes