### PR TITLE
feat(new-trace): Preventing span description truncation

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -532,8 +532,9 @@ const DescriptionWrapper = styled('div')`
   width: 100%;
   justify-content: space-between;
   flex-direction: row;
-  gap: ${space(0.5)};
+  gap: ${space(1)};
   word-break: break-word;
+  line-height: 1.4;
   padding: ${space(1)};
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -47,7 +47,7 @@ export function TransactionHighlights(props: HighlightProps) {
 
   const headerContent = (
     <HeaderContentWrapper>
-      <TextWrapper>{props.node.value.transaction}</TextWrapper>
+      <span>{props.node.value.transaction}</span>
       <CopyToClipboardButton
         borderless
         size="zero"
@@ -99,13 +99,12 @@ const HeaderContentWrapper = styled('div')`
   align-items: center;
   width: 100%;
   justify-content: space-between;
+  gap: ${space(1)};
+  font-size: ${p => p.theme.fontSizeMedium};
+  word-break: break-word;
+  line-height: 1.4;
 `;
 
 const BodyContentWrapper = styled('div')`
   padding: ${space(1)};
-`;
-
-const TextWrapper = styled('span')`
-  font-size: ${p => p.theme.fontSizeMedium};
-  ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -233,7 +233,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
           : width * initialSizeInPercentage;
 
       return {
-        min: traceState.preferences.layout === 'drawer bottom' ? 27 : 350,
+        min: traceState.preferences.layout === 'drawer bottom' ? 27 : 400,
         initialSize,
         ref: drawerRef,
       };


### PR DESCRIPTION
Before:
<img width="446" alt="Screenshot 2025-04-25 at 12 41 48 PM" src="https://github.com/user-attachments/assets/3b3901b0-9ef1-4b73-bd95-ee8b273ba762" />

After: 
<img width="456" alt="Screenshot 2025-04-25 at 12 42 21 PM" src="https://github.com/user-attachments/assets/25716233-5c26-4825-8fdc-a155aad05cd5" />
