### PR TITLE
fix(grouping): Fix hint when client sets `in_app` value

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -119,6 +119,7 @@ def get_hint_for_frame(
     """
     frame_type = "in-app" if frame_component.in_app else "system"
     client_in_app = get_path(frame, "data", "client_in_app")
+    rust_in_app = frame["in_app"]
     rust_hint = rust_frame.hint
     rust_hint_type = (
         None if rust_hint is None else "in-app" if rust_hint.startswith("marked") else "contributes"
@@ -147,6 +148,12 @@ def get_hint_for_frame(
     # Similarly, we don't need hints about marking frames in or out of app in the system stacktrace
     # because such changes don't actually have an effect there
     elif variant_name == "system" and rust_hint_type == "in-app":
+        use_rust_hint = False
+
+    # We don't want the rust enhancer taking credit for changing things if we know the value didn't
+    # actually change. (This only happens with in-app hints, not contributes hints, because of the
+    # weird (a.k.a. wrong) second condition in the rust enhancer's version of `in_app_changed`.)
+    elif variant_name == "app" and rust_hint_type == "in-app" and rust_in_app == client_in_app:
         use_rust_hint = False
 
     return rust_hint if use_rust_hint else incoming_hint

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -118,6 +118,7 @@ def get_hint_for_frame(
     Determine a hint to use for the frame, handling special-casing and precedence.
     """
     frame_type = "in-app" if frame_component.in_app else "system"
+    client_in_app = get_path(frame, "data", "client_in_app")
     rust_hint = rust_frame.hint
     rust_hint_type = (
         None if rust_hint is None else "in-app" if rust_hint.startswith("marked") else "contributes"
@@ -127,7 +128,12 @@ def get_hint_for_frame(
 
     if variant_name == "app":
         default_hint = "non app frame" if not frame_component.in_app else frame_component.hint
-        incoming_hint = default_hint
+        client_in_app_hint = (
+            f"marked {"in-app" if client_in_app else "out of app"} by the client"
+            if client_in_app is not None
+            else None
+        )
+        incoming_hint = client_in_app_hint or default_hint
 
     # Prevent clobbering an existing hint with no hint
     if rust_hint is None:

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -125,6 +125,10 @@ def get_hint_for_frame(
     incoming_hint = frame_component.hint
     use_rust_hint = True
 
+    if variant_name == "app":
+        default_hint = "non app frame" if not frame_component.in_app else frame_component.hint
+        incoming_hint = default_hint
+
     # Prevent clobbering an existing hint with no hint
     if rust_hint is None:
         use_rust_hint = False

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -444,9 +444,7 @@ def _single_stacktrace_variant(
             if frame.in_app:
                 found_in_app_frame = True
             else:
-                # We have to do this here (rather than it being done in the rust enhancer) because
-                # the rust enhancer doesn't know about system vs app variants
-                frame_component.update(contributes=False, hint="non app frame")
+                frame_component.update(contributes=False)
 
         frame_components.append(frame_component)
         frames_for_filtering.append(frame.get_raw_data())

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:31:42.842448+00:00'
+created: '2025-04-25T21:24:04.530339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,243 +30,243 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "__pthread_start"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "__pthread_body"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "___rust_maybe_catch_panic"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "arbiter.rs"
               function*
                 "actix::arbiter::Arbiter::new_with_builder::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::block_on"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_reactor::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_reactor::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "clock.rs"
               function*
                 "tokio_timer::clock::clock::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "clock.rs"
               function*
                 "tokio_timer::clock::clock::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "handle.rs"
               function*
                 "tokio_timer::timer::handle::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "handle.rs"
               function*
                 "tokio_timer::timer::handle::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "global.rs"
               function*
                 "tokio_executor::global::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "global.rs"
               function*
                 "tokio_executor::global::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Entered<T>::block_on"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Entered<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduler<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::CurrentRunner::set_spawn"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduled<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_future_notify"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_fn_notify"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::std::set"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "then.rs"
               function*
                 "futures::future::then::Then<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "chain.rs"
               function*
                 "futures::future::chain::Chain<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "either.rs"
               function*
                 "futures::future::either::Either<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "acceptor.rs"
               function*
                 "actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "and_then.rs"
               function*
                 "actix_net::service::and_then::AndThenFuture<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "map_err.rs"
               function*
                 "actix_net::service::map_err::MapErrFuture<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "channel.rs"
               function*
                 "actix_web::server::channel::HttpChannel<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "channel.rs"
               function*
                 "actix_web::server::channel::HttpChannel<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll_handler"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::parse"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "pipeline.rs"
               function*
                 "actix_web::pipeline::Pipeline<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<::log::macros::log macros>"
               function*
                 "actix_web::pipeline::ProcessResponse<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.152070+00:00'
+created: '2025-04-25T21:24:04.792001+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "(unknown)"
               function*
                 "lambda_method"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "SentryTest2.Controllers.ValuesController"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:31:43.250561+00:00'
+created: '2025-04-25T21:24:04.933150+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.439416+00:00'
+created: '2025-04-25T21:24:05.490353+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,36 +30,36 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "@callee_guaranteed"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "@callee_guaranteed"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "@callee_guaranteed"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "@callee_guaranteed"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-23T19:15:05.776111+00:00'
+created: '2025-04-25T21:24:05.888016+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,7 +33,7 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.862251+00:00'
+created: '2025-04-25T21:24:05.996693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,35 +30,35 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.safe"
               function*
                 "safe_execute"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.services"
               function*
                 "<lambda>"
               context-line*
                 "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "getsentry.quotas"
               function*
                 "is_rate_limited"
               context-line*
                 "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.quotas.redis"
               function*
                 "is_rate_limited"
               context-line*
                 "rejections = is_rate_limited(client, keys, args)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.redis"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:08.608016+00:00'
+created: '2025-04-25T21:24:07.610987+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:08.666420+00:00'
+created: '2025-04-25T21:24:07.737044+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,14 +31,14 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*
               "ValueError"
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:09.372857+00:00'
+created: '2025-04-25T21:24:09.042954+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,12 +31,12 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*
                   "do_stuff"
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*
@@ -45,7 +45,7 @@ contributing variants:
               "DoStuffException"
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:10.162087+00:00'
+created: '2025-04-25T21:24:10.384900+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "async_patch.dart"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:10.690384+00:00'
+created: '2025-04-25T21:24:11.257371+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:11.597289+00:00'
+created: '2025-04-25T21:24:12.147691+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,37 +29,37 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_logging.dart"
             function*
               "SentryLogging.log"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_dio.dart"
             function*
               "SentryDio.dio"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_file.dart"
             function*
               "SentryFile.file"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_hive.dart"
             function*
               "SentryHive.hive"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_isar.dart"
             function*
               "SentryIsar.isar"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_sqflite.dart"
             function*
               "SentrySqflite.sqflite"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_drift.dart"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:11.646538+00:00'
+created: '2025-04-25T21:24:12.235763+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_exception_factory.dart"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:11.699954+00:00'
+created: '2025-04-25T21:24:12.328805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "sentry_exception_factory.dart"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.569294+00:00'
+created: '2025-04-25T21:24:13.693563+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "main"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.599351+00:00'
+created: '2025-04-25T21:24:15.681098+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,84 +35,84 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.base"
               function*
                 "_wrapped"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "process_event"
               context-line*
                 "return _do_process_event(cache_key, start_time, event_id, process_event)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "_do_process_event"
               context-line*
                 "new_data = process_stacktraces(data)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.stacktraces"
               function*
                 "process_stacktraces"
               context-line*
                 "if processor.preprocess_step(processing_task):"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.plugin"
               function*
                 "preprocess_step"
               context-line*
                 "referenced_images=referenced_images,"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.symbolizer"
               function*
                 "__init__"
               context-line*
                 "with_conversion_errors=True)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "get_symcaches"
               context-line*
                 "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "_load_cachefiles_via_fs"
               context-line*
                 "model.cache_file.save_to(cachefile_path)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "save_to"
               context-line*
                 "delete=False).detach_tempfile()"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "_get_chunked_blob"
               context-line*
                 "delete=delete"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "__init__"
               context-line*
                 "self._prefetch(prefetch_to, delete)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.805429+00:00'
+created: '2025-04-25T21:24:16.105597+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,77 +30,77 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "main.m"
               function*
                 "main"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "TableView.layoutSubviews"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "AnyTableViewController.tableView"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "anytableviewcontroller.swift"
               function*
                 "AnyTableViewController.tableView"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "closure"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "dailydigesttableviewsection.swift"
               function*
                 "DailyDigestTableViewSection.photoCell"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "Sequence.compactMap<T>"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "closure"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSource"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "CurrentUserProfile.isVideoAutoplay.getter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "currentuserprofile.swift"
               function*
                 "CurrentUserProfile.isVideoAutoplay.getter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "currentuserprofile.swift"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.869988+00:00'
+created: '2025-04-25T21:24:16.219666+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -41,7 +41,7 @@ contributing variants:
               "service.getName(): \"Tomcat\";  Protocol handler start failed"
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "io.sentry.example.Application"
                 function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:14.832466+00:00'
+created: '2025-04-25T21:24:17.974157+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
               context-line*
                 "this.setState({"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "this.fetchData();"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/api"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:14.887950+00:00'
+created: '2025-04-25T21:24:18.063981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
               context-line*
                 "this.setState({"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "this.fetchData();"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/api"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:15.016114+00:00'
+created: '2025-04-25T21:24:18.391888+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,19 +30,19 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "server.php"
               context-line*
                 "require_once __DIR__.'/public/index.php';"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "index.php"
               function*
                 "require_once"
               context-line*
                 "$request = Illuminate\\Http\\Request::capture()"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "web.php"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:14.934698+00:00'
+created: '2025-04-25T21:24:18.229715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "server.php"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:15.965960+00:00'
+created: '2025-04-25T21:24:20.162094+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,16 +30,16 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "_main"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "___rust_maybe_catch_panic"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "log_demo::main"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "log::__private_api_log"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.167354+00:00'
+created: '2025-04-25T21:24:20.779206+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,38 +30,38 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub"
               function* (trimmed javascript function)
                 "withScope"
               context-line*
                 "*/"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "onunhandledrejection.ts"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub.ts"
               function* (trimmed javascript function)
                 "captureException"
               context-line*
                 "if (maxBreadcrumbs <= 0) {"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub"
               function* (trimmed javascript function)
                 "invokeClient"
               context-line*
                 "* @returns Scope, the new cloned scope"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "baseclient.ts"
               function* (trimmed javascript function)
                 "captureException"
               context-line*
                 "promisedEvent"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "backend.ts"
               function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.268586+00:00'
+created: '2025-04-25T21:24:21.016970+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,7 +31,7 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.322207+00:00'
+created: '2025-04-25T21:24:21.123365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,14 +30,14 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.web.frontend.release_webhook"
               function*
                 "post"
               context-line*
                 "hook.handle(request)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry_plugins.heroku.plugin"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.427311+00:00'
+created: '2025-04-25T21:24:21.326606+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,14 +30,14 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.safe"
               function*
                 "safe_execute"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.integrations.slack.notify_action"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.484363+00:00'
+created: '2025-04-25T21:24:21.429272+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "App"
               context-line*
                 "<Button"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "App"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.526716+00:00'
+created: '2025-04-25T21:24:21.511467+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "bar.m"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.626287+00:00'
+created: '2025-04-25T21:24:21.686378+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.925041+00:00'
+created: '2025-04-25T21:24:22.351558+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:17.161684+00:00'
+created: '2025-04-25T21:24:22.887218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:17.260968+00:00'
+created: '2025-04-25T21:24:23.087468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.c"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:17.371396+00:00'
+created: '2025-04-25T21:24:23.314397+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "samplescript.cs"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:02.715373+00:00'
+created: '2025-04-25T21:24:24.179882+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,240 +30,240 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "__pthread_body"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "___rust_maybe_catch_panic"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "arbiter.rs"
               function*
                 "actix::arbiter::Arbiter::new_with_builder::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::block_on"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_reactor::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_reactor::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "clock.rs"
               function*
                 "tokio_timer::clock::clock::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "clock.rs"
               function*
                 "tokio_timer::clock::clock::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "handle.rs"
               function*
                 "tokio_timer::timer::handle::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "handle.rs"
               function*
                 "tokio_timer::timer::handle::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "global.rs"
               function*
                 "tokio_executor::global::with_default"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "global.rs"
               function*
                 "tokio_executor::global::with_default::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "runtime.rs"
               function*
                 "tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Entered<T>::block_on"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Entered<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduler<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::CurrentRunner::set_spawn"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*
                 "tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "scheduler.rs"
               function*
                 "tokio_current_thread::scheduler::Scheduled<T>::tick"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_future_notify"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_fn_notify"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::enter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::std::set"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::enter::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mod.rs"
               function*
                 "futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "then.rs"
               function*
                 "futures::future::then::Then<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "chain.rs"
               function*
                 "futures::future::chain::Chain<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "either.rs"
               function*
                 "futures::future::either::Either<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "acceptor.rs"
               function*
                 "actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "and_then.rs"
               function*
                 "actix_net::service::and_then::AndThenFuture<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "map_err.rs"
               function*
                 "actix_net::service::map_err::MapErrFuture<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "channel.rs"
               function*
                 "actix_web::server::channel::HttpChannel<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "channel.rs"
               function*
                 "actix_web::server::channel::HttpChannel<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll_handler"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "h1.rs"
               function*
                 "actix_web::server::h1::Http1Dispatcher<T>::parse"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "pipeline.rs"
               function*
                 "actix_web::pipeline::Pipeline<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<::log::macros::log macros>"
               function*
                 "actix_web::pipeline::ProcessResponse<T>::poll_io"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "lib.rs"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.637008+00:00'
+created: '2025-04-25T21:24:24.436583+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "(unknown)"
               function*
                 "lambda_method"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "SentryTest2.Controllers.ValuesController"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.690072+00:00'
+created: '2025-04-25T21:24:24.541096+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.905648+00:00'
+created: '2025-04-25T21:24:24.945868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,13 +30,13 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-23T19:16:09.526442+00:00'
+created: '2025-04-25T21:24:25.252502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,7 +33,7 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
               function*
                 "unicorn"
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.121116+00:00'
+created: '2025-04-25T21:24:25.375715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,35 +30,35 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.safe"
               function*
                 "safe_execute"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.services"
               function*
                 "<lambda>"
               context-line*
                 "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "getsentry.quotas"
               function*
                 "is_rate_limited"
               context-line*
                 "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.quotas.redis"
               function*
                 "is_rate_limited"
               context-line*
                 "rejections = is_rate_limited(client, keys, args)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.redis"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:29.214470+00:00'
+created: '2025-04-25T21:24:27.170117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:29.774348+00:00'
+created: '2025-04-25T21:24:27.263161+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,14 +31,14 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*
               "ValueError"
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.209191+00:00'
+created: '2025-04-25T21:24:28.589930+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,12 +31,12 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*
                   "do_stuff"
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*
@@ -45,7 +45,7 @@ contributing variants:
               "DoStuffException"
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:11.422688+00:00'
+created: '2025-04-25T21:24:33.279634+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "main"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.265612+00:00'
+created: '2025-04-25T21:24:35.418030+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,84 +35,84 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.base"
               function*
                 "_wrapped"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "process_event"
               context-line*
                 "return _do_process_event(cache_key, start_time, event_id, process_event)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "_do_process_event"
               context-line*
                 "new_data = process_stacktraces(data)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.stacktraces"
               function*
                 "process_stacktraces"
               context-line*
                 "if processor.preprocess_step(processing_task):"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.plugin"
               function*
                 "preprocess_step"
               context-line*
                 "referenced_images=referenced_images,"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.symbolizer"
               function*
                 "__init__"
               context-line*
                 "with_conversion_errors=True)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "get_symcaches"
               context-line*
                 "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "_load_cachefiles_via_fs"
               context-line*
                 "model.cache_file.save_to(cachefile_path)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "save_to"
               context-line*
                 "delete=False).detach_tempfile()"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "_get_chunked_blob"
               context-line*
                 "delete=delete"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "__init__"
               context-line*
                 "self._prefetch(prefetch_to, delete)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.609666+00:00'
+created: '2025-04-25T21:24:35.815206+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,62 +30,62 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "TableView.layoutSubviews"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "AnyTableViewController.tableView"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "anytableviewcontroller.swift"
               function*
                 "AnyTableViewController.tableView"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "dailydigesttableviewsection.swift"
               function*
                 "DailyDigestTableViewSection.photoCell"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "Sequence.compactMap<T>"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSources"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "mediaslideshow+extensions.swift"
               function*
                 "MediaSlideshow.toSource"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "<compiler-generated>"
               function*
                 "CurrentUserProfile.isVideoAutoplay.getter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "currentuserprofile.swift"
               function*
                 "CurrentUserProfile.isVideoAutoplay.getter"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "currentuserprofile.swift"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.410488+00:00'
+created: '2025-04-25T21:24:37.866024+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
               context-line*
                 "this.setState({"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "this.fetchData();"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/api"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.556436+00:00'
+created: '2025-04-25T21:24:37.967829+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
               context-line*
                 "this.setState({"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "this.fetchData();"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
               context-line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "app/api"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.765760+00:00'
+created: '2025-04-25T21:24:38.161169+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,19 +30,19 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "server.php"
               context-line*
                 "require_once __DIR__.'/public/index.php';"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "index.php"
               function*
                 "require_once"
               context-line*
                 "$request = Illuminate\\Http\\Request::capture()"
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "web.php"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.642957+00:00'
+created: '2025-04-25T21:24:38.055277+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "server.php"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.047452+00:00'
+created: '2025-04-25T21:24:39.699520+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,16 +30,16 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "_main"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "___rust_maybe_catch_panic"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "log_demo::main"
-            frame*
+            frame* (marked in-app by the client)
               function*
                 "log::__private_api_log"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.442060+00:00'
+created: '2025-04-25T21:24:40.066191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,38 +30,38 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub"
               function* (trimmed javascript function)
                 "withScope"
               context-line*
                 "*/"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "onunhandledrejection.ts"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub.ts"
               function* (trimmed javascript function)
                 "captureException"
               context-line*
                 "if (maxBreadcrumbs <= 0) {"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "hub"
               function* (trimmed javascript function)
                 "invokeClient"
               context-line*
                 "* @returns Scope, the new cloned scope"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "baseclient.ts"
               function* (trimmed javascript function)
                 "captureException"
               context-line*
                 "promisedEvent"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "backend.ts"
               function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.635138+00:00'
+created: '2025-04-25T21:24:40.238320+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,7 +31,7 @@ contributing variants:
         chained-exception*
           exception*
             stacktrace*
-              frame*
+              frame* (marked in-app by the client)
                 filename*
                   "baz.py"
             type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.731458+00:00'
+created: '2025-04-25T21:24:40.328924+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,14 +30,14 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.web.frontend.release_webhook"
               function*
                 "post"
               context-line*
                 "hook.handle(request)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry_plugins.heroku.plugin"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.859502+00:00'
+created: '2025-04-25T21:24:40.509301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,14 +30,14 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.utils.safe"
               function*
                 "safe_execute"
               context-line*
                 "result = func(*args, **kwargs)"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "sentry.integrations.slack.notify_action"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.954035+00:00'
+created: '2025-04-25T21:24:40.629665+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "App"
               context-line*
                 "<Button"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "App"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.996398+00:00'
+created: '2025-04-25T21:24:40.715654+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "bar.m"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.091123+00:00'
+created: '2025-04-25T21:24:40.887229+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.379151+00:00'
+created: '2025-04-25T21:24:41.413332+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.633867+00:00'
+created: '2025-04-25T21:24:42.036118+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       app*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "foo.py"
   system*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.726962+00:00'
+created: '2025-04-25T21:24:42.442507+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.c"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.843896+00:00'
+created: '2025-04-25T21:24:42.687609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "samplescript.cs"
               function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:37.734922+00:00'
+created: '2025-04-29T22:29:11.928739+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-23T19:06:00.383739+00:00'
+created: '2025-04-29T22:29:14.124783+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:52.381880+00:00'
+created: '2025-04-29T22:29:38.582773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:16.786208+00:00'
+created: '2025-04-25T21:22:16.434462+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             function*
               "__pthread_start"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "__pthread_body"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "thread.rs"
             function*
@@ -26,367 +26,367 @@ app:
               "boxed.rs"
             function*
               "alloc::boxed::FnBox<T>::call_box"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panic.rs"
             function*
               "std::panic::catch_unwind"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panicking.rs"
             function*
               "std::panicking::try"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panicking.rs"
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panic.rs"
             function*
               "std::panic::AssertUnwindSafe<T>::call_once"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "backtrace.rs"
             function*
               "std::sys_common::backtrace::__rust_begin_short_backtrace"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "arbiter.rs"
             function*
               "actix::arbiter::Arbiter::new_with_builder::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::block_on"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_reactor::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_reactor::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "clock.rs"
             function*
               "tokio_timer::clock::clock::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "clock.rs"
             function*
               "tokio_timer::clock::clock::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "handle.rs"
             function*
               "tokio_timer::timer::handle::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "handle.rs"
             function*
               "tokio_timer::timer::handle::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "global.rs"
             function*
               "tokio_executor::global::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "global.rs"
             function*
               "tokio_executor::global::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Entered<T>::block_on"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Entered<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduler<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::CurrentRunner::set_spawn"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduled<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_future_notify"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_fn_notify"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::enter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::std::set"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:alloc::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "alloc::boxed::Box<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "then.rs"
             function*
               "futures::future::then::Then<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "chain.rs"
             function*
               "futures::future::chain::Chain<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "either.rs"
             function*
               "futures::future::either::Either<T>::poll"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "either.rs"
             function*
               "futures::future::either::Either<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "acceptor.rs"
             function*
               "actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "and_then.rs"
             function*
               "actix_net::service::and_then::AndThenFuture<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "map_err.rs"
             function*
               "actix_net::service::map_err::MapErrFuture<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "channel.rs"
             function*
               "actix_web::server::channel::HttpChannel<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "channel.rs"
             function*
               "actix_web::server::channel::HttpChannel<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll_handler"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::parse"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "pipeline.rs"
             function*
               "actix_web::pipeline::Pipeline<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<::log::macros::log macros>"
             function*
               "actix_web::pipeline::ProcessResponse<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "log::__private_api_log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "log.rs"
             function*
               "sentry::integrations::log::Logger::log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with_active"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with::{{closure}}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.222069+00:00'
+created: '2025-04-25T21:22:16.557923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,756 +10,756 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.app.ActivityThread"
             filename (module takes precedence)
               "activitythread.java"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Looper"
             filename (module takes precedence)
               "looper.java"
             function*
               "loop"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "handleCallback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer$CallbackRecord"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.AdapterHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.ChildHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
             filename (module takes precedence)
@@ -772,14 +772,14 @@ app:
           "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "getStackTrace"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "dalvik.system.VMStack"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.278839+00:00'
+created: '2025-04-25T21:22:16.666374+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,157 +10,157 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Routing.EndpointMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeFilterPipelineAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "Next"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "Rethrow"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeNextResourceFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeInnerFilterAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "Next"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "Rethrow"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeNextActionFilterAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeActionMethodAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor+SyncObjectResultExecutor"
             function*
               "Execute"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.Extensions.Internal.ObjectMethodExecutor"
             function*
               "Execute"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "(unknown)"
             function*
               "lambda_method"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "SentryTest2.Controllers.ValuesController"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:17.385619+00:00'
+created: '2025-04-25T21:22:16.789159+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__00+[Something else]_block_invoke_2"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:17.475602+00:00'
+created: '2025-04-25T21:22:16.918214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,18 +10,18 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__kernel_rt_sigreturn"
-          frame (non app frame)
-          frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
             function*
               "kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.465771+00:00'
+created: '2025-04-25T21:22:17.234439+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "foo.bar"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.421711+00:00'
+created: '2025-04-25T21:22:17.087554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "bar.bar"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.521412+00:00'
+created: '2025-04-25T21:22:17.384014+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,59 +10,59 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_main_queue_callback_4CF"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_call_block_and_release"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
@@ -70,55 +70,55 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-23T19:07:03.263727+00:00'
+created: '2025-04-25T21:22:17.983773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,28 +13,28 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_main_queue_drain"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_block_async_invoke2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[NSBlockOperation main]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
@@ -46,10 +46,10 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_lane_barrier_sync_invoke_and_complete"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.713009+00:00'
+created: '2025-04-25T21:22:18.675228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "safe_execute"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.services"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "<lambda>"
             context-line*
               "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "getsentry.quotas"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "is_rate_limited"
             context-line*
               "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.quotas.redis"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "is_rate_limited"
             context-line*
               "rejections = is_rate_limited(client, keys, args)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.redis"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "call_script"
             context-line*
               "return script(keys, args, client)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__call__"
             context-line*
               "return client.evalsha(self.sha, len(keys), *args)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "evalsha"
             context-line*
               "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "execute_command"
             context-line*
               "return self.parse_response(connection, command_name, **options)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "parse_response"
             context-line*
               "response = connection.read_response()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.connection"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "read_response"
             context-line*
               "response = self._parser.read_response()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "redis.connection"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.192317+00:00'
+created: '2025-04-25T21:22:22.816738+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.139694+00:00'
+created: '2025-04-25T21:22:22.370588+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.238208+00:00'
+created: '2025-04-25T21:22:23.117702+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.340523+00:00'
+created: '2025-04-25T21:22:23.643626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,73 +18,73 @@ app:
           "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoSources0"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoSource0"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__eventFetcherSourceCallback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__processEventQueue"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplicationAccessibility sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIWindow sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIWindow _sendTouchesForEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl touchesEnded:withEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl _sendActionsForEvents:withEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "ViewController.captureError"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "ViewController.captureError"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.385024+00:00'
+created: '2025-04-25T21:22:23.894490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "baz.py"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:47.432793+00:00'
+created: '2025-04-25T21:22:24.157632+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*
@@ -20,7 +20,7 @@ app:
             "hello world"
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:48.032921+00:00'
+created: '2025-04-25T21:22:26.725358+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,12 +11,12 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
                 "do_stuff"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
@@ -27,12 +27,12 @@ app:
             "Can't do the stuff"
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
                 "do_other_stuff"
-            frame (ignored due to recursion)
+            frame (marked in-app by the client)
               module*
                 "dostuff"
               function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:48.189226+00:00'
+created: '2025-04-25T21:22:27.103761+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,14 +10,14 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "app/components/modals/createTeamModal"
             filename (module takes precedence)
               "createteammodal.jsx"
             context-line*
               "onError(err);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "app/views/settings/components/forms/form"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:48.483275+00:00'
+created: '2025-04-25T21:22:27.620573+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,22 +10,22 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "objc_release"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:48.968013+00:00'
+created: '2025-04-25T21:22:29.080361+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "async_patch.dart"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:49.523847+00:00'
+created: '2025-04-25T21:22:30.080042+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.010205+00:00'
+created: '2025-04-25T21:22:31.342432+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,37 +9,37 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_logging.dart"
           function*
             "SentryLogging.log"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_dio.dart"
           function*
             "SentryDio.dio"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_file.dart"
           function*
             "SentryFile.file"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_hive.dart"
           function*
             "SentryHive.hive"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_isar.dart"
           function*
             "SentryIsar.isar"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_sqflite.dart"
           function*
             "SentrySqflite.sqflite"
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_drift.dart"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.056815+00:00'
+created: '2025-04-25T21:22:31.475969+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.103260+00:00'
+created: '2025-04-25T21:22:31.604309+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "sentry_exception_factory.dart"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.782425+00:00'
+created: '2025-04-25T21:22:33.320305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "cron.go"
             function*
               "FuncJob.Run"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "main"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.998316+00:00'
+created: '2025-04-25T21:22:36.130473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.050999+00:00'
+created: '2025-04-25T21:22:36.289790+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.194486+00:00'
+created: '2025-04-25T21:22:36.661991+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,136 +10,136 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "main.m"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoObservers"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Transaction::observer_callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Transaction::commit"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Context::commit_transaction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Layer::layout_and_display_if_needed"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Layer::layout_if_needed"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[CALayer layoutSublayers]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView layoutSubviews]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView _updateVisibleCellsNow:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "AnyTableViewController.tableView"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "AnyTableViewController.tableView"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "closure"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "dailydigesttableviewsection.swift"
             function*
               "DailyDigestTableViewSection.photoCell"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "closure"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSource"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "CurrentUserProfile.isVideoAutoplay.getter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "currentuserprofile.swift"
             function*
               "CurrentUserProfile.isVideoAutoplay.getter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "currentuserprofile.swift"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.248614+00:00'
+created: '2025-04-25T21:22:36.787711+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,161 +11,161 @@ app:
       chained-exception*
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
                 "application.java"
               function*
                 "main"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
               filename (module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.coyote.AbstractProtocol"
               filename (module takes precedence)
                 "abstractprotocol.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.AbstractEndpoint"
               filename (module takes precedence)
                 "abstractendpoint.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.NioEndpoint"
               filename (module takes precedence)
                 "nioendpoint.java"
               function*
                 "bind"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketAdaptor"
               filename (module takes precedence)
                 "serversocketadaptor.java"
               function*
                 "bind"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketChannelImpl"
               filename (module takes precedence)
                 "serversocketchannelimpl.java"
               function*
                 "bind"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
                 "net.java"
               function*
                 "bind"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
                 "net.java"
               function*
                 "bind"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
@@ -178,105 +178,105 @@ app:
             "Address already in use"
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
                 "application.java"
               function*
                 "main"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
               filename (module takes precedence)
@@ -289,98 +289,98 @@ app:
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
                 "application.java"
               function*
                 "main"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (non app frame)
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.311966+00:00'
+created: '2025-04-25T21:22:36.907134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,385 +10,385 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "runWorker"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.SocketProcessorBase"
             filename (module takes precedence)
               "socketprocessorbase.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.NioEndpoint$SocketProcessor"
             filename (module takes precedence)
               "nioendpoint.java"
             function*
               "doRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProtocol$ConnectionHandler"
             filename (module takes precedence)
               "abstractprotocol.java"
             function*
               "process"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProcessorLight"
             filename (module takes precedence)
               "abstractprocessorlight.java"
             function*
               "process"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.http11.Http11Processor"
             filename (module takes precedence)
               "http11processor.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.connector.CoyoteAdapter"
             filename (module takes precedence)
               "coyoteadapter.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardEngineValve"
             filename (module takes precedence)
               "standardenginevalve.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.valves.ErrorReportValve"
             filename (module takes precedence)
               "errorreportvalve.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardHostValve"
             filename (module takes precedence)
               "standardhostvalve.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.authenticator.AuthenticatorBase"
             filename (module takes precedence)
               "authenticatorbase.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardContextValve"
             filename (module takes precedence)
               "standardcontextvalve.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardWrapperValve"
             filename (module takes precedence)
               "standardwrappervalve.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.CharacterEncodingFilter"
             filename (module takes precedence)
               "characterencodingfilter.java"
             function*
               "doFilterInternal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HiddenHttpMethodFilter"
             filename (module takes precedence)
               "hiddenhttpmethodfilter.java"
             function*
               "doFilterInternal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HttpPutFormContentFilter"
             filename (module takes precedence)
               "httpputformcontentfilter.java"
             function*
               "doFilterInternal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.RequestContextFilter"
             filename (module takes precedence)
               "requestcontextfilter.java"
             function*
               "doFilterInternal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.websocket.server.WsFilter"
             filename (module takes precedence)
               "wsfilter.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
             filename (module takes precedence)
               "httpservlet.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
             filename (module takes precedence)
               "httpservlet.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "doGet"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "processRequest"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
             filename (module takes precedence)
               "dispatcherservlet.java"
             function*
               "doService"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
             filename (module takes precedence)
               "dispatcherservlet.java"
             function*
               "doDispatch"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter"
             filename (module takes precedence)
               "abstracthandlermethodadapter.java"
             function*
               "handle"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
             filename (module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "handleInternal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
             filename (module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "invokeHandlerMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod"
             filename (module takes precedence)
               "servletinvocablehandlermethod.java"
             function*
               "invokeAndHandle"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
             filename (module takes precedence)
               "invocablehandlermethod.java"
             function*
               "invokeForRequest"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
             filename (module takes precedence)
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.DelegatingMethodAccessorImpl"
             filename (module takes precedence)
               "delegatingmethodaccessorimpl.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
             filename (module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
             filename (module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "io.sentry.example.Application"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.447381+00:00'
+created: '2025-04-25T21:22:37.302955+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,62 +10,62 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "dispatchInteractiveEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "interactiveUpdates"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "interactiveUpdates$1"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performSyncWork"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performWork"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performWorkOnRoot"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "renderRoot"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "replayUnitOfWork"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "invokeGuardedCallback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function* (trimmed javascript function)
               "invokeGuardedCallbackDev"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "index.js"
             function* (trimmed javascript function)
               "sentryWrapped"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.731247+00:00'
+created: '2025-04-25T21:22:37.889186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,48 +10,48 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (anonymous filename discarded)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.778127+00:00'
+created: '2025-04-25T21:22:38.020036+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,52 +10,52 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eval code"
             function*
               "eval code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "native code"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.840625+00:00'
+created: '2025-04-25T21:22:38.124192+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,45 +10,45 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "test/<"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.910651+00:00'
+created: '2025-04-25T21:22:38.229223+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,64 +10,64 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (anonymous filename discarded)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:52.967999+00:00'
+created: '2025-04-25T21:22:38.381472+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,68 +10,68 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eval code"
             function*
               "eval code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (module takes precedence)
               "native code"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.031385+00:00'
+created: '2025-04-25T21:22:38.528860+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,61 +10,61 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "test/<"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.088860+00:00'
+created: '2025-04-25T21:22:38.699742+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,67 +10,67 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.142552+00:00'
+created: '2025-04-25T21:22:38.847084+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,53 +10,53 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.213658+00:00'
+created: '2025-04-25T21:22:39.003267+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "M"
             context-line*
               "fn();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "fn"
             context-line*
               "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "run"
             context-line*
               "result = handler(value); // may throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "_next"
             context-line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "asyncGeneratorStep"
             context-line*
               "var info = gen[key](arg);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "key"
             context-line*
               "return this._invoke(method, arg);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "this"
             context-line*
               "var record = tryCatch(innerFn, self, context);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "tryCatch"
             context-line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "fn"
             context-line*
               "this.setState({"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "this"
             context-line (discarded because line too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "this"
             context-line (discarded because line too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "If"
             context-line (discarded because line too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "Yg"
             context-line (discarded because line too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "Xg"
             context-line (discarded because line too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "rh"
             context-line (discarded because line too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "X"
             context-line*
               "this.fetchData();"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -163,7 +163,7 @@ app:
               "this"
             context-line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/api"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.275043+00:00'
+created: '2025-04-25T21:22:39.148367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,12 +10,12 @@ app:
     app*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame (marked in-app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "promiseReactionJob"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -24,7 +24,7 @@ app:
               "_next"
             context-line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -33,7 +33,7 @@ app:
               "asyncGeneratorStep"
             context-line*
               "var info = gen[key](arg);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -42,7 +42,7 @@ app:
               "key"
             context-line*
               "var record = tryCatch(innerFn, self, context);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -51,7 +51,7 @@ app:
               "tryCatch"
             context-line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
             filename (module takes precedence)
@@ -60,7 +60,7 @@ app:
               "call"
             context-line*
               "this.setState({"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
             filename (module takes precedence)
@@ -69,7 +69,7 @@ app:
               "setState"
             context-line (discarded because line too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -78,7 +78,7 @@ app:
               "enqueueSetState"
             context-line (discarded because line too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -87,7 +87,7 @@ app:
               "tag"
             context-line (discarded because line too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -96,7 +96,7 @@ app:
               "Yg"
             context-line (discarded because line too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -105,7 +105,7 @@ app:
               "Xg"
             context-line (discarded because line too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -114,7 +114,7 @@ app:
               "ih"
             context-line (discarded because line too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -123,7 +123,7 @@ app:
               "q"
             context-line*
               "this.fetchData();"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -132,7 +132,7 @@ app:
               "fetchData"
             context-line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/api"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.388959+00:00'
+created: '2025-04-25T21:22:39.447441+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,348 +10,348 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "server.php"
             context-line*
               "require_once __DIR__.'/public/index.php';"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "index.php"
             function*
               "require_once"
             context-line*
               "$request = Illuminate\\Http\\Request::capture()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::handle"
             context-line*
               "$response = $this->sendRequestThroughRouter($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter"
             context-line*
               "->then($this->dispatchToRouter());"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
             context-line*
               "return $pipeline($this->passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "checkformaintenancemode.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "validatepostsize.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "trustproxies.php"
             function*
               "Fideloper\\Proxy\\TrustProxies::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $destination($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}"
             context-line*
               "return $this->router->dispatch($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatch"
             context-line*
               "return $this->dispatchToRoute($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatchToRoute"
             context-line*
               "return $this->runRoute($request, $this->findRoute($request));"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRoute"
             context-line*
               "$this->runRouteWithinStack($route, $request)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRouteWithinStack"
             context-line*
               "});"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
             context-line*
               "return $pipeline($this->passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "encryptcookies.php"
             function*
               "Illuminate\\Cookie\\Middleware\\EncryptCookies::handle"
             context-line*
               "return $this->encrypt($next($this->decrypt($request)));"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "addqueuedcookiestoresponse.php"
             function*
               "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle"
             context-line*
               "$response = $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "startsession.php"
             function*
               "Illuminate\\Session\\Middleware\\StartSession::handle"
             context-line*
               "$response = $next($request), $session"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "shareerrorsfromsession.php"
             function*
               "Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "verifycsrftoken.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"
             context-line*
               "return tap($next($request), function ($response) use ($request) {"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "substitutebindings.php"
             function*
               "Illuminate\\Routing\\Middleware\\SubstituteBindings::handle"
             context-line*
               "return $next($request);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $destination($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}"
             context-line*
               "$request, $route->run()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::run"
             context-line*
               "return $this->runCallable();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::runCallable"
             context-line*
               "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "web.php"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.330340+00:00'
+created: '2025-04-25T21:22:39.288487+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,19 +10,19 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "server.php"
             context-line*
               "require_once __DIR__.'/public/index.php';"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function (ignored anonymous function)
               "class@anonymous\u0000/var/www/html/dummy.php0x7190ad3c35cf::run"
             context-line*
               "return $callable($passable);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.709955+00:00'
+created: '2025-04-25T21:22:40.406371+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,88 +10,88 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_pthread_start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "free"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "malloc_report"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "malloc_vreport"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "abort"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "pthread_kill"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.913540+00:00'
+created: '2025-04-25T21:22:40.885143+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -19,7 +19,7 @@ app:
               "M"
             context-line (discarded because line too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -28,7 +28,7 @@ app:
               "S/<"
             context-line (discarded because line too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -37,7 +37,7 @@ app:
               "i"
             context-line (discarded because line too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -46,7 +46,7 @@ app:
               "b"
             context-line (discarded because line too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -55,7 +55,7 @@ app:
               "n"
             context-line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -64,7 +64,7 @@ app:
               "g/</t[e]"
             context-line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -73,7 +73,7 @@ app:
               "_invoke</<"
             context-line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -82,7 +82,7 @@ app:
               "W"
             context-line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -91,7 +91,7 @@ app:
               "e/<"
             context-line (discarded because line too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -100,7 +100,7 @@ app:
               "e/</a</<"
             context-line (discarded because line too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -109,7 +109,7 @@ app:
               "exports/<"
             context-line (discarded because line too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -118,7 +118,7 @@ app:
               "L"
             context-line (discarded because line too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -127,7 +127,7 @@ app:
               "exports/</<"
             context-line (discarded because line too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -136,7 +136,7 @@ app:
               "c"
             context-line (discarded because line too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -145,7 +145,7 @@ app:
               "n"
             context-line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -154,7 +154,7 @@ app:
               "g/</t[e]"
             context-line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -163,7 +163,7 @@ app:
               "_invoke</<"
             context-line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -172,7 +172,7 @@ app:
               "W"
             context-line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -181,7 +181,7 @@ app:
               "e/<"
             context-line (discarded because line too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -190,7 +190,7 @@ app:
               "componentPromise"
             context-line (discarded because line too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -199,7 +199,7 @@ app:
               "e"
             context-line (discarded because line too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.964452+00:00'
+created: '2025-04-25T21:22:41.029421+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.154232+00:00'
+created: '2025-04-25T21:22:41.171868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,25 +10,25 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "destructor'"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter10"
-          frame (non app frame)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.200267+00:00'
+created: '2025-04-25T21:22:41.286424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,20 +10,20 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter10"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.303834+00:00'
+created: '2025-04-25T21:22:41.401429+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,26 +10,26 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "destructor'"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter12"
-          frame (non app frame)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.353792+00:00'
+created: '2025-04-25T21:22:41.501319+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:33.475196+00:00'
+created: '2025-04-25T21:22:41.610667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,19 +13,19 @@ app:
           frame (non app frame)
             function*
               "application_frame"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "malloc_zone_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate_from_block"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate_from_block.cold.1"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.465350+00:00'
+created: '2025-04-25T21:22:41.730155+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,46 +10,46 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             function*
               "_main"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start_internal"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "log_demo::main"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "log::__private_api_log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::integrations::log::Logger::log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with_active"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with_active::{{closure}}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function (ignored unknown function)
               "<unknown>"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function (ignored unknown function)
               "<redacted>"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.522676+00:00'
+created: '2025-04-25T21:22:41.851721+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.583804+00:00'
+created: '2025-04-25T21:22:41.968141+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,27 +10,27 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "`anonymous namespace'::start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.633600+00:00'
+created: '2025-04-25T21:22:42.100296+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,22 +10,22 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "(anonymous namespace)::start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "(anonymous namespace)::crash"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.695046+00:00'
+created: '2025-04-25T21:22:42.187456+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub"
             filename (module takes precedence)
@@ -19,14 +19,14 @@ app:
               "withScope"
             context-line*
               "*/"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "onunhandledrejection.ts"
             filename (module takes precedence)
               "onunhandledrejection.ts"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -35,7 +35,7 @@ app:
               "mockConstructor [as captureException]"
             context-line*
               "return fn.apply(this, arguments);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -44,7 +44,7 @@ app:
               "<anonymous>"
             context-line*
               "})();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -53,7 +53,7 @@ app:
               "finalReturnValue"
             context-line*
               "return specificMockImpl.apply(this, arguments);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -62,7 +62,7 @@ app:
               "<anonymous>"
             context-line*
               "return original.apply(this, arguments);"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub.ts"
             filename (module takes precedence)
@@ -71,7 +71,7 @@ app:
               "captureException"
             context-line*
               "if (maxBreadcrumbs <= 0) {"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub"
             filename (module takes precedence)
@@ -80,7 +80,7 @@ app:
               "invokeClient"
             context-line*
               "* @returns Scope, the new cloned scope"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "baseclient.ts"
             filename (module takes precedence)
@@ -89,7 +89,7 @@ app:
               "captureException"
             context-line*
               "promisedEvent"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "backend.ts"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.810852+00:00'
+created: '2025-04-25T21:22:42.632715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*
@@ -20,7 +20,7 @@ app:
             "hello world"
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (non app frame)
+            frame (marked out of app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.863257+00:00'
+created: '2025-04-25T21:22:42.923669+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "get_response"
             context-line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "view"
             context-line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_wrapper"
             context-line*
               "return bound_func(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "wrapped_view"
             context-line*
               "return view_func(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "dispatch"
             context-line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "dispatch"
             context-line*
               "return handler(request, *args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.web.frontend.release_webhook"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "post"
             context-line*
               "hook.handle(request)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry_plugins.heroku.plugin"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "handle"
             context-line*
               "email = request.POST['user']"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.920293+00:00'
+created: '2025-04-25T21:22:43.195177+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "get_response"
             context-line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "view"
             context-line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_wrapper"
             context-line*
               "return bound_func(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "wrapped_view"
             context-line*
               "return view_func(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "dispatch"
             context-line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "handle"
             context-line*
               "email = request.POST['user']"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.973338+00:00'
+created: '2025-04-25T21:22:43.631715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "safe_execute"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.integrations.slack.notify_action"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "send_notification"
             context-line*
               "resp.raise_for_status()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "requests.models"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.066263+00:00'
+created: '2025-04-25T21:22:44.192778+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "value"
             context-line*
               "return this.flushedQueue();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "flushedQueue"
             context-line*
               "this._inCall--;"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_inCall"
             context-line*
               "return this.flushedQueue();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "flushedQueue"
             context-line*
               "this._lastFlush = new Date().getTime();"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "_lastFlush"
             context-line*
               "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "_receiveRootNodeIDEvent"
             context-line*
               "batchedUpdates(function() {"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "batchedUpdates"
             context-line*
               "return _batchedUpdates(fn, bookkeeping);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_batchedUpdates"
             context-line*
               "return fn(a);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "fn"
             context-line*
               "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -100,10 +100,10 @@ app:
               "forEachAccumulated"
             context-line*
               "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "[native code] forEach"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -112,7 +112,7 @@ app:
               "D"
             context-line*
               "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -121,7 +121,7 @@ app:
               "executeDispatch"
             context-line*
               "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -130,7 +130,7 @@ app:
               "invokeGuardedCallbackAndCatchFirstError"
             context-line*
               "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -139,7 +139,7 @@ app:
               "apply"
             context-line*
               "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -148,7 +148,7 @@ app:
               "apply"
             context-line*
               "var funcArgs = Array.prototype.slice.call(arguments, 3);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -157,7 +157,7 @@ app:
               "arguments"
             context-line*
               "touchableHandleResponderRelease: function(e) {"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -166,7 +166,7 @@ app:
               "_receiveSignal"
             context-line*
               "this._performSideEffectsForTransition(curState, nextState, signal, e);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -175,7 +175,7 @@ app:
               "_performSideEffectsForTransition"
             context-line*
               "this.touchableHandlePress(e);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android"
             filename (module takes precedence)
@@ -184,7 +184,7 @@ app:
               "this"
             context-line*
               "this.props.onPress && this.props.onPress(e);"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "App"
             filename (module takes precedence)
@@ -193,7 +193,7 @@ app:
               "onPress"
             context-line*
               "<Button"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "App"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.229398+00:00'
+created: '2025-04-25T21:22:44.524866+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "bar.m"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.374330+00:00'
+created: '2025-04-25T21:22:44.719740+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,49 +9,49 @@ app:
   component:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.448302+00:00'
+created: '2025-04-25T21:22:44.984901+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.790588+00:00'
+created: '2025-04-25T21:22:46.214047+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.840924+00:00'
+created: '2025-04-25T21:22:46.354804+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,15 +9,15 @@ app:
   component:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename (anonymous filename discarded)
             "<anonymous>"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "dojo.js"
           function*
             "c"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "dojo.js"
           function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:56.060369+00:00'
+created: '2025-04-25T21:22:46.817292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,40 +9,40 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:56.157175+00:00'
+created: '2025-04-25T21:22:47.014680+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:56.259517+00:00'
+created: '2025-04-25T21:22:47.197828+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,42 +10,42 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eventsystem.cs"
             function*
               "UnityEngine.EventSystems.EventSystem:Update()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "executeevents.cs"
             function*
               "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "executeevents.cs"
             function*
               "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "button.cs"
             function*
               "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "button.cs"
             function*
               "UnityEngine.UI.Button.Press ()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "unityevent_0.cs"
             function*
               "UnityEngine.Events.UnityEvent.Invoke ()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "unityevent.cs"
             function*
               "UnityEngine.Events.InvokableCall.Invoke ()"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "samplescript.cs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:56.367161+00:00'
+created: '2025-04-25T21:21:47.453623+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,10 +13,10 @@ app:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "__pthread_body"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "thread.rs"
             function*
@@ -26,367 +26,367 @@ app:
               "boxed.rs"
             function*
               "alloc::boxed::FnBox<T>::call_box"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panic.rs"
             function*
               "std::panic::catch_unwind"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panicking.rs"
             function*
               "std::panicking::try"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panicking.rs"
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "panic.rs"
             function*
               "std::panic::AssertUnwindSafe<T>::call_once"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "backtrace.rs"
             function*
               "std::sys_common::backtrace::__rust_begin_short_backtrace"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "arbiter.rs"
             function*
               "actix::arbiter::Arbiter::new_with_builder::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::block_on"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_reactor::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_reactor::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "clock.rs"
             function*
               "tokio_timer::clock::clock::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "clock.rs"
             function*
               "tokio_timer::clock::clock::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "handle.rs"
             function*
               "tokio_timer::timer::handle::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "handle.rs"
             function*
               "tokio_timer::timer::handle::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "global.rs"
             function*
               "tokio_executor::global::with_default"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "global.rs"
             function*
               "tokio_executor::global::with_default::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "runtime.rs"
             function*
               "tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Entered<T>::block_on"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Entered<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduler<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::CurrentRunner::set_spawn"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "scheduler.rs"
             function*
               "tokio_current_thread::scheduler::Scheduled<T>::tick"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_future_notify"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_fn_notify"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::enter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::std::set"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::enter::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mod.rs"
             function*
               "futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}"
-          frame (marked out of app by stack trace rule (family:native function:alloc::* -app))
+          frame (marked out of app by the client)
             filename*
               "mod.rs"
             function*
               "alloc::boxed::Box<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "then.rs"
             function*
               "futures::future::then::Then<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "chain.rs"
             function*
               "futures::future::chain::Chain<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "either.rs"
             function*
               "futures::future::either::Either<T>::poll"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "either.rs"
             function*
               "futures::future::either::Either<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "acceptor.rs"
             function*
               "actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "and_then.rs"
             function*
               "actix_net::service::and_then::AndThenFuture<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "map_err.rs"
             function*
               "actix_net::service::map_err::MapErrFuture<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "channel.rs"
             function*
               "actix_web::server::channel::HttpChannel<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "channel.rs"
             function*
               "actix_web::server::channel::HttpChannel<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll_handler"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "h1.rs"
             function*
               "actix_web::server::h1::Http1Dispatcher<T>::parse"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "pipeline.rs"
             function*
               "actix_web::pipeline::Pipeline<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<::log::macros::log macros>"
             function*
               "actix_web::pipeline::ProcessResponse<T>::poll_io"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "lib.rs"
             function*
               "log::__private_api_log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "log.rs"
             function*
               "sentry::integrations::log::Logger::log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with_active"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             filename*
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::try_with"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*
               "sentry::hub::Hub::with::{{closure}}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "hub.rs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-04T17:56:16.235509+00:00'
+created: '2025-04-25T21:21:47.696063+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,756 +10,756 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.app.ActivityThread"
             filename (module takes precedence)
               "activitythread.java"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Looper"
             filename (module takes precedence)
               "looper.java"
             function*
               "loop"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "handleCallback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.Choreographer$CallbackRecord"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "onLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.AdapterHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.ChildHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
             filename (module takes precedence)
@@ -772,14 +772,14 @@ app:
           "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "getStackTrace"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "dalvik.system.VMStack"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.236519+00:00'
+created: '2025-04-25T21:21:47.907164+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,157 +10,157 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Routing.EndpointMiddleware"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeFilterPipelineAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "Next"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "Rethrow"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"
             function*
               "InvokeNextResourceFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeInnerFilterAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "Next"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "Rethrow"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeNextActionFilterAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.CompilerServices.TaskAwaiter"
             function*
               "HandleNonSuccessAndDebuggerNotification"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "System.Runtime.ExceptionServices.ExceptionDispatchInfo"
             function*
               "Throw"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"
             function*
               "InvokeActionMethodAsync"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor+SyncObjectResultExecutor"
             function*
               "Execute"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "Microsoft.Extensions.Internal.ObjectMethodExecutor"
             function*
               "Execute"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "(unknown)"
             function*
               "lambda_method"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "SentryTest2.Controllers.ValuesController"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:56.723299+00:00'
+created: '2025-04-25T21:21:48.052430+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__00+[Something else]_block_invoke_2"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:56.816485+00:00'
+created: '2025-04-25T21:21:48.170589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,18 +10,18 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__kernel_rt_sigreturn"
-          frame (non app frame)
-          frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
             function*
               "kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.806109+00:00'
+created: '2025-04-25T21:21:48.378124+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "foo.bar"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.651461+00:00'
+created: '2025-04-25T21:21:48.269776+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "bar.bar"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.043918+00:00'
+created: '2025-04-25T21:21:48.505427+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,37 +10,37 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_main_queue_callback_4CF"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_dispatch_call_block_and_release"
           frame (ignored by stack trace rule (category:internals -group))
@@ -48,13 +48,13 @@ app:
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
           frame (ignored by stack trace rule (category:internals -group))
@@ -62,7 +62,7 @@ app:
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
@@ -75,10 +75,10 @@ app:
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
           frame (ignored by stack trace rule (category:internals -group))
@@ -86,39 +86,39 @@ app:
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "stripped_application_code"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-23T19:08:06.988108+00:00'
+created: '2025-04-25T21:21:48.840944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,28 +13,28 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "unicorn"
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_main_queue_drain"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_block_async_invoke2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[NSBlockOperation main]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
@@ -46,10 +46,10 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "SentrySetupInteractor.setupSentry"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_lane_barrier_sync_invoke_and_complete"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.303069+00:00'
+created: '2025-04-25T21:21:49.005158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "safe_execute"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.services"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "<lambda>"
             context-line*
               "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "getsentry.quotas"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "is_rate_limited"
             context-line*
               "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.quotas.redis"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "is_rate_limited"
             context-line*
               "rejections = is_rate_limited(client, keys, args)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.redis"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "call_script"
             context-line*
               "return script(keys, args, client)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__call__"
             context-line*
               "return client.evalsha(self.sha, len(keys), *args)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "evalsha"
             context-line*
               "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "execute_command"
             context-line*
               "return self.parse_response(connection, command_name, **options)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.client"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "parse_response"
             context-line*
               "response = connection.read_response()"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.connection"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "read_response"
             context-line*
               "response = self._parser.read_response()"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "redis.connection"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.091140+00:00'
+created: '2025-04-25T21:21:50.688440+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.032977+00:00'
+created: '2025-04-25T21:21:50.400405+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.149842+00:00'
+created: '2025-04-25T21:21:50.850828+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.249449+00:00'
+created: '2025-04-25T21:21:51.210373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,73 +18,73 @@ app:
           "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoSources0"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoSource0"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__eventFetcherSourceCallback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__processEventQueue"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplicationAccessibility sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIWindow sendEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIWindow _sendTouchesForEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl touchesEnded:withEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl _sendActionsForEvents:withEvent:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (marked out of app by stack trace rule (family:native function:__*[[]Sentry* -app -group))
+          frame (marked out of app by the client)
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "ViewController.captureError"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             function*
               "ViewController.captureError"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.296356+00:00'
+created: '2025-04-25T21:21:51.359658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "baz.py"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.349772+00:00'
+created: '2025-04-25T21:21:51.625521+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*
@@ -20,7 +20,7 @@ app:
             "hello world"
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:10.924364+00:00'
+created: '2025-04-25T21:21:53.163918+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,12 +11,12 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
                 "do_stuff"
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
@@ -27,12 +27,12 @@ app:
             "Can't do the stuff"
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               module*
                 "dostuff"
               function*
                 "do_other_stuff"
-            frame (ignored due to recursion)
+            frame (marked in-app by the client)
               module*
                 "dostuff"
               function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.072504+00:00'
+created: '2025-04-25T21:21:53.534358+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,14 +10,14 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "app/components/modals/createTeamModal"
             filename (module takes precedence)
               "createteammodal.jsx"
             context-line*
               "onError(err);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "app/views/settings/components/forms/form"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.332812+00:00'
+created: '2025-04-25T21:21:54.336775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,22 +10,22 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "objc_release"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:05.247773+00:00'
+created: '2025-04-25T21:22:03.909577+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "cron.go"
             function*
               "FuncJob.Run"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "main"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.595052+00:00'
+created: '2025-04-25T21:22:07.330426+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.646686+00:00'
+created: '2025-04-25T21:22:07.441352+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (custom fingerprint takes precedence)
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "_wrapped"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "process_event"
             context-line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_do_process_event"
             context-line*
               "new_data = process_stacktraces(data)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "process_stacktraces"
             context-line*
               "if processor.preprocess_step(processing_task):"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "preprocess_step"
             context-line*
               "referenced_images=referenced_images,"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "__init__"
             context-line*
               "with_conversion_errors=True)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "get_symcaches"
             context-line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_load_cachefiles_via_fs"
             context-line*
               "model.cache_file.save_to(cachefile_path)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "save_to"
             context-line*
               "delete=False).detach_tempfile()"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "_get_chunked_blob"
             context-line*
               "delete=delete"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "__init__"
             context-line*
               "self._prefetch(prefetch_to, delete)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.models.file"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "_prefetch"
             context-line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "__exit__"
             context-line*
               "self.shutdown(wait=True)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "shutdown"
             context-line*
               "t.join(sys.maxint)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "join"
             context-line*
               "self.__block.wait(delay)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "threading"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "wait"
             context-line*
               "_sleep(delay)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "billiard.pool"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.887007+00:00'
+created: '2025-04-25T21:22:07.744470+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "start"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
@@ -18,73 +18,73 @@ app:
               "main.m"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIApplication _run]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRunLoopDoObservers"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Transaction::observer_callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Transaction::commit"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Context::commit_transaction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Layer::layout_and_display_if_needed"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CA::Layer::layout_if_needed"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[CALayer layoutSublayers]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView layoutSubviews]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView _updateVisibleCellsNow:]"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "AnyTableViewController.tableView"
-          frame (ignored due to recursion)
+          frame (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "AnyTableViewController.tableView"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "anytableviewcontroller.swift"
             function*
@@ -94,22 +94,22 @@ app:
               "<compiler-generated>"
             function*
               "closure"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "dailydigesttableviewsection.swift"
             function*
               "DailyDigestTableViewSection.photoCell"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
@@ -119,27 +119,27 @@ app:
               "<compiler-generated>"
             function*
               "closure"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSources"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "mediaslideshow+extensions.swift"
             function*
               "MediaSlideshow.toSource"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "<compiler-generated>"
             function*
               "CurrentUserProfile.isVideoAutoplay.getter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "currentuserprofile.swift"
             function*
               "CurrentUserProfile.isVideoAutoplay.getter"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "currentuserprofile.swift"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-07T18:37:44.563033+00:00'
+created: '2025-04-25T21:22:07.867238+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,161 +11,161 @@ app:
       chained-exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
                 "application.java"
               function*
                 "main"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
               filename (module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.coyote.AbstractProtocol"
               filename (module takes precedence)
                 "abstractprotocol.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.AbstractEndpoint"
               filename (module takes precedence)
                 "abstractendpoint.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.NioEndpoint"
               filename (module takes precedence)
                 "nioendpoint.java"
               function*
                 "bind"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketAdaptor"
               filename (module takes precedence)
                 "serversocketadaptor.java"
               function*
                 "bind"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketChannelImpl"
               filename (module takes precedence)
                 "serversocketchannelimpl.java"
               function*
                 "bind"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
                 "net.java"
               function*
                 "bind"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
                 "net.java"
               function*
                 "bind"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
               filename (module takes precedence)
@@ -178,105 +178,105 @@ app:
             "Address already in use"
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
                 "application.java"
               function*
                 "main"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
               filename (module takes precedence)
@@ -296,91 +296,91 @@ app:
                 "application.java"
               function*
                 "main"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "run"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
               filename (module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
               filename (module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
               filename (module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
               filename (module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
               filename (module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
-            frame (marked out of app by stack trace rule (category:framework -app))
+            frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
               filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-07T18:37:44.915617+00:00'
+created: '2025-04-25T21:22:07.989953+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,385 +10,385 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "runWorker"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.SocketProcessorBase"
             filename (module takes precedence)
               "socketprocessorbase.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.NioEndpoint$SocketProcessor"
             filename (module takes precedence)
               "nioendpoint.java"
             function*
               "doRun"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProtocol$ConnectionHandler"
             filename (module takes precedence)
               "abstractprotocol.java"
             function*
               "process"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProcessorLight"
             filename (module takes precedence)
               "abstractprocessorlight.java"
             function*
               "process"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.coyote.http11.Http11Processor"
             filename (module takes precedence)
               "http11processor.java"
             function*
               "service"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.connector.CoyoteAdapter"
             filename (module takes precedence)
               "coyoteadapter.java"
             function*
               "service"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardEngineValve"
             filename (module takes precedence)
               "standardenginevalve.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.valves.ErrorReportValve"
             filename (module takes precedence)
               "errorreportvalve.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardHostValve"
             filename (module takes precedence)
               "standardhostvalve.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.authenticator.AuthenticatorBase"
             filename (module takes precedence)
               "authenticatorbase.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardContextValve"
             filename (module takes precedence)
               "standardcontextvalve.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardWrapperValve"
             filename (module takes precedence)
               "standardwrappervalve.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.CharacterEncodingFilter"
             filename (module takes precedence)
               "characterencodingfilter.java"
             function*
               "doFilterInternal"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HiddenHttpMethodFilter"
             filename (module takes precedence)
               "hiddenhttpmethodfilter.java"
             function*
               "doFilterInternal"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HttpPutFormContentFilter"
             filename (module takes precedence)
               "httpputformcontentfilter.java"
             function*
               "doFilterInternal"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
             filename (module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.RequestContextFilter"
             filename (module takes precedence)
               "requestcontextfilter.java"
             function*
               "doFilterInternal"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.tomcat.websocket.server.WsFilter"
             filename (module takes precedence)
               "wsfilter.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
             filename (module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
             filename (module takes precedence)
               "httpservlet.java"
             function*
               "service"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "service"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
             filename (module takes precedence)
               "httpservlet.java"
             function*
               "service"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "doGet"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
             filename (module takes precedence)
               "frameworkservlet.java"
             function*
               "processRequest"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
             filename (module takes precedence)
               "dispatcherservlet.java"
             function*
               "doService"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
             filename (module takes precedence)
               "dispatcherservlet.java"
             function*
               "doDispatch"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter"
             filename (module takes precedence)
               "abstracthandlermethodadapter.java"
             function*
               "handle"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
             filename (module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "handleInternal"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
             filename (module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "invokeHandlerMethod"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod"
             filename (module takes precedence)
               "servletinvocablehandlermethod.java"
             function*
               "invokeAndHandle"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
             filename (module takes precedence)
               "invocablehandlermethod.java"
             function*
               "invokeForRequest"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
             filename (module takes precedence)
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.DelegatingMethodAccessorImpl"
             filename (module takes precedence)
               "delegatingmethodaccessorimpl.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
             filename (module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
             filename (module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame (marked out of app by stack trace rule (category:framework -app))
+          frame (marked out of app by the client)
             module*
               "io.sentry.example.Application"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.173981+00:00'
+created: '2025-04-25T21:22:08.287079+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,62 +10,62 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "dispatchInteractiveEvent"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "interactiveUpdates"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "interactiveUpdates$1"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performSyncWork"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performWork"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "performWorkOnRoot"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "renderRoot"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "replayUnitOfWork"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function*
               "invokeGuardedCallback"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function* (trimmed javascript function)
               "invokeGuardedCallbackDev"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "index.js"
             function* (trimmed javascript function)
               "sentryWrapped"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             filename*
               "react-dom.development.js"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.588390+00:00'
+created: '2025-04-25T21:22:08.768980+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,48 +10,48 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (anonymous filename discarded)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.650778+00:00'
+created: '2025-04-25T21:22:08.885692+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,52 +10,52 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eval code"
             function*
               "eval code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "native code"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.712905+00:00'
+created: '2025-04-25T21:22:08.995269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,45 +10,45 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function (ignored unknown function name)
               "test/<"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.779854+00:00'
+created: '2025-04-25T21:22:09.130154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,64 +10,64 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (anonymous filename discarded)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.839680+00:00'
+created: '2025-04-25T21:22:09.242170+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,68 +10,68 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function* (trimmed javascript function)
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eval code"
             function*
               "eval code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (module takes precedence)
               "native code"
             function* (trimmed javascript function)
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "Anonymous function"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.893060+00:00'
+created: '2025-04-25T21:22:09.356012+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,61 +10,61 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function (ignored unknown function name)
               "test/<"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.960305+00:00'
+created: '2025-04-25T21:22:09.470253+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,67 +10,67 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "test"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.047428+00:00'
+created: '2025-04-25T21:22:09.621261+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,53 +10,53 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "testMethod"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "eval"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "test"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "map"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callback"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*
               "callAnotherThing"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "aha"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "test.html"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.102577+00:00'
+created: '2025-04-25T21:22:09.739839+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "M"
             context-line*
               "fn();"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "fn"
             context-line*
               "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "run"
             context-line*
               "result = handler(value); // may throw"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "_next"
             context-line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "asyncGeneratorStep"
             context-line*
               "var info = gen[key](arg);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "key"
             context-line*
               "return this._invoke(method, arg);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "this"
             context-line*
               "var record = tryCatch(innerFn, self, context);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "tryCatch"
             context-line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "fn"
             context-line*
               "this.setState({"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "this"
             context-line (discarded because line too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -109,7 +109,7 @@ app:
               "this"
             context-line (discarded because line too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -118,7 +118,7 @@ app:
               "If"
             context-line (discarded because line too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -127,7 +127,7 @@ app:
               "Yg"
             context-line (discarded because line too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -136,7 +136,7 @@ app:
               "Xg"
             context-line (discarded because line too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -145,7 +145,7 @@ app:
               "rh"
             context-line (discarded because line too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -154,7 +154,7 @@ app:
               "X"
             context-line*
               "this.fetchData();"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -163,7 +163,7 @@ app:
               "this"
             context-line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/api"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.146125+00:00'
+created: '2025-04-25T21:22:09.858005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,12 +10,12 @@ app:
     app*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame (marked in-app by the client)
             filename (native code indicated by filename)
               "[native code]"
             function*
               "promiseReactionJob"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -24,7 +24,7 @@ app:
               "_next"
             context-line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
             filename (module takes precedence)
@@ -33,7 +33,7 @@ app:
               "asyncGeneratorStep"
             context-line*
               "var info = gen[key](arg);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -42,7 +42,7 @@ app:
               "key"
             context-line*
               "var record = tryCatch(innerFn, self, context);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
             filename (module takes precedence)
@@ -51,7 +51,7 @@ app:
               "tryCatch"
             context-line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
             filename (module takes precedence)
@@ -60,7 +60,7 @@ app:
               "call"
             context-line*
               "this.setState({"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
             filename (module takes precedence)
@@ -69,7 +69,7 @@ app:
               "setState"
             context-line (discarded because line too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -78,7 +78,7 @@ app:
               "enqueueSetState"
             context-line (discarded because line too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -87,7 +87,7 @@ app:
               "tag"
             context-line (discarded because line too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -96,7 +96,7 @@ app:
               "Yg"
             context-line (discarded because line too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -105,7 +105,7 @@ app:
               "Xg"
             context-line (discarded because line too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
             filename (module takes precedence)
@@ -114,7 +114,7 @@ app:
               "ih"
             context-line (discarded because line too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -123,7 +123,7 @@ app:
               "q"
             context-line*
               "this.fetchData();"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
             filename (module takes precedence)
@@ -132,7 +132,7 @@ app:
               "fetchData"
             context-line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "app/api"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.258663+00:00'
+created: '2025-04-25T21:22:10.083814+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,348 +10,348 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "server.php"
             context-line*
               "require_once __DIR__.'/public/index.php';"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "index.php"
             function*
               "require_once"
             context-line*
               "$request = Illuminate\\Http\\Request::capture()"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::handle"
             context-line*
               "$response = $this->sendRequestThroughRouter($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter"
             context-line*
               "->then($this->dispatchToRouter());"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
             context-line*
               "return $pipeline($this->passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "checkformaintenancemode.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "validatepostsize.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "trustproxies.php"
             function*
               "Fideloper\\Proxy\\TrustProxies::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $destination($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}"
             context-line*
               "return $this->router->dispatch($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatch"
             context-line*
               "return $this->dispatchToRoute($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatchToRoute"
             context-line*
               "return $this->runRoute($request, $this->findRoute($request));"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRoute"
             context-line*
               "$this->runRouteWithinStack($route, $request)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRouteWithinStack"
             context-line*
               "});"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
             context-line*
               "return $pipeline($this->passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "encryptcookies.php"
             function*
               "Illuminate\\Cookie\\Middleware\\EncryptCookies::handle"
             context-line*
               "return $this->encrypt($next($this->decrypt($request)));"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "addqueuedcookiestoresponse.php"
             function*
               "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle"
             context-line*
               "$response = $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "startsession.php"
             function*
               "Illuminate\\Session\\Middleware\\StartSession::handle"
             context-line*
               "$response = $next($request), $session"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "shareerrorsfromsession.php"
             function*
               "Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "verifycsrftoken.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"
             context-line*
               "return tap($next($request), function ($response) use ($request) {"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context-line*
               "? $pipe->{$this->method}(...$parameters)"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "substitutebindings.php"
             function*
               "Illuminate\\Routing\\Middleware\\SubstituteBindings::handle"
             context-line*
               "return $next($request);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
             context-line*
               "return $destination($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}"
             context-line*
               "$request, $route->run()"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::run"
             context-line*
               "return $this->runCallable();"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::runCallable"
             context-line*
               "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "web.php"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.190870+00:00'
+created: '2025-04-25T21:22:09.959580+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,19 +10,19 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "server.php"
             context-line*
               "require_once __DIR__.'/public/index.php';"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function* (anonymous class method)
               "run"
             context-line*
               "return $callable($passable);"
-          frame (marked out of app by stack trace rule (path:**/vendor/** -app))
+          frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.681320+00:00'
+created: '2025-04-25T21:22:10.692332+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,88 +10,88 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "_pthread_start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "stripped_application_code"
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "free"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "malloc_report"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "malloc_vreport"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "abort"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "pthread_kill"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.924713+00:00'
+created: '2025-04-25T21:22:11.236295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -19,7 +19,7 @@ app:
               "M"
             context-line (discarded because line too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -28,7 +28,7 @@ app:
               "S/<"
             context-line (discarded because line too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -37,7 +37,7 @@ app:
               "i"
             context-line (discarded because line too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -46,7 +46,7 @@ app:
               "b"
             context-line (discarded because line too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -55,7 +55,7 @@ app:
               "n"
             context-line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -64,7 +64,7 @@ app:
               "g/</t[e]"
             context-line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -73,7 +73,7 @@ app:
               "_invoke</<"
             context-line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -82,7 +82,7 @@ app:
               "W"
             context-line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -91,7 +91,7 @@ app:
               "e/<"
             context-line (discarded because line too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -100,7 +100,7 @@ app:
               "e/</a</<"
             context-line (discarded because line too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -109,7 +109,7 @@ app:
               "exports/<"
             context-line (discarded because line too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -118,7 +118,7 @@ app:
               "L"
             context-line (discarded because line too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -127,7 +127,7 @@ app:
               "exports/</<"
             context-line (discarded because line too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -136,7 +136,7 @@ app:
               "c"
             context-line (discarded because line too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -145,7 +145,7 @@ app:
               "n"
             context-line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -154,7 +154,7 @@ app:
               "g/</t[e]"
             context-line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -163,7 +163,7 @@ app:
               "_invoke</<"
             context-line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)
@@ -172,7 +172,7 @@ app:
               "W"
             context-line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -181,7 +181,7 @@ app:
               "e/<"
             context-line (discarded because line too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -190,7 +190,7 @@ app:
               "componentPromise"
             context-line (discarded because line too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/app"
             filename (ignored because frame points to a URL)
@@ -199,7 +199,7 @@ app:
               "e"
             context-line (discarded because line too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             module*
               "sentry/dist/vendor"
             filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.980268+00:00'
+created: '2025-04-25T21:22:11.400931+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:11.326908+00:00'
+created: '2025-04-25T21:22:11.550057+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,25 +10,25 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "destructor'"
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter10"
-          frame (non app frame)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:11.440700+00:00'
+created: '2025-04-25T21:22:11.681430+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,20 +10,20 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter10"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:11.534819+00:00'
+created: '2025-04-25T21:22:11.795630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,26 +10,26 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "destructor'"
-          frame (marked out of app by stack trace rule (category:system -app))
+          frame (marked out of app by the client)
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by the client)
+          frame (marked out of app by the client)
             function*
               "OpenAdapter12"
-          frame (non app frame)
+          frame (marked out of app by the client)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.350421+00:00'
+created: '2025-04-25T21:22:11.924203+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:11.713029+00:00'
+created: '2025-04-25T21:22:12.050592+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,19 +13,19 @@ app:
           frame (non app frame)
             function*
               "application_frame"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "malloc_zone_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate_from_block"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by the client)
             function*
               "nanov2_allocate_from_block.cold.1"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.460985+00:00'
+created: '2025-04-25T21:22:12.168925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,46 +10,46 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             function*
               "_main"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start_internal"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "___rust_maybe_catch_panic"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by the client)
             function*
               "std::rt::lang_start::{{closure}}"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "log_demo::main"
-          frame*
+          frame* (marked in-app by the client)
             function*
               "log::__private_api_log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::integrations::log::Logger::log"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with_active"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "sentry::hub::Hub::with_active::{{closure}}"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function (ignored unknown function)
               "<unknown>"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function (ignored unknown function)
               "<redacted>"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.504033+00:00'
+created: '2025-04-25T21:22:12.278502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.554825+00:00'
+created: '2025-04-25T21:22:12.392747+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,27 +10,27 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "`anonymous namespace'::start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.648486+00:00'
+created: '2025-04-25T21:22:12.501597+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,22 +10,22 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "main"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "(anonymous namespace)::start"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*
               "(anonymous namespace)::crash"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "main.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.708037+00:00'
+created: '2025-04-25T21:22:12.623025+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub"
             filename (module takes precedence)
@@ -19,14 +19,14 @@ app:
               "withScope"
             context-line*
               "*/"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "onunhandledrejection.ts"
             filename (module takes precedence)
               "onunhandledrejection.ts"
             function (ignored unknown function name)
               "<anonymous>"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -35,7 +35,7 @@ app:
               "mockConstructor [as captureException]"
             context-line*
               "return fn.apply(this, arguments);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -44,7 +44,7 @@ app:
               "<anonymous>"
             context-line*
               "})();"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -53,7 +53,7 @@ app:
               "finalReturnValue"
             context-line*
               "return specificMockImpl.apply(this, arguments);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
             filename (module takes precedence)
@@ -62,7 +62,7 @@ app:
               "<anonymous>"
             context-line*
               "return original.apply(this, arguments);"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub.ts"
             filename (module takes precedence)
@@ -71,7 +71,7 @@ app:
               "captureException"
             context-line*
               "if (maxBreadcrumbs <= 0) {"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "hub"
             filename (module takes precedence)
@@ -80,7 +80,7 @@ app:
               "invokeClient"
             context-line*
               "* @returns Scope, the new cloned scope"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "baseclient.ts"
             filename (module takes precedence)
@@ -89,7 +89,7 @@ app:
               "captureException"
             context-line*
               "promisedEvent"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "backend.ts"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.810944+00:00'
+created: '2025-04-25T21:22:12.945442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
           type*
@@ -20,7 +20,7 @@ app:
             "hello world"
         exception*
           stacktrace (ignored because it contains no in-app frames)
-            frame (non app frame)
+            frame (marked out of app by the client)
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.870095+00:00'
+created: '2025-04-25T21:22:13.058609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "get_response"
             context-line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "view"
             context-line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_wrapper"
             context-line*
               "return bound_func(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "wrapped_view"
             context-line*
               "return view_func(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "dispatch"
             context-line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "dispatch"
             context-line*
               "return handler(request, *args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.web.frontend.release_webhook"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "post"
             context-line*
               "hook.handle(request)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry_plugins.heroku.plugin"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "handle"
             context-line*
               "email = request.POST['user']"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.927985+00:00'
+created: '2025-04-25T21:22:13.177400+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "get_response"
             context-line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "view"
             context-line*
               "return self.dispatch(request, *args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_wrapper"
             context-line*
               "return bound_func(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "wrapped_view"
             context-line*
               "return view_func(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.decorators"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "dispatch"
             context-line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.views.generic.base"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "handle"
             context-line*
               "email = request.POST['user']"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.991859+00:00'
+created: '2025-04-25T21:22:13.281494+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "safe_execute"
             context-line*
               "result = func(*args, **kwargs)"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "sentry.integrations.slack.notify_action"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "send_notification"
             context-line*
               "resp.raise_for_status()"
-          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+          frame (marked out of app by the client)
             module*
               "requests.models"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.065833+00:00'
+created: '2025-04-25T21:22:13.414468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -19,7 +19,7 @@ app:
               "value"
             context-line*
               "return this.flushedQueue();"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -28,7 +28,7 @@ app:
               "flushedQueue"
             context-line*
               "this._inCall--;"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -37,7 +37,7 @@ app:
               "_inCall"
             context-line*
               "return this.flushedQueue();"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
             filename (module takes precedence)
@@ -46,7 +46,7 @@ app:
               "flushedQueue"
             context-line*
               "this._lastFlush = new Date().getTime();"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -55,7 +55,7 @@ app:
               "_lastFlush"
             context-line*
               "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -64,7 +64,7 @@ app:
               "_receiveRootNodeIDEvent"
             context-line*
               "batchedUpdates(function() {"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -73,7 +73,7 @@ app:
               "batchedUpdates"
             context-line*
               "return _batchedUpdates(fn, bookkeeping);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -82,7 +82,7 @@ app:
               "_batchedUpdates"
             context-line*
               "return fn(a);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -91,7 +91,7 @@ app:
               "fn"
             context-line*
               "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -100,10 +100,10 @@ app:
               "forEachAccumulated"
             context-line*
               "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
-          frame (non app frame)
+          frame (marked out of app by the client)
             function*
               "[native code] forEach"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -112,7 +112,7 @@ app:
               "D"
             context-line*
               "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -121,7 +121,7 @@ app:
               "executeDispatch"
             context-line*
               "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -130,7 +130,7 @@ app:
               "invokeGuardedCallbackAndCatchFirstError"
             context-line*
               "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -139,7 +139,7 @@ app:
               "apply"
             context-line*
               "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
             filename (module takes precedence)
@@ -148,7 +148,7 @@ app:
               "apply"
             context-line*
               "var funcArgs = Array.prototype.slice.call(arguments, 3);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -157,7 +157,7 @@ app:
               "arguments"
             context-line*
               "touchableHandleResponderRelease: function(e) {"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -166,7 +166,7 @@ app:
               "_receiveSignal"
             context-line*
               "this._performSideEffectsForTransition(curState, nextState, signal, e);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
             filename (module takes precedence)
@@ -175,7 +175,7 @@ app:
               "_performSideEffectsForTransition"
             context-line*
               "this.touchableHandlePress(e);"
-          frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
+          frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android"
             filename (module takes precedence)
@@ -184,7 +184,7 @@ app:
               "this"
             context-line*
               "this.props.onPress && this.props.onPress(e);"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "App"
             filename (module takes precedence)
@@ -193,7 +193,7 @@ app:
               "onPress"
             context-line*
               "<Button"
-          frame*
+          frame* (marked in-app by the client)
             module*
               "App"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.111860+00:00'
+created: '2025-04-25T21:22:13.498456+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "bar.m"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.167124+00:00'
+created: '2025-04-25T21:22:13.604760+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,49 +9,49 @@ app:
   component:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by the client)
           module*
             "com.example.Application"
           filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.220340+00:00'
+created: '2025-04-25T21:22:13.737660+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.555984+00:00'
+created: '2025-04-25T21:22:14.434463+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
         frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.615361+00:00'
+created: '2025-04-25T21:22:14.552509+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,15 +9,15 @@ app:
   component:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because it contains no in-app frames)
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename (anonymous filename discarded)
             "<anonymous>"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "dojo.js"
           function*
             "c"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "dojo.js"
           function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.833763+00:00'
+created: '2025-04-25T21:22:15.001608+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,40 +9,40 @@ app:
   component:
     app*
       stacktrace*
-        frame*
+        frame* (marked in-app by the client)
           filename*
             "foo.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
-        frame (non app frame)
+        frame (marked out of app by the client)
           filename*
             "bar.py"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:19.084434+00:00'
+created: '2025-04-25T21:22:15.234636+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       threads*
         stacktrace*
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:19.265209+00:00'
+created: '2025-04-25T21:22:15.466823+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,42 +10,42 @@ app:
     app*
       exception*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "eventsystem.cs"
             function*
               "UnityEngine.EventSystems.EventSystem:Update()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "executeevents.cs"
             function*
               "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "executeevents.cs"
             function*
               "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "button.cs"
             function*
               "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "button.cs"
             function*
               "UnityEngine.UI.Button.Press ()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "unityevent_0.cs"
             function*
               "UnityEngine.Events.UnityEvent.Invoke ()"
-          frame (non app frame)
+          frame (marked out of app by the client)
             filename*
               "unityevent.cs"
             function*
               "UnityEngine.Events.InvokableCall.Invoke ()"
-          frame*
+          frame* (marked in-app by the client)
             filename*
               "samplescript.cs"
             function*

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -655,24 +655,74 @@ class AssembleStacktraceComponentTest(TestCase):
             - App variant frames never contribute if they're out of app
             - App variant frame hints for system frames are only used if they relate to in-app-ness
             - System variant frame hints are only used if they relate to ignoring/un-ignoring
+            - In-app hints in either variant aren't used if the rust result matches the incoming
+              value set by the client
             - In all other cases, the frame results from rust are used
             - For both variants, the rust stacktrace results are used. (There's one exception to
               this rule, but it needs its own test - see
               `test_marks_app_stacktrace_non_contributing_if_no_in_app_frames` below.)
         """
-        incoming_frames = [
+        incoming_frames: list[dict[str, Any]] = [
             {"in_app": True},
             {"in_app": True},
             {"in_app": True},
             {"in_app": True},
             {"in_app": True},
             {"in_app": True},
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
+            {
+                "in_app": True,
+                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
+            },
             {"in_app": False},
             {"in_app": False},
             {"in_app": False},
             {"in_app": False},
             {"in_app": False},
             {"in_app": False},
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
+            {
+                "in_app": False,
+                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
+            },
         ]
 
         app_variant_frame_components = [
@@ -682,12 +732,24 @@ class AssembleStacktraceComponentTest(TestCase):
             self.in_app_frame(contributes=True, hint=None),
             self.in_app_frame(contributes=True, hint=None),
             self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
+            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
             self.system_frame(contributes=False, hint="non app frame"),
             self.system_frame(contributes=False, hint="non app frame"),
             self.system_frame(contributes=False, hint="non app frame"),
             self.system_frame(contributes=False, hint="non app frame"),
             self.system_frame(contributes=False, hint="non app frame"),
             self.system_frame(contributes=False, hint="non app frame"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
+            self.system_frame(contributes=False, hint="marked out of app by the client"),
         ]
         system_variant_frame_components = [
             self.in_app_frame(contributes=True, hint=None),
@@ -696,6 +758,18 @@ class AssembleStacktraceComponentTest(TestCase):
             self.in_app_frame(contributes=True, hint=None),
             self.in_app_frame(contributes=True, hint=None),
             self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.in_app_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
+            self.system_frame(contributes=True, hint=None),
             self.system_frame(contributes=True, hint=None),
             self.system_frame(contributes=True, hint=None),
             self.system_frame(contributes=True, hint=None),
@@ -722,8 +796,20 @@ class AssembleStacktraceComponentTest(TestCase):
             (True, "un-ignored by stacktrace rule (...)"),
             (True, "marked in-app by stacktrace rule (...)"),
             (True, None),
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked in-app by stacktrace rule (...)"),
+            (False, None),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked in-app by stacktrace rule (...)"),
+            (True, None),
             # All the possible results which could be sent back for system frames (IOW, everything
             # but "marked in-app").
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked out of app by stacktrace rule (...)"),
+            (False, None),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked out of app by stacktrace rule (...)"),
+            (True, None),
             (False, "ignored by stacktrace rule (...)"),
             (False, "marked out of app by stacktrace rule (...)"),
             (False, None),
@@ -733,26 +819,56 @@ class AssembleStacktraceComponentTest(TestCase):
         ]
 
         app_expected_frame_results = [
-            # With the in-app frames, all of the rust results are used
+            # With the in-app frames with no `client_in_app` value, all of the rust results are used
             (False, "ignored by stacktrace rule (...)"),
             (False, "marked in-app by stacktrace rule (...)"),
             (False, None),
             (True, "un-ignored by stacktrace rule (...)"),
             (True, "marked in-app by stacktrace rule (...)"),
             (True, None),
+            # With the in-app frames which do have a `client_in_app` value, the rust results are
+            # used only if they aren't taking credit for marking the frame in-app, since the frame
+            # already was in-app.
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked in-app by the client"),
+            (False, "marked in-app by the client"),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked in-app by the client"),
+            (True, "marked in-app by the client"),
             # With the system frames, none of them contributes (regardless of what rust says),
-            # because they're all out of app, and the rust hint is only used when it relates to a
-            # `-app` rule.
+            # because they're all out of app. For the ones with no `client_in_app` value, the rust
+            # hint is only used when it relates to a `-app` rule.
             (False, "non app frame"),
             (False, "marked out of app by stacktrace rule (...)"),
             (False, "non app frame"),
             (False, "non app frame"),
             (False, "marked out of app by stacktrace rule (...)"),
             (False, "non app frame"),
+            # For the ones which do have a `client_in_app` value, the rust hint is never used,
+            # because either it's for a +/-group rule or it's taking credit for marking the frame
+            # out of app, even though it already was out of app.
+            (False, "marked out of app by the client"),
+            (False, "marked out of app by the client"),
+            (False, "marked out of app by the client"),
+            (False, "marked out of app by the client"),
+            (False, "marked out of app by the client"),
+            (False, "marked out of app by the client"),
         ]
         system_expected_frame_results = [
             # For all frames in this variant, the rust hint is used when it relates to a `+/-group`
             # rule, but not when it relates to a `+/-app` rule
+            (False, "ignored by stacktrace rule (...)"),
+            (False, None),
+            (False, None),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, None),
+            (True, None),
+            (False, "ignored by stacktrace rule (...)"),
+            (False, None),
+            (False, None),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, None),
+            (True, None),
             (False, "ignored by stacktrace rule (...)"),
             (False, None),
             (False, None),

--- a/tests/sentry/stacktraces/test_in_app_normalization.py
+++ b/tests/sentry/stacktraces/test_in_app_normalization.py
@@ -34,6 +34,32 @@ def make_event(stacktraces: list[Any]) -> dict[str, Any]:
     return {"exception": {"values": [{"stacktrace": stacktrace} for stacktrace in stacktraces]}}
 
 
+class NormalizeStacktracesFroGroupingTest(TestCase):
+    def test_sets_client_in_app(self):
+        event_data_with_client_values = make_event(
+            [
+                make_stacktrace(
+                    frame_0_in_app=True,
+                    frame_1_in_app=False,
+                )
+            ]
+        )
+
+        normalize_stacktraces_for_grouping(event_data_with_client_values)
+
+        frames = event_data_with_client_values["exception"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["data"]["client_in_app"] is True
+        assert frames[1]["data"]["client_in_app"] is False
+
+        event_data_no_client_values = make_event([make_stacktrace()])
+
+        normalize_stacktraces_for_grouping(event_data_no_client_values)
+
+        frames = event_data_no_client_values["exception"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["data"].get("client_in_app") is None
+        assert frames[1]["data"].get("client_in_app") is None
+
+
 class NormalizeInApptest(TestCase):
     def test_changes_in_app_None_into_in_app_False(self):
         event_data = make_event(


### PR DESCRIPTION
There is a bug in the rust enhancer, such that sometimes, it takes credit for changing `in_app` values it hasn't actually changed. This happens when

- a frame comes in from the client with `in_app: False`,
- the frame is non-contributing (as all non-in-app frames are in the app variant), and
- rust finds a rule which confirms the out-of-app-ness.

In that case, it will return a "marked out of app by xxx" hint, even though the frame was already `in_app: False`.

The same thing happens in the reverse situation (a client in-app value of True, on a contributing frame, with a rule confirming the in-app-ness).

This fixes that by creating a more accurate hint ("marked in-app/out of app by the client") and using it rather than the rust hint in the cases described above. (This involves storing in frame data the incoming client `in_app` value, which is actually something that would be helpful for grouping info as well, so yay for bonus side effects.)