### PR TITLE
chore(ci): Handle artifacts should continue on error

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -26,6 +26,7 @@ runs:
   steps:
     - name: Download and Verify Codecov CLI
       shell: bash
+      continue-on-error: true
       run: |
         ./.github/actions/artifacts/download_codecov_cli.py
     - name: Upload Coverage and Test Results


### PR DESCRIPTION
This job should not fail and block deploys since it is not on the critical path