### PR TITLE
Feat(jira-server): Adds new tabs for user-mapping integration feature

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -443,17 +443,15 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     const hasCodeOwners =
       provider!.features.includes('codeowners') &&
       organization.features.includes('integrations-codeowners');
+    const hasUserMapping = provider!.features.includes('user-mapping');
 
-    // if no code mappings, render the single tab
-    if (!hasStacktraceLinking) {
-      return renderMainTab();
-    }
-
-    // otherwise render the tab view
-    const tabs: Array<[Tab, string]> = [
-      ['repos', t('Repositories')],
-      ['codeMappings', t('Code Mappings')],
-    ];
+    const tabs: Array<[Tab, string]> = [];
+    const stackTraceLinkingTabs: Array<[Tab, string]> = hasStacktraceLinking
+      ? [
+          ['repos', t('Repositories')],
+          ['codeMappings', t('Code Mappings')],
+        ]
+      : [];
 
     const codeOwnerTabs: Array<[Tab, string]> = hasCodeOwners
       ? [
@@ -462,7 +460,23 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
         ]
       : [];
 
-    const allTabs = tabs.concat(codeOwnerTabs);
+    // User mappings are mutually exclusive with stacktrace linking
+    // and code owners, so only render the main settings tab and user mappings.
+    const userMappingTabs: Array<[Tab, string]> = hasUserMapping
+      ? [
+          ['repos', t('Settings')],
+          ['userMappings', t('User Mappings')],
+        ]
+      : [];
+
+    const allTabs = tabs
+      .concat(stackTraceLinkingTabs)
+      .concat(codeOwnerTabs)
+      .concat(userMappingTabs);
+
+    if (allTabs.length === 0) {
+      return renderMainTab();
+    }
 
     return (
       <Fragment>


### PR DESCRIPTION
UI changes for #90026

## Changes
- Adds handling for `user-mapping` integration feature, which renders the `User Mapping` tab, along with a main `Settings` tab
- Minor refactors for tab rendering for `stacktrace-link` and `codeowners` features.

## Screenshots
### Settings Tab
<img width="1525" alt="Screenshot 2025-04-24 at 2 42 56 PM" src="https://github.com/user-attachments/assets/cf4bf75c-6977-420e-b178-d630c9874b13" />

### User Mappings Tab
<img width="1835" alt="Screenshot 2025-04-24 at 3 03 06 PM" src="https://github.com/user-attachments/assets/45aa04dd-c2d9-48ae-b792-f0c6557cca63" />

### Stacktrace Linking Integration [No Visual Changes]
<img width="1442" alt="Screenshot 2025-04-24 at 2 42 36 PM" src="https://github.com/user-attachments/assets/76e04d6e-fbc8-4740-bec1-d63cd1741b19" />


