### PR TITLE
ref(dashboards): Remove `Plottable.constrain`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -30,10 +30,6 @@ export class Area extends ContinuousTimeSeries implements Plottable {
     this.#incompleteTimeSeries = incompleteTimeSeries;
   }
 
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
-    return new Area(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
-  }
-
   onHighlight(dataIndex: number): void {
     const {config = {}} = this;
     // The incomplete series prepends the final data point from the complete

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -23,10 +23,6 @@ interface BarsConfig extends ContinuousTimeSeriesConfig {
 }
 
 export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable {
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
-    return new Bars(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
-  }
-
   onHighlight(dataIndex: number): void {
     const {config = {}} = this;
     const datum = this.timeSeries.values.at(dataIndex);

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
@@ -103,9 +103,6 @@ describe('ContinuousTimeSeries', () => {
 });
 
 class Dots extends ContinuousTimeSeries implements Plottable {
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
-    return new Dots(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
-  }
   toSeries(_plottingOptions: any) {
     return [LineSeries({})];
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -30,10 +30,6 @@ export class Line extends ContinuousTimeSeries implements Plottable {
     this.#incompleteTimeSeries = incompleteTimeSeries;
   }
 
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
-    return new Line(this.constrainTimeSeries(boundaryStart, boundaryEnd), this.config);
-  }
-
   onHighlight(seriesDataIndex: number): void {
     const {config = {}} = this;
     // The incomplete series prepends the final data point from the complete

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/plottable.tsx
@@ -12,11 +12,6 @@ export type PlottableTimeSeriesValueType =
  */
 export interface Plottable {
   /**
-   * Returns a cloned Plottable, constraining any time-series data within the
-   * date boundaries provided
-   */
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null): Plottable;
-  /**
    * Type of the underlying data
    */
   dataType: PlottableTimeSeriesValueType;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -203,10 +203,6 @@ export class Samples implements Plottable {
     };
   }
 
-  constrain(boundaryStart: Date | null, boundaryEnd: Date | null) {
-    return new Samples(this.constrainSamples(boundaryStart, boundaryEnd), this.config);
-  }
-
   #getSampleByIndex(dataIndex: number): ValidSampleRow | undefined {
     const sample = this.sampleTableData.data.at(dataIndex);
 


### PR DESCRIPTION
These methods are no longer in use, since the Releases panel doesn't render plots via constraining the dataset.
