### PR TITLE
fix(nav): Slim down primary nav bar by 4px

### DIFF
--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -1,4 +1,4 @@
 export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
 
-export const PRIMARY_SIDEBAR_WIDTH = 78;
+export const PRIMARY_SIDEBAR_WIDTH = 74;
 export const SECONDARY_SIDEBAR_WIDTH = 190;

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -18,6 +18,7 @@ import {withChonk} from 'sentry/utils/theme/withChonk';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {PRIMARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import {NavLayout} from 'sentry/views/nav/types';
 import {isLinkActive} from 'sentry/views/nav/utils';
@@ -263,8 +264,6 @@ const baseNavItemStyles = (p: {isMobile: boolean; theme: Theme}) => css`
     padding: ${space(1)} 0;
     min-height: 42px;
     width: 46px;
-    letter-spacing: -0.02em;
-    font-size: 10px;
   `}
 `;
 
@@ -307,6 +306,7 @@ const NavLinkLabel = styled('div')`
   justify-content: center;
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-weight: ${p => p.theme.fontWeightBold};
+  letter-spacing: -0.05em;
 `;
 
 const ChonkNavLink = chonkStyled(Link, {
@@ -393,9 +393,10 @@ const StyledNavLink = styled(Link, {
   ${p =>
     !p.isMobile &&
     css`
-      width: 56px;
-      padding-top: ${space(0.75)};
-      padding-bottom: ${space(1.5)};
+      width: ${PRIMARY_SIDEBAR_WIDTH - 8}px;
+      padding-top: ${space(0.5)};
+      padding-bottom: ${space(1)};
+      gap: ${space(0.5)};
 
       &:hover {
         ${NavLinkIconContainer} {


### PR DESCRIPTION
Small difference but should hopefully make the nav a little better since we expanded it to fit "Dashboards"

Before/after:

<img src="https://github.com/user-attachments/assets/b7b33a94-47a7-4c4b-a0ed-9f013b6c032f" height="700" />
<img src="https://github.com/user-attachments/assets/b8dd3c49-dfce-449c-9fcc-89ef0599fa6a" height="700" />
