### PR TITLE
fix(stacktrace-link): Use new Java logic

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -118,6 +118,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable custom dynamic sampling rates
     manager.add("organizations:dynamic-sampling-custom", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable new munging logic for java frames
+    manager.add("organizations:java-frame-munging-new-logic", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable issue platform deletion
     manager.add("organizations:issue-platform-deletion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable archive/escalating issue workflow features in v2

--- a/src/sentry/integrations/utils/stacktrace_link.py
+++ b/src/sentry/integrations/utils/stacktrace_link.py
@@ -10,6 +10,7 @@ from sentry.integrations.source_code_management.repository import RepositoryInte
 from sentry.issues.auto_source_code_config.code_mapping import (
     convert_stacktrace_frame_path_to_source_path,
 )
+from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.event_frames import EventFrame
@@ -83,6 +84,7 @@ class StacktraceLinkOutcome(TypedDict):
 def get_stacktrace_config(
     configs: list[RepositoryProjectPathConfig],
     ctx: StacktraceLinkContext,
+    organization: Organization | None = None,
 ) -> StacktraceLinkOutcome:
     result: StacktraceLinkOutcome = {
         "source_url": None,
@@ -97,6 +99,7 @@ def get_stacktrace_config(
             platform=ctx["platform"],
             sdk_name=ctx["sdk_name"],
             code_mapping=config,
+            organization=organization,
         )
         result["src_path"] = src_path
         if not src_path:

--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -153,7 +153,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         scope = Scope.get_isolation_scope()
 
         set_top_tags(scope, project, ctx, len(configs) > 0)
-        result = get_stacktrace_config(configs, ctx)
+        result = get_stacktrace_config(configs, ctx, project.organization)
         error = result["error"]
         src_path = result["src_path"]
         # Post-processing before exiting scope context


### PR DESCRIPTION
The stacktrace-link endpoint uses the original munging logic, which has a bug.

This change switches to the new logic and is gated behind a feature flag.