### PR TITLE
chore(typescript): Remove `baseUrl` in anticipation for deprecation.

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -95,19 +95,18 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
 
-    "baseUrl": "../",
     "paths": {
-      "sentry/*": ["static/app/*"],
-      "sentry-fixture/*": ["tests/js/fixtures/*"],
-      "sentry-test/*": ["tests/js/sentry-test/*"],
-      "getsentry-test/*": ["tests/js/getsentry-test/*"],
-      "sentry-images/*": ["static/images/*"],
-      "sentry-locale/*": ["src/sentry/locale/*"],
-      "sentry-logos/*": ["src/sentry/static/sentry/images/logos/*"],
-      "sentry-fonts/*": ["static/fonts/*"],
-      "getsentry/*": ["static/gsApp/*"],
-      "getsentry-images/*": ["static/images/*"],
-      "admin/*": ["static/gsAdmin/*"]
+      "sentry/*": ["../static/app/*"],
+      "sentry-fixture/*": ["../tests/js/fixtures/*"],
+      "sentry-test/*": ["../tests/js/sentry-test/*"],
+      "getsentry-test/*": ["../tests/js/getsentry-test/*"],
+      "sentry-images/*": ["../static/images/*"],
+      "sentry-locale/*": ["../src/sentry/locale/*"],
+      "sentry-logos/*": ["../src/sentry/static/sentry/images/logos/*"],
+      "sentry-fonts/*": ["../static/fonts/*"],
+      "getsentry/*": ["../static/gsApp/*"],
+      "getsentry-images/*": ["../static/images/*"],
+      "admin/*": ["../static/gsAdmin/*"]
     },
 
     "plugins": [


### PR DESCRIPTION
[We recently tried to build the Sentry codebase](https://github.com/microsoft/typescript-go/issues/807) with [the native port of the TypeScript compiler](https://github.com/microsoft/typescript-go). Unfortunately, the compiler issued a flood of errors because the Sentry project relies on `baseUrl` which we are leaning towards removing.

Path mapping will still be supported - but `baseUrl` has not been required for path mapping since TypeScript 4.1, and has been discouraged from use. `baseUrl` occasionally permits paths that may not be intended to be valid (e.g. importing from `static/app/foo/Bar` instead of `sentry/foo/Bar`). It may also be the case that `baseUrl` can result in extra lookups, but don't quote me on that.

Instead, each path can be given an explicit relative prefix (or optionally use `${configDir}`, though that is likely not ideal much of the time). This PR does exactly that and future-proofs the Sentry codebase.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
