### PR TITLE
fix(rate-limits): Return correct response from api when concurrently rate limiting

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -26,6 +26,10 @@ DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
     "{limit} requests in {window} seconds"
 )
+DEFAULT_CONCURRENT_ERROR_MESSAGE = (
+    "You are attempting to go above the allowed concurrency for this endpoint. Concurrency limit is "
+    "{limit}"
+)
 logger = logging.getLogger("sentry.api.rate-limit")
 
 
@@ -114,6 +118,11 @@ class RatelimitMiddleware:
                             DEFAULT_ERROR_MESSAGE.format(
                                 limit=request.rate_limit_metadata.limit,
                                 window=request.rate_limit_metadata.window,
+                            )
+                            if request.rate_limit_metadata.rate_limit_type
+                            == RateLimitType.FIXED_WINDOW
+                            else DEFAULT_CONCURRENT_ERROR_MESSAGE.format(
+                                limit=request.rate_limit_metadata.concurrent_limit
                             )
                         ),
                         status=429,

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -113,20 +113,17 @@ class RatelimitMiddleware:
                             "window": request.rate_limit_metadata.window,
                         },
                     )
-                    response = HttpResponse(
-                        orjson.dumps(
-                            DEFAULT_ERROR_MESSAGE.format(
-                                limit=request.rate_limit_metadata.limit,
-                                window=request.rate_limit_metadata.window,
-                            )
-                            if request.rate_limit_metadata.rate_limit_type
-                            == RateLimitType.FIXED_WINDOW
-                            else DEFAULT_CONCURRENT_ERROR_MESSAGE.format(
-                                limit=request.rate_limit_metadata.concurrent_limit
-                            )
-                        ),
-                        status=429,
-                    )
+                    if request.rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW:
+                        response_text = DEFAULT_ERROR_MESSAGE.format(
+                            limit=request.rate_limit_metadata.limit,
+                            window=request.rate_limit_metadata.window,
+                        )
+                    else:
+                        response_text = DEFAULT_CONCURRENT_ERROR_MESSAGE.format(
+                            limit=request.rate_limit_metadata.concurrent_limit
+                        )
+
+                    response = HttpResponse(orjson.dumps(response_text), status=429)
                     assert request.method is not None
                     return apply_cors_headers(
                         request=request, response=response, allowed_methods=[request.method]

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -118,7 +118,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             response = self.middleware.process_view(request, self._test_endpoint, [], {})
             assert request.will_be_rate_limited
             assert response
-            assert "You are attempting to use this endpoint too frequently. Limit is 0 requests in 100 seconds" in response.serialize().decode(
+            assert "You are attempting to use this endpoint too frequently. Limit is 0 requests in 100 seconds" in response.serialize().decode(  # type: ignore[attr-defined]
                 "utf-8"
             )
             assert response["Access-Control-Allow-Methods"] == "GET"
@@ -148,7 +148,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             response = self.middleware.process_view(request, self._test_endpoint, [], {})
             assert request.will_be_rate_limited
             assert response
-            assert "You are attempting to go above the allowed concurrency for this endpoint. Concurrency limit is 1" in response.serialize().decode(
+            assert "You are attempting to go above the allowed concurrency for this endpoint. Concurrency limit is 1" in response.serialize().decode(  # type: ignore[attr-defined]
                 "utf-8"
             )
             assert response["Access-Control-Allow-Methods"] == "GET"

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -118,6 +118,39 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             response = self.middleware.process_view(request, self._test_endpoint, [], {})
             assert request.will_be_rate_limited
             assert response
+            assert "You are attempting to use this endpoint too frequently. Limit is 0 requests in 100 seconds" in response.serialize().decode(
+                "utf-8"
+            )
+            assert response["Access-Control-Allow-Methods"] == "GET"
+            assert response["Access-Control-Allow-Origin"] == "*"
+            assert response["Access-Control-Allow-Headers"]
+            assert response["Access-Control-Expose-Headers"]
+
+    @patch("sentry.middleware.ratelimit.get_rate_limit_value")
+    @patch("sentry.ratelimits.utils.ratelimiter.is_limited_with_value")
+    @override_settings(ENFORCE_CONCURRENT_RATE_LIMITS=True)
+    def test_positive_concurrent_rate_limit_response_headers(
+        self, is_limited_with_value, default_rate_limit_mock
+    ):
+        request = self.factory.get("/")
+
+        with (
+            freeze_time("2000-01-01"),
+            patch.object(RatelimitMiddlewareTest.TestEndpoint, "enforce_rate_limit", True),
+            patch("sentry.ratelimits.concurrent.rate_limit_info") as rate_limit_info,
+        ):
+            rate_limit_info.return_value = (1, False, 0)
+
+            default_rate_limit_mock.return_value = RateLimit(
+                limit=0, window=100, concurrent_limit=1
+            )
+            is_limited_with_value.return_value = (False, 0, 0)
+            response = self.middleware.process_view(request, self._test_endpoint, [], {})
+            assert request.will_be_rate_limited
+            assert response
+            assert "You are attempting to go above the allowed concurrency for this endpoint. Concurrency limit is 1" in response.serialize().decode(
+                "utf-8"
+            )
             assert response["Access-Control-Allow-Methods"] == "GET"
             assert response["Access-Control-Allow-Origin"] == "*"
             assert response["Access-Control-Allow-Headers"]


### PR DESCRIPTION
When we concurrently rate limit people we return headers correctly detailing the concurrent rate limit, but the response text itself is confusing and says that they've exceeded a fixed window limit instead.

<!-- Describe your PR here. -->