### PR TITLE
fix(nav): Fix secondary nav focus ring colors

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -284,6 +284,11 @@ const StyledNavItem = styled(Link)<ItemProps>`
   line-height: 177.75%;
   border-radius: ${p => p.theme.borderRadius};
 
+  &:focus-visible {
+    box-shadow: 0 0 0 2px ${p => p.theme.focusBorder};
+    color: currentColor;
+  }
+
   &[aria-selected='true'] {
     color: ${p => p.theme.purple400};
     font-weight: ${p => p.theme.fontWeightBold};


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/70ee2f06-1504-4b94-bd6d-6e7622805d13)


after: 

![image](https://github.com/user-attachments/assets/b4c5858d-2828-4b3f-a228-d8417e9f6926)

copied straight from the [primary navigation's focus ring styles](https://github.com/getsentry/sentry/blob/e0c4dae8f8e807e3f94b3c622b7fddc01caea5f1/static/app/views/nav/primary/components.tsx#L252)