### PR TITLE
fix(event-contexts): Rename Expo Updates to OTA Updates

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -66,9 +66,9 @@ ATTR_CHOICES: dict[str, Columns | None] = {
     "os.distribution_name": Columns.OS_DISTRIBUTION_NAME,
     "os.distribution_version": Columns.OS_DISTRIBUTION_VERSION,
     "symbolicated_in_app": Columns.SYMBOLICATED_IN_APP,
-    "expo_updates.channel": Columns.EXPO_UPDATES_CHANNEL,
-    "expo_updates.runtime_version": Columns.EXPO_UPDATES_RUNTIME_VERSION,
-    "expo_updates.update_id": Columns.EXPO_UPDATES_UPDATE_ID,
+    "ota_updates.channel": Columns.OTA_UPDATES_CHANNEL,
+    "ota_updates.runtime_version": Columns.OTA_UPDATES_RUNTIME_VERSION,
+    "ota_updates.update_id": Columns.OTA_UPDATES_UPDATE_ID,
 }
 
 
@@ -437,7 +437,7 @@ class OsAttributeHandler(AttributeHandler):
         return []
 
 
-@attribute_registry.register("expo_updates")
+@attribute_registry.register("ota_updates")
 class ExpoUpdatesAttributeHandler(AttributeHandler):
     minimum_path_length = 2
 
@@ -445,8 +445,8 @@ class ExpoUpdatesAttributeHandler(AttributeHandler):
     def _handle(cls, path: list[str], event: GroupEvent) -> list[str]:
         if path[1] in ("channel", "runtime_version", "update_id"):
             contexts = event.data.get("contexts", {})
-            expo_updates_context = contexts.get("expo_updates")
-            if expo_updates_context is None:
-                expo_updates_context = {}
-            return [expo_updates_context.get(path[1])]
+            ota_updates_context = contexts.get("ota_updates")
+            if ota_updates_context is None:
+                ota_updates_context = {}
+            return [ota_updates_context.get(path[1])]
         return []

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -830,27 +830,27 @@ class Columns(Enum):
         alias="symbolicated_in_app",
     )
 
