### PR TITLE
ref(perf-issues): Consolidate File IO override option

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -96,7 +96,12 @@ class PerformanceDetector(ABC):
         pass
 
     @classmethod
-    def is_creation_allowed_for_system(cls) -> bool:
+    def is_detection_allowed_for_system(cls) -> bool:
+        """
+        This method determines whether the detector should be run at all for this Sentry instance.
+
+        See `_detect_performance_problems` in `performance_detection.py` for more context.
+        """
         system_option = DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION.get(cls.type, None)
 
         if not system_option:
@@ -116,10 +121,22 @@ class PerformanceDetector(ABC):
             return False
 
     def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return False  # Creation is off by default. Ideally, it should auto-generate the feature flag name, and check its value
+        """
+        After running the detector, this method determines whether the found problems should be
+        passed to the issue platform for a given organization.
+
+        See `_detect_performance_problems` in `performance_detection.py` for more context.
+        """
+        return False
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
-        return False  # Creation is off by default. Ideally, it should auto-generate the project option name, and check its value
+        """
+        After running the detector, this method determines whether the found problems should be
+        passed to the issue platform for a given project.
+
+        See `_detect_performance_problems` in `performance_detection.py` for more context.
+        """
+        return False
 
     @classmethod
     def is_event_eligible(cls, event, project: Project | None = None) -> bool:

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -95,8 +95,9 @@ class PerformanceDetector(ABC):
     def on_complete(self) -> None:
         pass
 
-    def is_creation_allowed_for_system(self) -> bool:
-        system_option = DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION.get(self.__class__.type, None)
+    @classmethod
+    def is_creation_allowed_for_system(cls) -> bool:
+        system_option = DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION.get(cls.type, None)
 
         if not system_option:
             return False
@@ -119,10 +120,6 @@ class PerformanceDetector(ABC):
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
         return False  # Creation is off by default. Ideally, it should auto-generate the project option name, and check its value
-
-    @classmethod
-    def is_detector_enabled(cls) -> bool:
-        return True
 
     @classmethod
     def is_event_eligible(cls, event, project: Project | None = None) -> bool:

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -48,7 +48,8 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         self.stored_problems: PerformanceProblemsMap = {}
         self.spans: list[Span] = []
 
-    def is_creation_allowed_for_system(self) -> bool:
+    @classmethod
+    def is_creation_allowed_for_system(cls) -> bool:
         # Defer to the issue platform for whether to create issues
         # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
         return True

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -49,7 +49,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         self.spans: list[Span] = []
 
     @classmethod
-    def is_creation_allowed_for_system(cls) -> bool:
+    def is_detection_allowed_for_system(cls) -> bool:
         # Defer to the issue platform for whether to create issues
         # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
         return True

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -7,7 +7,6 @@ from typing import Any
 import sentry_sdk
 from symbolic.proguard import ProguardMapper
 
-from sentry import options
 from sentry.issues.grouptype import (
     GroupType,
     PerformanceDBMainThreadGroupType,
@@ -121,10 +120,6 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
     type = DetectorType.FILE_IO_MAIN_THREAD
     settings_key = DetectorType.FILE_IO_MAIN_THREAD
     group_type = PerformanceFileIOMainThreadGroupType
-
-    @classmethod
-    def is_detector_enabled(cls) -> bool:
-        return not options.get("performance_issues.file_io_main_thread.disabled")
 
     def _prepare_deobfuscation(self) -> None:
         event = self._event

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -353,7 +353,7 @@ def _detect_performance_problems(
         detectors: list[PerformanceDetector] = [
             detector_class(detection_settings, data)
             for detector_class in DETECTOR_CLASSES
-            if detector_class.is_detector_enabled()
+            if detector_class.is_creation_allowed_for_system()
         ]
 
     for detector in detectors:
@@ -380,7 +380,6 @@ def _detect_performance_problems(
         for detector in detectors:
             if all(
                 [
-                    detector.is_creation_allowed_for_system(),
                     detector.is_creation_allowed_for_organization(organization),
                     detector.is_creation_allowed_for_project(project),
                 ]

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -353,7 +353,7 @@ def _detect_performance_problems(
         detectors: list[PerformanceDetector] = [
             detector_class(detection_settings, data)
             for detector_class in DETECTOR_CLASSES
-            if detector_class.is_creation_allowed_for_system()
+            if detector_class.is_detection_allowed_for_system()
         ]
 
     for detector in detectors:


### PR DESCRIPTION
This PR removes the `performance_issues.file_io_main_thread.disabled` override option for the FileIOMainThread detector. There are already system options that were being checked after detection to stop issue creation, but instead, we will defer to the Issue Platform on whether or not an issue should be created.

I've documented this change on the base class's methods and changed `creation` to `detection` since it establishes the detector will not be run if the option is set to false.