### PR TITLE
ref: convert AuthTokenType to a StrEnum

### DIFF
--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -121,7 +121,7 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
     name = models.CharField(max_length=255, null=True)
     token = models.CharField(max_length=71, unique=True, default=generate_token)
     hashed_token = models.CharField(max_length=128, unique=True, null=True)
-    token_type = models.CharField(max_length=7, choices=AuthTokenType, null=True)
+    token_type = models.CharField(max_length=7, choices=AuthTokenType.choices(), null=True)
     token_last_characters = models.CharField(max_length=4, null=True)
     refresh_token = models.CharField(max_length=71, unique=True, null=True, default=generate_token)
     hashed_refresh_token = models.CharField(max_length=128, unique=True, null=True)

--- a/src/sentry/types/token.py
+++ b/src/sentry/types/token.py
@@ -1,7 +1,7 @@
-from django.db import models
+import enum
 
 
-class AuthTokenType(models.TextChoices):
+class AuthTokenType(enum.StrEnum):
     """
     Represents the various API/auth token types in the Sentry code base.
     The values equate to the expected prefix of each of the token types.
@@ -14,3 +14,7 @@ class AuthTokenType(models.TextChoices):
 
     # tokens created prior to our prefixing
     __empty__: None = None
+
+    @classmethod
+    def choices(cls) -> list[tuple[None, None] | tuple[str, str]]:
+        return [(None, None), *((e.value, e.name.replace("_", " ").title()) for e in cls)]


### PR DESCRIPTION
TextChoices has some weird typing interaction with _StrPromise and doesn't really buy us much over a normal enum if we aren't using custom labels

<!-- Describe your PR here. -->