### PR TITLE
feat(insights): set default sampling mode to normal

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -40,7 +40,7 @@ interface UseDiscoverOptions<Fields> {
 }
 
 // The default sampling mode for eap queries
-export const DEFAULT_SAMPLING_MODE: SamplingMode = 'BEST_EFFORT';
+export const DEFAULT_SAMPLING_MODE: SamplingMode = 'NORMAL';
 
 export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
   options: UseDiscoverOptions<Fields> = {},


### PR DESCRIPTION
Normal has a 8s query length, but best_effort has a 30 which we feel is a little too long.