### PR TITLE
fix(taskworker): Add helper functions to allow JSON encoding EmailMultiAlternatives

### DIFF
--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -29,7 +29,7 @@ def _get_user_from_email(group: Group, email: str) -> RpcUser | None:
     return None
 
 
-def process_inbound_email(mailfrom: str, group_id: int, payload: str):
+def process_inbound_email(mailfrom: str, group_id: int, payload: str) -> None:
     from sentry.models.group import Group
     from sentry.web.forms import NewNoteForm
 
@@ -59,7 +59,7 @@ def process_inbound_email(mailfrom: str, group_id: int, payload: str):
         namespace=notifications_tasks,
     ),
 )
-def send_email(message: EmailMultiAlternatives | dict[str, Any]):
+def send_email(message: EmailMultiAlternatives | dict[str, Any]) -> None:
     if not isinstance(message, EmailMultiAlternatives):
         message = message_from_dict(message)
     send_messages([message])
@@ -75,7 +75,7 @@ def send_email(message: EmailMultiAlternatives | dict[str, Any]):
         namespace=notifications_control_tasks,
     ),
 )
-def send_email_control(message):
+def send_email_control(message: EmailMultiAlternatives | dict[str, Any]) -> None:
     if not isinstance(message, EmailMultiAlternatives):
         message = message_from_dict(message)
     send_messages([message])

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Any
+
+from django.core.mail import EmailMultiAlternatives
 
 from sentry.auth import access
 from sentry.models.group import Group
@@ -9,6 +12,7 @@ from sentry.taskworker.namespaces import notifications_control_tasks, notificati
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils.email import send_messages
+from sentry.utils.email.message_builder import message_from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +59,9 @@ def process_inbound_email(mailfrom: str, group_id: int, payload: str):
         namespace=notifications_tasks,
     ),
 )
-def send_email(message):
+def send_email(message: EmailMultiAlternatives | dict[str, Any]):
+    if not isinstance(message, EmailMultiAlternatives):
+        message = message_from_dict(message)
     send_messages([message])
 
 
@@ -70,4 +76,6 @@ def send_email(message):
     ),
 )
 def send_email_control(message):
+    if not isinstance(message, EmailMultiAlternatives):
+        message = message_from_dict(message)
     send_messages([message])

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -75,6 +75,25 @@ def inline_css(value: str) -> str:
     return html
 
 
+def message_to_dict(message: EmailMultiAlternatives) -> dict[str, Any]:
+    return {
+        "subject": message.subject,
+        "body": message.body,
+        "from_email": message.from_email,
+        "to": message.to,
+        "cc": message.cc,
+        "bcc": message.bcc,
+        "attachments": message.attachments,
+        "headers": message.extra_headers,
+        "reply_to": message.reply_to,
+        "alternatives": message.alternatives,
+    }
+
+
+def message_from_dict(raw: dict[str, Any]) -> EmailMultiAlternatives:
+    return EmailMultiAlternatives(**raw)
+
+
 class MessageBuilder:
     def __init__(
         self,
@@ -250,7 +269,7 @@ class MessageBuilder:
             send_email_task = send_email.delay
             if SiloMode.get_current_mode() == SiloMode.CONTROL:
                 send_email_task = send_email_control.delay
-            safe_execute(send_email_task, message=message)
+            safe_execute(send_email_task, message=message_to_dict(message))
             extra["message_id"] = message.extra_headers["Message-Id"]
             metrics.incr("email.queued", instance=self.type, skip_internal=False)
             if fmt == LoggingFormat.HUMAN:


### PR DESCRIPTION
This object is pickled and used in Celery, but needs to be JSON encodable for the taskworker. Add
helper functions that can convert the EmailMultiAlternatives class to and from a dictionary so it
can be safely passed through the taskworker.

Note that this does not encode the connections object, but that property is rebuilt on demand.