### PR TITLE
fix(schema-hints): Move drawer search bar to next line

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -167,15 +167,16 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
         <HeaderContainer>
           <SchemaHintsHeader>{t('Filter Attributes')}</SchemaHintsHeader>
           <StyledInputGroup>
+            <InputGroup.LeadingItems disablePointerEvents>
+              <IconSearch size="sm" />
+            </InputGroup.LeadingItems>
             <SearchInput
               size="sm"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               aria-label={t('Search attributes')}
+              placeholder={t('Search')}
             />
-            <InputGroup.TrailingItems disablePointerEvents>
-              <IconSearch size="md" />
-            </InputGroup.TrailingItems>
           </StyledInputGroup>
         </HeaderContainer>
         <StyledMultipleCheckbox name={t('Filter keys')} value={selectedFilterKeys}>
@@ -213,10 +214,9 @@ const StyledDrawerBody = styled(DrawerBody)`
 
 const HeaderContainer = styled('div')`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   margin-bottom: ${space(2)};
-  gap: ${space(1.5)};
+  gap: ${space(1)};
 `;
 
 const CheckboxLabelContainer = styled('div')`


### PR DESCRIPTION
Per Indragie and Dora's request. Search bar was too small and looks better on a separate line.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/734b78c6-9aed-4786-a421-875b0e6fbbe2) | ![image](https://github.com/user-attachments/assets/a185f6c4-59aa-428c-b2a8-e5daeaace9f1) | 