### PR TITLE
ref(grouping): Refactor logic handling rust enhancer results

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -252,42 +252,35 @@ class Enhancements:
         frame_counts: Counter[str] = Counter()
 
         # Update frame components with results from rust
-        for frame_component, rust_frame in zip(frame_components, rust_frames):
-            # TODO: Remove the first condition once we get rid of the legacy config
-            if (
-                not (self.bases and self.bases[0].startswith("legacy"))
-                and variant_name == "app"
-                and not frame_component.in_app
-            ):
-                # System frames should never contribute in the app variant, so force
-                # `contribtues=False`, regardless of the rust results. Use the rust hint if it
-                # explains the `in_app` value (but not if it explains the `contributing` value,
-                # because we're ignoring that)
-                #
-                # TODO: Right now, if stacktrace rules have modified both the `in_app` and
-                # `contributes` values, then the hint you get back from the rust enhancers depends
-                # on the order in which those changes happened, which in turn depends on both the
-                # order of stacktrace rules and the order of the actions within a stacktrace rule.
-                # Ideally we'd get both hints back.
-                hint = (
-                    rust_frame.hint
-                    if rust_frame.hint and rust_frame.hint.startswith("marked out of app")
-                    else frame_component.hint
-                )
-                frame_component.update(contributes=False, hint=hint)
-            elif variant_name == "system":
-                # We don't need hints about marking frames in or out of app in the system stacktrace
-                # because such changes don't actually have an effect there
-                hint = (
-                    rust_frame.hint
-                    if rust_frame.hint
-                    and not rust_frame.hint.startswith("marked in-app")
-                    and not rust_frame.hint.startswith("marked out of app")
-                    else frame_component.hint
-                )
-                frame_component.update(contributes=rust_frame.contributes, hint=hint)
+        for frame, frame_component, rust_frame in zip(frames, frame_components, rust_frames):
+            frame_type = "in-app" if frame_component.in_app else "system"
+            rust_contributes = bool(rust_frame.contributes)  # bool-ing this for mypy's sake
+            rust_hint = rust_frame.hint
+            rust_hint_type = (
+                None
+                if rust_hint is None
+                else "in-app" if rust_hint.startswith("marked") else "contributes"
+            )
+
+            # System frames should never contribute in the app variant, so if that's what we have,
+            # force `contribtues=False`, regardless of the rust results
+            if variant_name == "app" and frame_type == "system":
+                contributes = False
             else:
-                frame_component.update(contributes=rust_frame.contributes, hint=rust_frame.hint)
+                contributes = rust_contributes
+
+            hint = get_hint_for_frame(variant_name, frame, frame_component, rust_frame)
+
+            # TODO: Remove this workaround once we remove the legacy config. It's done this way (as
+            # a second pass at setting the values that undoes what the first pass did, rather than
+            # being incorporated into the first pass) so that we won't have to change any of the
+            # main logic when we remove it.
+            if self.bases and self.bases[0].startswith("legacy"):
+                contributes = rust_contributes
+                if not (variant_name == "system" and rust_hint_type == "in-app"):
+                    hint = rust_hint
+
+            frame_component.update(contributes=contributes, hint=hint)
 
             # Add this frame to our tally
             key = f"{"in_app" if frame_component.in_app else "system"}_{"contributing" if frame_component.contributes else "non_contributing"}_frames"

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -643,9 +643,11 @@ class AssembleStacktraceComponentTest(TestCase):
         ):
             assert (
                 frame_component.contributes is expected_contributes
-            ), f"frame {i} has incorrect `contributes` value"
+            ), f"frame {i} has incorrect `contributes` value. Expected {expected_contributes} but got {frame_component.contributes}."
 
-            assert frame_component.hint == expected_hint, f"frame {i} has incorrect `hint` value"
+            assert (
+                frame_component.hint == expected_hint
+            ), f"frame {i} has incorrect `hint` value. Expected '{expected_hint}' but got '{frame_component.hint}'."
 
     def test_uses_or_ignores_rust_results_as_appropriate(self):
         """

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -658,6 +658,21 @@ class AssembleStacktraceComponentTest(TestCase):
               this rule, but it needs its own test - see
               `test_marks_app_stacktrace_non_contributing_if_no_in_app_frames` below.)
         """
+        incoming_frames = [
+            {"in_app": True},
+            {"in_app": True},
+            {"in_app": True},
+            {"in_app": True},
+            {"in_app": True},
+            {"in_app": True},
+            {"in_app": False},
+            {"in_app": False},
+            {"in_app": False},
+            {"in_app": False},
+            {"in_app": False},
+            {"in_app": False},
+        ]
+
         app_variant_frame_components = [
             self.in_app_frame(contributes=True, hint=None),
             self.in_app_frame(contributes=True, hint=None),
@@ -760,14 +775,14 @@ class AssembleStacktraceComponentTest(TestCase):
             app_stacktrace_component = enhancements.assemble_stacktrace_component(
                 variant_name="app",
                 frame_components=app_variant_frame_components,
-                frames=[{}] * 6,
+                frames=incoming_frames,
                 platform="javascript",
                 exception_data={},
             )
             system_stacktrace_component = enhancements.assemble_stacktrace_component(
                 variant_name="system",
                 frame_components=system_variant_frame_components,
-                frames=[{}] * 6,
+                frames=incoming_frames,
                 platform="javascript",
                 exception_data={},
             )
@@ -789,6 +804,11 @@ class AssembleStacktraceComponentTest(TestCase):
         Test that if frame special-casing for the app variant results in no contributing frames, the
         stacktrace is marked non-contributing.
         """
+        incoming_frames = [
+            {"in_app": False},
+            {"in_app": True},
+            {"in_app": True},
+        ]
         frame_components = [
             # All possibilities (all combos of app vs system, contributing vs not) except a
             # contributing system frame, since that will never be passed to
@@ -840,7 +860,7 @@ class AssembleStacktraceComponentTest(TestCase):
             stacktrace_component1 = enhancements1.assemble_stacktrace_component(
                 variant_name="app",
                 frame_components=frame_components,
-                frames=[{}] * 3,
+                frames=incoming_frames,
                 platform="javascript",
                 exception_data={},
             )
@@ -858,7 +878,7 @@ class AssembleStacktraceComponentTest(TestCase):
             stacktrace_component2 = enhancements2.assemble_stacktrace_component(
                 variant_name="app",
                 frame_components=frame_components,
-                frames=[{}] * 3,
+                frames=incoming_frames,
                 platform="javascript",
                 exception_data={},
             )


### PR DESCRIPTION
The current logic governing when we listen to the results from the rust enhancer and when we igore them is sufficiently complicated that even I, who wrote it (not even that long ago), was tying my brain in knots trying to keep track of it and trying to then add to it to fix another edge case I found. 

That edge case will be fixed in an upcoming PR, but that PR is going to be really hard to review if it just adds complication to already-too-much-complication. This therefore refactors the existing code into what is hopefully a much more straightforward, comprehensible form, so that both it and the upcoming changes make more sense. It also fixes a bug in the relevant in the relevant tests, and makes the error messages clearer when in case they fail.

Note to reviewers: Though you could look at the before and after and try to make sure the logic stayed the same, I don't actually recommend spending time parsing the "before". (As mentioned above, the logic is kind of opaque.) We know the new logic is equivalent to the old logic because none of the snapshots are affected by this change. I'm more interested in whether or not the "after" makes sense on its own merits.