### PR TITLE
fix(explore): Update tables to use progressive loading 

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -65,6 +65,7 @@ export type MetaType = Record<string, any> & {
 export type EventsMetaType = {fields: Record<string, ColumnType>} & {
   units: Record<string, string>;
 } & {
+  dataScanned?: 'full' | 'partial';
   discoverSplitDecision?: WidgetType;
   isMetricsData?: boolean;
   isMetricsExtractedData?: boolean;

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -1,6 +1,7 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import type {NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -33,9 +34,20 @@ export function useExploreAggregatesTable({
   limit,
   query,
 }: UseExploreAggregatesTableOptions) {
+  const canTriggerHighAccuracy = useCallback(
+    (results: ReturnType<typeof useSpansQuery<any[]>>) => {
+      const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
+      const hasData = defined(results.data) && results.data.length > 0;
+      return !hasData && canGoToHigherAccuracyTier;
+    },
+    []
+  );
   return useProgressiveQuery<typeof useExploreAggregatesTableImp>({
     queryHookImplementation: useExploreAggregatesTableImp,
     queryHookArgs: {enabled, limit, query},
+    queryOptions: {
+      canTriggerHighAccuracy,
+    },
   });
 }
 

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -1,0 +1,128 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useNavigate');
+jest.mock('sentry/utils/usePageFilters');
+
+function createWrapper(org: Organization) {
+  return function TestWrapper({children}: {children: React.ReactNode}) {
+    const queryClient = makeTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <OrganizationContext value={org}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useExploreTimeseries', () => {
+  let mockNormalRequestUrl: jest.Mock;
+
+  beforeEach(() => {
+    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [2],
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  it('triggers the high accuracy request when there is no data and a partial scan', async function () {
+    mockNormalRequestUrl = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [],
+        meta: {
+          dataScanned: 'partial',
+          fields: {},
+        },
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === SAMPLING_MODE.NORMAL;
+        },
+      ],
+    });
+    const mockHighAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === undefined;
+        },
+      ],
+      method: 'GET',
+    });
+    renderHook(
+      () =>
+        useExploreSpansTable({
+          query: 'test value',
+          enabled: true,
+          limit: 10,
+        }),
+      {
+        wrapper: createWrapper(
+          OrganizationFixture({
+            features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
+          })
+        ),
+      }
+    );
+
+    expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);
+    expect(mockNormalRequestUrl).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sampling: SAMPLING_MODE.NORMAL,
+          query: 'test value !transaction.span_id:00',
+        }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
+    });
+    expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'test value !transaction.span_id:00',
+        }),
+      })
+    );
+    expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.not.objectContaining({
+          sampling: expect.anything(),
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -36,7 +36,7 @@ export function useExploreSpansTable({
 }: UseExploreSpansTableOptions) {
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useSpansQuery<any[]>>) => {
-      const canGoToHigherAccuracyTier = results.meta?.canGoToHigherAccuracyTier;
+      const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
       const hasData = defined(results.data) && results.data.length > 0;
       return !hasData && canGoToHigherAccuracyTier;
     },

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -1,6 +1,7 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import type {NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -33,10 +34,22 @@ export function useExploreSpansTable({
   limit,
   query,
 }: UseExploreSpansTableOptions) {
+  const canTriggerHighAccuracy = useCallback(
+    (results: ReturnType<typeof useSpansQuery<any[]>>) => {
+      const canGoToHigherAccuracyTier = results.meta?.canGoToHigherAccuracyTier;
+      const hasData = defined(results.data) && results.data.length > 0;
+      return !hasData && canGoToHigherAccuracyTier;
+    },
+    []
+  );
   return useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
     queryHookArgs: {enabled, limit, query},
-    queryOptions: {queryMode: QUERY_MODE.SERIAL, withholdBestEffort: true},
+    queryOptions: {
+      queryMode: QUERY_MODE.SERIAL,
+      withholdBestEffort: true,
+      canTriggerHighAccuracy,
+    },
   });
 }
 

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -48,8 +48,8 @@ export const useExploreTimeseries = ({
   const isTopN = topEvents ? topEvents > 0 : false;
 
   const canTriggerHighAccuracy = useCallback(
-    (data: ReturnType<typeof useExploreTimeseriesImpl>['result']['data']) => {
-      return shouldTriggerHighAccuracy(data, visualizes, isTopN);
+    (result: ReturnType<typeof useExploreTimeseriesImpl>['result']) => {
+      return shouldTriggerHighAccuracy(result.data, visualizes, isTopN);
     },
     [visualizes, isTopN]
   );

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -322,9 +322,11 @@ describe('useProgressiveQuery', function () {
             queryHookImplementation: useMockHookImpl,
             queryHookArgs: {enabled: true, query: 'test value'},
             queryOptions: {
-              canTriggerHighAccuracy: data => {
+              canTriggerHighAccuracy: results => {
                 // Simulate checking if there is data and more data is available
-                return defined(data) && data.meta.dataScanned === 'partial';
+                return (
+                  defined(results.data) && results.data.meta.dataScanned === 'partial'
+                );
               },
             },
           }),

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -36,7 +36,7 @@ interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {
   // Enforces that isFetched is always present in the result, required for the
   // progressive loading to surface the correct data.
   queryHookImplementation: (props: Parameters<TQueryFn>[0]) => ReturnType<TQueryFn> & {
-    result: {
+    result: ReturnType<TQueryFn>['result'] & {
       data: any;
       isFetched: boolean;
     };
@@ -45,7 +45,7 @@ interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {
 }
 
 interface QueryOptions<TQueryFn extends (...args: any[]) => any> {
-  canTriggerHighAccuracy?: (data: ReturnType<TQueryFn>['result']['data']) => boolean;
+  canTriggerHighAccuracy?: (data: ReturnType<TQueryFn>['result']) => boolean;
   queryMode?: QueryMode;
   withholdBestEffort?: boolean;
 }
@@ -127,8 +127,7 @@ export function useProgressiveQuery<
   let triggerHighAccuracy = false;
   if (normalSamplingModeRequest.result.isFetched) {
     triggerHighAccuracy =
-      queryOptions?.canTriggerHighAccuracy?.(normalSamplingModeRequest.result.data) ??
-      false;
+      queryOptions?.canTriggerHighAccuracy?.(normalSamplingModeRequest.result) ?? false;
   }
   // queryExtras is not passed in here because this request should be unsampled.
   const highAccuracyRequest = queryHookImplementation({

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
@@ -1,0 +1,158 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {
+  useMultiQueryTableAggregateMode,
+  useMultiQueryTableSampleMode,
+} from 'sentry/views/explore/multiQueryMode/hooks/useMultiQueryTable';
+import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useNavigate');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/views/explore/multiQueryMode/locationUtils', () => {
+  const actual = jest.requireActual('sentry/views/explore/multiQueryMode/locationUtils');
+  return {
+    ...actual,
+    useReadQueriesFromLocation: jest.fn(),
+  };
+});
+
+function createWrapper(org: Organization) {
+  return function TestWrapper({children}: {children: React.ReactNode}) {
+    const queryClient = makeTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <OrganizationContext value={org}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useMultiQueryTable', () => {
+  let mockNormalRequestUrl: jest.Mock;
+
+  beforeEach(() => {
+    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [2],
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['aggregate', useMultiQueryTableAggregateMode],
+    ['sample', useMultiQueryTableSampleMode],
+  ])(
+    `triggers the high accuracy request when there is no data and a partial scan for %s mode`,
+    async function (_mode, hook) {
+      jest.mocked(useReadQueriesFromLocation).mockReturnValue([
+        {
+          query: 'test value',
+          groupBys: [],
+          sortBys: [],
+          yAxes: [],
+          chartType: ChartType.LINE,
+          fields: [],
+        },
+      ]);
+      mockNormalRequestUrl = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        body: {
+          data: [],
+          meta: {
+            dataScanned: 'partial',
+            fields: {},
+          },
+        },
+        method: 'GET',
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.sampling === SAMPLING_MODE.NORMAL;
+          },
+        ],
+      });
+      const mockHighAccuracyRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.sampling === undefined;
+          },
+        ],
+        method: 'GET',
+      });
+      renderHook(
+        () =>
+          hook({
+            enabled: true,
+            groupBys: [],
+            query: 'test value',
+            sortBys: [],
+            yAxes: [],
+          }),
+        {
+          wrapper: createWrapper(
+            OrganizationFixture({
+              features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
+            })
+          ),
+        }
+      );
+
+      expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);
+      expect(mockNormalRequestUrl).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            sampling: SAMPLING_MODE.NORMAL,
+            query: 'test value !transaction.span_id:00',
+          }),
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
+      });
+      expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'test value !transaction.span_id:00',
+          }),
+        })
+      );
+      expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.not.objectContaining({
+            sampling: expect.anything(),
+          }),
+        })
+      );
+    }
+  );
+});

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -35,15 +35,15 @@ export function useMultiQueryTimeseries({
   index,
 }: UseMultiQueryTimeseriesOptions) {
   const canTriggerHighAccuracy = useCallback(
-    (data: ReturnType<typeof useMultiQueryTimeseriesImpl>['result']['data']) => {
-      const hasData = Object.values(data).some(result => {
+    (results: ReturnType<typeof useMultiQueryTimeseriesImpl>['result']) => {
+      const hasData = Object.values(results.data).some(result => {
         return Object.values(result).some(series => {
           return series.sampleCount?.some(({value}) => {
             return value > 0;
           });
         });
       });
-      const canGetMoreData = Object.values(data).some(result => {
+      const canGetMoreData = Object.values(results.data).some(result => {
         return Object.values(result).some(series => {
           return series.dataScanned === 'partial';
         });


### PR DESCRIPTION
Updates the hook to pass along the results instead of the data because
the tables don't store the metadata under data, so we need to pass a
level up.