### PR TITLE
feat(schema-hints): Auto focus search on drawer open

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -176,6 +176,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
               onChange={e => setSearchQuery(e.target.value)}
               aria-label={t('Search attributes')}
               placeholder={t('Search')}
+              autoFocus
             />
           </StyledInputGroup>
         </HeaderContainer>


### PR DESCRIPTION
Adds autoFocus prop to the drawer search bar so users can type as soon as they open the drawer