### PR TITLE
fix(onboarding): Do not allow multiple project creation requests at the same time

### DIFF
--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -135,5 +135,8 @@ export function useConfigureSdk({
     [createPlatformProject, onboardingContext, organization, createProject]
   );
 
-  return {configureSdk, isLoadingData: isLoadingTeams || !projectsLoaded};
+  return {
+    configureSdk,
+    isLoadingData: isLoadingTeams || !projectsLoaded || createProject.isPending,
+  };
 }

--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -88,6 +88,11 @@ export function useConfigureSdk({
         return;
       }
 
+      if (createProject.isPending) {
+        // prevent multiple submissions at the same time
+        return;
+      }
+
       if (
         selectedPlatform.type !== 'language' ||
         !Object.values(SupportedLanguages).includes(
@@ -127,7 +132,7 @@ export function useConfigureSdk({
         }
       );
     },
-    [createPlatformProject, onboardingContext, organization]
+    [createPlatformProject, onboardingContext, organization, createProject]
   );
 
   return {configureSdk, isLoadingData: isLoadingTeams || !projectsLoaded};


### PR DESCRIPTION
If during onboarding user would click multiple times on the platform, it would result in multiple create project requests being sent. This prevents sending additional requests if already there is one pending request for project creation.
