### PR TITLE
fix(alerts): Fix dataset label for EAP

### DIFF
--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any
 
+import sentry_sdk
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from parsimonious.exceptions import ParseError
@@ -84,7 +85,10 @@ def handle_send_historical_data_to_seer(
         raise TimeoutError(f"Failed to send data to Seer - cannot {method} alert rule.")
     except ParseError:
         raise ParseError("Failed to parse Seer store data response")
-    except (ValidationError, Exception):
+    except ValidationError:
+        raise ValidationError(f"Failed to send data to Seer - cannot {method} alert rule.")
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
         raise ValidationError(f"Failed to send data to Seer - cannot {method} alert rule.")
 
 

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -245,8 +245,7 @@ def fetch_historical_data(
         start = end - timedelta(days=NUM_DAYS)
     granularity = snuba_query.time_window
 
-    dataset_label = snuba_query.dataset
-    dataset = get_dataset_from_label(dataset_label)
+    dataset = get_dataset_from_label(snuba_query.dataset)
 
     if not project or not dataset or not organization:
         return None

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -211,6 +211,8 @@ def get_dataset_from_label(dataset_label: str):
     if dataset_label == "events":
         # DATASET_OPTIONS expects the name 'errors'
         dataset_label = "errors"
+    elif dataset_label == "events_analytics_platform":
+        dataset_label = "spans"
     elif dataset_label in ["generic_metrics", "transactions"]:
         # XXX: performance alerts dataset differs locally vs in prod
         dataset_label = "metricsEnhanced"
@@ -244,15 +246,6 @@ def fetch_historical_data(
     granularity = snuba_query.time_window
 
     dataset_label = snuba_query.dataset
-
-    if dataset_label == "events":
-        # DATASET_OPTIONS expects the name 'errors'
-        dataset_label = "errors"
-    elif dataset_label == "events_analytics_platform":
-        dataset_label = "spans"
-    elif dataset_label in ["generic_metrics", "transactions"]:
-        # XXX: performance alerts dataset differs locally vs in prod
-        dataset_label = "metricsEnhanced"
     dataset = get_dataset_from_label(dataset_label)
 
     if not project or not dataset or not organization:


### PR DESCRIPTION
Dataset label translation was happening in two places, and I missed a spot.
Added an endpoint test.
Explicitly capturing sentry exception when it's an unknown exception