### PR TITLE
feat(eap-alerts): Remove beta badges

### DIFF
--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -1,7 +1,6 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Select} from 'sentry/components/core/select';
 import type {FormFieldProps} from 'sentry/components/forms/formField';
 import FormField from 'sentry/components/forms/formField';
@@ -112,19 +111,7 @@ export default function WizardField({
         ...(hasEAPAlerts(organization)
           ? [
               {
-                label: (
-                  <span>
-                    {AlertWizardAlertNames.eap_metrics}
-                    <FeatureBadge
-                      type="beta"
-                      tooltipProps={{
-                        title: t(
-                          'This feature is available for early adopters and the UX may change'
-                        ),
-                      }}
-                    />
-                  </span>
-                ),
+                label: AlertWizardAlertNames.eap_metrics,
                 value: 'eap_metrics' as const,
               },
             ]

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -89,14 +89,6 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
  * for adding feature badges or other call-outs for newer alert types.
  */
 export const AlertWizardExtraContent: Partial<Record<AlertType, React.ReactNode>> = {
-  eap_metrics: (
-    <FeatureBadge
-      type="beta"
-      tooltipProps={{
-        title: t('This feature is available for early adopters and the UX may change'),
-      }}
-    />
-  ),
   uptime_monitor: <FeatureBadge type="new" />,
 };
 


### PR DESCRIPTION
Removes the beta badges from Alerts. These were the ones I found:

<img width="213" alt="Screenshot 2025-04-25 at 1 05 26 PM" src="https://github.com/user-attachments/assets/0a7a83fc-2379-4068-b6c8-6c5b7edbeacd" />
<img width="422" alt="Screenshot 2025-04-25 at 1 05 23 PM" src="https://github.com/user-attachments/assets/f58e429b-31bd-4011-a1ed-b6cefa5ff202" />


After:
<img width="220" alt="Screenshot 2025-04-25 at 1 05 32 PM" src="https://github.com/user-attachments/assets/6d229588-11fb-4832-9dee-965061f149cb" />
<img width="480" alt="Screenshot 2025-04-25 at 1 05 37 PM" src="https://github.com/user-attachments/assets/72b10cb8-4d34-45bd-b2ca-5ce9170a0dbd" />
