### PR TITLE
ref(shared-views): Make new view have copy and starred by default

### DIFF
--- a/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.spec.tsx
@@ -104,7 +104,7 @@ describe('CreateIssueViewModal', function () {
           },
           query: 'is:unresolved foo',
           querySort: IssueSortOptions.TRENDS,
-          starred: false,
+          starred: true,
         },
       })
     );

--- a/static/app/views/issueList/issueViews/createIssueViewModal.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.tsx
@@ -78,7 +78,7 @@ export function CreateIssueViewModal({
       period: '14d',
       utc: null,
     },
-    starred: false,
+    starred: true,
   };
 
   return (

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
@@ -103,7 +103,7 @@ describe('IssueViewSaveButton', function () {
           projects: [1],
           environments: ['prod'],
           timeFilters: {period: '7d', utc: null, start: null, end: null},
-          starred: false,
+          starred: true,
         },
       })
     );
@@ -138,7 +138,7 @@ describe('IssueViewSaveButton', function () {
 
     const nameInput = within(modal).getByRole('textbox', {name: 'Name'});
 
-    expect(nameInput).toHaveValue(mockGroupSearchView.name);
+    expect(nameInput).toHaveValue(`${mockGroupSearchView.name} (Copy)`);
     await userEvent.clear(nameInput);
     await userEvent.type(nameInput, 'My View');
 
@@ -158,7 +158,7 @@ describe('IssueViewSaveButton', function () {
           projects: [1],
           environments: ['prod'],
           timeFilters: {period: '7d', utc: null, start: null, end: null},
-          starred: false,
+          starred: true,
         },
       })
     );
@@ -248,7 +248,7 @@ describe('IssueViewSaveButton', function () {
 
     const nameInput = within(modal).getByRole('textbox', {name: 'Name'});
 
-    expect(nameInput).toHaveValue(mockGroupSearchView.name);
+    expect(nameInput).toHaveValue(`${mockGroupSearchView.name} (Copy)`);
     await userEvent.clear(nameInput);
     await userEvent.type(nameInput, 'My View');
 
@@ -268,7 +268,7 @@ describe('IssueViewSaveButton', function () {
           projects: [1],
           environments: ['prod'],
           timeFilters: {period: '7d', utc: null, start: null, end: null},
-          starred: false,
+          starred: true,
         },
       })
     );

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -121,7 +121,7 @@ export function IssueViewSaveButton({query, sort}: IssueViewSaveButtonProps) {
     openModal(props => (
       <CreateIssueViewModal
         {...props}
-        name={view ? `${view.name} (Copy)` : 'New View'}
+        name={view ? `${view.name} (Copy)` : undefined}
         query={query}
         querySort={sort}
         projects={selection.projects}

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -121,7 +121,7 @@ export function IssueViewSaveButton({query, sort}: IssueViewSaveButtonProps) {
     openModal(props => (
       <CreateIssueViewModal
         {...props}
-        name={view?.name}
+        name={view ? `${view.name} (Copy)` : 'New View'}
         query={query}
         querySort={sort}
         projects={selection.projects}


### PR DESCRIPTION
This PR...

1. Appends "(Copy) to the default name for a duplicated view 
2. Makes views starred by default 