### PR TITLE
fix(ourlogs): Avoid errors if you remove a column being sorted on

### DIFF
--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -12,5 +12,9 @@ export function defaultLogFields(): OurLogKnownFieldKey[] {
 }
 
 export function getLogFieldsFromLocation(location: Location): OurLogFieldKey[] {
-  return decodeList(location.query[LOGS_FIELDS_KEY]);
+  const fields = decodeList(location.query[LOGS_FIELDS_KEY]);
+  if (fields.length) {
+    return fields;
+  }
+  return defaultLogFields();
 }

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -89,7 +89,7 @@ export function LogsPageParamsProvider({
     : getLogFieldsFromLocation(location);
   const sortBys = isTableEditingFrozen
     ? [logsTimestampDescendingSortBy]
-    : getLogSortBysFromLocation(location);
+    : getLogSortBysFromLocation(location, fields);
   const projectIds = isOnEmbeddedView
     ? (limitToProjectIds ?? [-1])
     : decodeProjects(location);

--- a/static/app/views/explore/contexts/logs/sortBys.tsx
+++ b/static/app/views/explore/contexts/logs/sortBys.tsx
@@ -12,18 +12,31 @@ export const logsTimestampDescendingSortBy: Sort = {
   kind: 'desc' as const,
 };
 
-function defaultLogSortBys(): Sort[] {
-  return [logsTimestampDescendingSortBy];
-}
-
-export function getLogSortBysFromLocation(location: Location): Sort[] {
+export function getLogSortBysFromLocation(location: Location, fields: string[]): Sort[] {
   const sortBys = decodeSorts(location.query[LOGS_SORT_BYS_KEY]);
 
   if (sortBys.length > 0) {
-    return sortBys;
+    if (sortBys.every(sortBy => fields.includes(sortBy.field))) {
+      return sortBys;
+    }
   }
 
-  return defaultLogSortBys();
+  if (fields.includes(OurLogKnownFieldKey.TIMESTAMP)) {
+    return [logsTimestampDescendingSortBy];
+  }
+
+  if (!fields[0]) {
+    throw new Error(
+      'fields should not be empty - did you somehow delete all of the fields?'
+    );
+  }
+
+  return [
+    {
+      field: fields[0],
+      kind: 'desc' as const,
+    },
+  ];
 }
 
 export function updateLocationWithLogSortBys(


### PR DESCRIPTION
For example, if you deleted a column after sorting on it, we used to error. Now, we always find a valid sort and valid columns, regardless of what you have done.

Fixes LOGS-74
