### PR TITLE
Use new navigation in admin view

### DIFF
--- a/static/app/views/admin/adminLayout.tsx
+++ b/static/app/views/admin/adminLayout.tsx
@@ -3,39 +3,43 @@ import styled from '@emotion/styled';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import {BreadcrumbProvider} from 'sentry/views/settings/components/settingsBreadcrumb/context';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 import SettingsNavigation from 'sentry/views/settings/components/settingsNavigation';
 
-const renderAdminNavigation = () => (
-  <SettingsNavigation
-    stickyTop="0"
-    navigationObjects={[
-      {
-        name: 'System Status',
-        items: [
-          {path: '/manage/', index: true, title: 'Overview'},
-          {path: '/manage/buffer/', title: 'Buffer'},
-          {path: '/manage/queue/', title: 'Queue'},
-          {path: '/manage/quotas/', title: 'Quotas'},
-          {path: '/manage/status/environment/', title: 'Environment'},
-          {path: '/manage/status/packages/', title: 'Packages'},
-          {path: '/manage/status/mail/', title: 'Mail'},
-          {path: '/manage/status/warnings/', title: 'Warnings'},
-          {path: '/manage/settings/', title: 'Settings'},
-        ],
-      },
-      {
-        name: 'Manage',
-        items: [
-          {path: '/manage/organizations/', title: 'Organizations'},
-          {path: '/manage/projects/', title: 'Projects'},
-          {path: '/manage/users/', title: 'Users'},
-        ],
-      },
-    ]}
-  />
-);
+// TODO: Move this to /views/nav/secondary/sections/admin/adminSecondaryNav.tsx when new navigation is GA'd
+export function AdminNavigation() {
+  return (
+    <SettingsNavigation
+      stickyTop="0"
+      navigationObjects={[
+        {
+          name: 'System Status',
+          items: [
+            {path: '/manage/', index: true, title: 'Overview'},
+            {path: '/manage/buffer/', title: 'Buffer'},
+            {path: '/manage/queue/', title: 'Queue'},
+            {path: '/manage/quotas/', title: 'Quotas'},
+            {path: '/manage/status/environment/', title: 'Environment'},
+            {path: '/manage/status/packages/', title: 'Packages'},
+            {path: '/manage/status/mail/', title: 'Mail'},
+            {path: '/manage/status/warnings/', title: 'Warnings'},
+            {path: '/manage/settings/', title: 'Settings'},
+          ],
+        },
+        {
+          name: 'Manage',
+          items: [
+            {path: '/manage/organizations/', title: 'Organizations'},
+            {path: '/manage/projects/', title: 'Projects'},
+            {path: '/manage/users/', title: 'Users'},
+          ],
+        },
+      ]}
+    />
+  );
+}
 
 type Props = {
   children: React.ReactNode;
@@ -46,7 +50,10 @@ function AdminLayout({children, ...props}: Props) {
     <SentryDocumentTitle noSuffix title={t('Sentry Admin')}>
       <Page>
         <BreadcrumbProvider>
-          <SettingsLayout renderNavigation={renderAdminNavigation} {...props}>
+          <SettingsLayout
+            renderNavigation={prefersStackedNav() ? undefined : AdminNavigation}
+            {...props}
+          >
             {children}
           </SettingsLayout>
         </BreadcrumbProvider>

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -37,7 +37,7 @@ interface SidebarItemDropdownProps {
   items: MenuItemProps[];
   label: string;
   children?: React.ReactNode;
-  forceLabel?: boolean;
+  disableTooltip?: boolean;
   onOpen?: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -60,13 +60,26 @@ interface SidebarItemProps extends React.HTMLAttributes<HTMLLIElement> {
   children: React.ReactNode;
   label: string;
   showLabel: boolean;
+  disableTooltip?: boolean;
 }
 
-export function SidebarItem({children, label, showLabel, ...props}: SidebarItemProps) {
+export function SidebarItem({
+  children,
+  label,
+  showLabel,
+  disableTooltip,
+  ...props
+}: SidebarItemProps) {
   const {layout} = useNavContext();
   return (
     <IconDefaultsProvider legacySize={layout === NavLayout.MOBILE ? '16px' : '21px'}>
-      <Tooltip title={label} disabled={showLabel} position="right" skipWrapper delay={0}>
+      <Tooltip
+        title={label}
+        disabled={showLabel || disableTooltip}
+        position="right"
+        skipWrapper
+        delay={0}
+      >
         <SidebarListItem {...props}>{children}</SidebarListItem>
       </Tooltip>
     </IconDefaultsProvider>
@@ -78,14 +91,14 @@ export function SidebarMenu({
   children,
   analyticsKey,
   label,
-  forceLabel,
   onOpen,
+  disableTooltip,
 }: SidebarItemDropdownProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const {layout} = useNavContext();
 
-  const showLabel = forceLabel || layout === NavLayout.MOBILE;
+  const showLabel = layout === NavLayout.MOBILE;
 
   return (
     <DropdownMenu
@@ -94,7 +107,11 @@ export function SidebarMenu({
       minMenuWidth={200}
       trigger={(props, isOpen) => {
         return (
-          <SidebarItem label={label} showLabel={showLabel}>
+          <SidebarItem
+            label={label}
+            showLabel={showLabel}
+            disableTooltip={disableTooltip}
+          >
             <NavButton
               {...props}
               aria-label={showLabel ? undefined : label}

--- a/static/app/views/nav/primary/config.tsx
+++ b/static/app/views/nav/primary/config.tsx
@@ -36,4 +36,8 @@ export const PRIMARY_NAV_GROUP_CONFIG: PrimaryNavGroupConfig = {
     basePaths: ['codecov'],
     label: t('Codecov'),
   },
+  [PrimaryNavGroup.ADMIN]: {
+    basePaths: ['manage'],
+    label: t('Admin'),
+  },
 };

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -17,7 +17,9 @@ import {withChonk} from 'sentry/utils/theme/withChonk';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useNavContext} from 'sentry/views/nav/context';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {NavLayout} from 'sentry/views/nav/types';
+import {useActiveNavGroup} from 'sentry/views/nav/useActiveNavGroup';
 import {isLinkActive} from 'sentry/views/nav/utils';
 
 type SecondaryNavProps = {
@@ -53,8 +55,9 @@ export function SecondaryNav({children}: SecondaryNavProps) {
   return createPortal(children, secondaryNavEl);
 }
 
-SecondaryNav.Header = function SecondaryNavHeader({children}: {children: ReactNode}) {
+SecondaryNav.Header = function SecondaryNavHeader({children}: {children?: ReactNode}) {
   const {isCollapsed, setIsCollapsed, layout} = useNavContext();
+  const group = useActiveNavGroup();
 
   if (layout === NavLayout.MOBILE) {
     return null;
@@ -62,7 +65,7 @@ SecondaryNav.Header = function SecondaryNavHeader({children}: {children: ReactNo
 
   return (
     <Header>
-      <div>{children}</div>
+      <div>{children ?? PRIMARY_NAV_GROUP_CONFIG[group].label}</div>
       <div>
         <Button
           borderless

--- a/static/app/views/nav/secondary/secondaryNavContent.tsx
+++ b/static/app/views/nav/secondary/secondaryNavContent.tsx
@@ -1,6 +1,7 @@
 import type {ReactNode} from 'react';
 
 import {unreachable} from 'sentry/utils/unreachable';
+import {AdminSecondaryNav} from 'sentry/views/nav/secondary/sections/admin/adminSecondaryNav';
 import CodecovSecondaryNav from 'sentry/views/nav/secondary/sections/codecov/codecovSecondaryNav';
 import {DashboardsSecondaryNav} from 'sentry/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav';
 import {ExploreSecondaryNav} from 'sentry/views/nav/secondary/sections/explore/exploreSecondaryNav';
@@ -26,6 +27,8 @@ export function SecondaryNavContent(): ReactNode {
       return <CodecovSecondaryNav />;
     case PrimaryNavGroup.SETTINGS:
       return <SettingsSecondaryNav />;
+    case PrimaryNavGroup.ADMIN:
+      return <AdminSecondaryNav />;
     default:
       unreachable(activeNavGroup);
       return null;

--- a/static/app/views/nav/secondary/sections/admin/adminSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/admin/adminSecondaryNav.tsx
@@ -1,0 +1,5 @@
+import {AdminNavigation} from 'sentry/views/admin/adminLayout';
+
+export function AdminSecondaryNav() {
+  return <AdminNavigation />;
+}

--- a/static/app/views/nav/types.tsx
+++ b/static/app/views/nav/types.tsx
@@ -10,4 +10,5 @@ export enum PrimaryNavGroup {
   INSIGHTS = 'insights',
   SETTINGS = 'settings',
   CODECOV = 'codecov',
+  ADMIN = 'admin',
 }

--- a/static/app/views/nav/userDropdown.tsx
+++ b/static/app/views/nav/userDropdown.tsx
@@ -4,6 +4,7 @@ import {logout} from 'sentry/actionCreators/account';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import {t} from 'sentry/locale';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import useApi from 'sentry/utils/useApi';
 import {useUser} from 'sentry/utils/useUser';
 import {useNavContext} from 'sentry/views/nav/context';
@@ -24,6 +25,7 @@ export function UserDropdown() {
     <SidebarMenu
       label={user.email}
       analyticsKey="account"
+      disableTooltip
       items={[
         {
           key: 'user',
@@ -43,7 +45,7 @@ export function UserDropdown() {
               key: 'admin',
               label: t('Admin'),
               to: '/manage/',
-              hidden: !user?.isSuperuser,
+              hidden: !isActiveSuperuser(),
             },
             {
               key: 'signout',

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -4,9 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import {space} from 'sentry/styles/space';
 import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
-import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
-import {PrimaryNavGroup} from 'sentry/views/nav/types';
 import SettingsNavigationGroup from 'sentry/views/settings/components/settingsNavigationGroup';
 import SettingsNavigationGroupDeprecated from 'sentry/views/settings/components/settingsNavigationGroupDeprecated';
 import type {NavigationProps, NavigationSection} from 'sentry/views/settings/types';
@@ -44,9 +42,7 @@ function SettingsSecondaryNavigation({
 
   return (
     <SecondaryNav>
-      <SecondaryNav.Header>
-        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.SETTINGS].label}
-      </SecondaryNav.Header>
+      <SecondaryNav.Header />
       <SecondaryNav.Body>
         {navWithHooks.map(config => (
           <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />


### PR DESCRIPTION
Similar changes that were done in settings to get the nav items to render in the secondary navigation rather than in the page. This is for the `sentry.io/manage` page which is used for self hosted customers.

![CleanShot 2025-04-25 at 13 36 20](https://github.com/user-attachments/assets/e657a561-0bff-46d8-afab-54bfddeffa96)