-    EXPO_UPDATES_CHANNEL = Column(
-        group_name="events.contexts[expo_updates.channel]",
-        event_name="contexts[expo_updates.channel]",
-        transaction_name="contexts[expo_updates.channel]",
-        discover_name="contexts[expo_updates.channel]",
-        issue_platform_name="contexts[expo_updates.channel]",
-        alias="expo_updates.channel",
+    OTA_UPDATES_CHANNEL = Column(
+        group_name="events.contexts[ota_updates.channel]",
+        event_name="contexts[ota_updates.channel]",
+        transaction_name="contexts[ota_updates.channel]",
+        discover_name="contexts[ota_updates.channel]",
+        issue_platform_name="contexts[ota_updates.channel]",
+        alias="ota_updates.channel",
     )
 
-    EXPO_UPDATES_RUNTIME_VERSION = Column(
-        group_name="events.contexts[expo_updates.runtime_version]",
-        event_name="contexts[expo_updates.runtime_version]",
-        transaction_name="contexts[expo_updates.runtime_version]",
-        discover_name="contexts[expo_updates.runtime_version]",
-        alias="expo_updates.runtime_version",
+    OTA_UPDATES_RUNTIME_VERSION = Column(
+        group_name="events.contexts[ota_updates.runtime_version]",
+        event_name="contexts[ota_updates.runtime_version]",
+        transaction_name="contexts[ota_updates.runtime_version]",
+        discover_name="contexts[ota_updates.runtime_version]",
+        alias="ota_updates.runtime_version",
     )
 
-    EXPO_UPDATES_UPDATE_ID = Column(
-        group_name="events.contexts[expo_updates.update_id]",
-        event_name="contexts[expo_updates.update_id]",
-        transaction_name="contexts[expo_updates.update_id]",
-        discover_name="contexts[expo_updates.update_id]",
-        alias="expo_updates.update_id",
+    OTA_UPDATES_UPDATE_ID = Column(
+        group_name="events.contexts[ota_updates.update_id]",
+        event_name="contexts[ota_updates.update_id]",
+        transaction_name="contexts[ota_updates.update_id]",
+        discover_name="contexts[ota_updates.update_id]",
+        alias="ota_updates.update_id",
     )

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -133,9 +133,9 @@ export enum FieldKey {
   USER_SEGMENT = 'user.segment',
   APP_IN_FOREGROUND = 'app.in_foreground',
   FUNCTION_DURATION = 'function.duration',
-  EXPO_UPDATES_CHANNEL = 'expo_updates.channel',
-  EXPO_UPDATES_RUNTIME_VERSION = 'expo_updates.runtime_version',
-  EXPO_UPDATES_UPDATE_ID = 'expo_updates.update_id',
+  OTA_UPDATES_CHANNEL = 'ota_updates.channel',
+  OTA_UPDATES_RUNTIME_VERSION = 'ota_updates.runtime_version',
+  OTA_UPDATES_UPDATE_ID = 'ota_updates.update_id',
 }
 
 export enum FieldValueType {
@@ -1840,17 +1840,17 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.DURATION,
   },
-  [FieldKey.EXPO_UPDATES_CHANNEL]: {
+  [FieldKey.OTA_UPDATES_CHANNEL]: {
     desc: t('The channel name of the build from EAS Update'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.EXPO_UPDATES_RUNTIME_VERSION]: {
+  [FieldKey.OTA_UPDATES_RUNTIME_VERSION]: {
     desc: t('The runtime version of the current build from EAS Update'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.EXPO_UPDATES_UPDATE_ID]: {
+  [FieldKey.OTA_UPDATES_UPDATE_ID]: {
     desc: t('The UUID that uniquely identifies the update.'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
@@ -1960,9 +1960,9 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.USER_ID,
   FieldKey.USER_IP,
   FieldKey.USER_USERNAME,
-  FieldKey.EXPO_UPDATES_CHANNEL,
-  FieldKey.EXPO_UPDATES_RUNTIME_VERSION,
-  FieldKey.EXPO_UPDATES_UPDATE_ID,
+  FieldKey.OTA_UPDATES_CHANNEL,
+  FieldKey.OTA_UPDATES_RUNTIME_VERSION,
+  FieldKey.OTA_UPDATES_UPDATE_ID,
 ];
 
 export const ISSUE_FIELDS: FieldKey[] = [
@@ -2032,9 +2032,9 @@ export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS: Set<FieldKey> = new
   FieldKey.USER_ID,
   FieldKey.USER_IP,
   FieldKey.USER_USERNAME,
-  FieldKey.EXPO_UPDATES_CHANNEL,
-  FieldKey.EXPO_UPDATES_RUNTIME_VERSION,
-  FieldKey.EXPO_UPDATES_UPDATE_ID,
+  FieldKey.OTA_UPDATES_CHANNEL,
+  FieldKey.OTA_UPDATES_RUNTIME_VERSION,
+  FieldKey.OTA_UPDATES_UPDATE_ID,
 ]);
 
 /**
@@ -2150,9 +2150,9 @@ export const DISCOVER_FIELDS = [
   SpanOpBreakdown.SPANS_UI,
 
   // Expo Updates fields
-  FieldKey.EXPO_UPDATES_CHANNEL,
-  FieldKey.EXPO_UPDATES_RUNTIME_VERSION,
-  FieldKey.EXPO_UPDATES_UPDATE_ID,
+  FieldKey.OTA_UPDATES_CHANNEL,
+  FieldKey.OTA_UPDATES_RUNTIME_VERSION,
+  FieldKey.OTA_UPDATES_UPDATE_ID,
 ];
 
 export enum ReplayFieldKey {

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -65,7 +65,7 @@ class EventAttributeConditionTest(RuleTestCase):
                     "crash_type": "crash",
                 },
                 "os": {"distribution_name": "ubuntu", "distribution_version": "22.04"},
-                "expo_updates": {
+                "ota_updates": {
                     "channel": "production",
                     "runtime_version": "1.0.0",
                     "update_id": "12345678-1234-1234-1234-1234567890ab",
@@ -862,12 +862,12 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         self.assertDoesNotPass(rule, event)
 
-    def test_expo_updates_channel_and_runtime_version_and_update_id(self):
+    def test_ota_updates_channel_and_runtime_version_and_update_id(self):
         event = self.get_event()
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.channel",
+                "attribute": "ota_updates.channel",
                 "value": "production",
             }
         )
@@ -876,7 +876,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.runtime_version",
+                "attribute": "ota_updates.runtime_version",
                 "value": "1.0.0",
             }
         )
@@ -885,7 +885,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.update_id",
+                "attribute": "ota_updates.update_id",
                 "value": "12345678-1234-1234-1234-1234567890ab",
             }
         )
@@ -894,7 +894,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.channel",
+                "attribute": "ota_updates.channel",
                 "value": "does-not-exist",
             }
         )
@@ -903,7 +903,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.runtime_version",
+                "attribute": "ota_updates.runtime_version",
                 "value": "1.0.0-does-not-exist",
             }
         )
@@ -912,7 +912,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.update_id",
+                "attribute": "ota_updates.update_id",
                 "value": "123-does-not-exist",
             }
         )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -73,7 +73,7 @@ class TestEventAttributeCondition(ConditionTestCase):
                     "crash_type": "crash",
                 },
                 "os": {"distribution_name": "ubuntu", "distribution_version": "22.04"},
-                "expo_updates": {
+                "ota_updates": {
                     "channel": "production",
                     "runtime_version": "1.0.0",
                     "update_id": "123",
@@ -1137,11 +1137,11 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.event_data)
 
-    def test_expo_updates(self):
+    def test_ota_updates(self):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.channel",
+                "attribute": "ota_updates.channel",
                 "value": "production",
             }
         )
@@ -1150,7 +1150,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.channel",
+                "attribute": "ota_updates.channel",
                 "value": "development",
             }
         )
@@ -1159,7 +1159,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.runtime_version",
+                "attribute": "ota_updates.runtime_version",
                 "value": "1.0.0",
             }
         )
@@ -1168,7 +1168,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.runtime_version",
+                "attribute": "ota_updates.runtime_version",
                 "value": "2.0.0",
             }
         )
@@ -1177,7 +1177,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.update_id",
+                "attribute": "ota_updates.update_id",
                 "value": "123",
             }
         )
@@ -1186,7 +1186,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.update_id",
+                "attribute": "ota_updates.update_id",
                 "value": "876",
             }
         )
@@ -1195,7 +1195,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.dc.comparison.update(
             {
                 "match": MatchType.EQUAL,
-                "attribute": "expo_updates.non_existent",
+                "attribute": "ota_updates.non_existent",
                 "value": "876",
             }
         )


### PR DESCRIPTION
Follow up to 
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162

We decided to use more generic naming in:
- https://github.com/getsentry/relay/pull/4690

