### PR TITLE
ref(insights): Refactor `ChartWidgetLoader` to make import paths static

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -7,7 +7,8 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {ChartId, ChartWidgetLoader} from './chartWidgetLoader';
+import type {ChartId} from './chartWidgetLoader';
+import {ChartWidgetLoader} from './chartWidgetLoader';
 
 // Mock this component so it doesn't yell at us for no plottables
 jest.mock(

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -5,20 +5,20 @@ import path from 'node:path';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+
 import {ChartWidgetLoader} from './chartWidgetLoader';
 
 // Mock this component so it doesn't yell at us for no plottables
 jest.mock(
   'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization',
   () => {
-    function TimeSeriesWidgetVisualization() {
-      return null;
-    }
-    TimeSeriesWidgetVisualization.LoadingPlaceholder = function () {
+    const TimeSeriesWidgetVisualizationMock = jest.fn(() => null);
+    TimeSeriesWidgetVisualizationMock.LoadingPlaceholder = function () {
       return <div />;
     };
     return {
-      TimeSeriesWidgetVisualization,
+      TimeSeriesWidgetVisualization: TimeSeriesWidgetVisualizationMock,
     };
   }
 );
@@ -56,7 +56,15 @@ jest.mock(
 jest.mock('sentry/views/insights/sessions/queries/useReleaseNewIssues', () => ({
   __esModule: true,
   default: jest.fn(() => ({
-    series: [],
+    series: [{}],
+    isPending: false,
+    isError: false,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useRecentIssues', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    recentIssues: [],
     isPending: false,
     isError: false,
   })),
@@ -64,12 +72,172 @@ jest.mock('sentry/views/insights/sessions/queries/useReleaseNewIssues', () => ({
 jest.mock('sentry/views/insights/sessions/queries/useNewAndResolvedIssues', () => ({
   __esModule: true,
   default: jest.fn(() => ({
-    series: [],
+    series: [{}],
     isPending: false,
     isError: false,
   })),
 }));
-
+jest.mock('sentry/views/insights/sessions/queries/useCrashFreeSessions', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    isError: false,
+  })),
+}));
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useResourceLandingSeries',
+  () => ({
+    useResourceLandingSeries: jest.fn(() => ({
+      data: {
+        'epm()': {},
+        'avg(span.self_time)': {},
+        'avg(http.response_content_length)': {},
+        'avg(http.response_transfer_size)': {},
+        'avg(http.decoded_response_content_length)': {},
+      },
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useResourceSummarySeries',
+  () => ({
+    useResourceSummarySeries: jest.fn(() => ({
+      data: {
+        'epm()': {},
+        'avg(span.self_time)': {},
+        'avg(http.response_content_length)': {},
+        'avg(http.response_transfer_size)': {},
+        'avg(http.decoded_response_content_length)': {},
+      },
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock('sentry/views/insights/queues/queries/usePublishQueuesTimeSeriesQuery', () => ({
+  usePublishQueuesTimeSeriesQuery: jest.fn(() => ({
+    data: {},
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/queues/queries/useProcessQueuesTimeSeriesQuery', () => ({
+  useProcessQueuesTimeSeriesQuery: jest.fn(() => ({
+    data: {
+      'avg(messaging.message.receive.latency)': {},
+    },
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingDurationQuery',
+  () => ({
+    useDatabaseLandingDurationQuery: jest.fn(() => ({
+      data: {
+        'avg(span.self_time)': {},
+      },
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingThroughputQuery',
+  () => ({
+    useDatabaseLandingThroughputQuery: jest.fn(() => ({
+      data: {
+        'epm()': {},
+      },
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
+  useMetricsSeries: jest.fn(() => ({
+    data: {
+      'performance_score(measurements.score.lcp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.fcp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.cls)': {
+        data: [],
+      },
+      'performance_score(measurements.score.inp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.ttfb)': {
+        data: [],
+      },
+      'count()': {
+        data: [],
+      },
+    },
+    isPending: false,
+    error: null,
+  })),
+  useSpanMetricsSeries: jest.fn(() => ({
+    data: {
+      'cache_miss_rate()': {},
+      'http_response_rate(3)': {},
+      'http_response_rate(4)': {},
+      'http_response_rate(5)': {},
+      'epm()': {},
+      'avg(span.self_time)': {},
+      'avg(http.response_content_length)': {},
+      'avg(http.response_transfer_size)': {},
+      'avg(http.decoded_response_content_length)': {},
+    },
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useErroredSessions', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useSessionHealthBreakdown', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useReleaseSessionPercentage', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useReleaseSessionCounts', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useUserHealthBreakdown', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [{}],
+    isPending: false,
+    error: null,
+  })),
+}));
 // Dynamically get all widget IDs from the widgets directory
 const WIDGETS_DIR = path.join(
   __dirname,
@@ -86,8 +254,8 @@ const widgetIds = fs
   .map(file => file.replace('.tsx', ''));
 
 describe('ChartWidgetLoader - unmocked imports', () => {
-  beforeAll(() => {
-    jest.unmock('@tanstack/react-query');
+  afterAll(() => {
+    jest.resetAllMocks();
   });
 
   beforeEach(() => {
@@ -97,41 +265,6 @@ describe('ChartWidgetLoader - unmocked imports', () => {
       body: {
         data: [[123, []]],
       },
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-stats/',
-      body: {
-        data: [
-          [123, [{count: 1}]],
-          [124, [{count: 2}]],
-        ],
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/sessions/',
-      body: {
-        groups: [],
-        intervals: [],
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues-metrics/',
-      body: {
-        data: [],
-        meta: {
-          fields: {
-            'count()': 'integer',
-          },
-        },
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/undefined/issues/',
-      body: [],
     });
   });
 
@@ -154,6 +287,13 @@ describe('ChartWidgetLoader - unmocked imports', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
     });
+
+    expect(TimeSeriesWidgetVisualization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: widgetId,
+      }),
+      undefined
+    );
   });
 
   it('shows error state for invalid widget id', async () => {

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {ChartWidgetLoader} from './chartWidgetLoader';
+import {ChartId, ChartWidgetLoader} from './chartWidgetLoader';
 
 // Mock this component so it doesn't yell at us for no plottables
 jest.mock(
@@ -274,7 +274,7 @@ describe('ChartWidgetLoader - unmocked imports', () => {
   // - `id` must match the filename
   // - have a `default` export that is a React component (component name should be TitleCase of `id`)
   // - be mapped via `id` -> dynamic import in `chartWidgetLoader.tsx`
-  it.each(widgetIds)('can load widget: %s', async (widgetId: string) => {
+  it.each(widgetIds as ChartId[])('can load widget: %s', async widgetId => {
     render(<ChartWidgetLoader id={widgetId} />);
 
     // Initially should show loading state from ChartWidgetLoader, it will disappear when dynamic import completes.
@@ -295,6 +295,7 @@ describe('ChartWidgetLoader - unmocked imports', () => {
 
   it('shows error state for invalid widget id', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // @ts-expect-error - fails type check because `invalid-widget` is not a valid chart id, but we want to test that it shows an error state
     render(<ChartWidgetLoader id="invalid-widget" />);
 
     await waitFor(() => {

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -1,0 +1,169 @@
+// eslint-disable-next-line import/no-nodejs-modules
+import fs from 'node:fs';
+// eslint-disable-next-line import/no-nodejs-modules
+import path from 'node:path';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ChartWidgetLoader} from './chartWidgetLoader';
+
+// Mock this component so it doesn't yell at us for no plottables
+jest.mock(
+  'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization',
+  () => {
+    function TimeSeriesWidgetVisualization() {
+      return null;
+    }
+    TimeSeriesWidgetVisualization.LoadingPlaceholder = function () {
+      return <div />;
+    };
+    return {
+      TimeSeriesWidgetVisualization,
+    };
+  }
+);
+
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingDurationQuery',
+  () => ({
+    useDatabaseLandingDurationQuery: jest.fn(() => ({
+      data: {},
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingThroughputQuery',
+  () => ({
+    useDatabaseLandingThroughputQuery: jest.fn(() => ({
+      data: {},
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock(
+  'sentry/views/insights/common/components/widgets/hooks/useAiPipelineGroup',
+  () => ({
+    useAiPipelineGroup: jest.fn(() => ({
+      data: {},
+      isPending: false,
+      error: null,
+    })),
+  })
+);
+jest.mock('sentry/views/insights/sessions/queries/useReleaseNewIssues', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [],
+    isPending: false,
+    isError: false,
+  })),
+}));
+jest.mock('sentry/views/insights/sessions/queries/useNewAndResolvedIssues', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    series: [],
+    isPending: false,
+    isError: false,
+  })),
+}));
+
+// Dynamically get all widget IDs from the widgets directory
+const WIDGETS_DIR = path.join(
+  __dirname,
+  '../../views/insights/common/components/widgets'
+);
+const widgetIds = fs
+  .readdirSync(WIDGETS_DIR)
+  .filter(
+    file =>
+      file.endsWith('.tsx') &&
+      file !== 'types.tsx' &&
+      !fs.statSync(path.join(WIDGETS_DIR, file)).isDirectory()
+  )
+  .map(file => file.replace('.tsx', ''));
+
+describe('ChartWidgetLoader - unmocked imports', () => {
+  beforeAll(() => {
+    jest.unmock('@tanstack/react-query');
+  });
+
+  beforeEach(() => {
+    // Mock API responses
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: {
+        data: [[123, []]],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [123, [{count: 1}]],
+          [124, [{count: 2}]],
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sessions/',
+      body: {
+        groups: [],
+        intervals: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-metrics/',
+      body: {
+        data: [],
+        meta: {
+          fields: {
+            'count()': 'integer',
+          },
+        },
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/undefined/issues/',
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  // All widgets in `static/app/views/insights/common/components/widgets` must:
+  // - have a `id` prop with the widget name
+  // - `id` must match the filename
+  // - have a `default` export that is a React component (component name should be TitleCase of `id`)
+  // - be mapped via `id` -> dynamic import in `chartWidgetLoader.tsx`
+  it.each(widgetIds)('can load widget: %s', async (widgetId: string) => {
+    render(<ChartWidgetLoader id={widgetId} />);
+
+    // Initially should show loading state from ChartWidgetLoader, it will disappear when dynamic import completes.
+    // We only need to check that the dynamic import completes for these tests as that means ChartWidgetLoader is able to load all widgets
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error state for invalid widget id', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<ChartWidgetLoader id="invalid-widget" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Error loading widget')).toBeInTheDocument();
+    });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -14,9 +14,6 @@ jest.mock(
   'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization',
   () => {
     const TimeSeriesWidgetVisualizationMock = jest.fn(() => null);
-    TimeSeriesWidgetVisualizationMock.LoadingPlaceholder = function () {
-      return <div />;
-    };
     return {
       TimeSeriesWidgetVisualization: TimeSeriesWidgetVisualizationMock,
     };

--- a/static/app/components/charts/chartWidgetLoader.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader.spec.tsx
@@ -7,7 +7,7 @@ import {
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ChartWidgetLoader} from './chartWidgetLoader';
+import {ChartId, ChartWidgetLoader} from './chartWidgetLoader';
 
 const mockUseQuery = jest.fn();
 jest.mock('@sentry/core', () => ({
@@ -39,7 +39,7 @@ describe('ChartWidgetLoader', () => {
   });
 
   const defaultProps = {
-    id: 'test-widget',
+    id: 'test-widget' as ChartId,
     height: '200px',
   };
 

--- a/static/app/components/charts/chartWidgetLoader.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader.spec.tsx
@@ -7,7 +7,8 @@ import {
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ChartId, ChartWidgetLoader} from './chartWidgetLoader';
+import type {ChartId} from './chartWidgetLoader';
+import {ChartWidgetLoader} from './chartWidgetLoader';
 
 const mockUseQuery = jest.fn();
 jest.mock('@sentry/core', () => ({

--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -13,6 +13,161 @@ interface Props extends LoadableChartWidgetProps {
   id: string;
 }
 
+// We need to map the widget id to the dynamic import because we want the import paths to be statically analyzable.
+const CHART_MAP: Record<
+  string,
+  () => Promise<{default: React.FC<LoadableChartWidgetProps>}>
+> = {
+  [EVENT_GRAPH_WIDGET_ID]: () =>
+    import('sentry/views/issueDetails/streamline/eventGraphWidget'),
+  unhealthySessionsChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/unhealthySessionsChartWidget'
+    ),
+  userHealthCountChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/userHealthCountChartWidget'),
+  userHealthRateChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/userHealthRateChartWidget'),
+  sessionHealthRateChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/sessionHealthRateChartWidget'
+    ),
+  resourceSummaryAverageSizeChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget'
+    ),
+  resourceSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryDurationChartWidget'
+    ),
+  resourceSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget'
+    ),
+  sessionHealthCountChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/sessionHealthCountChartWidget'
+    ),
+  resourceLandingDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceLandingDurationChartWidget'
+    ),
+  resourceLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceLandingThroughputChartWidget'
+    ),
+  crashFreeSessionsChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget'
+    ),
+  releaseSessionCountChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/releaseSessionCountChartWidget'
+    ),
+  releaseSessionPercentageChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/releaseSessionPercentageChartWidget'
+    ),
+  llmNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget'
+    ),
+  llmPipelineDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget'
+    ),
+  llmTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget'
+    ),
+  llmGroupPipelineDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget'
+    ),
+  llmGroupTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget'
+    ),
+  llmEventTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmEventTotalTokensUsedChartWidget'
+    ),
+  llmGroupNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget'
+    ),
+  llmEventNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmEventNumberOfPipelinesChartWidget'
+    ),
+  queuesSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget'
+    ),
+  releaseNewIssuesChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget'),
+  performanceScoreBreakdownChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget'
+    ),
+  queuesLandingLatencyChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesLandingLatencyChartWidget'
+    ),
+  queuesLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesLandingThroughputChartWidget'
+    ),
+  queuesSummaryLatencyChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget'
+    ),
+  newAndResolvedIssueChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget'
+    ),
+  databaseSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget'
+    ),
+  databaseLandingDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseLandingDurationChartWidget'
+    ),
+  databaseLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseLandingThroughputChartWidget'
+    ),
+  databaseSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget'
+    ),
+  cacheThroughputChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/cacheThroughputChartWidget'),
+  cacheMissRateChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/cacheMissRateChartWidget'),
+  httpResponseCodesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget'
+    ),
+  httpThroughputChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/httpThroughputChartWidget'),
+  httpDomainSummaryResponseCodesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget'
+    ),
+  httpDomainSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget'
+    ),
+  httpDurationChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/httpDurationChartWidget'),
+  httpDomainSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget'
+    ),
+} as const;
+
 /**
  * Render an Insights Widget by id.
  *
@@ -28,11 +183,12 @@ export function ChartWidgetLoader(props: Props) {
   const query = useQuery<{default: React.FC<LoadableChartWidgetProps>}>({
     queryKey: [`widget-${props.id}`],
     queryFn: () => {
-      if (props.id === EVENT_GRAPH_WIDGET_ID) {
-        return import('sentry/views/issueDetails/streamline/eventGraphWidget');
+      const importChartFn = CHART_MAP[props.id];
+      if (typeof importChartFn === 'function') {
+        return importChartFn();
       }
 
-      return import(`sentry/views/insights/common/components/widgets/${props.id}`);
+      return Promise.reject(new Error(`Widget ${props.id} not found`));
     },
   });
 

--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -6,295 +6,164 @@ import {t} from 'sentry/locale';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {EVENT_GRAPH_WIDGET_ID} from 'sentry/views/issueDetails/streamline/eventGraphWidget';
 
+export type ChartId = keyof typeof CHART_MAP;
 interface Props extends LoadableChartWidgetProps {
   /**
    * ID of the Chart
    */
-  id: string;
+  id: ChartId;
 }
-
 // We need to map the widget id to the dynamic import because we want the import paths to be statically analyzable.
-const CHART_MAP: Map<
-  string,
-  () => Promise<{default: React.FC<LoadableChartWidgetProps>}>
-> = new Map([
-  [
-    EVENT_GRAPH_WIDGET_ID,
-    () => import('sentry/views/issueDetails/streamline/eventGraphWidget'),
-  ],
-  [
-    'unhealthySessionsChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/unhealthySessionsChartWidget'
-      ),
-  ],
-  [
-    'userHealthCountChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/userHealthCountChartWidget'
-      ),
-  ],
-  [
-    'userHealthRateChartWidget',
-    () =>
-      import('sentry/views/insights/common/components/widgets/userHealthRateChartWidget'),
-  ],
-  [
-    'sessionHealthRateChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/sessionHealthRateChartWidget'
-      ),
-  ],
-  [
-    'resourceSummaryAverageSizeChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget'
-      ),
-  ],
-  [
-    'resourceSummaryDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/resourceSummaryDurationChartWidget'
-      ),
-  ],
-  [
-    'resourceSummaryThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget'
-      ),
-  ],
-  [
-    'sessionHealthCountChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/sessionHealthCountChartWidget'
-      ),
-  ],
-  [
-    'resourceLandingDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/resourceLandingDurationChartWidget'
-      ),
-  ],
-  [
-    'resourceLandingThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/resourceLandingThroughputChartWidget'
-      ),
-  ],
-  [
-    'crashFreeSessionsChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget'
-      ),
-  ],
-  [
-    'releaseSessionCountChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/releaseSessionCountChartWidget'
-      ),
-  ],
-  [
-    'releaseSessionPercentageChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/releaseSessionPercentageChartWidget'
-      ),
-  ],
-  [
-    'llmNumberOfPipelinesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget'
-      ),
-  ],
-  [
-    'llmPipelineDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget'
-      ),
-  ],
-  [
-    'llmTotalTokensUsedChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget'
-      ),
-  ],
-  [
-    'llmGroupPipelineDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget'
-      ),
-  ],
-  [
-    'llmGroupTotalTokensUsedChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget'
-      ),
-  ],
-  [
-    'llmEventTotalTokensUsedChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmEventTotalTokensUsedChartWidget'
-      ),
-  ],
-  [
-    'llmGroupNumberOfPipelinesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget'
-      ),
-  ],
-  [
-    'llmEventNumberOfPipelinesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/llmEventNumberOfPipelinesChartWidget'
-      ),
-  ],
-  [
-    'queuesSummaryThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget'
-      ),
-  ],
-  [
-    'releaseNewIssuesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget'
-      ),
-  ],
-  [
-    'performanceScoreBreakdownChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget'
-      ),
-  ],
-  [
-    'queuesLandingLatencyChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/queuesLandingLatencyChartWidget'
-      ),
-  ],
-  [
-    'queuesLandingThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/queuesLandingThroughputChartWidget'
-      ),
-  ],
-  [
-    'queuesSummaryLatencyChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget'
-      ),
-  ],
-  [
-    'newAndResolvedIssueChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget'
-      ),
-  ],
-  [
-    'databaseSummaryThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget'
-      ),
-  ],
-  [
-    'databaseLandingDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/databaseLandingDurationChartWidget'
-      ),
-  ],
-  [
-    'databaseLandingThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/databaseLandingThroughputChartWidget'
-      ),
-  ],
-  [
-    'databaseSummaryDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget'
-      ),
-  ],
-  [
-    'cacheThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/cacheThroughputChartWidget'
-      ),
-  ],
-  [
-    'cacheMissRateChartWidget',
-    () =>
-      import('sentry/views/insights/common/components/widgets/cacheMissRateChartWidget'),
-  ],
-  [
-    'httpResponseCodesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget'
-      ),
-  ],
-  [
-    'httpThroughputChartWidget',
-    () =>
-      import('sentry/views/insights/common/components/widgets/httpThroughputChartWidget'),
-  ],
-  [
-    'httpDomainSummaryResponseCodesChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget'
-      ),
-  ],
-  [
-    'httpDomainSummaryThroughputChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget'
-      ),
-  ],
-  [
-    'httpDurationChartWidget',
-    () =>
-      import('sentry/views/insights/common/components/widgets/httpDurationChartWidget'),
-  ],
-  [
-    'httpDomainSummaryDurationChartWidget',
-    () =>
-      import(
-        'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget'
-      ),
-  ],
-]);
+const CHART_MAP = {
+  [EVENT_GRAPH_WIDGET_ID]: () =>
+    import('sentry/views/issueDetails/streamline/eventGraphWidget'),
+  unhealthySessionsChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/unhealthySessionsChartWidget'
+    ),
+  userHealthCountChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/userHealthCountChartWidget'),
+  userHealthRateChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/userHealthRateChartWidget'),
+  sessionHealthRateChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/sessionHealthRateChartWidget'
+    ),
+  resourceSummaryAverageSizeChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget'
+    ),
+  resourceSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryDurationChartWidget'
+    ),
+  resourceSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget'
+    ),
+  sessionHealthCountChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/sessionHealthCountChartWidget'
+    ),
+  resourceLandingDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceLandingDurationChartWidget'
+    ),
+  resourceLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/resourceLandingThroughputChartWidget'
+    ),
+  crashFreeSessionsChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget'
+    ),
+  releaseSessionCountChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/releaseSessionCountChartWidget'
+    ),
+  releaseSessionPercentageChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/releaseSessionPercentageChartWidget'
+    ),
+  llmNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget'
+    ),
+  llmPipelineDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget'
+    ),
+  llmTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget'
+    ),
+  llmGroupPipelineDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget'
+    ),
+  llmGroupTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget'
+    ),
+  llmEventTotalTokensUsedChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmEventTotalTokensUsedChartWidget'
+    ),
+  llmGroupNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget'
+    ),
+  llmEventNumberOfPipelinesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/llmEventNumberOfPipelinesChartWidget'
+    ),
+  queuesSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget'
+    ),
+  releaseNewIssuesChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget'),
+  performanceScoreBreakdownChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget'
+    ),
+  queuesLandingLatencyChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesLandingLatencyChartWidget'
+    ),
+  queuesLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesLandingThroughputChartWidget'
+    ),
+  queuesSummaryLatencyChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget'
+    ),
+  newAndResolvedIssueChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget'
+    ),
+  databaseSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget'
+    ),
+  databaseLandingDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseLandingDurationChartWidget'
+    ),
+  databaseLandingThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseLandingThroughputChartWidget'
+    ),
+  databaseSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget'
+    ),
+  cacheThroughputChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/cacheThroughputChartWidget'),
+  cacheMissRateChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/cacheMissRateChartWidget'),
+  httpResponseCodesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget'
+    ),
+  httpThroughputChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/httpThroughputChartWidget'),
+  httpDomainSummaryResponseCodesChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget'
+    ),
+  httpDomainSummaryThroughputChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget'
+    ),
+  httpDurationChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/httpDurationChartWidget'),
+  httpDomainSummaryDurationChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget'
+    ),
+} satisfies Record<string, () => Promise<{default: React.FC<LoadableChartWidgetProps>}>>;
 
 /**
  * Render an Insights Widget by id.
@@ -311,9 +180,11 @@ export function ChartWidgetLoader(props: Props) {
   const query = useQuery<{default: React.FC<LoadableChartWidgetProps>}>({
     queryKey: [`widget-${props.id}`],
     queryFn: () => {
-      const importChartFn = CHART_MAP.get(props.id);
-      if (typeof importChartFn === 'function') {
-        return importChartFn();
+      if (CHART_MAP.hasOwnProperty(props.id)) {
+        const importChartFn = CHART_MAP[props.id];
+        if (typeof importChartFn === 'function') {
+          return importChartFn();
+        }
       }
 
       return Promise.reject(new Error(`Widget "${props.id}" not found`));

--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -14,159 +14,287 @@ interface Props extends LoadableChartWidgetProps {
 }
 
 // We need to map the widget id to the dynamic import because we want the import paths to be statically analyzable.
-const CHART_MAP: Record<
+const CHART_MAP: Map<
   string,
   () => Promise<{default: React.FC<LoadableChartWidgetProps>}>
-> = {
-  [EVENT_GRAPH_WIDGET_ID]: () =>
-    import('sentry/views/issueDetails/streamline/eventGraphWidget'),
-  unhealthySessionsChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/unhealthySessionsChartWidget'
-    ),
-  userHealthCountChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/userHealthCountChartWidget'),
-  userHealthRateChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/userHealthRateChartWidget'),
-  sessionHealthRateChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/sessionHealthRateChartWidget'
-    ),
-  resourceSummaryAverageSizeChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget'
-    ),
-  resourceSummaryDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/resourceSummaryDurationChartWidget'
-    ),
-  resourceSummaryThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget'
-    ),
-  sessionHealthCountChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/sessionHealthCountChartWidget'
-    ),
-  resourceLandingDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/resourceLandingDurationChartWidget'
-    ),
-  resourceLandingThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/resourceLandingThroughputChartWidget'
-    ),
-  crashFreeSessionsChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget'
-    ),
-  releaseSessionCountChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/releaseSessionCountChartWidget'
-    ),
-  releaseSessionPercentageChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/releaseSessionPercentageChartWidget'
-    ),
-  llmNumberOfPipelinesChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget'
-    ),
-  llmPipelineDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget'
-    ),
-  llmTotalTokensUsedChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget'
-    ),
-  llmGroupPipelineDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget'
-    ),
-  llmGroupTotalTokensUsedChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget'
-    ),
-  llmEventTotalTokensUsedChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmEventTotalTokensUsedChartWidget'
-    ),
-  llmGroupNumberOfPipelinesChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget'
-    ),
-  llmEventNumberOfPipelinesChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/llmEventNumberOfPipelinesChartWidget'
-    ),
-  queuesSummaryThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget'
-    ),
-  releaseNewIssuesChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget'),
-  performanceScoreBreakdownChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget'
-    ),
-  queuesLandingLatencyChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/queuesLandingLatencyChartWidget'
-    ),
-  queuesLandingThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/queuesLandingThroughputChartWidget'
-    ),
-  queuesSummaryLatencyChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget'
-    ),
-  newAndResolvedIssueChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget'
-    ),
-  databaseSummaryThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget'
-    ),
-  databaseLandingDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/databaseLandingDurationChartWidget'
-    ),
-  databaseLandingThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/databaseLandingThroughputChartWidget'
-    ),
-  databaseSummaryDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget'
-    ),
-  cacheThroughputChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/cacheThroughputChartWidget'),
-  cacheMissRateChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/cacheMissRateChartWidget'),
-  httpResponseCodesChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget'
-    ),
-  httpThroughputChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/httpThroughputChartWidget'),
-  httpDomainSummaryResponseCodesChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget'
-    ),
-  httpDomainSummaryThroughputChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget'
-    ),
-  httpDurationChartWidget: () =>
-    import('sentry/views/insights/common/components/widgets/httpDurationChartWidget'),
-  httpDomainSummaryDurationChartWidget: () =>
-    import(
-      'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget'
-    ),
-} as const;
+> = new Map([
+  [
+    EVENT_GRAPH_WIDGET_ID,
+    () => import('sentry/views/issueDetails/streamline/eventGraphWidget'),
+  ],
+  [
+    'unhealthySessionsChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/unhealthySessionsChartWidget'
+      ),
+  ],
+  [
+    'userHealthCountChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/userHealthCountChartWidget'
+      ),
+  ],
+  [
+    'userHealthRateChartWidget',
+    () =>
+      import('sentry/views/insights/common/components/widgets/userHealthRateChartWidget'),
+  ],
+  [
+    'sessionHealthRateChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/sessionHealthRateChartWidget'
+      ),
+  ],
+  [
+    'resourceSummaryAverageSizeChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget'
+      ),
+  ],
+  [
+    'resourceSummaryDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/resourceSummaryDurationChartWidget'
+      ),
+  ],
+  [
+    'resourceSummaryThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget'
+      ),
+  ],
+  [
+    'sessionHealthCountChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/sessionHealthCountChartWidget'
+      ),
+  ],
+  [
+    'resourceLandingDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/resourceLandingDurationChartWidget'
+      ),
+  ],
+  [
+    'resourceLandingThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/resourceLandingThroughputChartWidget'
+      ),
+  ],
+  [
+    'crashFreeSessionsChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget'
+      ),
+  ],
+  [
+    'releaseSessionCountChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/releaseSessionCountChartWidget'
+      ),
+  ],
+  [
+    'releaseSessionPercentageChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/releaseSessionPercentageChartWidget'
+      ),
+  ],
+  [
+    'llmNumberOfPipelinesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget'
+      ),
+  ],
+  [
+    'llmPipelineDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget'
+      ),
+  ],
+  [
+    'llmTotalTokensUsedChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget'
+      ),
+  ],
+  [
+    'llmGroupPipelineDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget'
+      ),
+  ],
+  [
+    'llmGroupTotalTokensUsedChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget'
+      ),
+  ],
+  [
+    'llmEventTotalTokensUsedChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmEventTotalTokensUsedChartWidget'
+      ),
+  ],
+  [
+    'llmGroupNumberOfPipelinesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget'
+      ),
+  ],
+  [
+    'llmEventNumberOfPipelinesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/llmEventNumberOfPipelinesChartWidget'
+      ),
+  ],
+  [
+    'queuesSummaryThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget'
+      ),
+  ],
+  [
+    'releaseNewIssuesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget'
+      ),
+  ],
+  [
+    'performanceScoreBreakdownChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget'
+      ),
+  ],
+  [
+    'queuesLandingLatencyChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/queuesLandingLatencyChartWidget'
+      ),
+  ],
+  [
+    'queuesLandingThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/queuesLandingThroughputChartWidget'
+      ),
+  ],
+  [
+    'queuesSummaryLatencyChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget'
+      ),
+  ],
+  [
+    'newAndResolvedIssueChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget'
+      ),
+  ],
+  [
+    'databaseSummaryThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget'
+      ),
+  ],
+  [
+    'databaseLandingDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/databaseLandingDurationChartWidget'
+      ),
+  ],
+  [
+    'databaseLandingThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/databaseLandingThroughputChartWidget'
+      ),
+  ],
+  [
+    'databaseSummaryDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget'
+      ),
+  ],
+  [
+    'cacheThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/cacheThroughputChartWidget'
+      ),
+  ],
+  [
+    'cacheMissRateChartWidget',
+    () =>
+      import('sentry/views/insights/common/components/widgets/cacheMissRateChartWidget'),
+  ],
+  [
+    'httpResponseCodesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget'
+      ),
+  ],
+  [
+    'httpThroughputChartWidget',
+    () =>
+      import('sentry/views/insights/common/components/widgets/httpThroughputChartWidget'),
+  ],
+  [
+    'httpDomainSummaryResponseCodesChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget'
+      ),
+  ],
+  [
+    'httpDomainSummaryThroughputChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget'
+      ),
+  ],
+  [
+    'httpDurationChartWidget',
+    () =>
+      import('sentry/views/insights/common/components/widgets/httpDurationChartWidget'),
+  ],
+  [
+    'httpDomainSummaryDurationChartWidget',
+    () =>
+      import(
+        'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget'
+      ),
+  ],
+]);
 
 /**
  * Render an Insights Widget by id.
@@ -183,12 +311,12 @@ export function ChartWidgetLoader(props: Props) {
   const query = useQuery<{default: React.FC<LoadableChartWidgetProps>}>({
     queryKey: [`widget-${props.id}`],
     queryFn: () => {
-      const importChartFn = CHART_MAP[props.id];
+      const importChartFn = CHART_MAP.get(props.id);
       if (typeof importChartFn === 'function') {
         return importChartFn();
       }
 
-      return Promise.reject(new Error(`Widget ${props.id} not found`));
+      return Promise.reject(new Error(`Widget "${props.id}" not found`));
     },
   });
 

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestin
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatTimeSeriesResultsToChartData} from 'sentry/views/insights/browser/webVitals/components/charts/formatTimeSeriesResultsToChartData';
-import {PerformanceScoreBreakdownChartWidget} from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
+import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -15,7 +15,7 @@ import type {
   ProjectScore,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
-import {PerformanceScoreBreakdownChartWidget} from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
+import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
 
 type Props = {
   isProjectScoreLoading?: boolean;

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -31,7 +31,7 @@ import {WebVitalMetersPlaceholder} from 'sentry/views/insights/browser/webVitals
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
-import {PerformanceScoreBreakdownChartWidget} from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
+import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';

--- a/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
@@ -24,7 +24,7 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
     <InsightsLineChartWidget
       {...props}
       id="cacheMissRateChartWidget"
-      title={DataTitles[`cache_miss_rate()`]}
+      title={DataTitles[`${CACHE_MISS_RATE}()`]}
       series={[data[`${CACHE_MISS_RATE}()`]]}
       isLoading={isPending}
       error={error}

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -111,7 +111,7 @@ export default function PerformanceScoreBreakdownChartWidget(
 
   return (
     <InsightsTimeSeriesWidget
-      id={props.id}
+      id="performanceScoreBreakdownChartWidget"
       title={t('Score Breakdown')}
       height="100%"
       visualizationType="area"

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -18,7 +18,9 @@ import {
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
 
-export function PerformanceScoreBreakdownChartWidget(props: LoadableChartWidgetProps) {
+export default function PerformanceScoreBreakdownChartWidget(
+  props: LoadableChartWidgetProps
+) {
   const {
     transaction,
     [SpanIndexedField.BROWSER_NAME]: browserTypes,
@@ -109,6 +111,7 @@ export function PerformanceScoreBreakdownChartWidget(props: LoadableChartWidgetP
 
   return (
     <InsightsTimeSeriesWidget
+      id={props.id}
       title={t('Score Breakdown')}
       height="100%"
       visualizationType="area"

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -111,6 +111,7 @@ export default function PerformanceScoreBreakdownChartWidget(
 
   return (
     <InsightsTimeSeriesWidget
+      {...props}
       id="performanceScoreBreakdownChartWidget"
       title={t('Score Breakdown')}
       height="100%"

--- a/static/app/views/insights/common/components/widgets/types.tsx
+++ b/static/app/views/insights/common/components/widgets/types.tsx
@@ -11,7 +11,6 @@ export interface LoadableChartWidgetProps {
    */
   height?: string | number;
 
