### PR TITLE
Update Discord invite link within Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Sentry is a developer-first error tracking and performance monitoring platform t
 - [Documentation](https://docs.sentry.io/)
 - [Discussions](https://github.com/getsentry/sentry/discussions) (Bugs, feature requests,
   general questions)
-- [Discord](https://discord.gg/PXa5Apfe7K)
+- [Discord](https://discord.com/invite/sentry)
 - [Contributing](https://docs.sentry.io/internal/contributing/)
 - [Bug Tracker](https://github.com/getsentry/sentry/issues)
 - [Code](https://github.com/getsentry/sentry)


### PR DESCRIPTION
Updated the Discord invite link within [README.md](https://github.com/getsentry/sentry/blob/master/README.md), which previously lead to an invalid invite screen, and now matches the link available on the docs site - https://docs.sentry.io/.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
