### PR TITLE
feat(issue-taxonomy): Update issue search to support new categories

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -190,7 +190,6 @@ def convert_category_value(
         if not group_category:
             raise InvalidSearchQuery(f"Invalid category value of '{category}'")
         results.extend(GROUP_TYPE_REGISTRY.get_by_category(group_category.value))
-        results.extend(GROUP_TYPE_REGISTRY.get_by_category_v2(group_category.value))
     return results
 
 

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -19,11 +19,8 @@ from sentry.api.event_search import (
 )
 from sentry.api.event_search import parse_search_query as base_parse_query
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import (
-    GroupCategory,
-    get_group_type_by_slug,
-    get_group_types_by_category,
-)
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_slug
+from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.models.environment import Environment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES
 from sentry.models.organization import Organization
@@ -192,7 +189,8 @@ def convert_category_value(
         group_category = getattr(GroupCategory, category.upper(), None)
         if not group_category:
             raise InvalidSearchQuery(f"Invalid category value of '{category}'")
-        results.extend(get_group_types_by_category(group_category.value))
+        results.extend(GROUP_TYPE_REGISTRY.get_by_category(group_category.value))
+        results.extend(GROUP_TYPE_REGISTRY.get_by_category_v2(group_category.value))
     return results
 
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -88,7 +88,6 @@ class GroupTypeRegistry:
     _registry: dict[int, type[GroupType]] = field(default_factory=dict)
     _slug_lookup: dict[str, type[GroupType]] = field(default_factory=dict)
     _category_lookup: dict[int, set[int]] = field(default_factory=lambda: defaultdict(set))
-    _category_lookup_v2: dict[int, set[int]] = field(default_factory=lambda: defaultdict(set))
 
     def add(self, group_type: type[GroupType]) -> None:
         if self._registry.get(group_type.type_id):
@@ -98,7 +97,7 @@ class GroupTypeRegistry:
         self._registry[group_type.type_id] = group_type
         self._slug_lookup[group_type.slug] = group_type
         self._category_lookup[group_type.category].add(group_type.type_id)
-        self._category_lookup_v2[group_type.category_v2].add(group_type.type_id)
+        self._category_lookup[group_type.category_v2].add(group_type.type_id)
 
     def all(self) -> list[type[GroupType]]:
         return list(self._registry.values())
@@ -133,10 +132,7 @@ class GroupTypeRegistry:
         return {type.type_id for type in self._registry.values()}
 
     def get_by_category(self, category: int) -> set[int]:
-        return self._category_lookup.get(category, set())
-
-    def get_by_category_v2(self, category: int) -> set[int]:
-        return self._category_lookup_v2.get(category, set())
+        return self._category_lookup[category]
 
     def get_by_slug(self, slug: str) -> type[GroupType] | None:
         if slug not in self._slug_lookup:

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -133,10 +133,10 @@ class GroupTypeRegistry:
         return {type.type_id for type in self._registry.values()}
 
     def get_by_category(self, category: int) -> set[int]:
-        return self._category_lookup[category]
+        return self._category_lookup.get(category, set())
 
     def get_by_category_v2(self, category: int) -> set[int]:
-        return self._category_lookup_v2[category]
+        return self._category_lookup_v2.get(category, set())
 
     def get_by_slug(self, slug: str) -> type[GroupType] | None:
         if slug not in self._slug_lookup:

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -22,7 +22,8 @@ from sentry.api.issue_search import (
     value_converters,
 )
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
+from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.models.release import ReleaseStatus
 from sentry.search.utils import get_teams_for_users
@@ -401,8 +402,8 @@ class ConvertFirstReleaseValueTest(TestCase):
 
 class ConvertCategoryValueTest(TestCase):
     def test(self):
-        error_group_types = get_group_types_by_category(GroupCategory.ERROR.value)
-        perf_group_types = get_group_types_by_category(GroupCategory.PERFORMANCE.value)
+        error_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.ERROR.value)
+        perf_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.PERFORMANCE.value)
         assert (
             set(convert_category_value(["error"], [self.project], self.user, None))
             == error_group_types
@@ -415,6 +416,16 @@ class ConvertCategoryValueTest(TestCase):
             set(convert_category_value(["error", "performance"], [self.project], self.user, None))
             == error_group_types | perf_group_types
         )
+
+        # Also works with new categories
+        assert set(
+            convert_category_value(["outage"], [self.project], self.user, None)
+        ) == GROUP_TYPE_REGISTRY.get_by_category_v2(GroupCategory.OUTAGE.value)
+        assert set(
+            convert_category_value(["performance_best_practice"], [self.project], self.user, None)
+        ) == GROUP_TYPE_REGISTRY.get_by_category_v2(GroupCategory.PERFORMANCE_BEST_PRACTICE.value)
+
+        # Should raise an error for invalid values
         with pytest.raises(InvalidSearchQuery):
             convert_category_value(["hellboy"], [self.project], self.user, None)
 

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -420,10 +420,10 @@ class ConvertCategoryValueTest(TestCase):
         # Also works with new categories
         assert set(
             convert_category_value(["outage"], [self.project], self.user, None)
-        ) == GROUP_TYPE_REGISTRY.get_by_category_v2(GroupCategory.OUTAGE.value)
+        ) == GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.OUTAGE.value)
         assert set(
             convert_category_value(["performance_best_practice"], [self.project], self.user, None)
-        ) == GROUP_TYPE_REGISTRY.get_by_category_v2(GroupCategory.PERFORMANCE_BEST_PRACTICE.value)
+        ) == GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.PERFORMANCE_BEST_PRACTICE.value)
 
         # Should raise an error for invalid values
         with pytest.raises(InvalidSearchQuery):

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -184,13 +184,21 @@ class GroupRegistryTest(BaseGroupTypeTest):
                 ErrorGroupType,
             }
 
-    def test_get_by_category_v2(self) -> None:
+    def test_get_by_category(self) -> None:
         registry = GroupTypeRegistry()
         registry.add(ErrorGroupType)
         registry.add(PerformanceSlowDBQueryGroupType)
         registry.add(PerformanceNPlusOneGroupType)
-        assert registry.get_by_category_v2(GroupCategory.ERROR.value) == {ErrorGroupType.type_id}
-        assert registry.get_by_category_v2(GroupCategory.PERFORMANCE_BEST_PRACTICE.value) == {
+
+        # Works for old category mapping
+        assert registry.get_by_category(GroupCategory.ERROR.value) == {ErrorGroupType.type_id}
+        assert registry.get_by_category(GroupCategory.PERFORMANCE.value) == {
+            PerformanceSlowDBQueryGroupType.type_id,
+            PerformanceNPlusOneGroupType.type_id,
+        }
+
+        # Works for new category mapping
+        assert registry.get_by_category(GroupCategory.PERFORMANCE_BEST_PRACTICE.value) == {
             PerformanceSlowDBQueryGroupType.type_id,
             PerformanceNPlusOneGroupType.type_id,
         }


### PR DESCRIPTION
Adds support for both the new and old category mappings when searching issues. For example, `issue.category:performance` will still return the same issues, but `issue.category:performance_regression` will return a subset of the former.  This allows us to slowly roll out the new categories and defer migrating the old search values until later on.

![CleanShot 2025-04-23 at 18 34 37](https://github.com/user-attachments/assets/2d67c326-e282-4060-bba7-aad33d2b043e)
