### PR TITLE
fix(schema-hints): Search bar width adjustment on logs page

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -38,13 +38,20 @@ import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
-const LOGS_QUERY_BUILDER_WIDTH_OFFSET = 130;
 
 interface SchemaHintsListProps extends SchemaHintsPageParams {
   numberTags: TagCollection;
   stringTags: TagCollection;
   supportedAggregates: AggregationKey[];
   isLoading?: boolean;
+  /**
+   * The width of all elements to the right of the search bar.
+   * This is used to ensure that the search bar is the correct width when the drawer is open.
+   */
+  searchBarWidthOffset?: number;
+  /**
+   * The are of the product that the schema hints are being rendered in
+   */
   source?: SchemaHintsSources;
 }
 
@@ -99,6 +106,7 @@ function SchemaHintsList({
   stringTags,
   isLoading,
   source = SchemaHintsSources.EXPLORE,
+  searchBarWidthOffset,
 }: SchemaHintsListProps) {
   const schemaHintsContainerRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
@@ -242,7 +250,7 @@ function SchemaHintsList({
   useEffect(() => {
     const adjustSearchBarWidth = () => {
       if (isDrawerOpen && searchBarWrapperRef.current && panelRef.current) {
-        searchBarWrapperRef.current.style.width = `calc(100% - ${source === SchemaHintsSources.LOGS ? panelRef.current.clientWidth - LOGS_QUERY_BUILDER_WIDTH_OFFSET : panelRef.current.clientWidth}px)`;
+        searchBarWrapperRef.current.style.width = `calc(100% - ${searchBarWidthOffset ? panelRef.current.clientWidth - searchBarWidthOffset : panelRef.current.clientWidth}px)`;
       }
     };
 
@@ -255,7 +263,7 @@ function SchemaHintsList({
     }
 
     return () => resizeObserver.disconnect();
-  }, [isDrawerOpen, panelRef, searchBarWrapperRef, source]);
+  }, [isDrawerOpen, panelRef, searchBarWidthOffset, searchBarWrapperRef]);
 
   const onHintClick = useCallback(
     (hint: Tag) => {

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -38,6 +38,7 @@ import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
+const LOGS_QUERY_BUILDER_WIDTH_OFFSET = 130;
 
 interface SchemaHintsListProps extends SchemaHintsPageParams {
   numberTags: TagCollection;
@@ -241,7 +242,7 @@ function SchemaHintsList({
   useEffect(() => {
     const adjustSearchBarWidth = () => {
       if (isDrawerOpen && searchBarWrapperRef.current && panelRef.current) {
-        searchBarWrapperRef.current.style.width = `calc(100% - ${panelRef.current.clientWidth}px)`;
+        searchBarWrapperRef.current.style.width = `calc(100% - ${source === SchemaHintsSources.LOGS ? panelRef.current.clientWidth - LOGS_QUERY_BUILDER_WIDTH_OFFSET : panelRef.current.clientWidth}px)`;
       }
     };
 
@@ -254,7 +255,7 @@ function SchemaHintsList({
     }
 
     return () => resizeObserver.disconnect();
-  }, [isDrawerOpen, panelRef, searchBarWrapperRef]);
+  }, [isDrawerOpen, panelRef, searchBarWrapperRef, source]);
 
   const onHintClick = useCallback(
     (hint: Tag) => {
@@ -282,8 +283,8 @@ function SchemaHintsList({
                   location.pathname !== newLocation.pathname ||
                   // will close if anything but the filter query has changed
                   !isEqual(
-                    omit(location.query, ['query', 'field', 'search', 'logsQuery']),
-                    omit(newLocation.query, ['query', 'field', 'search', 'logsQuery'])
+                    omit(location.query, ['query', 'field', 'logsFields', 'logsQuery']),
+                    omit(newLocation.query, ['query', 'field', 'logsFields', 'logsQuery'])
                   )
                 );
               },

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -64,6 +64,8 @@ export function LogsTabContent({
   const tableData = useExploreLogsTable({});
   const pageFilters = usePageFilters();
   usePersistentLogsPageParameters(); // persist the columns you chose last time
+
+  const columnEditorButtonRef = useRef<HTMLButtonElement>(null);
   // always use the smallest interval possible (the most bars)
   const interval = getIntervalOptionsForPageFilter(pageFilters.selection.datetime)?.[0]
     ?.value;
@@ -147,7 +149,11 @@ export function LogsTabContent({
             </StyledPageFilterBar>
             <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
 
-            <Button onClick={openColumnEditor} icon={<IconTable />}>
+            <Button
+              onClick={openColumnEditor}
+              icon={<IconTable />}
+              ref={columnEditorButtonRef}
+            >
               {t('Edit Table')}
             </Button>
           </FilterBarContainer>
@@ -160,6 +166,7 @@ export function LogsTabContent({
                 isLoading={numberAttributesLoading || stringAttributesLoading}
                 exploreQuery={logsSearch.formatString()}
                 source={SchemaHintsSources.LOGS}
+                searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
               />
             </SchemaHintsSection>
           </Feature>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -133,7 +133,7 @@ export function LogsTabContent({
       <Layout.Body noRowGap>
         <Layout.Main fullWidth>
           <FilterBarContainer>
-            <PageFilterBar condensed>
+            <StyledPageFilterBar condensed>
               <ProjectPageFilter />
               <EnvironmentPageFilter />
               <DatePageFilter
@@ -144,7 +144,7 @@ export function LogsTabContent({
                   ...relativeOptions,
                 })}
               />
-            </PageFilterBar>
+            </StyledPageFilterBar>
             <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
 
             <Button onClick={openColumnEditor} icon={<IconTable />}>
@@ -180,9 +180,13 @@ export function LogsTabContent({
 }
 
 const FilterBarContainer = styled('div')`
-  display: flex;
-  gap: ${space(2)};
+  gap: ${space(1)};
   margin-bottom: ${space(1)};
+  display: grid;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    grid-template-columns: minmax(300px, auto) 1fr auto;
+  }
 `;
 
 const LogsItemContainer = styled('div')`
@@ -192,4 +196,8 @@ const LogsItemContainer = styled('div')`
 
 const LogsGraphContainer = styled(LogsItemContainer)`
   height: 200px;
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  width: auto;
 `;


### PR DESCRIPTION
The way the logs filter container was set up prevented the search bar from changing size the way we intended. I've changed the styling to match traces. Also i'm aware that I've used a constant to account for the extra elements in the logs filter container but it seems like this page is going to be refactored a bit (according to Colin) and the `Edit Table` button may get moved(?) If not I'll change it in the future to account for that but this is mainly a quick fix so that the search bar behaves correctly when the drawer opens. 