### PR TITLE
fix(aci): issue alert migration / dual write logic fixes

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -197,9 +197,7 @@ def create_issue_category_data_condition(
 def create_issue_occurrences_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
-    comparison = {
-        "value": int(data["value"]),
-    }
+    comparison = {"value": max(int(data["value"]), 0)}
 
     return DataConditionKwargs(
         type=Condition.ISSUE_OCCURRENCES,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -204,7 +204,10 @@ class IssueAlertMigrator:
         no_conditions = len(conditions) == 0
         no_data_conditions = len(data_conditions) == 0
         only_has_every_event_cond = (
-            len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+            len(
+                [condition for condition in conditions if condition["id"] == EveryEventCondition.id]
+            )
+            > 0
         )
 
         if not self.is_dry_run:

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -39,7 +39,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
 
     def test_dual_write__min_zero(self):
         dcg = self.create_data_condition_group()
-        self.payload["value"] = -10
+        self.payload["value"] = "-10"
         dc = self.translate_to_data_condition(self.payload, dcg)
 
         assert dc.type == self.condition

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -37,6 +37,18 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+    def test_dual_write__min_zero(self):
+        dcg = self.create_data_condition_group()
+        self.payload["value"] = -10
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "value": 0,
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
     def test_json_schema(self):
         self.dc.comparison.update({"value": 2000})
         self.dc.save()

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -342,6 +342,7 @@ class IssueAlertMigratorTest(TestCase):
     def test_run__every_event_condition__any(self):
         conditions = [
             {"id": EveryEventCondition.id},
+            {"id": EveryEventCondition.id},
             {"id": RegressionEventCondition.id},
         ]
         issue_alert = self.create_project_rule(


### PR DESCRIPTION
Fixes SENTRY-3SW8

Some issue alerts have the value for issue occurrence conditions set to negative. This should be >=0.

We were also unable to migrate issue alerts with more than 1 `EveryEventCondition` (there are a handful with 2) since we assumed people would only have 1.