### PR TITLE
fix(analytics?): fix getting id when default_user is None for analytics

### DIFF
--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -196,7 +196,7 @@ def record_issue_assigned(project, group, user, **kwargs):
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.get_default_owner().id
+        default_user_id = project.organization.default_owner_id or "unknown"
     analytics.record(
         "issue.assigned",
         user_id=user_id,
@@ -227,7 +227,7 @@ def record_issue_resolved(organization_id, project, group, user, resolution_type
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.get_default_owner().id
+        default_user_id = project.organization.default_owner_id or "unknown"
 
     analytics.record(
         "issue.resolved",
@@ -248,7 +248,7 @@ def record_issue_unresolved(project, user, group, transition_type, **kwargs):
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.get_default_owner().id
+        default_user_id = project.organization.default_owner_id or "unknown"
 
     analytics.record(
         "issue.unresolved",

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -52,6 +52,8 @@ from sentry.signals import (
 from sentry.utils import metrics
 from sentry.utils.javascript import has_sourcemap
 
+UNKNOWN_DEFAULT_USER_ID = "unknown"
+
 DEFAULT_TAGS = frozenset(
     [
         "level",
@@ -196,7 +198,7 @@ def record_issue_assigned(project, group, user, **kwargs):
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.default_owner_id or "unknown"
+        default_user_id = project.organization.default_owner_id or UNKNOWN_DEFAULT_USER_ID
     analytics.record(
         "issue.assigned",
         user_id=user_id,
@@ -227,7 +229,7 @@ def record_issue_resolved(organization_id, project, group, user, resolution_type
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.default_owner_id or "unknown"
+        default_user_id = project.organization.default_owner_id or UNKNOWN_DEFAULT_USER_ID
 
     analytics.record(
         "issue.resolved",
@@ -248,7 +250,7 @@ def record_issue_unresolved(project, user, group, transition_type, **kwargs):
         user_id = default_user_id = user.id
     else:
         user_id = None
-        default_user_id = project.organization.default_owner_id or "unknown"
+        default_user_id = project.organization.default_owner_id or UNKNOWN_DEFAULT_USER_ID
 
     analytics.record(
         "issue.unresolved",

--- a/tests/sentry/receivers/test_signals.py
+++ b/tests/sentry/receivers/test_signals.py
@@ -2,7 +2,15 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
-from sentry.signals import issue_mark_reviewed, issue_unignored, issue_update_priority
+from sentry.models.groupassignee import GroupAssignee
+from sentry.signals import (
+    issue_assigned,
+    issue_mark_reviewed,
+    issue_resolved,
+    issue_unignored,
+    issue_unresolved,
+    issue_update_priority,
+)
 from sentry.testutils.cases import SnubaTestCase, TestCase
 
 
@@ -66,4 +74,143 @@ class SignalsTest(TestCase, SnubaTestCase):
             reason="reason",
             issue_category="error",
             issue_type="error",
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_resolved_with_default_owner(self, mock_record):
+        """Test analytics is called with default owner ID when no user is provided"""
+
+        issue_resolved.send(
+            organization_id=self.organization.id,
+            project=self.project,
+            group=self.group,
+            user=None,
+            resolution_type="now",
+            sender=type(self.project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.resolved",
+            user_id=None,
+            project_id=self.project.id,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            group_id=self.group.id,
+            resolution_type="now",
+            issue_type="error",
+            issue_category="error",
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_resolved_without_default_owner(self, mock_record):
+        """Test analytics is called with 'unknown' when no user or default owner exists"""
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        group = self.create_group(project=project)
+
+        issue_resolved.send(
+            organization_id=organization.id,
+            project=project,
+            group=group,
+            user=None,
+            resolution_type="now",
+            sender=type(project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.resolved",
+            user_id=None,
+            project_id=project.id,
+            default_user_id="unknown",
+            organization_id=organization.id,
+            group_id=group.id,
+            resolution_type="now",
+            issue_type="error",
+            issue_category="error",
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_unresolved_with_default_owner(self, mock_record):
+        """Test analytics is called with default owner ID when no user is provided"""
+        issue_unresolved.send(
+            project=self.project,
+            group=self.group,
+            user=None,
+            transition_type="manual",
+            sender=type(self.project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.unresolved",
+            user_id=None,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            group_id=self.group.id,
+            transition_type="manual",
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_unresolved_without_default_owner(self, mock_record):
+        """Test analytics is called with 'unknown' when no user or default owner exists"""
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        group = self.create_group(project=project)
+
+        issue_unresolved.send(
+            project=project,
+            group=group,
+            user=None,
+            transition_type="manual",
+            sender=type(project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.unresolved",
+            user_id=None,
+            default_user_id="unknown",
+            organization_id=organization.id,
+            group_id=group.id,
+            transition_type="manual",
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_assigned_with_default_owner(self, mock_record):
+        """Test analytics is called with default owner ID when no user is provided"""
+        GroupAssignee.objects.create(
+            group_id=self.group.id, user_id=self.owner.id, project_id=self.project.id
+        )
+        issue_assigned.send(
+            project=self.project,
+            group=self.group,
+            user=None,
+            transition_type="manual",
+            sender=type(self.project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.assigned",
+            user_id=None,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            group_id=self.group.id,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_issue_assigned_without_default_owner(self, mock_record):
+        """Test analytics is called with 'unknown' when no user or default owner exists"""
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        group = self.create_group(project=project)
+        GroupAssignee.objects.create(
+            group_id=group.id, user_id=self.owner.id, project_id=project.id
+        )
+
+        issue_assigned.send(
+            project=project,
+            group=group,
+            user=None,
+            transition_type="manual",
+            sender=type(project),
+        )
+        mock_record.assert_called_once_with(
+            "issue.assigned",
+            user_id=None,
+            default_user_id="unknown",
+            organization_id=organization.id,
+            group_id=group.id,
         )


### PR DESCRIPTION
From the sending out[ issue_X signals on 3p issue updating PR](https://github.com/getsentry/sentry/pull/89877#discussion_r2056940879). Since these receivers are also fired and we're also emitting with a None user, make sure they don't fail.