### PR TITLE
fix(taskworker) Change process_detction_bucket callers

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -89,7 +89,7 @@ def schedule_detections():
             for _ in range(minutes_since_last_processed):
                 metrics.incr("uptime.detectors.scheduler.scheduled_bucket")
                 last_processed = last_processed + timedelta(minutes=1)
-                process_detection_bucket.delay(last_processed)
+                process_detection_bucket.delay(last_processed.isoformat())
 
             cluster.set(LAST_PROCESSED_KEY, int(last_processed.timestamp()), timedelta(hours=1))
     except UnableToAcquireLock:
@@ -109,6 +109,7 @@ def process_detection_bucket(bucket: datetime.datetime | str):
     """
     Schedules url detection for all projects in this time bucket that saw promising urls.
     """
+    # TODO(taskworker) Remove datetime type and always parse str
     if isinstance(bucket, str):
         bucket = parse_datetime(bucket)
 

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -70,7 +70,10 @@ class ScheduleDetectionsTest(UptimeTestCase):
         ) as mock_process_detection_bucket:
             schedule_detections()
             mock_process_detection_bucket.delay.assert_has_calls(
-                [call(last_processed_bucket + timedelta(minutes=i)) for i in range(1, 11)]
+                [
+                    call((last_processed_bucket + timedelta(minutes=i)).isoformat())
+                    for i in range(1, 11)
+                ]
             )
         last_processed = cluster.get(LAST_PROCESSED_KEY)
         assert last_processed is not None
@@ -97,7 +100,8 @@ class ProcessDetectionBucketTest(UptimeTestCase):
         with mock.patch(
             "sentry.uptime.detectors.tasks.process_organization_url_ranking"
         ) as mock_process_project_url_ranking:
-            process_detection_bucket(timezone.now().replace(second=0, microsecond=0))
+            now = timezone.now().replace(second=0, microsecond=0)
+            process_detection_bucket(now.isoformat())
             mock_process_project_url_ranking.delay.assert_not_called()
 
     def test_bucket(self):
@@ -115,7 +119,7 @@ class ProcessDetectionBucketTest(UptimeTestCase):
         with mock.patch(
             "sentry.uptime.detectors.tasks.process_organization_url_ranking"
         ) as mock_process_organization_url_ranking:
-            process_detection_bucket(bucket)
+            process_detection_bucket(bucket.isoformat())
             mock_process_organization_url_ranking.delay.assert_has_calls(
                 [call(self.project.organization.id), call(other_project.organization.id)],
                 any_order=True,


### PR DESCRIPTION
With str|datetime handling deployed, we can change the callers to pass str instead of datetimes. In order to use taskworkers, all parameters need to be json encodable. While we have patched json encoding to handle datetime values, json decoding does not convert those strings back into datetime objects. To maintain consistent types, we should use strings.

Refs #90393