### PR TITLE
chore(explore): Remove unused route override

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -153,7 +153,6 @@ const useTraceCountSeries = ({
       search: new MutableSearch(query ?? ''),
       yAxis: ['count()'],
       interval: getInterval(pageFilters.selection.datetime, 'metrics'),
-      overriddenRoute: 'traces-stats',
       enabled,
     },
     'api.trace-explorer.stats'


### PR DESCRIPTION
This override is never used and just goes to events-stats.