### PR TITLE
chore(migrations): Removed vendored code from `SafePostgresDatabaseSchemaEditor`.

### DIFF
--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -1,16 +1,10 @@
-from contextlib import contextmanager
-
-from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql.schema import (
     DatabaseSchemaEditor as PostgresDatabaseSchemaEditor,
 )
 from django.db.models import Field
 from django.db.models.base import ModelBase
 from django_zero_downtime_migrations.backends.postgres.schema import (
-    DUMMY_SQL,
     DatabaseSchemaEditorMixin,
-    MultiStatementSQL,
-    PGLock,
     Unsafe,
     UnsafeOperationException,
 )
@@ -102,73 +96,6 @@ class SafePostgresDatabaseSchemaEditor(DatabaseSchemaEditorMixin, PostgresDataba
                 "More info here: https://develop.sentry.dev/database-migrations/#deleting-columns"
             )
         super(DatabaseSchemaEditorMixin, self).remove_field(model, field)
-
-    def execute(self, sql, params=()):
-        if sql is DUMMY_SQL:
-            return
-        statements = []
-        if isinstance(sql, MultiStatementSQL):
-            statements.extend(sql)
-        elif isinstance(sql, Statement) and isinstance(sql.template, MultiStatementSQL):
-            statements.extend(Statement(s, **sql.parts) for s in sql.template)
-        else:
-            statements.append(sql)
-        for statement in statements:
-            idempotent_condition = None
-            if isinstance(statement, PGLock):
-                use_timeouts = statement.use_timeouts
-                disable_statement_timeout = statement.disable_statement_timeout
-                idempotent_condition = statement.idempotent_condition
-                statement = statement.sql
-            elif isinstance(statement, Statement) and isinstance(statement.template, PGLock):
-                use_timeouts = statement.template.use_timeouts
-                disable_statement_timeout = statement.template.disable_statement_timeout
-                if statement.template.idempotent_condition is not None:
-                    idempotent_condition = statement.template.idempotent_condition % statement.parts
-                statement = Statement(statement.template.sql, **statement.parts)
-            else:
-                use_timeouts = False
-                disable_statement_timeout = False
-
-            if not self._skip_applied(idempotent_condition):
-                if use_timeouts:
-                    with self._set_operation_timeout(self.STATEMENT_TIMEOUT, self.LOCK_TIMEOUT):
-                        PostgresDatabaseSchemaEditor.execute(self, statement, params)
-                elif disable_statement_timeout and self.FLEXIBLE_STATEMENT_TIMEOUT:
-                    with self._set_operation_timeout(self.ZERO_TIMEOUT):
-                        PostgresDatabaseSchemaEditor.execute(self, statement, params)
-                else:
-                    PostgresDatabaseSchemaEditor.execute(self, statement, params)
-
-    @contextmanager
-    def _set_operation_timeout(self, statement_timeout=None, lock_timeout=None):
-        if self.collect_sql:
-            previous_statement_timeout = self.ZERO_TIMEOUT
-            previous_lock_timeout = self.ZERO_TIMEOUT
-        else:
-            with self.connection.cursor() as cursor:
-                cursor.execute(self._sql_get_statement_timeout)
-                (previous_statement_timeout,) = cursor.fetchone()
-                cursor.execute(self._sql_get_lock_timeout)
-                (previous_lock_timeout,) = cursor.fetchone()
-        if statement_timeout is not None:
-            PostgresDatabaseSchemaEditor.execute(
-                self, self._sql_set_statement_timeout % {"statement_timeout": statement_timeout}
-            )
-        if lock_timeout is not None:
-            PostgresDatabaseSchemaEditor.execute(
-                self, self._sql_set_lock_timeout % {"lock_timeout": lock_timeout}
-            )
-        yield
-        if statement_timeout is not None:
-            PostgresDatabaseSchemaEditor.execute(
-                self,
-                self._sql_set_statement_timeout % {"statement_timeout": previous_statement_timeout},
-            )
-        if lock_timeout is not None:
-            PostgresDatabaseSchemaEditor.execute(
-                self, self._sql_set_lock_timeout % {"lock_timeout": previous_lock_timeout}
-            )
 
 
 class DatabaseSchemaEditorProxy:


### PR DESCRIPTION
We vendored and slightly modified this code in https://github.com/getsentry/sentry/pull/79052.

We've removed the code that actually uses this change in https://github.com/getsentry/sentry/pull/90455. I copied the code from our migration framework back over this, and there are no other customizations, so we can safely remove.
