### PR TITLE
chore(perf-issues): Remove usage of GA'd flags

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -269,7 +269,6 @@ DETAILED_PROJECT = {
             "performance-issues-compressed-assets-detector",
             "device-class-synthesis",
             "profiling-billing",
-            "performance-file-io-main-thread-detector",
             "integrations-deployment",
             "performance-m-n-plus-one-db-queries-visible",
             "mobile-cpu-memory-in-transactions",

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -220,7 +220,6 @@ DETAILED_PROJECT = {
             "performance-n-plus-one-api-calls-post-process-group",
             "performance-db-main-thread-post-process-group",
             "performance-metrics-backed-transaction-summary",
-            "performance-db-main-thread-detector",
             "issue-platform",
             "performance-consecutive-db-issue",
             "performance-consecutive-http-post-process-group",

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -200,9 +200,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
         return data.get("blocked_main_thread", False) is True
 
     def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return features.has(
-            "organizations:performance-file-io-main-thread-detector", organization, actor=None
-        )
+        return True
 
 
 class DBMainThreadDetector(BaseIOMainThreadDetector):

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -7,7 +7,7 @@ from typing import Any
 import sentry_sdk
 from symbolic.proguard import ProguardMapper
 
-from sentry import features, options
+from sentry import options
 from sentry.issues.grouptype import (
     GroupType,
     PerformanceDBMainThreadGroupType,
@@ -241,6 +241,4 @@ class DBMainThreadDetector(BaseIOMainThreadDetector):
         return data.get("blocked_main_thread", False) is True
 
     def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return features.has(
-            "organizations:performance-db-main-thread-detector", organization, actor=None
-        )
+        return True

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -15,7 +15,6 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
     url_name: str
     FEATURES = [
         "organizations:performance-view",
-        "organizations:performance-file-io-main-thread-detector",
         "organizations:trace-view-load-more",
         "organizations:performance-slow-db-issue",
     ]

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -12,7 +12,6 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
     url_name = "sentry-api-0-organization-trace"
     FEATURES = [
         "organizations:trace-spans-format",
-        "organizations:performance-file-io-main-thread-detector",
         "organizations:performance-slow-db-issue",
     ]
 


### PR DESCRIPTION
These flags are already GA'd in `getsentry`, so this should be a no-op. After this I can remove their feature handlers, and unregister them

Affects these flags.
```
performance-file-io-main-thread-detector
performance-db-main-thread-detector
```