### PR TITLE
feat(dashboards-eap): Remove new badge

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import RadioGroup, {type RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
@@ -27,12 +26,7 @@ function WidgetBuilderDatasetSelector() {
   datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 
   if (organization.features.includes('dashboards-eap')) {
-    datasetChoices.push([
-      WidgetType.SPANS,
-      <FeatureBadgeAlignmentWrapper aria-label={t('Spans')} key={'dataset-choice-spans'}>
-        {t('Spans')} <FeatureBadge type="new" />
-      </FeatureBadgeAlignmentWrapper>,
-    ]);
+    datasetChoices.push([WidgetType.SPANS, t('Spans')]);
   }
   datasetChoices.push([WidgetType.ISSUE, t('Issues')]);
   datasetChoices.push([WidgetType.RELEASE, t('Releases')]);
@@ -81,13 +75,6 @@ const DatasetChoices = styled(RadioGroup<WidgetType>)`
   flex-direction: row;
   flex-wrap: wrap;
   gap: ${space(2)};
-`;
-
-const FeatureBadgeAlignmentWrapper = styled('div')`
-  ${FeatureBadge} {
-    position: relative;
-    top: -1px;
-  }
 `;
 
 const StyledSectionHeader = styled(SectionHeader)`


### PR DESCRIPTION
We don't want a badge to show next to spans in the dataset selector.
<img width="601" alt="Screenshot 2025-04-25 at 1 01 35 PM" src="https://github.com/user-attachments/assets/0d373bc0-fb2c-4960-93e4-e0fa14286e13" />
