### PR TITLE
chore(shared-views): Remove issue view tabs if sharing enabled

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1072,7 +1072,8 @@ function IssueListOverview({
           <LeftNavViewsHeader selectedProjectIds={selection.projects} title={title} />
         )}
         {!prefersStackedNav &&
-          (organization.features.includes('issue-stream-custom-views') ? (
+          (organization.features.includes('issue-stream-custom-views') &&
+          !organization.features.includes('issue-view-sharing') ? (
             <ErrorBoundary message={'Failed to load custom tabs'} mini>
               <IssueViewsIssueListHeader
                 router={router}


### PR DESCRIPTION
Turns off horizontal issue views for users if they have Issue View sharing enabled. 

I would have loved to axe these components completely, but we can't do it until we release sharing to EA completely. 