-  // TODO(billy): This should be required when all chart widgets are converted
   /**
    * Unique ID for the widget
    *

--- a/static/app/views/releases/drawer/releasesDrawer.tsx
+++ b/static/app/views/releases/drawer/releasesDrawer.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 import {logger} from '@sentry/core';
 
+import type {ChartId} from 'sentry/components/charts/chartWidgetLoader';
 import {
   EventDrawerBody,
   EventDrawerContainer,
@@ -72,7 +73,7 @@ export function ReleasesDrawer() {
   }
 
   if (start && end) {
-    return <ReleasesDrawerList chart={rdChart} pageFilters={pageFilters} />;
+    return <ReleasesDrawerList chart={rdChart as ChartId} pageFilters={pageFilters} />;
   }
 
   return (

--- a/static/app/views/releases/drawer/releasesDrawerList.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerList.tsx
@@ -3,7 +3,10 @@ import type {SeriesOption} from 'echarts';
 import type {MarkLineOption} from 'echarts/types/dist/shared';
 import type {EChartsInstance} from 'echarts-for-react';
 
-import {ChartWidgetLoader} from 'sentry/components/charts/chartWidgetLoader';
+import {
+  type ChartId,
+  ChartWidgetLoader,
+} from 'sentry/components/charts/chartWidgetLoader';
 import {
   EventDrawerBody,
   EventDrawerContainer,
@@ -23,7 +26,7 @@ import {ReleaseDrawerTable} from './releasesDrawerTable';
 
 interface ReleasesDrawerListProps {
   pageFilters: PageFilters;
-  chart?: string;
+  chart?: ChartId;
 }
 
 type MarkLineDataCallbackFn = (item: SeriesDataUnit) => boolean;


### PR DESCRIPTION
Create a map of `id` -> `() => import()` in `<ChartWidgetLoader>` so that all module import paths are static (so that it is statically analyzable). Adds a test to make sure that all widgets are importable by said component as well.

All widgets in `static/app/views/insights/common/components/widgets` must:
- have a `id` prop with the widget name
- `id` must match the filename
- have a `default` export that is a React component (component name should be TitleCase of `id`)
- be mapped via `id` -> dynamic import in `chartWidgetLoader.tsx`
