### PR TITLE
feat(issue-views): Immediately create issue view with create button

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2215,10 +2215,6 @@ function buildRoutes() {
           () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')
         )}
       />
-      <Route
-        path="views/new/"
-        component={make(() => import('sentry/views/issueList/pages/newViewPage'))}
-      />
       <Route path="views/:viewId/" component={errorHandler(OverviewWrapper)} />
       <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
 

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -15,7 +15,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import IssueListActions from 'sentry/views/issueList/actions';
 import AddViewPage from 'sentry/views/issueList/addViewPage';
 import GroupListBody from 'sentry/views/issueList/groupListBody';
-import {isNewViewPage} from 'sentry/views/issueList/issueViews/utils';
 import {NewViewEmptyState} from 'sentry/views/issueList/newViewEmptyState';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
@@ -72,7 +71,7 @@ function IssueListTable({
   const {newViewActive} = useContext(NewTabContext);
 
   const isNewViewEmptyStateActive =
-    isNewViewPage(location.pathname) &&
+    location.query.new === 'true' &&
     !issuesLoading &&
     !error &&
     !issuesSuccessfullyLoaded;

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
@@ -57,11 +58,18 @@ function SegmentedIssueViewSaveButton({
 
   const saveView = () => {
     if (view) {
-      updateGroupSearchView({
-        id: view.id,
-        name: view.name,
-        ...createIssueViewFromUrl({query: location.query}),
-      });
+      updateGroupSearchView(
+        {
+          id: view.id,
+          name: view.name,
+          ...createIssueViewFromUrl({query: location.query}),
+        },
+        {
+          onSuccess: () => {
+            addSuccessMessage(t('Saved changes'));
+          },
+        }
+      );
     }
   };
 

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Button, LinkButton} from 'sentry/components/core/button';
+import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -14,11 +14,18 @@ import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import {unreachable} from 'sentry/utils/unreachable';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getIssueViewQueryParams} from 'sentry/views/issueList/issueViews/getIssueViewQueryParams';
+import {
+  DEFAULT_ENVIRONMENTS,
+  DEFAULT_TIME_FILTERS,
+} from 'sentry/views/issueList/issueViews/issueViews';
 import {IssueViewsTable} from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsTable';
+import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
 import {useDeleteGroupSearchView} from 'sentry/views/issueList/mutations/useDeleteGroupSearchView';
 import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
 import type {GroupSearchViewBackendSortOption} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
@@ -31,6 +38,8 @@ import {
   GroupSearchViewCreatedBy,
   GroupSearchViewSort,
 } from 'sentry/views/issueList/types';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import useDefaultProject from 'sentry/views/nav/secondary/sections/issues/issueViews/useDefaultProject';
 
 type IssueViewSectionProps = {
   createdBy: GroupSearchViewCreatedBy;
@@ -219,6 +228,9 @@ export default function IssueViewsList() {
   const location = useLocation();
   const query = typeof location.query.query === 'string' ? location.query.query : '';
   const openFeedbackForm = useFeedbackForm();
+  const {mutate: createGroupSearchView, isPending: isCreatingView} =
+    useCreateGroupSearchView();
+  const defaultProject = useDefaultProject();
 
   if (!organization.features.includes('issue-view-sharing')) {
     return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
@@ -250,19 +262,44 @@ export default function IssueViewsList() {
                 {t('Give Feedback')}
               </Button>
             ) : null}
-            <LinkButton
-              to={`/organizations/${organization.slug}/issues/views/new/`}
+            <Button
               priority="primary"
               icon={<IconAdd />}
               size="sm"
+              disabled={isCreatingView}
+              busy={isCreatingView}
               onClick={() => {
                 trackAnalytics('issue_views.table.create_view_clicked', {
                   organization,
                 });
+                createGroupSearchView(
+                  {
+                    name: t('New View'),
+                    query: 'is:unresolved',
+                    projects: defaultProject,
+                    environments: DEFAULT_ENVIRONMENTS,
+                    timeFilters: DEFAULT_TIME_FILTERS,
+                    querySort: IssueSortOptions.DATE,
+                    starred: true,
+                  },
+                  {
+                    onSuccess: data => {
+                      navigate({
+                        pathname: normalizeUrl(
+                          `/organizations/${organization.slug}/issues/views/${data.id}/`
+                        ),
+                        query: {
+                          ...getIssueViewQueryParams({view: data}),
+                          new: 'true',
+                        },
+                      });
+                    },
+                  }
+                );
               }}
             >
               {t('Create View')}
-            </LinkButton>
+            </Button>
           </ButtonBar>
         </Layout.HeaderActions>
       </Layout.Header>

--- a/static/app/views/issueList/issueViews/utils.tsx
+++ b/static/app/views/issueList/issueViews/utils.tsx
@@ -4,16 +4,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
-const NEW_VIEW_PAGE_REGEX = /\/issues\/views\/new\/?$/;
-
-/**
- * Returns true if the current path is the "New View" page
- * /issues/views/new/
- */
-export function isNewViewPage(pathname: string) {
-  return NEW_VIEW_PAGE_REGEX.test(pathname);
-}
-
 export function canEditIssueView({
   groupSearchView,
   organization,

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1492,7 +1492,7 @@ describe('IssueList', function () {
             location: {
               ...initialRouterConfig.location,
               pathname: '/organizations/org-slug/issues/views/new/',
-              query: {},
+              query: {new: 'true'},
             },
           },
         }
@@ -1510,6 +1510,9 @@ describe('IssueList', function () {
       await waitFor(() => {
         expect(testRouter.location.query.query).toBe('is:unresolved timesSeen:>100');
       });
+      // ?new=true should be removed
+      expect(testRouter.location.query.new).toBeUndefined();
+
       expect(fetchDataMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByText('Suggested Queries')).not.toBeInTheDocument();
     });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -501,8 +501,30 @@ function IssueListOverview({
     [getEndpointParams, api, organization.slug]
   );
 
+  // Blank views are created with ?new=true, in order to show the empty state.
+  // We want to clear this query param when data is fetched.
+  const resetNewViewQueryParam = useCallback(() => {
+    if (location.query.new) {
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {
+            ...location.query,
+            new: undefined,
+          },
+        },
+        {
+          replace: true,
+          preventScrollReset: true,
+        }
+      );
+    }
+  }, [location.pathname, navigate, location.query]);
+
   const fetchData = useCallback(
     (fetchAllCounts = false) => {
+      resetNewViewQueryParam();
+
       if (realtimeActive || (!actionTakenRef.current && !undoRef.current)) {
         GroupStore.loadInitialData([]);
 
@@ -614,13 +636,14 @@ function IssueListOverview({
       });
     },
     [
+      resetNewViewQueryParam,
       realtimeActive,
       sort,
       api,
       organization,
       requestParams,
-      fetchStats,
       fetchCounts,
+      fetchStats,
       navigate,
       location.query,
       query,

--- a/static/app/views/issueList/overviewWrapper.tsx
+++ b/static/app/views/issueList/overviewWrapper.tsx
@@ -8,9 +8,11 @@ type OverviewWrapperProps = RouteComponentProps<
 >;
 
 export function OverviewWrapper(props: OverviewWrapperProps) {
+  const shouldFetchOnMount = !props.location.query.new;
+
   return (
     <IssueListContainer>
-      <IssueListOverview {...props} />
+      <IssueListOverview {...props} shouldFetchOnMount={shouldFetchOnMount} />
     </IssueListContainer>
   );
 }

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -10,7 +10,6 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {IssueViewParams} from 'sentry/views/issueList/issueViews/issueViews';
-import {isNewViewPage} from 'sentry/views/issueList/issueViews/utils';
 import {useUpdateGroupSearchViewStarredOrder} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {IssueViewAddViewButton} from 'sentry/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton';
@@ -93,11 +92,6 @@ export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps)
           {t('All Views')}
         </SecondaryNav.Item>
       )}
-      {isNewViewPage(location.pathname) ? (
-        <SecondaryNav.Item to={`${baseUrl}/views/new/`} isActive>
-          {t('New View')}
-        </SecondaryNav.Item>
-      ) : null}
     </SecondaryNav.Section>
   );
 }


### PR DESCRIPTION
Removes the route for `/views/new/` and instead creates the view immediately upon clicking "Create View". We still need to show the new view empty state, so I added a `?new=true` query param for this purpose which should get cleared any time the results are fetched.