### PR TITLE
fix(taskworker) Don't include datetimes in send_resource_change_webhook params

### DIFF
--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -247,7 +247,9 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
                 args=[self.organization.slug, group.id, group_event.event_id],
             )
         )
-        assert data["data"]["event"]["issue_url"] == absolute_uri(f"/api/0/issues/{group.id}/")
+        assert data["data"]["event"]["issue_url"] == absolute_uri(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/"
+        )
         assert data["data"]["event"]["issue_id"] == str(group.id)
 
         assert kwargs["headers"].keys() >= {
@@ -434,7 +436,7 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
             )
         )
         assert data["data"]["event"]["issue_url"] == absolute_uri(
-            f"/api/0/issues/{group_event.group.id}/"
+            f"/api/0/organizations/{self.organization.slug}/issues/{group_event.group.id}/"
         )
         assert data["data"]["event"]["issue_id"] == str(group_event.group.id)
         assert data["data"]["event"]["occurrence"] == convert_dict_key_case(


### PR DESCRIPTION
datetime objects require pickle to maintain their type across task activation boundaries. Convert the task payload parameters before sending the task so that we have consistent types.

I've also updated the issue link we send in webhooks to use the organization scoped URL as that URL works across all regions and base domains.

Fixes #90447
