### PR TITLE
ref(uptime): Write uptime_status in create_uptime_subscription

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -75,6 +75,7 @@ def create_uptime_subscription(
     headers: Sequence[tuple[str, str]] | None = None,
     body: str | None = None,
     trace_sampling: bool = False,
+    uptime_status: UptimeStatus = UptimeStatus.OK,
 ) -> UptimeSubscription:
     """
     Creates a new uptime subscription. This creates the row in postgres, and fires a task that will send the config
@@ -98,6 +99,7 @@ def create_uptime_subscription(
         headers=headers,  # type: ignore[misc]
         body=body,
         trace_sampling=trace_sampling,
+        uptime_status=uptime_status,
     )
 
     # Associate active regions with this subscription
@@ -212,6 +214,7 @@ def create_project_uptime_subscription(
             headers=headers,
             body=body,
             trace_sampling=trace_sampling,
+            uptime_status=uptime_status,
         )
         owner_user_id = None
         owner_team_id = None


### PR DESCRIPTION
This does not actually change any behavior other than in tests, since we are actually never passing `uptime_status` to the create_uptime_subscription or create_project_uptime_subscription