### PR TITLE
:wrench: chore(aci): use open periods for links in metric alert links

### DIFF
--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -14,7 +14,7 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group, GroupStatus
-from sentry.models.groupopenperiod import GroupOpenPeriod, get_open_periods_for_group
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
@@ -180,10 +180,9 @@ class MetricIssueContext:
         if occurrence is None:
             raise ValueError("Occurrence is required for alert context")
 
-        open_periods = get_open_periods_for_group(group, limit=1)
-        if len(open_periods) == 0:
+        open_period = GroupOpenPeriod.objects.filter(group=group).order_by("-date_started").first()
+        if open_period is None:
             raise ValueError("No open periods found for group")
-        open_period = open_periods[0]
 
         return cls(
             # TODO(iamrajjoshi): Replace with something once we know how we want to build the link

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -221,7 +221,7 @@ def incident_attachment_info(
 
     if features.has("organizations:workflow-engine-trigger-actions", organization):
         try:
-            alert_rule_detector = AlertRuleDetector.objects.get(
+            alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector_id=alert_context.action_identifier_id
             )
         except AlertRuleDetector.DoesNotExist:
@@ -238,13 +238,13 @@ def incident_attachment_info(
 
         workflow_engine_params = title_link_params.copy()
 
-        incident = Incident.objects.get(id=open_period_incident.incident_id)
-
-        workflow_engine_params["alert"] = str(incident.identifier)
-
-        title_link = build_title_link(
-            alert_rule_detector.alert_rule_id, organization, workflow_engine_params
+        incident_identifier = Incident.objects.values_list("identifier", flat=True).get(
+            id=open_period_incident.incident_id
         )
+
+        workflow_engine_params["alert"] = str(incident_identifier)
+
+        title_link = build_title_link(alert_rule_id, organization, workflow_engine_params)
 
     elif features.has("organizations:workflow-engine-ui-links", organization):
         if metric_issue_context.group is None:

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -237,7 +237,10 @@ def incident_attachment_info(
             )
 
         workflow_engine_params = title_link_params.copy()
-        workflow_engine_params["alert"] = str(open_period_incident.incident_id)
+
+        incident = Incident.objects.get(id=open_period_incident.incident_id)
+
+        workflow_engine_params["alert"] = str(incident.identifier)
 
         title_link = build_title_link(
             alert_rule_detector.alert_rule_id, organization, workflow_engine_params

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -224,6 +224,8 @@ def incident_attachment_info(
             alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector_id=alert_context.action_identifier_id
             )
+            if alert_rule_id is None:
+                raise ValueError("Alert rule id not found when querying for AlertRuleDetector")
         except AlertRuleDetector.DoesNotExist:
             raise ValueError("Alert rule detector not found when querying for AlertRuleDetector")
 

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -146,9 +146,14 @@ class BaseIssueAlertHandler(ABC):
             if job.workflow_id == -1:
                 data["actions"][0]["legacy_rule_id"] = -1
             else:
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(
-                    workflow_id=job.workflow_id,
-                )
+                try:
+                    alert_rule_workflow = AlertRuleWorkflow.objects.get(
+                        workflow_id=job.workflow_id,
+                    )
+                except AlertRuleWorkflow.DoesNotExist:
+                    raise ValueError(
+                        "AlertRuleWorkflow not found when querying for AlertRuleWorkflow"
+                    )
 
                 if alert_rule_workflow.rule_id is None:
                     raise ValueError("Rule not found when querying for AlertRuleWorkflow")

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -93,6 +93,7 @@ from sentry.models.files.file import File
 from sentry.models.group import Group
 from sentry.models.grouphistory import GroupHistory
 from sentry.models.grouplink import GroupLink
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
@@ -183,6 +184,7 @@ from sentry.workflow_engine.models import (
     Detector,
     DetectorState,
     DetectorWorkflow,
+    IncidentGroupOpenPeriod,
     Workflow,
     WorkflowDataConditionGroup,
 )
@@ -2306,6 +2308,17 @@ class Factories:
 
         return AlertRuleWorkflow.objects.create(
             alert_rule_id=alert_rule_id, rule_id=rule_id, workflow=workflow, **kwargs
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_incident_group_open_period(
+        incident: Incident,
+        group_open_period: GroupOpenPeriod,
+        **kwargs,
+    ) -> IncidentGroupOpenPeriod:
+        return IncidentGroupOpenPeriod.objects.create(
+            incident_id=incident.id, group_open_period=group_open_period, **kwargs
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -681,6 +681,10 @@ class Fixtures:
         # TODO: this is only needed during the ACI migration
         return Factories.create_alert_rule_workflow(*args, **kwargs)
 
+    def create_incident_group_open_period(self, *args, **kwargs):
+        # TODO: this is only needed during the ACI migration
+        return Factories.create_incident_group_open_period(*args, **kwargs)
+
     def create_workflow_data_condition_group(self, *args, **kwargs):
         return Factories.create_workflow_data_condition_group(*args, **kwargs)
 

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -100,7 +100,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert metric_issue_context.group is not None
 
         detector = self.create_detector(project=self.project)
-        self.create_alert_rule_detector(alert_rule_id=incident.alert_rule.id, detector=detector)
+        self.create_alert_rule_detector(alert_rule_id=alert_rule.id, detector=detector)
 
         open_period = (
             GroupOpenPeriod.objects.filter(group=self.group).order_by("-date_started").first()

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -9,6 +9,7 @@ from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRule
 from sentry.incidents.models.incident import IncidentStatus, IncidentTrigger
 from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.metric_alerts import incident_attachment_info
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, TestCase
@@ -70,6 +71,74 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         )
 
     @with_feature("organizations:workflow-engine-trigger-actions")
+    def test_returns_correct_info_with_workflow_engine_dual_write(self):
+        """
+        This tests that we lookup the correct incident and alert rule during dual write ACI migration.
+        """
+        alert_rule = self.create_alert_rule()
+        date_started = self.now
+        incident = self.create_incident(
+            self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CLOSED.value,
+            date_started=date_started,
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        metric_value = 123
+        referrer = "metric_alert_custom"
+        notification_uuid = str(uuid.uuid4())
+
+        metric_issue_context = MetricIssueContext.from_legacy_models(
+            incident, IncidentStatus.CLOSED, metric_value
+        )
+        metric_issue_context.group = self.group
+        assert metric_issue_context.group is not None
+
+        detector = self.create_detector(project=self.project)
+        self.create_alert_rule_detector(alert_rule_id=incident.alert_rule.id, detector=detector)
+
+        open_period = (
+            GroupOpenPeriod.objects.filter(group=self.group).order_by("-date_started").first()
+        )
+        assert open_period is not None
+        self.create_incident_group_open_period(incident, open_period)
+
+        data = incident_attachment_info(
+            organization=incident.organization,
+            alert_context=AlertContext(
+                name=alert_rule.name,
+                # Setting the action identifier id to the detector id since that's what the NOA does
+                action_identifier_id=detector.id,
+                threshold_type=AlertRuleThresholdType(alert_rule.threshold_type),
+                detection_type=AlertRuleDetectionType(alert_rule.detection_type),
+                comparison_delta=alert_rule.comparison_delta,
+                sensitivity=alert_rule.sensitivity,
+                resolve_threshold=alert_rule.resolve_threshold,
+                alert_threshold=None,
+            ),
+            metric_issue_context=metric_issue_context,
+            notification_uuid=notification_uuid,
+            referrer=referrer,
+        )
+
+        assert data["title"] == f"Resolved: {alert_rule.name}"
+        assert data["status"] == "Resolved"
+        assert data["text"] == "123 events in the last 10 minutes"
+        # We still build the link using the alert_rule_id and the incident identifier
+        assert (
+            data["title_link"]
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer={referrer}&detection_type=static&notification_uuid={notification_uuid}"
+        )
+        assert (
+            data["logo_url"]
+            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
+        )
+
     @with_feature("organizations:workflow-engine-ui-links")
     def test_returns_correct_info_with_workflow_engine_ui_links(self):
         alert_rule = self.create_alert_rule()

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -93,12 +93,6 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         referrer = "metric_alert_custom"
         notification_uuid = str(uuid.uuid4())
 
-        metric_issue_context = MetricIssueContext.from_legacy_models(
-            incident, IncidentStatus.CLOSED, metric_value
-        )
-        metric_issue_context.group = self.group
-        assert metric_issue_context.group is not None
-
         detector = self.create_detector(project=self.project)
         self.create_alert_rule_detector(alert_rule_id=alert_rule.id, detector=detector)
 
@@ -107,6 +101,14 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         )
         assert open_period is not None
         self.create_incident_group_open_period(incident, open_period)
+
+        metric_issue_context = MetricIssueContext.from_legacy_models(
+            incident, IncidentStatus.CLOSED, metric_value
+        )
+        # Setting the open period identifier to the open period id, since we are testing the lookup
+        metric_issue_context.open_period_identifier = open_period.id
+        metric_issue_context.group = self.group
+        assert metric_issue_context.group is not None
 
         data = incident_attachment_info(
             organization=incident.organization,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -107,7 +107,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -112,7 +112,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -108,7 +108,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -104,7 +104,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -102,7 +102,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -115,7 +115,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             title=self.group_event.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -110,7 +110,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
 
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -230,6 +230,13 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
                 },
             ),
         )
+        self.group.priority = PriorityLevel.HIGH.value
+        self.group.save()
+        self.open_period, _ = GroupOpenPeriod.objects.get_or_create(
+            group=self.group,
+            project=self.project,
+            date_started=self.group_event.group.first_seen,
+        )
         self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         self.handler = TestHandler()
 
@@ -380,7 +387,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         )
         self.assert_metric_issue_context(
             metric_issue_context,
-            open_period_identifier=self.group_event.group.id,
+            open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
             new_status=IncidentStatus.CRITICAL,
             metric_value=123.45,


### PR DESCRIPTION
starting to fixing up some TODOs left in NOA.

Here, i get the open_period correctly and use it to render links correctly.

during aci dual write, we will look up incident and alert rule to build the legacy links correctly
