### PR TITLE
fix(Taskworker): Send strings to the delete_groups task

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -211,7 +211,7 @@ class SnubaProtocolEventStream(EventStream):
             "transaction_id": uuid4().hex,
             "project_id": project_id,
             "group_ids": list(group_ids),
-            "datetime": datetime.now(tz=timezone.utc),
+            "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),
         }
 
         self._send(project_id, "start_delete_groups", extra_data=(state,), asynchronous=False)

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1523,7 +1523,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.eventstream.backend")
     def test_delete_by_id(self, mock_eventstream):
-        eventstream_state = {"event_stream_state": uuid4()}
+        eventstream_state = {"event_stream_state": uuid4().hex}
         mock_eventstream.start_delete_groups = Mock(return_value=eventstream_state)
 
         groups = self.create_groups(
@@ -1570,7 +1570,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.eventstream.backend")
     def test_delete_performance_issue_by_id(self, mock_eventstream):
-        eventstream_state = {"event_stream_state": uuid4()}
+        eventstream_state = {"event_stream_state": uuid4().hex}
         mock_eventstream.start_delete_groups = Mock(return_value=eventstream_state)
 
         group1, group2 = self.create_groups(


### PR DESCRIPTION
Instead of implicitly encoding datetimes to str, pass an encoded string. Also modify the tests to
stop sending unencoded hex strings.

This also exposes a toggle TASK_TYPE_CHECKING to enforce stricter task typing when running tests.