### PR TITLE
feat(grouping): Enable splitting enhancement rules by type

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -237,6 +237,12 @@ class Enhancements:
     # from cache.
     # See ``GroupingConfigLoader._get_enhancements`` in src/sentry/grouping/api.py.
 
+    # TODO: Once we switch to always using split enhancements, these can go away
+    classifier_rules: list[EnhancementRule] = []
+    contributes_rules: list[EnhancementRule] = []
+    classifier_rust_enhancements: RustEnhancements = EMPTY_RUST_ENHANCEMENTS
+    contributes_rust_enhancements: RustEnhancements = EMPTY_RUST_ENHANCEMENTS
+
     def __init__(
         self,
         rules: list[EnhancementRule],

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -48,7 +48,9 @@ VALID_PROFILING_ACTIONS_SET = frozenset(["+app", "-app"])
 
 
 def merge_rust_enhancements(
-    bases: list[str], rust_enhancements: RustEnhancements
+    bases: list[str],
+    rust_enhancements: RustEnhancements,
+    type: Literal["classifier", "contributes"] | None = None,
 ) -> RustEnhancements:
     """
     This will merge the parsed enhancements together with the `bases`.
@@ -59,7 +61,16 @@ def merge_rust_enhancements(
     for base_id in bases:
         base = ENHANCEMENT_BASES.get(base_id)
         if base:
-            merged_rust_enhancements.extend_from(base.rust_enhancements)
+            base_rust_enhancements = (
+                base.rust_enhancements
+                if type is None
+                else (
+                    base.classifier_rust_enhancements
+                    if type == "classifier"
+                    else base.contributes_rust_enhancements
+                )
+            )
+            merged_rust_enhancements.extend_from(base_rust_enhancements)
     merged_rust_enhancements.extend_from(rust_enhancements)
     return merged_rust_enhancements
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -477,7 +477,11 @@ class Enhancements:
     @classmethod
     @sentry_sdk.tracing.trace
     def from_rules_text(
-        cls, rules_text: str, bases: list[str] | None = None, id: str | None = None
+        cls,
+        rules_text: str,
+        bases: list[str] | None = None,
+        id: str | None = None,
+        version: int | None = None,
     ) -> Enhancements:
         """Create an `Enhancements` object from a text blob containing stacktrace rules"""
         rust_enhancements = get_rust_enhancements("config_string", rules_text)
@@ -487,6 +491,7 @@ class Enhancements:
         return Enhancements(
             rules,
             rust_enhancements=rust_enhancements,
+            version=version,
             bases=bases,
             id=id,
         )

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -82,6 +82,9 @@ def get_rust_enhancements(
         raise InvalidEnhancerConfig(str(e))
 
 
+EMPTY_RUST_ENHANCEMENTS = get_rust_enhancements("config_string", "")
+
+
 # TODO: Convert this into a typeddict in ophio
 RustExceptionData = dict[str, bytes | None]
 

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/3.pysnap
@@ -1,0 +1,214 @@
+---
+created: '2025-04-27T03:05:59.368654+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_enhancer.py
+---
+bases:
+- common:v1
+classifier_rules:
+- actions:
+  - flag: true
+    key: app
+    range: null
+  matchers:
+  - key: path
+    negated: false
+    pattern: '*/code/game/whatever/*'
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: native
+  - key: module
+    negated: false
+    pattern: std::*
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: module
+    negated: false
+    pattern: core::*
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: javascript
+  - key: path
+    negated: false
+    pattern: '*/test.js'
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: javascript
+  - key: app
+    negated: false
+    pattern: '1'
+  - key: path
+    negated: false
+    pattern: '*/test.js'
+contributes_rules:
+- actions:
+  - flag: false
+    key: group
+    range: up
+  - flag: false
+    key: group
+    range: null
+  matchers:
+  - key: function
+    negated: false
+    pattern: panic_handler
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartWin32
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartLinux
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartMac
+- actions:
+  - value: 3
+    var: max-frames
+  matchers:
+  - key: family
+    negated: false
+    pattern: native
+- actions:
+  - value: 12
+    var: max-frames
+  matchers:
+  - key: value
+    negated: false
+    pattern: '*something*'
+id: null
+rules:
+- actions:
+  - flag: true
+    key: app
+    range: null
+  matchers:
+  - key: path
+    negated: false
+    pattern: '*/code/game/whatever/*'
+- actions:
+  - flag: false
+    key: group
+    range: up
+  - flag: false
+    key: group
+    range: null
+  matchers:
+  - key: function
+    negated: false
+    pattern: panic_handler
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartWin32
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartLinux
+- actions:
+  - flag: false
+    key: group
+    range: down
+  matchers:
+  - key: function
+    negated: false
+    pattern: ThreadStartMac
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: native
+  - key: module
+    negated: false
+    pattern: std::*
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: module
+    negated: false
+    pattern: core::*
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: javascript
+  - key: path
+    negated: false
+    pattern: '*/test.js'
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    negated: false
+    pattern: javascript
+  - key: app
+    negated: false
+    pattern: '1'
+  - key: path
+    negated: false
+    pattern: '*/test.js'
+- actions:
+  - value: 3
+    var: max-frames
+  matchers:
+  - key: family
+    negated: false
+    pattern: native
+- actions:
+  - value: 12
+    var: max-frames
+  matchers:
+  - key: value
+    negated: false
+    pattern: '*something*'
+version: 3

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -32,10 +32,13 @@ def convert_to_dict(obj: object) -> object | dict[str, Any]:
             continue
         elif key in [
             "rust_enhancements",
+            "classifier_rust_enhancements",
+            "contributes_rust_enhancements",
             "is_classifier",
             "sets_contributes",
             "has_classifier_actions",
             "has_contributes_actions",
+            "run_split_enhancements",
         ]:
             continue
         elif isinstance(value, list):
@@ -96,7 +99,7 @@ def assert_no_matching_frame_found(
     assert not bool(get_matching_frame_actions(rule, frames, platform, exception_data, cache))
 
 
-@pytest.mark.parametrize("version", [2])
+@pytest.mark.parametrize("version", [2, 3])
 def test_basic_parsing(insta_snapshot, version):
     enhancements = Enhancements.from_rules_text(
         """
@@ -113,8 +116,8 @@ def test_basic_parsing(insta_snapshot, version):
             error.value:"*something*"                       max-frames=12
         """,
         bases=["common:v1"],
+        version=version,
     )
-    enhancements.version = version
 
     insta_snapshot(convert_to_dict(enhancements))
 

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -534,8 +534,8 @@ def test_keep_profiling_rules(test_input, expected):
 
 
 class EnhancementsTest(TestCase):
-    def test_differentiates_between_classifier_and_contributes_rules(self):
-        rules_text = """
+    def setUp(self):
+        self.rules_text = """
             function:sit              +app                  # should end up in classifiers
             function:roll_over        category=trick        # should end up in classifiers
             function:shake            +group                # should end up in contributes
@@ -543,7 +543,9 @@ class EnhancementsTest(TestCase):
             function:stay             min-frames=12         # should end up in contributes
             function:kangaroo         -app -group           # should end up in both
             """
-        rules = parse_enhancements(rules_text)
+
+    def test_differentiates_between_classifier_and_contributes_rules(self):
+        rules = parse_enhancements(self.rules_text)
 
         expected_results = [
             # (has_classifier_actions, has_contributes_actions, classifier_actions, contributes_actions)
@@ -577,6 +579,33 @@ class EnhancementsTest(TestCase):
             assert rule.has_contributes_actions == expected_has_contributes_actions_value
             assert classifier_rule_actions == expected_as_classifier_rule_actions
             assert contributes_rule_actions == expected_as_contributes_rule_actions
+
+    def test_splits_rules_correctly(self):
+        enhancements = Enhancements.from_rules_text(self.rules_text, version=3)
+        assert [rule.text for rule in enhancements.classifier_rules] == [
+            "function:sit +app",
+            "function:roll_over category=trick",
+            "function:kangaroo -app",  # Split of `function:kangaroo -app -group`
+        ]
+        assert [rule.text for rule in enhancements.contributes_rules] == [
+            "function:shake +group",
+            "function:lie_down max-frames=11",
+            "function:stay min-frames=12",
+            "function:kangaroo -group",  # Split of `function:kangaroo -app -group`
+        ]
+
+    def test_obeys_version_for_splitting_choice(self):
+        enhancements = Enhancements.from_rules_text(self.rules_text)
+        assert enhancements.classifier_rules == []
+        assert enhancements.contributes_rules == []
+
+        enhancements = Enhancements.from_rules_text(self.rules_text, version=2)
+        assert enhancements.classifier_rules == []
+        assert enhancements.contributes_rules == []
+
+        enhancements = Enhancements.from_rules_text(self.rules_text, version=3)
+        assert len(enhancements.classifier_rules) > 0
+        assert len(enhancements.contributes_rules) > 0
 
 
 class AssembleStacktraceComponentTest(TestCase):


### PR DESCRIPTION
In the current stacktrace rules/enhancement system, rules can serve as "classifier" rules (rules which set a frame's `category` and `in_app` values) or "contributes" rules (rules which determine whether or not a frame is used for grouping) or both. During ingest, we ask the rust enhancer to apply these changes separately, in `apply_category_and_updated_in_app_to_frames` and `assemble_stacktrace_component` respectively.

In both cases we test each frame against all of the rules, not just the applicable ones. Not only is this a waste of time and computing power, it also leads to problems with our hint data when a rule is used for both classifier and contributes purposes, because in that case we only return one of the two hints. (Which one we return depends, among other things, on whether the rule is `function:xxx -app +group` or `function:xxx +group -app`.)

As a first step towards solving these problems, this PR adds to the python enhancer the ability to split its rules into separate classifier and contributes buckets, and store them, along with their rust versions, on the `Enhancements` object. (Follow-up PRs will handle actually using the rules.) This is controlled by the enhancements' `version` parameter (though nothing yet passes the new version, so the splitting is disabled for the moment).

Note: Creating the split rust enhancements relies on merging them with split versions of the base enhancements, which don't exist yet. For now the bases can fall back to the dummy/empty versions which live on the class. This will also be fixed in an upcoming PR.