### PR TITLE
feat(ACI): Clean up Detector, DCG, and DCs when project is deleted

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -46,6 +46,7 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
         from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
         from sentry.snuba.models import QuerySubscription
         from sentry.uptime.models import ProjectUptimeSubscription
+        from sentry.workflow_engine.models import Detector
 
         relations: list[BaseRelation] = [
             # ProjectKey gets revoked immediately, in bulk
@@ -98,6 +99,7 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
                 {"snuba_query__subscriptions__project": instance},
             )
         )
+        relations.append(ModelRelation(Detector, {"project_id": instance.id}))
 
         # Release needs to handle deletes after Group is cleaned up as the foreign
         # key is protected

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -120,6 +120,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         name_prefix: str = "test",
         workflow_triggers: DataConditionGroup | None = None,
         detector_type: str = MetricIssue.slug,
+        project: Project | None = None,
         **kwargs,
     ) -> tuple[Workflow, Detector, DetectorWorkflow, DataConditionGroup]:
         """
@@ -146,7 +147,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         detector = self.create_detector(
             name=f"{name_prefix}_detector",
             type=detector_type,
-            project=self.project,
+            project=project if project else self.project,
         )
 
         detector_workflow = self.create_detector_workflow(


### PR DESCRIPTION
Add the `Detector` to the project deletion task so all the associated models get cleaned up nicely