### PR TITLE
ref(dashboards): Rename `TimeSeries` meta keys

### DIFF
--- a/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
+++ b/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
@@ -14,8 +14,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'string',
-        unit: null,
+        valueType: 'string',
+        valueUnit: null,
       },
     };
 
@@ -37,8 +37,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.SECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.SECOND,
       },
     };
 
@@ -55,8 +55,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.SECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.SECOND,
       },
     };
 
@@ -69,8 +69,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.MILLISECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.MILLISECOND,
       },
     });
   });
@@ -85,8 +85,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'size',
-        unit: SizeUnit.MEBIBYTE,
+        valueType: 'size',
+        valueUnit: SizeUnit.MEBIBYTE,
       },
     };
 
@@ -99,8 +99,8 @@ describe('scaleTimeSeriesData', () => {
         },
       ],
       meta: {
-        type: 'size',
-        unit: SizeUnit.BYTE,
+        valueType: 'size',
+        valueUnit: SizeUnit.BYTE,
       },
     });
   });

--- a/static/app/utils/timeSeries/scaleTimeSeriesData.tsx
+++ b/static/app/utils/timeSeries/scaleTimeSeriesData.tsx
@@ -23,7 +23,7 @@ export function scaleTimeSeriesData(
 ): TimeSeries {
   // TODO: Instead of a fallback, allow this to be `null`, which might happen
   const sourceType =
-    (timeSeries.meta?.type as AggregationOutputType) ??
+    (timeSeries.meta?.valueType as AggregationOutputType) ??
     (FALLBACK_TYPE as AggregationOutputType);
 
   // Don't bother trying to convert numbers, dates, etc.
@@ -31,7 +31,7 @@ export function scaleTimeSeriesData(
     return timeSeries;
   }
 
-  const sourceUnit = timeSeries.meta?.unit;
+  const sourceUnit = timeSeries.meta?.valueUnit;
 
   if (!destinationUnit || sourceUnit === destinationUnit) {
     return timeSeries;
@@ -82,8 +82,8 @@ export function scaleTimeSeriesData(
     }),
     meta: {
       ...timeSeries.meta,
-      type: sourceType,
-      unit: destinationUnit,
+      valueType: sourceType,
+      valueUnit: destinationUnit,
     },
   };
 }

--- a/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
+++ b/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
@@ -32,8 +32,8 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.MILLISECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.MILLISECOND,
       },
     };
 
@@ -82,8 +82,8 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.MILLISECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.MILLISECOND,
       },
     };
 
@@ -140,8 +140,8 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.MILLISECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.MILLISECOND,
       },
     };
 
@@ -205,8 +205,8 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
         },
       ],
       meta: {
-        type: 'duration',
-        unit: DurationUnit.MILLISECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.MILLISECOND,
       },
     };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -21,8 +21,8 @@ type AttributeValueUnit = DataUnit | null;
 type TimeSeriesValueType = AttributeValueType;
 export type TimeSeriesValueUnit = AttributeValueUnit;
 export type TimeSeriesMeta = {
-  type: TimeSeriesValueType;
-  unit: TimeSeriesValueUnit;
+  valueType: TimeSeriesValueType;
+  valueUnit: TimeSeriesValueUnit;
   isOther?: boolean;
 };
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
@@ -4,8 +4,8 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 export const sampleDurationTimeSeries: TimeSeries = {
   field: 'p99(span.duration)',
   meta: {
-    type: 'duration',
-    unit: DurationUnit.MILLISECOND,
+    valueType: 'duration',
+    valueUnit: DurationUnit.MILLISECOND,
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
@@ -3,8 +3,8 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 export const sampleScoreTimeSeries: TimeSeries = {
   field: 'performance_score(measurements.score.lcp)',
   meta: {
-    type: 'score',
-    unit: null,
+    valueType: 'score',
+    valueUnit: null,
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
@@ -4,8 +4,8 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 export const sampleThroughputTimeSeries: TimeSeries = {
   field: 'eps()',
   meta: {
-    type: 'rate',
-    unit: RateUnit.PER_SECOND,
+    valueType: 'rate',
+    valueUnit: RateUnit.PER_SECOND,
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -79,13 +79,13 @@ export abstract class ContinuousTimeSeries<
   }
 
   get dataType(): PlottableTimeSeriesValueType {
-    return isAPlottableTimeSeriesValueType(this.timeSeries.meta.type)
-      ? this.timeSeries.meta.type
+    return isAPlottableTimeSeriesValueType(this.timeSeries.meta.valueType)
+      ? this.timeSeries.meta.valueType
       : FALLBACK_TYPE;
   }
 
   get dataUnit(): TimeSeriesValueUnit {
-    return this.timeSeries.meta.unit;
+    return this.timeSeries.meta.valueUnit;
   }
 
   get start(): number | null {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -352,8 +352,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleThroughputTimeSeries,
                   field: 'equation|spm() + 1',
                   meta: {
-                    type: 'number',
-                    unit: null,
+                    valueType: 'number',
+                    valueUnit: null,
                   },
                 }),
                 new Line({
@@ -372,24 +372,24 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleDurationTimeSeries,
                   field: 'custom_agg(duration)',
                   meta: {
-                    type: 'number',
-                    unit: null,
+                    valueType: 'number',
+                    valueUnit: null,
                   },
                 }),
                 new Line({
                   ...sampleDurationTimeSeriesP50,
                   field: 'custom_agg2(duration)',
                   meta: {
-                    type: 'integer',
-                    unit: null,
+                    valueType: 'integer',
+                    valueUnit: null,
                   },
                 }),
                 new Line({
                   ...sampleThroughputTimeSeries,
                   field: 'custom_agg3(duration)',
                   meta: {
-                    type: 'duration',
-                    unit: DurationUnit.MILLISECOND,
+                    valueType: 'duration',
+                    valueUnit: DurationUnit.MILLISECOND,
                   },
                 }),
               ]}
@@ -435,8 +435,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         };
       }),
       meta: {
-        type: 'duration',
-        unit: DurationUnit.SECOND,
+        valueType: 'duration',
+        valueUnit: DurationUnit.SECOND,
       },
     };
 
