### PR TITLE
chore(perf-issues): Remove unused detector

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -20,7 +20,6 @@ class DetectorType(Enum):
     SLOW_DB_QUERY = "slow_db_query"
     RENDER_BLOCKING_ASSET_SPAN = "render_blocking_assets"
     N_PLUS_ONE_DB_QUERIES = "n_plus_one_db"
-    N_PLUS_ONE_DB_QUERIES_EXTENDED = "n_plus_one_db_ext"
     N_PLUS_ONE_API_CALLS = "n_plus_one_api_calls"
     CONSECUTIVE_DB_OP = "consecutive_db"
     CONSECUTIVE_HTTP_OP = "consecutive_http"
@@ -35,7 +34,6 @@ class DetectorType(Enum):
 # Detector and the corresponding system option must be added to this list to have issues created.
 DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION = {
     DetectorType.N_PLUS_ONE_DB_QUERIES: "performance.issues.n_plus_one_db.problem-creation",
-    DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: "performance.issues.n_plus_one_db_ext.problem-creation",
     DetectorType.CONSECUTIVE_DB_OP: "performance.issues.consecutive_db.problem-creation",
     DetectorType.CONSECUTIVE_HTTP_OP: "performance.issues.consecutive_http.flag_disabled",
     DetectorType.LARGE_HTTP_PAYLOAD: "performance.issues.large_http_payload.flag_disabled",

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -266,31 +266,6 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         return f"1-{problem_class}-{full_fingerprint}"
 
 
-class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
-    """
-    Detector goals:
-    - Extend N+1 DB Detector to make it compatible with more frameworks.
-    """
-
-    type = DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED
-
-    __slots__ = (
-        "stored_problems",
-        "potential_parents",
-        "source_span",
-        "n_hash",
-        "n_spans",
-    )
-
-    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        # Only collecting metrics.
-        return False
-
-    def is_creation_allowed_for_project(self, project: Project | None) -> bool:
-        # Only collecting metrics.
-        return False
-
-
 def contains_complete_query(span: Span, is_source: bool | None = False) -> bool:
     # Remove the truncation check from the n_plus_one db detector.
     query = span.get("description", None)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -30,10 +30,7 @@ from .detectors.io_main_thread_detector import DBMainThreadDetector, FileIOMainT
 from .detectors.large_payload_detector import LargeHTTPPayloadDetector
 from .detectors.mn_plus_one_db_span_detector import MNPlusOneDBSpanDetector
 from .detectors.n_plus_one_api_calls_detector import NPlusOneAPICallsDetector
-from .detectors.n_plus_one_db_span_detector import (
-    NPlusOneDBSpanDetector,
-    NPlusOneDBSpanDetectorExtended,
-)
+from .detectors.n_plus_one_db_span_detector import NPlusOneDBSpanDetector
 from .detectors.render_blocking_asset_span_detector import RenderBlockingAssetSpanDetector
 from .detectors.slow_db_query_detector import SlowDBQueryDetector
 from .detectors.uncompressed_asset_detector import UncompressedAssetSpanDetector
@@ -246,10 +243,6 @@ def get_detection_settings(project_id: int | None = None) -> dict[DetectorType, 
             "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
             "detection_enabled": settings["n_plus_one_db_queries_detection_enabled"],
         },
-        DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: {
-            "count": settings["n_plus_one_db_count"],
-            "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
-        },
         DetectorType.CONSECUTIVE_DB_OP: {
             # time saved by running all queries in parallel
             "min_time_saved": settings["consecutive_db_min_time_saved_threshold"],  # ms
@@ -322,7 +315,6 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
     SlowDBQueryDetector,
     RenderBlockingAssetSpanDetector,
     NPlusOneDBSpanDetector,
-    NPlusOneDBSpanDetectorExtended,
     FileIOMainThreadDetector,
     NPlusOneAPICallsDetector,
     NPlusOneAPICallsExperimentalDetector,

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -408,18 +408,18 @@ class PerformanceDetectionTest(TestCase):
         assert_n_plus_one_db_problem(perf_problems)
 
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
-    def test_detects_multiple_performance_issues_in_n_plus_one_query(self):
+    def test_detects_performance_issues_in_n_plus_one_query(self):
         n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 8
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
                     "_pi_all_issue_count",
-                    2,
+                    len(perf_problems),
                 ),
                 call(
                     "_pi_sdk_name",
@@ -435,11 +435,6 @@ class PerformanceDetectionTest(TestCase):
                     "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 ),
                 call("_pi_n_plus_one_db", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_ext_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
             ],
         )
         assert_n_plus_one_db_problem(perf_problems)


### PR DESCRIPTION
The `NPlusOneDBSpanDetectorExtended`  didn't seem to be implemented. Removing an unregistering the settings.
