### PR TITLE
fix(schema-hints): Remove aggregates from spans table fields

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -24,6 +24,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
+import {isAggregateField} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   type AggregationKey,
@@ -213,7 +214,9 @@ function SpansTabContentImpl({
     onSearch: (newQuery: string) => {
       const newFields = new MutableSearch(newQuery)
         .getFilterKeys()
-        .map(key => (key.startsWith('!') ? key.slice(1) : key));
+        .map(key => (key.startsWith('!') ? key.slice(1) : key))
+        // don't add aggregate functions to table fields
+        .filter(key => !isAggregateField(key));
       setExplorePageParams({
         query: newQuery,
         fields: [...new Set([...fields, ...newFields])],


### PR DESCRIPTION
Previously when searching on aggregates mode the aggregate field will get added to the spans sample table (which is not supposed to happen). This filters out the aggregate queries when deciding which fields to add on search.

Context slack threads for repro:
https://sentry.slack.com/archives/C05FUFGPGFM/p1745505308654109
https://sentry.slack.com/archives/C05FUFGPGFM/p1745587801538049
