### PR TITLE
ref(aci): update automation list view to use query data

### DIFF
--- a/static/app/views/automations/components/automationListRow.tsx
+++ b/static/app/views/automations/components/automationListRow.tsx
@@ -6,38 +6,24 @@ import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {ConnectionCell} from 'sentry/components/workflowEngine/gridCell/connectionCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
-import {TitleCell} from 'sentry/components/workflowEngine/gridCell/titleCell';
 import {space} from 'sentry/styles/space';
-import type {ActionType} from 'sentry/types/workflowEngine/actions';
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
+import {AUTOMATIONS_BASE_URL} from 'sentry/views/automations/routes';
 
-export type Automation = {
-  actions: ActionType[];
-  id: string;
-  link: string;
-  monitorIds: string[];
-  name: string;
-  details?: string[];
-  disabled?: boolean;
-  lastTriggered?: Date;
-};
-
-type AutomationListRowProps = Automation & {
+type AutomationListRowProps = {
+  automation: Automation;
   handleSelect: (id: string, checked: boolean) => void;
   selected: boolean;
 };
 
 export function AutomationListRow({
-  actions,
-  id,
-  lastTriggered,
-  link,
-  monitorIds,
-  name,
-  details,
+  automation,
   handleSelect,
   selected,
-  disabled,
 }: AutomationListRowProps) {
+  const actions = useAutomationActions(automation);
+  const {id, name, disabled, lastTriggered, detectorIds = []} = automation;
   return (
     <RowWrapper disabled={disabled}>
       <InteractionStateLayer />
@@ -49,12 +35,7 @@ export function AutomationListRow({
           }}
         />
         <CellWrapper>
-          <StyledTitleCell
-            name={name}
-            link={link}
-            details={details}
-            disabled={disabled}
-          />
+          <TitleCell href={`${AUTOMATIONS_BASE_URL}/${id}/`}>{name}</TitleCell>
         </CellWrapper>
       </Flex>
       <CellWrapper className="last-triggered">
@@ -64,7 +45,7 @@ export function AutomationListRow({
         <ActionCell actions={actions} disabled={disabled} />
       </CellWrapper>
       <CellWrapper className="connected-monitors">
-        <ConnectionCell ids={monitorIds} type="detector" disabled={disabled} />
+        <ConnectionCell ids={detectorIds} type="detector" disabled={disabled} />
       </CellWrapper>
     </RowWrapper>
   );
@@ -76,16 +57,26 @@ const StyledCheckbox = styled(Checkbox)<{checked?: boolean}>`
   opacity: 1;
 `;
 
-const CellWrapper = styled(Flex)`
+const CellWrapper = styled('div')`
+  justify-content: start;
   padding: 0 ${space(2)};
-  flex: 1;
   overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+  min-width: 0;
 `;
 
-const StyledTitleCell = styled(TitleCell)`
+const TitleCell = styled('a')`
   padding: ${space(2)};
   margin: -${space(2)};
+  color: ${p => p.theme.textColor};
+
+  &:hover,
+  &:active {
+    text-decoration: underline;
+    color: ${p => p.theme.textColor};
+  }
 `;
 
 const RowWrapper = styled('div')<{disabled?: boolean}>`
@@ -139,6 +130,6 @@ const RowWrapper = styled('div')<{disabled?: boolean}>`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: 3fr 1fr 1fr 1fr;
+    grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr;
   }
 `;

--- a/static/app/views/automations/components/automationListRow.tsx
+++ b/static/app/views/automations/components/automationListRow.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Flex} from 'sentry/components/container/flex';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Link from 'sentry/components/links/link';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {ConnectionCell} from 'sentry/components/workflowEngine/gridCell/connectionCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
@@ -35,7 +36,7 @@ export function AutomationListRow({
           }}
         />
         <CellWrapper>
-          <TitleCell href={`${AUTOMATIONS_BASE_URL}/${id}/`}>{name}</TitleCell>
+          <TitleCell to={`${AUTOMATIONS_BASE_URL}/${id}/`}>{name}</TitleCell>
         </CellWrapper>
       </Flex>
       <CellWrapper className="last-triggered">
@@ -67,7 +68,7 @@ const CellWrapper = styled('div')`
   min-width: 0;
 `;
 
-const TitleCell = styled('a')`
+const TitleCell = styled(Link)`
   padding: ${space(2)};
   margin: -${space(2)};
   color: ${p => p.theme.textColor};

--- a/static/app/views/automations/components/automationListTable.tsx
+++ b/static/app/views/automations/components/automationListTable.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -10,16 +11,12 @@ import {
 } from 'sentry/components/workflowEngine/useBulkActions';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {
-  type Automation,
-  AutomationListRow,
-} from 'sentry/views/automations/components/automationListRow';
+import {AutomationListRow} from 'sentry/views/automations/components/automationListRow';
+import {useAutomationsQuery} from 'sentry/views/automations/hooks/utils';
 
-type AutomationListTableProps = {
-  automations: Automation[];
-};
+function AutomationListTable() {
+  const {data: automations = [], isLoading} = useAutomationsQuery();
 
-function AutomationListTable({automations}: AutomationListTableProps) {
   const {
     selectedRows,
     handleSelect,
@@ -44,27 +41,22 @@ function AutomationListTable({automations}: AutomationListTableProps) {
         </Flex>
         <Flex className="action">
           <HeaderDivider />
-          <Heading>{t('Action')}</Heading>
+          <Heading>{t('Actions')}</Heading>
         </Flex>
         <Flex className="connected-monitors">
           <HeaderDivider />
-          <Heading>{t('Connected Monitors')}</Heading>
+          <Heading>{t('Monitors')}</Heading>
         </Flex>
       </StyledPanelHeader>
       <PanelBody>
+        {isLoading ? <LoadingIndicator /> : null}
+
         {automations.map(automation => (
           <AutomationListRow
             key={automation.id}
-            actions={automation.actions}
-            id={automation.id}
-            lastTriggered={automation.lastTriggered}
-            link={automation.link}
-            monitorIds={automation.monitorIds}
-            name={automation.name}
-            details={automation.details}
+            automation={automation}
             handleSelect={handleSelect}
             selected={selectedRows.includes(automation.id)}
-            disabled={automation.disabled}
           />
         ))}
       </PanelBody>
@@ -91,6 +83,7 @@ const StyledPanelHeader = styled(PanelHeader)`
   min-height: 40px;
   align-items: center;
   display: grid;
+  text-transform: none;
 
   .last-triggered,
   .action,
@@ -123,7 +116,7 @@ const StyledPanelHeader = styled(PanelHeader)`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: 3fr 1fr 1fr 1fr;
+    grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr;
   }
 `;
 

--- a/static/app/views/automations/components/automationListTable.tsx
+++ b/static/app/views/automations/components/automationListTable.tsx
@@ -12,7 +12,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {AutomationListRow} from 'sentry/views/automations/components/automationListRow';
-import {useAutomationsQuery} from 'sentry/views/automations/hooks/utils';
+import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 
 function AutomationListTable() {
   const {data: automations = [], isLoading} = useAutomationsQuery();

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -1,0 +1,16 @@
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export interface UseAutomationsQueryOptions {
+  query?: string;
+  sort?: string;
+}
+export function useAutomationsQuery(_options: UseAutomationsQueryOptions = {}) {
+  const {slug} = useOrganization();
+
+  return useApiQuery<Automation[]>([`/organizations/${slug}/workflows/`], {
+    staleTime: 0,
+    retry: false,
+  });
+}

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,0 +1,14 @@
+import type {ActionType} from 'sentry/types/workflowEngine/actions';
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+
+export function useAutomationActions(automation: Automation): ActionType[] {
+  return [
+    ...new Set(
+      automation.actionFilters
+        .flatMap(dataConditionGroup =>
+          dataConditionGroup.actions?.map(action => action.type)
+        )
+        .filter(x => x)
+    ),
+  ] as ActionType[];
+}

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,20 +1,5 @@
 import type {ActionType} from 'sentry/types/workflowEngine/actions';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import useOrganization from 'sentry/utils/useOrganization';
-
-export interface UseAutomationsQueryOptions {
-  query?: string;
-  sort?: string;
-}
-export function useAutomationsQuery(_options: UseAutomationsQueryOptions = {}) {
-  const {slug} = useOrganization();
-
-  return useApiQuery<Automation[]>([`/organizations/${slug}/workflows/`], {
-    staleTime: 0,
-    retry: false,
-  });
-}
 
 export function useAutomationActions(automation: Automation): ActionType[] {
   return [

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,5 +1,20 @@
 import type {ActionType} from 'sentry/types/workflowEngine/actions';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export interface UseAutomationsQueryOptions {
+  query?: string;
+  sort?: string;
+}
+export function useAutomationsQuery(_options: UseAutomationsQueryOptions = {}) {
+  const {slug} = useOrganization();
+
+  return useApiQuery<Automation[]>([`/organizations/${slug}/workflows/`], {
+    staleTime: 0,
+    retry: false,
+  });
+}
 
 export function useAutomationActions(automation: Automation): ActionType[] {
   return [

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -21,7 +21,7 @@ export default function AutomationsList() {
       <ActionsProvider actions={<Actions />}>
         <ListLayout>
           <TableHeader />
-          <AutomationListTable automations={[]} />
+          <AutomationListTable />
         </ListLayout>
       </ActionsProvider>
     </SentryDocumentTitle>

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -3,8 +3,8 @@ import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell
 import {TitleCell} from 'sentry/components/workflowEngine/gridCell/titleCell';
 import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t} from 'sentry/locale';
-import type {ActionType} from 'sentry/types/workflowEngine/actions';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {AUTOMATIONS_BASE_URL} from 'sentry/views/automations/routes';
 
 const columns = defineColumns<Automation>({
@@ -26,23 +26,12 @@ const columns = defineColumns<Automation>({
   actionFilters: {
     Header: () => t('Actions'),
     Cell: ({row}) => {
-      const actions = getAutomationActions(row);
+      const actions = useAutomationActions(row);
       return <ActionCell actions={actions} />;
     },
   },
 });
 
-function getAutomationActions(automation: Automation) {
-  return [
-    ...new Set(
-      automation.actionFilters
-        .flatMap(dataConditionGroup =>
-          dataConditionGroup.actions?.map(action => action.type)
-        )
-        .filter(x => x)
-    ),
-  ] as ActionType[];
-}
 export interface ConnectedAutomationsListProps {
   automations: Automation[];
 }


### PR DESCRIPTION
updating the list view to use the actual `Automation` type and use data from `useAutomationsQuery()`

still need to add the Projects column with the project stack, once we have the hook to fetch connected projects