@@ -718,8 +718,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
       ...sampleThroughputTimeSeries,
       field: 'error_rate()',
       meta: {
-        type: 'rate',
-        unit: RateUnit.PER_SECOND,
+        valueType: 'rate',
+        valueUnit: RateUnit.PER_SECOND,
       },
     };
 
@@ -978,6 +978,6 @@ function hasTimestamp(release: Partial<Release>): release is Release {
 }
 
 const NULL_META: TimeSeriesMeta = {
-  type: null,
-  unit: null,
+  valueType: null,
+  valueUnit: null,
 };

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -240,8 +240,8 @@ export function convertEventsStatsToTimeSeriesData(
       value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
     })),
     meta: {
-      type: seriesData.meta?.fields?.[seriesName]!,
-      unit: seriesData.meta?.units?.[seriesName] as DataUnit,
+      valueType: seriesData.meta?.fields?.[seriesName]!,
+      valueUnit: seriesData.meta?.units?.[seriesName] as DataUnit,
     },
     confidence: determineSeriesConfidence(seriesData),
     sampleCount: seriesData.meta?.accuracy?.sampleCount,

--- a/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
+++ b/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
@@ -7,8 +7,8 @@ export function convertSeriesToTimeseries(series: DiscoverSeries): TimeSeries {
     field: series.seriesName,
     meta: {
       // This behavior is a little awkward. Normally `meta` shouldn't be missing, but we sometime return blank meta from helper hooks
-      type: series.meta?.fields?.[series.seriesName] ?? null,
-      unit: (series.meta?.units?.[series.seriesName] ?? null) as DataUnit,
+      valueType: series.meta?.fields?.[series.seriesName] ?? null,
+      valueUnit: (series.meta?.units?.[series.seriesName] ?? null) as DataUnit,
     },
     values: (series?.data ?? []).map(datum => {
       const timestamp =

--- a/tests/js/fixtures/timeSeries.ts
+++ b/tests/js/fixtures/timeSeries.ts
@@ -5,8 +5,8 @@ export function TimeSeriesFixture(params: Partial<TimeSeries> = {}): TimeSeries 
   return {
     field: 'eps()',
     meta: {
-      type: 'rate',
-      unit: RateUnit.PER_SECOND
+      valueType: 'rate',
+      valueUnit: RateUnit.PER_SECOND
     },
     values: [
       {


### PR DESCRIPTION
Closes [DAIN-380: Rename `type` and `unit` to `valueType` and `valueUnit`](https://linear.app/getsentry/issue/DAIN-380/rename-type-and-unit-to-valuetype-and-valueunit). More work to align with `/events-timeseries/` responses. Renames `type` and `unit` to match!
