### PR TITLE
ref(✂️): remove unused Component Hooks

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -7,7 +7,6 @@ import type {ProductSelectionProps} from 'sentry/components/onboarding/productSe
 import type SidebarItem from 'sentry/components/sidebar/sidebarItem';
 import type DateRange from 'sentry/components/timeRangeSelector/dateRange';
 import type SelectorItems from 'sentry/components/timeRangeSelector/selectorItems';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import type {UseExperiment} from 'sentry/utils/useExperiment';
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
@@ -91,8 +90,6 @@ type DisabledMemberTooltipProps = {children: React.ReactNode};
 
 type DashboardHeadersProps = {organization: Organization};
 
-type MetricsSamplesListProps = {children: React.ReactNode; organization: Organization};
-
 type ReplayFeedbackButton = {children: React.ReactNode};
 type ReplayListPageHeaderProps = {children?: React.ReactNode};
 type ReplayOnboardingAlertProps = {children: React.ReactNode};
@@ -104,17 +101,6 @@ type ProfilingBetaAlertBannerProps = {
 };
 
 type ContinuousProfilingBetaAlertBannerProps = {
-  organization: Organization;
-};
-
-type ProfilingUpgradePlanButtonProps = ButtonProps & {
-  children: React.ReactNode;
-  fallback: React.ReactNode;
-  organization: Organization;
-};
-
-type ProfilingAM1OrMMXUpgradeProps = {
-  fallback: React.ReactNode;
   organization: Organization;
 };
 
@@ -153,9 +139,6 @@ type MonitorCreatedCallback = (organization: Organization) => void;
 
 type CronsOnboardingPanelProps = {children: React.ReactNode};
 
