### PR TITLE
fix(taskworker) Activation headers need to be string

### DIFF
--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -151,7 +151,9 @@ class Task(Generic[P, R]):
             del headers["sentry-monitor-config"]
 
         for key, value in headers.items():
-            if not isinstance(value, (str, bytes, int, bool, float)):
+            if value is None or isinstance(value, (str, bytes, int, bool, float)):
+                headers[key] = str(value)
+            else:
                 raise ValueError(
                     "Only scalar header values are supported. "
                     f"The `{key}` header value is of type {type(value)}"

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -240,7 +240,7 @@ def test_create_activation_tracing(task_namespace: TaskNamespace) -> None:
     assert "baggage" in headers
 
 
-def test_create_activation_headers(task_namespace: TaskNamespace) -> None:
+def test_create_activation_tracing_headers(task_namespace: TaskNamespace) -> None:
     @task_namespace.register(name="test.parameters")
     def with_parameters(one: str, two: int, org_id: int) -> None:
         raise NotImplementedError
@@ -254,6 +254,26 @@ def test_create_activation_headers(task_namespace: TaskNamespace) -> None:
     assert headers["sentry-trace"]
     assert "baggage" in headers
     assert headers["key"] == "value"
+
+
+def test_create_activation_headers_scalars(task_namespace: TaskNamespace) -> None:
+    @task_namespace.register(name="test.parameters")
+    def with_parameters(one: str, two: int, org_id: int) -> None:
+        raise NotImplementedError
+
+    headers = {
+        "str": "value",
+        "int": 22,
+        "float": 3.14,
+        "bool": False,
+        "none": None,
+    }
+    activation = with_parameters.create_activation(["one", 22], {"org_id": 99}, headers)
+    assert activation.headers["str"] == "value"
+    assert activation.headers["int"] == "22"
+    assert activation.headers["float"] == "3.14"
+    assert activation.headers["bool"] == "False"
+    assert activation.headers["none"] == "None"
 
 
 def test_create_activation_headers_nested(task_namespace: TaskNamespace) -> None:


### PR DESCRIPTION
While celery supports all data types in headers (because of pickle), the protobuf's for TaskActivations only support str values. By casting all header values to str() we can accept more variety in header values.

Fixes SENTRY-FOR-SENTRY-AR2
