### PR TITLE
chore(perf-issues): Actually enable experiment

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -30,6 +30,7 @@ class DetectorType(Enum):
     UNCOMPRESSED_ASSETS = "uncompressed_assets"
     DB_MAIN_THREAD = "db_main_thread"
     HTTP_OVERHEAD = "http_overhead"
+    EXPERIMENTAL_N_PLUS_ONE_API_CALLS = "experimental_n_plus_one_api_calls"
 
 
 # Detector and the corresponding system option must be added to this list to have issues created.

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -27,19 +27,19 @@ from sentry.utils.performance_issues.types import PerformanceProblemsMap, Span
 
 class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
     """
-    Detect parallel network calls to the same endpoint.
+    Detect parallel network calls to the same parameterized endpoint.
 
       [-------- transaction -----------]
          [-------- parent span -----------]
-          [n0] https://service.io/resources/?id=12443
-          [n1] https://service.io/resources/?id=13342
-          [n2] https://service.io/resources/?id=13441
+          [n0] https://service.io/resources/1/?id=12443
+          [n1] https://service.io/resources/2/?id=13342
+          [n2] https://service.io/resources/3/?id=13441
           ...
     """
 
     __slots__ = ["stored_problems"]
-    type = DetectorType.N_PLUS_ONE_API_CALLS
-    settings_key = DetectorType.N_PLUS_ONE_API_CALLS
+    type = DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS
+    settings_key = DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS
 
     def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
         super().__init__(settings, event)
@@ -47,6 +47,11 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         # TODO: Only store the span IDs and timestamps instead of entire span objects
         self.stored_problems: PerformanceProblemsMap = {}
         self.spans: list[Span] = []
+
+    def is_creation_allowed_for_system(self) -> bool:
+        # Defer to the issue platform for whether to create issues
+        # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
+        return True
 
     def visit_span(self, span: Span) -> None:
         if not NPlusOneAPICallsExperimentalDetector.is_span_eligible(span):

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -281,6 +281,13 @@ def get_detection_settings(project_id: int | None = None) -> dict[DetectorType, 
             "allowed_span_ops": ["http.client"],
             "detection_enabled": settings["n_plus_one_api_calls_detection_enabled"],
         },
+        DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS: {
+            "total_duration": settings["n_plus_one_api_calls_total_duration_threshold"],  # ms
+            "concurrency_threshold": 10,  # ms
+            "count": 5,
+            "allowed_span_ops": ["http.client"],
+            "detection_enabled": settings["n_plus_one_api_calls_detection_enabled"],
+        },
         DetectorType.M_N_PLUS_ONE_DB: {
             "total_duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
             "minimum_occurrences_of_pattern": 3,

--- a/tests/sentry/utils/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
@@ -38,8 +38,10 @@ class NPlusOneAPICallsExperimentalDetectorTest(TestCase):
         return list(detector.stored_problems.values())
 
     def create_event(self, description_maker: Callable[[int], str]) -> dict[str, Any]:
-        total_duration = self._settings[DetectorType.N_PLUS_ONE_API_CALLS]["total_duration"] + 1
-        count = self._settings[DetectorType.N_PLUS_ONE_API_CALLS]["count"] + 1
+        total_duration = (
+            self._settings[DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS]["total_duration"] + 1
+        )
+        count = self._settings[DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS]["count"] + 1
         hash = uuid4().hex[:16]
 
         return create_event(
@@ -176,14 +178,14 @@ class NPlusOneAPICallsExperimentalDetectorTest(TestCase):
     def test_does_not_detect_problems_with_low_span_count(self):
         event = get_event("n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream")
         event["spans"] = self.create_eligible_spans(
-            1000, self._settings[DetectorType.N_PLUS_ONE_API_CALLS]["count"]
+            1000, self._settings[DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS]["count"]
         )
 
         problems = self.find_problems(event)
         assert len(problems) == 1
 
         event["spans"] = self.create_eligible_spans(
-            1000, self._settings[DetectorType.N_PLUS_ONE_API_CALLS]["count"] - 1
+            1000, self._settings[DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS]["count"] - 1
         )
 
         problems = self.find_problems(event)


### PR DESCRIPTION
There was a check I missed with releasing the experimental detector. PerformanceDetectors opt out early based on some hard coded system options, but we can use the issue platform method instead, since those can be modified in flagpole.