-type SentryLogoProps = SVGIconProps & {
-  pride?: boolean;
-};
 export type ParntershipAgreementType = 'standard' | 'partner_presence';
 export type PartnershipAgreementProps = {
   agreements: ParntershipAgreementType[];
@@ -187,7 +170,6 @@ type ComponentHooks = {
   'component:data-consent-banner': () => React.ComponentType<{source: string}> | null;
   'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
   'component:data-consent-priority-learn-more': () => React.ComponentType | null;
-  'component:ddm-metrics-samples-list': () => React.ComponentType<MetricsSamplesListProps>;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
   'component:disabled-member': () => React.ComponentType<DisabledMemberViewProps>;
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
@@ -205,15 +187,12 @@ type ComponentHooks = {
   'component:partnership-agreement': React.ComponentType<PartnershipAgreementProps>;
   'component:product-selection-availability': () => React.ComponentType<ProductSelectionAvailabilityProps>;
   'component:product-unavailable-cta': () => React.ComponentType<ProductUnavailableCTAProps>;
-  'component:profiling-am1-or-mmx-upgrade': () => React.ComponentType<ProfilingAM1OrMMXUpgradeProps>;
   'component:profiling-billing-banner': () => React.ComponentType<ProfilingBetaAlertBannerProps>;
-  'component:profiling-upgrade-plan-button': () => React.ComponentType<ProfilingUpgradePlanButtonProps>;
   'component:replay-feedback-button': () => React.ComponentType<ReplayFeedbackButton>;
   'component:replay-list-page-header': () => React.ComponentType<ReplayListPageHeaderProps> | null;
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:replay-settings-alert': () => React.ComponentType | null;
-  'component:sentry-logo': () => React.ComponentType<SentryLogoProps>;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;
   'component:superuser-warning-excluded': SuperuserWarningExcluded;

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
-import type {ButtonProps} from 'sentry/components/core/button';
 import {Button} from 'sentry/components/core/button';
 import {IconClose, IconInfo, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -259,113 +258,6 @@ function ProfilingBetaAlertBannerComponent(props: ProfilingBetaAlertBannerProps)
 export const ProfilingBetaAlertBanner = withSubscription(
   ProfilingBetaAlertBannerComponent,
   {noLoader: true}
-);
-
-type UpgradePlanButtonProps = ButtonProps & {
-  children: React.ReactNode;
-  fallback: React.ReactNode;
-  organization: Organization;
-  subscription: Subscription;
-};
-
-const hidePromptTiers: string[] = [PlanTier.AM2, PlanTier.AM3];
-
-function UpgradePlanButton(props: UpgradePlanButtonProps) {
-  const {subscription, organization, ...buttonProps} = props;
-
-  if (hidePromptTiers.includes(subscription.planTier)) {
-    return <Fragment>{props.fallback}</Fragment>;
-  }
-
-  const userCanUpgradePlan = organization.access?.includes('org:billing');
-
-  if (subscription.canSelfServe) {
-    if (userCanUpgradePlan) {
-      return (
-        <Button
-          {...buttonProps}
-          onClick={evt => {
-            openAM2ProfilingUpsellModal({
-              organization,
-              subscription,
-            });
-            trackOpenModal({organization, subscription});
-            props.onClick?.(evt);
-          }}
-        >
-          {t('Update Plan')}
-        </Button>
-      );
-    }
-    return (
-      <Button
-        {...buttonProps}
-        to={makeLinkToOwnersAndBillingMembers(
-          organization,
-          `profiling_onboard_${
-            subscription.planTier === PlanTier.AM1 ? 'am1' : 'mmx'
-          }-alert`
-        )}
-        onClick={() => trackManageSubscriptionClicked({organization, subscription})}
-      >
-        {t('See who can update')}
-      </Button>
-    );
-  }
-  return (
-    <Button
-      {...buttonProps}
-      to={`/settings/${organization.slug}/billing/overview/?referrer=profiling_onboard_${
-        subscription.planTier === PlanTier.AM1 ? 'am1' : 'mmx'
-      }-alert`}
-      onClick={() => trackManageSubscriptionClicked({organization, subscription})}
-    >
-      {t('Manage subscription')}
-    </Button>
-  );
-}
-
-export const ProfilingUpgradePlanButton = withSubscription(UpgradePlanButton, {
-  noLoader: true,
-});
-
-interface ProfilingAM1OrMMXUpgradeProps {
-  fallback: React.ReactNode;
-  organization: Organization;
-  subscription: Subscription;
-}
-
-function ProfilingAM1OrMMXUpgradeComponent({
-  organization,
-  subscription,
-  fallback,
-}: ProfilingAM1OrMMXUpgradeProps) {
-  if (hidePromptTiers.includes(subscription.planTier)) {
-    return <Fragment>{fallback}</Fragment>;
-  }
-
-  const userCanUpgradePlan = organization.access?.includes('org:billing');
-  return (
-    <Fragment>
-      <h3>{t('Function level insights')}</h3>
-      <p>
-        {userCanUpgradePlan
-          ? t(
-              'Discover slow-to-execute or resource intensive functions within your application. To access profiling, please update to the latest version of your plan.'
-            )
-          : t(
-              'Discover slow-to-execute or resource intensive functions within your application. To access profiling, please request your account owner to update to the latest version of your plan.'
-            )}
-      </p>
-    </Fragment>
-  );
-}
-
-export const ProfilingAM1OrMMXUpgrade = withSubscription(
-  ProfilingAM1OrMMXUpgradeComponent,
-  {
-    noLoader: true,
-  }
 );
 
 interface ContinuousProfilingBetaAlertBannerInner {

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -77,9 +77,7 @@ import OpenInDiscoverBtn from './components/openInDiscoverBtn';
 import {
   ContinuousProfilingBetaAlertBanner,
   ContinuousProfilingBetaSDKAlertBanner,
-  ProfilingAM1OrMMXUpgrade,
   ProfilingBetaAlertBanner,
-  ProfilingUpgradePlanButton,
 } from './components/profiling/alerts';
 import ReplayOnboardingAlert from './components/replayOnboardingAlert';
 import ReplaySettingsAlert from './components/replaySettingsAlert';
@@ -239,8 +237,6 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:replay-settings-alert': () => ReplaySettingsAlert,
   'component:product-unavailable-cta': () => ProductUnavailableCTA,
   'component:profiling-billing-banner': () => ProfilingBetaAlertBanner,
-  'component:profiling-upgrade-plan-button': () => ProfilingUpgradePlanButton,
-  'component:profiling-am1-or-mmx-upgrade': () => ProfilingAM1OrMMXUpgrade,
   'component:product-selection-availability': () => ProductSelectionAvailability,
   'component:superuser-access-category': SuperuserAccessCategory,
   'component:superuser-warning': p => <SuperuserWarning {...p} />,


### PR DESCRIPTION
These two hooks were registered:

```
'component:profiling-upgrade-plan-button': () => ProfilingUpgradePlanButton,
'component:profiling-am1-or-mmx-upgrade': () => ProfilingAM1OrMMXUpgrade,
```

but the hook itself was never consumed anywhere in the application, which means it can’t show up in the UI. So this PR removes those hooks and the associated components.