### PR TITLE
feat(billing): add profiling billing banner to org stats

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -180,6 +180,7 @@ type ComponentHooks = {
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
+  'component:org-stats-profiling-banner': () => React.ComponentType<RouteComponentProps>;
   'component:organization-header': () => React.ComponentType<OrganizationHeaderProps>;
   'component:organization-membership-settings': () => React.ComponentType<MembershipSettingsProps>;
   'component:partnership-agreement': React.ComponentType<PartnershipAgreementProps>;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -180,7 +180,7 @@ type ComponentHooks = {
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
-  'component:org-stats-profiling-banner': () => React.ComponentType<RouteComponentProps>;
+  'component:org-stats-profiling-banner': () => React.ComponentType;
   'component:organization-header': () => React.ComponentType<OrganizationHeaderProps>;
   'component:organization-membership-settings': () => React.ComponentType<MembershipSettingsProps>;
   'component:partnership-agreement': React.ComponentType<PartnershipAgreementProps>;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -45,6 +45,9 @@ import UsageStatsOrg from './usageStatsOrg';
 import {UsageStatsProjects} from './usageStatsProjects';
 
 const HookHeader = HookOrDefault({hookName: 'component:org-stats-banner'});
+const HookOrgStatsProfilingBanner = HookOrDefault({
+  hookName: 'component:org-stats-profiling-banner',
+});
 
 export const PAGE_QUERY_PARAMS = [
   // From DatePageFilter
@@ -352,6 +355,11 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
   render() {
     const {organization} = this.props;
     const hasTeamInsights = organization.features.includes('team-insights');
+    const showProfilingBanner = [
+      'profileDuration',
+      'profileDurationUI',
+      'profiles',
+    ].includes(this.dataCategory);
 
     return (
       <SentryDocumentTitle title={t('Usage Stats')} orgSlug={organization.slug}>
@@ -383,6 +391,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
                   {this.renderProjectPageControl()}
                   {this.renderEstimationDisclaimer()}
                 </ControlsWrapper>
+                {showProfilingBanner && (
+                  <HookOrgStatsProfilingBanner router={this.props.router} />
+                )}
                 <div>
                   <ErrorBoundary mini>{this.renderUsageStatsOrg()}</ErrorBoundary>
                 </div>

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -355,11 +355,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
   render() {
     const {organization} = this.props;
     const hasTeamInsights = organization.features.includes('team-insights');
-    const showProfilingBanner = [
-      'profileDuration',
-      'profileDurationUI',
-      'profiles',
-    ].includes(this.dataCategory);
+    const showProfilingBanner = this.dataCategory === 'profiles';
 
     return (
       <SentryDocumentTitle title={t('Usage Stats')} orgSlug={organization.slug}>
@@ -391,9 +387,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
                   {this.renderProjectPageControl()}
                   {this.renderEstimationDisclaimer()}
                 </ControlsWrapper>
-                {showProfilingBanner && (
-                  <HookOrgStatsProfilingBanner router={this.props.router} />
-                )}
+                {showProfilingBanner && <HookOrgStatsProfilingBanner />}
                 <div>
                   <ErrorBoundary mini>{this.renderUsageStatsOrg()}</ErrorBoundary>
                 </div>

--- a/static/gsApp/hooks/orgStatsProfilingBanner.tsx
+++ b/static/gsApp/hooks/orgStatsProfilingBanner.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button';
-import {IconProfiling} from 'sentry/icons';
+import {IconShow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -13,21 +13,25 @@ function OrgStatsProfilingBanner() {
       <HeaderItem>
         <h6>{t('Profiling has a new billing model!')}</h6>
         <span>
+          {t(`
           We've split Profiling into two products targeted at different use cases –
           Continuous Profiling for the backend and UI Profiling for the frontend. These
           products are billed separately.
+          `)}
         </span>
       </HeaderItem>
       <CategoryItemLeft>
         <h6>{t('UI Profile Hours')}</h6>
         <span>
+          {t(`
           Ensure great UX on browser and mobile apps by fixing issues that cause long load
           times and unresponsive interactions.
+          `)}
         </span>
         <div>
           <StyledProfilingButton
             size="sm"
-            icon={<IconProfiling size="sm" />}
+            icon={<IconShow size="sm" />}
             title={t('Go to UI Profile Hours')}
             aria-label={t('Go to UI Profile Hours')}
             to={{
@@ -42,13 +46,15 @@ function OrgStatsProfilingBanner() {
       <CategoryItemRight>
         <h6>{t('Continuous Profile Hours')}</h6>
         <span>
+          {t(`
           Find performance bottlenecks in backend services that cause high request latency
           and excessive infrastructure costs.
+          `)}
         </span>
         <div>
           <StyledProfilingButton
             size="sm"
-            icon={<IconProfiling size="sm" />}
+            icon={<IconShow size="sm" />}
             title={t('Go to Continuous Profile Hours')}
             aria-label={t('Go to Continuous Profile Hours')}
             to={{

--- a/static/gsApp/hooks/orgStatsProfilingBanner.tsx
+++ b/static/gsApp/hooks/orgStatsProfilingBanner.tsx
@@ -31,9 +31,7 @@ function OrgStatsProfilingBanner() {
         <div>
           <StyledProfilingButton
             size="sm"
-            icon={<IconShow size="sm" />}
-            title={t('Go to UI Profile Hours')}
-            aria-label={t('Go to UI Profile Hours')}
+            icon={<IconShow />}
             to={{
               ...location,
               query: {...location.query, dataCategory: 'profileDurationUI'},
@@ -54,9 +52,7 @@ function OrgStatsProfilingBanner() {
         <div>
           <StyledProfilingButton
             size="sm"
-            icon={<IconShow size="sm" />}
-            title={t('Go to Continuous Profile Hours')}
-            aria-label={t('Go to Continuous Profile Hours')}
+            icon={<IconShow />}
             to={{
               ...location,
               query: {...location.query, dataCategory: 'profileDuration'},
@@ -74,7 +70,7 @@ const BannerGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr;
   border: 1px solid ${p => p.theme.border};
-  border-radius: 5px;
+  border-radius: ${p => p.theme.borderRadius};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {

--- a/static/gsApp/hooks/orgStatsProfilingBanner.tsx
+++ b/static/gsApp/hooks/orgStatsProfilingBanner.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button';
 import {IconProfiling} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -10,7 +11,7 @@ function OrgStatsProfilingBanner() {
   return (
     <BannerGrid>
       <HeaderItem>
-        <h6>Profiling has a new billing model!</h6>
+        <h6>{t('Profiling has a new billing model!')}</h6>
         <span>
           We've split Profiling into two products targeted at different use cases –
           Continuous Profiling for the backend and UI Profiling for the frontend. These
@@ -18,7 +19,7 @@ function OrgStatsProfilingBanner() {
         </span>
       </HeaderItem>
       <CategoryItemLeft>
-        <h6>UI Profile Hours</h6>
+        <h6>{t('UI Profile Hours')}</h6>
         <span>
           Ensure great UX on browser and mobile apps by fixing issues that cause long load
           times and unresponsive interactions.
@@ -27,19 +28,19 @@ function OrgStatsProfilingBanner() {
           <StyledProfilingButton
             size="sm"
             icon={<IconProfiling size="sm" />}
-            title="Go to UI Profile Hours"
-            aria-label="Go to UI Profile Hours"
+            title={t('Go to UI Profile Hours')}
+            aria-label={t('Go to UI Profile Hours')}
             to={{
               ...location,
               query: {...location.query, dataCategory: 'profileDurationUI'},
             }}
           >
-            Go to UI Profile Hours
+            {t('Go to UI Profile Hours')}
           </StyledProfilingButton>
         </div>
       </CategoryItemLeft>
       <CategoryItemRight>
-        <h6>Continuous Profile Hours</h6>
+        <h6>{t('Continuous Profile Hours')}</h6>
         <span>
           Find performance bottlenecks in backend services that cause high request latency
           and excessive infrastructure costs.
@@ -48,14 +49,14 @@ function OrgStatsProfilingBanner() {
           <StyledProfilingButton
             size="sm"
             icon={<IconProfiling size="sm" />}
-            title="Go to Continuous Profile Hours"
-            aria-label="Go to Continuous Profile Hours"
+            title={t('Go to Continuous Profile Hours')}
+            aria-label={t('Go to Continuous Profile Hours')}
             to={{
               ...location,
               query: {...location.query, dataCategory: 'profileDuration'},
             }}
           >
-            Go to Continuous Profile Hours
+            {t('Go to Continuous Profile Hours')}
           </StyledProfilingButton>
         </div>
       </CategoryItemRight>

--- a/static/gsApp/hooks/orgStatsProfilingBanner.tsx
+++ b/static/gsApp/hooks/orgStatsProfilingBanner.tsx
@@ -1,0 +1,123 @@
+import styled from '@emotion/styled';
+import type {Location} from 'history';
+
+import {Button} from 'sentry/components/core/button';
+import {IconProfiling} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+type Props = {
+  router: InjectedRouter & {location?: Location};
+};
+
+function OrgStatsProfilingBanner({router}: Props) {
+  return (
+    <BannerGrid>
+      <HeaderItem>
+        <h6>Profiling has a new billing model!</h6>
+        <span>
+          We've split Profiling into two products targeted at different use cases –
+          Continuous Profiling for the backend and UI Profiling for the frontend. These
+          products are billed separately.
+        </span>
+      </HeaderItem>
+      <CategoryItemLeft>
+        <h6>UI Profile Hours</h6>
+        <span>
+          Ensure great UX on browser and mobile apps by fixing issues that cause long load
+          times and unresponsive interactions.
+        </span>
+        <div>
+          <StyledProfilingButton
+            size="sm"
+            icon={<IconProfiling size="sm" />}
+            title="Go to UI Profile Hours"
+            aria-label="Go to UI Profile Hours"
+            onClick={() => router.push(normalizeUrl('/profiling/'))}
+          >
+            Go to UI Profile Hours
+          </StyledProfilingButton>
+        </div>
+      </CategoryItemLeft>
+      <CategoryItemRight>
+        <h6>Continuous Profile Hours</h6>
+        <span>
+          Find performance bottlenecks in backend services that cause high request latency
+          and excessive infrastructure costs.
+        </span>
+        <div>
+          <StyledProfilingButton
+            size="sm"
+            icon={<IconProfiling size="sm" />}
+            title="Go to Continuous Profile Hours"
+            aria-label="Go to Continuous Profile Hours"
+            onClick={() => router.push(normalizeUrl('/profiling/'))}
+          >
+            Go to Continuous Profile Hours
+          </StyledProfilingButton>
+        </div>
+      </CategoryItemRight>
+    </BannerGrid>
+  );
+}
+
+const BannerGrid = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 1px solid ${p => p.theme.border};
+  border-radius: 5px;
+  margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+`;
+
+const HeaderItem = styled('div')`
+  grid-column: span 1;
+
+  padding: ${space(2)};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-bottom: 1px solid ${p => p.theme.border};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    grid-column: span 2;
+    border-bottom: 1px solid ${p => p.theme.border};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-column: span 1;
+    border-bottom: none;
+  }
+`;
+
+const CategoryItemLeft = styled('div')`
+  grid-column: span 1;
+  border-bottom: 1px solid ${p => p.theme.border};
+  padding: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    border-right: 1px solid ${p => p.theme.border};
+    border-bottom: none;
+  }
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    border-left: 1px solid ${p => p.theme.border};
+    border-right: 1px solid ${p => p.theme.border};
+    border-bottom: none;
+  }
+`;
+
+const CategoryItemRight = styled('div')`
+  grid-column: span 1;
+  padding: ${space(2)};
+`;
+
+const StyledProfilingButton = styled(Button)`
+  margin-top: ${space(1)};
+`;
+
+export default OrgStatsProfilingBanner;

--- a/static/gsApp/hooks/orgStatsProfilingBanner.tsx
+++ b/static/gsApp/hooks/orgStatsProfilingBanner.tsx
@@ -1,17 +1,12 @@
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
-import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button';
 import {IconProfiling} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 
-type Props = {
-  router: InjectedRouter & {location?: Location};
-};
-
-function OrgStatsProfilingBanner({router}: Props) {
+function OrgStatsProfilingBanner() {
+  const location = useLocation();
   return (
     <BannerGrid>
       <HeaderItem>
@@ -34,7 +29,10 @@ function OrgStatsProfilingBanner({router}: Props) {
             icon={<IconProfiling size="sm" />}
             title="Go to UI Profile Hours"
             aria-label="Go to UI Profile Hours"
-            onClick={() => router.push(normalizeUrl('/profiling/'))}
+            to={{
+              ...location,
+              query: {...location.query, dataCategory: 'profileDurationUI'},
+            }}
           >
             Go to UI Profile Hours
           </StyledProfilingButton>
@@ -52,7 +50,10 @@ function OrgStatsProfilingBanner({router}: Props) {
             icon={<IconProfiling size="sm" />}
             title="Go to Continuous Profile Hours"
             aria-label="Go to Continuous Profile Hours"
-            onClick={() => router.push(normalizeUrl('/profiling/'))}
+            to={{
+              ...location,
+              query: {...location.query, dataCategory: 'profileDuration'},
+            }}
           >
             Go to Continuous Profile Hours
           </StyledProfilingButton>
@@ -116,7 +117,7 @@ const CategoryItemRight = styled('div')`
   padding: ${space(2)};
 `;
 
-const StyledProfilingButton = styled(Button)`
+const StyledProfilingButton = styled(LinkButton)`
   margin-top: ${space(1)};
 `;
 

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -58,6 +58,7 @@ import MemberListHeader from 'getsentry/hooks/memberListHeader';
 import OrganizationMembershipSettingsForm from 'getsentry/hooks/organizationMembershipSettingsForm';
 import {getOrgRoles} from 'getsentry/hooks/organizationRoles';
 import OrgStatsBanner from 'getsentry/hooks/orgStatsBanner';
+import OrgStatsProfilingBanner from 'getsentry/hooks/orgStatsProfilingBanner';
 import hookRootRoutes from 'getsentry/hooks/rootRoutes';
 import hookSettingsRoutes from 'getsentry/hooks/settingsRoutes';
 import hookSidebarDropdownMenu from 'getsentry/hooks/sidebarDropdownMenu';
@@ -224,6 +225,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:disabled-custom-symbol-sources': () => DisabledCustomSymbolSources,
   'component:dashboards-header': () => DashboardBanner,
   'component:org-stats-banner': () => OrgStatsBanner,
+  'component:org-stats-profiling-banner': () => OrgStatsProfilingBanner,
   'component:enhanced-org-stats': () => EnhancedOrganizationStats,
   'component:first-party-integration-alert': () => FirstPartyIntegrationAlertHook,
   'component:first-party-integration-additional-cta': () =>


### PR DESCRIPTION
Linear: https://linear.app/getsentry/issue/BIL-496/org-stats-should-inform-customers-how-to-migrate-to-new-sdk

Figma: https://www.figma.com/design/IjYeQp4VI5vjoDBaWZTTcO/Continuous-profiling-edge-cases?node-id=150-511
