### PR TITLE
feat(perf-issues): Re-enable some performance detectors

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1641,12 +1641,12 @@ register(
 )
 register(
     "performance.issues.consecutive_http.problem-creation",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "performance.issues.large_http_payload.problem-creation",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -1686,7 +1686,7 @@ register(
 )
 register(
     "performance.issues.http_overhead.problem-creation",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1641,12 +1641,12 @@ register(
 )
 register(
     "performance.issues.consecutive_http.problem-creation",
-    default=1.0,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "performance.issues.large_http_payload.problem-creation",
-    default=1.0,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
A few detectors had been accidentally disabled. This will re-enable them :+1: