### PR TITLE
fix(aci): handle issue alert delete race condition

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -206,7 +206,7 @@ def delete_migrated_issue_alert(rule: Rule) -> int | None:
         delete_workflow(workflow)
     except DataConditionGroup.DoesNotExist:
         logger.exception(
-            "workflow_engine.issue_alert.missing_model",
+            "Deleting workflow but DCG does not exist",
             extra={"workflow_id": workflow_id, "rule_id": rule.id},
         )
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -374,7 +374,8 @@ class RuleMigrationHelpersTest(TestCase):
         with patch.object(
             mock_workflow, "when_condition_group", side_effect=DataConditionGroup.DoesNotExist
         ):
-            delete_migrated_issue_alert(self.issue_alert)
+            workflow_id = delete_migrated_issue_alert(self.issue_alert)
+            assert workflow_id == workflow.id
 
         assert not AlertRuleWorkflow.objects.filter(rule_id=self.issue_alert.id).exists()
         assert not Workflow.objects.filter(id=workflow.id).exists()


### PR DESCRIPTION
We are encountering an issue where there is a race condition while deleting workflows via a signal when an org/project is being deleted.

When we attempt to fetch `workflow.when_condition_group`, we get a DataConditionGroup.DoesNotExist error. We should handle this corrrectly by deleting the AlertRuleWorkflow lookup appropriately if the workflow is actually deleted.

Fixes SENTRY-3T08