### PR TITLE
fix(billing): Fix customer history types in admin

### DIFF
--- a/static/gsAdmin/components/customers/customerHistory.tsx
+++ b/static/gsAdmin/components/customers/customerHistory.tsx
@@ -7,12 +7,15 @@ import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 
 import ResultGrid from 'admin/components/resultGrid';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
-import type {ReservedBudget, ReservedBudgetMetricHistory} from 'getsentry/types';
+import type {
+  BillingHistory,
+  ReservedBudget,
+  ReservedBudgetMetricHistory,
+} from 'getsentry/types';
 import {formatReservedWithUnits, formatUsageWithUnits} from 'getsentry/utils/billing';
 import {getPlanCategoryName, sortCategories} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
-import type {BillingHistory} from 'getsentry/types';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;

--- a/static/gsAdmin/components/customers/customerHistory.tsx
+++ b/static/gsAdmin/components/customers/customerHistory.tsx
@@ -12,6 +12,7 @@ import {formatReservedWithUnits, formatUsageWithUnits} from 'getsentry/utils/bil
 import {getPlanCategoryName, sortCategories} from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
+import type {BillingHistory} from 'getsentry/types';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;
@@ -40,17 +41,18 @@ function CustomerHistory({orgId, ...props}: Props) {
           Usage
         </th>,
       ]}
-      columnsForRow={(row: any) => {
+      columnsForRow={(row: BillingHistory) => {
         const sortedCategories = sortCategories(row.categories);
-        const reservedBudgets: ReservedBudget[] = row.reservedBudgets;
+        const reservedBudgets: ReservedBudget[] = row.reservedBudgets ?? [];
         const reservedBudgetMetricHistories: Record<string, ReservedBudgetMetricHistory> =
           {};
         const reservedBudgetNameMapping: Record<string, string> = {};
 
         // in _admin, always use DS names regardless of whether DS was actually used in the period
         // if DS is available (ie. when stored spans are billed)
-        const shouldUseDynamicSamplingNames =
-          DataCategory.SPANS_INDEXED in row.planDetails.planCategories;
+        const shouldUseDynamicSamplingNames = row.planDetails
+          ? DataCategory.SPANS_INDEXED in row.planDetails.planCategories
+          : false;
 
         if (row.hasReservedBudgets) {
           reservedBudgets.forEach(budget => {


### PR DESCRIPTION
The admin customer details pages crash for the billing test accounts since the test plans are now deleted.

I've fixed this by using a proper type and add checks for falsey values (i.e. null and undefined).

<img width="1728" alt="Screenshot 2025-04-28 at 3 30 53 PM" src="https://github.com/user-attachments/assets/83cc9160-5439-44ee-aa17-78b2c1b077ab" />
