### PR TITLE
ref(issue-views): Refactor pinned search -> default view logic

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -56,30 +56,30 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
         )
 
         # This entire endpoint will be removed once custom views are GA'd
-        default_view, created = GroupSearchView.objects.create_or_update(
-            organization=organization,
-            user_id=request.user.id,
-            values={
-                "name": "Default Search",
-                "query": result["query"],
-                "query_sort": result["sort"],
-                "visibility": GroupSearchViewVisibility.ORGANIZATION,
-            },
-        )
-        if created:
-            default_view_id = default_view.id
+        first_starred_view = GroupSearchViewStarred.objects.filter(
+            organization=organization, user_id=request.user.id, position=0
+        ).first()
+
+        if first_starred_view:
+            default_view = first_starred_view.group_search_view
+            default_view.query = result["query"]
+            default_view.query_sort = result["sort"]
+            default_view.save()
         else:
-            default_view_id = GroupSearchView.objects.get(
+            new_default_view = GroupSearchView.objects.create(
                 organization=organization,
                 user_id=request.user.id,
-            ).id
-
-        GroupSearchViewStarred.objects.create_or_update(
-            organization=organization,
-            user_id=request.user.id,
-            group_search_view_id=default_view_id,
-            values={"position": 0},
-        )
+                name="Default Search",
+                query=result["query"],
+                query_sort=result["sort"],
+                visibility=GroupSearchViewVisibility.ORGANIZATION,
+            )
+            GroupSearchViewStarred.objects.create(
+                organization=organization,
+                user_id=request.user.id,
+                group_search_view_id=new_default_view.id,
+                position=0,
+            )
 
         pinned_search = SavedSearch.objects.get(
             organization=organization,


### PR DESCRIPTION
fixes SENTRY-3RSM

Fixes this^ bug by refactoring how we update the "default" issue view when a pinned search is updated. 

Previously, we attempted to retrieve the default view if it existed by querying for it with a .get(). This caused the above error because users would have two views to start with, and the get() only expected one object to be returned. 

Now, we query for the default view by looking for the starred view in the first position, which is guaranteed to by the GroupSearchViewStarred table's unique constraints to only have one entry. 