### PR TITLE
feat(billing): add legacy label to profiles

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -15,7 +15,7 @@ import {OrganizationStats, PAGE_QUERY_PARAMS} from 'sentry/views/organizationSta
 
 import {ChartDataTransform} from './usageChart';
 
-describe('OrganizationStats', function () {
+describe('OrganizationStats', () => {
   const defaultSelection: PageFilters = {
     projects: [],
     environments: [],
@@ -449,7 +449,30 @@ describe('OrganizationStats', function () {
       screen.getByRole('option', {name: 'Continuous Profile Hours'})
     ).toBeInTheDocument();
     // Should show Profiles (transaction) option
+    expect(screen.getByRole('option', {name: 'Profiles (legacy)'})).toBeInTheDocument();
+  });
+
+  it('shows both profile hours without continuous-profiling feature', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />);
+
+    await userEvent.click(await screen.findByText('Category'));
+
+    // shows Profiles option
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
+
+    // does not show continuous profiling
+    expect(
+      screen.queryByRole('option', {name: 'Continuous Profile Hours'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: 'Profiles (legacy)'})
+    ).not.toBeInTheDocument();
   });
 
   it('shows only profile duration category when both profiling features are enabled', async () => {
@@ -495,7 +518,7 @@ describe('OrganizationStats', function () {
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
   });
 
-  it('denies access on no projects', async function () {
+  it('denies access on no projects', async () => {
     act(() => ProjectsStore.loadInitialData([]));
 
     render(<OrganizationStats {...defaultProps} />);
@@ -529,7 +552,7 @@ describe('OrganizationStats', function () {
     ).toBeInTheDocument();
   });
 
-  it('denies access without project membership', async function () {
+  it('denies access without project membership', async () => {
     const newOrg = initializeOrg({
       organization: {
         openMembership: false,

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -254,6 +254,11 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
 
+    const hasProfiling = organization.features.includes('continuous-profiling');
+    const hasProfilingStats = organization.features.includes(
+      'continuous-profiling-stats'
+    );
+
     const options = CHART_OPTIONS_DATACATEGORY.filter(opt => {
       if (isSelfHostedErrorsOnly) {
         return opt.value === DATA_CATEGORY_INFO.error.plural;
@@ -277,15 +282,20 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         DATA_CATEGORY_INFO.profileDuration.plural === opt.value ||
         DATA_CATEGORY_INFO.profileDurationUI.plural === opt.value
       ) {
-        return (
-          organization.features.includes('continuous-profiling-stats') ||
-          organization.features.includes('continuous-profiling')
-        );
+        return hasProfiling || hasProfilingStats;
       }
       if (DATA_CATEGORY_INFO.profile.plural === opt.value) {
-        return !organization.features.includes('continuous-profiling-stats');
+        return !hasProfilingStats;
       }
       return true;
+    }).map(opt => {
+      if (
+        (hasProfiling || hasProfilingStats) &&
+        DATA_CATEGORY_INFO.profile.plural === opt.value
+      ) {
+        return {...opt, label: `${opt.label} (legacy)`};
+      }
+      return opt;
     });
 
     return (


### PR DESCRIPTION
Add "legacy" to transaction profiles label for customers with continuous profiling.

See: https://linear.app/getsentry/issue/BIL-496/org-stats-should-inform-customers-how-to-migrate-to-new-sdk
